### PR TITLE
Change divisor (from 5 to 20)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RemascConfig.java
+++ b/rskj-core/src/main/java/co/rsk/config/RemascConfig.java
@@ -43,7 +43,7 @@ public class RemascConfig {
     // Reward to block miners who included uncles in their blocks. Available reward / publishersDivisor is the total reward.
     private long publishersDivisor = 10;
 
-    private long lateUncleInclusionPunishmentDivisor = 5;
+    private long lateUncleInclusionPunishmentDivisor = 20;
 
     public long getMaturity() {
         return maturity;


### PR DESCRIPTION
Original issue description:

"REMASC is punshing late inclusion with the 20% instead of 5%."

REMASC is applying 5%, the JSON conguration file use 20 as divisor (100/20 == 5%). The difference is in the default value in RemascConfig class: the field was initialized with 5 (100/5 == 20%).

This pull request change the default value, from 5 to 20, but it is not a hard fork: the testnet nodes are configured with a JSON file with divisor == 20
