### PR TITLE
Refactor block in blockchain logic, to avoid reading the full blocks

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
@@ -44,7 +44,7 @@ public class BlockUtils {
         final List<BlockInformation> blocks = blockChain.getBlocksInformationByNumber(blockNumber);
 
         for (final BlockInformation bi : blocks) {
-            if (new ByteArrayWrapper(bi.getHash()).equals(key)) {
+            if (key.equals(bi.getHash())) {
                 return true;
             }
         }

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
@@ -43,13 +43,7 @@ public class BlockUtils {
         final ByteArrayWrapper key = new ByteArrayWrapper(blockHash);
         final List<BlockInformation> blocks = blockChain.getBlocksInformationByNumber(blockNumber);
 
-        for (final BlockInformation bi : blocks) {
-            if (key.equals(bi.getHash())) {
-                return true;
-            }
-        }
-
-        return false;
+        return blocks.stream().anyMatch(bi -> key.equalsToByteArray(bi.getHash()));
     }
 
     public static Set<ByteArrayWrapper> unknownDirectAncestorsHashes(Block block, Blockchain blockChain, BlockStore store) {

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
@@ -22,6 +22,7 @@ import co.rsk.net.BlockStore;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Blockchain;
+import org.ethereum.db.BlockInformation;
 import org.ethereum.db.ByteArrayWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,20 +36,15 @@ public class BlockUtils {
     private static final Logger logger = LoggerFactory.getLogger("blockprocessor");
 
     public static boolean blockInSomeBlockChain(Block block, Blockchain blockChain) {
-        return blockInSomeBlockChain(block.getHash(), blockChain);
+        return blockInSomeBlockChain(block.getHash(), block.getNumber(), blockChain);
     }
 
-    public static boolean blockInSomeBlockChain(byte[] blockHash, Blockchain blockChain) {
-        final Block block = blockChain.getBlockByHash(blockHash);
+    public static boolean blockInSomeBlockChain(byte[] blockHash, long blockNumber, Blockchain blockChain) {
+        final ByteArrayWrapper key = new ByteArrayWrapper(blockHash);
+        final List<BlockInformation> blocks = blockChain.getBlocksInformationByNumber(blockNumber);
 
-        if (block == null)
-            return false;
-
-        final ByteArrayWrapper key = new ByteArrayWrapper(block.getHash());
-        final List<Block> blocks = blockChain.getBlocksByNumber(block.getNumber());
-
-        for (final Block b : blocks) {
-            if (new ByteArrayWrapper(b.getHash()).equals(key)) {
+        for (final BlockInformation bi : blocks) {
+            if (new ByteArrayWrapper(bi.getHash()).equals(key)) {
                 return true;
             }
         }

--- a/rskj-core/src/main/java/org/ethereum/db/ByteArrayWrapper.java
+++ b/rskj-core/src/main/java/org/ethereum/db/ByteArrayWrapper.java
@@ -71,4 +71,11 @@ public class ByteArrayWrapper implements Comparable<ByteArrayWrapper>, Serializa
     public String toString() {
         return Hex.toHexString(data);
     }
+
+    public boolean equalsToByteArray(byte[] bytes) {
+        if (bytes == null) {
+            return false;
+        }
+        return FastByteComparisons.compareTo(data, 0, data.length, bytes, 0, bytes.length) == 0;
+    }
 }


### PR DESCRIPTION
Refactor to improve block already in blockchain detection. Given the block height, it avoids the read of the full blocks at that height, using directly the known hashes.

