### PR TITLE
Feature/rfs 36 change federation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -20,6 +20,7 @@ package co.rsk.config;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
+import co.rsk.peg.Federation;
 
 import java.util.List;
 
@@ -27,12 +28,7 @@ public class BridgeConstants {
 
     protected String btcParamsString;
 
-    protected List<BtcECKey> federatorPublicKeys;
-    protected int federatorsRequiredToSign;
-    protected Script federationPubScript;
-    protected Address federationAddress;
-    // We ignore txs to the federation before this time
-    protected long federationAddressCreationTime;
+    protected Federation genesisFederation;
 
     protected int btc2RskMinimumAcceptableConfirmations;
     protected int btc2RskMinimumAcceptableConfirmationsOnRsk;
@@ -54,23 +50,7 @@ public class BridgeConstants {
         return btcParamsString;
     }
 
-    public List<BtcECKey> getFederatorPublicKeys() {
-        return federatorPublicKeys;
-    }
-
-    public int getFederatorsRequiredToSign() {
-        return federatorsRequiredToSign;
-    }
-
-    public Script getFederationPubScript() {
-        return federationPubScript;
-    }
-
-    public Address getFederationAddress() {
-        return federationAddress;
-    }
-
-    public long getFederationAddressCreationTime() { return federationAddressCreationTime; }
+    public Federation getGenesisFederation() { return genesisFederation; }
 
     public int getBtc2RskMinimumAcceptableConfirmations() {
         return btc2RskMinimumAcceptableConfirmations;
@@ -88,7 +68,6 @@ public class BridgeConstants {
         return btcBroadcastingMinimumAcceptableBlocks;
     }
 
-    
     public int getUpdateBridgeExecutionPeriod() { return updateBridgeExecutionPeriod; }
 
     public int getMaxBtcHeadersPerRskBlock() { return maxBtcHeadersPerRskBlock; }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -18,13 +18,16 @@
 
 package co.rsk.config;
 
-import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.Federation;
 import com.google.common.collect.Lists;
-import co.rsk.bitcoinj.script.Script;
-import co.rsk.bitcoinj.script.ScriptBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
+
+import java.util.List;
 
 
 public class BridgeDevNetConstants extends BridgeConstants {
@@ -40,26 +43,24 @@ public class BridgeDevNetConstants extends BridgeConstants {
         BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03301f6c4422aa96d85f52a93612a0c6eeea3d04cfa32f97a7a764c67e062e992a"));
         BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02d33a1f8f5cfa2f7be71b0002710f4c8f3ea44fef40056be7b89ed3ca0eb3431c"));
 
-        federatorPublicKeys = Lists.newArrayList(federator0PublicKey, federator1PublicKey, federator2PublicKey);
-
-        federatorsRequiredToSign = 2;
-
-        Script redeemScript = ScriptBuilder.createRedeemScript(federatorsRequiredToSign, federatorPublicKeys);
-        federationPubScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-//      To recalculate federationAddress
-//      federationAddress = Address.fromP2SHScript(btcParams, federationPubScript);
-        try {
-            federationAddress = Address.fromBase58(getBtcParams(), "2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX");
-        } catch (AddressFormatException e) {
-            logger.error("Federation address format is invalid");
-            throw new RskConfigurationException(e.getMessage(), e);
-        }
+        List<BtcECKey> genesisFederationPublicKeys = Lists.newArrayList(
+                federator0PublicKey, federator1PublicKey, federator2PublicKey
+        );
 
         // To recreate the value use
         // federationAddressCreationTime = new GregorianCalendar(2009,0,1).getTimeInMillis() / 1000;
         // Currently set to:
         // Tue Aug 23 21:53:20 ART 2016
-        federationAddressCreationTime = 1472000000l;
+        long genesisFederationAddressCreationTime = 1472000000l;
+
+        // Expected federation address is:
+        // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
+        genesisFederation = new Federation(
+                2,
+                genesisFederationPublicKeys,
+                genesisFederationAddressCreationTime,
+                getBtcParams()
+        );
 
         btc2RskMinimumAcceptableConfirmations = 10;
         rsk2BtcMinimumAcceptableConfirmations = 10;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
+import java.time.Instant;
 import java.util.List;
 
 
@@ -48,17 +49,17 @@ public class BridgeDevNetConstants extends BridgeConstants {
         );
 
         // To recreate the value use
-        // federationAddressCreationTime = new GregorianCalendar(2009,0,1).getTimeInMillis() / 1000;
+        // genesisFederationAddressCreatedAt = Instant.ofEpochMilli(new GregorianCalendar(2009,0,1).getTimeInMillis());
         // Currently set to:
         // Tue Aug 23 21:53:20 ART 2016
-        long genesisFederationAddressCreationTime = 1472000000l;
+        Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1472000000l);
 
         // Expected federation address is:
         // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
         genesisFederation = new Federation(
                 2,
                 genesisFederationPublicKeys,
-                genesisFederationAddressCreationTime,
+                genesisFederationAddressCreatedAt,
                 getBtcParams()
         );
 

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -18,14 +18,14 @@
 
 package co.rsk.config;
 
-import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.Federation;
 import com.google.common.collect.Lists;
-import co.rsk.bitcoinj.script.Script;
-import co.rsk.bitcoinj.script.ScriptBuilder;
 import org.ethereum.crypto.HashUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.spongycastle.util.encoders.Hex;
 
 import java.nio.charset.StandardCharsets;
 import java.util.GregorianCalendar;
@@ -37,11 +37,11 @@ public class BridgeRegTestConstants extends BridgeConstants {
     private static final Logger logger = LoggerFactory.getLogger("BridgeRegTestConstants");
 
     private static BridgeRegTestConstants instance = new BridgeRegTestConstants();
-    protected List<BtcECKey> federatorPrivateKeys;
-
     public static BridgeRegTestConstants getInstance() {
         return instance;
     }
+
+    protected List<BtcECKey> federatorPrivateKeys;
 
     BridgeRegTestConstants() {
         btcParamsString = NetworkParameters.ID_REGTEST;
@@ -50,22 +50,15 @@ public class BridgeRegTestConstants extends BridgeConstants {
         BtcECKey federator1PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator2".getBytes(StandardCharsets.UTF_8)));
         BtcECKey federator2PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator3".getBytes(StandardCharsets.UTF_8)));
 
-        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0362634ab57dae9cb373a5d536e66a8c4f67468bbcfb063809bab643072d78a124"));
-        BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03c5946b3fbae03a654237da863c9ed534e0878657175b132b8ca630f245df04db"));
-        BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02cd53fc53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1"));
-
         federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey);
-        federatorPublicKeys = Lists.newArrayList(federator0PublicKey, federator1PublicKey, federator2PublicKey);
 
-        federatorsRequiredToSign = 2;
-
-        Script redeemScript = ScriptBuilder.createRedeemScript(federatorsRequiredToSign, federatorPublicKeys);
-        federationPubScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-//      To recalculate federationAddress
-        federationAddress = Address.fromP2SHScript(getBtcParams(), federationPubScript);
-
-        // To recreate the value use
-        federationAddressCreationTime = new GregorianCalendar(2016,0,1).getTimeInMillis();
+        long genesisFederationCreationTime = new GregorianCalendar(2016,0,1).getTimeInMillis();
+        genesisFederation = Federation.fromPrivateKeys(
+                2,
+                federatorPrivateKeys,
+                genesisFederationCreationTime,
+                getBtcParams()
+        );
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -28,7 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
-import java.util.GregorianCalendar;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 
@@ -52,11 +53,11 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey);
 
-        long genesisFederationCreationTime = new GregorianCalendar(2016,0,1).getTimeInMillis();
+        Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
         genesisFederation = Federation.fromPrivateKeys(
                 2,
                 federatorPrivateKeys,
-                genesisFederationCreationTime,
+                genesisFederationCreatedAt,
                 getBtcParams()
         );
 

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -18,14 +18,16 @@
 
 package co.rsk.config;
 
-import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.Federation;
 import com.google.common.collect.Lists;
-import co.rsk.bitcoinj.script.Script;
-import co.rsk.bitcoinj.script.ScriptBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
+import java.util.List;
 
 public class BridgeTestNetConstants extends BridgeConstants {
 
@@ -56,24 +58,28 @@ public class BridgeTestNetConstants extends BridgeConstants {
         BtcECKey federator13PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0297d72f4c58b62495adbd49398b39d8fca69c6714ecaec49bd09e9dfcd9dc35cf"));
         BtcECKey federator14PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03c5dc2281b1bf3a8db339dceb4867bbcca1a633f3a65d5f80f6e8aca35b9b191c"));
 
-        federatorPublicKeys = Lists.newArrayList(federator0PublicKey, federator1PublicKey, federator2PublicKey,
-                                                 federator3PublicKey, federator4PublicKey, federator5PublicKey,
-                                                 federator6PublicKey, federator7PublicKey, federator8PublicKey,
-                                                 federator9PublicKey, federator10PublicKey, federator11PublicKey,
-                                                 federator12PublicKey, federator13PublicKey, federator14PublicKey);
-
-        federatorsRequiredToSign = 7;
-
-        Script redeemScript = ScriptBuilder.createRedeemScript(federatorsRequiredToSign, federatorPublicKeys);
-        federationPubScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-//      The federation address is "2NBPystfboREksK6hMCZesfH444zB3BkUUm"
-        federationAddress = Address.fromP2SHScript(getBtcParams(), federationPubScript);
+        List<BtcECKey> genesisFederationPublicKeys = Lists.newArrayList(
+                federator0PublicKey, federator1PublicKey, federator2PublicKey,
+                federator3PublicKey, federator4PublicKey, federator5PublicKey,
+                federator6PublicKey, federator7PublicKey, federator8PublicKey,
+                federator9PublicKey, federator10PublicKey, federator11PublicKey,
+                federator12PublicKey, federator13PublicKey, federator14PublicKey
+        );
 
         // To recreate the value use
         // federationAddressCreationTime = new GregorianCalendar(2017,4,10).getTimeInMillis() / 1000;
         // Currently set to:
         // Wed May 10 00:00:00 ART 2017
-        federationAddressCreationTime = 1494385200l;
+        long genesisFederationAddressCreationTime = 1494385200l;
+
+        // Expected federation address is:
+        // 2NBPystfboREksK6hMCZesfH444zB3BkUUm
+        genesisFederation = new Federation(
+                7,
+                genesisFederationPublicKeys,
+                genesisFederationAddressCreationTime,
+                getBtcParams()
+        );
 
         btc2RskMinimumAcceptableConfirmations = 10;
         rsk2BtcMinimumAcceptableConfirmations = 10;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
+import java.time.Instant;
 import java.util.List;
 
 public class BridgeTestNetConstants extends BridgeConstants {
@@ -67,17 +68,17 @@ public class BridgeTestNetConstants extends BridgeConstants {
         );
 
         // To recreate the value use
-        // federationAddressCreationTime = new GregorianCalendar(2017,4,10).getTimeInMillis() / 1000;
+        // genesisFederationAddressCreatedAt = new GregorianCalendar(2017,4,10).getTimeInMillis() / 1000;
         // Currently set to:
         // Wed May 10 00:00:00 ART 2017
-        long genesisFederationAddressCreationTime = 1494385200l;
+        Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1494385200l);
 
         // Expected federation address is:
         // 2NBPystfboREksK6hMCZesfH444zB3BkUUm
         genesisFederation = new Federation(
                 7,
                 genesisFederationPublicKeys,
-                genesisFederationAddressCreationTime,
+                genesisFederationAddressCreatedAt,
                 getBtcParams()
         );
 

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -85,6 +85,14 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function IS_BTC_TX_HASH_ALREADY_PROCESSED = CallTransaction.Function.fromSignature("isBtcTxHashAlreadyProcessed", new String[]{"string"}, new String[]{"bool"});
     // Returns whether a given btc tx hash was already processed by the bridge
     public static final CallTransaction.Function GET_BTC_TX_HASH_PROCESSED_HEIGHT = CallTransaction.Function.fromSignature("getBtcTxHashProcessedHeight", new String[]{"string"}, new String[]{"int64"});
+    // Returns the number of federates in the currently active federation
+    public static final CallTransaction.Function GET_FEDERATION_SIZE = CallTransaction.Function.fromSignature("getFederationSize", new String[]{}, new String[]{"uint"});
+    // Returns the public key of the federator at the specified index
+    public static final CallTransaction.Function GET_FEDERATOR_PUBLIC_KEY = CallTransaction.Function.fromSignature("getFederatorPublicKey", new String[]{"uint"}, new String[]{"bytes65"});
+    // Returns the creation time of the federation
+    public static final CallTransaction.Function GET_FEDERATION_CREATION_TIME = CallTransaction.Function.fromSignature("getFederationCreationTime", new String[]{}, new String[]{"uint64"});
+
+    // Log topics used by the Bridge
     public static final DataWord RELEASE_BTC_TOPIC = new DataWord("release_btc_topic".getBytes(StandardCharsets.UTF_8));
 
     private static Map<CallTransaction.Function, Long> functionCostMap = new HashMap<>();
@@ -119,6 +127,9 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         this.functions.put(new ByteArrayWrapper(GET_MINIMUM_LOCK_TX_VALUE.encodeSignature()),   GET_MINIMUM_LOCK_TX_VALUE);
         this.functions.put(new ByteArrayWrapper(IS_BTC_TX_HASH_ALREADY_PROCESSED.encodeSignature()),  IS_BTC_TX_HASH_ALREADY_PROCESSED);
         this.functions.put(new ByteArrayWrapper(GET_BTC_TX_HASH_PROCESSED_HEIGHT.encodeSignature()),  GET_BTC_TX_HASH_PROCESSED_HEIGHT);
+        this.functions.put(new ByteArrayWrapper(GET_FEDERATION_SIZE.encodeSignature()), GET_FEDERATION_SIZE);
+        this.functions.put(new ByteArrayWrapper(GET_FEDERATOR_PUBLIC_KEY.encodeSignature()), GET_FEDERATOR_PUBLIC_KEY);
+        this.functions.put(new ByteArrayWrapper(GET_FEDERATION_CREATION_TIME.encodeSignature()), GET_FEDERATION_CREATION_TIME);
 
         bridgeConstants = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
 
@@ -135,6 +146,9 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         functionCostMap.put(GET_MINIMUM_LOCK_TX_VALUE,             50011L);
         functionCostMap.put(IS_BTC_TX_HASH_ALREADY_PROCESSED,      50012L);
         functionCostMap.put(GET_BTC_TX_HASH_PROCESSED_HEIGHT,      50013L);
+        functionCostMap.put(GET_FEDERATION_SIZE,                   50014L);
+        functionCostMap.put(GET_FEDERATOR_PUBLIC_KEY,              50015L);
+        functionCostMap.put(GET_FEDERATION_CREATION_TIME,          50016L);
 
     }
 
@@ -477,6 +491,44 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         } catch (Exception e) {
             logger.warn("Exception in getBtcTxHashProcessedHeight", e);
             throw new RuntimeException("Exception in getBtcTxHashProcessedHeight", e);
+        }
+    }
+
+    public Integer getFederationSize(Object[] args)
+    {
+        logger.trace("getFederationSize");
+
+        try {
+            return bridgeSupport.getFederationSize();
+        } catch (IOException e) {
+            logger.warn("Exception in getFederationSize", e);
+            throw new RuntimeException("Exception in getFederationSize", e);
+        }
+    }
+
+    public byte[] getFederatorPublicKey(Object[] args)
+    {
+        logger.trace("getFederatorPublicKey");
+
+        try {
+            int index = (int) args[0];
+            return bridgeSupport.getFederatorPublicKey(index);
+        } catch (Exception e) {
+            logger.warn("Exception in getFederatorPublicKey", e);
+            throw new RuntimeException("Exception in getFederatorPublicKey", e);
+        }
+    }
+
+    public Long getFederationCreationTime(Object[] args)
+    {
+        logger.trace("getFederationCreationTime");
+
+        try {
+            // Return the creation time in milliseconds from the epoch
+            return bridgeSupport.getFederationCreationTime();
+        } catch (IOException e) {
+            logger.warn("Exception in getFederationCreationTime", e);
+            throw new RuntimeException("Exception in getFederationCreationTime", e);
         }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -140,10 +140,10 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
     @Override
     public long getGasForData(byte[] data) {
-        // Required gas is arbitrary
         if (BridgeUtils.isFreeBridgeTx(rskTx, rskExecutionBlock.getNumber())) {
             return 0;
         }
+
         BridgeParsedData bridgeParsedData = parseData(data);
 
         Long functionCost;
@@ -439,7 +439,12 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public String getFederationAddress(Object[] args)
     {
         logger.trace("getFederationAddress");
-        return bridgeSupport.getFederationAddress().toString();
+        try {
+            return bridgeSupport.getFederationAddress().toString();
+        } catch (IOException e) {
+            logger.warn("Exception in getFederationAddress", e);
+            throw new RuntimeException("Exception in getFederationAddress", e);
+        }
     }
 
 

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -87,8 +87,10 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function GET_BTC_TX_HASH_PROCESSED_HEIGHT = CallTransaction.Function.fromSignature("getBtcTxHashProcessedHeight", new String[]{"string"}, new String[]{"int64"});
     // Returns the number of federates in the currently active federation
     public static final CallTransaction.Function GET_FEDERATION_SIZE = CallTransaction.Function.fromSignature("getFederationSize", new String[]{}, new String[]{"uint"});
+    // Returns the number of minimum required signatures from the currently active federation
+    public static final CallTransaction.Function GET_FEDERATION_THRESHOLD = CallTransaction.Function.fromSignature("getFederationThreshold", new String[]{}, new String[]{"uint"});
     // Returns the public key of the federator at the specified index
-    public static final CallTransaction.Function GET_FEDERATOR_PUBLIC_KEY = CallTransaction.Function.fromSignature("getFederatorPublicKey", new String[]{"uint"}, new String[]{"bytes65"});
+    public static final CallTransaction.Function GET_FEDERATOR_PUBLIC_KEY = CallTransaction.Function.fromSignature("getFederatorPublicKey", new String[]{"uint"}, new String[]{"bytes"});
     // Returns the creation time of the federation
     public static final CallTransaction.Function GET_FEDERATION_CREATION_TIME = CallTransaction.Function.fromSignature("getFederationCreationTime", new String[]{}, new String[]{"uint64"});
 
@@ -128,6 +130,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         this.functions.put(new ByteArrayWrapper(IS_BTC_TX_HASH_ALREADY_PROCESSED.encodeSignature()),  IS_BTC_TX_HASH_ALREADY_PROCESSED);
         this.functions.put(new ByteArrayWrapper(GET_BTC_TX_HASH_PROCESSED_HEIGHT.encodeSignature()),  GET_BTC_TX_HASH_PROCESSED_HEIGHT);
         this.functions.put(new ByteArrayWrapper(GET_FEDERATION_SIZE.encodeSignature()), GET_FEDERATION_SIZE);
+        this.functions.put(new ByteArrayWrapper(GET_FEDERATION_THRESHOLD.encodeSignature()), GET_FEDERATION_THRESHOLD);
         this.functions.put(new ByteArrayWrapper(GET_FEDERATOR_PUBLIC_KEY.encodeSignature()), GET_FEDERATOR_PUBLIC_KEY);
         this.functions.put(new ByteArrayWrapper(GET_FEDERATION_CREATION_TIME.encodeSignature()), GET_FEDERATION_CREATION_TIME);
 
@@ -147,8 +150,9 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         functionCostMap.put(IS_BTC_TX_HASH_ALREADY_PROCESSED,      50012L);
         functionCostMap.put(GET_BTC_TX_HASH_PROCESSED_HEIGHT,      50013L);
         functionCostMap.put(GET_FEDERATION_SIZE,                   50014L);
-        functionCostMap.put(GET_FEDERATOR_PUBLIC_KEY,              50015L);
-        functionCostMap.put(GET_FEDERATION_CREATION_TIME,          50016L);
+        functionCostMap.put(GET_FEDERATION_THRESHOLD,              50015L);
+        functionCostMap.put(GET_FEDERATOR_PUBLIC_KEY,              50016L);
+        functionCostMap.put(GET_FEDERATION_CREATION_TIME,          50017L);
 
     }
 
@@ -506,12 +510,24 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         }
     }
 
+    public Integer getFederationThreshold(Object[] args)
+    {
+        logger.trace("getFederationThreshold");
+
+        try {
+            return bridgeSupport.getFederationThreshold();
+        } catch (IOException e) {
+            logger.warn("Exception in getFederationThreshold", e);
+            throw new RuntimeException("Exception in getFederationThreshold", e);
+        }
+    }
+
     public byte[] getFederatorPublicKey(Object[] args)
     {
         logger.trace("getFederatorPublicKey");
 
         try {
-            int index = (int) args[0];
+            int index = ((BigInteger) args[0]).intValue();
             return bridgeSupport.getFederatorPublicKey(index);
         } catch (Exception e) {
             logger.warn("Exception in getFederatorPublicKey", e);

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -541,7 +541,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
         try {
             // Return the creation time in milliseconds from the epoch
-            return bridgeSupport.getFederationCreationTime();
+            return bridgeSupport.getFederationCreationTime().toEpochMilli();
         } catch (IOException e) {
             logger.warn("Exception in getFederationCreationTime", e);
             throw new RuntimeException("Exception in getFederationCreationTime", e);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeBtcWallet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeBtcWallet.java
@@ -33,12 +33,12 @@ import java.util.Arrays;
  * @author Oscar Guindzberg
  */
 public class BridgeBtcWallet extends Wallet {
-    private BridgeConstants bridgeConstants;
+    private Federation federation;
     private Context btcContext;
 
-    public BridgeBtcWallet(Context btcContext, BridgeConstants bridgeConstants) {
+    public BridgeBtcWallet(Context btcContext, Federation federation) {
         super(btcContext);
-        this.bridgeConstants = bridgeConstants;
+        this.federation = federation;
         this.btcContext = btcContext;
     }
 
@@ -53,11 +53,11 @@ public class BridgeBtcWallet extends Wallet {
 //      I leave the code here just in case we decide to rollback to use the full original bitcoinj Wallet
 //      "keyChainGroupLock.lock();"
         try {
-            if (!Arrays.equals(bridgeConstants.getFederationPubScript().getPubKeyHash(), payToScriptHash)) {
+            if (!Arrays.equals(federation.getScript().getPubKeyHash(), payToScriptHash)) {
                 return null;
             }
-            Script redeemScript = ScriptBuilder.createRedeemScript(bridgeConstants.getFederatorsRequiredToSign(), bridgeConstants.getFederatorPublicKeys());
-            return RedeemData.of(bridgeConstants.getFederatorPublicKeys(), redeemScript);
+            Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getPublicKeys());
+            return RedeemData.of(federation.getPublicKeys(), redeemScript);
         } finally {
 //          Oscar: Comment out this line since we now have our own bitcoinj wallet and we disabled this feature
 //          I leave the code here just in case we decide to rollback to use the full original bitcoinj Wallet

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeBtcWallet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeBtcWallet.java
@@ -18,7 +18,6 @@
 
 package co.rsk.peg;
 
-import co.rsk.config.BridgeConstants;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
@@ -53,7 +52,7 @@ public class BridgeBtcWallet extends Wallet {
 //      I leave the code here just in case we decide to rollback to use the full original bitcoinj Wallet
 //      "keyChainGroupLock.lock();"
         try {
-            if (!Arrays.equals(federation.getScript().getPubKeyHash(), payToScriptHash)) {
+            if (!Arrays.equals(federation.getP2SHScript().getPubKeyHash(), payToScriptHash)) {
                 return null;
             }
             Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getPublicKeys());

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -18,12 +18,9 @@
 
 package co.rsk.peg;
 
+import co.rsk.bitcoinj.core.*;
 import co.rsk.crypto.Sha3Hash;
 import org.apache.commons.lang3.tuple.Pair;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.BtcTransaction;
-import co.rsk.bitcoinj.core.UTXO;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
@@ -33,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Created by mario on 20/04/17.
@@ -203,7 +201,7 @@ public class BridgeSerializationUtils {
         if (data == null || data.length == 0)
             return map;
 
-        RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
+        RLPList rlpList = (RLPList) RLP.decode2(data).get(0);
 
         // List size must be even - key, value pairs expected in sequence
         if (rlpList.size() % 2 != 0) {
@@ -213,11 +211,58 @@ public class BridgeSerializationUtils {
         int numEntries = rlpList.size() / 2;
 
         for (int k = 0; k < numEntries; k++) {
-            Sha256Hash hash = Sha256Hash.wrap(rlpList.get(k*2).getRLPData());
-            Long number = new BigInteger(rlpList.get(k*2 + 1).getRLPData()).longValue();
+            Sha256Hash hash = Sha256Hash.wrap(rlpList.get(k * 2).getRLPData());
+            Long number = new BigInteger(rlpList.get(k * 2 + 1).getRLPData()).longValue();
             map.put(hash, number);
         }
 
         return map;
+    }
+
+    // A federation is serialized as a list in the following order:
+    // creation time (8 bytes)
+    // # of signatures required (4 bytes)
+    // list of public keys -> [pubkey1, pubkey2, ..., pubkeyn],
+    // ordered in lexicographical ordered of each public key's hex representation
+    public static byte[] serializeFederation(Federation federation) {
+        List<byte[]> publicKeys = federation.getPublicKeys().stream()
+                .map(key -> key.getPubKey())
+                .collect(Collectors.toList());
+        return RLP.encodeList(
+                RLP.encodeBigInteger(BigInteger.valueOf(federation.getCreationTime())),
+                RLP.encodeBigInteger(BigInteger.valueOf(federation.getNumberOfSignaturesRequired())),
+                RLP.encodeList((byte[][])publicKeys.toArray())
+        );
+    }
+
+    // For the serialization format, see BridgeSerializationUtils::serializeFederation
+    public static Federation deserializeFederation(byte[] data, Context btcContext) {
+        RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
+
+        if (rlpList.size() != 3) {
+            throw new RuntimeException(String.format("Invalid serialized Federation. Expected 3 elements but got {}", rlpList.size()));
+        }
+
+        byte[] creationTimeBytes = rlpList.get(0).getRLPData();
+        if (creationTimeBytes.length != 8) {
+            throw new RuntimeException(String.format("Invalid serialized Federation creation time. Expected 8 bytes but got {}", creationTimeBytes.length));
+        }
+        long creationTime = new BigInteger(creationTimeBytes).longValue();
+
+        byte[] numberOfSignaturesRequiredBytes = rlpList.get(1).getRLPData();
+        if (numberOfSignaturesRequiredBytes.length != 4) {
+            throw new RuntimeException(String.format("Invalid serialized Federation # of signatures required. Expected 4 bytes but got {}", numberOfSignaturesRequiredBytes.length));
+        }
+        int numberOfSignaturesRequired =  new BigInteger(creationTimeBytes).intValue();
+
+        List<BtcECKey> pubKeys = ((RLPList) rlpList.get(2)).stream()
+                .map(pubKeyBytes -> BtcECKey.fromPublicOnly(pubKeyBytes.getRLPData()))
+                .collect(Collectors.toList());
+
+        if (pubKeys.size() < numberOfSignaturesRequired) {
+            throw new RuntimeException(String.format("Invalid serialized Federation # of public keys. Expected at least {} but got {}", numberOfSignaturesRequired, pubKeys.size()));
+        }
+
+        return new Federation(numberOfSignaturesRequired, pubKeys, creationTime, btcContext.getParams());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -222,10 +222,11 @@ public class BridgeSerializationUtils {
     // A federation is serialized as a list in the following order:
     // creation time (8 bytes)
     // # of signatures required (4 bytes)
-    // list of public keys -> [pubkey1, pubkey2, ..., pubkeyn],
-    // ordered in lexicographical ordered of each public key's hex representation
+    // list of public keys -> [pubkey1, pubkey2, ..., pubkeyn], sorted
+    // using the lexicographical order of the public keys (see BtcECKey.PUBKEY_COMPARATOR).
     public static byte[] serializeFederation(Federation federation) {
         List<byte[]> publicKeys = federation.getPublicKeys().stream()
+                .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .map(key -> key.getPubKey())
                 .collect(Collectors.toList());
         return RLP.encodeList(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -230,7 +231,7 @@ public class BridgeSerializationUtils {
                 .map(key -> key.getPubKey())
                 .collect(Collectors.toList());
         return RLP.encodeList(
-                RLP.encodeBigInteger(BigInteger.valueOf(federation.getCreationTime())),
+                RLP.encodeBigInteger(BigInteger.valueOf(federation.getCreationTime().toEpochMilli())),
                 RLP.encodeBigInteger(BigInteger.valueOf(federation.getNumberOfSignaturesRequired())),
                 RLP.encodeList((byte[][])publicKeys.toArray())
         );
@@ -248,7 +249,7 @@ public class BridgeSerializationUtils {
         if (creationTimeBytes.length != 8) {
             throw new RuntimeException(String.format("Invalid serialized Federation creation time. Expected 8 bytes but got {}", creationTimeBytes.length));
         }
-        long creationTime = new BigInteger(creationTimeBytes).longValue();
+        Instant creationTime = Instant.ofEpochMilli(new BigInteger(creationTimeBytes).longValue());
 
         byte[] numberOfSignaturesRequiredBytes = rlpList.get(1).getRLPData();
         if (numberOfSignaturesRequiredBytes.length != 4) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -113,7 +113,7 @@ public class BridgeStorageProvider {
 
         btcWallet = new BridgeBtcWallet(btcContext, federation);
         btcWallet.setUTXOProvider(utxoProvider);
-        btcWallet.addWatchedAddress(federation.getAddress(), federation.getCreationTime());
+        btcWallet.addWatchedAddress(federation.getAddress(), federation.getCreationTime().toEpochMilli());
         btcWallet.setCoinSelector(new RskAllowUnconfirmedCoinSelector());
 //      Oscar: Comment out these setting since we now have our own bitcoinj wallet and we disabled these features
 //      I leave the code here just in case we decide to rollback to use the full original bitcoinj Wallet

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -45,11 +45,7 @@ public class BridgeStorageProvider {
     private static final String BTC_TX_HASHES_ALREADY_PROCESSED_KEY = "btcTxHashesAP";
     private static final String RSK_TXS_WAITING_FOR_CONFIRMATIONS_KEY = "rskTxsWaitingFC";
     private static final String RSK_TXS_WAITING_FOR_SIGNATURES_KEY = "rskTxsWaitingFS";
-<<<<<<< HEAD
-=======
-    private static final String RSK_TXS_WAITING_FOR_BROADCASTING_KEY = "rskTxsWaitingFB";
     private static final String BRIDGE_ACTIVE_FEDERATION_KEY = "bridgeActiveFederation";
->>>>>>> Currently active federation now stored in the blockchain, non-working version
 
     private static final NetworkParameters networkParameters = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -685,6 +685,14 @@ public class BridgeSupport {
      * @return the federation size
      */
     public Integer getFederationSize() throws IOException {
+        return getFederation().getPublicKeys().size();
+    }
+
+    /**
+     * Returns the federation's minimum required signatures
+     * @return the federation minimum required signatures
+     */
+    public Integer getFederationThreshold() throws IOException {
         return getFederation().getNumberOfSignaturesRequired();
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -681,6 +681,37 @@ public class BridgeSupport {
     }
 
     /**
+     * Returns the federation's size
+     * @return the federation size
+     */
+    public Integer getFederationSize() throws IOException {
+        return getFederation().getNumberOfSignaturesRequired();
+    }
+
+    /**
+     * Returns the public key of the federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @return the federator's public key
+     */
+    public byte[] getFederatorPublicKey(int index) throws IOException {
+        List<BtcECKey> publicKeys = getFederation().getPublicKeys();
+
+        if (index < 0 || index >= publicKeys.size()) {
+            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and {}", publicKeys.size() - 1));
+        }
+
+        return publicKeys.get(index).getPubKey();
+    }
+
+    /**
+     * Returns the federation's creation time
+     * @return the federation creation time
+     */
+    public Long getFederationCreationTime() throws IOException {
+        return getFederation().getCreationTime();
+    }
+
+    /**
      * Returns the minimum amount of satoshis a user should send to the federation.
      * @return the minimum amount of satoshis a user should send to the federation.
      */
@@ -708,7 +739,5 @@ public class BridgeSupport {
     BtcBlockStore getBtcBlockStore() {
         return btcBlockStore;
     }
-
-
 }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -48,6 +48,7 @@ import org.spongycastle.util.encoders.Hex;
 
 import java.io.*;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.*;
 
 import static org.ethereum.util.BIUtil.toBI;
@@ -96,7 +97,7 @@ public class BridgeSupport {
         btcBlockStore = new RepositoryBlockStore(repository, contractAddress);
         if (btcBlockStore.getChainHead().getHeader().getHash().equals(btcParams.getGenesisBlock().getHash())) {
             // We are building the blockstore for the first time, so we have not set the checkpoints yet.
-            long time = getFederation().getCreationTime();
+            long time = getFederation().getCreationTime().toEpochMilli();
             InputStream checkpoints = this.getCheckPoints();
             if (time > 0 && checkpoints != null) {
                 CheckpointManager.checkpoint(btcParams, checkpoints, btcBlockStore, time);
@@ -715,7 +716,7 @@ public class BridgeSupport {
      * Returns the federation's creation time
      * @return the federation creation time
      */
-    public Long getFederationCreationTime() throws IOException {
+    public Instant getFederationCreationTime() throws IOException {
         return getFederation().getCreationTime();
     }
 
@@ -737,7 +738,7 @@ public class BridgeSupport {
             return new StoredBlock(genesis, genesis.getWork(), 0);
         }
         CheckpointManager manager = new CheckpointManager(bridgeConstants.getBtcParams(), checkpoints);
-        long time = getFederation().getCreationTime();
+        long time = getFederation().getCreationTime().toEpochMilli();
         // Go back 1 week to match CheckpointManager.checkpoint() behaviour
         time -= 86400 * 7;
         return manager.getCheckpointBefore(time);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -68,7 +68,7 @@ public class BridgeUtils {
         int i = 0;
         for (TransactionInput transactionInput : tx.getInputs()) {
             try {
-                transactionInput.getScriptSig().correctlySpends(tx, i, federation.getScript(), Script.ALL_VERIFY_FLAGS);
+                transactionInput.getScriptSig().correctlySpends(tx, i, federation.getP2SHScript(), Script.ALL_VERIFY_FLAGS);
                 // There is an input spending from the federation address, this is not a lock tx
                 return false;
             } catch (ScriptException se) {
@@ -89,7 +89,7 @@ public class BridgeUtils {
         int i = 0;
         for (TransactionInput transactionInput : tx.getInputs()) {
             try {
-                transactionInput.getScriptSig().correctlySpends(tx, i, federation.getScript(), Script.ALL_VERIFY_FLAGS);
+                transactionInput.getScriptSig().correctlySpends(tx, i, federation.getP2SHScript(), Script.ALL_VERIFY_FLAGS);
                 // There is an input spending from the federation address, this is a release tx
                 return true;
             } catch (ScriptException se) {

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -24,6 +24,7 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,21 +38,20 @@ import java.util.stream.Collectors;
 public final class Federation {
     private int numberOfSignaturesRequired;
     private List<BtcECKey> publicKeys;
-    // TODO: it would be (really) good to have the creation time as a proper date/time
-    private long creationTime;
+    private Instant creationTime;
     private NetworkParameters btcParams;
     private Script redeemScript;
     private Script p2shScript;
     private Address address;
 
-    public static Federation fromPrivateKeys(int numberOfSignaturesRequired, List<BtcECKey> privateKeys, long creationTime, NetworkParameters btcParams) {
+    public static Federation fromPrivateKeys(int numberOfSignaturesRequired, List<BtcECKey> privateKeys, Instant creationTime, NetworkParameters btcParams) {
         List<BtcECKey> publicKeys = privateKeys.stream()
                 .map(key -> BtcECKey.fromPublicOnly(key.getPubKey()))
                 .collect(Collectors.toList());
         return new Federation(numberOfSignaturesRequired, publicKeys, creationTime, btcParams);
     }
 
-    public Federation(int numberOfSignaturesRequired, List<BtcECKey> publicKeys, long creationTime, NetworkParameters btcParams) {
+    public Federation(int numberOfSignaturesRequired, List<BtcECKey> publicKeys, Instant creationTime, NetworkParameters btcParams) {
         this.numberOfSignaturesRequired = numberOfSignaturesRequired;
         this.publicKeys = Collections.unmodifiableList(publicKeys);
         this.creationTime = creationTime;
@@ -69,7 +69,7 @@ public final class Federation {
         return this.numberOfSignaturesRequired;
     }
 
-    public long getCreationTime() {
+    public Instant getCreationTime() {
         return creationTime;
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Immutable representation of an RSK Federation in the context of
+ * a specific BTC network.
+ *
+ * @author Ariel Mendelzon
+ */
+public final class Federation {
+    private int numberOfSignaturesRequired;
+    private List<BtcECKey> publicKeys;
+    private long creationTime;
+    private NetworkParameters btcParams;
+    private Script script;
+    private Address address;
+
+    public static Federation fromPrivateKeys(int numberOfSignaturesRequired, List<BtcECKey> privateKeys, long creationTime, NetworkParameters btcParams) {
+        List<BtcECKey> publicKeys = privateKeys.stream()
+                .map(key -> BtcECKey.fromPublicOnly(key.getPubKey()))
+                .collect(Collectors.toList());
+        return new Federation(numberOfSignaturesRequired, publicKeys, creationTime, btcParams);
+    }
+
+    public Federation(int numberOfSignaturesRequired, List<BtcECKey> publicKeys, long creationTime, NetworkParameters btcParams) {
+        this.numberOfSignaturesRequired = numberOfSignaturesRequired;
+        this.publicKeys = Collections.unmodifiableList(publicKeys);
+        this.creationTime = creationTime;
+        this.btcParams = btcParams;
+        // Calculated once on-demand
+        this.script = null;
+        this.address = null;
+    }
+
+    public List<BtcECKey> getPublicKeys() {
+        return publicKeys;
+    }
+
+    public int getNumberOfSignaturesRequired() {
+        return this.numberOfSignaturesRequired;
+    }
+
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    public NetworkParameters getBtcParams() {
+        return btcParams;
+    }
+
+    public Script getScript() {
+        if (script == null) {
+            script = ScriptBuilder.createRedeemScript(getNumberOfSignaturesRequired(), getPublicKeys());
+        }
+
+        return script;
+    }
+
+    public Address getAddress() {
+        if (address == null) {
+            address = Address.fromP2SHScript(btcParams, getScript());
+        }
+
+        return address;
+    }
+
+    @Override
+    public String toString() {
+        return getAddress().toString();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -39,7 +39,8 @@ public final class Federation {
     private List<BtcECKey> publicKeys;
     private long creationTime;
     private NetworkParameters btcParams;
-    private Script script;
+    private Script redeemScript;
+    private Script p2shScript;
     private Address address;
 
     public static Federation fromPrivateKeys(int numberOfSignaturesRequired, List<BtcECKey> privateKeys, long creationTime, NetworkParameters btcParams) {
@@ -55,7 +56,7 @@ public final class Federation {
         this.creationTime = creationTime;
         this.btcParams = btcParams;
         // Calculated once on-demand
-        this.script = null;
+        this.redeemScript = null;
         this.address = null;
     }
 
@@ -75,17 +76,25 @@ public final class Federation {
         return btcParams;
     }
 
-    public Script getScript() {
-        if (script == null) {
-            script = ScriptBuilder.createRedeemScript(getNumberOfSignaturesRequired(), getPublicKeys());
+    public Script getRedeemScript() {
+        if (redeemScript == null) {
+            redeemScript = ScriptBuilder.createRedeemScript(getNumberOfSignaturesRequired(), getPublicKeys());
         }
 
-        return script;
+        return redeemScript;
+    }
+
+    public Script getP2SHScript() {
+        if (p2shScript == null) {
+            p2shScript = ScriptBuilder.createP2SHOutputScript(getNumberOfSignaturesRequired(), getPublicKeys());
+        }
+
+        return p2shScript;
     }
 
     public Address getAddress() {
         if (address == null) {
-            address = Address.fromP2SHScript(btcParams, getScript());
+            address = Address.fromP2SHScript(btcParams, getP2SHScript());
         }
 
         return address;

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 public final class Federation {
     private int numberOfSignaturesRequired;
     private List<BtcECKey> publicKeys;
+    // TODO: it would be (really) good to have the creation time as a proper date/time
     private long creationTime;
     private NetworkParameters btcParams;
     private Script redeemScript;

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -23,8 +23,10 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
+import org.ethereum.db.ByteArrayWrapper;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,7 +55,10 @@ public final class Federation {
 
     public Federation(int numberOfSignaturesRequired, List<BtcECKey> publicKeys, Instant creationTime, NetworkParameters btcParams) {
         this.numberOfSignaturesRequired = numberOfSignaturesRequired;
-        this.publicKeys = Collections.unmodifiableList(publicKeys);
+        // Sorting public keys ensures same order of federators for same public keys
+        // Immutability provides protection unless unwanted modification, thus making the Federation instance
+        // effectively immutable
+        this.publicKeys = Collections.unmodifiableList(publicKeys.stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList()));
         this.creationTime = creationTime;
         this.btcParams = btcParams;
         // Calculated once on-demand
@@ -105,5 +110,43 @@ public final class Federation {
     @Override
     public String toString() {
         return String.format("%d of %d signatures federation", numberOfSignaturesRequired, publicKeys.size());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other instanceof Federation) {
+            return this.equalsFederation((Federation) other);
+        }
+
+        return false;
+    }
+
+    public boolean equalsFederation(Federation other) {
+        if (other == null) {
+            return false;
+        }
+
+        if (this == other) {
+            return true;
+        }
+
+        ByteArrayWrapper[] thisPublicKeys = this.getPublicKeys().stream()
+                .sorted(BtcECKey.PUBKEY_COMPARATOR)
+                .map(k -> new ByteArrayWrapper(k.getPubKey()))
+                .toArray(ByteArrayWrapper[]::new);
+        ByteArrayWrapper[] otherPublicKeys = other.getPublicKeys().stream()
+                .sorted(BtcECKey.PUBKEY_COMPARATOR)
+                .map(k -> new ByteArrayWrapper(k.getPubKey()))
+                .toArray(ByteArrayWrapper[]::new);
+
+        return this.getNumberOfSignaturesRequired() == other.getNumberOfSignaturesRequired() &&
+                this.getPublicKeys().size() == other.getPublicKeys().size() &&
+                this.getCreationTime().equals(other.getCreationTime()) &&
+                this.btcParams.equals(other.btcParams) &&
+                Arrays.equals(thisPublicKeys, otherPublicKeys);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -58,6 +58,7 @@ public final class Federation {
         this.btcParams = btcParams;
         // Calculated once on-demand
         this.redeemScript = null;
+        this.p2shScript = null;
         this.address = null;
     }
 
@@ -103,6 +104,6 @@ public final class Federation {
 
     @Override
     public String toString() {
-        return getAddress().toString();
+        return String.format("%d of %d signatures federation", numberOfSignaturesRequired, publicKeys.size());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/FederationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationProvider.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+/**
+ * Implementors of this interface must be able to provide a federation instance.
+ *
+ * @author Ariel Mendelzon
+ */
+public interface FederationProvider {
+    Federation getFederation();
+}

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -181,7 +181,7 @@ public class Transaction implements SerializableObject {
         if (!parsed)
             rlpParse();
 
-		//Federators txs to the bridge are free during system setup
+		// Federators txs to the bridge are free during system setup
         if (BridgeUtils.isFreeBridgeTx(this, block.getNumber())) {
             return 0;
         }

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
@@ -20,6 +20,7 @@ package co.rsk.net.handler;
 
 import co.rsk.TestHelpers.Tx;
 import co.rsk.config.RskSystemProperties;
+import co.rsk.peg.Federation;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.*;
@@ -173,7 +174,9 @@ public class TxValidatorTest {
         Mockito.when(transaction.getSignature()).thenReturn(new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.ONE));
         Mockito.when(transaction.transactionCost(Mockito.any())).thenReturn(new Long(0));
         Mockito.when(transaction.getGasLimitAsInteger()).thenReturn(BigInteger.ZERO);
-        byte[] federator0PubKey = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getFederatorPublicKeys().get(0).getPubKey();
+        // Federation is the genesis federation ATM
+        Federation federation = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getGenesisFederation();
+        byte[] federator0PubKey = federation.getPublicKeys().get(0).getPubKey();
         Mockito.when(transaction.getKey()).thenReturn(ECKey.fromPublicOnly(federator0PubKey));
         return transaction;
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -156,14 +156,11 @@ public class BridgeSerializationUtilsTest {
         PowerMockito.mockStatic(RLP.class);
         mock_RLP_decode2_forFederation();
 
-        byte[][] publicKeyBytes = new byte[][]{
-            BtcECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(200)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(300)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(400)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(500)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
-        };
+        byte[][] publicKeyBytes = Arrays.asList(100, 200, 300, 400, 500, 600).stream()
+            .map(k -> BtcECKey.fromPrivate(BigInteger.valueOf(k)))
+            .sorted(BtcECKey.PUBKEY_COMPARATOR)
+            .map(k -> k.getPubKey())
+            .toArray(byte[][]::new);
 
         StringBuilder sampleBuilder = new StringBuilder();
         sampleBuilder.append("03"); // Length of outer list

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -234,10 +234,12 @@ public class BridgeStorageProviderTest {
         Repository track = repository.startTracking();
 
         BridgeConstants bridgeConstants = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
-        provider0.getBtcUTXOs().add(new UTXO(hash1, 1, Coin.COIN, 0, false, ScriptBuilder.createOutputScript(bridgeConstants.getFederationAddress())));
-        provider0.getBtcUTXOs().add(new UTXO(hash2, 2, Coin.FIFTY_COINS, 0, false, ScriptBuilder.createOutputScript(bridgeConstants.getFederationAddress())));
+        provider0.getBtcUTXOs().add(new UTXO(hash1, 1, Coin.COIN, 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
+        provider0.getBtcUTXOs().add(new UTXO(hash2, 2, Coin.FIFTY_COINS, 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
         provider0.save();
         track.commit();
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -252,6 +252,8 @@ public class BridgeSupportTest {
 
     @Test
     public void callUpdateCollectionsFundsEnoughForJustTheSmallerTx() throws IOException, BlockStoreException {
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
         BtcTransaction tx1 = new BtcTransaction(btcParams);
         tx1.addOutput(Coin.valueOf(30,0), new BtcECKey().toAddress(btcParams));
         BtcTransaction tx2 = new BtcTransaction(btcParams);
@@ -270,7 +272,14 @@ public class BridgeSupportTest {
         provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
         provider0.getRskTxsWaitingForConfirmations().put(hash2, tx2);
         provider0.getRskTxsWaitingForConfirmations().put(hash3, tx3);
-        provider0.getBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.valueOf(12,0), 0, false, ScriptBuilder.createOutputScript(bridgeConstants.getFederationAddress())));
+        provider0.getBtcUTXOs().add(new UTXO(
+                PegTestUtils.createHash(),
+                1,
+                Coin.valueOf(12,0),
+                0,
+                false,
+                ScriptBuilder.createOutputScript(federation.getAddress())
+        ));
 
         provider0.save();
 
@@ -323,6 +332,8 @@ public class BridgeSupportTest {
 
     @Test
     public void callUpdateCollectionsThrowsCouldNotAdjustDownwards() throws IOException, BlockStoreException {
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
         BtcTransaction tx1 = new BtcTransaction(btcParams);
         tx1.addOutput(Coin.valueOf(37500), new BtcECKey().toAddress(btcParams));
         Sha3Hash hash1 = PegTestUtils.createHash3();
@@ -333,7 +344,14 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
         provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
-        provider0.getBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.valueOf(1000000), 0, false, ScriptBuilder.createOutputScript(bridgeConstants.getFederationAddress())));
+        provider0.getBtcUTXOs().add(new UTXO(
+                PegTestUtils.createHash(),
+                1,
+                Coin.valueOf(1000000),
+                0,
+                false,
+                ScriptBuilder.createOutputScript(federation.getAddress())
+        ));
 
         provider0.save();
 
@@ -376,6 +394,8 @@ public class BridgeSupportTest {
 
     @Test
     public void callUpdateCollectionsThrowsExceededMaxTransactionSize() throws IOException, BlockStoreException {
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
         BtcTransaction tx1 = new BtcTransaction(btcParams);
         tx1.addOutput(Coin.COIN.multiply(7), new BtcECKey().toAddress(btcParams));
         Sha3Hash hash1 = PegTestUtils.createHash3();
@@ -387,7 +407,14 @@ public class BridgeSupportTest {
 
         provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
         for (int i = 0; i < 2000; i++) {
-            provider0.getBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.CENT, 0, false, ScriptBuilder.createOutputScript(bridgeConstants.getFederationAddress())));
+            provider0.getBtcUTXOs().add(new UTXO(
+                    PegTestUtils.createHash(),
+                    1,
+                    Coin.CENT,
+                    0,
+                    false,
+                    ScriptBuilder.createOutputScript(federation.getAddress())
+            ));
         }
 
         provider0.save();
@@ -430,6 +457,8 @@ public class BridgeSupportTest {
 
     @Test
     public void callUpdateCollectionsChangeGetsOutOfDust() throws IOException, BlockStoreException {
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
         BtcTransaction tx1 = new BtcTransaction(btcParams);
         tx1.addOutput(Coin.COIN, new BtcECKey().toAddress(btcParams));
         Sha3Hash hash1 = PegTestUtils.createHash3();
@@ -464,7 +493,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
         provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
-        provider0.getBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.COIN.add(Coin.valueOf(100)), 0, false, ScriptBuilder.createOutputScript(bridgeConstants.getFederationAddress())));
+        provider0.getBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.COIN.add(Coin.valueOf(100)), 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
 
         provider0.save();
 
@@ -602,12 +631,14 @@ public class BridgeSupportTest {
 
     @Test
     public void addSignatureToMissingTransaction() throws Exception {
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
 
         BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, (Block) null, null, null, Collections.emptyList());
 
-        bridgeSupport.addSignature(1, bridgeConstants.getFederatorPublicKeys().get(0), null, PegTestUtils.createHash().getBytes());
+        bridgeSupport.addSignature(1, federation.getPublicKeys().get(0), null, PegTestUtils.createHash().getBytes());
         bridgeSupport.save();
 
         track.commit();
@@ -685,6 +716,8 @@ public class BridgeSupportTest {
      * @param expectedResult "InvalidParameters", "PartiallySigned" or "FullySigned"
      */
     private void addSignatureFromValidFederator(List<BtcECKey> privateKeysToSignWith, int numberOfInputsToSign, boolean signatureCanonical, boolean signTwice, String expectedResult) throws Exception {
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
         Repository repository = new RepositoryImpl();
 
         final Sha3Hash sha3Hash = PegTestUtils.createHash3();
@@ -693,7 +726,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
         BtcTransaction prevTx = new BtcTransaction(btcParams);
-        TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, bridgeConstants.getFederationAddress());
+        TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, federation.getAddress());
         prevTx.addOutput(prevOut);
         UTXO utxo = new UTXO(prevTx.getHash(), 0, prevOut.getValue(), 0, false, prevOut.getScriptPubKey());
         provider.getBtcUTXOs().add(utxo);
@@ -726,7 +759,7 @@ public class BridgeSupportTest {
         for (int i = 0; i < numberOfInputsToSign; i++) {
             derEncodedSigs.add(derEncodedSig);
         }
-        bridgeSupport.addSignature(1, bridgeConstants.getFederatorPublicKeys().get(0), derEncodedSigs, sha3Hash.getBytes());
+        bridgeSupport.addSignature(1, federation.getPublicKeys().get(0), derEncodedSigs, sha3Hash.getBytes());
         if (signTwice) {
             // Create another valid signature with the same private key
             ECDSASigner signer = new ECDSASigner();
@@ -734,7 +767,7 @@ public class BridgeSupportTest {
             signer.init(true, privKey);
             BigInteger[] components = signer.generateSignature(sighash.getBytes());
             BtcECKey.ECDSASignature sig2 = new BtcECKey.ECDSASignature(components[0], components[1]).toCanonicalised();
-            bridgeSupport.addSignature(1, bridgeConstants.getFederatorPublicKeys().get(0), Lists.newArrayList(sig2.encodeToDER()), sha3Hash.getBytes());
+            bridgeSupport.addSignature(1, federation.getPublicKeys().get(0), Lists.newArrayList(sig2.encodeToDER()), sha3Hash.getBytes());
         }
         if (privateKeysToSignWith.size()>1) {
             BtcECKey.ECDSASignature sig2 = privateKeysToSignWith.get(1).sign(sighash);
@@ -743,7 +776,7 @@ public class BridgeSupportTest {
             for (int i = 0; i < numberOfInputsToSign; i++) {
                 derEncodedSigs2.add(derEncodedSig2);
             }
-            bridgeSupport.addSignature(1, bridgeConstants.getFederatorPublicKeys().get(1), derEncodedSigs2, sha3Hash.getBytes());
+            bridgeSupport.addSignature(1, federation.getPublicKeys().get(1), derEncodedSigs2, sha3Hash.getBytes());
         }
         bridgeSupport.save();
         track.commit();
@@ -999,6 +1032,8 @@ public class BridgeSupportTest {
 
     @Test
     public void registerBtcTransactionReleaseTx() throws BlockStoreException, AddressFormatException, IOException {
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
         Repository repository = new RepositoryImpl();
         repository.addBalance(Hex.decode(PrecompiledContracts.BRIDGE_ADDR), BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
         Repository track = repository.startTracking();
@@ -1010,29 +1045,29 @@ public class BridgeSupportTest {
         BtcTransaction tx = new BtcTransaction(this.btcParams);
         Address address = ScriptBuilder.createP2SHOutputScript(2, Lists.newArrayList(new BtcECKey(), new BtcECKey(), new BtcECKey())).getToAddress(bridgeConstants.getBtcParams());
         tx.addOutput(Coin.COIN, address);
-        Address address2 = bridgeConstants.getFederationAddress();
+        Address address2 = federation.getAddress();
         tx.addOutput(Coin.COIN, address2);
 
         // Create previous tx
         BtcTransaction prevTx = new BtcTransaction(btcParams);
-        TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, bridgeConstants.getFederationAddress());
+        TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, federation.getAddress());
         prevTx.addOutput(prevOut);
         // Create tx input
         tx.addInput(prevOut);
         // Create tx input base script sig
         Script scriptSig = PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(bridgeConstants);
         // Create sighash
-        Script redeemScript = ScriptBuilder.createRedeemScript(bridgeConstants.getFederatorsRequiredToSign(), bridgeConstants.getFederatorPublicKeys());
+        Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getPublicKeys());
         Sha256Hash sighash = tx.hashForSignature(0, redeemScript, BtcTransaction.SigHash.ALL, false);
         // Sign by federator 0
         BtcECKey.ECDSASignature sig0 = bridgeConstants.getFederatorPrivateKeys().get(0).sign(sighash);
         TransactionSignature txSig0 = new TransactionSignature(sig0, BtcTransaction.SigHash.ALL, false);
-        int sigIndex0 = scriptSig.getSigInsertionIndex(sighash, bridgeConstants.getFederatorPublicKeys().get(0));
+        int sigIndex0 = scriptSig.getSigInsertionIndex(sighash, federation.getPublicKeys().get(0));
         scriptSig = ScriptBuilder.updateScriptWithSignature(scriptSig, txSig0.encodeToBitcoin(), sigIndex0, 1, 1);
         // Sign by federator 1
         BtcECKey.ECDSASignature sig1 = bridgeConstants.getFederatorPrivateKeys().get(1).sign(sighash);
         TransactionSignature txSig1 = new TransactionSignature(sig1, BtcTransaction.SigHash.ALL, false);
-        int sigIndex1 = scriptSig.getSigInsertionIndex(sighash, bridgeConstants.getFederatorPublicKeys().get(1));
+        int sigIndex1 = scriptSig.getSigInsertionIndex(sighash, federation.getPublicKeys().get(1));
         scriptSig = ScriptBuilder.updateScriptWithSignature(scriptSig, txSig1.encodeToBitcoin(), sigIndex1, 1, 1);
         // Set scipt sign to tx input
         tx.getInput(0).setScriptSig(scriptSig);
@@ -1079,6 +1114,8 @@ public class BridgeSupportTest {
 
     @Test
     public void registerBtcTransactionLockTx() throws BlockStoreException, AddressFormatException, IOException {
+        // Federation is the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
         Repository repository = new RepositoryImpl();
         repository.addBalance(Hex.decode(PrecompiledContracts.BRIDGE_ADDR), BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
         Block executionBlock = Mockito.mock(Block.class);
@@ -1089,7 +1126,7 @@ public class BridgeSupportTest {
         BridgeConstants bridgeConstants = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
 
         BtcTransaction tx = new BtcTransaction(this.btcParams);
-        Address address = bridgeConstants.getFederationAddress();
+        Address address = federation.getAddress();
         tx.addOutput(Coin.COIN, address);
         BtcECKey srcKey = new BtcECKey();
         tx.addInput(PegTestUtils.createHash(), 0, ScriptBuilder.createInputScript(null, srcKey));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -306,7 +306,9 @@ public class BridgeTest {
     }
 
     @Test
-    public void getFederationAddress() throws Exception{
+    public void getFederationAddress() throws Exception {
+        // Case with genesis federation
+        Federation federation = bridgeConstants.getGenesisFederation();
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
 
@@ -315,7 +317,7 @@ public class BridgeTest {
 
         byte[] data = Bridge.GET_FEDERATION_ADDRESS.encode();
 
-        Assert.assertArrayEquals(Bridge.GET_FEDERATION_ADDRESS.encodeOutputs(bridgeConstants.getFederationAddress().toString()), bridge.execute(data));
+        Assert.assertArrayEquals(Bridge.GET_FEDERATION_ADDRESS.encodeOutputs(federation.getAddress().toString()), bridge.execute(data));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -46,6 +46,7 @@ import org.mockito.invocation.InvocationOnMock;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.*;
 
 import static org.mockito.Matchers.any;
@@ -672,5 +673,52 @@ public class BridgeTest {
         }
         Assert.assertTrue(thrown);
         verify(bridgeSupportMock, never()).getBtcTxHashProcessedHeight(any());
+    }
+
+    @Test
+    public void getFederationSize() throws IOException {
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
+        bridge.init(null, null, null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        when(bridgeSupportMock.getFederationSize()).thenReturn(1234);
+
+        Assert.assertEquals(1234, bridge.getFederationSize(new Object[]{}).intValue());
+    }
+
+    @Test
+    public void getFederationThreshold() throws IOException {
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
+        bridge.init(null, null, null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        when(bridgeSupportMock.getFederationThreshold()).thenReturn(5678);
+
+        Assert.assertEquals(5678, bridge.getFederationThreshold(new Object[]{}).intValue());
+    }
+
+    @Test
+    public void getFederationCreationTime() throws IOException {
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
+        bridge.init(null, null, null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        when(bridgeSupportMock.getFederationCreationTime()).thenReturn(Instant.ofEpochMilli(5000));
+
+        Assert.assertEquals(5000, bridge.getFederationCreationTime(new Object[]{}).intValue());
+    }
+
+    @Test
+    public void getFederatorPublicKey() throws IOException {
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
+        bridge.init(null, null, null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        when(bridgeSupportMock.getFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
+                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toByteArray());
+
+        Assert.assertTrue(Arrays.equals(new byte[]{10}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(10)})));
+        Assert.assertTrue(Arrays.equals(new byte[]{20}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(20)})));
+        Assert.assertTrue(Arrays.equals(new byte[]{1, 0}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(256)})));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -63,7 +63,7 @@ public class BridgeUtilsTest {
         BridgeRegTestConstants bridgeConstants = BridgeRegTestConstants.getInstance();
         Federation federation = bridgeConstants.getGenesisFederation();
         Wallet wallet = new BridgeBtcWallet(btcContext, federation);
-        wallet.addWatchedAddress(federation.getAddress(), federation.getCreationTime());
+        wallet.addWatchedAddress(federation.getAddress(), federation.getCreationTime().toEpochMilli());
         Address address = federation.getAddress();
 
         // Tx sending less than 1 btc to the federation, not a lock tx

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -1,0 +1,175 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.db.RepositoryImpl;
+import co.rsk.trie.TrieStoreImpl;
+import org.ethereum.core.Repository;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.spongycastle.util.encoders.Hex;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+
+@RunWith(PowerMockRunner.class)
+public class FederationTest {
+    private Federation federation;
+
+    @Before
+    public void createFederation() {
+        federation = new Federation(
+                3,
+                Arrays.asList(new BtcECKey[]{
+                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
+                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
+                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
+                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
+                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
+                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
+                }),
+                ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
+                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
+    }
+
+    @Test
+    public void publicKeysImmutable() {
+        boolean exception = false;
+        try {
+            federation.getPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
+        } catch (Exception e) {
+            exception = true;
+        }
+        Assert.assertTrue(exception);
+
+        exception = false;
+        try {
+            federation.getPublicKeys().remove(0);
+        } catch (Exception e) {
+            exception = true;
+        }
+        Assert.assertTrue(exception);
+    }
+
+    @PrepareForTest({ ScriptBuilder.class })
+    @Test
+    public void redeemScript() {
+        final List<Integer> calls = new ArrayList<>();
+        PowerMockito.mockStatic(ScriptBuilder.class);
+        PowerMockito.when(ScriptBuilder.createRedeemScript(any(int.class), any(List.class))).thenAnswer((invocationOnMock) -> {
+            calls.add(1);
+            int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
+            List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
+            Assert.assertEquals(3, numberOfSignaturesRequired);
+            Assert.assertEquals(6, publicKeys.size());
+            Assert.assertTrue(Arrays.equals(publicKeys.get(0).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(1).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(200)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(2).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(300)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(3).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(400)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(4).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(500)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(5).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey()));
+            return new Script(new byte[]{(byte)0xaa});
+        });
+        Assert.assertTrue(Arrays.equals(federation.getRedeemScript().getProgram(), new byte[]{(byte) 0xaa}));
+        Assert.assertTrue(Arrays.equals(federation.getRedeemScript().getProgram(), new byte[]{(byte) 0xaa}));
+        // Make sure the script creation happens only once
+        Assert.assertEquals(1, calls.size());
+    }
+
+    @PrepareForTest({ ScriptBuilder.class })
+    @Test
+    public void P2SHScript() {
+        final List<Integer> calls = new ArrayList<>();
+        PowerMockito.mockStatic(ScriptBuilder.class);
+        PowerMockito.when(ScriptBuilder.createP2SHOutputScript(any(int.class), any(List.class))).thenAnswer((invocationOnMock) -> {
+            calls.add(0);
+            int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
+            List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
+            Assert.assertEquals(3, numberOfSignaturesRequired);
+            Assert.assertEquals(6, publicKeys.size());
+            Assert.assertTrue(Arrays.equals(publicKeys.get(0).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(1).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(200)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(2).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(300)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(3).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(400)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(4).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(500)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(5).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey()));
+            return new Script(new byte[]{(byte)0xaa});
+        });
+        Assert.assertTrue(Arrays.equals(federation.getP2SHScript().getProgram(), new byte[]{(byte) 0xaa}));
+        Assert.assertTrue(Arrays.equals(federation.getP2SHScript().getProgram(), new byte[]{(byte) 0xaa}));
+        // Make sure the script creation happens only once
+        Assert.assertEquals(1, calls.size());
+    }
+
+    @PrepareForTest({ ScriptBuilder.class })
+    @Test
+    public void Address() {
+        // Since we can't mock both Address and ScriptBuilder at the same time (due to PowerMockito limitations)
+        // we use a well known P2SH and its corresponding address
+        // and just mock the ScriptBuilder
+        // a914896ed9f3446d51b5510f7f0b6ef81b2bde55140e87 => 2N5muMepJizJE1gR7FbHJU6CD18V3BpNF9p
+        final List<Integer> calls = new ArrayList<>();
+        PowerMockito.mockStatic(ScriptBuilder.class);
+        PowerMockito.when(ScriptBuilder.createP2SHOutputScript(any(int.class), any(List.class))).thenAnswer((invocationOnMock) -> {
+            calls.add(0);
+            int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
+            List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
+            Assert.assertEquals(3, numberOfSignaturesRequired);
+            Assert.assertEquals(6, publicKeys.size());
+            Assert.assertTrue(Arrays.equals(publicKeys.get(0).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(1).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(200)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(2).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(300)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(3).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(400)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(4).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(500)).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(5).getPubKey(), BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey()));
+            return new Script(Hex.decode("a914896ed9f3446d51b5510f7f0b6ef81b2bde55140e87"));
+        });
+
+        Assert.assertEquals("2N5muMepJizJE1gR7FbHJU6CD18V3BpNF9p", federation.getAddress().toBase58());
+        Assert.assertEquals("2N5muMepJizJE1gR7FbHJU6CD18V3BpNF9p", federation.getAddress().toBase58());
+        // Make sure the address creation happens only once
+        Assert.assertEquals(1, calls.size());
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("3 of 6 signatures federation", federation.toString());
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -58,15 +58,17 @@ public class PegTestUtils {
     }
 
     public static Script createBaseInputScriptThatSpendsFromTheFederation(BridgeConstants bridgeConstants) {
-        Script scriptPubKey = bridgeConstants.getFederationPubScript();
-        Script redeemScript = createBaseRedeemScriptThatSpendsFromTheFederation(bridgeConstants);
-        RedeemData redeemData = RedeemData.of(bridgeConstants.getFederatorPublicKeys(), redeemScript);
+        // Spending is from the genesis federation ATM
+        Federation federation = bridgeConstants.getGenesisFederation();
+        Script scriptPubKey = federation.getScript();
+        Script redeemScript = createBaseRedeemScriptThatSpendsFromTheFederation(federation);
+        RedeemData redeemData = RedeemData.of(federation.getPublicKeys(), redeemScript);
         Script inputScript = scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript);
         return inputScript;
     }
 
-    public static Script createBaseRedeemScriptThatSpendsFromTheFederation(BridgeConstants bridgeConstants) {
-        Script redeemScript = ScriptBuilder.createRedeemScript(bridgeConstants.getFederatorsRequiredToSign(), bridgeConstants.getFederatorPublicKeys());
+    public static Script createBaseRedeemScriptThatSpendsFromTheFederation(Federation federation) {
+        Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getPublicKeys());
         return redeemScript;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -60,7 +60,7 @@ public class PegTestUtils {
     public static Script createBaseInputScriptThatSpendsFromTheFederation(BridgeConstants bridgeConstants) {
         // Spending is from the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        Script scriptPubKey = federation.getScript();
+        Script scriptPubKey = federation.getP2SHScript();
         Script redeemScript = createBaseRedeemScriptThatSpendsFromTheFederation(federation);
         RedeemData redeemData = RedeemData.of(federation.getPublicKeys(), redeemScript);
         Script inputScript = scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript);


### PR DESCRIPTION
The active federation is now stored in the Bridge contract. A new active federation can potentially be saved for each block. There is no "genesis" federation stored in the genesis block (the store will return `null`), but in that case the Bridge pulls the genesis federation from the BridgeConstants (i.e., the genesis federation is precompiled).

This also adds a few methods to the bridge so that the currently active federation can be queried:
- `getFederationSize()`
- `getFederationThreshold()`
- `getFederationCreationTime()`
- `getFederatorPublicKey(index)`

At the moment a running node with this version runs exactly as the previous version, since there is no way to set a new federation. The idea is to build the add/remove functionality on top of this.