### PR TITLE
Improving rpc

### DIFF
--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -29,7 +29,9 @@ import co.rsk.net.discovery.UDPServer;
 import co.rsk.rpc.CorsConfiguration;
 import org.ethereum.cli.CLIInterface;
 import org.ethereum.config.DefaultConfig;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.rpc.JsonRpcNettyServer;
+import org.ethereum.rpc.JsonRpcWeb3FilterHandler;
 import org.ethereum.rpc.JsonRpcWeb3ServerHandler;
 import org.ethereum.rpc.Web3;
 import org.slf4j.Logger;
@@ -118,11 +120,13 @@ public class Start {
     private void enableRpc() throws InterruptedException {
         Web3 web3Service = web3Factory.newInstance();
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Service, rskSystemProperties.getRpcModules());
+        JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler(RskSystemProperties.CONFIG.corsDomains());
         new JsonRpcNettyServer(
             rskSystemProperties.rpcPort(),
             rskSystemProperties.soLingerTime(),
             true,
             new CorsConfiguration(),
+            filterHandler,
             serverHandler
         ).start();
     }

--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -29,7 +29,6 @@ import co.rsk.net.discovery.UDPServer;
 import co.rsk.rpc.CorsConfiguration;
 import org.ethereum.cli.CLIInterface;
 import org.ethereum.config.DefaultConfig;
-import org.ethereum.config.SystemProperties;
 import org.ethereum.rpc.JsonRpcNettyServer;
 import org.ethereum.rpc.JsonRpcWeb3FilterHandler;
 import org.ethereum.rpc.JsonRpcWeb3ServerHandler;
