### PR TITLE
Add the packaging metadata to build the rskj snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: rskj
+version: git
+summary: RSKj is a Java implementation of the RSK protocol
+description: |
+  RskJ is a Java implementation of the RSK node. For more information about
+  RSK, visit www.rsk.co
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  rskj:
+    command: java -cp $SNAP/jar/rskj-core-0.2.5-GINGER-all.jar "$@" co.rsk.Start
+  gennodekeyid:
+    command: java -cp $SNAP/jar/rskj-core-0.2.5-GINGER-all.jar co.rsk.GenNodeKeyId
+
+parts:
+  rskj:
+    source: .
+    plugin: gradle
+    prepare: ./configure.sh
+    gradle-options: [build, shadow, -x, test]
+    gradle-output-dir: rskj-core/build/libs


### PR DESCRIPTION
This package will let you publish the latest rskj in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.