### PR TITLE
Disable wallet by default

### DIFF
--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -115,7 +115,7 @@ public class Start {
     }
 
     private void enableRpc(Rsk rsk) throws InterruptedException {
-        Web3 web3Service = new Web3RskImpl(rsk, minerServer, minerClient);
+        Web3 web3Service = new Web3RskImpl(rsk, minerClient, minerServer);
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Service, rskSystemProperties.getRpcModules());
         new JsonRpcNettyServer(
             rskSystemProperties.rpcPort(),

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -169,6 +169,10 @@ public class RskSystemProperties extends SystemProperties {
                 configFromFiles.getInt("rpc.port") : 4444;
     }
 
+    public boolean isWalletEnabled() {
+        return configFromFiles.hasPath("wallet.enabled");
+    }
+
     public List<WalletAccount> walletAccounts() {
         if (!configFromFiles.hasPath("wallet.accounts"))
             return Collections.emptyList();

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -170,7 +170,8 @@ public class RskSystemProperties extends SystemProperties {
     }
 
     public boolean isWalletEnabled() {
-        return configFromFiles.hasPath("wallet.enabled");
+        return configFromFiles.hasPath("wallet.enabled") &&
+                configFromFiles.getBoolean("wallet.enabled");
     }
 
     public List<WalletAccount> walletAccounts() {

--- a/rskj-core/src/main/java/co/rsk/core/DisabledWalletException.java
+++ b/rskj-core/src/main/java/co/rsk/core/DisabledWalletException.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.core;
+
+public class DisabledWalletException extends RuntimeException {
+    public DisabledWalletException() {
+        super("The local wallet feature is disabled");
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -24,9 +24,9 @@ import co.rsk.crypto.KeyCrypterAes;
 import org.ethereum.core.Account;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.SHA3Helper;
-import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.db.ByteArrayWrapper;
+import org.ethereum.rpc.TypeConverter;
 import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -34,21 +34,18 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-/**
- * Created by ajlopez on 15/09/2016.
- */
 public class Wallet {
     @GuardedBy("accessLock")
-    private KeyValueDataSource keyDS = new HashMapDB();
+    private final KeyValueDataSource keyDS;
 
     @GuardedBy("accessLock")
-    private Map<ByteArrayWrapper, byte[]> accounts = new HashMap<>();
+    private final Map<ByteArrayWrapper, byte[]> accounts = new HashMap<>();
 
     private final Object accessLock = new Object();
-    private Map<ByteArrayWrapper, Long> unlocksTimeouts = new HashMap<>();
+    private final Map<ByteArrayWrapper, Long> unlocksTimeouts = new HashMap<>();
 
-    public void setStore(KeyValueDataSource ds) {
-        this.keyDS = ds;
+    public Wallet(KeyValueDataSource keyDS) {
+        this.keyDS = keyDS;
     }
 
     public List<byte[]> getAccountAddresses() {
@@ -68,9 +65,16 @@ public class Wallet {
         return addresses;
     }
 
+    public String[] getAccountAddressesAsHex() {
+        return getAccountAddresses().stream()
+                .map(TypeConverter::toJsonHex)
+                .toArray(String[]::new);
+    }
+
     public byte[] addAccount() {
         Account account = new Account(new ECKey());
-        return addAccount(account);
+        saveAccount(account);
+        return account.getAddress();
     }
 
     public byte[] addAccount(String passphrase) {

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -18,12 +18,12 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.RskSystemProperties;
-import co.rsk.mine.MinerClient;
-import co.rsk.mine.MinerServer;
 import co.rsk.config.RskMiningConstants;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Rsk;
 import co.rsk.core.WalletFactory;
+import co.rsk.mine.MinerClient;
+import co.rsk.mine.MinerServer;
 import co.rsk.mine.MinerWork;
 import org.apache.commons.lang3.ArrayUtils;
 import org.ethereum.core.Block;

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -23,7 +23,6 @@ import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
 import co.rsk.config.RskMiningConstants;
 import co.rsk.core.Rsk;
-import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.mine.MinerWork;
 import org.apache.commons.lang3.ArrayUtils;
@@ -52,7 +51,7 @@ public class Web3RskImpl extends Web3Impl {
     private static final Logger logger = LoggerFactory.getLogger("web3");
     private final MinerServer minerServer;
 
-    public Web3RskImpl(Rsk rsk, MinerServer minerServer, MinerClient minerClient) {
+    public Web3RskImpl(Rsk rsk, MinerClient minerClient, MinerServer minerServer) {
         super(rsk, RskSystemProperties.CONFIG, WalletFactory.createPersistentWallet(), minerClient, minerServer);
         this.minerServer = minerServer;
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -20,16 +20,17 @@ package co.rsk.rpc;
 
 import co.rsk.config.RskMiningConstants;
 import co.rsk.config.RskSystemProperties;
-import co.rsk.core.Rsk;
-import co.rsk.core.WalletFactory;
 import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
 import co.rsk.mine.MinerWork;
+import co.rsk.rpc.modules.eth.EthModule;
+import co.rsk.rpc.modules.personal.PersonalModule;
 import org.apache.commons.lang3.ArrayUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.db.BlockStore;
+import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.Web3Impl;
 import org.slf4j.Logger;
@@ -51,8 +52,13 @@ public class Web3RskImpl extends Web3Impl {
     private static final Logger logger = LoggerFactory.getLogger("web3");
     private final MinerServer minerServer;
 
-    public Web3RskImpl(Rsk rsk, MinerClient minerClient, MinerServer minerServer) {
-        super(rsk, RskSystemProperties.CONFIG, WalletFactory.createPersistentWallet(), minerClient, minerServer);
+    public Web3RskImpl(Ethereum eth,
+                       RskSystemProperties properties,
+                       MinerClient minerClient,
+                       MinerServer minerServer,
+                       PersonalModule personalModule,
+                       EthModule ethModule) {
+        super(eth, properties, minerClient, minerServer, personalModule, ethModule);
         this.minerServer = minerServer;
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.dto.CompilationResultDTO;
+import org.ethereum.rpc.exception.JsonRpcUnimplementedMethodException;
+import org.ethereum.vm.program.ProgramResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static org.ethereum.rpc.TypeConverter.toJsonHex;
+
+// TODO add all RPC methods
+@Component
+public class EthModule
+    implements EthModuleSolidity, EthModuleWallet {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("web3");
+
+    private final Ethereum eth;
+    private final EthModuleSolidity ethModuleSolidity;
+    private final EthModuleWallet ethModuleWallet;
+
+    @Autowired
+    public EthModule(Ethereum eth, EthModuleSolidity ethModuleSolidity, EthModuleWallet ethModuleWallet) {
+        this.eth = eth;
+        this.ethModuleSolidity = ethModuleSolidity;
+        this.ethModuleWallet = ethModuleWallet;
+    }
+
+    @Override
+    public String[] accounts() {
+        return ethModuleWallet.accounts();
+    }
+
+    public String call(Web3.CallArguments args, String bnOrId) {
+        String s = null;
+        try {
+            if (!"latest".equals(bnOrId)) {
+                throw new JsonRpcUnimplementedMethodException("Method only supports 'latest' as a parameter so far.");
+            }
+
+            ProgramResult res = createCallTxAndExecute(args);
+            return s = toJsonHex(res.getHReturn());
+        } finally {
+            LOGGER.debug("eth_call(): {}" + s);
+        }
+    }
+
+    @Override
+    public Map<String, CompilationResultDTO> compileSolidity(String contract) throws Exception {
+        return ethModuleSolidity.compileSolidity(contract);
+    }
+
+    public String estimateGas(Web3.CallArguments args) {
+        String s = null;
+        try {
+            ProgramResult res = createCallTxAndExecute(args);
+            return s = toJsonHex(res.getGasUsed());
+        } finally {
+            LOGGER.debug("eth_estimateGas(): {}" + s);
+        }
+    }
+
+    @Override
+    public String sendTransaction(Web3.CallArguments args) {
+        return ethModuleWallet.sendTransaction(args);
+    }
+
+    private ProgramResult createCallTxAndExecute(Web3.CallArguments args) {
+        byte[] nonce = new byte[]{0};
+        Transaction tx = Transaction.create(nonce, args);
+
+        // sign with an empty key because we don't need to use a real key for constant calls
+        tx.sign(new byte[32]);
+
+        // TODO inject Blockchain through constructor if necessary
+        Block block = eth.getWorldManager().getBlockchain().getBestBlock();
+
+        return eth.callConstantCallTransaction(tx, block);
+    }
+
+    public String sign(String addr, String data) {
+        return ethModuleWallet.sign(addr, data);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleSolidity.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleSolidity.java
@@ -16,31 +16,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package co.rsk.core;
+package co.rsk.rpc.modules.eth;
 
-import org.ethereum.datasource.KeyValueDataSource;
-import org.ethereum.datasource.LevelDbDataSource;
+import org.ethereum.rpc.dto.CompilationResultDTO;
 
-/**
- * Created by mario on 06/12/16.
- */
-public class WalletFactory {
+import java.util.Map;
 
-    public static Wallet createPersistentWallet() {
-        return createPersistentWallet("wallet");
-    }
+public interface EthModuleSolidity {
 
-    public static Wallet createPersistentWallet(String storeName) {
-        Wallet wallet = new Wallet();
-        KeyValueDataSource ds = new LevelDbDataSource(storeName);
-        ds.init();
-        wallet.setStore(ds);
-        return wallet;
-    }
-
-    public static Wallet createWallet() {
-        return new Wallet();
-    }
-
-
+    Map<String, CompilationResultDTO> compileSolidity(String contract) throws Exception;
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleSolidityDisabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleSolidityDisabled.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import org.ethereum.rpc.dto.CompilationResultDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EthModuleSolidityDisabled implements EthModuleSolidity {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("web3");
+
+    @Override
+    public Map<String, CompilationResultDTO> compileSolidity(String contract) throws Exception {
+        LOGGER.debug("eth_compileSolidity(): Solidity compiler not enabled");
+        return new HashMap<>();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleSolidityEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleSolidityEnabled.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import org.ethereum.core.CallTransaction;
+import org.ethereum.rpc.dto.CompilationInfoDTO;
+import org.ethereum.rpc.dto.CompilationResultDTO;
+import org.ethereum.solidity.compiler.SolidityCompiler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EthModuleSolidityEnabled implements EthModuleSolidity {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("web3");
+
+    private final SolidityCompiler solidityCompiler;
+
+    public EthModuleSolidityEnabled(SolidityCompiler solidityCompiler) {
+        this.solidityCompiler = solidityCompiler;
+    }
+
+    @Override
+    public Map<String, CompilationResultDTO> compileSolidity(String contract) throws Exception {
+        Map<String, CompilationResultDTO> compilationResultDTOMap = new HashMap<>();
+        try {
+            SolidityCompiler.Result res = solidityCompiler.compile(contract.getBytes(StandardCharsets.UTF_8), true, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
+            if (!res.errors.isEmpty()) {
+                throw new RuntimeException("Compilation error: " + res.errors);
+            }
+            org.ethereum.solidity.compiler.CompilationResult result = org.ethereum.solidity.compiler.CompilationResult.parse(res.output);
+            org.ethereum.solidity.compiler.CompilationResult.ContractMetadata contractMetadata = result.contracts.values().iterator().next();
+
+            CompilationInfoDTO compilationInfo = new CompilationInfoDTO();
+            compilationInfo.setSource(contract);
+            compilationInfo.setLanguage("Solidity");
+            compilationInfo.setLanguageVersion("0");
+            compilationInfo.setCompilerVersion(result.version);
+            compilationInfo.setAbiDefinition(new CallTransaction.Contract(contractMetadata.abi));
+
+            CompilationResultDTO compilationResult = new CompilationResultDTO(contractMetadata, compilationInfo);
+            String contractName = (String)result.contracts.keySet().toArray()[0];
+
+            compilationResultDTOMap.put(contractName, compilationResult);
+
+            return compilationResultDTOMap;
+        } finally {
+            LOGGER.debug("eth_compileSolidity(" + contract + ")" + compilationResultDTOMap);
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWallet.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWallet.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import org.ethereum.rpc.Web3;
+
+public interface EthModuleWallet {
+
+    String[] accounts();
+
+    String sendTransaction(Web3.CallArguments args);
+
+    String sign(String addr, String data);
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletDisabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletDisabled.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+public class EthModuleWalletDisabled implements EthModuleWallet {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("web3");
+
+    @Override
+    public String[] accounts() {
+        String[] accounts = {};
+        LOGGER.debug("eth_accounts(): {}", Arrays.toString(accounts));
+        return accounts;
+    }
+
+    @Override
+    public String sendTransaction(Web3.CallArguments args) {
+        LOGGER.debug("eth_sendTransaction({}): {}", args, null);
+        throw new JsonRpcInvalidParamException("Local wallet is disabled in this node");
+    }
+
+    @Override
+    public String sign(String addr, String data) {
+        LOGGER.debug("eth_sign({}, {}): {}", addr, data, null);
+        throw new JsonRpcInvalidParamException("Local wallet is disabled in this node");
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import co.rsk.core.Wallet;
+import org.ethereum.core.Account;
+import org.ethereum.core.PendingState;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
+import org.ethereum.vm.GasCost;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static org.ethereum.rpc.TypeConverter.stringHexToByteArray;
+
+public class EthModuleWalletEnabled implements EthModuleWallet {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("web3");
+
+    private final Ethereum eth;
+    private final Wallet wallet;
+
+    public EthModuleWalletEnabled(Ethereum eth, Wallet wallet) {
+        this.eth = eth;
+        this.wallet = wallet;
+    }
+
+    @Override
+    public String sendTransaction(Web3.CallArguments args) {
+        Account account = this.getAccount(args.from);
+        String s = null;
+        try {
+            if (account == null)
+                throw new JsonRpcInvalidParamException("From address private key could not be found in this node");
+
+            String toAddress = args.to != null ? Hex.toHexString(stringHexToByteArray(args.to)) : null;
+
+            BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
+            BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
+            BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
+
+            if (args.data != null && args.data.startsWith("0x"))
+                args.data = args.data.substring(2);
+
+            // TODO inject PendingState through constructor if necessary
+            PendingState pendingState = eth.getWorldManager().getPendingState();
+            synchronized (pendingState) {
+                BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : (pendingState.getRepository().getNonce(account.getAddress()));
+                Transaction tx = Transaction.create(toAddress, value, accountNonce, gasPrice, gasLimit, args.data);
+                tx.sign(account.getEcKey().getPrivKeyBytes());
+                eth.submitTransaction(tx.toImmutableTransaction());
+                s = TypeConverter.toJsonHex(tx.getHash());
+            }
+            return s;
+        } finally {
+            LOGGER.debug("eth_sendTransaction({}): {}", args, s);
+        }
+    }
+
+    @Override
+    public String sign(String addr, String data) {
+        String s = null;
+        try {
+            Account account = this.wallet.getAccount(stringHexToByteArray(addr));
+            if (account == null)
+                throw new JsonRpcInvalidParamException("Account not found");
+
+            return s = this.sign(data, account.getEcKey());
+        } finally {
+            LOGGER.debug("eth_sign({}, {}): {}", addr, data, s);
+        }
+    }
+
+    @Override
+    public String[] accounts() {
+        String[] s = null;
+        try {
+            return s = wallet.getAccountAddressesAsHex();
+        } finally {
+            LOGGER.debug("eth_accounts(): " + Arrays.toString(s));
+        }
+    }
+
+    private Account getAccount(String address) {
+        return this.wallet.getAccount(stringHexToByteArray(address));
+    }
+
+    private String sign(String data, ECKey ecKey) {
+        byte[] dataHash = TypeConverter.stringHexToByteArray(data);
+        ECKey.ECDSASignature signature = ecKey.sign(dataHash);
+
+        String signatureAsString = signature.r.toString() + signature.s.toString() + signature.v;
+
+        return TypeConverter.toJsonHex(signatureAsString);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModule.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.personal;
+
+import co.rsk.config.RskSystemProperties;
+import org.ethereum.rpc.Web3;
+
+public interface PersonalModule {
+    String dumpRawKey(String address) throws Exception;
+
+    String importRawKey(String key, String passphrase);
+
+    void init(RskSystemProperties properties);
+
+    String[] listAccounts();
+
+    boolean lockAccount(String address);
+
+    String newAccountWithSeed(String seed);
+
+    String newAccount(String passphrase);
+
+    String sendTransaction(Web3.CallArguments args, String passphrase) throws Exception;
+
+    boolean unlockAccount(String address, String passphrase, String duration);
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletDisabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletDisabled.java
@@ -19,7 +19,7 @@
 package co.rsk.rpc.modules.personal;
 
 import co.rsk.config.RskSystemProperties;
-import co.rsk.core.DisabledWalletException;
+import org.ethereum.rpc.exception.DisabledWalletException;
 import org.ethereum.rpc.Web3;
 
 public class PersonalModuleWalletDisabled implements PersonalModule {

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletDisabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletDisabled.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.personal;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.DisabledWalletException;
+import org.ethereum.rpc.Web3;
+
+public class PersonalModuleWalletDisabled implements PersonalModule {
+    @Override
+    public void init(RskSystemProperties properties) {
+        // Init steps are only needed when using a wallet.
+        // This method is called from Web3Impl even if the wallet is disabled,
+        // so we don't throw here.
+    }
+
+    @Override
+    public String newAccountWithSeed(String seed) {
+        throw new DisabledWalletException();
+    }
+
+    @Override
+    public String newAccount(String passphrase) {
+        throw new DisabledWalletException();
+    }
+
+    @Override
+    public String[] listAccounts() {
+        throw new DisabledWalletException();
+    }
+
+    @Override
+    public String importRawKey(String key, String passphrase) {
+        throw new DisabledWalletException();
+    }
+
+    @Override
+    public String sendTransaction(Web3.CallArguments args, String passphrase) {
+        throw new DisabledWalletException();
+    }
+
+    @Override
+    public boolean unlockAccount(String address, String passphrase, String duration) {
+        throw new DisabledWalletException();
+    }
+
+    @Override
+    public boolean lockAccount(String address) {
+        throw new DisabledWalletException();
+    }
+
+    @Override
+    public String dumpRawKey(String address) {
+        throw new DisabledWalletException();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -1,0 +1,196 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.personal;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.config.WalletAccount;
+import co.rsk.core.Wallet;
+import org.ethereum.config.blockchain.RegTestConfig;
+import org.ethereum.core.Account;
+import org.ethereum.core.Transaction;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
+import org.ethereum.vm.GasCost;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+public class PersonalModuleWalletEnabled implements PersonalModule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("web3");
+
+    private final Ethereum eth;
+    private final Wallet wallet;
+
+    public PersonalModuleWalletEnabled(Ethereum eth, Wallet wallet) {
+        this.eth = eth;
+        this.wallet = wallet;
+    }
+
+    @Override
+    public void init(RskSystemProperties properties) {
+        if (properties.getBlockchainConfig() instanceof RegTestConfig) {
+            newAccountWithSeed("cow");
+        }
+
+        // This creates a new account based on a configured secret passphrase,
+        // which is then used to set the current miner coinbase address.
+        // Generally used for testing, since you usually don't want to store
+        // wallets in production for security reasons.
+        Account coinbaseAccount = properties.localCoinbaseAccount();
+        if (coinbaseAccount != null) {
+            this.wallet.addAccount(coinbaseAccount);
+        }
+
+        // initializes wallet accounts based on configuration
+        for (WalletAccount acc : properties.walletAccounts()) {
+            this.wallet.addAccountWithPrivateKey(Hex.decode(acc.getPrivateKey()));
+        }
+    }
+
+    @Override
+    public String newAccountWithSeed(String seed) {
+        String s = null;
+        try {
+            byte[] address = this.wallet.addAccountWithSeed(seed);
+            return s = TypeConverter.toJsonHex(address);
+        } finally {
+            LOGGER.debug("personal_newAccountWithSeed(*****): {}", s);
+        }
+    }
+
+    @Override
+    public String newAccount(String passphrase) {
+        String s = null;
+        try {
+            byte[] address = this.wallet.addAccount(passphrase);
+            return s = TypeConverter.toJsonHex(address);
+        } finally {
+            LOGGER.debug("personal_newAccount(*****): {}", s);
+        }
+    }
+
+    @Override
+    public String[] listAccounts() {
+        String[] ret = null;
+        try {
+            return ret = wallet.getAccountAddressesAsHex();
+        } finally {
+            LOGGER.debug("personal_listAccounts(): {}", Arrays.toString(ret));
+        }
+    }
+
+    @Override
+    public String importRawKey(String key, String passphrase) {
+        String s = null;
+        try {
+            byte[] address = this.wallet.addAccountWithPrivateKey(Hex.decode(key), passphrase);
+            return s = TypeConverter.toJsonHex(address);
+        } finally {
+            LOGGER.debug("personal_importRawKey(*****): {}", s);
+        }
+    }
+
+    @Override
+    public String sendTransaction(Web3.CallArguments args, String passphrase) throws Exception {
+        String s = null;
+        try {
+            return s = sendTransaction(args, getAccount(args.from, passphrase));
+        } finally {
+            LOGGER.debug("eth_sendTransaction(" + args + "): " + s);
+        }
+    }
+
+    @Override
+    public boolean unlockAccount(String address, String passphrase, String duration) {
+        long dur = (long) 1000 * 60 * 30;
+        if (duration != null && duration.length() > 0) {
+            try {
+                dur = convertFromJsonHexToLong(duration);
+            } catch (Exception e) {
+                throw new JsonRpcInvalidParamException("Can't parse duration param", e);
+            }
+        }
+
+        return this.wallet.unlockAccount(TypeConverter.stringHexToByteArray(address), passphrase, dur);
+    }
+
+    @Override
+    public boolean lockAccount(String address) {
+        return this.wallet.lockAccount(TypeConverter.stringHexToByteArray(address));
+    }
+
+    @Override
+    public String dumpRawKey(String address) throws Exception {
+        String s = null;
+        try {
+            Account account = wallet.getAccount(TypeConverter.stringHexToByteArray(convertFromJsonHexToHex(address)));
+            if (account == null)
+                throw new Exception("Address private key is locked or could not be found in this node");
+
+            return s = TypeConverter.toJsonHex(Hex.toHexString(account.getEcKey().getPrivKeyBytes()));
+        } finally {
+            LOGGER.debug("personal_dumpRawKey(*****): {}", s);
+        }
+    }
+
+    private Account getAccount(String from, String passphrase) {
+        return wallet.getAccount(TypeConverter.stringHexToByteArray(from), passphrase);
+    }
+
+    private String sendTransaction(Web3.CallArguments args, Account account) throws Exception {
+        if (account == null)
+            throw new Exception("From address private key could not be found in this node");
+
+        String toAddress = args.to != null ? Hex.toHexString(TypeConverter.stringHexToByteArray(args.to)) : null;
+
+        BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : (eth.getWorldManager().getPendingState().getRepository().getNonce(account.getAddress()));
+        BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
+        BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
+        BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION);
+
+        if (args.data != null && args.data.startsWith("0x"))
+            args.data = args.data.substring(2);
+
+        Transaction tx = Transaction.create(toAddress, value, accountNonce, gasPrice, gasLimit, args.data);
+
+        tx.sign(account.getEcKey().getPrivKeyBytes());
+
+        eth.submitTransaction(tx);
+
+        return TypeConverter.toJsonHex(tx.getHash());
+    }
+
+    private String convertFromJsonHexToHex(String x) throws Exception {
+        if (!x.startsWith("0x"))
+            throw new Exception("Incorrect hex syntax");
+        return x.substring(2);
+    }
+
+    private long convertFromJsonHexToLong(String x) throws Exception {
+        if (!x.startsWith("0x"))
+            throw new Exception("Incorrect hex syntax");
+        return Long.parseLong(x.substring(2), 16);
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -40,7 +40,6 @@ import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.LevelDbDataSource;
 import org.ethereum.db.*;
 import org.ethereum.net.rlpx.Node;
-import org.ethereum.solidity.compiler.SolidityCompiler;
 import org.ethereum.util.FileUtil;
 import org.ethereum.validator.ProofOfWorkRule;
 import org.mapdb.DB;
@@ -241,11 +240,5 @@ public class DefaultConfig {
         PeerExplorer peerExplorer = appCtx.getBean(PeerExplorer.class);
         RskSystemProperties rskConfig = RskSystemProperties.CONFIG;
         return new UDPServer(rskConfig.bindIp(), rskConfig.listenPort(), peerExplorer);
-    }
-
-    @Bean
-    public SolidityCompiler solidityCompiler() {
-        RskSystemProperties rskConfig = RskSystemProperties.CONFIG;
-        return new SolidityCompiler(rskConfig);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/rskj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -28,7 +28,6 @@ import org.ethereum.db.BlockStore;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.client.ConfigCapabilities;
 import org.ethereum.net.server.ChannelManager;
-import org.ethereum.solidity.compiler.SolidityCompiler;
 
 /**
  * WorldManager is a singleton containing references to different parts of the system.
@@ -64,5 +63,4 @@ public interface WorldManager {
 
     NetworkStateExporter getNetworkStateExporter();
 
-    SolidityCompiler getSolidityCompiler();
 }

--- a/rskj-core/src/main/java/org/ethereum/manager/WorldManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/manager/WorldManagerImpl.java
@@ -33,7 +33,6 @@ import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.NodeManager;
 import org.ethereum.net.client.ConfigCapabilities;
 import org.ethereum.net.server.ChannelManager;
-import org.ethereum.solidity.compiler.SolidityCompiler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -91,9 +90,6 @@ public class WorldManagerImpl implements WorldManager {
 
     @Autowired
     private NetworkStateExporter networkStateExporter;
-
-    @Autowired
-    private SolidityCompiler solidityCompiler;
 
     @Override
     @PostConstruct
@@ -154,11 +150,6 @@ public class WorldManagerImpl implements WorldManager {
     @Override
     public NetworkStateExporter getNetworkStateExporter() {
         return networkStateExporter;
-    }
-
-    @Override
-    public SolidityCompiler getSolidityCompiler() {
-        return this.solidityCompiler;
     }
 
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -18,29 +18,23 @@
 
 package org.ethereum.rpc;
 
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Rsk;
 import co.rsk.core.SnapshotManager;
 import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerManager;
 import co.rsk.mine.MinerServer;
-import co.rsk.peg.Bridge;
-import co.rsk.rpc.ModuleDescription;
-import com.google.common.annotations.VisibleForTesting;
-import co.rsk.config.RskSystemProperties;
-import co.rsk.config.WalletAccount;
-import co.rsk.core.Wallet;
 import co.rsk.net.BlockProcessor;
+import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeState;
 import co.rsk.peg.BridgeStateReader;
-import co.rsk.rpc.modules.PersonalModule;
+import co.rsk.rpc.ModuleDescription;
+import co.rsk.rpc.modules.eth.EthModule;
+import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.scoring.InvalidInetAddressException;
 import co.rsk.scoring.PeerScoringInformation;
 import co.rsk.scoring.PeerScoringManager;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.map.HashedMap;
-import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.*;
-import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockInformation;
 import org.ethereum.db.TransactionInfo;
@@ -52,16 +46,13 @@ import org.ethereum.manager.WorldManager;
 import org.ethereum.net.client.Capability;
 import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
-import org.ethereum.rpc.dto.CompilationInfoDTO;
 import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
 import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
 import org.ethereum.rpc.exception.JsonRpcUnimplementedMethodException;
-import org.ethereum.solidity.compiler.SolidityCompiler;
 import org.ethereum.util.BuildInfo;
 import org.ethereum.vm.DataWord;
-import org.ethereum.vm.GasCost;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
@@ -101,52 +92,27 @@ public class Web3Impl implements Web3 {
 
     private final Object filterLock = new Object();
 
-    private Wallet wallet;
-
     private MinerClient minerClient;
     private MinerServer minerServer;
-
-    private SolidityCompiler solidityCompiler;
 
     private PeerScoringManager peerScoringManager;
 
     private PersonalModule personalModule;
+    private EthModule ethModule;
 
-    // Kept for testing purposes
-    public Web3Impl(SolidityCompiler compiler, Wallet wallet) {
-        this(compiler, wallet, null);
-    }
-
-    // Kept for testing purposes
-    public Web3Impl(SolidityCompiler compiler, Wallet wallet, Ethereum eth) {
-        this.solidityCompiler = compiler;
-        this.wallet = wallet;
-        this.eth = eth;
-        this.personalModule = new PersonalModule(eth, wallet);
-    }
-
-    // Create with default modules, but we expect to inject them in the future
-    public Web3Impl(Ethereum eth,
-                    RskSystemProperties properties,
-                    Wallet wallet,
-                    MinerClient minerClient,
-                    MinerServer minerServer) {
-        this(eth, properties, wallet, minerClient, minerServer, new PersonalModule(eth, wallet));
-    }
-
-    public Web3Impl(Ethereum eth,
-                    RskSystemProperties properties,
-                    Wallet wallet,
-                    MinerClient minerClient,
-                    MinerServer minerServer,
-                    PersonalModule personalModule) {
+    protected Web3Impl(Ethereum eth,
+                       RskSystemProperties properties,
+                       MinerClient minerClient,
+                       MinerServer minerServer,
+                       PersonalModule personalModule,
+                       EthModule ethModule) {
         this.eth = eth;
         this.worldManager = eth.getWorldManager();
         this.repository = eth.getRepository();
-        this.wallet = wallet;
         this.minerClient = minerClient;
         this.minerServer = minerServer;
         this.personalModule = personalModule;
+        this.ethModule = ethModule;
 
         if (eth instanceof Rsk)
             this.peerScoringManager = ((Rsk) eth).getPeerScoringManager();
@@ -155,28 +121,10 @@ public class Web3Impl implements Web3 {
 
         compositeEthereumListener = new CompositeEthereumListener();
 
-        this.solidityCompiler = this.worldManager.getSolidityCompiler();
-
         compositeEthereumListener.addListener(this.setupListener());
 
         this.eth.addListener(compositeEthereumListener);
-
-        // TODO adding default accounts, just so that integration tests pass
-        if (properties.getBlockchainConfig() instanceof RegTestConfig) {
-            personal_newAccountWithSeed("cow");
-        }
-
-        // This creates a new account based on a configured secret passphrase,
-        // which is then used to set the current miner coinbase address.
-        // Generally used for testing, since you usually don't want to store
-        // wallets in production for security reasons.
-        Account coinbaseAccount = properties.localCoinbaseAccount();
-        if (coinbaseAccount != null)
-            personal_newAccount(coinbaseAccount);
-
-        // initializes wallet accounts based on configuration
-        for (WalletAccount acc : properties.walletAccounts())
-            this.wallet.addAccountWithPrivateKey(Hex.decode(acc.getPrivateKey()));
+        personalModule.init(properties);
     }
 
     public EthereumListener setupListener() {
@@ -226,25 +174,6 @@ public class Web3Impl implements Web3 {
             throw new Exception("Incorrect hex syntax");
         x = x.substring(2);
         return x;
-    }
-
-    public String[] toJsonHexArray(Collection<String> c) {
-        String[] arr = new String[c.size()];
-        int i = 0;
-        for (String item : c) {
-            arr[i++] = toJsonHex(item);
-        }
-        return arr;
-    }
-
-    public String[] listObjectHashtoJsonHexArray(Collection<SerializableObject> c) {
-        String[] arr = new String[c.size()];
-        int i = 0;
-        for (SerializableObject item : c) {
-            // Todo: Which hash is required? RawHash or Hash ?
-            arr[i++] = toJsonHex(item.getHash());
-        }
-        return arr;
     }
 
     public String web3_clientVersion() {
@@ -431,14 +360,7 @@ public class Web3Impl implements Web3 {
     }
 
     public String[] eth_accounts() {
-        String[] s = null;
-        try {
-            return s = personal_listAccounts();
-        } finally {
-            if (logger.isDebugEnabled()) {
-                logger.debug("eth_accounts(): " + Arrays.toString(s));
-            }
-        }
+        return ethModule.accounts();
     }
 
     public String eth_blockNumber() {
@@ -614,60 +536,11 @@ public class Web3Impl implements Web3 {
     }
 
     public String eth_sign(String addr, String data) throws Exception {
-        String s = null;
-        try {
-            return s = this.sign(data, getAccount(JSonHexToHex(addr)));
-        } finally {
-            if (logger.isDebugEnabled())
-                logger.debug("eth_sign({}, {}): {}", addr, data, s);
-        }
-    }
-
-    private String sign(String data, Account account) {
-        if (account == null)
-            throw new JsonRpcInvalidParamException("Account not found");
-
-        byte[] dataHash = TypeConverter.stringHexToByteArray(data);
-        ECKey.ECDSASignature signature = account.getEcKey().sign(dataHash);
-
-        String signatureAsString = signature.r.toString() + signature.s.toString() + signature.v;
-
-        // byte[] rlpSig = RLP.encode(signature);
-        return TypeConverter.toJsonHex(signatureAsString);
+        return ethModule.sign(addr, data);
     }
 
     public String eth_sendTransaction(CallArguments args) throws Exception {
-        return this.sendTransaction(args, this.getAccount(args.from));
-    }
-
-    private String sendTransaction(CallArguments args, Account account) throws Exception {
-        String s = null;
-        try {
-            if (account == null)
-                throw new JsonRpcInvalidParamException("From address private key could not be found in this node");
-
-            String toAddress = args.to != null ? Hex.toHexString(stringHexToByteArray(args.to)) : null;
-
-            BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
-            BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
-            BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
-
-            if (args.data != null && args.data.startsWith("0x"))
-                args.data = args.data.substring(2);
-
-            PendingState pendingState = worldManager.getPendingState();
-            synchronized (pendingState) {
-                BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : (pendingState.getRepository().getNonce(account.getAddress()));
-                Transaction tx = Transaction.create(toAddress, value, accountNonce, gasPrice, gasLimit, args.data);
-                tx.sign(account.getEcKey().getPrivKeyBytes());
-                eth.submitTransaction(tx.toImmutableTransaction());
-                s = TypeConverter.toJsonHex(tx.getHash());
-            }
-            return s;
-        } finally {
-            if (logger.isDebugEnabled())
-                logger.debug("eth_sendTransaction({}): {}", args, s);
-        }
+        return this.ethModule.sendTransaction(args);
     }
 
     public String eth_sendRawTransaction(String rawData) throws Exception {
@@ -705,16 +578,11 @@ public class Web3Impl implements Web3 {
     }
 
     public String eth_call(CallArguments args, String bnOrId) throws Exception {
-        if (!bnOrId.equals("latest"))
-            throw new JsonRpcUnimplementedMethodException("Method only supports 'latest' as a parameter so far.");
-
-        ProgramResult res = createCallTxAndExecute(args, this.getKeyToSign(args.from));
-        return toJsonHex(res.getHReturn());
+        return ethModule.call(args, bnOrId);
     }
 
     public String eth_estimateGas(CallArguments args) throws Exception {
-        ProgramResult res = createCallTxAndExecute(args, this.getKeyToSign(args.from));
-        return toJsonHex(res.getGasUsed());
+        return ethModule.estimateGas(args);
     }
 
     public BlockInformationResult getBlockInformationResult(BlockInformation blockInformation) {
@@ -981,32 +849,7 @@ public class Web3Impl implements Web3 {
 
     @Override
     public Map<String, CompilationResultDTO> eth_compileSolidity(String contract) throws Exception {
-        Map<String, CompilationResultDTO> compilationResultDTOMap = new HashedMap<>();
-        try {
-            SolidityCompiler.Result res = solidityCompiler.compile(contract.getBytes(StandardCharsets.UTF_8), true, SolidityCompiler.Options.ABI, SolidityCompiler.Options.BIN);
-            if (!res.errors.isEmpty()) {
-                throw new RuntimeException("Compilation error: " + res.errors);
-            }
-            org.ethereum.solidity.compiler.CompilationResult result = org.ethereum.solidity.compiler.CompilationResult.parse(res.output);
-            org.ethereum.solidity.compiler.CompilationResult.ContractMetadata contractMetadata = result.contracts.values().iterator().next();
-
-            CompilationInfoDTO compilationInfo = new CompilationInfoDTO();
-            compilationInfo.setSource(contract);
-            compilationInfo.setLanguage("Solidity");
-            compilationInfo.setLanguageVersion("0");
-            compilationInfo.setCompilerVersion(result.version);
-            compilationInfo.setAbiDefinition(new CallTransaction.Contract(contractMetadata.abi));
-
-            CompilationResultDTO compilationResult = new CompilationResultDTO(contractMetadata, compilationInfo);
-            String contractName = (String)result.contracts.keySet().toArray()[0];
-
-            compilationResultDTOMap.put(contractName, compilationResult);
-
-            return compilationResultDTOMap;
-        } finally {
-            if (logger.isDebugEnabled())
-                logger.debug("eth_compileSolidity(" + contract + ")" + compilationResultDTOMap);
-        }
+        return ethModule.compileSolidity(contract);
     }
 
     @Override
@@ -1404,16 +1247,6 @@ public class Web3Impl implements Web3 {
         }
     }
 
-    private void personal_newAccount(Account account) {
-        try {
-            this.wallet.addAccount(account);
-        } finally {
-            if (logger.isDebugEnabled()) {
-                logger.debug("personal_newAccount(*****): " + toJsonHex(account.getAddress()));
-            }
-        }
-    }
-
     @Override
     public String personal_newAccountWithSeed(String seed) {
         return personalModule.newAccountWithSeed(seed);
@@ -1464,38 +1297,6 @@ public class Web3Impl implements Web3 {
         ProgramResult res = createCallTxAndExecute(arguments, new byte[32]);
         BridgeState state = BridgeStateReader.readSate(TypeConverter.removeZeroX(toJsonHex(res.getHReturn())));
         return state.stateToMap();
-    }
-
-    private Account getDefaultAccount() {
-        List<byte[]> accountAddresses = this.wallet.getAccountAddresses();
-
-        if (!CollectionUtils.isEmpty(accountAddresses)) {
-            return this.wallet.getAccount(accountAddresses.get(0));
-        }
-
-        return null;
-    }
-
-    @VisibleForTesting
-    public Account getAccount(String address) {
-        return this.wallet.getAccount(stringHexToByteArray(address));
-    }
-
-    @VisibleForTesting
-    public Account getAccount(String address, String passphrase) {
-        return this.wallet.getAccount(stringHexToByteArray(address), passphrase);
-    }
-
-    private byte[] getKeyToSign(String address) {
-        byte[] privateKey = new byte[32];
-
-        Account account;
-        account = (address != null) ? this.wallet.getAccount(stringHexToByteArray(address)) : this.getDefaultAccount();
-
-        if (account != null)
-            privateKey = account.getEcKey().getPrivKeyBytes();
-
-        return privateKey;
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/DisabledWalletException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/DisabledWalletException.java
@@ -16,10 +16,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package co.rsk.core;
+package org.ethereum.rpc.exception;
 
-public class DisabledWalletException extends RuntimeException {
+public class DisabledWalletException extends RskJsonRpcRequestException {
+
+    private static final Integer ERROR_CODE = -32604;
+
     public DisabledWalletException() {
-        super("The local wallet feature is disabled");
+        super(ERROR_CODE, "The local wallet feature is disabled");
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/WalletFactory.java
+++ b/rskj-core/src/test/java/co/rsk/core/WalletFactory.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.core;
+
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.LevelDbDataSource;
+
+public class WalletFactory {
+
+    public static Wallet createPersistentWallet(String storeName) {
+        KeyValueDataSource ds = new LevelDbDataSource(storeName);
+        ds.init();
+        return new Wallet(ds);
+    }
+
+    public static Wallet createWallet() {
+        return new Wallet(new HashMapDB());
+    }
+
+}

--- a/rskj-core/src/test/java/co/rsk/core/WalletTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/WalletTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class WalletTest {
     @Test
     public void getEmptyAccountList() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         List<byte[]> addresses = wallet.getAccountAddresses();
 
@@ -42,7 +42,7 @@ public class WalletTest {
 
     @Test
     public void addAccountWithSeed() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         byte[] address = wallet.addAccountWithSeed("seed");
 
@@ -66,7 +66,7 @@ public class WalletTest {
 
     @Test
     public void addAccountWithPassphrase() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         byte[] address = wallet.addAccount("passphrase");
 
@@ -91,7 +91,7 @@ public class WalletTest {
 
     @Test
     public void unlockAccountWithPassphrase() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         byte[] address = wallet.addAccount("passphrase");
 
@@ -122,14 +122,14 @@ public class WalletTest {
 
     @Test
     public void unlockNonexistentAccount() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         Assert.assertFalse(wallet.unlockAccount(new byte[] { 0x01, 0x02, 0x03 }, "passphrase"));
     }
 
     @Test
     public void lockAccount() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         byte[] address = wallet.addAccount("passphrase");
 
@@ -151,14 +151,14 @@ public class WalletTest {
 
     @Test
     public void lockNonexistentAccount() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         Assert.assertFalse(wallet.lockAccount(new byte[] { 0x01, 0x02, 0x03 }));
     }
 
     @Test
     public void addAccountWithRandomPrivateKey() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         byte[] address = wallet.addAccount();
 
@@ -173,7 +173,7 @@ public class WalletTest {
 
     @Test
     public void getUnknownAccount() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
 
         Account account = wallet.getAccount(new byte[] { 0x01, 0x02, 0x03 });
 
@@ -182,7 +182,7 @@ public class WalletTest {
 
     @Test
     public void addAccountWithPrivateKey() {
-        Wallet wallet = new Wallet();
+        Wallet wallet = WalletFactory.createWallet();
         byte[] privateKeyBytes = SHA3Helper.sha3("seed".getBytes());
 
         byte[] address = wallet.addAccountWithPrivateKey(privateKeyBytes);

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -18,7 +18,11 @@
 
 package co.rsk.rpc;
 
+import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
+import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.Web3Impl;
+import org.ethereum.rpc.Web3Mocks;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,7 +34,9 @@ import java.util.Map;
 public class Web3ImplRpcTest {
     @Test
     public void getRpcModules() {
-        Web3Impl web3 = new Web3Impl(null, null);
+        Ethereum eth = Web3Mocks.getMockEthereum();
+        PersonalModule pm = new PersonalModuleWalletDisabled();
+        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -23,7 +23,6 @@ import co.rsk.mine.MinerServer;
 import co.rsk.peg.PegTestUtils;
 import co.rsk.core.NetworkStateExporter;
 import co.rsk.core.Rsk;
-import co.rsk.core.Wallet;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Transaction;
@@ -65,7 +64,7 @@ public class Web3RskImplTest {
         Mockito.when(blockchain.getBestBlock()).thenReturn(block);
         Mockito.when(rsk.getWorldManager()).thenReturn(worldManager);
 
-        Web3RskImpl web3 = new Web3RskImpl(rsk, Mockito.mock(MinerServer.class), Mockito.mock(MinerClient.class));
+        Web3RskImpl web3 = new Web3RskImpl(rsk, Mockito.mock(MinerClient.class), Mockito.mock(MinerServer.class));
         web3.ext_dumpState();
     }
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -18,11 +18,17 @@
 
 package co.rsk.rpc;
 
-import co.rsk.mine.MinerClient;
-import co.rsk.mine.MinerServer;
-import co.rsk.peg.PegTestUtils;
 import co.rsk.core.NetworkStateExporter;
 import co.rsk.core.Rsk;
+import co.rsk.core.WalletFactory;
+import co.rsk.peg.PegTestUtils;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.Wallet;
+import co.rsk.rpc.modules.eth.EthModule;
+import co.rsk.rpc.modules.eth.EthModuleSolidityDisabled;
+import co.rsk.rpc.modules.eth.EthModuleWalletEnabled;
+import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.personal.PersonalModuleWalletEnabled;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Transaction;
@@ -30,6 +36,7 @@ import org.ethereum.db.BlockStore;
 import org.ethereum.manager.WorldManager;
 import org.ethereum.rpc.LogFilterElement;
 import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.Web3Mocks;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.junit.Test;
@@ -64,7 +71,10 @@ public class Web3RskImplTest {
         Mockito.when(blockchain.getBestBlock()).thenReturn(block);
         Mockito.when(rsk.getWorldManager()).thenReturn(worldManager);
 
-        Web3RskImpl web3 = new Web3RskImpl(rsk, Mockito.mock(MinerClient.class), Mockito.mock(MinerServer.class));
+        Wallet wallet = WalletFactory.createWallet();
+        PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
+        EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
+        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em);
         web3.ext_dumpState();
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
@@ -51,6 +51,14 @@ public class SimpleEthereum implements Ethereum {
     public WorldManager worldManager;
     public Repository repository;
 
+    public SimpleEthereum() {
+        this(null);
+    }
+
+    public SimpleEthereum(SimpleWorldManager worldManager) {
+        this.worldManager = worldManager;
+    }
+
     @Override
     public void connect(InetAddress addr, int port, String remoteId) {
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleWorldManager.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleWorldManager.java
@@ -30,7 +30,6 @@ import org.ethereum.listener.EthereumListener;
 import org.ethereum.manager.WorldManager;
 import org.ethereum.net.client.ConfigCapabilities;
 import org.ethereum.net.server.ChannelManager;
-import org.ethereum.solidity.compiler.SolidityCompiler;
 
 /**
  * Created by Ruben Altman on 09/06/2016.
@@ -43,12 +42,14 @@ public class SimpleWorldManager implements WorldManager {
     BlockStore blockStore;
     EthereumListener listener;
 
-    public SimpleWorldManager() {
-        this(null);
-    }
+    public SimpleWorldManager() { }
 
     public SimpleWorldManager(SimpleBlockProcessor nodeBlockProcessor) {
         this.nodeBlockProcessor = nodeBlockProcessor;
+    }
+
+    public SimpleWorldManager(PendingState pendingState) {
+        this.pendingState = pendingState;
     }
 
     @Override
@@ -136,8 +137,4 @@ public class SimpleWorldManager implements WorldManager {
         return null;
     }
 
-    @Override
-    public SolidityCompiler getSolidityCompiler() {
-        return null;
-    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -19,22 +19,27 @@
 package org.ethereum.rpc;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.core.bc.PendingStateImpl;
-import co.rsk.mine.MinerClient;
-import co.rsk.mine.MinerServer;
+import co.rsk.rpc.Web3RskImpl;
+import co.rsk.rpc.modules.eth.EthModule;
+import co.rsk.rpc.modules.eth.EthModuleSolidityDisabled;
+import co.rsk.rpc.modules.eth.EthModuleWalletEnabled;
+import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.personal.PersonalModuleWalletEnabled;
 import co.rsk.test.World;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import org.ethereum.core.*;
+import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.Repository;
-import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.Simples.SimpleEthereum;
 import org.ethereum.rpc.Simples.SimpleWorldManager;
+import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
@@ -82,7 +87,7 @@ public class Web3ImplLogsTest {
         SimpleEthereum eth = new SimpleEthereum();
         eth.repository = (Repository) world.getBlockChain().getRepository();
         eth.worldManager = worldManager;
-        Web3Impl web3 = new Web3Impl(eth, RskSystemProperties.CONFIG, WalletFactory.createWallet(), Mockito.mock(MinerClient.class), Mockito.mock(MinerServer.class));
+        Web3Impl web3 = createWeb3(eth, WalletFactory.createPersistentWallet("wallet"));
 
         // TODO tricky link to listener
         world.getBlockChain().setListener(web3.setupListener());
@@ -289,7 +294,7 @@ public class Web3ImplLogsTest {
         SimpleEthereum eth = new SimpleEthereum();
         eth.repository = (Repository) world.getBlockChain().getRepository();
         eth.worldManager = worldManager;
-        Web3Impl web3 = new Web3Impl(eth, RskSystemProperties.CONFIG, WalletFactory.createPersistentWallet("testwallet"), Mockito.mock(MinerClient.class), Mockito.mock(MinerServer.class));
+        Web3Impl web3 = createWeb3(eth, WalletFactory.createPersistentWallet("testwallet"));
 
         // TODO tricky link to listener
         world.getBlockChain().setListener(web3.setupListener());
@@ -330,7 +335,7 @@ public class Web3ImplLogsTest {
         SimpleEthereum eth = new SimpleEthereum();
         eth.repository = (Repository) world.getBlockChain().getRepository();
         eth.worldManager = worldManager;
-        Web3Impl web3 = new Web3Impl(eth, RskSystemProperties.CONFIG, WalletFactory.createPersistentWallet("testwallet2"), Mockito.mock(MinerClient.class), Mockito.mock(MinerServer.class));
+        Web3Impl web3 = createWeb3(eth, WalletFactory.createPersistentWallet("testwallet2"));
 
         // TODO tricky link to listener
         world.getBlockChain().setListener(web3.setupListener());
@@ -387,7 +392,7 @@ public class Web3ImplLogsTest {
         SimpleEthereum eth = new SimpleEthereum();
         eth.repository = (Repository) world.getBlockChain().getRepository();
         eth.worldManager = worldManager;
-        Web3Impl web3 = new Web3Impl(eth, RskSystemProperties.CONFIG, WalletFactory.createPersistentWallet("testwallet3"), Mockito.mock(MinerClient.class), Mockito.mock(MinerServer.class));
+        Web3Impl web3 = createWeb3(eth, WalletFactory.createPersistentWallet("testwallet3"));
 
         // TODO tricky link to listener
         world.getBlockChain().setListener(web3.setupListener());
@@ -438,9 +443,19 @@ public class Web3ImplLogsTest {
         }
     }
 
+    private Web3Impl createWeb3() {
+        return createWeb3(Web3Mocks.getMockEthereum(), WalletFactory.createWallet());
+    }
+
+    private Web3Impl createWeb3(Ethereum eth, Wallet wallet) {
+        PersonalModule personalModule = new PersonalModuleWalletEnabled(eth, wallet);
+        EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
+        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule);
+    }
+
     private Web3Impl getWeb3() {
         World world = new World();
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         Account acc1 = new AccountBuilder(world).name("notDefault").balance(BigInteger.valueOf(10000000)).build();
 
         Block genesis = world.getBlockByName("g00");
@@ -454,7 +469,7 @@ public class Web3ImplLogsTest {
 
     private Web3Impl getWeb3WithThreeEmptyBlocks() {
         World world = new World();
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         Account acc1 = new AccountBuilder(world).name("notDefault").balance(BigInteger.valueOf(10000000)).build();
 
         Block genesis = world.getBlockByName("g00");
@@ -501,7 +516,7 @@ public class Web3ImplLogsTest {
         Block block1 = new BlockBuilder(world).parent(genesis).transactions(txs).build();
         world.getBlockChain().tryToConnect(block1);
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.personal_newAccountWithSeed("notDefault");
 
         web3.repository = (Repository) world.getBlockChain().getRepository();
@@ -526,7 +541,7 @@ public class Web3ImplLogsTest {
         Block block1 = new BlockBuilder(world).parent(genesis).transactions(txs).build();
         world.getBlockChain().tryToConnect(block1);
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.personal_newAccountWithSeed("notDefault");
 
         web3.repository = (Repository) world.getBlockChain().getRepository();
@@ -560,7 +575,7 @@ public class Web3ImplLogsTest {
         Block block2 = new BlockBuilder(world).parent(block1).transactions(tx2s).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block2));
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.personal_newAccountWithSeed("default");
         web3.personal_newAccountWithSeed("notDefault");
 
@@ -601,7 +616,7 @@ public class Web3ImplLogsTest {
         Block block3 = new BlockBuilder(world).parent(block2).transactions(tx3s).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block3));
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.personal_newAccountWithSeed("default");
         web3.personal_newAccountWithSeed("notDefault");
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -20,9 +20,14 @@ package org.ethereum.rpc;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Wallet;
-import co.rsk.mine.MinerClient;
-import co.rsk.mine.MinerServer;
+import co.rsk.core.WalletFactory;
 import co.rsk.net.NodeID;
+import co.rsk.rpc.Web3RskImpl;
+import co.rsk.rpc.modules.eth.EthModule;
+import co.rsk.rpc.modules.eth.EthModuleSolidityDisabled;
+import co.rsk.rpc.modules.eth.EthModuleWalletEnabled;
+import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.personal.PersonalModuleWalletEnabled;
 import co.rsk.scoring.EventType;
 import co.rsk.scoring.PeerScoringInformation;
 import co.rsk.scoring.PeerScoringManager;
@@ -33,7 +38,6 @@ import org.ethereum.rpc.Simples.SimpleWorldManager;
 import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.spongycastle.util.encoders.Hex;
 
 import java.net.InetAddress;
@@ -315,9 +319,10 @@ public class Web3ImplScoringTest {
         worldManager.setBlockchain(world.getBlockChain());
         rsk.worldManager = worldManager;
 
-        Web3Impl web3 = new Web3Impl(rsk, RskSystemProperties.CONFIG, new Wallet(), Mockito.mock(MinerClient.class), Mockito.mock(MinerServer.class));
-
-        return web3;
+        Wallet wallet = WalletFactory.createWallet();
+        PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
+        EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
+        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em);
     }
 
     private static NodeID generateNodeID() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -19,30 +19,24 @@
 package org.ethereum.rpc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
-import co.rsk.core.WalletFactory;
 import co.rsk.config.ConfigUtils;
 import co.rsk.core.bc.BlockChainStatus;
 import co.rsk.mine.MinerClientImpl;
 import co.rsk.mine.MinerManagerTest;
 import co.rsk.mine.MinerServer;
 import co.rsk.mine.MinerServerImpl;
+import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
 import co.rsk.test.World;
 import co.rsk.validators.BlockValidationRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
-import org.ethereum.facade.Ethereum;
-import org.ethereum.manager.WorldManager;
 import org.ethereum.rpc.Simples.SimpleEthereum;
 import org.ethereum.rpc.Simples.SimpleWorldManager;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
-
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by ajlopez on 15/04/2017.
@@ -170,9 +164,10 @@ public class Web3ImplSnapshotTest {
         Assert.assertEquals(32, minerServer.increaseTime(0));
     }
 
-    private Web3Impl createWeb3(World world, SimpleEthereum ethereum, MinerServer minerServer) {
+    private static Web3Impl createWeb3(World world, SimpleEthereum ethereum, MinerServer minerServer) {
         MinerClientImpl minerClient = new MinerClientImpl();
-        Web3Impl web3 = new Web3Impl(getMockEthereum(), getMockProperties(), WalletFactory.createWallet(), minerClient, minerServer);
+        PersonalModule pm = new PersonalModuleWalletDisabled();
+        Web3Impl web3 = new Web3Impl(Web3Mocks.getMockEthereum(), Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null);
 
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
@@ -186,24 +181,12 @@ public class Web3ImplSnapshotTest {
         return web3;
     }
 
-    private Ethereum getMockEthereum() {
-        WorldManager mockWorldManager = mock(WorldManager.class, RETURNS_DEEP_STUBS);
-        when(mockWorldManager.getBlockchain().getBestBlock().getNumber()).thenReturn(0L);
-        Ethereum ethMock = mock(Ethereum.class);
-        when(ethMock.getWorldManager()).thenReturn(mockWorldManager);
-        return ethMock;
-    }
-
-    private RskSystemProperties getMockProperties() {
-        return mock(RskSystemProperties.class);
-    }
-
-    private Web3Impl createWeb3(World world) {
+    private static Web3Impl createWeb3(World world) {
         SimpleEthereum ethereum = new SimpleEthereum();
         return createWeb3(world, ethereum, getMinerServerForTest(world, ethereum));
     }
 
-    private MinerServer getMinerServerForTest(World world, SimpleEthereum ethereum) {
+    static MinerServer getMinerServerForTest(World world, SimpleEthereum ethereum) {
         BlockValidationRule rule = new MinerManagerTest.BlockValidationRuleDummy();
         return new MinerServerImpl(ethereum, world.getBlockChain(), world.getBlockChain().getBlockStore(),
                 world.getBlockChain().getPendingState(), world.getBlockChain().getRepository(), ConfigUtils.getDefaultMiningConfig(), rule);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -19,10 +19,19 @@
 package org.ethereum.rpc;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.core.bc.PendingStateImpl;
 import co.rsk.mine.MinerClient;
 import co.rsk.net.simples.SimpleBlockProcessor;
+import co.rsk.rpc.Web3RskImpl;
+import co.rsk.rpc.modules.eth.EthModule;
+import co.rsk.rpc.modules.eth.EthModuleSolidityDisabled;
+import co.rsk.rpc.modules.eth.EthModuleSolidityEnabled;
+import co.rsk.rpc.modules.eth.EthModuleWalletEnabled;
+import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
+import co.rsk.rpc.modules.personal.PersonalModuleWalletEnabled;
 import co.rsk.test.World;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
@@ -33,74 +42,72 @@ import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.Repository;
-import org.ethereum.manager.WorldManager;
+import org.ethereum.rpc.Simples.*;
 import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
-import org.ethereum.rpc.Simples.*;
 import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
 import org.ethereum.solidity.compiler.SolidityCompiler;
 import org.ethereum.vm.program.ProgramResult;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.spongycastle.util.encoders.Hex;
-import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.ethereum.rpc.TypeConverter.stringHexToByteArray;
 
 /**
  * Created by Ruben Altman on 09/06/2016.
  */
 public class Web3ImplTest {
+
+    Wallet wallet;
+
     @Test
     public void web3_clientVersion() throws Exception {
-        Web3 web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3 web3 = createWeb3();
 
         String clientVersion = web3.web3_clientVersion();
 
-        Assert.isTrue(clientVersion.toLowerCase().contains("rsk"), "client version is not including rsk!");
+        Assert.assertTrue("client version is not including rsk!", clientVersion.toLowerCase().contains("rsk"));
     }
 
     @Test
     public void net_version() throws Exception {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = new SimpleWorldManager();
 
         String netVersion = web3.net_version();
 
-        Assert.isTrue(netVersion.compareTo(Byte.toString(RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getChainId())) == 0, "RSK net version different than expected");
+        Assert.assertTrue("RSK net version different than expected", netVersion.compareTo(Byte.toString(RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getChainId())) == 0);
     }
 
     @Test
     public void eth_protocolVersion() throws Exception {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = new SimpleWorldManager();
 
         String netVersion = web3.eth_protocolVersion();
 
-        Assert.isTrue(netVersion.compareTo("1") == 0, "RSK net version different than one");
+        Assert.assertTrue("RSK net version different than one", netVersion.compareTo("1") == 0);
     }
 
 
     @Test
     public void net_peerCount() throws Exception {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = new SimpleWorldManager();
 
         String peerCount  = web3.net_peerCount();
 
-        Assert.isTrue(peerCount.compareTo("0x2") == 0, "Different number of peers than expected");
+        Assert.assertTrue("Different number of peers than expected", peerCount.compareTo("0x2") == 0);
     }
 
 
@@ -108,40 +115,42 @@ public class Web3ImplTest {
     public void web3_sha3() throws Exception {
         String toHash = "RSK";
 
-        Web3 web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3 web3 = createWeb3();
 
         String result = web3.web3_sha3(toHash);
 
         // Function must apply the Keccak-256 algorithm
         // Result taken from https://emn178.github.io/online-tools/keccak_256.html
-        Assert.isTrue(result.compareTo("0x80553b6b348ae45ab8e8bf75e77064818c0a772f13cf8d3a175d3815aec59b56") == 0, "hash does not match");
+        Assert.assertTrue("hash does not match", result.compareTo("0x80553b6b348ae45ab8e8bf75e77064818c0a772f13cf8d3a175d3815aec59b56") == 0);
     }
 
     @Test
     public void eth_syncing_returnFalseWhenNotSyncing()  {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
+        web3.worldManager = new SimpleWorldManager();
         SimpleBlockProcessor nodeProcessor = new SimpleBlockProcessor();
         web3.worldManager = new SimpleWorldManager(nodeProcessor);
         nodeProcessor.lastKnownBlockNumber = 0;
 
         Object result = web3.eth_syncing();
 
-        Assert.isTrue(!(boolean)result, "Node is not syncing, must return false");
+        Assert.assertTrue("Node is not syncing, must return false", !(boolean)result);
     }
 
     @Test
     public void eth_syncing_returnSyncingResultWhenSyncing()  {
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
+        web3.worldManager = new SimpleWorldManager();
         SimpleBlockProcessor nodeProcessor = new SimpleBlockProcessor();
         web3.worldManager = new SimpleWorldManager(nodeProcessor);
         nodeProcessor.lastKnownBlockNumber = 5;
 
         Object result = web3.eth_syncing();
 
-        Assert.isTrue(result instanceof Web3.SyncingResult, "Node is syncing, must return sync manager");
-        Assert.isTrue(((Web3.SyncingResult)result).highestBlock.compareTo("0x5") == 0, "Highest block is 5");
-        Assert.isTrue(((Web3.SyncingResult)result).currentBlock.compareTo("0x0") == 0, "Simple blockchain starts from genesis block");
+        Assert.assertTrue("Node is syncing, must return sync manager", result instanceof Web3.SyncingResult);
+        Assert.assertTrue("Highest block is 5", ((Web3.SyncingResult)result).highestBlock.compareTo("0x5") == 0);
+        Assert.assertTrue("Simple blockchain starts from genesis block", ((Web3.SyncingResult)result).currentBlock.compareTo("0x0") == 0);
     }
 
     @Test
@@ -149,7 +158,7 @@ public class Web3ImplTest {
         World world = new World();
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(10000)).build();
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         web3.repository = (Repository) world.getBlockChain().getRepository();
         SimpleWorldManager worldManager = new SimpleWorldManager();
@@ -164,7 +173,7 @@ public class Web3ImplTest {
         World world = new World();
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(10000)).build();
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         web3.repository = (Repository) world.getBlockChain().getRepository();
         SimpleWorldManager worldManager = new SimpleWorldManager();
@@ -179,7 +188,7 @@ public class Web3ImplTest {
         World world = new World();
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(10000)).build();
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         web3.repository = (Repository) world.getBlockChain().getRepository();
         SimpleWorldManager worldManager = new SimpleWorldManager();
@@ -201,7 +210,7 @@ public class Web3ImplTest {
         Block block1 = new BlockBuilder().parent(genesis).build();
         world.getBlockChain().tryToConnect(block1);
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         web3.repository = (Repository) world.getBlockChain().getRepository();
         SimpleWorldManager worldManager = new SimpleWorldManager();
@@ -227,7 +236,7 @@ public class Web3ImplTest {
         Block block1 = new BlockBuilder(world).parent(genesis).transactions(txs).build();
         org.junit.Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         web3.repository = (Repository) world.getBlockChain().getRepository();
         SimpleWorldManager worldManager = new SimpleWorldManager();
@@ -246,24 +255,24 @@ public class Web3ImplTest {
 
     @Test
     public void eth_mining()  {
-        Ethereum ethMock = getMockEthereum();
-        RskSystemProperties mockProperties = getMockProperties();
+        Ethereum ethMock = Web3Mocks.getMockEthereum();
+        RskSystemProperties mockProperties = Web3Mocks.getMockProperties();
         MinerClient minerClient = new SimpleMinerClient();
+        PersonalModule personalModule = new PersonalModuleWalletDisabled();
+        Web3 web3 = new Web3Impl(ethMock, mockProperties, minerClient, null, personalModule, null);
 
-        Web3 web3 = new Web3Impl(ethMock, mockProperties, WalletFactory.createWallet(), minerClient, null);
-
-        Assert.isTrue(!web3.eth_mining(), "Node is not mining");
+        Assert.assertTrue("Node is not mining", !web3.eth_mining());
 
         minerClient.mine();
-        Assert.isTrue(web3.eth_mining(), "Node is mining");
+        Assert.assertTrue("Node is mining", web3.eth_mining());
 
         minerClient.stop();
-        Assert.isTrue(!web3.eth_mining(), "Node is not mining");
+        Assert.assertTrue("Node is not mining", !web3.eth_mining());
     }
 
     @Test
     public void getGasPrice()  {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.eth = new SimpleEthereum();
         String expectedValue = Hex.toHexString(new BigInteger("20000000000").toByteArray());
         expectedValue = "0x" + (expectedValue.startsWith("0") ? expectedValue.substring(1) : expectedValue);
@@ -272,7 +281,7 @@ public class Web3ImplTest {
 
     @Test
     public void sendRawTransaction() throws Exception {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         SimpleEthereum eth = new SimpleEthereum();
         web3.eth = eth;
 
@@ -297,7 +306,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder().name("acc1").build();
@@ -306,7 +315,7 @@ public class Web3ImplTest {
 
         String hashString = Hex.toHexString(tx.getHash());
 
-        Assert.isNull(web3.eth_getTransactionReceipt(hashString));
+        Assert.assertNull(web3.eth_getTransactionReceipt(hashString));
     }
 
     @Test
@@ -316,7 +325,7 @@ public class Web3ImplTest {
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(2000000)).build();
@@ -353,7 +362,7 @@ public class Web3ImplTest {
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(2000000)).build();
@@ -373,7 +382,7 @@ public class Web3ImplTest {
 
         TransactionReceiptDTO tr = web3.eth_getTransactionReceipt(hashString);
 
-        Assert.isNull(tr);
+        Assert.assertNull(tr);
     }
 
     @Test
@@ -382,7 +391,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(2000000)).build();
@@ -398,7 +407,7 @@ public class Web3ImplTest {
 
         TransactionResultDTO tr = web3.eth_getTransactionByHash(hashString);
 
-        Assert.notNull(tr);
+        Assert.assertNotNull(tr);
         org.junit.Assert.assertEquals("0x" + hashString, tr.hash);
 
         String blockHashString = "0x" + Hex.toHexString(block1.getHash());
@@ -414,7 +423,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(2000000)).build();
@@ -429,7 +438,7 @@ public class Web3ImplTest {
 
         TransactionResultDTO tr = web3.eth_getTransactionByHash(hashString);
 
-        Assert.notNull(tr);
+        Assert.assertNotNull(tr);
 
         org.junit.Assert.assertEquals("0x" + hashString, tr.hash);
         org.junit.Assert.assertEquals("0", tr.nonce);
@@ -445,7 +454,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(2000000)).build();
@@ -465,7 +474,7 @@ public class Web3ImplTest {
 
         TransactionResultDTO tr = web3.eth_getTransactionByHash(hashString);
 
-        Assert.isNull(tr);
+        Assert.assertNull(tr);
     }
 
     @Test
@@ -474,7 +483,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(2000000)).build();
@@ -491,7 +500,7 @@ public class Web3ImplTest {
 
         TransactionResultDTO tr = web3.eth_getTransactionByBlockHashAndIndex(blockHashString, "0x0");
 
-        Assert.notNull(tr);
+        Assert.assertNotNull(tr);
         org.junit.Assert.assertEquals("0x" + hashString, tr.hash);
 
         org.junit.Assert.assertEquals("0x" + blockHashString, tr.blockHash);
@@ -503,7 +512,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Block genesis = world.getBlockChain().getBestBlock();
@@ -514,7 +523,7 @@ public class Web3ImplTest {
 
         TransactionResultDTO tr = web3.eth_getTransactionByBlockHashAndIndex(blockHashString, "0x0");
 
-        Assert.isNull(tr);
+        Assert.assertNull(tr);
     }
 
     @Test
@@ -523,7 +532,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(2000000)).build();
@@ -540,7 +549,7 @@ public class Web3ImplTest {
 
         TransactionResultDTO tr = web3.eth_getTransactionByBlockNumberAndIndex("0x01", "0x0");
 
-        Assert.notNull(tr);
+        Assert.assertNotNull(tr);
         org.junit.Assert.assertEquals("0x" + hashString, tr.hash);
 
         org.junit.Assert.assertEquals("0x" + blockHashString, tr.blockHash);
@@ -552,7 +561,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Block genesis = world.getBlockChain().getBestBlock();
@@ -561,7 +570,7 @@ public class Web3ImplTest {
 
         TransactionResultDTO tr = web3.eth_getTransactionByBlockNumberAndIndex("0x1", "0x0");
 
-        Assert.isNull(tr);
+        Assert.assertNull(tr);
     }
 
     @Test
@@ -570,7 +579,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
         web3.repository = (Repository) world.getRepository();
 
@@ -587,12 +596,12 @@ public class Web3ImplTest {
 
         String count = web3.eth_getTransactionCount(accountAddress, "0x1");
 
-        Assert.notNull(count);
+        Assert.assertNotNull(count);
         org.junit.Assert.assertEquals("0x1", count);
 
         count = web3.eth_getTransactionCount(accountAddress, "0x0");
 
-        Assert.notNull(count);
+        Assert.assertNotNull(count);
         org.junit.Assert.assertEquals("0x0", count);
     }
 
@@ -602,7 +611,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Block genesis = world.getBlockChain().getBestBlock();
@@ -617,14 +626,14 @@ public class Web3ImplTest {
 
         Web3.BlockResult bresult = web3.eth_getBlockByNumber("0x1", false);
 
-        Assert.notNull(bresult);
+        Assert.assertNotNull(bresult);
 
         String blockHash = "0x" + Hex.toHexString(block1b.getHash());
         org.junit.Assert.assertEquals(blockHash, bresult.hash);
 
         bresult = web3.eth_getBlockByNumber("0x2", true);
 
-        Assert.notNull(bresult);
+        Assert.assertNotNull(bresult);
 
         blockHash = "0x" + Hex.toHexString(block2b.getHash());
         org.junit.Assert.assertEquals(blockHash, bresult.hash);
@@ -636,7 +645,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Block genesis = world.getBlockChain().getBestBlock();
@@ -651,7 +660,7 @@ public class Web3ImplTest {
 
         Web3.BlockInformationResult[] bresult = web3.eth_getBlocksByNumber("0x1");
 
-        Assert.notNull(bresult);
+        Assert.assertNotNull(bresult);
 
         org.junit.Assert.assertEquals(2, bresult.length);
         org.junit.Assert.assertEquals(TypeConverter.toJsonHex(block1.getHash()), bresult[0].hash);
@@ -664,7 +673,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Block genesis = world.getBlockChain().getBestBlock();
@@ -675,7 +684,7 @@ public class Web3ImplTest {
 
         Web3.BlockResult blockResult = web3.eth_getBlockByNumber("latest", false);
 
-        Assert.notNull(blockResult);
+        Assert.assertNotNull(blockResult);
         String blockHash = TypeConverter.toJsonHex(Hex.toHexString(block1.getHash()));
         org.junit.Assert.assertEquals(blockHash, blockResult.hash);
     }
@@ -686,7 +695,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Block genesis = world.getBlockChain().getBestBlock();
@@ -696,7 +705,7 @@ public class Web3ImplTest {
 
         Web3.BlockResult blockResult = web3.eth_getBlockByNumber("earliest", false);
 
-        Assert.notNull(blockResult);
+        Assert.assertNotNull(blockResult);
         String blockHash = TypeConverter.toJsonHex(genesis.getHash());
         org.junit.Assert.assertEquals(blockHash, blockResult.hash);
     }
@@ -707,12 +716,12 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Web3.BlockResult blockResult = web3.eth_getBlockByNumber("0x1234", false);
 
-        Assert.isNull(blockResult);
+        Assert.assertNull(blockResult);
     }
 
     @Test
@@ -721,7 +730,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Block genesis = world.getBlockChain().getBestBlock();
@@ -741,7 +750,7 @@ public class Web3ImplTest {
 
         Web3.BlockResult bresult = web3.eth_getBlockByHash(block1HashString, false);
 
-        Assert.notNull(bresult);
+        Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block1HashString, bresult.hash);
         org.junit.Assert.assertEquals("0x00", bresult.extraData);
         org.junit.Assert.assertEquals(0, bresult.transactions.length);
@@ -749,12 +758,12 @@ public class Web3ImplTest {
 
         bresult = web3.eth_getBlockByHash(block1bHashString, true);
 
-        Assert.notNull(bresult);
+        Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block1bHashString, bresult.hash);
 
         bresult = web3.eth_getBlockByHash(block2bHashString, true);
 
-        Assert.notNull(bresult);
+        Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block2bHashString, bresult.hash);
     }
 
@@ -764,7 +773,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(220000)).build();
@@ -782,7 +791,7 @@ public class Web3ImplTest {
 
         Web3.BlockResult bresult = web3.eth_getBlockByHash(block1HashString, true);
 
-        Assert.notNull(bresult);
+        Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block1HashString, bresult.hash);
         org.junit.Assert.assertEquals(1, bresult.transactions.length);
         org.junit.Assert.assertEquals(block1HashString, ((TransactionResultDTO) bresult.transactions[0]).blockHash);
@@ -795,7 +804,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(220000)).build();
@@ -813,7 +822,7 @@ public class Web3ImplTest {
 
         Web3.BlockResult bresult = web3.eth_getBlockByHash(block1HashString, false);
 
-        Assert.notNull(bresult);
+        Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block1HashString, bresult.hash);
         org.junit.Assert.assertEquals(1, bresult.transactions.length);
         org.junit.Assert.assertEquals(TypeConverter.toJsonHex(tx.getHash()), bresult.transactions[0]);
@@ -826,12 +835,12 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
 
         Web3.BlockResult blockResult = web3.eth_getBlockByHash("0x1234", false);
 
-        Assert.isNull(blockResult);
+        Assert.assertNull(blockResult);
     }
 
     @Test
@@ -840,7 +849,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
         web3.repository = (Repository) world.getRepository();
 
@@ -858,7 +867,7 @@ public class Web3ImplTest {
 
         String scode = web3.eth_getCode(accountAddress, "0x1");
 
-        Assert.notNull(scode);
+        Assert.assertNotNull(scode);
         org.junit.Assert.assertEquals("0x" + Hex.toHexString(code), scode);
     }
 
@@ -893,22 +902,10 @@ public class Web3ImplTest {
         Block block1 = new BlockBuilder(world).parent(genesis).transactions(txs).build();
         world.getBlockChain().tryToConnect(block1);
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3Mocked(world, block1);
+
         web3.personal_newAccountWithSeed("default");
         web3.personal_newAccountWithSeed("notDefault");
-
-        web3.repository = (Repository) world.getBlockChain().getRepository();
-        SimpleWorldManager worldManager = new SimpleWorldManager();
-        worldManager.setBlockchain(world.getBlockChain());
-        PendingState pendingState = new PendingStateImpl(world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
-        worldManager.setPendingState(pendingState);
-        web3.worldManager = worldManager;
-
-        Ethereum ethMock = Mockito.mock(Ethereum.class);
-        ProgramResult res = new ProgramResult();
-        res.setHReturn(TypeConverter.stringHexToByteArray("0x0000000000000000000000000000000000000000000000000000000064617665"));
-        Mockito.when(ethMock.callConstantCallTransaction(argThat(new TransactionFromMatcher(tx.getSender())), eq(block1))).thenReturn(res);
-        web3.eth = ethMock;
 
         Web3.CallArguments argsForCall = new Web3.CallArguments();
         argsForCall.to = TypeConverter.toJsonHex(tx.getContractAddress());
@@ -950,22 +947,10 @@ public class Web3ImplTest {
         Block block1 = new BlockBuilder(world).parent(genesis).transactions(txs).build();
         world.getBlockChain().tryToConnect(block1);
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3Mocked(world, block1);
+
         web3.personal_newAccountWithSeed("default");
         web3.personal_newAccountWithSeed("notDefault");
-
-        web3.repository = (Repository) world.getBlockChain().getRepository();
-        SimpleWorldManager worldManager = new SimpleWorldManager();
-        worldManager.setBlockchain(world.getBlockChain());
-        PendingState pendingState = new PendingStateImpl(world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
-        worldManager.setPendingState(pendingState);
-        web3.worldManager = worldManager;
-
-        Ethereum ethMock = Mockito.mock(Ethereum.class);
-        ProgramResult res = new ProgramResult();
-        res.setHReturn(TypeConverter.stringHexToByteArray("0x0000000000000000000000000000000000000000000000000000000064617665"));
-        Mockito.when(ethMock.callConstantCallTransaction(argThat(new TransactionFromMatcher(tx.getSender())), eq(block1))).thenReturn(res);
-        web3.eth = ethMock;
 
         Web3.CallArguments argsForCall = new Web3.CallArguments();
         argsForCall.from = TypeConverter.toJsonHex(acc1.getAddress());
@@ -983,7 +968,7 @@ public class Web3ImplTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.worldManager = worldManager;
         web3.repository = (Repository) world.getRepository();
 
@@ -1004,13 +989,13 @@ public class Web3ImplTest {
         SimplePeerServer peerServer = new SimplePeerServer();
         eth.peerServer = peerServer;
 
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
         web3.eth = eth;
 
-        Assert.isTrue(!web3.net_listening(), "Node is not listening");
+        Assert.assertTrue("Node is not listening", !web3.net_listening());
 
         peerServer.isListening = true;
-        Assert.isTrue(web3.net_listening(), "Node is listening");
+        Assert.assertTrue("Node is listening", web3.net_listening());
     }
 
     @Test
@@ -1019,36 +1004,35 @@ public class Web3ImplTest {
         SimpleMinerServer minerServer= new SimpleMinerServer();
         minerServer.coinbase = originalCoibase;
 
-        Ethereum ethMock = getMockEthereum();
-        RskSystemProperties mockProperties = getMockProperties();
+        Ethereum ethMock = Web3Mocks.getMockEthereum();
+        RskSystemProperties mockProperties = Web3Mocks.getMockProperties();
+        PersonalModule personalModule = new PersonalModuleWalletDisabled();
+        Web3 web3 = new Web3Impl(ethMock, mockProperties, null, minerServer, personalModule, null);
 
-        Web3 web3 = new Web3Impl(ethMock, mockProperties, WalletFactory.createWallet(), null, minerServer);
-
-        Assert.isTrue(web3.eth_coinbase().compareTo("0x" + originalCoibase) == 0, "Not returning coinbase specified on miner server");
+        Assert.assertTrue("Not returning coinbase specified on miner server", web3.eth_coinbase().compareTo("0x" + originalCoibase) == 0);
     }
 
     @Test
     public void eth_accounts()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
+        int originalAccounts = web3.personal_listAccounts().length;
 
         String addr1 = web3.personal_newAccountWithSeed("sampleSeed1");
         String addr2 = web3.personal_newAccountWithSeed("sampleSeed2");
 
-        String[] accounts = web3.eth_accounts();
+        Set<String> accounts = Arrays.stream(web3.eth_accounts()).collect(Collectors.toSet());
 
-        Assert.isTrue(accounts.length == 2, "Not all accounts are being retrieved");
-        String address1 = accounts[0];
-        String originalAddress = addr1;
+        Assert.assertEquals("Not all accounts are being retrieved", originalAccounts + 2, accounts.size());
 
-        Assert.isTrue(originalAddress.compareTo(address1) == 0, "Account 1 address is wrong");
-        Assert.isTrue(accounts[1].compareTo(addr2) == 0);
+        Assert.assertTrue(accounts.contains(addr1));
+        Assert.assertTrue(accounts.contains(addr2));
     }
 
     @Test
     public void eth_sign()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         String addr1 = web3.personal_newAccountWithSeed("sampleSeed1");
         String addr2 = web3.personal_newAccountWithSeed("sampleSeed2");
@@ -1063,22 +1047,22 @@ public class Web3ImplTest {
             e.printStackTrace();
         }
 
-        String expectedSignature = "0x" + web3.getAccount(addr1).getEcKey().sign(hash).r.toString() + web3.getAccount(addr1).getEcKey().sign(hash).s.toString() + web3.getAccount(addr1).getEcKey().sign(hash).v;
+        String expectedSignature = "0x" + wallet.getAccount(stringHexToByteArray(addr1)).getEcKey().sign(hash).r.toString() + wallet.getAccount(stringHexToByteArray(addr1)).getEcKey().sign(hash).s.toString() + wallet.getAccount(stringHexToByteArray(addr1)).getEcKey().sign(hash).v;
 
-        Assert.isTrue(expectedSignature.compareTo(signature) == 0, "Signature is not the same one returned by the key");
+        Assert.assertTrue("Signature is not the same one returned by the key", expectedSignature.compareTo(signature) == 0);
     }
 
     @Test
     public void createNewAccount()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         String addr = web3.personal_newAccount("passphrase1");
 
         Account account = null;
 
         try {
-            account = web3.getAccount(addr, "passphrase1");
+            account = wallet.getAccount(stringHexToByteArray(addr), "passphrase1");
         }
         catch (Exception e) {
             e.printStackTrace();
@@ -1092,23 +1076,24 @@ public class Web3ImplTest {
     @Test
     public void listAccounts()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
+        int originalAccounts = web3.personal_listAccounts().length;
 
         String addr1 = web3.personal_newAccount("passphrase1");
         String addr2 = web3.personal_newAccount("passphrase2");
 
-        String[] addresses = web3.personal_listAccounts();
+        Set<String> addresses = Arrays.stream(web3.personal_listAccounts()).collect(Collectors.toSet());
 
         org.junit.Assert.assertNotNull(addresses);
-        org.junit.Assert.assertEquals(2, addresses.length);
-        org.junit.Assert.assertTrue(addr1.equals(addresses[0]) || addr1.equals(addresses[1]));
-        org.junit.Assert.assertTrue(addr2.equals(addresses[0]) || addr2.equals(addresses[1]));
+        org.junit.Assert.assertEquals(originalAccounts + 2, addresses.size());
+        org.junit.Assert.assertTrue(addresses.contains(addr1));
+        org.junit.Assert.assertTrue(addresses.contains(addr2));
     }
 
     @Test
     public void importAccountUsingRawKey()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         ECKey eckey = new ECKey();
 
@@ -1116,11 +1101,11 @@ public class Web3ImplTest {
 
         org.junit.Assert.assertNotNull(address);
 
-        Account account0 = web3.getAccount(address);
+        Account account0 = wallet.getAccount(stringHexToByteArray(address));
 
         org.junit.Assert.assertNull(account0);
 
-        Account account = web3.getAccount(address, "passphrase1");
+        Account account = wallet.getAccount(stringHexToByteArray(address), "passphrase1");
 
         org.junit.Assert.assertNotNull(account);
         org.junit.Assert.assertEquals(address, "0x" + Hex.toHexString(account.getAddress()));
@@ -1129,7 +1114,7 @@ public class Web3ImplTest {
 
     @Test
     public void dumpRawKey() throws Exception {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         ECKey eckey = new ECKey();
 
@@ -1145,7 +1130,7 @@ public class Web3ImplTest {
     @Test
     public void sendPersonalTransaction()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet(), new SimpleEthereum());
+        Web3Impl web3 = createWeb3();
 
         // **** Initializes data ******************
         String addr1 = web3.personal_newAccount("passphrase1");
@@ -1178,27 +1163,28 @@ public class Web3ImplTest {
 
         // ***** Verifies tx hash
         Transaction tx = Transaction.create(toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
-        tx.sign(web3.getAccount(addr1, "passphrase1").getEcKey().getPrivKeyBytes());
+        Account account = wallet.getAccount(stringHexToByteArray(addr1), "passphrase1");
+        tx.sign(account.getEcKey().getPrivKeyBytes());
 
         String expectedHash = TypeConverter.toJsonHex(tx.getHash());
 
-        Assert.isTrue(expectedHash.compareTo(txHash) == 0, "Method is not creating the expected transaction");
+        Assert.assertTrue("Method is not creating the expected transaction", expectedHash.compareTo(txHash) == 0);
     }
 
     @Test
     public void unlockAccount()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         String addr = web3.personal_newAccount("passphrase1");
 
-        Account account0 = web3.getAccount(addr);
+        Account account0 = wallet.getAccount(stringHexToByteArray(addr));
 
         org.junit.Assert.assertNull(account0);
 
         org.junit.Assert.assertTrue(web3.personal_unlockAccount(addr, "passphrase1", ""));
 
-        Account account = web3.getAccount(addr);
+        Account account = wallet.getAccount(stringHexToByteArray(addr));
 
         org.junit.Assert.assertNotNull(account);
     }
@@ -1206,11 +1192,11 @@ public class Web3ImplTest {
     @Test(expected = JsonRpcInvalidParamException.class)
     public void unlockAccountInvalidDuration()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         String addr = web3.personal_newAccount("passphrase1");
 
-        Account account0 = web3.getAccount(addr);
+        Account account0 = wallet.getAccount(stringHexToByteArray(addr));
 
         org.junit.Assert.assertNull(account0);
 
@@ -1222,23 +1208,23 @@ public class Web3ImplTest {
     @Test
     public void lockAccount()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
+        Web3Impl web3 = createWeb3();
 
         String addr = web3.personal_newAccount("passphrase1");
 
-        Account account0 = web3.getAccount(addr);
+        Account account0 = wallet.getAccount(stringHexToByteArray(addr));
 
         org.junit.Assert.assertNull(account0);
 
         org.junit.Assert.assertTrue(web3.personal_unlockAccount(addr, "passphrase1", ""));
 
-        Account account = web3.getAccount(addr);
+        Account account = wallet.getAccount(stringHexToByteArray(addr));
 
         org.junit.Assert.assertNotNull(account);
 
         org.junit.Assert.assertTrue(web3.personal_lockAccount(addr));
 
-        Account account1 = web3.getAccount(addr);
+        Account account1 = wallet.getAccount(stringHexToByteArray(addr));
 
         org.junit.Assert.assertNull(account1);
     }
@@ -1246,18 +1232,8 @@ public class Web3ImplTest {
     @Test
     public void eth_sendTransaction()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
-        SimpleEthereum eth = new SimpleEthereum();
-        web3.eth = eth;
-        SimpleWorldManager worldManager = new SimpleWorldManager();
         BigInteger nonce = BigInteger.ONE;
-        PendingState pendingState = Mockito.mock(PendingState.class);
-        org.ethereum.core.Repository repository = Mockito.mock(org.ethereum.core.Repository.class);
-        Mockito.when(pendingState.getRepository()).thenReturn(repository);
-        Mockito.when(repository.getNonce(Mockito.any())).thenReturn(nonce);
-
-        worldManager.setPendingState(pendingState);
-        web3.worldManager =  worldManager;
+        Web3Impl web3 = createWeb3();
 
         // **** Initializes data ******************
         String addr1 = web3.personal_newAccountWithSeed("sampleSeed1");
@@ -1289,26 +1265,57 @@ public class Web3ImplTest {
 
         // ***** Verifies tx hash
         Transaction tx = Transaction.create(toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
-        tx.sign(web3.getAccount(addr1).getEcKey().getPrivKeyBytes());
+        tx.sign(wallet.getAccount(stringHexToByteArray(addr1)).getEcKey().getPrivKeyBytes());
 
         String expectedHash = TypeConverter.toJsonHex(tx.getHash());
 
-        Assert.isTrue(expectedHash.compareTo(txHash) == 0, "Method is not creating the expected transaction");
+        Assert.assertTrue("Method is not creating the expected transaction", expectedHash.compareTo(txHash) == 0);
+    }
+
+    private Web3Impl createWeb3() {
+        BigInteger nonce = BigInteger.ONE;
+        PendingState pendingState = Web3Mocks.getMockPendingState(nonce);
+        SimpleWorldManager worldManager = new SimpleWorldManager(pendingState);
+        return createWeb3(Web3Mocks.getMockEthereum());
+    }
+
+    private Web3Impl createWeb3Mocked(World world, Block block1) {
+        SimpleWorldManager worldManager = new SimpleWorldManager();
+        worldManager.setBlockchain(world.getBlockChain());
+        PendingState pendingState = new PendingStateImpl(world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        worldManager.setPendingState(pendingState);
+        Ethereum ethMock = Mockito.mock(Ethereum.class);
+        ProgramResult res = new ProgramResult();
+        res.setHReturn(TypeConverter.stringHexToByteArray("0x0000000000000000000000000000000000000000000000000000000064617665"));
+        Mockito.when(ethMock.callConstantCallTransaction(Matchers.any(), Matchers.eq(block1))).thenReturn(res);
+        Mockito.when(ethMock.getWorldManager()).thenReturn(worldManager);
+        return createWeb3(ethMock);
+    }
+
+    private Web3Impl createWeb3(Ethereum eth) {
+        wallet = WalletFactory.createWallet();
+        PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(eth, wallet);
+        EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
+        MinerClient minerClient = new SimpleMinerClient();
+        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule);
     }
 
     @Test
     @Ignore
     public void eth_compileSolidity() throws Exception {
-        SystemProperties systemProperties = Mockito.mock(SystemProperties.class);
+        RskSystemProperties systemProperties = Mockito.mock(RskSystemProperties.class);
         String solc = System.getProperty("solc");
         if(StringUtils.isEmpty(solc))
             solc = "/usr/bin/solc";
 
         Mockito.when(systemProperties.customSolcPath()).thenReturn(solc);
-        Web3Impl web3 = new Web3Impl(new SolidityCompiler(systemProperties), WalletFactory.createWallet());
+        Ethereum eth = Mockito.mock(Ethereum.class);
+        EthModule ethModule = new EthModule(eth, new EthModuleSolidityEnabled(new SolidityCompiler(systemProperties)), null);
+        PersonalModule personalModule = new PersonalModuleWalletDisabled();
+        Web3Impl web3 = new Web3RskImpl(eth, systemProperties, null, null, personalModule, ethModule);
         String contract = "pragma solidity ^0.4.1; contract rsk { function multiply(uint a) returns(uint d) {   return a * 7;   } }";
 
-            Map<String, CompilationResultDTO> result = web3.eth_compileSolidity(contract);
+        Map<String, CompilationResultDTO> result = web3.eth_compileSolidity(contract);
 
         org.junit.Assert.assertNotNull(result);
 
@@ -1320,30 +1327,27 @@ public class Web3ImplTest {
         org.junit.Assert.assertEquals(contract , dto.info.getSource());
     }
 
-    class TransactionFromMatcher extends ArgumentMatcher<Transaction> {
+    @Test
+    public void eth_compileSolidityWithoutSolidity() throws Exception {
+        SystemProperties systemProperties = Mockito.mock(SystemProperties.class);
+        String solc = System.getProperty("solc");
+        if(StringUtils.isEmpty(solc))
+            solc = "/usr/bin/solc";
 
-        private byte[] from;
+        Mockito.when(systemProperties.customSolcPath()).thenReturn(solc);
 
-        TransactionFromMatcher(byte[] from) {
-            this.from = from;
-        }
+        Wallet wallet = WalletFactory.createWallet();
+        Ethereum eth = Mockito.mock(Ethereum.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(eth.getWorldManager().getBlockchain().getBestBlock().getNumber()).thenReturn(1L);
+        EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
+        Web3Impl web3 = new Web3RskImpl(eth, RskSystemProperties.CONFIG, null, null, new PersonalModuleWalletDisabled(), ethModule);
 
-        @Override
-        public boolean matches(Object argument) {
-            Transaction tx = (Transaction)argument;
-            return Arrays.equals(tx.getSender(), from);
-        }
+        String contract = "pragma solidity ^0.4.1; contract rsk { function multiply(uint a) returns(uint d) {   return a * 7;   } }";
+
+        Map<String, CompilationResultDTO> result = web3.eth_compileSolidity(contract);
+
+        org.junit.Assert.assertNotNull(result);
+        org.junit.Assert.assertEquals(0, result.size());
     }
 
-    private Ethereum getMockEthereum() {
-        WorldManager mockWorldManager = mock(WorldManager.class, RETURNS_DEEP_STUBS);
-        when(mockWorldManager.getBlockchain().getBestBlock().getNumber()).thenReturn(0L);
-        Ethereum ethMock = mock(Ethereum.class);
-        when(ethMock.getWorldManager()).thenReturn(mockWorldManager);
-        return ethMock;
-    }
-
-    private RskSystemProperties getMockProperties() {
-        return mock(RskSystemProperties.class);
-    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -1145,9 +1145,7 @@ public class Web3ImplTest {
     @Test
     public void sendPersonalTransaction()
     {
-        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet());
-        SimpleEthereum eth = new SimpleEthereum();
-        web3.eth = eth;
+        Web3Impl web3 = new Web3Impl(null, WalletFactory.createWallet(), new SimpleEthereum());
 
         // **** Initializes data ******************
         String addr1 = web3.personal_newAccount("passphrase1");

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.rpc;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.mine.MinerClient;
+import co.rsk.mine.MinerServer;
+import org.ethereum.core.PendingState;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.manager.WorldManager;
+import org.mockito.Mockito;
+
+import java.math.BigInteger;
+
+import static org.mockito.Mockito.*;
+
+public class Web3Mocks {
+    public static Ethereum getMockEthereum() {
+        WorldManager mockWorldManager = mock(WorldManager.class, RETURNS_DEEP_STUBS);
+        when(mockWorldManager.getBlockchain().getBestBlock().getNumber()).thenReturn(0L);
+        Ethereum ethMock = mock(Ethereum.class);
+        when(ethMock.getWorldManager()).thenReturn(mockWorldManager);
+        return ethMock;
+    }
+
+    public static RskSystemProperties getMockProperties() {
+        return mock(RskSystemProperties.class);
+    }
+
+    public static MinerClient getMockMinerClient() {
+        return mock(MinerClient.class);
+    }
+
+    public static MinerServer getMockMinerServer() {
+        return mock(MinerServer.class);
+    }
+
+    public static PendingState getMockPendingState(BigInteger nonce) {
+        org.ethereum.core.Repository repository = Mockito.mock(org.ethereum.core.Repository.class);
+        Mockito.when(repository.getNonce(Mockito.any())).thenReturn(nonce);
+        PendingState pendingState = Mockito.mock(PendingState.class);
+        Mockito.when(pendingState.getRepository()).thenReturn(repository);
+        return pendingState;
+    }
+}


### PR DESCRIPTION
### How to tackle this PR

1. `Web3` creation now lives in `RskFactory.getWeb3Factory`
   1. It's a factory and not a constructor parameter because we want to be able to decide whether to create the instance or not
   1. `wallet.enabled` config decides which classes get instantiated: if disabled, the classes that access the persistent wallet won't even be instantiated
1. The `Wallet` implementation code was moved to `LocalWallet`, `Wallet` is now just an interface
1. `Web3` now delegates some calls
   1. `EthModule` handles `eth_XXX` RPC calls
   1. `PersonalModule` handles `personal_XXX` RPC calls
   1. Different implementations of these classes enable running the client without a `Wallet` or `Solidity`
1. The `SolidityCompiler` dependency was wrapped in `EthModule`, making it easy to disable