@@ -120,7 +119,7 @@ public class Start {
     private void enableRpc() throws InterruptedException {
         Web3 web3Service = web3Factory.newInstance();
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Service, rskSystemProperties.getRpcModules());
-        JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler(RskSystemProperties.CONFIG.corsDomains());
+        JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler(rskSystemProperties.corsDomains());
         new JsonRpcNettyServer(
             rskSystemProperties.rpcPort(),
             rskSystemProperties.soLingerTime(),

--- a/rskj-core/src/main/java/co/rsk/rpc/OriginValidator.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/OriginValidator.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * Created by ajlopez on 06/10/2017.
+ */
+public class OriginValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger("jsonrpc");
+
+    private URI[] origins;
+    private boolean allowAllOrigins;
+
+    public OriginValidator() {
+        this.origins = new URI[0];
+    }
+
+    public OriginValidator(String uriList) {
+        if (uriList == null)
+            this.origins = new URI[0];
+        else if ("*".equals(uriList.trim()))
+            this.allowAllOrigins = true;
+        else {
+            try {
+                this.origins = toUris(uriList);
+            } catch (URISyntaxException e) {
+                LOGGER.error("Error creating OriginValidator, origins {}, {}", uriList, e);
+
+                // no origin
+                this.origins = new URI[0];
+            }
+        }
+    }
+
+    public boolean isValidOrigin(String origin) {
+        if (this.allowAllOrigins)
+            return true;
+
+        URI originUri = null;
+
+        try {
+            originUri = new URI(origin);
+        } catch (URISyntaxException e) {
+            return false;
+        }
+
+        for (URI uri : origins)
+            if (originUri.equals(uri))
+                return true;
+
+        return false;
+    }
+
+    public boolean isValidReferer(String referer) {
+        if (this.allowAllOrigins)
+            return true;
+
+        URL refererUrl = null;
+
+        try {
+            refererUrl = new URL(referer);
+        } catch (MalformedURLException e) {
+            return false;
+        }
+
+        String refererProtocol = refererUrl.getProtocol();
+
+        if (refererProtocol == null)
+            return false;
+
+        String refererHost = refererUrl.getHost();
+
+        if (refererHost == null)
+            return false;
+
+        int refererPort = refererUrl.getPort();
+
+        for (int k = 0; k < origins.length; k++) {
+            if (refererProtocol.equals(origins[k].getScheme()) &&
+                    refererHost.equals(origins[k].getHost()) &&
+                    refererPort == origins[k].getPort())
+                return true;
+        }
+
+        return false;
+    }
+
+    private static URI[] toUris(@Nonnull String list) throws URISyntaxException {
+        String[] elements = list.split(" ");
+        URI[] uris = new URI[elements.length];
+
+        for (int k = 0; k < elements.length; k++)
+            uris[k] = new URI(elements[k].trim());
+
+        return uris;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/JsonRpcNettyServer.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/JsonRpcNettyServer.java
@@ -23,13 +23,15 @@ public class JsonRpcNettyServer {
     private int socketLinger;
     private boolean reuseAddress;
     private CorsConfiguration corsConfiguration;
+    private final JsonRpcWeb3FilterHandler jsonRpcWeb3FilterHandler;
     private final JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler;
 
-    public JsonRpcNettyServer(int port, int socketLinger, boolean reuseAddress, CorsConfiguration corsConfiguration, JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler) {
+    public JsonRpcNettyServer(int port, int socketLinger, boolean reuseAddress, CorsConfiguration corsConfiguration, JsonRpcWeb3FilterHandler jsonRpcWeb3FilterHandler, JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler) {
         this.port = port;
         this.socketLinger = socketLinger;
         this.reuseAddress = reuseAddress;
         this.corsConfiguration = corsConfiguration;
+        this.jsonRpcWeb3FilterHandler = jsonRpcWeb3FilterHandler;
         this.jsonRpcWeb3ServerHandler = jsonRpcWeb3ServerHandler;
         this.bossGroup = new NioEventLoopGroup();
         this.workerGroup = new NioEventLoopGroup();
@@ -59,6 +61,7 @@ public class JsonRpcNettyServer {
                             .build())
                         );
                     }
+                    p.addLast(jsonRpcWeb3FilterHandler);
                     p.addLast(jsonRpcWeb3ServerHandler);
                 }
             });

--- a/rskj-core/src/main/java/org/ethereum/rpc/JsonRpcWeb3FilterHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/JsonRpcWeb3FilterHandler.java
@@ -1,0 +1,60 @@
+package org.ethereum.rpc;
+
+import co.rsk.rpc.OriginValidator;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URISyntaxException;
+
+/**
+ * Created by ajlopez on 18/10/2017.
+ */
+
+@ChannelHandler.Sharable
+public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger("jsonrpc");
+
+    private OriginValidator originValidator;
+
+    public JsonRpcWeb3FilterHandler(String corsOrigins) {
+        this.originValidator = new OriginValidator(corsOrigins);
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
+        HttpMethod httpMethod = request.getMethod();
+        HttpResponse response;
+
+        if (HttpMethod.POST.equals(httpMethod)) {
+            HttpHeaders headers = request.headers();
+
+            String contentType = headers.get(HttpHeaders.Names.CONTENT_TYPE);
+            String origin = headers.get(HttpHeaders.Names.ORIGIN);
+            String referer = headers.get(HttpHeaders.Names.REFERER);
+
+            if (!"application/json".equals(contentType) && !"application/json-rpc".equals(contentType)) {
+                LOGGER.error("Unsupported content type");
+                response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE);
+            } else if (origin != null && !this.originValidator.isValidOrigin(origin)) {
+                LOGGER.error("Invalid origin");
+                response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN);
+            } else if (referer != null && !this.originValidator.isValidReferer(referer)) {
+                LOGGER.error("Invalid referer");
+                response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN);
+            }
+            else {
+                ctx.fireChannelRead(request);
+                return;
+            }
+        } else {
+            response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_IMPLEMENTED);
+        }
+
+        ctx.write(response).addListener(ChannelFutureListener.CLOSE);
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/JsonRpcWeb3ServerHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/JsonRpcWeb3ServerHandler.java
@@ -47,27 +47,33 @@ public class JsonRpcWeb3ServerHandler extends SimpleChannelInboundHandler<FullHt
         HttpMethod httpMethod = request.getMethod();
         HttpResponse response;
         if (HttpMethod.POST.equals(httpMethod)) {
-            ByteBuf responseContent = Unpooled.buffer();
-            HttpResponseStatus responseStatus = HttpResponseStatus.OK;
-            try (ByteBufOutputStream os = new ByteBufOutputStream(responseContent);
-                 ByteBufInputStream is = new ByteBufInputStream(request.content())){
-                int result = jsonRpcServer.handleRequest(is, os);
-                responseStatus = HttpResponseStatus.valueOf(DefaultHttpStatusCodeProvider.INSTANCE.getHttpStatusCode(result));
-            } catch (Exception e) {
-                LOGGER.error("Unexpected error", e);
-                responseContent = buildErrorContent(JSON_RPC_SERVER_ERROR_HIGH_CODE, HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
-                responseStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR;
-            } finally {
-                response = new DefaultFullHttpResponse(
-                    HttpVersion.HTTP_1_1,
-                    responseStatus,
-                    responseContent
-                );
-            }
+            response = processRequest(request);
         } else {
             response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_IMPLEMENTED);
         }
         ctx.write(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private HttpResponse processRequest(FullHttpRequest request) throws JsonProcessingException {
+        HttpResponse response;
+        ByteBuf responseContent = Unpooled.buffer();
+        HttpResponseStatus responseStatus = HttpResponseStatus.OK;
+        try (ByteBufOutputStream os = new ByteBufOutputStream(responseContent);
+             ByteBufInputStream is = new ByteBufInputStream(request.content())){
+            int result = jsonRpcServer.handleRequest(is, os);
+            responseStatus = HttpResponseStatus.valueOf(DefaultHttpStatusCodeProvider.INSTANCE.getHttpStatusCode(result));
+        } catch (Exception e) {
+            LOGGER.error("Unexpected error", e);
+            responseContent = buildErrorContent(JSON_RPC_SERVER_ERROR_HIGH_CODE, HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
+            responseStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+        } finally {
+            response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                responseStatus,
+                responseContent
+            );
+        }
+        return response;
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/rpc/OriginValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/OriginValidatorTest.java
@@ -1,0 +1,150 @@
+package co.rsk.rpc;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+
+/**
+ * Created by ajlopez on 06/10/2017.
+ */
+public class OriginValidatorTest {
+    @Test
+    public void noOrigin() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("");
+
+        Assert.assertFalse(validator.isValidOrigin("http://localhost"));
+        Assert.assertFalse(validator.isValidOrigin("https://rks.co"));
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rks.co/index.html"));
+    }
+
+    @Test
+    public void noOriginWithSpaces() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("  ");
+
+        Assert.assertFalse(validator.isValidOrigin("http://localhost"));
+        Assert.assertFalse(validator.isValidOrigin("https://rks.co"));
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rks.co/index.html"));
+    }
+
+    @Test
+    public void nullOrigin() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator(null);
+
+        Assert.assertFalse(validator.isValidOrigin("http://localhost"));
+        Assert.assertFalse(validator.isValidOrigin("https://rks.co"));
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rks.co/index.html"));
+    }
+
+    @Test
+    public void allOriginsUsingWildcard() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("*");
+
+        Assert.assertTrue(validator.isValidOrigin("http://localhost"));
+        Assert.assertTrue(validator.isValidOrigin("https://rks.co"));
+
+        Assert.assertTrue(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertTrue(validator.isValidReferer("https://rks.co/index.html"));
+    }
+
+    @Test
+    public void allowLocalhost() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("http://localhost");
+
+        Assert.assertTrue(validator.isValidOrigin("http://localhost"));
+        Assert.assertFalse(validator.isValidOrigin("https://rks.co"));
+
+        Assert.assertTrue(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rks.co/index.html"));
+    }
+
+    @Test
+    public void invalidRefererWithDifferentProtocol() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("http://localhost");
+
+        Assert.assertFalse(validator.isValidReferer("https://localhost/index.html"));
+    }
+
+    @Test
+    public void invalidRefererWithDifferentHost() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("http://localhost");
+
+        Assert.assertFalse(validator.isValidReferer("http://rsk.co/index.html"));
+    }
+
+    @Test
+    public void invalidRefererWithDifferentPort() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("http://localhost");
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost:3000/index.html"));
+    }
+
+    @Test
+    public void allowDomain() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("https://rsk.co");
+
+        Assert.assertFalse(validator.isValidOrigin("http://localhost"));
+        Assert.assertTrue(validator.isValidOrigin("https://rsk.co"));
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertTrue(validator.isValidReferer("https://rsk.co/index.html"));
+    }
+
+    @Test()
+    public void allowTwoDomains() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("https://rsk.co https://rsk.com.ar");
+
+        Assert.assertFalse(validator.isValidOrigin("http://localhost"));
+        Assert.assertTrue(validator.isValidOrigin("https://rsk.co"));
+        Assert.assertTrue(validator.isValidOrigin("https://rsk.com.ar"));
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertTrue(validator.isValidReferer("https://rsk.co/index.html"));
+        Assert.assertTrue(validator.isValidReferer("https://rsk.com.ar/index.html"));
+    }
+
+    @Test
+    public void invalidUriInCreation() {
+        OriginValidator validator = new OriginValidator("//");
+
+        Assert.assertFalse(validator.isValidOrigin("http://localhost"));
+        Assert.assertFalse(validator.isValidOrigin("https://rsk.co"));
+        Assert.assertFalse(validator.isValidOrigin("https://rsk.com.ar"));
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rsk.co/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rsk.com.ar/index.html"));
+    }
+
+    @Test
+    public void noReferer() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator("");
+
+        Assert.assertFalse(validator.isValidOrigin("http://localhost"));
+        Assert.assertFalse(validator.isValidOrigin("https://rsk.co"));
+        Assert.assertFalse(validator.isValidOrigin("https://rsk.com.ar"));
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rsk.co/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rsk.com.ar/index.html"));
+    }
+
+    @Test
+    public void defaultValidator() throws URISyntaxException {
+        OriginValidator validator = new OriginValidator();
+
+        Assert.assertFalse(validator.isValidOrigin("http://localhost"));
+        Assert.assertFalse(validator.isValidOrigin("https://rsk.co"));
+        Assert.assertFalse(validator.isValidOrigin("https://rsk.com.ar"));
+
+        Assert.assertFalse(validator.isValidReferer("http://localhost/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rsk.co/index.html"));
+        Assert.assertFalse(validator.isValidReferer("https://rsk.com.ar/index.html"));
+    }
+}


### PR DESCRIPTION
Checks that can help to make it harder for attackers to succeed implementing CSRF attacks but should not be considered enough because they assume correct web browser behavior:

- Check content type is json: application/json
- Check origin and referer headers match the whitelisted domain name for CORS.

