### PR TITLE
Constant moved to config, multiplier and divisor

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RemascConfig.java
+++ b/rskj-core/src/main/java/co/rsk/config/RemascConfig.java
@@ -45,6 +45,14 @@ public class RemascConfig {
 
     private long lateUncleInclusionPunishmentDivisor = 20;
 
+    // Multiplier and Divisor for paid fees comparison in selection rule
+    private long paidFeesMultiplier = 2;
+    private long paidFeesDivisor = 1;
+
+    public long getPaidFeesMultiplier() { return paidFeesMultiplier; }
+
+    public long getPaidFeesDivisor() { return paidFeesDivisor; }
+
     public long getMaturity() {
         return maturity;
     }

--- a/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
@@ -201,11 +201,12 @@ public class Remasc {
         // Find out if main chain block selection rule was broken
         for (Sibling sibling : siblings) {
             // Sibling pays significant more fees than block in the main chain OR Sibling has lower hash than block in the main chain
-            if (sibling.getPaidFees() > 2 * processingBlockHeader.getPaidFees() ||
+            if (sibling.getPaidFees() > remascConstants.getPaidFeesMultiplier() * processingBlockHeader.getPaidFees() / remascConstants.getPaidFeesDivisor() ||
                     FastByteComparisons.compareTo(sibling.getHash(), 0, 32, processingBlockHeader.getHash(), 0, 32) < 0) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/rskj-core/src/main/resources/remasc.json
+++ b/rskj-core/src/main/resources/remasc.json
@@ -15,7 +15,9 @@
       "punishmentDivisor" : 10,
       "publishersDivisor" : 10,
       "rskLabsAddress" : "dabadabadabadabadabadabadabadabadaba0001",
-      "lateUncleInclusionPunishmentDivisor": 20
+      "lateUncleInclusionPunishmentDivisor": 20,
+      "paidFeesMultiplier": 2,
+      "paidFeesDivisor": 1
    },
    "main": {
       "maturity" : 50,
@@ -24,7 +26,9 @@
       "punishmentDivisor" : 10,
       "publishersDivisor" : 10,
       "rskLabsAddress" : "dabadabadabadabadabadabadabadabadaba0004",
-      "lateUncleInclusionPunishmentDivisor": 20
+      "lateUncleInclusionPunishmentDivisor": 20,
+      "paidFeesMultiplier": 2,
+      "paidFeesDivisor": 1
    },
    "testnet": {
       "maturity" : 50,
@@ -33,6 +37,8 @@
       "punishmentDivisor" : 10,
       "publishersDivisor" : 10,
       "rskLabsAddress" : "dabadabadabadabadabadabadabadabadaba0003",
-      "lateUncleInclusionPunishmentDivisor": 20
+      "lateUncleInclusionPunishmentDivisor": 20,
+      "paidFeesMultiplier": 2,
+      "paidFeesDivisor": 1
    }
 }


### PR DESCRIPTION
Instead of using "2 *" in REMASC selection rule, use a multiplier and divisor from configuration