### PR TITLE
Sealed block

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
@@ -184,6 +184,11 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
      */
     @Override
     public ImportResult tryToConnect(Block block) {
+        if (block == null)
+            return ImportResult.INVALID_BLOCK;
+        
+        block.seal();
+
         if (blockRecorder != null)
             blockRecorder.writeBlock(block);
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
@@ -186,8 +186,11 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
     public ImportResult tryToConnect(Block block) {
         if (block == null)
             return ImportResult.INVALID_BLOCK;
-        
-        block.seal();
+
+        if (!block.isSealed()) {
+            panicProcessor.panic("unsealedblock", String.format("Unsealed block %s %s", block.getNumber(), Hex.toHexString(block.getHash())));
+            block.seal();
+        }
 
         if (blockRecorder != null)
             blockRecorder.writeBlock(block);

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -167,7 +167,7 @@ public class MinerServerImpl implements MinerServer {
             }
 
             // clone the block
-            newBlock = new Block(workingBlock.getEncoded());
+            newBlock = workingBlock.cloneBlock();
 
             logger.debug("blocksWaitingforPoW size " + blocksWaitingforPoW.size());
         }

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -177,6 +177,7 @@ public class MinerServerImpl implements MinerServer {
         newBlock.setBitcoinMergedMiningHeader(bitcoinMergedMiningBlock.cloneAsHeader().bitcoinSerialize());
         newBlock.setBitcoinMergedMiningCoinbaseTransaction(compressCoinbase(bitcoinMergedMiningCoinbaseTransaction.bitcoinSerialize()));
         newBlock.setBitcoinMergedMiningMerkleProof(bitcoinMergedMiningMerkleBranch.bitcoinSerialize());
+        newBlock.seal();
 
         if (!isValid(newBlock)) {
             logger.error("Invalid block supplied by miner " + " : " + newBlock.getShortHash() + " " + newBlock.getShortHashForMergedMining() + " at height " + newBlock.getNumber() + ". Hash: " + newBlock.getShortHash());

--- a/rskj-core/src/main/java/co/rsk/net/messages/BlockHeadersMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/BlockHeadersMessage.java
@@ -68,10 +68,12 @@ public class BlockHeadersMessage extends Message {
         RLPList paramsList = (RLPList) RLP.decode2(encoded).get(0);
 
         blockHeaders = new ArrayList<>();
+
         for (int i = 0; i < paramsList.size(); ++i) {
             RLPList rlpData = ((RLPList) paramsList.get(i));
-            blockHeaders.add(new BlockHeader(rlpData));
+            blockHeaders.add(new BlockHeader(rlpData, true));
         }
+
         parsed = true;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -70,7 +70,7 @@ public class Block {
 
     private Trie txsState;
 
-    /* Indicates if this block cannot be changed */
+    /* Indicates if this block can or cannot be changed */
     private volatile boolean sealed;
 
     public Block(byte[] rawData) {

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -70,9 +70,12 @@ public class Block {
 
     private Trie txsState;
 
+    protected boolean sealed;
+
     /* Constructors */
     public Block(byte[] rawData) {
         this.rlpEncoded = rawData;
+        this.sealed = true;
     }
 
     public Block(BlockHeader header) {
@@ -159,7 +162,6 @@ public class Block {
         this.flushRLP();
     }
 
-
     public Block(byte[] parentHash, byte[] unclesHash, byte[] coinbase, byte[] logsBloom,
                  byte[] difficulty, long number, byte[] gasLimit,
                  long gasUsed, long timestamp,
@@ -180,6 +182,17 @@ public class Block {
         }
 
         this.parsed = true;
+    }
+
+    public void seal() {
+        this.sealed = true;
+    }
+
+    public Block cloneBlock() {
+        Block clone = new Block(this.getEncoded());
+        clone.sealed = false;
+
+        return clone;
     }
 
     private void parseRLP() {
@@ -207,6 +220,9 @@ public class Block {
     }
 
     public void setTransactionsList(List<Transaction> transactionsList) {
+        if (this.sealed)
+            throw new RuntimeException("Sealed block: trying to alter transaction list");
+
         this.transactionsList = transactionsList;
         rlpEncoded = null;
     }
@@ -248,6 +264,9 @@ public class Block {
     }
 
     public void setStateRoot(byte[] stateRoot) {
+        if (this.sealed)
+            throw new RuntimeException("Sealed block: trying to alter state root");
+
         if (!parsed)
             parseRLP();
         this.header.setStateRoot(stateRoot);
@@ -332,6 +351,9 @@ public class Block {
     }
 
   public void setExtraData(byte[] data) {
+      if (this.sealed)
+          throw new RuntimeException("Sealed block: trying to alter extra data");
+
         this.header.setExtraData(data);
         rlpEncoded = null;
     }
@@ -514,6 +536,9 @@ public class Block {
     }
 
     public void addUncle(BlockHeader uncle) {
+        if (this.sealed)
+            throw new RuntimeException("Sealed block: trying to add uncle");
+
         uncleList.add(uncle);
         this.getHeader().setUnclesHash(SHA3Helper.sha3(getUnclesEncoded()));
         rlpEncoded = null;
@@ -600,6 +625,9 @@ public class Block {
     }
 
     public void setBitcoinMergedMiningHeader(byte[] bitcoinMergedMiningHeader) {
+        if (this.sealed)
+            throw new RuntimeException("Sealed block: trying to alter bitcoin merged mining header");
+
         this.header.setBitcoinMergedMiningHeader(bitcoinMergedMiningHeader);
         rlpEncoded = null;
     }
@@ -613,6 +641,9 @@ public class Block {
     }
 
     public void setBitcoinMergedMiningMerkleProof(byte[] bitcoinMergedMiningMerkleProof) {
+        if (this.sealed)
+            throw new RuntimeException("Sealed block: trying to alter bitcoin merged mining Merkle proof");
+
         this.header.setBitcoinMergedMiningMerkleProof(bitcoinMergedMiningMerkleProof);
         rlpEncoded = null;
     }
@@ -626,6 +657,9 @@ public class Block {
     }
 
     public void setBitcoinMergedMiningCoinbaseTransaction(byte[] bitcoinMergedMiningCoinbaseTransaction) {
+        if (this.sealed)
+            throw new RuntimeException("Sealed block: trying to alter bitcoin merged mining coinbase transaction");
+
         this.header.setBitcoinMergedMiningCoinbaseTransaction(bitcoinMergedMiningCoinbaseTransaction);
         rlpEncoded = null;
     }
@@ -651,6 +685,9 @@ public class Block {
     }
 
     private byte[] calcTxTrie(List<Transaction> transactions){
+        if (this.sealed)
+            throw new RuntimeException("Sealed block: trying to alter transaction root");
+
         this.txsState = getTxTrie(transactions);
 
         return txsState.getHash();

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -70,6 +70,7 @@ public class Block {
 
     private Trie txsState;
 
+    /* Indicates if this block cannot be changed */
     protected boolean sealed;
 
     /* Constructors */
@@ -186,15 +187,20 @@ public class Block {
 
     public void seal() {
         this.sealed = true;
+        this.header.seal();
     }
 
     public boolean isSealed() {
         return this.sealed;
     }
 
+    // Clone this block allowing modifications
     public Block cloneBlock() {
         Block clone = new Block(this.getEncoded());
         clone.sealed = false;
+        clone.parseRLP();;
+        // Allow modifications to header
+        clone.header.unseal();
 
         return clone;
     }
@@ -224,6 +230,7 @@ public class Block {
     }
 
     public void setTransactionsList(List<Transaction> transactionsList) {
+        /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
             throw new RuntimeException("Sealed block: trying to alter transaction list");
 
@@ -268,6 +275,7 @@ public class Block {
     }
 
     public void setStateRoot(byte[] stateRoot) {
+        /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
             throw new RuntimeException("Sealed block: trying to alter state root");
 
@@ -347,7 +355,6 @@ public class Block {
         return this.header.getGasUsed();
     }
 
-
     public byte[] getExtraData() {
         if (!parsed)
             parseRLP();
@@ -355,6 +362,7 @@ public class Block {
     }
 
   public void setExtraData(byte[] data) {
+      /* A sealed block is immutable, cannot be changed */
       if (this.sealed)
           throw new RuntimeException("Sealed block: trying to alter extra data");
 
@@ -442,7 +450,6 @@ public class Block {
     }
 
     private void parseTxs(RLPList txTransactions) {
-
         this.txsState = new TrieImpl();
         int txsStateIndex = 0;
         for (int i = 0; i < txTransactions.size(); i++) {
@@ -629,6 +636,7 @@ public class Block {
     }
 
     public void setBitcoinMergedMiningHeader(byte[] bitcoinMergedMiningHeader) {
+        /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
             throw new RuntimeException("Sealed block: trying to alter bitcoin merged mining header");
 
@@ -645,6 +653,7 @@ public class Block {
     }
 
     public void setBitcoinMergedMiningMerkleProof(byte[] bitcoinMergedMiningMerkleProof) {
+        /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
             throw new RuntimeException("Sealed block: trying to alter bitcoin merged mining Merkle proof");
 
@@ -689,6 +698,7 @@ public class Block {
     }
 
     private byte[] calcTxTrie(List<Transaction> transactions){
+        /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
             throw new RuntimeException("Sealed block: trying to alter transaction root");
 

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -188,6 +188,10 @@ public class Block {
         this.sealed = true;
     }
 
+    public boolean isSealed() {
+        return this.sealed;
+    }
+
     public Block cloneBlock() {
         Block clone = new Block(this.getEncoded());
         clone.sealed = false;

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -711,10 +711,4 @@ public class Block {
         this.rlpEncoded = null;
         this.parsed = true;
     }
-
-    public static class SealedBlockException extends RuntimeException {
-        public SealedBlockException(String message) {
-            super("Sealed block: " + message);
-        }
-    }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -232,7 +232,7 @@ public class Block {
     public void setTransactionsList(List<Transaction> transactionsList) {
         /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block: trying to alter transaction list");
+            throw new SealedBlockException("trying to alter transaction list");
 
         this.transactionsList = transactionsList;
         rlpEncoded = null;
@@ -277,7 +277,7 @@ public class Block {
     public void setStateRoot(byte[] stateRoot) {
         /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block: trying to alter state root");
+            throw new SealedBlockException("trying to alter state root");
 
         if (!parsed)
             parseRLP();
@@ -364,7 +364,7 @@ public class Block {
   public void setExtraData(byte[] data) {
       /* A sealed block is immutable, cannot be changed */
       if (this.sealed)
-          throw new RuntimeException("Sealed block: trying to alter extra data");
+          throw new SealedBlockException("trying to alter extra data");
 
         this.header.setExtraData(data);
         rlpEncoded = null;
@@ -548,7 +548,7 @@ public class Block {
 
     public void addUncle(BlockHeader uncle) {
         if (this.sealed)
-            throw new RuntimeException("Sealed block: trying to add uncle");
+            throw new SealedBlockException("trying to add uncle");
 
         uncleList.add(uncle);
         this.getHeader().setUnclesHash(SHA3Helper.sha3(getUnclesEncoded()));
@@ -638,7 +638,7 @@ public class Block {
     public void setBitcoinMergedMiningHeader(byte[] bitcoinMergedMiningHeader) {
         /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block: trying to alter bitcoin merged mining header");
+            throw new SealedBlockException("trying to alter bitcoin merged mining header");
 
         this.header.setBitcoinMergedMiningHeader(bitcoinMergedMiningHeader);
         rlpEncoded = null;
@@ -655,7 +655,7 @@ public class Block {
     public void setBitcoinMergedMiningMerkleProof(byte[] bitcoinMergedMiningMerkleProof) {
         /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block: trying to alter bitcoin merged mining Merkle proof");
+            throw new SealedBlockException("trying to alter bitcoin merged mining Merkle proof");
 
         this.header.setBitcoinMergedMiningMerkleProof(bitcoinMergedMiningMerkleProof);
         rlpEncoded = null;
@@ -671,7 +671,7 @@ public class Block {
 
     public void setBitcoinMergedMiningCoinbaseTransaction(byte[] bitcoinMergedMiningCoinbaseTransaction) {
         if (this.sealed)
-            throw new RuntimeException("Sealed block: trying to alter bitcoin merged mining coinbase transaction");
+            throw new SealedBlockException("trying to alter bitcoin merged mining coinbase transaction");
 
         this.header.setBitcoinMergedMiningCoinbaseTransaction(bitcoinMergedMiningCoinbaseTransaction);
         rlpEncoded = null;
@@ -700,7 +700,7 @@ public class Block {
     private byte[] calcTxTrie(List<Transaction> transactions){
         /* A sealed block is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block: trying to alter transaction root");
+            throw new SealedBlockException("trying to alter transaction root");
 
         this.txsState = getTxTrie(transactions);
 
@@ -710,5 +710,11 @@ public class Block {
     public void flushRLP() {
         this.rlpEncoded = null;
         this.parsed = true;
+    }
+
+    public static class SealedBlockException extends RuntimeException {
+        public SealedBlockException(String message) {
+            super("Sealed block: " + message);
+        }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -96,6 +96,9 @@ public class BlockHeader implements SerializableObject {
     private byte[] minimumGasPrice;
     private int uncleCount;
 
+    /* Indicates if this block header cannot be changed */
+    protected boolean sealed;
+
     public BlockHeader(byte[] encoded) {
         this((RLPList) RLP.decode2(encoded).get(0));
     }
@@ -146,6 +149,7 @@ public class BlockHeader implements SerializableObject {
             this.bitcoinMergedMiningCoinbaseTransaction = rlpHeader.get(r++).getRLPData();
 
         }
+        this.sealed = true;
     }
 
     public BlockHeader(byte[] parentHash, byte[] unclesHash, byte[] coinbase,
@@ -197,6 +201,18 @@ public class BlockHeader implements SerializableObject {
         this.uncleCount = uncleCount;
     }
 
+    public boolean isSealed() {
+        return this.sealed;
+    }
+
+    public void unseal() {
+        this.sealed = false;
+    }
+
+    public void seal() {
+        this.sealed = true;
+    }
+
     public boolean isGenesis() {
         return this.getNumber() == Genesis.NUMBER;
     }
@@ -209,15 +225,15 @@ public class BlockHeader implements SerializableObject {
         return uncleCount;
     }
 
-    public void setUncleCount(int uCount) {
-        uncleCount = uCount;
-    }
-
     public byte[] getUnclesHash() {
         return unclesHash;
     }
 
     public void setUnclesHash(byte[] unclesHash) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter uncles hash");
+
         this.unclesHash = unclesHash;
     }
 
@@ -226,6 +242,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setCoinbase(byte[] coinbase) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter coinbase");
+
         this.coinbase = coinbase;
     }
 
@@ -234,6 +254,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setStateRoot(byte[] stateRoot) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter state root");
+
         this.stateRoot = stateRoot;
     }
 
@@ -242,6 +266,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setReceiptsRoot(byte[] receiptTrieRoot) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter receipts root");
+
         this.receiptTrieRoot = receiptTrieRoot;
     }
 
@@ -250,6 +278,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setTransactionsRoot(byte[] stateRoot) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter transactions root");
+
         this.txTrieRoot = stateRoot;
     }
 
@@ -266,8 +298,11 @@ public class BlockHeader implements SerializableObject {
         return new BigInteger(1, difficulty);
     }
 
-
     public void setDifficulty(byte[] difficulty) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter difficulty");
+
         this.difficulty = difficulty;
     }
 
@@ -276,6 +311,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setTimestamp(long timestamp) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter timestamp");
+
         this.timestamp = timestamp;
     }
 
@@ -284,6 +323,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setNumber(long number) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter number");
+
         this.number = number;
     }
 
@@ -292,6 +335,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setGasLimit(byte[] gasLimit) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter gas limit");
+
         this.gasLimit = gasLimit;
     }
 
@@ -300,6 +347,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setPaidFees(long paidFees) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter paid fees");
+
         this.paidFees = paidFees;
     }
 
@@ -308,6 +359,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setGasUsed(long gasUsed) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter gas used");
+
         this.gasUsed = gasUsed;
     }
 
@@ -316,10 +371,18 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setLogsBloom(byte[] logsBloom) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter logs bloom");
+
         this.logsBloom = logsBloom;
     }
 
     public void setExtraData(byte[] extraData) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter extra data");
+
         this.extraData = extraData;
     }
 
@@ -340,6 +403,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setMinimumGasPrice(byte[] minimumGasPrice) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter minimum gas price");
+
         this.minimumGasPrice = minimumGasPrice;
     }
 
@@ -432,7 +499,6 @@ public class BlockHeader implements SerializableObject {
         return BigIntegers.asUnsignedByteArray(32, BigInteger.ONE.shiftLeft(256).divide(getDifficultyBI()));
     }
 
-
     public BigInteger calcDifficulty(BlockHeader parent) {
         return SystemProperties.CONFIG.getBlockchainConfig().getConfigForBlock(getNumber()).
                 calcDifficulty(this, parent);
@@ -480,6 +546,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setBitcoinMergedMiningHeader(byte[] bitcoinMergedMiningHeader) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter bitcoin merged mining header");
+
         this.bitcoinMergedMiningHeader = bitcoinMergedMiningHeader;
     }
 
@@ -488,6 +558,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setBitcoinMergedMiningMerkleProof(byte[] bitcoinMergedMiningMerkleProof) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter bitcoin merged mining merkle proof");
+
         this.bitcoinMergedMiningMerkleProof = bitcoinMergedMiningMerkleProof;
     }
 
@@ -496,6 +570,10 @@ public class BlockHeader implements SerializableObject {
     }
 
     public void setBitcoinMergedMiningCoinbaseTransaction(byte[] bitcoinMergedMiningCoinbaseTransaction) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed)
+            throw new RuntimeException("Sealed block header: trying to alter bitcoin merged mining coinbase transaction");
+
         this.bitcoinMergedMiningCoinbaseTransaction = bitcoinMergedMiningCoinbaseTransaction;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -590,10 +590,4 @@ public class BlockHeader implements SerializableObject {
     public byte[] getHashForMergedMining() {
         return HashUtil.sha3(getEncoded(false));
     }
-
-    public static class SealedBlockHeaderException extends RuntimeException {
-        public SealedBlockHeaderException(String message) {
-            super("Sealed block header: " + message);
-        }
-    }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -232,7 +232,7 @@ public class BlockHeader implements SerializableObject {
     public void setUnclesHash(byte[] unclesHash) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter uncles hash");
+            throw new SealedBlockHeaderException("trying to alter uncles hash");
 
         this.unclesHash = unclesHash;
     }
@@ -244,7 +244,7 @@ public class BlockHeader implements SerializableObject {
     public void setCoinbase(byte[] coinbase) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter coinbase");
+            throw new SealedBlockHeaderException("trying to alter coinbase");
 
         this.coinbase = coinbase;
     }
@@ -256,7 +256,7 @@ public class BlockHeader implements SerializableObject {
     public void setStateRoot(byte[] stateRoot) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter state root");
+            throw new SealedBlockHeaderException("trying to alter state root");
 
         this.stateRoot = stateRoot;
     }
@@ -268,7 +268,7 @@ public class BlockHeader implements SerializableObject {
     public void setReceiptsRoot(byte[] receiptTrieRoot) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter receipts root");
+            throw new SealedBlockHeaderException("trying to alter receipts root");
 
         this.receiptTrieRoot = receiptTrieRoot;
     }
@@ -280,7 +280,7 @@ public class BlockHeader implements SerializableObject {
     public void setTransactionsRoot(byte[] stateRoot) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter transactions root");
+            throw new SealedBlockHeaderException("trying to alter transactions root");
 
         this.txTrieRoot = stateRoot;
     }
@@ -301,7 +301,7 @@ public class BlockHeader implements SerializableObject {
     public void setDifficulty(byte[] difficulty) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter difficulty");
+            throw new SealedBlockHeaderException("trying to alter difficulty");
 
         this.difficulty = difficulty;
     }
@@ -313,7 +313,7 @@ public class BlockHeader implements SerializableObject {
     public void setTimestamp(long timestamp) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter timestamp");
+            throw new SealedBlockHeaderException("trying to alter timestamp");
 
         this.timestamp = timestamp;
     }
@@ -325,7 +325,7 @@ public class BlockHeader implements SerializableObject {
     public void setNumber(long number) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter number");
+            throw new SealedBlockHeaderException("trying to alter number");
 
         this.number = number;
     }
@@ -337,7 +337,7 @@ public class BlockHeader implements SerializableObject {
     public void setGasLimit(byte[] gasLimit) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter gas limit");
+            throw new SealedBlockHeaderException("trying to alter gas limit");
 
         this.gasLimit = gasLimit;
     }
@@ -349,7 +349,7 @@ public class BlockHeader implements SerializableObject {
     public void setPaidFees(long paidFees) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter paid fees");
+            throw new SealedBlockHeaderException("trying to alter paid fees");
 
         this.paidFees = paidFees;
     }
@@ -361,7 +361,7 @@ public class BlockHeader implements SerializableObject {
     public void setGasUsed(long gasUsed) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter gas used");
+            throw new SealedBlockHeaderException("trying to alter gas used");
 
         this.gasUsed = gasUsed;
     }
@@ -373,7 +373,7 @@ public class BlockHeader implements SerializableObject {
     public void setLogsBloom(byte[] logsBloom) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter logs bloom");
+            throw new SealedBlockHeaderException("trying to alter logs bloom");
 
         this.logsBloom = logsBloom;
     }
@@ -381,7 +381,7 @@ public class BlockHeader implements SerializableObject {
     public void setExtraData(byte[] extraData) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter extra data");
+            throw new SealedBlockHeaderException("trying to alter extra data");
 
         this.extraData = extraData;
     }
@@ -405,7 +405,7 @@ public class BlockHeader implements SerializableObject {
     public void setMinimumGasPrice(byte[] minimumGasPrice) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter minimum gas price");
+            throw new SealedBlockHeaderException("trying to alter minimum gas price");
 
         this.minimumGasPrice = minimumGasPrice;
     }
@@ -548,7 +548,7 @@ public class BlockHeader implements SerializableObject {
     public void setBitcoinMergedMiningHeader(byte[] bitcoinMergedMiningHeader) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter bitcoin merged mining header");
+            throw new SealedBlockHeaderException("trying to alter bitcoin merged mining header");
 
         this.bitcoinMergedMiningHeader = bitcoinMergedMiningHeader;
     }
@@ -560,7 +560,7 @@ public class BlockHeader implements SerializableObject {
     public void setBitcoinMergedMiningMerkleProof(byte[] bitcoinMergedMiningMerkleProof) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter bitcoin merged mining merkle proof");
+            throw new SealedBlockHeaderException("trying to alter bitcoin merged mining merkle proof");
 
         this.bitcoinMergedMiningMerkleProof = bitcoinMergedMiningMerkleProof;
     }
@@ -572,7 +572,7 @@ public class BlockHeader implements SerializableObject {
     public void setBitcoinMergedMiningCoinbaseTransaction(byte[] bitcoinMergedMiningCoinbaseTransaction) {
         /* A sealed block header is immutable, cannot be changed */
         if (this.sealed)
-            throw new RuntimeException("Sealed block header: trying to alter bitcoin merged mining coinbase transaction");
+            throw new SealedBlockHeaderException("trying to alter bitcoin merged mining coinbase transaction");
 
         this.bitcoinMergedMiningCoinbaseTransaction = bitcoinMergedMiningCoinbaseTransaction;
     }
@@ -583,5 +583,11 @@ public class BlockHeader implements SerializableObject {
 
     public byte[] getHashForMergedMining() {
         return HashUtil.sha3(getEncoded(false));
+    }
+
+    public static class SealedBlockHeaderException extends RuntimeException {
+        public SealedBlockHeaderException(String message) {
+            super("Sealed block header: " + message);
+        }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderWrapper.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderWrapper.java
@@ -60,7 +60,7 @@ public class BlockHeaderWrapper {
 
         byte[] headerBytes = wrapper.get(0).getRLPData();
 
-        this.header= new BlockHeader(headerBytes);
+        this.header= new BlockHeader(headerBytes, true);
         this.nodeId = wrapper.get(1).getRLPData();
     }
 

--- a/rskj-core/src/main/java/org/ethereum/core/Genesis.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Genesis.java
@@ -56,6 +56,7 @@ public class Genesis extends Block {
 
     public Genesis(byte[] rawData){
         super(rawData);
+        this.sealed = false;
     }
 
     public Genesis(byte[] parentHash, byte[] unclesHash, byte[] coinbase, byte[] logsBloom,

--- a/rskj-core/src/main/java/org/ethereum/core/Genesis.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Genesis.java
@@ -55,9 +55,7 @@ public class Genesis extends Block {
     protected static final long NUMBER = 0;
 
     public Genesis(byte[] rawData){
-        super(rawData);
-        this.sealed = false;
-        this.getHeader().unseal();
+        super(rawData, false);
     }
 
     public Genesis(byte[] parentHash, byte[] unclesHash, byte[] coinbase, byte[] logsBloom,

--- a/rskj-core/src/main/java/org/ethereum/core/Genesis.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Genesis.java
@@ -57,6 +57,7 @@ public class Genesis extends Block {
     public Genesis(byte[] rawData){
         super(rawData);
         this.sealed = false;
+        this.getHeader().unseal();
     }
 
     public Genesis(byte[] parentHash, byte[] unclesHash, byte[] coinbase, byte[] logsBloom,

--- a/rskj-core/src/main/java/org/ethereum/core/SealedBlockException.java
+++ b/rskj-core/src/main/java/org/ethereum/core/SealedBlockException.java
@@ -1,0 +1,11 @@
+package org.ethereum.core;
+
+/**
+ * Created by ajlopez on 14/08/2017.
+ */
+
+public class SealedBlockException extends RuntimeException {
+    public SealedBlockException(String message) {
+        super("Sealed block: " + message);
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/core/SealedBlockHeaderException.java
+++ b/rskj-core/src/main/java/org/ethereum/core/SealedBlockHeaderException.java
@@ -1,0 +1,11 @@
+package org.ethereum.core;
+
+/**
+ * Created by ajlopez on 14/08/2017.
+ */
+
+public class SealedBlockHeaderException extends RuntimeException {
+    public SealedBlockHeaderException(String message) {
+        super("Sealed block header: " + message);
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/datasource/mapdb/Serializers.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/mapdb/Serializers.java
@@ -64,7 +64,7 @@ public class Serializers {
         @Override
         public BlockHeader deserialize(DataInput in, int available) throws IOException {
             byte[] bytes = BYTE_ARRAY.deserialize(in, available);
-            return bytes.length > 0 ? new BlockHeader(bytes) : null;
+            return bytes.length > 0 ? new BlockHeader(bytes, true) : null;
         }
     };
 

--- a/rskj-core/src/main/java/org/ethereum/net/eth/message/BlockHeadersMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/eth/message/BlockHeadersMessage.java
@@ -55,10 +55,12 @@ public class BlockHeadersMessage extends EthMessage {
         RLPList paramsList = (RLPList) RLP.decode2(encoded).get(0);
 
         blockHeaders = new ArrayList<>();
+
         for (int i = 0; i < paramsList.size(); ++i) {
             RLPList rlpData = ((RLPList) paramsList.get(i));
-            blockHeaders.add(new BlockHeader(rlpData));
+            blockHeaders.add(new BlockHeader(rlpData, true));
         }
+
         parsed = true;
     }
 

--- a/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
+++ b/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
@@ -174,7 +174,8 @@ public class BlockGenerator {
                 stateRoot, //EMPTY_TRIE_HASH,   // state root
                 txs,       // transaction list
                 null,        // uncle list
-                null
+                null,
+                0L
         );
     }
 
@@ -271,33 +272,8 @@ public class BlockGenerator {
                 EMPTY_TRIE_HASH,   // state root
                 txs,       // transaction list
                 null,        // uncle list
-                minimumGasPrice.toByteArray()
-        );
-    }
-
-    public static Block createEmptyGenesisBlock() {
-        Bloom logBloom = new Bloom();
-        Block original = BlockGenerator.getGenesisBlock();
-
-        return new Block(
-                original.getParentHash(), // parent hash
-                EMPTY_LIST_HASH, // uncle hash
-                original.getCoinbase(), // coinbase
-                logBloom.getData(), // logs bloom
-                original.getDifficulty(), // difficulty
-                0,
-                original.getGasLimit(),
-                original.getGasUsed(),
-                original.getTimestamp() + ++count,
-                EMPTY_BYTE_ARRAY,   // extraData
-                EMPTY_BYTE_ARRAY,   // mixHash
-                BigInteger.ZERO.toByteArray(),  // provisory nonce
-                EMPTY_TRIE_HASH,   // receipts root
-                EMPTY_TRIE_HASH,  // transaction receipts
-                EMPTY_TRIE_HASH,   // state root
-                null,       // transaction list
-                null,        // uncle list
-                BigInteger.valueOf(RskSystemProperties.RSKCONFIG.minerMinGasPrice()).toByteArray()
+                minimumGasPrice.toByteArray(),
+                0L
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -19,6 +19,7 @@
 package co.rsk.core;
 
 
+import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.peg.PegTestUtils;
 import org.spongycastle.util.encoders.Hex;
@@ -94,4 +95,109 @@ public class BlockTest {
         Assert.assertEquals(RemascTransaction.class, parsedBlock.getTransactionsList().get(2).getClass());
     }
 
+    @Test
+    public void sealedBlockAddUncle() {
+        Block block = BlockGenerator.createBlock(10, 0);
+        Block uncle = BlockGenerator.createBlock(9, 0);
+
+        block.seal();
+
+        try {
+            block.addUncle(uncle.getHeader());
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block: trying to add uncle", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockSetStateRoot() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.setStateRoot(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block: trying to alter state root", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockSetExtraData() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.setExtraData(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block: trying to alter extra data", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockSetTransactionList() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.setTransactionsList(null);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block: trying to alter transaction list", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockSetBitcoinMergedMiningCoinbaseTransaction() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.setBitcoinMergedMiningCoinbaseTransaction(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining coinbase transaction", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockSetBitcoinMergedMiningHeader() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.setBitcoinMergedMiningHeader(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining header", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockSetBitcoinMergedMiningMerkleProof() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.setBitcoinMergedMiningMerkleProof(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining Merkle proof", ex.getMessage());
+        }
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -87,7 +87,8 @@ public class BlockTest {
                 HashUtil.EMPTY_TRIE_HASH,    //EMPTY_TRIE_HASH,   // state root
                 txs,                            // transaction list
                 null,  // uncle list
-                BigInteger.TEN.toByteArray()
+                BigInteger.TEN.toByteArray(),
+                0L
         );
 
         Block parsedBlock = new Block(block.getEncoded());

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -22,12 +22,9 @@ package co.rsk.core;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.peg.PegTestUtils;
-import org.ethereum.core.BlockHeader;
+import org.ethereum.core.*;
 import org.spongycastle.util.encoders.Hex;
 import co.rsk.remasc.RemascTransaction;
-import org.ethereum.core.Block;
-import org.ethereum.core.Bloom;
-import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
@@ -117,7 +114,7 @@ public class BlockTest {
             block.addUncle(uncle.getHeader());
             Assert.fail();
         }
-        catch (Block.SealedBlockException ex) {
+        catch (SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to add uncle", ex.getMessage());
         }
     }
@@ -132,7 +129,7 @@ public class BlockTest {
             block.setStateRoot(new byte[32]);
             Assert.fail();
         }
-        catch (Block.SealedBlockException ex) {
+        catch (SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter state root", ex.getMessage());
         }
     }
@@ -147,7 +144,7 @@ public class BlockTest {
             block.setExtraData(new byte[32]);
             Assert.fail();
         }
-        catch (Block.SealedBlockException ex) {
+        catch (SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter extra data", ex.getMessage());
         }
     }
@@ -162,7 +159,7 @@ public class BlockTest {
             block.setTransactionsList(null);
             Assert.fail();
         }
-        catch (Block.SealedBlockException ex) {
+        catch (SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter transaction list", ex.getMessage());
         }
     }
@@ -177,7 +174,7 @@ public class BlockTest {
             block.setBitcoinMergedMiningCoinbaseTransaction(new byte[32]);
             Assert.fail();
         }
-        catch (Block.SealedBlockException ex) {
+        catch (SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining coinbase transaction", ex.getMessage());
         }
     }
@@ -192,7 +189,7 @@ public class BlockTest {
             block.setBitcoinMergedMiningHeader(new byte[32]);
             Assert.fail();
         }
-        catch (Block.SealedBlockException ex) {
+        catch (SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining header", ex.getMessage());
         }
     }
@@ -207,7 +204,7 @@ public class BlockTest {
             block.setBitcoinMergedMiningMerkleProof(new byte[32]);
             Assert.fail();
         }
-        catch (Block.SealedBlockException ex) {
+        catch (SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining Merkle proof", ex.getMessage());
         }
     }

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -96,6 +96,15 @@ public class BlockTest {
     }
 
     @Test
+    public void sealedBlockHasSealesBlockHeader() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        Assert.assertTrue(block.getHeader().isSealed());
+    }
+
+    @Test
     public void sealedBlockAddUncle() {
         Block block = BlockGenerator.createBlock(10, 0);
         Block uncle = BlockGenerator.createBlock(9, 0);
@@ -198,6 +207,246 @@ public class BlockTest {
         }
         catch (RuntimeException ex) {
             Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining Merkle proof", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetCoinbase() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setCoinbase(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter coinbase", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetStateRoot() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setStateRoot(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter state root", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetReceiptsRoot() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setReceiptsRoot(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter receipts root", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetTransactionsRoot() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setTransactionsRoot(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter transactions root", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetDifficulty() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setDifficulty(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter difficulty", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetTimestamp() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setTimestamp(10);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter timestamp", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetNumber() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setNumber(10);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter number", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetGasLimit() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setGasLimit(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter gas limit", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetPaidFees() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setPaidFees(10);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter paid fees", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetGasUsed() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setGasUsed(10);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter gas used", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetLogsBloom() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setLogsBloom(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter logs bloom", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetExtraData() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setExtraData(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter extra data", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetMinimumGasPrice() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setMinimumGasPrice(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter minimum gas price", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetBitcoinMergedMiningHeader() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setBitcoinMergedMiningHeader(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining header", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetBitcoinMergedMiningMerkleProof() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setBitcoinMergedMiningMerkleProof(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining merkle proof", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sealedBlockHeaderSetBitcoinMergedMiningCoinbaseTransaction() {
+        Block block = BlockGenerator.createBlock(10, 0);
+
+        block.seal();
+
+        try {
+            block.getHeader().setBitcoinMergedMiningCoinbaseTransaction(new byte[32]);
+            Assert.fail();
+        }
+        catch (RuntimeException ex) {
+            Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining coinbase transaction", ex.getMessage());
         }
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -22,6 +22,7 @@ package co.rsk.core;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.peg.PegTestUtils;
+import org.ethereum.core.BlockHeader;
 import org.spongycastle.util.encoders.Hex;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Block;
@@ -115,7 +116,7 @@ public class BlockTest {
             block.addUncle(uncle.getHeader());
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (Block.SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to add uncle", ex.getMessage());
         }
     }
@@ -130,7 +131,7 @@ public class BlockTest {
             block.setStateRoot(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (Block.SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter state root", ex.getMessage());
         }
     }
@@ -145,7 +146,7 @@ public class BlockTest {
             block.setExtraData(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (Block.SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter extra data", ex.getMessage());
         }
     }
@@ -160,7 +161,7 @@ public class BlockTest {
             block.setTransactionsList(null);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (Block.SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter transaction list", ex.getMessage());
         }
     }
@@ -175,7 +176,7 @@ public class BlockTest {
             block.setBitcoinMergedMiningCoinbaseTransaction(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (Block.SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining coinbase transaction", ex.getMessage());
         }
     }
@@ -190,7 +191,7 @@ public class BlockTest {
             block.setBitcoinMergedMiningHeader(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (Block.SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining header", ex.getMessage());
         }
     }
@@ -205,7 +206,7 @@ public class BlockTest {
             block.setBitcoinMergedMiningMerkleProof(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (Block.SealedBlockException ex) {
             Assert.assertEquals("Sealed block: trying to alter bitcoin merged mining Merkle proof", ex.getMessage());
         }
     }
@@ -220,7 +221,7 @@ public class BlockTest {
             block.getHeader().setCoinbase(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter coinbase", ex.getMessage());
         }
     }
@@ -235,7 +236,7 @@ public class BlockTest {
             block.getHeader().setStateRoot(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter state root", ex.getMessage());
         }
     }
@@ -250,7 +251,7 @@ public class BlockTest {
             block.getHeader().setReceiptsRoot(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter receipts root", ex.getMessage());
         }
     }
@@ -265,7 +266,7 @@ public class BlockTest {
             block.getHeader().setTransactionsRoot(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter transactions root", ex.getMessage());
         }
     }
@@ -280,7 +281,7 @@ public class BlockTest {
             block.getHeader().setDifficulty(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter difficulty", ex.getMessage());
         }
     }
@@ -295,7 +296,7 @@ public class BlockTest {
             block.getHeader().setTimestamp(10);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter timestamp", ex.getMessage());
         }
     }
@@ -310,7 +311,7 @@ public class BlockTest {
             block.getHeader().setNumber(10);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter number", ex.getMessage());
         }
     }
@@ -325,7 +326,7 @@ public class BlockTest {
             block.getHeader().setGasLimit(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter gas limit", ex.getMessage());
         }
     }
@@ -340,7 +341,7 @@ public class BlockTest {
             block.getHeader().setPaidFees(10);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter paid fees", ex.getMessage());
         }
     }
@@ -355,7 +356,7 @@ public class BlockTest {
             block.getHeader().setGasUsed(10);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter gas used", ex.getMessage());
         }
     }
@@ -370,7 +371,7 @@ public class BlockTest {
             block.getHeader().setLogsBloom(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter logs bloom", ex.getMessage());
         }
     }
@@ -385,7 +386,7 @@ public class BlockTest {
             block.getHeader().setExtraData(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter extra data", ex.getMessage());
         }
     }
@@ -400,7 +401,7 @@ public class BlockTest {
             block.getHeader().setMinimumGasPrice(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter minimum gas price", ex.getMessage());
         }
     }
@@ -415,7 +416,7 @@ public class BlockTest {
             block.getHeader().setBitcoinMergedMiningHeader(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining header", ex.getMessage());
         }
     }
@@ -430,7 +431,7 @@ public class BlockTest {
             block.getHeader().setBitcoinMergedMiningMerkleProof(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining merkle proof", ex.getMessage());
         }
     }
@@ -445,7 +446,7 @@ public class BlockTest {
             block.getHeader().setBitcoinMergedMiningCoinbaseTransaction(new byte[32]);
             Assert.fail();
         }
-        catch (RuntimeException ex) {
+        catch (BlockHeader.SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining coinbase transaction", ex.getMessage());
         }
     }

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -219,7 +219,7 @@ public class BlockTest {
             block.getHeader().setCoinbase(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter coinbase", ex.getMessage());
         }
     }
@@ -234,7 +234,7 @@ public class BlockTest {
             block.getHeader().setStateRoot(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter state root", ex.getMessage());
         }
     }
@@ -249,7 +249,7 @@ public class BlockTest {
             block.getHeader().setReceiptsRoot(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter receipts root", ex.getMessage());
         }
     }
@@ -264,7 +264,7 @@ public class BlockTest {
             block.getHeader().setTransactionsRoot(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter transactions root", ex.getMessage());
         }
     }
@@ -279,7 +279,7 @@ public class BlockTest {
             block.getHeader().setDifficulty(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter difficulty", ex.getMessage());
         }
     }
@@ -294,7 +294,7 @@ public class BlockTest {
             block.getHeader().setTimestamp(10);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter timestamp", ex.getMessage());
         }
     }
@@ -309,7 +309,7 @@ public class BlockTest {
             block.getHeader().setNumber(10);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter number", ex.getMessage());
         }
     }
@@ -324,7 +324,7 @@ public class BlockTest {
             block.getHeader().setGasLimit(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter gas limit", ex.getMessage());
         }
     }
@@ -339,7 +339,7 @@ public class BlockTest {
             block.getHeader().setPaidFees(10);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter paid fees", ex.getMessage());
         }
     }
@@ -354,7 +354,7 @@ public class BlockTest {
             block.getHeader().setGasUsed(10);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter gas used", ex.getMessage());
         }
     }
@@ -369,7 +369,7 @@ public class BlockTest {
             block.getHeader().setLogsBloom(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter logs bloom", ex.getMessage());
         }
     }
@@ -384,7 +384,7 @@ public class BlockTest {
             block.getHeader().setExtraData(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter extra data", ex.getMessage());
         }
     }
@@ -399,7 +399,7 @@ public class BlockTest {
             block.getHeader().setMinimumGasPrice(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter minimum gas price", ex.getMessage());
         }
     }
@@ -414,7 +414,7 @@ public class BlockTest {
             block.getHeader().setBitcoinMergedMiningHeader(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining header", ex.getMessage());
         }
     }
@@ -429,7 +429,7 @@ public class BlockTest {
             block.getHeader().setBitcoinMergedMiningMerkleProof(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining merkle proof", ex.getMessage());
         }
     }
@@ -444,7 +444,7 @@ public class BlockTest {
             block.getHeader().setBitcoinMergedMiningCoinbaseTransaction(new byte[32]);
             Assert.fail();
         }
-        catch (BlockHeader.SealedBlockHeaderException ex) {
+        catch (SealedBlockHeaderException ex) {
             Assert.assertEquals("Sealed block header: trying to alter bitcoin merged mining coinbase transaction", ex.getMessage());
         }
     }

--- a/rskj-core/src/test/java/co/rsk/peg/simples/SimpleBlock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/simples/SimpleBlock.java
@@ -40,7 +40,7 @@ public class SimpleBlock extends Block {
                        List<Transaction> transactionsList, List<BlockHeader> uncleList) {
         super(parentHash, unclesHash, coinbase, logsBloom, difficulty, number, gasLimit, gasUsed,
                 timestamp, extraData, mixHash, nonce, receiptsRoot, transactionsRoot, stateRoot,
-                transactionsList, uncleList, BigInteger.TEN.toByteArray());
+                transactionsList, uncleList, BigInteger.TEN.toByteArray(), 0L);
 
         this.transactionList = transactionsList;
     }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -230,6 +230,8 @@ class RemascTestRunner {
         for (Transaction tx : txs) {
             paidFees += BigIntegers.fromUnsignedByteArray(tx.getGasLimit()).longValue() * BigIntegers.fromUnsignedByteArray(tx.getGasPrice()).longValue();
         }
+
+        block.getHeader().unseal();
         block.getHeader().setPaidFees(paidFees);
 
         return block;

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -176,6 +176,12 @@ class RemascTestRunner {
 
         byte[] diffBytes = BigInteger.valueOf(difficulty).toByteArray();
 
+        long paidFees = 0;
+
+        for (Transaction tx : txs) {
+            paidFees += BigIntegers.fromUnsignedByteArray(tx.getGasLimit()).longValue() * BigIntegers.fromUnsignedByteArray(tx.getGasPrice()).longValue();
+        }
+
         Block block =  new Block(
                 parentBlock.getHash(),          // parent hash
                 EMPTY_LIST_HASH,       // uncle hash
@@ -194,14 +200,15 @@ class RemascTestRunner {
                 genesis.getStateRoot(),         //EMPTY_TRIE_HASH,   // state root
                 txs,                            // transaction list
                 uncles,                          // uncle list
-                BigInteger.TEN.toByteArray()
+                BigInteger.TEN.toByteArray(),
+                paidFees
         ) {
             private BlockHeader harcodedHashHeader;
 
             @Override
             public BlockHeader getHeader() {
                 if (harcodedHashHeader==null) {
-                    harcodedHashHeader = new BlockHeader(super.getHeader().getEncoded()) {
+                    harcodedHashHeader = new BlockHeader(super.getHeader().getEncoded(), false) {
                         @Override
                         public byte[] getHash() {
                             return blockHash.getBytes();
@@ -226,13 +233,6 @@ class RemascTestRunner {
                 harcodedHashHeader = null;
             }
         };
-        long paidFees = 0;
-        for (Transaction tx : txs) {
-            paidFees += BigIntegers.fromUnsignedByteArray(tx.getGasLimit()).longValue() * BigIntegers.fromUnsignedByteArray(tx.getGasPrice()).longValue();
-        }
-
-        block.getHeader().unseal();
-        block.getHeader().setPaidFees(paidFees);
 
         return block;
     }

--- a/rskj-core/src/test/java/org/ethereum/TestUtils.java
+++ b/rskj-core/src/test/java/org/ethereum/TestUtils.java
@@ -96,7 +96,7 @@ public final class TestUtils {
             byte[] newHash = randomHash();
 
             Block block = new Block(lastHash, newHash,  null, null, difficutly, lastIndex, new byte[] {0}, 0, 0, null, null,
-                    null, null, EMPTY_TRIE_HASH, randomHash(), null, null, null);
+                    null, null, EMPTY_TRIE_HASH, randomHash(), null, null, null, 0L);
 
             ++lastIndex;
             lastHash = block.getHash();

--- a/rskj-core/src/test/java/org/ethereum/db/BlockQueueTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/BlockQueueTest.java
@@ -182,8 +182,7 @@ public class BlockQueueTest {
         // testing addOrReplace()
         Block b1 = blocks.get(0);
         Block b1_ = blocks.get(1);
-        BlockHeader header = b1_.getHeader();
-        header.unseal();
+        BlockHeader header = b1_.getHeader().cloneHeader();
         header.setNumber(b1.getNumber());
         b1_ = new Block(header, b1_.getTransactionsList(), b1_.getUncleList());
 

--- a/rskj-core/src/test/java/org/ethereum/db/BlockQueueTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/BlockQueueTest.java
@@ -183,6 +183,7 @@ public class BlockQueueTest {
         Block b1 = blocks.get(0);
         Block b1_ = blocks.get(1);
         BlockHeader header = b1_.getHeader();
+        header.unseal();
         header.setNumber(b1.getNumber());
         b1_ = new Block(header, b1_.getTransactionsList(), b1_.getUncleList());
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/EthashTestCase.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/EthashTestCase.java
@@ -138,7 +138,7 @@ public class EthashTestCase {
 
     public BlockHeader getBlockHeader() {
         RLPList rlp = RLP.decode2(decode(header));
-        return new BlockHeader((RLPList) rlp.get(0));
+        return new BlockHeader((RLPList) rlp.get(0), true);
     }
 
     public byte[] getResultBytes() {


### PR DESCRIPTION
When a block is sealed, it cannot be modified. The seal includes the header.

If an unsealed block is sent to the blockchain, a panic is logged.

The blocks that are created using RLP are sealed.

The blocks that are completed by MinerServerImpl are sealed before they are added to the system.}
