### PR TITLE
Using block store cache

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -114,11 +114,11 @@ public class DefaultConfig {
 
 
         IndexedBlockStore cache = new IndexedBlockStore();
-        cache.init(new HashMap<Long, List<IndexedBlockStore.BlockInfo>>(), new HashMapDB(), null, null);
+        cache.init(new HashMap<>(), new HashMapDB(), null, null);
 
         IndexedBlockStore indexedBlockStore = new IndexedBlockStore();
 
-        indexedBlockStore.init(indexMap, blocksDB, null, indexDB);
+        indexedBlockStore.init(indexMap, blocksDB, cache, indexDB);
 
         return indexedBlockStore;
     }


### PR DESCRIPTION
Adding an in-memory block store cache

(use with blockchain.flush = true; to test in some nodes)