### PR TITLE
Fix genesis proc

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -164,6 +164,9 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public BlockProcessResult processBlock(@Nullable final MessageSender sender, @Nonnull final Block block) {
+        if (block.isGenesis())
+            return new BlockProcessResult(false, null);
+
         long bestBlockNumber = this.getBestBlockNumber();
         long blockNumber = block.getNumber();
 

--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -164,9 +164,6 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public BlockProcessResult processBlock(@Nullable final MessageSender sender, @Nonnull final Block block) {
-        if (block.isGenesis())
-            return new BlockProcessResult(false, null);
-
         long bestBlockNumber = this.getBestBlockNumber();
         long blockNumber = block.getNumber();
 

--- a/rskj-core/src/main/java/co/rsk/net/NodeMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeMessageHandler.java
@@ -244,6 +244,12 @@ public class NodeMessageHandler implements MessageHandler, Runnable {
     private void processBlockMessage(@Nonnull final MessageSender sender, @Nonnull final BlockMessage message) {
         final Block block = message.getBlock();
         logger.trace("Process block {} {}", block.getNumber(), block.getShortHash());
+
+        if (block.isGenesis()) {
+            logger.trace("Skip block processing {} {}", block.getNumber(), block.getShortHash());
+            return;
+        }
+
         Metrics.processBlockMessage("start", block, sender.getNodeID());
 
         boolean wasOrphan = !this.blockProcessor.hasBlockInSomeBlockchain(block.getHash());

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -200,18 +200,16 @@ public class NodeMessageHandlerTest {
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
         NodeMessageHandler processor = new NodeMessageHandler(sbp, null, null, null, scoring).disablePoWValidation();
         Block block = BlockGenerator.getGenesisBlock();
-        Message message = new BlockMessage(block);
-        processor.processMessage(sender, message);
 
         for (int i = 0; i < 50; i++) {
             block = BlockGenerator.createChildBlock(block);
         }
 
-        message = new BlockMessage(block);
+        Message message = new BlockMessage(block);
         processor.processMessage(sender, message);
 
         Assert.assertNotNull(sbp.getBlocks());
-        Assert.assertEquals(2, sbp.getBlocks().size());
+        Assert.assertEquals(1, sbp.getBlocks().size());
 
         Assert.assertFalse(scoring.isEmpty());
 
@@ -219,8 +217,8 @@ public class NodeMessageHandlerTest {
 
         Assert.assertNotNull(pscoring);
         Assert.assertFalse(pscoring.isEmpty());
-        Assert.assertEquals(2, pscoring.getTotalEventCounter());
-        Assert.assertEquals(2, pscoring.getEventCounter(EventType.VALID_BLOCK));
+        Assert.assertEquals(1, pscoring.getTotalEventCounter());
+        Assert.assertEquals(1, pscoring.getEventCounter(EventType.VALID_BLOCK));
         Assert.assertEquals(0, pscoring.getEventCounter(EventType.INVALID_BLOCK));
     }
 

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -120,6 +120,12 @@ public class NodeMessageHandlerTest {
 
         Assert.assertNotNull(sbp.getBlocks());
         Assert.assertEquals(0, sbp.getBlocks().size());
+        Assert.assertTrue(scoring.isEmpty());
+
+        PeerScoring pscoring = scoring.getPeerScoring(sender.getNodeID());
+
+        Assert.assertNotNull(pscoring);
+        Assert.assertTrue(pscoring.isEmpty());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -108,6 +108,21 @@ public class NodeMessageHandlerTest {
     }
 
     @Test
+    public void skipProcessGenesisBlock() throws UnknownHostException {
+        SimpleMessageSender sender = new SimpleMessageSender();
+        PeerScoringManager scoring = createPeerScoringManager();
+        SimpleBlockProcessor sbp = new SimpleBlockProcessor();
+        NodeMessageHandler processor = new NodeMessageHandler(sbp, null, null, null, scoring);
+        Block block = BlockGenerator.getGenesisBlock();
+        Message message = new BlockMessage(block);
+
+        processor.processMessage(sender, message);
+
+        Assert.assertNotNull(sbp.getBlocks());
+        Assert.assertEquals(0, sbp.getBlocks().size());
+    }
+
+    @Test
     public void postBlockMessageTwice() throws InterruptedException, UnknownHostException {
         MessageSender sender = new SimpleMessageSender();
         PeerScoringManager scoring = createPeerScoringManager();


### PR DESCRIPTION
Skip the genesis block processing when arrives from other node. The logic was added to MessageNodeHandler, with expected behavior new test

Tested locally (one miner, one no miner), and againts the testnet (one no miner, syncing from 0 blocks)