### PR TITLE
Fix Account Address for Contract Creation

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -340,7 +340,14 @@ public class Transaction implements SerializableObject {
         if (!parsed)
             rlpParse();
 
-        return this.receiveAddress == null || Arrays.equals(this.receiveAddress,ByteUtil.EMPTY_BYTE_ARRAY);
+        if (this.receiveAddress == null)
+            return true;
+
+        for (int k = 0; k < this.receiveAddress.length; k++)
+            if (this.receiveAddress[k] != 0)
+                return false;
+
+        return true;
     }
 
     /*

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -237,4 +237,40 @@ public class TransactionTest {
         System.out.println(strenc);
         System.out.println(strhash);
     }
+
+    @Test
+    public void isContractCreationWhenReceiveAddressIsNull() {
+        Transaction tx = Transaction.create(null, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Assert.assertTrue(tx.isContractCreation());
+    }
+
+    @Test
+    public void isContractCreationWhenReceiveAddressIsEmptyString() {
+        Transaction tx = Transaction.create("", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Assert.assertTrue(tx.isContractCreation());
+    }
+
+    @Test
+    public void isContractCreationWhenReceiveAddressIs00() {
+        Transaction tx = Transaction.create("00", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Assert.assertTrue(tx.isContractCreation());
+    }
+
+    @Test
+    public void isContractCreationWhenReceiveAddressIsFortyZeroes() {
+        Transaction tx = Transaction.create("0000000000000000000000000000000000000000", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Assert.assertTrue(tx.isContractCreation());
+    }
+
+    @Test
+    public void isNotContractCreationWhenReceiveAddressIsCowAddress() {
+        Transaction tx = Transaction.create("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Assert.assertFalse(tx.isContractCreation());
+    }
+
+    @Test
+    public void isNotContractCreationWhenReceiveAddressIsBridgeAddress() {
+        Transaction tx = Transaction.create(PrecompiledContracts.BRIDGE_ADDR, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Assert.assertFalse(tx.isContractCreation());
+    }
 }


### PR DESCRIPTION
Now, a transaction with receiver account address 0x0000000000000000000000000000000000000000 is recognized as a contract creation one

Some code tests were added. Manual command line tests also passed (with to address in null and with to address filled with zeroes)
