### PR TITLE
Use BigInteger in TxValidatorStep instead of byte[]

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/handler/TxValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxValidator.java
@@ -24,6 +24,7 @@ import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.manager.WorldManager;
 import org.ethereum.rpc.TypeConverter;
+import org.spongycastle.util.BigIntegers;
 
 import java.math.BigInteger;
 import java.util.LinkedList;
@@ -75,8 +76,8 @@ class TxValidator {
             if (state == null) {
                 state = new AccountState(BigInteger.ZERO, BigInteger.ZERO);
             }
-            byte[] blockGasLimit = worldManager.getBlockchain().getBestBlock().getGasLimit();
-            byte[] minimumGasPrice = worldManager.getBlockchain().getBestBlock().getMinimumGasPrice();
+            BigInteger blockGasLimit = BigIntegers.fromUnsignedByteArray(worldManager.getBlockchain().getBestBlock().getGasLimit());
+            BigInteger minimumGasPrice = BigIntegers.fromUnsignedByteArray(worldManager.getBlockchain().getBestBlock().getMinimumGasPrice());
             long bestBlockNumber = worldManager.getBlockchain().getBestBlock().getNumber();
 
             boolean valid = true;

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidator.java
@@ -29,9 +29,9 @@ import java.math.BigInteger;
 public class TxValidatorAccountBalanceValidator implements TxValidatorStep {
 
     @Override
-    public boolean validate(Transaction tx, AccountState state, byte[] gasLimit, byte[] minimumGasPrice, long bestBlockNumber) {
-        BigInteger txGasLimit = new BigInteger(1, tx.getGasLimit());
-        BigInteger maximumPrice = txGasLimit.multiply(new BigInteger(1, tx.getGasPrice()));
+    public boolean validate(Transaction tx, AccountState state, BigInteger gasLimit, BigInteger minimumGasPrice, long bestBlockNumber) {
+        BigInteger txGasLimit = tx.getGasLimitAsInteger();
+        BigInteger maximumPrice = txGasLimit.multiply(tx.getGasPriceAsInteger());
         return state.getBalance().compareTo(maximumPrice) >= 0;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorAccountStateValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorAccountStateValidator.java
@@ -21,13 +21,15 @@ package co.rsk.net.handler.txvalidator;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 
+import java.math.BigInteger;
+
 /**
  * Simple check if the account can be used
  */
 public class TxValidatorAccountStateValidator implements TxValidatorStep {
 
     @Override
-    public boolean validate(Transaction tx, AccountState state, byte[] gasLimit, byte[] minimumGasPrice, long bestBlockNumber) {
+    public boolean validate(Transaction tx, AccountState state, BigInteger gasLimit, BigInteger minimumGasPrice, long bestBlockNumber) {
         return !state.isDeleted();
     }
 

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidator.java
@@ -30,8 +30,8 @@ import java.math.BigInteger;
 public class TxValidatorGasLimitValidator implements TxValidatorStep {
 
     @Override
-    public boolean validate(Transaction tx, AccountState state, byte[] gasLimit, byte[] minimumGasPrice, long bestBlockNumber) {
-        BigInteger txGasLimit = new BigInteger(1, tx.getGasLimit());
-        return  txGasLimit.compareTo(new BigInteger(1, gasLimit)) <= 0;
+    public boolean validate(Transaction tx, AccountState state, BigInteger gasLimit, BigInteger minimumGasPrice, long bestBlockNumber) {
+        BigInteger txGasLimit = tx.getGasLimitAsInteger();
+        return gasLimit.compareTo(txGasLimit) >= 0;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidator.java
@@ -29,7 +29,7 @@ import java.math.BigInteger;
 public class TxValidatorIntrinsicGasLimitValidator implements TxValidatorStep {
 
     @Override
-    public boolean validate(Transaction tx, AccountState state, byte[] gasLimit, byte[] minimumGasPrice, long bestBlockNumber) {
+    public boolean validate(Transaction tx, AccountState state, BigInteger gasLimit, BigInteger minimumGasPrice, long bestBlockNumber) {
         BlockHeader blockHeader = new BlockHeader(new byte[]{},
                 new byte[]{},
                 new byte[]{},

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorMinimuGasPriceValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorMinimuGasPriceValidator.java
@@ -20,6 +20,7 @@ package co.rsk.net.handler.txvalidator;
 
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
+import org.spongycastle.util.BigIntegers;
 
 import java.math.BigInteger;
 
@@ -28,13 +29,8 @@ import java.math.BigInteger;
  */
 public class TxValidatorMinimuGasPriceValidator implements TxValidatorStep {
     @Override
-    public boolean validate(Transaction tx, AccountState state, byte[] gasLimit, byte[] minimumGasPrice, long bestBlockNumber) {
-        byte[] txGasPrice = tx.getGasPrice();
-        if (txGasPrice == null) {
-            return false;
-        }
-        BigInteger gasPrice = new BigInteger(1, txGasPrice);
-        BigInteger minimum = new BigInteger(1, minimumGasPrice);
-        return minimum.compareTo(gasPrice) <= 0;
+    public boolean validate(Transaction tx, AccountState state, BigInteger gasLimit, BigInteger minimumGasPrice, long bestBlockNumber) {
+        BigInteger gasPrice = tx.getGasPriceAsInteger();
+        return gasPrice != null && gasPrice.compareTo(minimumGasPrice) >= 0;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidator.java
@@ -30,8 +30,8 @@ import java.math.BigInteger;
 public class TxValidatorNonceRangeValidator implements  TxValidatorStep {
 
     @Override
-    public boolean validate(Transaction tx, AccountState state, byte[] gasLimit, byte[] minimumGasPrice, long bestBlockNumber) {
-        BigInteger nonce = new BigInteger(1, tx.getNonce());
+    public boolean validate(Transaction tx, AccountState state, BigInteger gasLimit, BigInteger minimumGasPrice, long bestBlockNumber) {
+        BigInteger nonce = tx.getNonceAsInteger();
         BigInteger stateNonce = state.getNonce();
         BigInteger maxNumberOfTxsPerAddress = BigInteger.valueOf(4);
         return stateNonce.compareTo(nonce) <= 0 && stateNonce.add(maxNumberOfTxsPerAddress).compareTo(nonce) >= 0;

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorStep.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorStep.java
@@ -21,12 +21,14 @@ package co.rsk.net.handler.txvalidator;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 
+import java.math.BigInteger;
+
 /**
  * When checking if a transaction is valid before relaying, each check
  * should be added here or as a TxFilter
  */
 public interface TxValidatorStep {
 
-    boolean validate(Transaction tx, AccountState state, byte[] gasLimit, byte[] minimumGasPrice, long bestBlockNumber);
+    boolean validate(Transaction tx, AccountState state, BigInteger gasLimit, BigInteger minimumGasPrice, long bestBlockNumber);
 
 }

--- a/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
+++ b/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
@@ -38,10 +38,11 @@ public class Tx {
         Mockito.when(transaction.getGasLimit()).thenReturn(BigInteger.valueOf(gaslimit).toByteArray());
         Mockito.when(transaction.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(gaslimit));
         Mockito.when(transaction.getGasPrice()).thenReturn(BigInteger.valueOf(gasprice).toByteArray());
+        Mockito.when(transaction.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(gasprice));
         Mockito.when(transaction.getNonce()).thenReturn(BigInteger.valueOf(nonce).toByteArray());
+        Mockito.when(transaction.getNonceAsInteger()).thenReturn(BigInteger.valueOf(nonce));
         Mockito.when(transaction.getSender()).thenReturn(BigInteger.valueOf(r.nextLong()).toByteArray());
         Mockito.when(transaction.getHash()).thenReturn(BigInteger.valueOf(hashes.nextLong()).toByteArray());
-        Mockito.when(transaction.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(gasprice));
         Mockito.when(transaction.acceptTransactionSignature()).thenReturn(Boolean.TRUE);
         Mockito.when(transaction.getReceiveAddress()).thenReturn(BigInteger.valueOf(r.nextLong()).toByteArray());
         ArrayList<Byte> bytes = new ArrayList();

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidatorTest.java
@@ -35,12 +35,12 @@ public class TxValidatorAccountBalanceValidatorTest {
         Transaction tx3 = Mockito.mock(Transaction.class);
         AccountState as = Mockito.mock(AccountState.class);
 
-        Mockito.when(tx1.getGasLimit()).thenReturn(BigInteger.valueOf(1).toByteArray());
-        Mockito.when(tx2.getGasLimit()).thenReturn(BigInteger.valueOf(1).toByteArray());
-        Mockito.when(tx3.getGasLimit()).thenReturn(BigInteger.valueOf(2).toByteArray());
-        Mockito.when(tx1.getGasPrice()).thenReturn(BigInteger.valueOf(1).toByteArray());
-        Mockito.when(tx2.getGasPrice()).thenReturn(BigInteger.valueOf(10000).toByteArray());
-        Mockito.when(tx3.getGasPrice()).thenReturn(BigInteger.valueOf(5000).toByteArray());
+        Mockito.when(tx1.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(1));
+        Mockito.when(tx2.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(1));
+        Mockito.when(tx3.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(2));
+        Mockito.when(tx1.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(1));
+        Mockito.when(tx2.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(10000));
+        Mockito.when(tx3.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(5000));
         Mockito.when(as.getBalance()).thenReturn(BigInteger.valueOf(10000));
 
         TxValidatorAccountBalanceValidator tvabv = new TxValidatorAccountBalanceValidator();
@@ -56,10 +56,10 @@ public class TxValidatorAccountBalanceValidatorTest {
         Transaction tx2 = Mockito.mock(Transaction.class);
         AccountState as = Mockito.mock(AccountState.class);
 
-        Mockito.when(tx1.getGasLimit()).thenReturn(BigInteger.valueOf(1).toByteArray());
-        Mockito.when(tx2.getGasLimit()).thenReturn(BigInteger.valueOf(2).toByteArray());
-        Mockito.when(tx1.getGasPrice()).thenReturn(BigInteger.valueOf(20).toByteArray());
-        Mockito.when(tx2.getGasPrice()).thenReturn(BigInteger.valueOf(10).toByteArray());
+        Mockito.when(tx1.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(1));
+        Mockito.when(tx2.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(2));
+        Mockito.when(tx1.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(20));
+        Mockito.when(tx2.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(10));
         Mockito.when(as.getBalance()).thenReturn(BigInteger.valueOf(19));
 
         TxValidatorAccountBalanceValidator tvabv = new TxValidatorAccountBalanceValidator();

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidatorTest.java
@@ -31,10 +31,10 @@ public class TxValidatorGasLimitValidatorTest {
         Transaction tx1 = Mockito.mock(Transaction.class);
         Transaction tx2 = Mockito.mock(Transaction.class);
 
-        Mockito.when(tx1.getGasLimit()).thenReturn(BigInteger.valueOf(1).toByteArray());
-        Mockito.when(tx2.getGasLimit()).thenReturn(BigInteger.valueOf(6).toByteArray());
+        Mockito.when(tx1.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(1));
+        Mockito.when(tx2.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(6));
 
-        byte[] gl = BigInteger.valueOf(6).toByteArray();
+        BigInteger gl = BigInteger.valueOf(6);
 
         TxValidatorGasLimitValidator tvglv = new TxValidatorGasLimitValidator();
 
@@ -47,9 +47,9 @@ public class TxValidatorGasLimitValidatorTest {
 
         Transaction tx1 = Mockito.mock(Transaction.class);
 
-        Mockito.when(tx1.getGasLimit()).thenReturn(BigInteger.valueOf(6).toByteArray());
+        Mockito.when(tx1.getGasLimitAsInteger()).thenReturn(BigInteger.valueOf(6));
 
-        byte[] gl = BigInteger.valueOf(3).toByteArray();
+        BigInteger gl = BigInteger.valueOf(3);
 
         TxValidatorGasLimitValidator tvglv = new TxValidatorGasLimitValidator();
 

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorMinimumGasPriceValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorMinimumGasPriceValidatorTest.java
@@ -33,16 +33,16 @@ public class TxValidatorMinimumGasPriceValidatorTest {
         Transaction tx2 = Mockito.mock(Transaction.class);
         Transaction tx3 = Mockito.mock(Transaction.class);
 
-        Mockito.when(tx1.getGasPrice()).thenReturn(BigInteger.valueOf(10).toByteArray());
-        Mockito.when(tx2.getGasPrice()).thenReturn(BigInteger.valueOf(11).toByteArray());
-        Mockito.when(tx3.getGasPrice()).thenReturn(BigInteger.valueOf(500000000).toByteArray());
+        Mockito.when(tx1.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(10));
+        Mockito.when(tx2.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(11));
+        Mockito.when(tx3.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(500000000));
 
         TxValidatorMinimuGasPriceValidator tvmgpv = new TxValidatorMinimuGasPriceValidator();
 
 
-        Assert.assertTrue(tvmgpv.validate(tx1, null, null, BigInteger.valueOf(10).toByteArray(), Long.MAX_VALUE));
-        Assert.assertTrue(tvmgpv.validate(tx2, null, null, BigInteger.valueOf(10).toByteArray(), Long.MAX_VALUE));
-        Assert.assertTrue(tvmgpv.validate(tx3, null, null, BigInteger.valueOf(10).toByteArray(), Long.MAX_VALUE));
+        Assert.assertTrue(tvmgpv.validate(tx1, null, null, BigInteger.valueOf(10), Long.MAX_VALUE));
+        Assert.assertTrue(tvmgpv.validate(tx2, null, null, BigInteger.valueOf(10), Long.MAX_VALUE));
+        Assert.assertTrue(tvmgpv.validate(tx3, null, null, BigInteger.valueOf(10), Long.MAX_VALUE));
     }
 
     @Test
@@ -51,15 +51,15 @@ public class TxValidatorMinimumGasPriceValidatorTest {
         Transaction tx2 = Mockito.mock(Transaction.class);
         Transaction tx3 = Mockito.mock(Transaction.class);
 
-        Mockito.when(tx1.getGasPrice()).thenReturn(BigInteger.valueOf(9).toByteArray());
-        Mockito.when(tx2.getGasPrice()).thenReturn(BigInteger.valueOf(0).toByteArray());
-        Mockito.when(tx3.getGasPrice()).thenReturn(null);
+        Mockito.when(tx1.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(9));
+        Mockito.when(tx2.getGasPriceAsInteger()).thenReturn(BigInteger.valueOf(0));
+        Mockito.when(tx3.getGasPriceAsInteger()).thenReturn(null);
 
         TxValidatorMinimuGasPriceValidator tvmgpv = new TxValidatorMinimuGasPriceValidator();
 
-        Assert.assertFalse(tvmgpv.validate(tx1, null, null, BigInteger.valueOf(10).toByteArray(), Long.MAX_VALUE));
-        Assert.assertFalse(tvmgpv.validate(tx2, null, null, BigInteger.valueOf(10).toByteArray(), Long.MAX_VALUE));
-        Assert.assertFalse(tvmgpv.validate(tx3, null, null, BigInteger.valueOf(10).toByteArray(), Long.MAX_VALUE));
+        Assert.assertFalse(tvmgpv.validate(tx1, null, null, BigInteger.valueOf(10), Long.MAX_VALUE));
+        Assert.assertFalse(tvmgpv.validate(tx2, null, null, BigInteger.valueOf(10), Long.MAX_VALUE));
+        Assert.assertFalse(tvmgpv.validate(tx3, null, null, BigInteger.valueOf(10), Long.MAX_VALUE));
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidatorTest.java
@@ -34,8 +34,8 @@ public class TxValidatorNonceRangeValidatorTest {
         Transaction tx2 = Mockito.mock(Transaction.class);
         AccountState as = Mockito.mock(AccountState.class);
 
-        Mockito.when(tx1.getNonce()).thenReturn(BigInteger.valueOf(0).toByteArray());
-        Mockito.when(tx2.getNonce()).thenReturn(BigInteger.valueOf(3).toByteArray());
+        Mockito.when(tx1.getNonceAsInteger()).thenReturn(BigInteger.valueOf(0));
+        Mockito.when(tx2.getNonceAsInteger()).thenReturn(BigInteger.valueOf(3));
         Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(0));
 
         TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator();
@@ -49,8 +49,8 @@ public class TxValidatorNonceRangeValidatorTest {
         Transaction tx2 = Mockito.mock(Transaction.class);
         AccountState as = Mockito.mock(AccountState.class);
 
-        Mockito.when(tx1.getNonce()).thenReturn(BigInteger.valueOf(0).toByteArray());
-        Mockito.when(tx2.getNonce()).thenReturn(BigInteger.valueOf(6).toByteArray());
+        Mockito.when(tx1.getNonceAsInteger()).thenReturn(BigInteger.valueOf(0));
+        Mockito.when(tx2.getNonceAsInteger()).thenReturn(BigInteger.valueOf(6));
         Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(1));
 
         TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator();


### PR DESCRIPTION
This is a higher-level API and is simpler. It also prevents converting back and forth and creating multiple arrays/instances.