### PR TITLE
Clean up getters and unused code

### DIFF
--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -29,6 +29,7 @@ import co.rsk.net.discovery.UDPServer;
 import co.rsk.rpc.CorsConfiguration;
 import org.ethereum.cli.CLIInterface;
 import org.ethereum.config.DefaultConfig;
+import org.ethereum.core.Repository;
 import org.ethereum.rpc.JsonRpcNettyServer;
 import org.ethereum.rpc.JsonRpcWeb3FilterHandler;
 import org.ethereum.rpc.JsonRpcWeb3ServerHandler;
@@ -50,6 +51,7 @@ public class Start {
     private MinerClient minerClient;
     private RskSystemProperties rskSystemProperties;
     private final Web3Factory web3Factory;
+    private final Repository repository;
 
     public static void main(String[] args) throws Exception {
         ApplicationContext ctx = new AnnotationConfigApplicationContext(DefaultConfig.class);
@@ -58,13 +60,20 @@ public class Start {
     }
 
     @Autowired
-    public Start(Rsk rsk, UDPServer udpServer, MinerServer minerServer, MinerClient minerClient, RskSystemProperties rskSystemProperties, Web3Factory web3Factory) {
+    public Start(Rsk rsk,
+                 UDPServer udpServer,
+                 MinerServer minerServer,
+                 MinerClient minerClient,
+                 RskSystemProperties rskSystemProperties,
+                 Web3Factory web3Factory,
+                 Repository repository) {
         this.rsk = rsk;
         this.udpServer = udpServer;
         this.minerServer = minerServer;
         this.minerClient = minerClient;
         this.rskSystemProperties = rskSystemProperties;
         this.web3Factory = web3Factory;
+        this.repository = repository;
     }
 
     public void startNode(String[] args) throws Exception {
@@ -131,11 +140,11 @@ public class Start {
     }
 
     private void enableSimulateTxs(Rsk rsk) {
-        new TxBuilder(rsk).simulateTxs();
+        new TxBuilder(rsk, repository).simulateTxs();
     }
 
     private void enableSimulateTxsEx(Rsk rsk) {
-        new TxBuilderEx().simulateTxs(rsk, rskSystemProperties);
+        new TxBuilderEx().simulateTxs(rsk, rskSystemProperties, repository);
     }
 
     private void waitRskSyncDone(Rsk rsk) throws InterruptedException {

--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -30,6 +30,7 @@ import co.rsk.rpc.CorsConfiguration;
 import org.ethereum.cli.CLIInterface;
 import org.ethereum.config.DefaultConfig;
 import org.ethereum.core.Repository;
+import org.ethereum.manager.WorldManager;
 import org.ethereum.rpc.JsonRpcNettyServer;
 import org.ethereum.rpc.JsonRpcWeb3FilterHandler;
 import org.ethereum.rpc.JsonRpcWeb3ServerHandler;
@@ -45,11 +46,12 @@ import org.springframework.stereotype.Component;
 public class Start {
     private static Logger logger = LoggerFactory.getLogger("start");
 
-    private Rsk rsk;
-    private UDPServer udpServer;
-    private MinerServer minerServer;
-    private MinerClient minerClient;
-    private RskSystemProperties rskSystemProperties;
+    private final Rsk rsk;
+    private final WorldManager worldManager;
+    private final UDPServer udpServer;
+    private final MinerServer minerServer;
+    private final MinerClient minerClient;
+    private final RskSystemProperties rskSystemProperties;
     private final Web3Factory web3Factory;
     private final Repository repository;
 
@@ -61,6 +63,7 @@ public class Start {
 
     @Autowired
     public Start(Rsk rsk,
+                 WorldManager worldManager,
                  UDPServer udpServer,
                  MinerServer minerServer,
                  MinerClient minerClient,
@@ -68,6 +71,7 @@ public class Start {
                  Web3Factory web3Factory,
                  Repository repository) {
         this.rsk = rsk;
+        this.worldManager = worldManager;
         this.udpServer = udpServer;
         this.minerServer = minerServer;
         this.minerClient = minerClient;
@@ -93,7 +97,7 @@ public class Start {
         }
 
         if (rskSystemProperties.simulateTxsEx()) {
-            enableSimulateTxsEx(rsk);
+            enableSimulateTxsEx(rsk, worldManager);
         }
 
         if (rskSystemProperties.isRpcEnabled()) {
@@ -140,11 +144,11 @@ public class Start {
     }
 
     private void enableSimulateTxs(Rsk rsk) {
-        new TxBuilder(rsk, repository).simulateTxs();
+        new TxBuilder(rsk, worldManager.getNodeBlockProcessor(), repository).simulateTxs();
     }
 
-    private void enableSimulateTxsEx(Rsk rsk) {
-        new TxBuilderEx().simulateTxs(rsk, rskSystemProperties, repository);
+    private void enableSimulateTxsEx(Rsk rsk, WorldManager worldManager) {
+        new TxBuilderEx().simulateTxs(rsk, worldManager, rskSystemProperties, repository);
     }
 
     private void waitRskSyncDone(Rsk rsk) throws InterruptedException {

--- a/rskj-core/src/main/java/co/rsk/core/Rsk.java
+++ b/rskj-core/src/main/java/co/rsk/core/Rsk.java
@@ -18,22 +18,13 @@
 
 package co.rsk.core;
 
-import co.rsk.mine.MinerServer;
-import co.rsk.mine.MinerClient;
-import co.rsk.net.MessageHandler;
 import co.rsk.net.NodeBlockProcessor;
-import co.rsk.net.sync.SyncConfiguration;
-import co.rsk.scoring.PeerScoringManager;
 import org.ethereum.facade.Ethereum;
 
 /**
  * Created by ajlopez on 3/3/2016.
  */
 public interface Rsk extends Ethereum {
-
-    MessageHandler getMessageHandler();
-
-    PeerScoringManager getPeerScoringManager();
 
     NodeBlockProcessor getNodeBlockProcessor();
 

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -236,8 +236,9 @@ public class RskFactory {
                                             PersonalModule personalModule,
                                             EthModule ethModule,
                                             ChannelManager channelManager,
-                                            Repository repository) {
-        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository);
+                                            Repository repository,
+                                            PeerScoringManager peerScoringManager) {
+        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager);
     }
 
     @Bean

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -88,6 +88,7 @@ public class RskFactory {
 
     @Bean
     public Rsk getRsk(WorldManager worldManager,
+                      Blockchain blockchain,
                       ChannelManager channelManager,
                       PeerServer peerServer,
                       ProgramInvokeFactory programInvokeFactory,
@@ -114,7 +115,7 @@ public class RskFactory {
         }
         if (rskSystemProperties.isBlocksEnabled()) {
             setupRecorder(rsk, rskSystemProperties.blocksRecorder());
-            setupPlayer(rsk, rskSystemProperties.blocksPlayer());
+            setupPlayer(rsk, channelManager, blockchain, rskSystemProperties.blocksPlayer());
         }
         return rsk;
     }
@@ -125,7 +126,7 @@ public class RskFactory {
         }
     }
 
-    private void setupPlayer(RskImpl rsk, @Nullable String blocksPlayerFileName) {
+    private void setupPlayer(RskImpl rsk, ChannelManager cm, Blockchain bc, @Nullable String blocksPlayerFileName) {
         if (blocksPlayerFileName == null) {
             return;
         }
@@ -133,9 +134,6 @@ public class RskFactory {
         new Thread(() -> {
             try (FileBlockPlayer bplayer = new FileBlockPlayer(blocksPlayerFileName)) {
                 rsk.setIsPlayingBlocks(true);
-
-                Blockchain bc = rsk.getWorldManager().getBlockchain();
-                ChannelManager cm = rsk.getChannelManager();
                 connectBlocks(bplayer, bc, cm);
             } catch (Exception e) {
                 logger.error("Error", e);

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -237,8 +237,10 @@ public class RskFactory {
                                             EthModule ethModule,
                                             ChannelManager channelManager,
                                             Repository repository,
-                                            PeerScoringManager peerScoringManager) {
-        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager);
+                                            PeerScoringManager peerScoringManager,
+                                            NetworkStateExporter networkStateExporter,
+                                            org.ethereum.db.BlockStore blockStore) {
+        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, networkStateExporter, blockStore);
     }
 
     @Bean

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -88,7 +88,6 @@ public class RskFactory {
 
     @Bean
     public Rsk getRsk(WorldManager worldManager,
-                      AdminInfo adminInfo,
                       ChannelManager channelManager,
                       PeerServer peerServer,
                       ProgramInvokeFactory programInvokeFactory,
@@ -104,7 +103,7 @@ public class RskFactory {
         logger.info("Running {},  core version: {}-{}", config.genesisInfo(), config.projectVersion(), config.projectVersionModifier());
         BuildInfo.printInfo();
 
-        RskImpl rsk = new RskImpl(worldManager, adminInfo, channelManager, peerServer, programInvokeFactory,
+        RskImpl rsk = new RskImpl(worldManager, channelManager, peerServer, programInvokeFactory,
                 pendingState, config, compositeEthereumListener, receiptStore, peerScoringManager, nodeBlockProcessor, nodeMessageHandler);
 
         rsk.init();

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -99,13 +99,14 @@ public class RskFactory {
                       PeerScoringManager peerScoringManager,
                       NodeBlockProcessor nodeBlockProcessor,
                       NodeMessageHandler nodeMessageHandler,
-                      RskSystemProperties rskSystemProperties) {
+                      RskSystemProperties rskSystemProperties,
+                      org.ethereum.core.Repository repository) {
 
         logger.info("Running {},  core version: {}-{}", config.genesisInfo(), config.projectVersion(), config.projectVersionModifier());
         BuildInfo.printInfo();
 
         RskImpl rsk = new RskImpl(worldManager, channelManager, peerServer, programInvokeFactory,
-                pendingState, config, compositeEthereumListener, receiptStore, peerScoringManager, nodeBlockProcessor, nodeMessageHandler);
+                pendingState, config, compositeEthereumListener, receiptStore, peerScoringManager, nodeBlockProcessor, nodeMessageHandler, repository);
 
         rsk.init();
         rsk.getBlockchain().setRsk(true);  //TODO: check if we can remove this field from org.ethereum.facade.Blockchain
@@ -234,8 +235,9 @@ public class RskFactory {
                                             MinerServer minerServer,
                                             PersonalModule personalModule,
                                             EthModule ethModule,
-                                            ChannelManager channelManager) {
-        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager);
+                                            ChannelManager channelManager,
+                                            Repository repository) {
+        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository);
     }
 
     @Bean

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -230,6 +230,7 @@ public class RskFactory {
 
     @Bean
     public Start.Web3Factory getWeb3Factory(Rsk rsk,
+                                            WorldManager worldManager,
                                             RskSystemProperties config,
                                             MinerClient minerClient,
                                             MinerServer minerServer,
@@ -241,7 +242,7 @@ public class RskFactory {
                                             NetworkStateExporter networkStateExporter,
                                             org.ethereum.db.BlockStore blockStore,
                                             PeerServer peerServer) {
-        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, networkStateExporter, blockStore, peerServer);
+        return () -> new Web3RskImpl(rsk, worldManager, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, networkStateExporter, blockStore, peerServer);
     }
 
     @Bean
@@ -336,21 +337,21 @@ public class RskFactory {
     }
 
     @Bean
-    public PersonalModule getPersonalModuleWallet(Rsk rsk, Wallet wallet) {
+    public PersonalModule getPersonalModuleWallet(Rsk rsk, Wallet wallet, PendingState pendingState) {
         if (wallet == null) {
             return new PersonalModuleWalletDisabled();
         }
 
-        return new PersonalModuleWalletEnabled(rsk, wallet);
+        return new PersonalModuleWalletEnabled(rsk, wallet, pendingState);
     }
 
     @Bean
-    public EthModuleWallet getEthModuleWallet(Rsk rsk, Wallet wallet) {
+    public EthModuleWallet getEthModuleWallet(Rsk rsk, Wallet wallet, PendingState pendingState) {
         if (wallet == null) {
             return new EthModuleWalletDisabled();
         }
 
-        return new EthModuleWalletEnabled(rsk, wallet);
+        return new EthModuleWalletEnabled(rsk, wallet, pendingState);
     }
 
     @Bean

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -239,8 +239,9 @@ public class RskFactory {
                                             Repository repository,
                                             PeerScoringManager peerScoringManager,
                                             NetworkStateExporter networkStateExporter,
-                                            org.ethereum.db.BlockStore blockStore) {
-        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, networkStateExporter, blockStore);
+                                            org.ethereum.db.BlockStore blockStore,
+                                            PeerServer peerServer) {
+        return () -> new Web3RskImpl(rsk, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, networkStateExporter, blockStore, peerServer);
     }
 
     @Bean

--- a/rskj-core/src/main/java/co/rsk/core/RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskImpl.java
@@ -24,10 +24,10 @@ import co.rsk.net.NodeMessageHandler;
 import co.rsk.scoring.PeerScoringManager;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.PendingState;
+import org.ethereum.core.Repository;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.facade.EthereumImpl;
 import org.ethereum.listener.CompositeEthereumListener;
-import org.ethereum.manager.AdminInfo;
 import org.ethereum.manager.WorldManager;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
@@ -51,8 +51,9 @@ public class RskImpl extends EthereumImpl implements Rsk {
                    ReceiptStore receiptStore,
                    PeerScoringManager peerScoringManager,
                    NodeBlockProcessor nodeBlockProcessor,
-                   NodeMessageHandler messageHandler) {
-        super(worldManager, channelManager, peerServer, programInvokeFactory, pendingState, config, compositeEthereumListener, receiptStore);
+                   NodeMessageHandler messageHandler,
+                   Repository repository) {
+        super(worldManager, channelManager, peerServer, programInvokeFactory, pendingState, config, compositeEthereumListener, receiptStore, repository);
         this.peerScoringManager = peerScoringManager;
         this.nodeBlockProcessor = nodeBlockProcessor;
         this.messageHandler = messageHandler;

--- a/rskj-core/src/main/java/co/rsk/core/RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskImpl.java
@@ -42,7 +42,6 @@ public class RskImpl extends EthereumImpl implements Rsk {
     private PeerScoringManager peerScoringManager;
 
     public RskImpl(WorldManager worldManager,
-                   AdminInfo adminInfo,
                    ChannelManager channelManager,
                    PeerServer peerServer,
                    ProgramInvokeFactory programInvokeFactory,
@@ -53,7 +52,7 @@ public class RskImpl extends EthereumImpl implements Rsk {
                    PeerScoringManager peerScoringManager,
                    NodeBlockProcessor nodeBlockProcessor,
                    NodeMessageHandler messageHandler) {
-        super(worldManager, adminInfo, channelManager, peerServer, programInvokeFactory, pendingState, config, compositeEthereumListener, receiptStore);
+        super(worldManager, channelManager, peerServer, programInvokeFactory, pendingState, config, compositeEthereumListener, receiptStore);
         this.peerScoringManager = peerScoringManager;
         this.nodeBlockProcessor = nodeBlockProcessor;
         this.messageHandler = messageHandler;

--- a/rskj-core/src/main/java/co/rsk/core/RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskImpl.java
@@ -60,16 +60,6 @@ public class RskImpl extends EthereumImpl implements Rsk {
     }
 
     @Override
-    public PeerScoringManager getPeerScoringManager() {
-        return this.peerScoringManager;
-    }
-
-    @Override
-    public MessageHandler getMessageHandler() {
-        return this.messageHandler;
-    }
-
-    @Override
     public NodeBlockProcessor getNodeBlockProcessor() {
         return this.nodeBlockProcessor;
     }

--- a/rskj-core/src/main/java/co/rsk/db/RepositoryImpl.java
+++ b/rskj-core/src/main/java/co/rsk/db/RepositoryImpl.java
@@ -34,9 +34,11 @@ import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
 import static org.ethereum.crypto.SHA3Helper.sha3;
@@ -219,24 +221,6 @@ public class RepositoryImpl implements Repository, org.ethereum.facade.Repositor
     public synchronized DataWord getStorageValue(byte[] addr, DataWord key) {
         ContractDetails details = getContractDetails(addr);
         return (details == null) ? null : details.get(key);
-    }
-
-    @Override
-    public int getStorageSize(byte[] addr) {
-        ContractDetails details = getContractDetails(addr);
-        return (details == null) ? 0 : details.getStorageSize();
-    }
-
-    @Override
-    public Set<DataWord> getStorageKeys(byte[] addr) {
-        ContractDetails details = getContractDetails(addr);
-        return (details == null) ? Collections.emptySet() : details.getStorageKeys();
-    }
-
-    @Override
-    public Map<DataWord, DataWord> getStorage(byte[] addr, @Nullable Collection<DataWord> keys) {
-        ContractDetails details = getContractDetails(addr);
-        return (details == null) ? Collections.emptyMap() : details.getStorage(keys);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -104,16 +104,26 @@ public class MinerServerImpl implements MinerServer {
 
     private BlockValidationRule validationRules;
 
+    private final BlockProcessor nodeBlockProcessor;
+
     private long timeAdjustment;
 
     @Autowired
-    public MinerServerImpl(Ethereum ethereum, Blockchain blockchain, BlockStore blockStore, PendingState pendingState, Repository repository, MiningConfig miningConfig, @Qualifier("minerServerBlockValidation") BlockValidationRule validationRules) {
+    public MinerServerImpl(Ethereum ethereum,
+                           Blockchain blockchain,
+                           BlockStore blockStore,
+                           PendingState pendingState,
+                           Repository repository,
+                           MiningConfig miningConfig,
+                           @Qualifier("minerServerBlockValidation") BlockValidationRule validationRules,
+                           BlockProcessor nodeBlockProcessor) {
         this.ethereum = ethereum;
         this.blockchain = blockchain;
         this.blockStore = blockStore;
         this.pendingState = pendingState;
         this.miningConfig = miningConfig;
         this.validationRules = validationRules;
+        this.nodeBlockProcessor = nodeBlockProcessor;
 
         executor = new BlockExecutor(repository, blockchain, blockStore, null);
 
@@ -457,12 +467,7 @@ public class MinerServerImpl implements MinerServer {
         }
 
         private boolean isSyncing() {
-            BlockProcessor processor = ethereum.getWorldManager().getNodeBlockProcessor();
-
-            if (processor == null)
-                return false;
-
-            return processor.isSyncingBlocks();
+            return nodeBlockProcessor.isSyncingBlocks();
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/mine/TxBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/mine/TxBuilder.java
@@ -18,6 +18,7 @@
 
 package co.rsk.mine;
 
+import co.rsk.net.BlockProcessor;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -40,7 +41,8 @@ import java.security.SecureRandom;
 
 public class TxBuilder {
 
-    private Ethereum ethereum;
+    private final Ethereum ethereum;
+    private final BlockProcessor blockProcessor;
     private final Repository repository;
 
     private static final Logger logger = LoggerFactory.getLogger("txbuilder");
@@ -49,8 +51,9 @@ public class TxBuilder {
     private byte[] privateKeyBytes  = HashUtil.sha3("this is a seed".getBytes(StandardCharsets.UTF_8));
     private ECKey key;
 
-    public TxBuilder(Ethereum ethereum, Repository repository) {
+    public TxBuilder(Ethereum ethereum, BlockProcessor blockProcessor, Repository repository) {
         this.ethereum = ethereum;
+        this.blockProcessor = blockProcessor;
         this.repository = repository;
     }
 
@@ -64,7 +67,7 @@ public class TxBuilder {
                 try {
                     Thread.sleep(60000);
 
-                    while (ethereum.getWorldManager().getNodeBlockProcessor().isSyncingBlocks()) {
+                    while (blockProcessor.isSyncingBlocks()) {
                         Thread.sleep(60000);
                     }
 

--- a/rskj-core/src/main/java/co/rsk/mine/TxBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/mine/TxBuilder.java
@@ -41,6 +41,7 @@ import java.security.SecureRandom;
 public class TxBuilder {
 
     private Ethereum ethereum;
+    private final Repository repository;
 
     private static final Logger logger = LoggerFactory.getLogger("txbuilder");
     private volatile boolean stop = false;
@@ -48,8 +49,9 @@ public class TxBuilder {
     private byte[] privateKeyBytes  = HashUtil.sha3("this is a seed".getBytes(StandardCharsets.UTF_8));
     private ECKey key;
 
-    public TxBuilder(Ethereum ethereum){
+    public TxBuilder(Ethereum ethereum, Repository repository) {
         this.ethereum = ethereum;
+        this.repository = repository;
     }
 
     public void simulateTxs( ) {
@@ -66,8 +68,6 @@ public class TxBuilder {
                         Thread.sleep(60000);
                     }
 
-                    Repository repository = (Repository) ethereum.getRepository();
-
                     SecureRandom random = new SecureRandom();
 
                     AccountState accountState = repository.getAccountState(key.getAddress());
@@ -75,7 +75,7 @@ public class TxBuilder {
 
                     while (!stop) {
                         if ((random.nextInt() % 10) == 0)
-                            nonce = ((Repository) ethereum.getRepository()).getAccountState(key.getAddress()).getNonce();
+                            nonce = repository.getAccountState(key.getAddress()).getNonce();
 
                         TxBuilder.this.createNewTx(nonce);
                         

--- a/rskj-core/src/main/java/co/rsk/mine/TxBuilderEx.java
+++ b/rskj-core/src/main/java/co/rsk/mine/TxBuilderEx.java
@@ -26,6 +26,7 @@ import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.facade.Ethereum;
+import org.ethereum.manager.WorldManager;
 import org.ethereum.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,10 @@ public class TxBuilderEx {
     private volatile boolean stop = false;
     private SecureRandom random = new SecureRandom();
 
-    public void simulateTxs(final Ethereum ethereum, RskSystemProperties properties, final Repository repository) {
+    public void simulateTxs(final Ethereum ethereum,
+                            WorldManager worldManager,
+                            RskSystemProperties properties,
+                            final Repository repository) {
         final byte[] privateKeyBytes = HashUtil.sha3(properties.simulateTxsExAccountSeed().getBytes(StandardCharsets.UTF_8));
         final ECKey key = ECKey.fromPrivate(privateKeyBytes);
 
@@ -69,7 +73,7 @@ public class TxBuilderEx {
                     logger.error("Interrupted", e);
                 }
 
-                while (ethereum.getWorldManager().getNodeBlockProcessor() != null && ethereum.getWorldManager().getNodeBlockProcessor().isSyncingBlocks()) {
+                while (worldManager.getNodeBlockProcessor() != null && worldManager.getNodeBlockProcessor().isSyncingBlocks()) {
                     try {
                         Thread.sleep(60000);
                     } catch (InterruptedException e) {
@@ -112,7 +116,7 @@ public class TxBuilderEx {
                         SecureRandom r = new SecureRandom();
                         Thread.sleep(10000 + (long)r.nextInt(20000));
 
-                        Repository prepository = ethereum.getWorldManager().getPendingState().getRepository();
+                        Repository prepository = worldManager.getPendingState().getRepository();
                         AccountState accountState;
 
                         accountState = prepository.getAccountState(targetAcc.getAddress());

--- a/rskj-core/src/main/java/co/rsk/mine/TxBuilderEx.java
+++ b/rskj-core/src/main/java/co/rsk/mine/TxBuilderEx.java
@@ -44,18 +44,11 @@ import java.security.SecureRandom;
 @Component
 public class TxBuilderEx {
 
-    private Ethereum ethereum;
-
-    protected org.ethereum.facade.Blockchain blockchain;
-
     private static final Logger logger = LoggerFactory.getLogger("txbuilderex");
     private volatile boolean stop = false;
     private SecureRandom random = new SecureRandom();
 
-    public void simulateTxs(final Ethereum ethereum, RskSystemProperties properties) {
-        this.ethereum = ethereum;
-        this.blockchain = ethereum.getBlockchain();
-
+    public void simulateTxs(final Ethereum ethereum, RskSystemProperties properties, final Repository repository) {
         final byte[] privateKeyBytes = HashUtil.sha3(properties.simulateTxsExAccountSeed().getBytes(StandardCharsets.UTF_8));
         final ECKey key = ECKey.fromPrivate(privateKeyBytes);
 
@@ -90,11 +83,10 @@ public class TxBuilderEx {
                     } catch (InterruptedException e) {
                         logger.error("Interrupted", e);
                     }
-                    Repository repository = (Repository) ethereum.getRepository();
                     AccountState fromAccountState = repository.getAccountState(key.getAddress());
 
                     Transaction tx = createNewTransaction(privateKeyBytes, targetAddress, BigInteger.valueOf(properties.simulateTxsExFounding()), fromAccountState.getNonce());
-                    sendTransaction(tx);
+                    sendTransaction(tx, ethereum);
                     logger.trace("Funding tx {} nonce {}", 10000000000L, getNonce(tx));
                 }
 
@@ -111,7 +103,7 @@ public class TxBuilderEx {
 
                 while (!stop) {
                     Transaction tx = createNewTransaction(targetAcc.getEcKey().getPrivKeyBytes(), target2Address, BigInteger.valueOf(value), nonce);
-                    sendTransaction(tx);
+                    sendTransaction(tx, ethereum);
                     logger.trace("Send tx value {} nonce {}", value, getNonce(tx));
                     value += 2;
                     lastNonce = nonce;
@@ -130,7 +122,7 @@ public class TxBuilderEx {
                         if (accnonce.compareTo(lastNonce) < 0) {
                             tx = createNewTransaction(targetAcc.getEcKey().getPrivKeyBytes(), target2Address, BigInteger.valueOf(accnonce.intValue() * 2 + 1), accnonce);
                             logger.trace("Resend tx value {} nonce {}", accnonce.intValue() * 2 + 1, getNonce(tx));
-                            sendTransaction(tx);
+                            sendTransaction(tx, ethereum);
                         }
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
@@ -149,10 +141,9 @@ public class TxBuilderEx {
         return new BigInteger(1, bytes).longValue();
     }
 
-    private void sendTransaction(Transaction tx) {
+    private static void sendTransaction(Transaction tx, Ethereum ethereum) {
         //Adds created transaction to the local node's memory pool
         ethereum.submitTransaction(tx);
-
         logger.info("Added pending tx: " + tx.getHash());
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -33,6 +33,7 @@ import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.db.BlockStore;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.Repository;
+import org.ethereum.manager.WorldManager;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.TypeConverter;
@@ -58,6 +59,7 @@ public class Web3RskImpl extends Web3Impl {
     private final BlockStore blockStore;
 
     public Web3RskImpl(Ethereum eth,
+                       WorldManager worldManager,
                        RskSystemProperties properties,
                        MinerClient minerClient,
                        MinerServer minerServer,
@@ -69,7 +71,7 @@ public class Web3RskImpl extends Web3Impl {
                        NetworkStateExporter networkStateExporter,
                        BlockStore blockStore,
                        PeerServer peerServer) {
-        super(eth, properties, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, peerServer);
+        super(eth, worldManager, properties, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, peerServer);
         this.networkStateExporter = networkStateExporter;
         this.blockStore = blockStore;
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -34,6 +34,7 @@ import org.ethereum.db.BlockStore;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.Repository;
 import org.ethereum.net.server.ChannelManager;
+import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.Web3Impl;
 import org.slf4j.Logger;
@@ -66,8 +67,9 @@ public class Web3RskImpl extends Web3Impl {
                        Repository repository,
                        PeerScoringManager peerScoringManager,
                        NetworkStateExporter networkStateExporter,
-                       BlockStore blockStore) {
-        super(eth, properties, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager);
+                       BlockStore blockStore,
+                       PeerServer peerServer) {
+        super(eth, properties, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, peerServer);
         this.networkStateExporter = networkStateExporter;
         this.blockStore = blockStore;
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -33,6 +33,7 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.db.BlockStore;
+import org.ethereum.facade.Repository;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.TypeConverter;
@@ -61,8 +62,9 @@ public class Web3RskImpl extends Web3Impl {
                        MinerServer minerServer,
                        PersonalModule personalModule,
                        EthModule ethModule,
-                       ChannelManager channelManager) {
-        super(eth, properties, minerClient, minerServer, personalModule, ethModule, channelManager);
+                       ChannelManager channelManager,
+                       Repository repository) {
+        super(eth, properties, minerClient, minerServer, personalModule, ethModule, channelManager, repository);
     }
 
     public MinerWork mnr_getWork() {

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -28,6 +28,7 @@ import co.rsk.mine.SubmitBlockResult;
 import co.rsk.rpc.exception.JsonRpcSubmitBlockException;
 import co.rsk.rpc.modules.eth.EthModule;
 import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.scoring.PeerScoringManager;
 import org.apache.commons.lang3.ArrayUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
@@ -63,8 +64,9 @@ public class Web3RskImpl extends Web3Impl {
                        PersonalModule personalModule,
                        EthModule ethModule,
                        ChannelManager channelManager,
-                       Repository repository) {
-        super(eth, properties, minerClient, minerServer, personalModule, ethModule, channelManager, repository);
+                       Repository repository,
+                       PeerScoringManager peerScoringManager) {
+        super(eth, properties, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager);
     }
 
     public MinerWork mnr_getWork() {

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -20,11 +20,8 @@ package co.rsk.rpc;
 
 import co.rsk.config.RskMiningConstants;
 import co.rsk.config.RskSystemProperties;
-import co.rsk.mine.MinerClient;
-import co.rsk.mine.MinerServer;
-import co.rsk.mine.MinerWork;
-import co.rsk.mine.SubmittedBlockInfo;
-import co.rsk.mine.SubmitBlockResult;
+import co.rsk.core.NetworkStateExporter;
+import co.rsk.mine.*;
 import co.rsk.rpc.exception.JsonRpcSubmitBlockException;
 import co.rsk.rpc.modules.eth.EthModule;
 import co.rsk.rpc.modules.personal.PersonalModule;
@@ -34,9 +31,9 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.db.BlockStore;
+import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.Repository;
 import org.ethereum.net.server.ChannelManager;
-import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.Web3Impl;
 import org.slf4j.Logger;
@@ -56,6 +53,8 @@ import java.util.List;
  */
 public class Web3RskImpl extends Web3Impl {
     private static final Logger logger = LoggerFactory.getLogger("web3");
+    private final NetworkStateExporter networkStateExporter;
+    private final BlockStore blockStore;
 
     public Web3RskImpl(Ethereum eth,
                        RskSystemProperties properties,
@@ -65,8 +64,12 @@ public class Web3RskImpl extends Web3Impl {
                        EthModule ethModule,
                        ChannelManager channelManager,
                        Repository repository,
-                       PeerScoringManager peerScoringManager) {
+                       PeerScoringManager peerScoringManager,
+                       NetworkStateExporter networkStateExporter,
+                       BlockStore blockStore) {
         super(eth, properties, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager);
+        this.networkStateExporter = networkStateExporter;
+        this.blockStore = blockStore;
     }
 
     public MinerWork mnr_getWork() {
@@ -106,9 +109,9 @@ public class Web3RskImpl extends Web3Impl {
     }
 
     public void ext_dumpState()  {
-        Block bestBlcock = worldManager.getBlockStore().getBestBlock();
+        Block bestBlcock = blockStore.getBestBlock();
         logger.info("Dumping state for block hash {}, block number {}", Hex.toHexString(bestBlcock.getHash()), bestBlcock.getNumber());
-        this.worldManager.getNetworkStateExporter().exportStatus(System.getProperty("user.dir") + "/" + "rskdump.json");
+        networkStateExporter.exportStatus(System.getProperty("user.dir") + "/" + "rskdump.json");
     }
 
     /**
@@ -117,8 +120,7 @@ public class Web3RskImpl extends Web3Impl {
      * @param includeUncles Whether to show uncle links (recommended value is false)
      */
     public void ext_dumpBlockchain(long numberOfBlocks, boolean includeUncles)  {
-        BlockStore bs = worldManager.getBlockStore();
-        Block bestBlock = bs.getBestBlock();
+        Block bestBlock = blockStore.getBestBlock();
         logger.info("Dumping blockchain starting on block number {}, to best block number {}", bestBlock.getNumber()-numberOfBlocks, bestBlock.getNumber());
         PrintWriter writer = null;
         try {
@@ -131,7 +133,7 @@ public class Web3RskImpl extends Web3Impl {
                 firstBlock = 0;
             }
             for (long i = firstBlock; i < bestBlock.getNumber(); i++) {
-                result.addAll(bs.getChainBlocksByNumber(i));
+                result.addAll(blockStore.getChainBlocksByNumber(i));
             }
             for (Block block : result) {
                 writer.println(toSmallHash(block.getHash()) + " " + block.getNumber()+"-"+toSmallHash(block.getHash()));

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
@@ -43,10 +43,12 @@ public class EthModuleWalletEnabled implements EthModuleWallet {
 
     private final Ethereum eth;
     private final Wallet wallet;
+    private final PendingState pendingState;
 
-    public EthModuleWalletEnabled(Ethereum eth, Wallet wallet) {
+    public EthModuleWalletEnabled(Ethereum eth, Wallet wallet, PendingState pendingState) {
         this.eth = eth;
         this.wallet = wallet;
+        this.pendingState = pendingState;
     }
 
     @Override
@@ -66,8 +68,6 @@ public class EthModuleWalletEnabled implements EthModuleWallet {
             if (args.data != null && args.data.startsWith("0x"))
                 args.data = args.data.substring(2);
 
-            // TODO inject PendingState through constructor if necessary
-            PendingState pendingState = eth.getWorldManager().getPendingState();
             synchronized (pendingState) {
                 BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : (pendingState.getRepository().getNonce(account.getAddress()));
                 Transaction tx = Transaction.create(toAddress, value, accountNonce, gasPrice, gasLimit, args.data);

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -23,6 +23,7 @@ import co.rsk.config.WalletAccount;
 import co.rsk.core.Wallet;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.Account;
+import org.ethereum.core.PendingState;
 import org.ethereum.core.Transaction;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.TypeConverter;
@@ -42,10 +43,12 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
 
     private final Ethereum eth;
     private final Wallet wallet;
+    private final PendingState pendingState;
 
-    public PersonalModuleWalletEnabled(Ethereum eth, Wallet wallet) {
+    public PersonalModuleWalletEnabled(Ethereum eth, Wallet wallet, PendingState pendingState) {
         this.eth = eth;
         this.wallet = wallet;
+        this.pendingState = pendingState;
     }
 
     @Override
@@ -165,7 +168,7 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
 
         String toAddress = args.to != null ? Hex.toHexString(TypeConverter.stringHexToByteArray(args.to)) : null;
 
-        BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : (eth.getWorldManager().getPendingState().getRepository().getNonce(account.getAddress()));
+        BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : (pendingState.getRepository().getNonce(account.getAddress()));
         BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
         BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
         BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION);

--- a/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -75,12 +75,6 @@ public interface Ethereum {
      */
     Future<Transaction> submitTransaction(Transaction transaction);
 
-    /**
-     * @return - repository for all state data.
-     */
-    Repository getRepository();
-
-
     void init();
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -23,7 +23,6 @@ import org.ethereum.core.Block;
 import org.ethereum.core.ImportResult;
 import org.ethereum.core.Transaction;
 import org.ethereum.listener.EthereumListener;
-import org.ethereum.manager.WorldManager;
 import org.ethereum.rpc.Web3;
 import org.ethereum.vm.program.ProgramResult;
 
@@ -89,9 +88,6 @@ public interface Ethereum {
      * be increased at some ratio (e.g. * 1.2)
      */
     long getGasPrice();
-
-    // TODO review world manager expose
-    WorldManager getWorldManager();
 
     // TODO added method, to review
     ProgramResult callConstant(Web3.CallArguments args);

--- a/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -24,7 +24,6 @@ import org.ethereum.core.ImportResult;
 import org.ethereum.core.Transaction;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.manager.WorldManager;
-import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.Web3;
 import org.ethereum.vm.program.ProgramResult;
 
@@ -93,9 +92,6 @@ public interface Ethereum {
 
     // TODO review world manager expose
     WorldManager getWorldManager();
-
-    // TODO review peer server expose
-    PeerServer getPeerServer();
 
     // TODO added method, to review
     ProgramResult callConstant(Web3.CallArguments args);

--- a/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -24,7 +24,6 @@ import org.ethereum.core.ImportResult;
 import org.ethereum.core.Transaction;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.manager.WorldManager;
-import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.Web3;
 import org.ethereum.vm.program.ProgramResult;
@@ -83,8 +82,6 @@ public interface Ethereum {
 
 
     void init();
-
-    ChannelManager getChannelManager();
 
     /**
      * @return - currently pending transactions received from the net

--- a/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -19,22 +19,17 @@
 
 package org.ethereum.facade;
 
-import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Block;
-import org.ethereum.core.CallTransaction;
 import org.ethereum.core.ImportResult;
 import org.ethereum.core.Transaction;
 import org.ethereum.listener.EthereumListener;
-import org.ethereum.manager.AdminInfo;
 import org.ethereum.manager.WorldManager;
-import org.ethereum.net.rlpx.Node;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.Web3;
 import org.ethereum.vm.program.ProgramResult;
 
 import java.math.BigInteger;
-import java.net.InetAddress;
 import java.util.List;
 import java.util.concurrent.Future;
 
@@ -81,37 +76,13 @@ public interface Ethereum {
      */
     Future<Transaction> submitTransaction(Transaction transaction);
 
-
-    /**
-     * Call a contract function locally without sending transaction to the network
-     * and without changing contract storage.
-     * @param receiveAddress hex encoded contract address
-     * @param function  contract function
-     * @param funcArgs  function arguments
-     * @return function result. The return value can be fetched via {@link ProgramResult#getHReturn()}
-     * and decoded with {@link org.ethereum.core.CallTransaction.Function#decodeResult(byte[])}.
-     */
-    ProgramResult callConstantFunction(String receiveAddress, CallTransaction.Function function,
-                                       Object... funcArgs);
-
-
     /**
      * @return - repository for all state data.
      */
     Repository getRepository();
 
-    /**
-     * @return - pending state repository
-     */
-    Repository getPendingState();
 
-
-    public void init();
-//  2.   // is blockchain still loading - if buffer is not empty
-
-    Repository getSnapshootTo(byte[] root);
-
-    AdminInfo getAdminInfo();
+    void init();
 
     ChannelManager getChannelManager();
 
@@ -119,11 +90,6 @@ public interface Ethereum {
      * @return - currently pending transactions received from the net
      */
     List<Transaction> getWireTransactions();
-
-    /**
-     * @return - currently pending transactions sent to the net
-     */
-    List<Transaction> getPendingStateTransactions();
 
     /**
      * Calculates a 'reasonable' Gas price based on statistics of the latest transaction's Gas prices
@@ -134,8 +100,6 @@ public interface Ethereum {
      */
     long getGasPrice();
 
-    void exitOn(long number);
-
     // TODO review world manager expose
     WorldManager getWorldManager();
 
@@ -144,6 +108,4 @@ public interface Ethereum {
 
     // TODO added method, to review
     ProgramResult callConstant(Web3.CallArguments args);
-
-    SystemProperties getSystemProperties();
 }

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -64,6 +64,7 @@ public class EthereumImpl implements Ethereum {
     private final ReceiptStore receiptStore;
 
     private GasPriceTracker gasPriceTracker = new GasPriceTracker();
+    private final Repository repository;
 
     public EthereumImpl(WorldManager worldManager,
                         ChannelManager channelManager,
@@ -72,7 +73,8 @@ public class EthereumImpl implements Ethereum {
                         PendingState pendingState,
                         SystemProperties config,
                         CompositeEthereumListener compositeEthereumListener,
-                        ReceiptStore receiptStore) {
+                        ReceiptStore receiptStore,
+                        Repository repository) {
         this.worldManager = worldManager;
         this.channelManager = channelManager;
         this.peerServer = peerServer;
@@ -81,6 +83,7 @@ public class EthereumImpl implements Ethereum {
         this.config = config;
         this.compositeEthereumListener = compositeEthereumListener;
         this.receiptStore = receiptStore;
+        this.repository = repository;
     }
 
     @Override
@@ -164,7 +167,7 @@ public class EthereumImpl implements Ethereum {
         Block bestBlock = getBlockchain().getBestBlock();
         return ReversibleTransactionExecutor.executeTransaction(
                 bestBlock.getCoinbase(),
-                (Repository) getRepository(),
+                repository,
                 worldManager.getBlockStore(),
                 receiptStore,
                 programInvokeFactory,
@@ -172,12 +175,6 @@ public class EthereumImpl implements Ethereum {
                 args
         ).getResult();
     }
-
-    @Override
-    public org.ethereum.facade.Repository getRepository() {
-        return worldManager.getRepository();
-    }
-
 
     @Override
     public List<Transaction> getWireTransactions() {

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -178,11 +178,6 @@ public class EthereumImpl implements Ethereum {
         return worldManager.getRepository();
     }
 
-    @Override
-    public ChannelManager getChannelManager() {
-        return channelManager;
-    }
-
 
     @Override
     public List<Transaction> getWireTransactions() {

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -190,7 +190,4 @@ public class EthereumImpl implements Ethereum {
     @Override
     public WorldManager getWorldManager() { return worldManager; }
 
-    // TODO Review peer server expose
-    @Override
-    public PeerServer getPeerServer() { return peerServer; }
 }

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -185,9 +185,4 @@ public class EthereumImpl implements Ethereum {
     public long getGasPrice() {
         return gasPriceTracker.getGasPrice();
     }
-
-    // TODO Review world manager expose
-    @Override
-    public WorldManager getWorldManager() { return worldManager; }
-
 }

--- a/rskj-core/src/main/java/org/ethereum/facade/Repository.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Repository.java
@@ -21,11 +21,7 @@ package org.ethereum.facade;
 
 import org.ethereum.vm.DataWord;
 
-import javax.annotation.Nullable;
 import java.math.BigInteger;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
 
 public interface Repository {
 
@@ -72,29 +68,4 @@ public interface Repository {
      * @return data in the form of a <code>DataWord</code>
      */
     DataWord getStorageValue(byte[] addr, DataWord key);
-
-    /**
-     * Retrieve storage size for a given account
-     *
-     * @param addr of the account
-     * @return storage entries count
-     */
-    int getStorageSize(byte[] addr);
-
-    /**
-     * Retrieve all storage keys for a given account
-     *
-     * @param addr of the account
-     * @return set of storage keys or empty set if account with specified address not exists
-     */
-    Set<DataWord> getStorageKeys(byte[] addr);
-
-    /**
-     * Retrieve storage entries from an account for given keys
-     *
-     * @param addr of the account
-     * @param keys
-     * @return storage entries for specified keys, or full storage if keys parameter is <code>null</code>
-     */
-    Map<DataWord, DataWord> getStorage(byte[] addr, @Nullable Collection<DataWord> keys);
 }

--- a/rskj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/rskj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -19,7 +19,6 @@
 
 package org.ethereum.manager;
 
-import co.rsk.core.NetworkStateExporter;
 import co.rsk.metrics.HashRateCalculator;
 import co.rsk.net.BlockProcessor;
 import org.ethereum.core.Blockchain;
@@ -27,7 +26,6 @@ import org.ethereum.core.PendingState;
 import org.ethereum.db.BlockStore;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.client.ConfigCapabilities;
-import org.ethereum.net.server.ChannelManager;
 
 /**
  * WorldManager is a singleton containing references to different parts of the system.
@@ -39,13 +37,7 @@ import org.ethereum.net.server.ChannelManager;
 
 public interface WorldManager {
 
-    void init();
-
     void addListener(EthereumListener listener);
-
-    ChannelManager getChannelManager();
-
-    org.ethereum.facade.Repository getRepository();
 
     Blockchain getBlockchain();
 
@@ -60,7 +52,5 @@ public interface WorldManager {
     BlockProcessor getNodeBlockProcessor();
 
     HashRateCalculator getHashRateCalculator();
-
-    NetworkStateExporter getNetworkStateExporter();
 
 }

--- a/rskj-core/src/main/java/org/ethereum/manager/WorldManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/manager/WorldManagerImpl.java
@@ -86,11 +86,7 @@ public class WorldManagerImpl implements WorldManager {
         this.channelManager = channelManager;
         this.listener = listener;
         this.nodeBlockProcessor = nodeBlockProcessor;
-    }
 
-    @Override
-    @PostConstruct
-    public void init() {
         BlockChainLoader loader = new BlockChainLoader(this.blockchain, this.config, this.blockStore, this.repository, this.listener);
         loader.loadBlockchain();
     }
@@ -99,16 +95,6 @@ public class WorldManagerImpl implements WorldManager {
     public void addListener(EthereumListener listener) {
         logger.info("Ethereum listener added");
         ((CompositeEthereumListener) this.listener).addListener(listener);
-    }
-
-    @Override
-    public ChannelManager getChannelManager() {
-        return channelManager;
-    }
-
-    @Override
-    public org.ethereum.facade.Repository getRepository() {
-        return (org.ethereum.facade.Repository)repository;
     }
 
     @Override
@@ -143,10 +129,5 @@ public class WorldManagerImpl implements WorldManager {
 
     @Override
     public HashRateCalculator getHashRateCalculator() { return hashRateCalculator; }
-
-    @Override
-    public NetworkStateExporter getNetworkStateExporter() {
-        return networkStateExporter;
-    }
 
 }

--- a/rskj-core/src/main/java/org/ethereum/manager/WorldManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/manager/WorldManagerImpl.java
@@ -51,41 +51,41 @@ public class WorldManagerImpl implements WorldManager {
 
     private static final Logger logger = LoggerFactory.getLogger("general");
 
-    @Autowired
-    private EthereumListener listener;
-
-    @Autowired
-    private ChannelManager channelManager;
-
-    @Autowired
-    private SystemProperties config;
-
-    @Autowired
-    private ConfigCapabilities configCapabilities;
-
-    @Autowired
-    private HashRateCalculator hashRateCalculator;
-
-    @Autowired
-    private BlockProcessor nodeBlockProcessor;
-
-    @Autowired
-    private NetworkStateExporter networkStateExporter;
-
     private final Blockchain blockchain;
     private final BlockStore blockStore;
     private final PendingState pendingState;
     private final Repository repository;
+    private final NetworkStateExporter networkStateExporter;
+    private final HashRateCalculator hashRateCalculator;
+    private final ConfigCapabilities configCapabilities;
+    private final SystemProperties config;
+    private final ChannelManager channelManager;
+    private final EthereumListener listener;
+    private final BlockProcessor nodeBlockProcessor;
 
     @Autowired
     public WorldManagerImpl(Blockchain blockchain,
                             BlockStore blockStore,
                             PendingState pendingState,
-                            Repository repository) {
+                            Repository repository,
+                            NetworkStateExporter networkStateExporter,
+                            HashRateCalculator hashRateCalculator,
+                            ConfigCapabilities configCapabilities,
+                            SystemProperties config,
+                            ChannelManager channelManager,
+                            EthereumListener listener,
+                            BlockProcessor nodeBlockProcessor) {
         this.blockchain = blockchain;
         this.blockStore = blockStore;
         this.pendingState = pendingState;
         this.repository = repository;
+        this.networkStateExporter = networkStateExporter;
+        this.hashRateCalculator = hashRateCalculator;
+        this.configCapabilities = configCapabilities;
+        this.config = config;
+        this.channelManager = channelManager;
+        this.listener = listener;
+        this.nodeBlockProcessor = nodeBlockProcessor;
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -19,7 +19,6 @@
 package org.ethereum.rpc;
 
 import co.rsk.config.RskSystemProperties;
-import co.rsk.core.Rsk;
 import co.rsk.core.SnapshotManager;
 import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerManager;
@@ -91,7 +90,7 @@ public class Web3Impl implements Web3 {
     protected MinerServer minerServer;
     private ChannelManager channelManager;
 
-    private PeerScoringManager peerScoringManager;
+    private final PeerScoringManager peerScoringManager;
 
     private PersonalModule personalModule;
     private EthModule ethModule;
@@ -103,7 +102,8 @@ public class Web3Impl implements Web3 {
                        PersonalModule personalModule,
                        EthModule ethModule,
                        ChannelManager channelManager,
-                       org.ethereum.facade.Repository repository) {
+                       org.ethereum.facade.Repository repository,
+                       PeerScoringManager peerScoringManager) {
         this.eth = eth;
         this.worldManager = eth.getWorldManager();
         this.repository = repository;
@@ -112,9 +112,7 @@ public class Web3Impl implements Web3 {
         this.personalModule = personalModule;
         this.ethModule = ethModule;
         this.channelManager = channelManager;
-
-        if (eth instanceof Rsk)
-            this.peerScoringManager = ((Rsk) eth).getPeerScoringManager();
+        this.peerScoringManager = peerScoringManager;
 
         initialBlockNumber = this.worldManager.getBlockchain().getBestBlock().getNumber();
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -102,10 +102,11 @@ public class Web3Impl implements Web3 {
                        MinerServer minerServer,
                        PersonalModule personalModule,
                        EthModule ethModule,
-                       ChannelManager channelManager) {
+                       ChannelManager channelManager,
+                       org.ethereum.facade.Repository repository) {
         this.eth = eth;
         this.worldManager = eth.getWorldManager();
-        this.repository = eth.getRepository();
+        this.repository = repository;
         this.minerClient = minerClient;
         this.minerServer = minerServer;
         this.personalModule = personalModule;

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -41,6 +41,7 @@ import org.ethereum.facade.Ethereum;
 import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.listener.EthereumListenerAdapter;
+import org.ethereum.manager.WorldManager;
 import org.ethereum.net.client.Capability;
 import org.ethereum.net.client.ConfigCapabilities;
 import org.ethereum.net.server.Channel;
@@ -105,6 +106,7 @@ public class Web3Impl implements Web3 {
     private EthModule ethModule;
 
     protected Web3Impl(Ethereum eth,
+                       WorldManager worldManager,
                        RskSystemProperties properties,
                        MinerClient minerClient,
                        MinerServer minerServer,
@@ -123,12 +125,12 @@ public class Web3Impl implements Web3 {
         this.channelManager = channelManager;
         this.peerScoringManager = peerScoringManager;
         this.peerServer = peerServer;
-        this.blockchain = eth.getWorldManager().getBlockchain();
-        this.nodeBlockProcessor = eth.getWorldManager().getNodeBlockProcessor();
-        this.hashRateCalculator = eth.getWorldManager().getHashRateCalculator();
-        this.configCapabilities = eth.getWorldManager().getConfigCapabilities();
-        this.blockStore = eth.getWorldManager().getBlockStore();
-        this.pendingState = eth.getWorldManager().getPendingState();
+        this.blockchain = worldManager.getBlockchain();
+        this.nodeBlockProcessor = worldManager.getNodeBlockProcessor();
+        this.hashRateCalculator = worldManager.getHashRateCalculator();
+        this.configCapabilities = worldManager.getConfigCapabilities();
+        this.blockStore = worldManager.getBlockStore();
+        this.pendingState = worldManager.getPendingState();
         initialBlockNumber = this.blockchain.getBestBlock().getNumber();
 
         compositeEthereumListener = new CompositeEthereumListener();

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -45,6 +45,7 @@ import org.ethereum.net.client.Capability;
 import org.ethereum.net.client.ConfigCapabilities;
 import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
+import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
@@ -90,8 +91,9 @@ public class Web3Impl implements Web3 {
     private MinerClient minerClient;
     protected MinerServer minerServer;
     private ChannelManager channelManager;
-
     private final PeerScoringManager peerScoringManager;
+    private final PeerServer peerServer;
+
     private final Blockchain blockchain;
     private final BlockProcessor nodeBlockProcessor;
     private final HashRateCalculator hashRateCalculator;
@@ -110,7 +112,8 @@ public class Web3Impl implements Web3 {
                        EthModule ethModule,
                        ChannelManager channelManager,
                        org.ethereum.facade.Repository repository,
-                       PeerScoringManager peerScoringManager) {
+                       PeerScoringManager peerScoringManager,
+                       PeerServer peerServer) {
         this.eth = eth;
         this.repository = repository;
         this.minerClient = minerClient;
@@ -119,6 +122,7 @@ public class Web3Impl implements Web3 {
         this.ethModule = ethModule;
         this.channelManager = channelManager;
         this.peerScoringManager = peerScoringManager;
+        this.peerServer = peerServer;
         this.blockchain = eth.getWorldManager().getBlockchain();
         this.nodeBlockProcessor = eth.getWorldManager().getNodeBlockProcessor();
         this.hashRateCalculator = eth.getWorldManager().getHashRateCalculator();
@@ -254,7 +258,7 @@ public class Web3Impl implements Web3 {
     public boolean net_listening() {
         Boolean s = null;
         try {
-            return s = eth.getPeerServer().isListening();
+            return s = peerServer.isListening();
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug("net_listening(): " + s);

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -466,126 +465,6 @@ public class RepositoryImplTest {
         RepositoryImpl repository = new RepositoryImpl();
 
         Assert.assertNotNull(repository.getDetailsDataStore());
-    }
-
-    @Test
-    public void getStorageKeysForUnknownAccount() {
-        RepositoryImpl repository = new RepositoryImpl();
-
-        Set<DataWord> keys = repository.getStorageKeys(randomAccountAddress());
-
-        Assert.assertNotNull(keys);
-        Assert.assertTrue(keys.isEmpty());
-    }
-
-    @Test
-    public void getStorageKeysForCreatedAccountWithoutStorage() {
-        byte[] accAddress = randomAccountAddress();
-
-        RepositoryImpl repository = new RepositoryImpl();
-
-        repository.createAccount(accAddress);
-
-        Set<DataWord> keys = repository.getStorageKeys(accAddress);
-
-        Assert.assertNotNull(keys);
-        Assert.assertTrue(keys.isEmpty());
-    }
-
-    @Test
-    public void getStorageKeysForAccountWithSavedData() {
-        byte[] accAddress = randomAccountAddress();
-
-        RepositoryImpl repository = new RepositoryImpl();
-
-        repository.createAccount(accAddress);
-        repository.addStorageRow(accAddress, DataWord.ONE, new DataWord(2));
-
-        Set<DataWord> keys = repository.getStorageKeys(accAddress);
-
-        Assert.assertNotNull(keys);
-        Assert.assertFalse(keys.isEmpty());
-        Assert.assertEquals(1, keys.size());
-        Assert.assertTrue(keys.contains(DataWord.ONE));
-    }
-
-    @Test
-    public void getStorageSizeForUnknownAccount() {
-        RepositoryImpl repository = new RepositoryImpl();
-
-        Assert.assertEquals(0, repository.getStorageSize(randomAccountAddress()));
-    }
-
-    @Test
-    public void getStorageSizeForCreatedAccountWithoutStorage() {
-        byte[] accAddress = randomAccountAddress();
-
-        RepositoryImpl repository = new RepositoryImpl();
-
-        repository.createAccount(accAddress);
-
-        Assert.assertEquals(0, repository.getStorageSize(accAddress));
-    }
-
-    @Test
-    public void getStorageSizeForAccountWithSavedData() {
-        byte[] accAddress = randomAccountAddress();
-
-        RepositoryImpl repository = new RepositoryImpl();
-
-        repository.createAccount(accAddress);
-        repository.addStorageRow(accAddress, DataWord.ONE, DataWord.ONE);
-
-        Assert.assertEquals(1, repository.getStorageSize(accAddress));
-    }
-
-    @Test
-    public void getStorageForUnknownAccount() {
-        RepositoryImpl repository = new RepositoryImpl();
-
-        Map<DataWord, DataWord> map = repository.getStorage(randomAccountAddress(), null);
-
-        Assert.assertNotNull(map);
-        Assert.assertTrue(map.isEmpty());
-    }
-
-    @Test
-    public void getStorageForCreatedAccountWithoutStorage() {
-        byte[] accAddress = randomAccountAddress();
-
-        RepositoryImpl repository = new RepositoryImpl();
-
-        repository.createAccount(accAddress);
-
-        Map<DataWord, DataWord> map = repository.getStorage(accAddress, null);
-
-        Assert.assertNotNull(map);
-        Assert.assertTrue(map.isEmpty());
-    }
-
-    @Test
-    public void getStorageForAccountWithSavedData() {
-        byte[] accAddress = randomAccountAddress();
-
-        RepositoryImpl repository = new RepositoryImpl();
-
-        Repository track = repository.startTracking();
-
-        track.createAccount(accAddress);
-        track.addStorageRow(accAddress, DataWord.ONE, new DataWord(2));
-
-        track.commit();
-
-        Map<DataWord, DataWord> map = repository.getStorage(accAddress, null);
-
-        Assert.assertNotNull(map);
-        Assert.assertFalse(map.isEmpty());
-
-        Assert.assertEquals(1, map.size());
-        Assert.assertTrue(map.containsKey(DataWord.ONE));
-
-        Assert.assertNotNull(map.get(DataWord.ONE));
-        Assert.assertEquals(new DataWord(2), map.get(DataWord.ONE));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -361,8 +361,8 @@ public class MinerManagerTest {
 
     private static class RskImplForTest extends RskImpl {
         public RskImplForTest() {
-            super(null, null, null, null,
-                    null, null, null, null, null, null, null);
+            super(null, null, null,
+                    null, null, null, null, null, null, null, null, null);
         }
     }
 }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -349,7 +349,7 @@ public class MinerManagerTest {
         worldManager.setBlockchain(blockchain);
         ethereum.repository = (org.ethereum.facade.Repository)blockchain.getRepository();
         ethereum.worldManager = worldManager;
-        return new MinerServerImpl(ethereum, blockchain, blockchain.getBlockStore(), blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), new BlockValidationRuleDummy());
+        return new MinerServerImpl(ethereum, blockchain, blockchain.getBlockStore(), blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), new BlockValidationRuleDummy(), worldManager.getNodeBlockProcessor());
     }
 
     public static class BlockValidationRuleDummy implements BlockValidationRule {

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -23,7 +23,6 @@ import co.rsk.core.RskImpl;
 import co.rsk.core.SnapshotManager;
 import co.rsk.test.World;
 import co.rsk.validators.BlockValidationRule;
-import co.rsk.validators.DummyBlockValidationRule;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.ethereum.core.Block;
@@ -362,7 +361,7 @@ public class MinerManagerTest {
 
     private static class RskImplForTest extends RskImpl {
         public RskImplForTest() {
-            super(null, null, null, null, null,
+            super(null, null, null, null,
                     null, null, null, null, null, null, null);
         }
     }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -64,8 +64,6 @@ public class MinerServerTest {
         Mockito.when(repository.getSnapshotTo(Mockito.any())).thenReturn(repository);
         Mockito.when(repository.getRoot()).thenReturn(blockchain.getRepository().getRoot());
         Mockito.when(repository.startTracking()).thenReturn(repository);
-        Mockito.when(ethereumImpl.getRepository()).thenReturn((org.ethereum.facade.Repository)
-                blockchain.getRepository());
 
         Transaction tx1 = Tx.create(0, 21000, 100, 0, 0, 0, new Random(0));
         byte[] s1 = new byte[32];
@@ -103,12 +101,11 @@ public class MinerServerTest {
     @Test
     public void submitBitcoinBlock() {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
-        Mockito.when(ethereumImpl.getRepository()).thenReturn((org.ethereum.facade.Repository) blockchain.getRepository());
         Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, blockchain, null, blockchain.getPendingState(), (Repository) ethereumImpl.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, blockchain, null, blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
 
         minerServer.start();
         MinerWork work = minerServer.getWork();
@@ -143,11 +140,10 @@ public class MinerServerTest {
         blockchain = world.getBlockChain();
 
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
-        Mockito.when(ethereumImpl.getRepository()).thenReturn((org.ethereum.facade.Repository) blockchain.getRepository());
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), (Repository) ethereumImpl.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
 
         minerServer.start();
         MinerWork work = minerServer.getWork();
@@ -180,12 +176,11 @@ public class MinerServerTest {
         blockchain = world.getBlockChain();
 
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
-        Mockito.when(ethereumImpl.getRepository()).thenReturn((org.ethereum.facade.Repository) blockchain.getRepository());
         Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), (Repository) ethereumImpl.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
 
         minerServer.start();
         MinerWork work = minerServer.getWork();
@@ -221,11 +216,10 @@ public class MinerServerTest {
     @Test
     public void workWithNoTransactionsZeroFees() {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
-        Mockito.when(ethereumImpl.getRepository()).thenReturn((org.ethereum.facade.Repository) blockchain.getRepository());
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), (Repository) ethereumImpl.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
 
         minerServer.start();
 
@@ -237,11 +231,10 @@ public class MinerServerTest {
     @Test
     public void initialWorkTurnsNotifyFlagOn() {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
-        Mockito.when(ethereumImpl.getRepository()).thenReturn((org.ethereum.facade.Repository) blockchain.getRepository());
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), (Repository) ethereumImpl.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
 
         minerServer.start();
 
@@ -253,11 +246,10 @@ public class MinerServerTest {
     @Test
     public void secondWorkWithNoChangesTurnsNotifyFlagOff() {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
-        Mockito.when(ethereumImpl.getRepository()).thenReturn((org.ethereum.facade.Repository) blockchain.getRepository());
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), (Repository) ethereumImpl.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
 
         minerServer.start();
 
@@ -273,11 +265,10 @@ public class MinerServerTest {
     @Test
     public void secondBuildBlockToMineTurnsNotifyFlagOff() {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
-        Mockito.when(ethereumImpl.getRepository()).thenReturn((org.ethereum.facade.Repository) blockchain.getRepository());
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), (Repository) ethereumImpl.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
 
         minerServer.start();
 

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -85,7 +85,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServerImpl minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, localPendingState, repository, ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServerImpl minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, localPendingState, repository, ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null);
 
         minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
         Block blockAtHeightOne = minerServer.getBlocksWaitingforPoW().entrySet().iterator().next().getValue();
@@ -105,7 +105,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, blockchain, null, blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, blockchain, null, blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null);
 
         minerServer.start();
         MinerWork work = minerServer.getWork();
@@ -143,7 +143,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, world.getBlockProcessor());
 
         minerServer.start();
         MinerWork work = minerServer.getWork();
@@ -180,7 +180,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, world.getBlockProcessor());
 
         minerServer.start();
         MinerWork work = minerServer.getWork();
@@ -219,7 +219,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null);
 
         minerServer.start();
 
@@ -234,7 +234,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null);
 
         minerServer.start();
 
@@ -249,7 +249,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null);
 
         minerServer.start();
 
@@ -268,7 +268,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule);
+        MinerServer minerServer = new MinerServerImpl(ethereumImpl, this.blockchain, null, blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null);
 
         minerServer.start();
 
@@ -287,7 +287,7 @@ public class MinerServerTest {
     public void getCurrentTimeInMilliseconds() {
         long current = System.currentTimeMillis() / 1000;
 
-        MinerServer server = new MinerServerImpl(null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null);
+        MinerServer server = new MinerServerImpl(null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null, null);
 
         long result = server.getCurrentTimeInSeconds();
 
@@ -299,7 +299,7 @@ public class MinerServerTest {
     public void increaseTime() {
         long current = System.currentTimeMillis() / 1000;
 
-        MinerServer server = new MinerServerImpl(null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null);
+        MinerServer server = new MinerServerImpl(null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null, null);
 
         Assert.assertEquals(10, server.increaseTime(10));
 
@@ -313,7 +313,7 @@ public class MinerServerTest {
     public void increaseTimeUsingNegativeNumberHasNoEffect() {
         long current = System.currentTimeMillis() / 1000;
 
-        MinerServer server = new MinerServerImpl(null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null);
+        MinerServer server = new MinerServerImpl(null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null, null);
 
         Assert.assertEquals(0, server.increaseTime(-10));
 
@@ -326,7 +326,7 @@ public class MinerServerTest {
     public void increaseTimeTwice() {
         long current = System.currentTimeMillis() / 1000;
 
-        MinerServer server = new MinerServerImpl(null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null);
+        MinerServer server = new MinerServerImpl(null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null, null);
 
         Assert.assertEquals(5, server.increaseTime(5));
         Assert.assertEquals(10, server.increaseTime(5));

--- a/rskj-core/src/test/java/co/rsk/mine/TxBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TxBuilderTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.mine;
 
+import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.rpc.Simples.SimpleEthereum;
 import org.junit.Test;
@@ -30,7 +31,7 @@ public class TxBuilderTest {
     @Test
     public void createBasicTransaction() {
         SimpleEthereum rsk = new SimpleEthereum();
-        TxBuilder builder = new TxBuilder(rsk);
+        TxBuilder builder = new TxBuilder(rsk, (Repository) rsk.repository);
 
         BigInteger gasPrice = BigInteger.ONE;
         BigInteger gasLimit = BigInteger.valueOf(21000);
@@ -46,7 +47,7 @@ public class TxBuilderTest {
     @Test
     public void createAndBroadcastTransaction() {
         SimpleEthereum rsk = new SimpleEthereum();
-        TxBuilder builder = new TxBuilder(rsk);
+        TxBuilder builder = new TxBuilder(rsk, (Repository) rsk.repository);
 
         BigInteger nonce = BigInteger.TEN;
 

--- a/rskj-core/src/test/java/co/rsk/mine/TxBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TxBuilderTest.java
@@ -18,10 +18,12 @@
 
 package co.rsk.mine;
 
+import co.rsk.net.BlockProcessor;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.rpc.Simples.SimpleEthereum;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.testng.Assert;
 
 import java.math.BigInteger;
@@ -31,7 +33,7 @@ public class TxBuilderTest {
     @Test
     public void createBasicTransaction() {
         SimpleEthereum rsk = new SimpleEthereum();
-        TxBuilder builder = new TxBuilder(rsk, (Repository) rsk.repository);
+        TxBuilder builder = new TxBuilder(rsk, null, (Repository) rsk.repository);
 
         BigInteger gasPrice = BigInteger.ONE;
         BigInteger gasLimit = BigInteger.valueOf(21000);
@@ -47,7 +49,8 @@ public class TxBuilderTest {
     @Test
     public void createAndBroadcastTransaction() {
         SimpleEthereum rsk = new SimpleEthereum();
-        TxBuilder builder = new TxBuilder(rsk, (Repository) rsk.repository);
+        BlockProcessor blockProcessor = Mockito.mock(BlockProcessor.class);
+        TxBuilder builder = new TxBuilder(rsk, blockProcessor, (Repository) rsk.repository);
 
         BigInteger nonce = BigInteger.TEN;
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -21,6 +21,7 @@ package co.rsk.rpc;
 import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
 import org.ethereum.facade.Ethereum;
+import org.ethereum.facade.Repository;
 import org.ethereum.rpc.Web3Impl;
 import org.ethereum.rpc.Web3Mocks;
 import org.junit.Assert;
@@ -36,7 +37,8 @@ public class Web3ImplRpcTest {
     public void getRpcModules() {
         Ethereum eth = Web3Mocks.getMockEthereum();
         PersonalModule pm = new PersonalModuleWalletDisabled();
-        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null);
+        Repository repository = Web3Mocks.getMockRepository();
+        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null, repository);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -38,7 +38,7 @@ public class Web3ImplRpcTest {
         Ethereum eth = Web3Mocks.getMockEthereum();
         PersonalModule pm = new PersonalModuleWalletDisabled();
         Repository repository = Web3Mocks.getMockRepository();
-        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null, repository, null);
+        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null, repository, null, null, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -38,7 +38,7 @@ public class Web3ImplRpcTest {
         Ethereum eth = Web3Mocks.getMockEthereum();
         PersonalModule pm = new PersonalModuleWalletDisabled();
         Repository repository = Web3Mocks.getMockRepository();
-        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null, repository, null, null, null);
+        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null, repository, null, null, null, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -38,7 +38,7 @@ public class Web3ImplRpcTest {
         Ethereum eth = Web3Mocks.getMockEthereum();
         PersonalModule pm = new PersonalModuleWalletDisabled();
         Repository repository = Web3Mocks.getMockRepository();
-        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null, repository);
+        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null, repository, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -22,6 +22,7 @@ import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.Repository;
+import org.ethereum.manager.WorldManager;
 import org.ethereum.rpc.Web3Impl;
 import org.ethereum.rpc.Web3Mocks;
 import org.junit.Assert;
@@ -36,9 +37,10 @@ public class Web3ImplRpcTest {
     @Test
     public void getRpcModules() {
         Ethereum eth = Web3Mocks.getMockEthereum();
+        WorldManager worldManager = Web3Mocks.getMockWorldManager();
         PersonalModule pm = new PersonalModuleWalletDisabled();
         Repository repository = Web3Mocks.getMockRepository();
-        Web3Impl web3 = new Web3RskImpl(eth, null, null, null, pm, null, null, repository, null, null, null, null);
+        Web3Impl web3 = new Web3RskImpl(eth, worldManager, null, null, null, pm, null, null, repository, null, null, null, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -72,7 +72,7 @@ public class Web3RskImplTest {
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
         EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, networkStateExporter, blockStore);
+        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, networkStateExporter, blockStore, null);
         web3.ext_dumpState();
     }
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -74,7 +74,7 @@ public class Web3RskImplTest {
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
         EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager());
+        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
         web3.ext_dumpState();
     }
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -67,12 +67,11 @@ public class Web3RskImplTest {
 
         Mockito.when(worldManager.getBlockchain()).thenReturn(blockchain);
         Mockito.when(blockchain.getBestBlock()).thenReturn(block);
-        Mockito.when(rsk.getWorldManager()).thenReturn(worldManager);
 
         Wallet wallet = WalletFactory.createWallet();
-        PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
-        EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, networkStateExporter, blockStore, null);
+        PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet, null);
+        EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet, null));
+        Web3RskImpl web3 = new Web3RskImpl(rsk, worldManager, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, networkStateExporter, blockStore, null);
         web3.ext_dumpState();
     }
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -66,15 +66,13 @@ public class Web3RskImplTest {
         Mockito.when(networkStateExporter.exportStatus(Mockito.anyString())).thenReturn(true);
 
         Mockito.when(worldManager.getBlockchain()).thenReturn(blockchain);
-        Mockito.when(worldManager.getNetworkStateExporter()).thenReturn(networkStateExporter);
-        Mockito.when(worldManager.getBlockStore()).thenReturn(blockStore);
         Mockito.when(blockchain.getBestBlock()).thenReturn(block);
         Mockito.when(rsk.getWorldManager()).thenReturn(worldManager);
 
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
         EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
+        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, networkStateExporter, blockStore);
         web3.ext_dumpState();
     }
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -74,7 +74,7 @@ public class Web3RskImplTest {
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
         EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
+        Web3RskImpl web3 = new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
         web3.ext_dumpState();
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
@@ -27,7 +27,6 @@ import org.ethereum.facade.Repository;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.listener.GasPriceTracker;
 import org.ethereum.manager.WorldManager;
-import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.Web3;
 import org.ethereum.vm.program.ProgramResult;
@@ -96,11 +95,6 @@ public class SimpleEthereum implements Ethereum {
     @Override
     public void init() {
 
-    }
-
-    @Override
-    public ChannelManager getChannelManager() {
-        return null;
     }
 
     @Override

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
@@ -18,9 +18,7 @@
 
 package org.ethereum.rpc.Simples;
 
-import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Block;
-import org.ethereum.core.CallTransaction;
 import org.ethereum.core.ImportResult;
 import org.ethereum.core.Transaction;
 import org.ethereum.facade.Blockchain;
@@ -28,9 +26,7 @@ import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.Repository;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.listener.GasPriceTracker;
-import org.ethereum.manager.AdminInfo;
 import org.ethereum.manager.WorldManager;
-import org.ethereum.net.rlpx.Node;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.Web3;
@@ -38,7 +34,6 @@ import org.ethereum.vm.program.ProgramResult;
 
 import javax.annotation.Nonnull;
 import java.math.BigInteger;
-import java.net.InetAddress;
 import java.util.List;
 import java.util.concurrent.Future;
 
@@ -94,33 +89,13 @@ public class SimpleEthereum implements Ethereum {
     }
 
     @Override
-    public ProgramResult callConstantFunction(String receiveAddress, CallTransaction.Function function, Object... funcArgs) {
-        return null;
-    }
-
-    @Override
     public Repository getRepository() {
         return repository;
     }
 
     @Override
-    public Repository getPendingState() {
-        return null;
-    }
-
-    @Override
     public void init() {
 
-    }
-
-    @Override
-    public Repository getSnapshootTo(byte[] root) {
-        return null;
-    }
-
-    @Override
-    public AdminInfo getAdminInfo() {
-        return null;
     }
 
     @Override
@@ -134,18 +109,8 @@ public class SimpleEthereum implements Ethereum {
     }
 
     @Override
-    public List<Transaction> getPendingStateTransactions() {
-        return null;
-    }
-
-    @Override
     public long getGasPrice() {
         return new GasPriceTracker().getGasPrice();
-    }
-
-    @Override
-    public void exitOn(long number) {
-
     }
 
     @Override
@@ -160,11 +125,6 @@ public class SimpleEthereum implements Ethereum {
 
     @Override
     public ProgramResult callConstant(Web3.CallArguments args) {
-        return null;
-    }
-
-    @Override
-    public SystemProperties getSystemProperties() {
         return null;
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
@@ -87,7 +87,6 @@ public class SimpleEthereum implements Ethereum {
         return null;
     }
 
-    @Override
     public Repository getRepository() {
         return repository;
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
@@ -27,7 +27,6 @@ import org.ethereum.facade.Repository;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.listener.GasPriceTracker;
 import org.ethereum.manager.WorldManager;
-import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.Web3;
 import org.ethereum.vm.program.ProgramResult;
 
@@ -41,7 +40,6 @@ import java.util.concurrent.Future;
  */
 public class SimpleEthereum implements Ethereum {
 
-    public PeerServer peerServer;
     public Transaction tx;
     public WorldManager worldManager;
     public Repository repository;
@@ -104,11 +102,6 @@ public class SimpleEthereum implements Ethereum {
     @Override
     public long getGasPrice() {
         return new GasPriceTracker().getGasPrice();
-    }
-
-    @Override
-    public WorldManager getWorldManager() {
-        return worldManager;
     }
 
     @Override

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
@@ -112,11 +112,6 @@ public class SimpleEthereum implements Ethereum {
     }
 
     @Override
-    public PeerServer getPeerServer() {
-        return peerServer;
-    }
-
-    @Override
     public ProgramResult callConstant(Web3.CallArguments args) {
         return null;
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleRsk.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleRsk.java
@@ -19,30 +19,12 @@
 package org.ethereum.rpc.Simples;
 
 import co.rsk.core.Rsk;
-import co.rsk.net.MessageHandler;
 import co.rsk.net.NodeBlockProcessor;
-import co.rsk.scoring.PeerScoringManager;
 
 /**
  * Created by ajlopez on 12/07/2017.
  */
 public class SimpleRsk extends SimpleEthereum implements Rsk {
-    private PeerScoringManager peerScoringManager;
-
-    @Override
-    public MessageHandler getMessageHandler() {
-        return null;
-    }
-
-    public void setPeerScoringManager(PeerScoringManager peerScoringManager) {
-        this.peerScoringManager = peerScoringManager;
-    }
-
-    @Override
-    public PeerScoringManager getPeerScoringManager() {
-        return this.peerScoringManager;
-    }
-
     @Override
     public NodeBlockProcessor getNodeBlockProcessor() {
         return null;

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleWorldManager.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleWorldManager.java
@@ -18,18 +18,15 @@
 
 package org.ethereum.rpc.Simples;
 
-import co.rsk.core.NetworkStateExporter;
 import co.rsk.metrics.HashRateCalculator;
 import co.rsk.net.BlockProcessor;
 import co.rsk.net.simples.SimpleBlockProcessor;
 import org.ethereum.core.PendingState;
 import org.ethereum.db.BlockStore;
-import org.ethereum.facade.Repository;
 import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.manager.WorldManager;
 import org.ethereum.net.client.ConfigCapabilities;
-import org.ethereum.net.server.ChannelManager;
 
 /**
  * Created by Ruben Altman on 09/06/2016.
@@ -48,11 +45,6 @@ public class SimpleWorldManager implements WorldManager {
         this.nodeBlockProcessor = nodeBlockProcessor;
     }
 
-    @Override
-    public void init() {
-
-    }
-
     public void setListener(EthereumListener listener) {
         this.listener = listener;
     }
@@ -63,16 +55,6 @@ public class SimpleWorldManager implements WorldManager {
             this.listener = new CompositeEthereumListener();
         }
         ((CompositeEthereumListener) this.listener).addListener(listener);
-    }
-
-    @Override
-    public ChannelManager getChannelManager() {
-        return new SimpleChannelManager();
-    }
-
-    @Override
-    public Repository getRepository() {
-        return null;
     }
 
     @Override
@@ -127,11 +109,6 @@ public class SimpleWorldManager implements WorldManager {
 
     @Override
     public HashRateCalculator getHashRateCalculator() {
-        return null;
-    }
-
-    @Override
-    public NetworkStateExporter getNetworkStateExporter() {
         return null;
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -450,7 +450,7 @@ public class Web3ImplLogsTest {
     private Web3Impl createWeb3(Ethereum eth, Wallet wallet) {
         PersonalModule personalModule = new PersonalModuleWalletEnabled(eth, wallet);
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
-        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager());
+        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
     }
 
     private Web3Impl getWeb3() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -450,7 +450,7 @@ public class Web3ImplLogsTest {
     private Web3Impl createWeb3(Ethereum eth, Wallet wallet) {
         PersonalModule personalModule = new PersonalModuleWalletEnabled(eth, wallet);
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
-        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null);
+        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null, null);
     }
 
     private Web3Impl getWeb3() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -19,6 +19,7 @@
 package org.ethereum.rpc;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.core.Rsk;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.core.bc.PendingStateImpl;
@@ -450,7 +451,7 @@ public class Web3ImplLogsTest {
     private Web3Impl createWeb3(Ethereum eth, Wallet wallet) {
         PersonalModule personalModule = new PersonalModuleWalletEnabled(eth, wallet);
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
-        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
+        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
     }
 
     private Web3Impl getWeb3() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -35,6 +35,7 @@ import co.rsk.test.builders.TransactionBuilder;
 import org.ethereum.core.*;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.facade.Repository;
+import org.ethereum.manager.WorldManager;
 import org.ethereum.rpc.Simples.SimpleEthereum;
 import org.ethereum.rpc.Simples.SimpleWorldManager;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
@@ -87,7 +88,7 @@ public class Web3ImplLogsTest {
         SimpleEthereum eth = new SimpleEthereum();
         eth.repository = (Repository) world.getBlockChain().getRepository();
         eth.worldManager = worldManager;
-        Web3Impl web3 = createWeb3(eth, WalletFactory.createPersistentWallet("wallet"));
+        Web3Impl web3 = createWeb3(eth, worldManager, WalletFactory.createPersistentWallet("wallet"));
 
         // TODO tricky link to listener
         world.getBlockChain().setListener(web3.setupListener());
@@ -294,7 +295,7 @@ public class Web3ImplLogsTest {
         SimpleEthereum eth = new SimpleEthereum();
         eth.repository = (Repository) world.getBlockChain().getRepository();
         eth.worldManager = worldManager;
-        Web3Impl web3 = createWeb3(eth, WalletFactory.createPersistentWallet("testwallet"));
+        Web3Impl web3 = createWeb3(eth, worldManager, WalletFactory.createPersistentWallet("testwallet"));
 
         // TODO tricky link to listener
         world.getBlockChain().setListener(web3.setupListener());
@@ -335,7 +336,7 @@ public class Web3ImplLogsTest {
         SimpleEthereum eth = new SimpleEthereum();
         eth.repository = (Repository) world.getBlockChain().getRepository();
         eth.worldManager = worldManager;
-        Web3Impl web3 = createWeb3(eth, WalletFactory.createPersistentWallet("testwallet2"));
+        Web3Impl web3 = createWeb3(eth, worldManager, WalletFactory.createPersistentWallet("testwallet2"));
 
         // TODO tricky link to listener
         world.getBlockChain().setListener(web3.setupListener());
@@ -392,7 +393,7 @@ public class Web3ImplLogsTest {
         SimpleEthereum eth = new SimpleEthereum();
         eth.repository = (Repository) world.getBlockChain().getRepository();
         eth.worldManager = worldManager;
-        Web3Impl web3 = createWeb3(eth, WalletFactory.createPersistentWallet("testwallet3"));
+        Web3Impl web3 = createWeb3(eth, worldManager, WalletFactory.createPersistentWallet("testwallet3"));
 
         // TODO tricky link to listener
         world.getBlockChain().setListener(web3.setupListener());
@@ -444,13 +445,13 @@ public class Web3ImplLogsTest {
     }
 
     private Web3Impl createWeb3(SimpleWorldManager worldManager) {
-        return createWeb3(Web3Mocks.getMockEthereum(worldManager), WalletFactory.createWallet());
+        return createWeb3(Web3Mocks.getMockEthereum(), worldManager, WalletFactory.createWallet());
     }
 
-    private Web3Impl createWeb3(Ethereum eth, Wallet wallet) {
-        PersonalModule personalModule = new PersonalModuleWalletEnabled(eth, wallet);
-        EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
-        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null, null);
+    private Web3Impl createWeb3(Ethereum eth, WorldManager worldManager, Wallet wallet) {
+        PersonalModule personalModule = new PersonalModuleWalletEnabled(eth, wallet, null);
+        EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet, null));
+        return new Web3RskImpl(eth, worldManager, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null, null);
     }
 
     private Web3Impl getWeb3() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -319,9 +319,9 @@ public class Web3ImplScoringTest {
         rsk.worldManager = worldManager;
 
         Wallet wallet = WalletFactory.createWallet();
-        PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
-        EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager, null, null, null);
+        PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet, null);
+        EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet, null));
+        return new Web3RskImpl(rsk, worldManager, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager, null, null, null);
     }
 
     private static NodeID generateNodeID() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -312,7 +312,6 @@ public class Web3ImplScoringTest {
 
     private static Web3Impl createWeb3(PeerScoringManager peerScoringManager) {
         SimpleRsk rsk = new SimpleRsk();
-        rsk.setPeerScoringManager(peerScoringManager);
 
         World world = new World();
         SimpleWorldManager worldManager = new SimpleWorldManager();
@@ -322,7 +321,7 @@ public class Web3ImplScoringTest {
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
         EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository());
+        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager);
     }
 
     private static NodeID generateNodeID() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -321,7 +321,7 @@ public class Web3ImplScoringTest {
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
         EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager, null, null);
+        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager, null, null, null);
     }
 
     private static NodeID generateNodeID() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -321,7 +321,7 @@ public class Web3ImplScoringTest {
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
         EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager);
+        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager, null, null);
     }
 
     private static NodeID generateNodeID() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -322,7 +322,7 @@ public class Web3ImplScoringTest {
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule pm = new PersonalModuleWalletEnabled(rsk, wallet);
         EthModule em = new EthModule(rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(rsk, wallet));
-        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager());
+        return new Web3RskImpl(rsk, RskSystemProperties.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository());
     }
 
     private static NodeID generateNodeID() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -174,7 +174,7 @@ public class Web3ImplSnapshotTest {
         ethereum.worldManager = worldManager;
         minerClient.setMinerServer(minerServer);
 
-        return new Web3Impl(ethereum, Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), ethereum.repository, null);
+        return new Web3Impl(ethereum, Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), ethereum.repository, null, null);
     }
 
     private static Web3Impl createWeb3(World world) {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -174,7 +174,7 @@ public class Web3ImplSnapshotTest {
         ethereum.worldManager = worldManager;
         minerClient.setMinerServer(minerServer);
 
-        return new Web3Impl(ethereum, Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), ethereum.repository, null, null);
+        return new Web3Impl(ethereum, worldManager, Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), ethereum.repository, null, null);
     }
 
     private static Web3Impl createWeb3(World world) {
@@ -185,7 +185,7 @@ public class Web3ImplSnapshotTest {
     static MinerServer getMinerServerForTest(World world, SimpleEthereum ethereum) {
         BlockValidationRule rule = new MinerManagerTest.BlockValidationRuleDummy();
         return new MinerServerImpl(ethereum, world.getBlockChain(), world.getBlockChain().getBlockStore(),
-                world.getBlockChain().getPendingState(), world.getBlockChain().getRepository(), ConfigUtils.getDefaultMiningConfig(), rule);
+                world.getBlockChain().getPendingState(), world.getBlockChain().getRepository(), ConfigUtils.getDefaultMiningConfig(), rule, world.getBlockProcessor());
     }
 
     private static void addBlocks(Blockchain blockchain, int size) {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -168,7 +168,7 @@ public class Web3ImplSnapshotTest {
     private static Web3Impl createWeb3(World world, SimpleEthereum ethereum, MinerServer minerServer) {
         MinerClientImpl minerClient = new MinerClientImpl();
         PersonalModule pm = new PersonalModuleWalletDisabled();
-        Web3Impl web3 = new Web3Impl(Web3Mocks.getMockEthereum(), Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager());
+        Web3Impl web3 = new Web3Impl(Web3Mocks.getMockEthereum(), Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
 
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -29,7 +29,6 @@ import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
 import co.rsk.test.World;
 import co.rsk.validators.BlockValidationRule;
-import co.rsk.validators.DummyBlockValidationRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
 import org.ethereum.rpc.Simples.SimpleEthereum;
@@ -168,18 +167,14 @@ public class Web3ImplSnapshotTest {
     private static Web3Impl createWeb3(World world, SimpleEthereum ethereum, MinerServer minerServer) {
         MinerClientImpl minerClient = new MinerClientImpl();
         PersonalModule pm = new PersonalModuleWalletDisabled();
-        Web3Impl web3 = new Web3Impl(Web3Mocks.getMockEthereum(), Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
 
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
         ethereum.repository = (org.ethereum.facade.Repository) world.getRepository();
         ethereum.worldManager = worldManager;
-
-        BlockValidationRule rule = new DummyBlockValidationRule();
-
         minerClient.setMinerServer(minerServer);
-        web3.worldManager = worldManager;
-        return web3;
+
+        return new Web3Impl(ethereum, Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), ethereum.repository, null);
     }
 
     private static Web3Impl createWeb3(World world) {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -168,7 +168,7 @@ public class Web3ImplSnapshotTest {
     private static Web3Impl createWeb3(World world, SimpleEthereum ethereum, MinerServer minerServer) {
         MinerClientImpl minerClient = new MinerClientImpl();
         PersonalModule pm = new PersonalModuleWalletDisabled();
-        Web3Impl web3 = new Web3Impl(Web3Mocks.getMockEthereum(), Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
+        Web3Impl web3 = new Web3Impl(Web3Mocks.getMockEthereum(), Web3Mocks.getMockProperties(), minerClient, minerServer, pm, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
 
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -262,7 +262,7 @@ public class Web3ImplTest {
         RskSystemProperties mockProperties = Web3Mocks.getMockProperties();
         MinerClient minerClient = new SimpleMinerClient();
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
-        Web3 web3 = new Web3Impl(ethMock, mockProperties, minerClient, null, personalModule, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
+        Web3 web3 = new Web3Impl(ethMock, mockProperties, minerClient, null, personalModule, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
 
         Assert.assertTrue("Node is not mining", !web3.eth_mining());
 
@@ -994,7 +994,7 @@ public class Web3ImplTest {
         Ethereum ethMock = Web3Mocks.getMockEthereum();
         RskSystemProperties mockProperties = Web3Mocks.getMockProperties();
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
-		Web3 web3 = new Web3Impl(ethMock, mockProperties, null, minerServerMock, personalModule, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
+        Web3 web3 = new Web3Impl(ethMock, mockProperties, null, minerServerMock, personalModule, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
 
         Assert.assertEquals("0x" + originalCoinbase, web3.eth_coinbase());
         Mockito.verify(minerServerMock, Mockito.times(1)).getCoinbaseAddress();
@@ -1283,7 +1283,7 @@ public class Web3ImplTest {
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
         MinerClient minerClient = new SimpleMinerClient();
         ChannelManager channelManager = new SimpleChannelManager();
-        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule, channelManager, Web3Mocks.getMockRepository());
+        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule, channelManager, Web3Mocks.getMockRepository(), null);
     }
 
     @Test
@@ -1298,7 +1298,7 @@ public class Web3ImplTest {
         Ethereum eth = Mockito.mock(Ethereum.class);
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityEnabled(new SolidityCompiler(systemProperties)), null);
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
-        Web3Impl web3 = new Web3RskImpl(eth, systemProperties, null, null, personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
+        Web3Impl web3 = new Web3RskImpl(eth, systemProperties, null, null, personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
         String contract = "pragma solidity ^0.4.1; contract rsk { function multiply(uint a) returns(uint d) {   return a * 7;   } }";
 
         Map<String, CompilationResultDTO> result = web3.eth_compileSolidity(contract);
@@ -1326,7 +1326,7 @@ public class Web3ImplTest {
         Ethereum eth = Mockito.mock(Ethereum.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(eth.getWorldManager().getBlockchain().getBestBlock().getNumber()).thenReturn(1L);
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
-        Web3Impl web3 = new Web3RskImpl(eth, RskSystemProperties.CONFIG, null, null, new PersonalModuleWalletDisabled(), ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
+        Web3Impl web3 = new Web3RskImpl(eth, RskSystemProperties.CONFIG, null, null, new PersonalModuleWalletDisabled(), ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null);
 
         String contract = "pragma solidity ^0.4.1; contract rsk { function multiply(uint a) returns(uint d) {   return a * 7;   } }";
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -262,7 +262,7 @@ public class Web3ImplTest {
         RskSystemProperties mockProperties = Web3Mocks.getMockProperties();
         MinerClient minerClient = new SimpleMinerClient();
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
-        Web3 web3 = new Web3Impl(ethMock, mockProperties, minerClient, null, personalModule, null, Web3Mocks.getMockChannelManager());
+        Web3 web3 = new Web3Impl(ethMock, mockProperties, minerClient, null, personalModule, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
 
         Assert.assertTrue("Node is not mining", !web3.eth_mining());
 
@@ -994,7 +994,7 @@ public class Web3ImplTest {
         Ethereum ethMock = Web3Mocks.getMockEthereum();
         RskSystemProperties mockProperties = Web3Mocks.getMockProperties();
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
-		Web3 web3 = new Web3Impl(ethMock, mockProperties, null, minerServerMock, personalModule, null, Web3Mocks.getMockChannelManager());
+		Web3 web3 = new Web3Impl(ethMock, mockProperties, null, minerServerMock, personalModule, null, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
 
         Assert.assertEquals("0x" + originalCoinbase, web3.eth_coinbase());
         Mockito.verify(minerServerMock, Mockito.times(1)).getCoinbaseAddress();
@@ -1283,7 +1283,7 @@ public class Web3ImplTest {
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
         MinerClient minerClient = new SimpleMinerClient();
         ChannelManager channelManager = new SimpleChannelManager();
-        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule, channelManager);
+        return new Web3RskImpl(eth, RskSystemProperties.CONFIG, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule, channelManager, Web3Mocks.getMockRepository());
     }
 
     @Test
@@ -1298,7 +1298,7 @@ public class Web3ImplTest {
         Ethereum eth = Mockito.mock(Ethereum.class);
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityEnabled(new SolidityCompiler(systemProperties)), null);
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
-        Web3Impl web3 = new Web3RskImpl(eth, systemProperties, null, null, personalModule, ethModule, Web3Mocks.getMockChannelManager());
+        Web3Impl web3 = new Web3RskImpl(eth, systemProperties, null, null, personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
         String contract = "pragma solidity ^0.4.1; contract rsk { function multiply(uint a) returns(uint d) {   return a * 7;   } }";
 
         Map<String, CompilationResultDTO> result = web3.eth_compileSolidity(contract);
@@ -1326,7 +1326,7 @@ public class Web3ImplTest {
         Ethereum eth = Mockito.mock(Ethereum.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(eth.getWorldManager().getBlockchain().getBestBlock().getNumber()).thenReturn(1L);
         EthModule ethModule = new EthModule(eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(eth, wallet));
-        Web3Impl web3 = new Web3RskImpl(eth, RskSystemProperties.CONFIG, null, null, new PersonalModuleWalletDisabled(), ethModule, Web3Mocks.getMockChannelManager());
+        Web3Impl web3 = new Web3RskImpl(eth, RskSystemProperties.CONFIG, null, null, new PersonalModuleWalletDisabled(), ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository());
 
         String contract = "pragma solidity ^0.4.1; contract rsk { function multiply(uint a) returns(uint d) {   return a * 7;   } }";
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
@@ -30,15 +30,13 @@ import static org.mockito.Mockito.*;
 
 public class Web3Mocks {
     public static Ethereum getMockEthereum() {
-        WorldManager mockWorldManager = mock(WorldManager.class, RETURNS_DEEP_STUBS);
-        when(mockWorldManager.getBlockchain().getBestBlock().getNumber()).thenReturn(0L);
-        return getMockEthereum(mockWorldManager);
+        return mock(Ethereum.class);
     }
 
-    public static Ethereum getMockEthereum(WorldManager worldManager) {
-        Ethereum ethMock = mock(Ethereum.class);
-        when(ethMock.getWorldManager()).thenReturn(worldManager);
-        return ethMock;
+    public static WorldManager getMockWorldManager() {
+        WorldManager mockWorldManager = mock(WorldManager.class, RETURNS_DEEP_STUBS);
+        when(mockWorldManager.getBlockchain().getBestBlock().getNumber()).thenReturn(0L);
+        return mockWorldManager;
     }
 
     public static RskSystemProperties getMockProperties() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
@@ -32,8 +32,12 @@ public class Web3Mocks {
     public static Ethereum getMockEthereum() {
         WorldManager mockWorldManager = mock(WorldManager.class, RETURNS_DEEP_STUBS);
         when(mockWorldManager.getBlockchain().getBestBlock().getNumber()).thenReturn(0L);
+        return getMockEthereum(mockWorldManager);
+    }
+
+    public static Ethereum getMockEthereum(WorldManager worldManager) {
         Ethereum ethMock = mock(Ethereum.class);
-        when(ethMock.getWorldManager()).thenReturn(mockWorldManager);
+        when(ethMock.getWorldManager()).thenReturn(worldManager);
         return ethMock;
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
@@ -21,13 +21,10 @@ package org.ethereum.rpc;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
-import org.ethereum.core.PendingState;
 import org.ethereum.facade.Ethereum;
+import org.ethereum.facade.Repository;
 import org.ethereum.manager.WorldManager;
 import org.ethereum.net.server.ChannelManager;
-import org.mockito.Mockito;
-
-import java.math.BigInteger;
 
 import static org.mockito.Mockito.*;
 
@@ -56,11 +53,7 @@ public class Web3Mocks {
         return mock(ChannelManager.class);
     }
 
-    public static PendingState getMockPendingState(BigInteger nonce) {
-        org.ethereum.core.Repository repository = Mockito.mock(org.ethereum.core.Repository.class);
-        Mockito.when(repository.getNonce(Mockito.any())).thenReturn(nonce);
-        PendingState pendingState = Mockito.mock(PendingState.class);
-        Mockito.when(pendingState.getRepository()).thenReturn(repository);
-        return pendingState;
+    public static Repository getMockRepository() {
+        return mock(Repository.class);
     }
 }


### PR DESCRIPTION
This PR is a big clean up refactor and made sense to make it all at once. Each commit removes or changes something and can be inspected individually.

Basically we remove getters and use constructor injection instead:

- `Rsk.getMessageHandler()`
- `Rsk.getPeerScoringManager()`
- `Repository.getStorageSize`
- `Repository.getStorageKeys`
- `Repository.getStorage`
- `Ethereum.getWorldManager`
- `Ethereum.callConstantFunction`
- `Ethereum.getRepository`
- `Ethereum.getPendingState`
- `Ethereum.getSnapshootTo`
- `Ethereum.getAdminInfo`
- `Ethereum.getChannelManager`
- `Ethereum.getPendingStateTransactions`
- `Ethereum.getPeerServer`
- `Ethereum.getSystemProperties`
- `WorldManager.init`
- `WorldManager.getChannelManager`
- `WorldManager.getRepository`
- `WorldManager.getNetworkStateExporter`