### PR TITLE
Enhancement/rfs 26 purge txs to lock

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -160,6 +160,7 @@ dependencies {
     testCompile "org.powermock:powermock-core:${powermockitoVersion}"
     testCompile "org.powermock:powermock-module-testng:${powermockitoVersion}"
     testCompile "org.powermock:powermock-module-junit4:${powermockitoVersion}"
+    testCompile "org.powermock:powermock-api-mockito:${powermockitoVersion}"
     testCompile "co.rsk:lll-compiler:${rskLllVersion}"
     testCompile "org.springframework:spring-tx:${springVersion}"
     testCompile "org.springframework:spring-orm:${springVersion}"

--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -216,6 +216,8 @@ dependencyVerification {
         'org.mapdb:mapdb:1268e9ec22ff770ef7e63d7cc72563406ad239422c791acc8b9ee4fdfba0bb1e',
         'org.mockito:mockito-core:d5831ee4f71055800821a34a3051cf1ed5b3702f295ffebd50f65fb5d81a71b8',
         'org.objenesis:objenesis:b043f03e466752f7f03e2326a3b13a49b7c649f8f2a2dc87715827e24f73d9c6',
+        'org.powermock:powermock-api-mockito:68667e82c0e5d8c65e7030403c56ddc8595bbd723bf04719976106c03a022b85',
+        'org.powermock:powermock-api-support:ade74743df908ebd859591c2136ce400443e57bbd8abdc0703871ac7309ac09b',
         'org.powermock:powermock-core:9b4da42d513500dda03f4d90e303647f6a7b50c6bc5ed88cd39118680f6b329f',
         'org.powermock:powermock-module-junit4-common:1b4928d42a8e6f0aa196d0f6fcf7831e0bc29b8a925ce755479b4bd29b3643bb',
         'org.powermock:powermock-module-junit4:a90e4bc135e349852eaebed9f1a14d404e14c5a8a7248b4e20e062879a97e63f',

--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -35,6 +35,7 @@ public class BridgeConstants {
     protected long federationAddressCreationTime;
 
     protected int btc2RskMinimumAcceptableConfirmations;
+    protected int btc2RskMinimumAcceptableConfirmationsOnRsk;
     protected int rsk2BtcMinimumAcceptableConfirmations;
     protected int btcBroadcastingMinimumAcceptableBlocks;
 
@@ -73,6 +74,10 @@ public class BridgeConstants {
 
     public int getBtc2RskMinimumAcceptableConfirmations() {
         return btc2RskMinimumAcceptableConfirmations;
+    }
+
+    public int getBtc2RskMinimumAcceptableConfirmationsOnRsk() {
+        return btc2RskMinimumAcceptableConfirmationsOnRsk;
     }
 
     public int getRsk2BtcMinimumAcceptableConfirmations() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
 import java.nio.charset.StandardCharsets;
+import java.util.GregorianCalendar;
 import java.util.List;
 
 
@@ -45,41 +46,24 @@ public class BridgeRegTestConstants extends BridgeConstants {
     BridgeRegTestConstants() {
         btcParamsString = NetworkParameters.ID_REGTEST;
 
-        BtcECKey federator0PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator1".getBytes(StandardCharsets.UTF_8)));
-        BtcECKey federator1PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator2".getBytes(StandardCharsets.UTF_8)));
-        BtcECKey federator2PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator3".getBytes(StandardCharsets.UTF_8)));
+        BtcECKey federator0PrivateKey = BtcECKey.fromPrivate(Hex.decode("d4b5aa0e4926aff7ba7fcb8b904328323243c5bc9af4c1781de8d4db4cc014a7"));
+        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(federator0PrivateKey.getPubKey());
 
-        federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey);
+        federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey);
+        federatorPublicKeys = Lists.newArrayList(federator0PublicKey);
 
-        // To recalculate federator private keys
-        // Hex.toHexString(ECKey.fromPrivate(HashUtil.sha3("federator1".getBytes())).getPubKey())
-        // Current federator secrets: federator1, federator2, federator3
-        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0362634ab57dae9cb373a5d536e66a8c4f67468bbcfb063809bab643072d78a124"));
-        BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03c5946b3fbae03a654237da863c9ed534e0878657175b132b8ca630f245df04db"));
-        BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02cd53fc53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1"));
-
-        federatorPublicKeys = Lists.newArrayList(federator0PublicKey, federator1PublicKey, federator2PublicKey);
-
-        federatorsRequiredToSign = 2;
+        federatorsRequiredToSign = 1;
 
         Script redeemScript = ScriptBuilder.createRedeemScript(federatorsRequiredToSign, federatorPublicKeys);
         federationPubScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
 //      To recalculate federationAddress
-//      federationAddress = Address.fromP2SHScript(btcParams, federationPubScript);
-        try {
-            federationAddress = Address.fromBase58(getBtcParams(), "2N5muMepJizJE1gR7FbHJU6CD18V3BpNF9p");
-        } catch (AddressFormatException e) {
-            logger.error("Federation address format is invalid");
-            throw new RskConfigurationException(e.getMessage(), e);
-        }
+        federationAddress = Address.fromP2SHScript(getBtcParams(), federationPubScript);
 
         // To recreate the value use
-        // federationAddressCreationTime = new GregorianCalendar(2016,0,1).getTimeInMillis();
-        // Currently set to:
-        // Jan 1 2016 00:00 GMT-3
-        federationAddressCreationTime = 1451617200;
+        federationAddressCreationTime = new GregorianCalendar(2016,0,1).getTimeInMillis();
 
         btc2RskMinimumAcceptableConfirmations = 3;
+        btc2RskMinimumAcceptableConfirmationsOnRsk = 5;
         rsk2BtcMinimumAcceptableConfirmations = 3;
         btcBroadcastingMinimumAcceptableBlocks = 3;
 

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -46,13 +46,18 @@ public class BridgeRegTestConstants extends BridgeConstants {
     BridgeRegTestConstants() {
         btcParamsString = NetworkParameters.ID_REGTEST;
 
-        BtcECKey federator0PrivateKey = BtcECKey.fromPrivate(Hex.decode("d4b5aa0e4926aff7ba7fcb8b904328323243c5bc9af4c1781de8d4db4cc014a7"));
-        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(federator0PrivateKey.getPubKey());
+        BtcECKey federator0PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator1".getBytes(StandardCharsets.UTF_8)));
+        BtcECKey federator1PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator2".getBytes(StandardCharsets.UTF_8)));
+        BtcECKey federator2PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator3".getBytes(StandardCharsets.UTF_8)));
 
-        federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey);
-        federatorPublicKeys = Lists.newArrayList(federator0PublicKey);
+        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0362634ab57dae9cb373a5d536e66a8c4f67468bbcfb063809bab643072d78a124"));
+        BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03c5946b3fbae03a654237da863c9ed534e0878657175b132b8ca630f245df04db"));
+        BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02cd53fc53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1"));
 
-        federatorsRequiredToSign = 1;
+        federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey);
+        federatorPublicKeys = Lists.newArrayList(federator0PublicKey, federator1PublicKey, federator2PublicKey);
+
+        federatorsRequiredToSign = 2;
 
         Script redeemScript = ScriptBuilder.createRedeemScript(federatorsRequiredToSign, federatorPublicKeys);
         federationPubScript = ScriptBuilder.createP2SHOutputScript(redeemScript);

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
@@ -46,6 +46,28 @@ public class BlockUtils {
         return blocks.stream().anyMatch(bi -> key.equalsToByteArray(bi.getHash()));
     }
 
+    public static boolean blockIsAncestorOf(Block blockA, Block blockB, Blockchain blockChain) {
+        if (blockA.getNumber() >= blockB.getNumber()) {
+            return false;
+        }
+
+        if (!blockInSomeBlockChain(blockA, blockChain) || !blockInSomeBlockChain(blockB, blockChain)) {
+            return false;
+        }
+
+        // Climb the blockchain up to A's number
+        Block currentBlock = blockB;
+        while (currentBlock != null && currentBlock.getNumber() > blockA.getNumber()) {
+            currentBlock = blockChain.getBlockByHash(currentBlock.getParentHash());
+        }
+
+        if (currentBlock == null) {
+            return false;
+        }
+
+        return Arrays.equals(blockA.getHash(), currentBlock.getHash());
+    }
+
     public static Set<ByteArrayWrapper> unknownDirectAncestorsHashes(Block block, Blockchain blockChain, BlockStore store) {
         Set<ByteArrayWrapper> hashes = new HashSet<>();
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
@@ -46,28 +46,6 @@ public class BlockUtils {
         return blocks.stream().anyMatch(bi -> key.equalsToByteArray(bi.getHash()));
     }
 
-    public static boolean blockIsAncestorOf(Block blockA, Block blockB, Blockchain blockChain) {
-        if (blockA.getNumber() >= blockB.getNumber()) {
-            return false;
-        }
-
-        if (!blockInSomeBlockChain(blockA, blockChain) || !blockInSomeBlockChain(blockB, blockChain)) {
-            return false;
-        }
-
-        // Climb the blockchain up to A's number
-        Block currentBlock = blockB;
-        while (currentBlock != null && currentBlock.getNumber() > blockA.getNumber()) {
-            currentBlock = blockChain.getBlockByHash(currentBlock.getParentHash());
-        }
-
-        if (currentBlock == null) {
-            return false;
-        }
-
-        return Arrays.equals(blockA.getHash(), currentBlock.getHash());
-    }
-
     public static Set<ByteArrayWrapper> unknownDirectAncestorsHashes(Block block, Blockchain blockChain, BlockStore store) {
         Set<ByteArrayWrapper> hashes = new HashSet<>();
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -185,9 +185,13 @@ public class BridgeSerializationUtils {
         byte[][] bytes = new byte[map.size() * 2][];
         int n = 0;
 
-        for (Map.Entry<Sha256Hash, Long> entry : map.entrySet()) {
-            bytes[n++] = RLP.encodeElement(entry.getKey().getBytes());
-            bytes[n++] = RLP.encodeBigInteger(BigInteger.valueOf(entry.getValue()));
+        List<Sha256Hash> sortedHashes = new ArrayList<>(map.keySet());
+        Collections.sort(sortedHashes);
+
+        for (Sha256Hash hash : sortedHashes) {
+            Long value = map.get(hash);
+            bytes[n++] = RLP.encodeElement(hash.getBytes());
+            bytes[n++] = RLP.encodeBigInteger(BigInteger.valueOf(value));
         }
 
         return RLP.encodeList(bytes);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -207,7 +207,7 @@ public class BridgeSerializationUtils {
 
         // List size must be even - key, value pairs expected in sequence
         if (rlpList.size() % 2 != 0) {
-            return map;
+            throw new RuntimeException("deserializeMapOfHashesToLong: expected an even number of entries, but odd given");
         }
 
         int numEntries = rlpList.size() / 2;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeState.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeState.java
@@ -41,7 +41,7 @@ import java.util.*;
  */
 public class BridgeState {
     private final int btcBlockchainBestChainHeight;
-    private final SortedSet<Sha256Hash> btcTxHashesAlreadyProcessed;
+    private final Map<Sha256Hash, Long> btcTxHashesAlreadyProcessed;
     private final List<UTXO> btcUTXOs;
     private final SortedMap<Sha3Hash, BtcTransaction> rskTxsWaitingForConfirmations;
     private final SortedMap<Sha3Hash, BtcTransaction> rskTxsWaitingForSignatures;
@@ -50,7 +50,7 @@ public class BridgeState {
 
     private static final NetworkParameters params =RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
 
-    private BridgeState(int btcBlockchainBestChainHeight, SortedSet<Sha256Hash> btcTxHashesAlreadyProcessed, List<UTXO> btcUTXOs,
+    private BridgeState(int btcBlockchainBestChainHeight, Map<Sha256Hash, Long> btcTxHashesAlreadyProcessed, List<UTXO> btcUTXOs,
                        SortedMap<Sha3Hash, BtcTransaction> rskTxsWaitingForConfirmations, SortedMap<Sha3Hash, BtcTransaction> rskTxsWaitingForSignatures,
                        SortedMap<Sha3Hash, Pair<BtcTransaction, Long>> rskTxsWaitingForBroadcasting) {
         this.btcBlockchainBestChainHeight = btcBlockchainBestChainHeight;
@@ -74,7 +74,7 @@ public class BridgeState {
         return this.btcBlockchainBestChainHeight;
     }
 
-    public SortedSet<Sha256Hash> getBtcTxHashesAlreadyProcessed() {
+    public Map<Sha256Hash, Long> getBtcTxHashesAlreadyProcessed() {
         return btcTxHashesAlreadyProcessed;
     }
 
@@ -109,7 +109,7 @@ public class BridgeState {
     public List<String> formatedAlreadyProcessedHashes() {
         List<String> hashes = new ArrayList<>();
         if(this.btcTxHashesAlreadyProcessed != null) {
-            this.btcTxHashesAlreadyProcessed.forEach(s -> hashes.add(s.toString()));
+            this.btcTxHashesAlreadyProcessed.keySet().forEach(s -> hashes.add(s.toString()));
         }
         return hashes;
     }
@@ -126,7 +126,7 @@ public class BridgeState {
 
     public byte[] getEncoded() throws IOException {
         byte[] rlpBtcBlockchainBestChainHeight = RLP.encodeBigInteger(BigInteger.valueOf(this.btcBlockchainBestChainHeight));
-        byte[] rlpBtcTxHashesAlreadyProcessed = RLP.encodeElement(BridgeSerializationUtils.serializeSet(btcTxHashesAlreadyProcessed));
+        byte[] rlpBtcTxHashesAlreadyProcessed = RLP.encodeElement(BridgeSerializationUtils.serializeMapOfHashesToLong(btcTxHashesAlreadyProcessed));
         byte[] rlpBtcUTXOs = RLP.encodeElement(BridgeSerializationUtils.serializeList(btcUTXOs));
         byte[] rlpRskTxsWaitingForBroadcasting = RLP.encodeElement(BridgeSerializationUtils.serializePairMap(rskTxsWaitingForBroadcasting));
         byte[] rlpRskTxsWaitingForConfirmations = RLP.encodeElement(BridgeSerializationUtils.serializeMap(rskTxsWaitingForConfirmations));
@@ -141,7 +141,7 @@ public class BridgeState {
         byte[] btcBlockchainBestChainHeightBytes = rlpList.get(0).getRLPData();
         int btcBlockchainBestChainHeight = btcBlockchainBestChainHeightBytes == null ? 0 : (new BigInteger(1, btcBlockchainBestChainHeightBytes)).intValue();
         byte[] btcTxHashesAlreadyProcessedBytes = rlpList.get(1).getRLPData();
-        SortedSet<Sha256Hash> btcTxHashesAlreadyProcessed = BridgeSerializationUtils.deserializeSet(btcTxHashesAlreadyProcessedBytes);
+        Map<Sha256Hash, Long> btcTxHashesAlreadyProcessed = BridgeSerializationUtils.deserializeMapOfHashesToLong(btcTxHashesAlreadyProcessedBytes);
         byte[] btcUTXOsBytes = rlpList.get(2).getRLPData();
         List<UTXO> btcUTXOs = BridgeSerializationUtils.deserializeList(btcUTXOsBytes);
         byte[] rskTxsWaitingForBroadcastingBytes = rlpList.get(3).getRLPData();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -30,10 +30,9 @@ import org.ethereum.vm.DataWord;
 import org.spongycastle.util.encoders.Hex;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.SortedSet;
+import java.util.*;
 
 /**
  * Provides an object oriented facade of the bridge contract memory.
@@ -53,7 +52,7 @@ public class BridgeStorageProvider {
     private Repository repository;
     private String contractAddress;
 
-    private SortedSet<Sha256Hash> btcTxHashesAlreadyProcessed;
+    private Map<Sha256Hash, Long> btcTxHashesAlreadyProcessed;
     // RSK release txs follow these steps: First, they are waiting for RSK confirmations, then they are waiting for federators' signatures,
     // then they are waiting for broadcasting in the bitcoin network (a tx is kept in this state for a while, even if already broadcasted, giving the chance to federators to rebroadcast it just in case),
     // then they are removed from contract's memory.
@@ -121,7 +120,7 @@ public class BridgeStorageProvider {
         repository.addStorageBytes(Hex.decode(contractAddress), address, data);
     }
 
-    public SortedSet<Sha256Hash> getBtcTxHashesAlreadyProcessed() throws IOException {
+    public Map<Sha256Hash, Long> getBtcTxHashesAlreadyProcessed() throws IOException {
         if (btcTxHashesAlreadyProcessed != null)
             return btcTxHashesAlreadyProcessed;
 
@@ -129,7 +128,7 @@ public class BridgeStorageProvider {
 
         byte[] data = repository.getStorageBytes(Hex.decode(contractAddress), address);
 
-        btcTxHashesAlreadyProcessed = BridgeSerializationUtils.deserializeSet(data);
+        btcTxHashesAlreadyProcessed = BridgeSerializationUtils.deserializeMapOfHashesToLong(data);
 
         return btcTxHashesAlreadyProcessed;
     }
@@ -138,7 +137,7 @@ public class BridgeStorageProvider {
         if (btcTxHashesAlreadyProcessed == null)
             return;
 
-        byte[] data = BridgeSerializationUtils.serializeSet(btcTxHashesAlreadyProcessed);
+        byte[] data = BridgeSerializationUtils.serializeMapOfHashesToLong(btcTxHashesAlreadyProcessed);
 
         DataWord address = new DataWord(BTC_TX_HASHES_ALREADY_PROCESSED_KEY.getBytes(StandardCharsets.UTF_8));
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -18,21 +18,22 @@
 
 package co.rsk.peg;
 
+import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.crypto.Sha3Hash;
 import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
 import org.apache.commons.lang3.tuple.Pair;
-import co.rsk.bitcoinj.core.*;
-import co.rsk.bitcoinj.wallet.Wallet;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
 import org.spongycastle.util.encoders.Hex;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
 
 /**
  * Provides an object oriented facade of the bridge contract memory.

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -93,8 +93,7 @@ public class BridgeSerializationUtilsTest {
         mock_RLP_decode2();
 
         byte[] sample = new byte[]{(byte)'b', 7, (byte)'d', 76, (byte) 'a'};
-        Map<Sha256Hash, Long> result = BridgeSerializationUtils.deserializeMapOfHashesToLong(sample);
-        assertEquals(BridgeSerializationUtils.deserializeMapOfHashesToLong(new byte[]{}), new HashMap<>());
+        assertEquals(BridgeSerializationUtils.deserializeMapOfHashesToLong(sample), new HashMap<>());
     }
 
     private void mock_RLP_encodeElement() {
@@ -137,8 +136,8 @@ public class BridgeSerializationUtilsTest {
         PowerMockito.when(RLP.decode2(any(byte[].class))).then((InvocationOnMock invocation) -> {
             RLPList result = new RLPList();
             byte[] arg = invocation.getArgumentAt(0, byte[].class);
-            // Odd byte -> hash of 64 bytes with same char from byte
-            // Even byte -> long from byte
+            // Even byte -> hash of 64 bytes with same char from byte
+            // Odd byte -> long from byte
             for (int i = 0; i < arg.length; i++) {
                 byte[] element;
                 if (i%2 == 0) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Sha256Hash;
+import org.apache.commons.codec.binary.Hex;
+import org.ethereum.util.RLP;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+
+@RunWith(PowerMockRunner.class)
+public class BridgeSerializationUtilsTest {
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @PrepareForTest({ RLP.class })
+    @Test
+    public void testSerializeMapOfHashesToLong() throws Exception {
+        PowerMockito.mockStatic(RLP.class);
+        // Identity prepending byte '0xdd'
+        PowerMockito.when(RLP.encodeElement(any(byte[].class))).then((InvocationOnMock invocation) -> {
+            byte[] arg = invocation.getArgumentAt(0, byte[].class);
+            byte[] result = new byte[arg.length+1];
+            result[0] = (byte) 0xdd;
+            for (int i = 0; i < arg.length; i++)
+                result[i+1] = arg[i];
+            return result;
+        });
+        // To byte array prepending byte '0xff'
+        PowerMockito.when(RLP.encodeBigInteger(any(BigInteger.class))).then((InvocationOnMock invocation) -> {
+            byte[] arg = (invocation.getArgumentAt(0, BigInteger.class)).toByteArray();
+            byte[] result = new byte[arg.length+1];
+            result[0] = (byte) 0xff;
+            for (int i = 0; i < arg.length; i++)
+                result[i+1] = arg[i];
+            return result;
+        });
+        // To flat byte array
+        PowerMockito.when(RLP.encodeList(anyVararg())).then((InvocationOnMock invocation) -> {
+            Object[] args = invocation.getArguments();
+            byte[][] bytes = new byte[args.length][];
+            for (int i = 0; i < args.length; i++)
+                bytes[i] = (byte[])args[i];
+            return flatten(bytes);
+        });
+
+        Map<Sha256Hash, Long> sample = new HashMap<>();
+        sample.put(Sha256Hash.wrap(charNTimes('b', 64)), 1L);
+        sample.put(Sha256Hash.wrap(charNTimes('d', 64)), 2L);
+        sample.put(Sha256Hash.wrap(charNTimes('a', 64)), 3L);
+        sample.put(Sha256Hash.wrap(charNTimes('c', 64)), 4L);
+
+        byte[] result = BridgeSerializationUtils.serializeMapOfHashesToLong(sample);
+        String hexResult = Hex.encodeHexString(result);
+        StringBuilder expectedBuilder = new StringBuilder();
+        char[] sorted = new char[]{'a','b','c','d'};
+        for (char c : sorted) {
+            String key = charNTimes(c, 64);
+            expectedBuilder.append("dd");
+            expectedBuilder.append(key);
+            expectedBuilder.append("ff");
+            expectedBuilder.append(Hex.encodeHexString(BigInteger.valueOf(sample.get(Sha256Hash.wrap(key))).toByteArray()));
+        }
+        assertEquals(expectedBuilder.toString(), hexResult);
+    }
+
+    private String charNTimes(char c, int n) {
+        StringBuilder sb = new StringBuilder(n);
+        for (int i = 0; i < n; i++)
+            sb.append(c);
+        return sb.toString();
+    }
+
+    private byte[] flatten(byte[][] bytes) {
+        int totalLength = 0;
+        for (int i = 0; i < bytes.length; i++)
+            totalLength += bytes[i].length;
+
+        byte[] result = new byte[totalLength];
+        int offset=0;
+        for (int i = 0; i < bytes.length; i++) {
+            for (int j = 0; j < bytes[i].length; j++)
+                result[offset+j] = bytes[i][j];
+            offset += bytes[i].length;
+        }
+        return result;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Matchers.anyVararg;
 public class BridgeSerializationUtilsTest {
     @PrepareForTest({ RLP.class })
     @Test
-    public void testSerializeMapOfHashesToLong() throws Exception {
+    public void serializeMapOfHashesToLong() throws Exception {
         PowerMockito.mockStatic(RLP.class);
         mock_RLP_encodeElement();
         mock_RLP_encodeBigInteger();
@@ -67,14 +67,14 @@ public class BridgeSerializationUtilsTest {
     }
 
     @Test
-    public void testdeserializeMapOfHashesToLong_emptyOrNull() throws Exception {
+    public void desserializeMapOfHashesToLong_emptyOrNull() throws Exception {
         assertEquals(BridgeSerializationUtils.deserializeMapOfHashesToLong(null), new HashMap<>());
         assertEquals(BridgeSerializationUtils.deserializeMapOfHashesToLong(new byte[]{}), new HashMap<>());
     }
 
     @PrepareForTest({ RLP.class })
     @Test
-    public void testdeserializeMapOfHashesToLong_nonEmpty() throws Exception {
+    public void desserializeMapOfHashesToLong_nonEmpty() throws Exception {
         PowerMockito.mockStatic(RLP.class);
         mock_RLP_decode2();
 
@@ -88,7 +88,7 @@ public class BridgeSerializationUtilsTest {
 
     @PrepareForTest({ RLP.class })
     @Test
-    public void testdeserializeMapOfHashesToLong_nonEmptyOddSize() throws Exception {
+    public void desserializeMapOfHashesToLong_nonEmptyOddSize() throws Exception {
         PowerMockito.mockStatic(RLP.class);
         mock_RLP_decode2();
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.Sha256Hash;
 import org.apache.commons.codec.binary.Hex;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
@@ -92,8 +93,14 @@ public class BridgeSerializationUtilsTest {
         PowerMockito.mockStatic(RLP.class);
         mock_RLP_decode2();
 
-        byte[] sample = new byte[]{(byte)'b', 7, (byte)'d', 76, (byte) 'a'};
-        assertEquals(BridgeSerializationUtils.deserializeMapOfHashesToLong(sample), new HashMap<>());
+        boolean thrown = false;
+        try {
+            byte[] sample = new byte[]{(byte)'b', 7, (byte)'d', 76, (byte) 'a'};
+            BridgeSerializationUtils.deserializeMapOfHashesToLong(sample);
+        } catch (RuntimeException e) {
+            thrown = true;
+        }
+        Assert.assertTrue(thrown);
     }
 
     private void mock_RLP_encodeElement() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -36,9 +36,7 @@ import org.spongycastle.util.encoders.Hex;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.SortedSet;
+import java.util.*;
 
 /**
  * Created by ajlopez on 6/7/2016.
@@ -52,7 +50,7 @@ public class BridgeStorageProviderTest {
         Repository repository = new RepositoryImpl();
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        SortedSet<Sha256Hash> processed = provider.getBtcTxHashesAlreadyProcessed();
+        Map<Sha256Hash, Long> processed = provider.getBtcTxHashesAlreadyProcessed();
 
         Assert.assertNotNull(processed);
         Assert.assertTrue(processed.isEmpty());
@@ -110,7 +108,7 @@ public class BridgeStorageProviderTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
-        SortedSet<Sha256Hash> processed = provider.getBtcTxHashesAlreadyProcessed();
+        Map<Sha256Hash, Long> processed = provider.getBtcTxHashesAlreadyProcessed();
 
         Assert.assertNotNull(processed);
         Assert.assertTrue(processed.isEmpty());
@@ -150,8 +148,8 @@ public class BridgeStorageProviderTest {
         Repository track = repository.startTracking();
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
-        provider0.getBtcTxHashesAlreadyProcessed().add(hash1);
-        provider0.getBtcTxHashesAlreadyProcessed().add(hash2);
+        provider0.getBtcTxHashesAlreadyProcessed().put(hash1, 1L);
+        provider0.getBtcTxHashesAlreadyProcessed().put(hash2, 1L);
         provider0.save();
         track.commit();
 
@@ -159,10 +157,11 @@ public class BridgeStorageProviderTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
-        SortedSet<Sha256Hash> processed = provider.getBtcTxHashesAlreadyProcessed();
+        Map<Sha256Hash, Long> processed = provider.getBtcTxHashesAlreadyProcessed();
+        Set<Sha256Hash> processedHashes = processed.keySet();
 
-        Assert.assertTrue(processed.contains(hash1));
-        Assert.assertTrue(processed.contains(hash2));
+        Assert.assertTrue(processedHashes.contains(hash1));
+        Assert.assertTrue(processedHashes.contains(hash2));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -826,7 +826,7 @@ public class BridgeSupportTest {
         BtcTransaction tx = createTransaction();
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
-        provider.getBtcTxHashesAlreadyProcessed().add(tx.getHash());
+        provider.getBtcTxHashesAlreadyProcessed().put(tx.getHash(), 1L);
 
         BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, null, null);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -49,6 +49,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
 import org.spongycastle.crypto.params.ECPrivateKeyParameters;
 import org.spongycastle.crypto.signers.ECDSASigner;
 import org.spongycastle.util.encoders.Hex;
@@ -1000,6 +1001,8 @@ public class BridgeSupportTest {
         Repository repository = new RepositoryImpl();
         repository.addBalance(Hex.decode(PrecompiledContracts.BRIDGE_ADDR), BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
         Repository track = repository.startTracking();
+        Block executionBlock = Mockito.mock(Block.class);
+        Mockito.when(executionBlock.getNumber()).thenReturn(10L);
 
         BridgeRegTestConstants bridgeConstants = (BridgeRegTestConstants) RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
 
@@ -1040,6 +1043,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress);
 
         BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain);
+        Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1077,6 +1081,8 @@ public class BridgeSupportTest {
     public void registerBtcTransactionLockTx() throws BlockStoreException, AddressFormatException, IOException {
         Repository repository = new RepositoryImpl();
         repository.addBalance(Hex.decode(PrecompiledContracts.BRIDGE_ADDR), BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
+        Block executionBlock = Mockito.mock(Block.class);
+        Mockito.when(executionBlock.getNumber()).thenReturn(10L);
 
         Repository track = repository.startTracking();
 
@@ -1095,7 +1101,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress);
 
         BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain);
-
+        Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
         byte[] bits = new byte[1];
         bits[0] = 0x01;
         List<Sha256Hash> hashes = new ArrayList<>();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -472,19 +472,6 @@ public class BridgeTest {
         }
     }
 
-//    @Test
-//    public void exceptionInGetBtcTxHashesAlreadyProcessed() {
-//        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-//
-//        try {
-//            bridge.getBtcTxHashesAlreadyProcessed(null);
-//            Assert.fail();
-//        }
-//        catch (RuntimeException ex) {
-//            Assert.assertEquals("Exception in getBtcTxHashesAlreadyProcessed", ex.getMessage());
-//        }
-//    }
-
     private BtcTransaction createTransaction() {
         return new SimpleBtcTransaction(networkParameters, PegTestUtils.createHash());
     }
@@ -561,11 +548,6 @@ public class BridgeTest {
         getGasForDataPaidTx(50017, Bridge.GET_BTC_BLOCKCHAIN_BLOCK_LOCATOR);
     }
 
-//    @Test
-//    public void getGasForDataGBTHAP() {
-//        getGasForDataPaidTx(50018, Bridge.GET_BTC_TX_HASHES_ALREADY_PROCESSED);
-//    }
-
     @Test
     public void getGasForDataGetFederationAddress() {
         getGasForDataPaidTx(50018, Bridge.GET_FEDERATION_ADDRESS);
@@ -575,8 +557,6 @@ public class BridgeTest {
     public void getGasForDataGetMinimumLockTxValue() {
         getGasForDataPaidTx(50019, Bridge.GET_MINIMUM_LOCK_TX_VALUE);
     }
-
-
 
     private void getGasForDataPaidTx(int expected, CallTransaction.Function function, Object... funcArgs) {
         BlockchainNetConfig blockchainNetConfigOriginal = RskSystemProperties.CONFIG.getBlockchainConfig();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -301,19 +301,6 @@ public class BridgeTest {
     }
 
     @Test
-    public void getBtcTxHashesAlreadyProcessed() throws Exception{
-        Repository repository = new RepositoryImpl();
-        Repository track = repository.startTracking();
-
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
-
-        byte[] data = Bridge.GET_BTC_TX_HASHES_ALREADY_PROCESSED.encode();
-
-        Assert.assertNotNull(bridge.execute(data));
-    }
-
-    @Test
     public void getFederationAddress() throws Exception{
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
@@ -480,18 +467,18 @@ public class BridgeTest {
         }
     }
 
-    @Test
-    public void exceptionInGetBtcTxHashesAlreadyProcessed() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-
-        try {
-            bridge.getBtcTxHashesAlreadyProcessed(null);
-            Assert.fail();
-        }
-        catch (RuntimeException ex) {
-            Assert.assertEquals("Exception in getBtcTxHashesAlreadyProcessed", ex.getMessage());
-        }
-    }
+//    @Test
+//    public void exceptionInGetBtcTxHashesAlreadyProcessed() {
+//        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
+//
+//        try {
+//            bridge.getBtcTxHashesAlreadyProcessed(null);
+//            Assert.fail();
+//        }
+//        catch (RuntimeException ex) {
+//            Assert.assertEquals("Exception in getBtcTxHashesAlreadyProcessed", ex.getMessage());
+//        }
+//    }
 
     private BtcTransaction createTransaction() {
         return new SimpleBtcTransaction(networkParameters, PegTestUtils.createHash());
@@ -569,10 +556,10 @@ public class BridgeTest {
         getGasForDataPaidTx(50017, Bridge.GET_BTC_BLOCKCHAIN_BLOCK_LOCATOR);
     }
 
-    @Test
-    public void getGasForDataGBTHAP() {
-        getGasForDataPaidTx(50018, Bridge.GET_BTC_TX_HASHES_ALREADY_PROCESSED);
-    }
+//    @Test
+//    public void getGasForDataGBTHAP() {
+//        getGasForDataPaidTx(50018, Bridge.GET_BTC_TX_HASHES_ALREADY_PROCESSED);
+//    }
 
     @Test
     public void getGasForDataGetFederationAddress() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -568,12 +568,12 @@ public class BridgeTest {
 
     @Test
     public void getGasForDataGetFederationAddress() {
-        getGasForDataPaidTx(50019, Bridge.GET_FEDERATION_ADDRESS);
+        getGasForDataPaidTx(50018, Bridge.GET_FEDERATION_ADDRESS);
     }
 
     @Test
     public void getGasForDataGetMinimumLockTxValue() {
-        getGasForDataPaidTx(50020, Bridge.GET_MINIMUM_LOCK_TX_VALUE);
+        getGasForDataPaidTx(50019, Bridge.GET_MINIMUM_LOCK_TX_VALUE);
     }
 
 


### PR DESCRIPTION
Removed `getBtcTxHashesAlreadyProcessed` in the Bridge, and added `isBtcTxHashAlreadyProcessed` and `getBtcTxHashProcessedHeight`, along with the corresponding storage support and tests.