### PR TITLE
Wallet with new Serialization to RLP, AND automatic old wallet conversion

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -32,7 +32,6 @@ import org.ethereum.util.RLPList;
 import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.concurrent.GuardedBy;
-import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 

--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -27,6 +27,8 @@ import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.db.ByteArrayWrapper;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -199,20 +201,15 @@ public class Wallet {
     }
 
     private byte[] decryptAES(byte[] encryptedBytes, byte[] passphrase) {
-        try {
-            ByteArrayInputStream in = new ByteArrayInputStream(encryptedBytes);
-            ObjectInputStream byteStream = new ObjectInputStream(in);
-            KeyCrypterScrypt keyCrypter = new KeyCrypterScrypt();
-            KeyParameter keyParameter = new KeyParameter(Sha256Hash.hash(passphrase));
+        RLPList rlpList = (RLPList)RLP.decode2(encryptedBytes).get(0);
+        byte[] encryptedPrivateBytes = rlpList.get(0).getRLPData();
+        byte[] initializationVector = rlpList.get(1).getRLPData();
+        KeyCrypterScrypt keyCrypter = new KeyCrypterScrypt();
+        KeyParameter keyParameter = new KeyParameter(Sha256Hash.hash(passphrase));
 
-            ArrayList<byte[]> bytes = (ArrayList<byte[]>) byteStream.readObject();
-            EncryptedData data = new EncryptedData(bytes.get(1), bytes.get(0));
+        EncryptedData data = new EncryptedData(initializationVector, encryptedPrivateBytes);
 
-            return keyCrypter.decrypt(data, keyParameter);
-        } catch (IOException | ClassNotFoundException e) {
-            //There are lines of code that should never be executed, this is one of those
-            throw new IllegalStateException(e);
-        }
+        return keyCrypter.decrypt(data, keyParameter);
     }
 
     private byte[] encryptAES(byte[] privateKeyBytes, byte[] passphrase) {
@@ -220,19 +217,9 @@ public class Wallet {
         KeyParameter keyParameter = new KeyParameter(Sha256Hash.hash(passphrase));
         EncryptedData enc = keyCrypter.encrypt(privateKeyBytes, keyParameter);
 
-        try {
-            ByteArrayOutputStream encryptedResult = new ByteArrayOutputStream();
-            ObjectOutputStream byteStream = new ObjectOutputStream(encryptedResult);
+        byte[] encryptedBytes = RLP.encode(enc.encryptedBytes);
+        byte[] initialisationVector = RLP.encode(enc.initialisationVector);
 
-            ArrayList<byte[]> bytes = new ArrayList<>();
-            bytes.add(enc.encryptedBytes);
-            bytes.add(enc.initialisationVector);
-            byteStream.writeObject(bytes);
-
-            return encryptedResult.toByteArray();
-        } catch (IOException e) {
-            //How is this even possible ???
-            throw new IllegalStateException(e);
-        }
+        return RLP.encodeList(encryptedBytes, initialisationVector);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/core/WalletFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/WalletFactory.java
@@ -25,9 +25,34 @@ import org.ethereum.datasource.LevelDbDataSource;
  * Created by mario on 06/12/16.
  */
 public class WalletFactory {
+    private static final String oldWalletName = "wallet";
+    private static final String walletName = "walletrlp";
+
+    private WalletFactory() {
+
+    }
+
+    public static boolean existsPersistentWallet() {
+        return existsPersistentWallet(walletName);
+    }
+
+    public static boolean existsPersistentWallet(String storeName) {
+        LevelDbDataSource ds = new LevelDbDataSource(storeName);
+
+        return ds.exists();
+    }
 
     public static Wallet createPersistentWallet() {
-        return createPersistentWallet("wallet");
+        if (existsPersistentWallet(oldWalletName) && !existsPersistentWallet(walletName)) {
+            Wallet wallet = createPersistentWallet(walletName);
+
+            LevelDbDataSource ds = new LevelDbDataSource(oldWalletName);
+            ds.init();
+
+            return wallet;
+        }
+
+        return createPersistentWallet(walletName);
     }
 
     public static Wallet createPersistentWallet(String storeName) {

--- a/rskj-core/src/main/java/co/rsk/datasource/LevelDbDataSourceTest.java
+++ b/rskj-core/src/main/java/co/rsk/datasource/LevelDbDataSourceTest.java
@@ -1,0 +1,24 @@
+package co.rsk.datasource;
+
+import org.ethereum.datasource.LevelDbDataSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by ajlopez on 09/08/2017.
+ */
+public class LevelDbDataSourceTest {
+    @Test
+    public void testDoesNotExists() {
+        LevelDbDataSource dataSource = new LevelDbDataSource("unknown");
+        Assert.assertFalse(dataSource.exists());
+    }
+
+    @Test
+    public void testCreateAndExists() {
+        LevelDbDataSource dataSource = new LevelDbDataSource("created");
+        dataSource.init();
+        Assert.assertTrue(dataSource.exists());
+        dataSource.close();
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -77,6 +77,25 @@ public class LevelDbDataSource implements KeyValueDataSource {
         logger.info("New LevelDbDataSource: " + name);
     }
 
+    public boolean exists() {
+        resetDbLock.writeLock().lock();
+
+        try {
+            logger.debug("~> LevelDbDataSource.exists(): {}", name);
+            Path dbPath;
+
+            if (Paths.get(config.databaseDir()).isAbsolute())
+                dbPath = Paths.get(config.databaseDir(), name);
+            else
+                dbPath = Paths.get(getProperty("user.dir"), config.databaseDir(), name);
+
+            return Files.exists(dbPath);
+        }
+        finally {
+            resetDbLock.writeLock().unlock();
+        }
+    }
+
     @Override
     public void init() {
         resetDbLock.writeLock().lock();

--- a/rskj-core/src/test/java/co/rsk/core/WalletFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/WalletFactoryTest.java
@@ -1,0 +1,64 @@
+package co.rsk.core;
+
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Random;
+
+/**
+ * Created by ajlopez on 09/08/2017.
+ */
+public class WalletFactoryTest {
+    @Test
+    public void convertBytes() {
+        Random random = new Random();
+        byte[] value1 = new byte[32];
+        byte[] value2 = new byte[32];
+        random.nextBytes(value1);
+        random.nextBytes(value2);
+
+        byte[] encryptedValues = serializeValues(value1, value2);
+
+        Values values = deserializeValues(encryptedValues);
+
+        Assert.assertArrayEquals(value1, values.value1);
+        Assert.assertArrayEquals(value2, values.value2);
+    }
+
+    private byte[] serializeValues(byte[] value1, byte[] value2) {
+        try {
+            ByteArrayOutputStream result = new ByteArrayOutputStream();
+            ObjectOutputStream byteStream = new ObjectOutputStream(result);
+
+            ArrayList<byte[]> bytes = new ArrayList<>();
+            bytes.add(value1);
+            bytes.add(value2);
+            byteStream.writeObject(bytes);
+
+            return result.toByteArray();
+        } catch (IOException e) {
+            //How is this even possible ???
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Values deserializeValues(byte[] encryptedValues) {
+        byte[] valuesBytes = WalletFactory.convertBytes(encryptedValues);
+        RLPList rlpList = (RLPList) RLP.decode2(valuesBytes).get(0);
+        Values values = new Values();
+        values.value1 = rlpList.get(0).getRLPData();
+        values.value2 = rlpList.get(1).getRLPData();
+        return values;
+    }
+
+    private static class Values {
+        public byte[] value1;
+        public byte[] value2;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/core/WalletFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/WalletFactoryTest.java
@@ -1,5 +1,6 @@
 package co.rsk.core;
 
+import org.ethereum.datasource.LevelDbDataSource;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.junit.Assert;
@@ -15,23 +16,62 @@ import java.util.Random;
  * Created by ajlopez on 09/08/2017.
  */
 public class WalletFactoryTest {
+    private static Random random = new Random();
+
     @Test
     public void convertBytes() {
-        Random random = new Random();
-        byte[] value1 = new byte[32];
-        byte[] value2 = new byte[32];
+        byte[] value1 = generateBytes();
+        byte[] value2 = generateBytes();
         random.nextBytes(value1);
         random.nextBytes(value2);
 
-        byte[] encryptedValues = serializeValues(value1, value2);
+        byte[] encryptedValues = serializeValuesToOldFormat(value1, value2);
 
-        Values values = deserializeValues(encryptedValues);
+        Values values = convertAndDeserializeValues(encryptedValues);
 
         Assert.assertArrayEquals(value1, values.value1);
         Assert.assertArrayEquals(value2, values.value2);
     }
 
-    private byte[] serializeValues(byte[] value1, byte[] value2) {
+    @Test
+    public void convertWallets() {
+        byte[] key1 = generateBytes();
+        byte[] value11 = generateBytes();
+        byte[] value12 = generateBytes();
+
+        byte[] key2 = generateBytes();
+        byte[] value21 = generateBytes();
+        byte[] value22 = generateBytes();
+
+        LevelDbDataSource ds = new LevelDbDataSource("oldwallet1");
+        ds.init();
+
+        ds.put(key1, serializeValuesToOldFormat(value11, value12));
+        ds.put(key2, serializeValuesToOldFormat(value21, value22));
+
+        ds.close();
+
+        WalletFactory.convertWallet("oldwallet1", "newwallet1");
+
+        LevelDbDataSource newds = new LevelDbDataSource("newwallet1");
+        newds.init();
+
+        byte[] value1 = newds.get(key1);
+        RLPList rlpList1 = (RLPList) RLP.decode2(value1).get(0);
+
+        Assert.assertArrayEquals(value11, rlpList1.get(0).getRLPData());
+        Assert.assertArrayEquals(value12, rlpList1.get(1).getRLPData());
+
+        byte[] value2 = newds.get(key2);
+        RLPList rlpList2 = (RLPList) RLP.decode2(value2).get(0);
+
+        Assert.assertArrayEquals(value21, rlpList2.get(0).getRLPData());
+        Assert.assertArrayEquals(value22, rlpList2.get(1).getRLPData());
+
+        newds.close();
+    }
+
+    private byte[] serializeValuesToOldFormat(byte[] value1, byte[] value2) {
         try {
             ByteArrayOutputStream result = new ByteArrayOutputStream();
             ObjectOutputStream byteStream = new ObjectOutputStream(result);
@@ -48,7 +88,7 @@ public class WalletFactoryTest {
         }
     }
 
-    private Values deserializeValues(byte[] encryptedValues) {
+    private Values convertAndDeserializeValues(byte[] encryptedValues) {
         byte[] valuesBytes = WalletFactory.convertBytes(encryptedValues);
         RLPList rlpList = (RLPList) RLP.decode2(valuesBytes).get(0);
         Values values = new Values();
@@ -60,5 +100,11 @@ public class WalletFactoryTest {
     private static class Values {
         public byte[] value1;
         public byte[] value2;
+    }
+
+    private static byte[] generateBytes() {
+        byte[] bytes = new byte[32];
+        random.nextBytes(bytes);
+        return bytes;
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
@@ -19,6 +19,7 @@
 
 package org.ethereum.datasource;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -31,7 +32,6 @@ import static org.junit.Assert.assertNotNull;
 
 @Ignore
 public class LevelDbDataSourceTest {
-
     @Test
     public void testBatchUpdating() {
         LevelDbDataSource dataSource = new LevelDbDataSource("test");


### PR DESCRIPTION
If the node has no wallet serialized with the new format, and an old format wallet exists, then the wallet is converted.

It includes the code from pull request 153 (new wallet serialization)