### PR TITLE
Feature/rfs 45 federation change voting

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -20,6 +20,7 @@ package co.rsk.config;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
+import co.rsk.peg.ABICallAuthorizer;
 import co.rsk.peg.Federation;
 
 import java.util.List;
@@ -41,6 +42,8 @@ public class BridgeConstants {
 
     protected Coin minimumLockTxValue;
     protected Coin minimumReleaseTxValue;
+
+    protected ABICallAuthorizer federationChangeAuthorizer;
 
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
@@ -75,4 +78,6 @@ public class BridgeConstants {
     public Coin getMinimumLockTxValue() { return minimumLockTxValue; }
 
     public Coin getMinimumReleaseTxValue() { return minimumReleaseTxValue; }
+
+    public ABICallAuthorizer getFederationChangeAuthorizer() { return federationChangeAuthorizer; }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -57,7 +57,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
         // Expected federation address is:
         // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
         genesisFederation = new Federation(
-                2,
                 genesisFederationPublicKeys,
                 genesisFederationAddressCreatedAt,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -21,16 +21,22 @@ package co.rsk.config;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.ABICallAuthorizer;
 import co.rsk.peg.Federation;
 import com.google.common.collect.Lists;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class BridgeRegTestConstants extends BridgeConstants {
@@ -72,6 +78,17 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         minimumLockTxValue = Coin.COIN;
         minimumReleaseTxValue = Coin.valueOf(500000);
+
+        // Keys generated with GenNodeKey using generators 'auth-a' through 'auth-e'
+        List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
+                "04dde17c5fab31ffc53c91c2390136c325bb8690dc135b0840075dd7b86910d8ab9e88baad0c32f3eea8833446a6bc5ff1cd2efa99ecb17801bcb65fc16fc7d991",
+                "04af886c67231476807e2a8eee9193878b9d94e30aa2ee469a9611d20e1e1c1b438e5044148f65e6e61bf03e9d72e597cb9cdea96d6fc044001b22099f9ec403e2",
+                "045d4dedf9c69ab3ea139d0f0da0ad00160b7663d01ce7a6155cd44a3567d360112b0480ab6f31cac7345b5f64862205ea7ccf555fcf218f87fa0d801008fecb61",
+                "04709f002ac4642b6a87ea0a9dc76eeaa93f71b3185985817ec1827eae34b46b5d869320efb5c5cbe2a5c13f96463fe0210710b53352a4314188daffe07bd54154",
+                "04aff62315e9c18004392a5d9e39496ff5794b2d9f43ab4e8ade64740d7fdfe896969be859b43f26ef5aa4b5a0d11808277b4abfa1a07cc39f2839b89cc2bc6b4c"
+        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+
+        federationChangeAuthorizer = new ABICallAuthorizer(federationChangeAuthorizedKeys);
     }
 
     public List<BtcECKey> getFederatorPrivateKeys() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -58,11 +58,11 @@ public class BridgeRegTestConstants extends BridgeConstants {
         BtcECKey federator2PrivateKey = BtcECKey.fromPrivate(HashUtil.sha3("federator3".getBytes(StandardCharsets.UTF_8)));
 
         federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey);
+        List<BtcECKey> federatorPublicKeys = federatorPrivateKeys.stream().map(key -> BtcECKey.fromPublicOnly(key.getPubKey())).collect(Collectors.toList());
 
         Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
-        genesisFederation = Federation.fromPrivateKeys(
-                2,
-                federatorPrivateKeys,
+        genesisFederation = new Federation(
+                federatorPublicKeys,
                 genesisFederationCreatedAt,
                 getBtcParams()
         );

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -76,7 +76,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
         // Expected federation address is:
         // 2NBPystfboREksK6hMCZesfH444zB3BkUUm
         genesisFederation = new Federation(
-                7,
                 genesisFederationPublicKeys,
                 genesisFederationAddressCreatedAt,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -90,6 +90,11 @@ public final class ReversibleTransactionExecutor extends TransactionExecutor {
         }
 
         @Override
+        public boolean isOnReversibleExecution() {
+            return true;
+        }
+
+        @Override
         public byte[] getSender() {
             return sendAddress;
         }

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -90,11 +90,6 @@ public final class ReversibleTransactionExecutor extends TransactionExecutor {
         }
 
         @Override
-        public boolean isOnReversibleExecution() {
-            return true;
-        }
-
-        @Override
         public byte[] getSender() {
             return sendAddress;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallAuthorizer.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallAuthorizer.java
@@ -18,11 +18,10 @@
 
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.BtcECKey;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Representation of a given state of the election
@@ -32,17 +31,35 @@ import java.util.Map;
  * @author Ariel Mendelzon
  */
 public class ABICallAuthorizer {
-    private List<BtcECKey> authorizedKeys;
+    private List<ECKey> authorizedKeys;
 
-    public ABICallAuthorizer(List<BtcECKey> authorizedKeys) {
+    public ABICallAuthorizer(List<ECKey> authorizedKeys) {
         this.authorizedKeys = authorizedKeys;
     }
 
-    public boolean isAuthorized(BtcECKey key) {
+    public boolean isAuthorized(Transaction tx) {
+        if (tx.getSignature() == null)
+            return false;
+
+        return isAuthorized(getVoter(tx));
+    }
+
+    public boolean isAuthorized(ECKey key) {
         return authorizedKeys.contains(key);
+    }
+
+    public ECKey getVoter(Transaction tx) {
+        if (tx.getSignature() == null)
+            return null;
+
+        return tx.getKey();
     }
 
     public int getNumberOfAuthorizedKeys() {
         return authorizedKeys.size();
+    }
+
+    public int getRequiredAuthorizedKeys() {
+        return getNumberOfAuthorizedKeys() / 2 + 1;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallAuthorizer.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallAuthorizer.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -46,6 +47,14 @@ public class ABICallAuthorizer {
 
     public boolean isAuthorized(ECKey key) {
         return authorizedKeys.contains(key);
+    }
+
+    public boolean isSenderAuthorized(Transaction tx) {
+        byte[] sender = tx.getSender();
+
+        return authorizedKeys.stream()
+                .map(key -> key.getAddress())
+                .anyMatch(address -> Arrays.equals(address, sender));
     }
 
     public ECKey getVoter(Transaction tx) {

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallAuthorizer.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallAuthorizer.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representation of a given state of the election
+ * of an ABI function call by a series of known
+ * and authorized electors.
+ *
+ * @author Ariel Mendelzon
+ */
+public class ABICallAuthorizer {
+    private List<BtcECKey> authorizedKeys;
+
+    public ABICallAuthorizer(List<BtcECKey> authorizedKeys) {
+        this.authorizedKeys = authorizedKeys;
+    }
+
+    public boolean isAuthorized(BtcECKey key) {
+        return authorizedKeys.contains(key);
+    }
+
+    public int getNumberOfAuthorizedKeys() {
+        return authorizedKeys.size();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallAuthorizer.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallAuthorizer.java
@@ -38,30 +38,18 @@ public class ABICallAuthorizer {
         this.authorizedKeys = authorizedKeys;
     }
 
-    public boolean isAuthorized(Transaction tx) {
-        if (tx.getSignature() == null)
-            return false;
+    public boolean isAuthorized(ABICallVoter voter) {
+        return authorizedKeys.stream()
+                .map(key -> key.getAddress())
+                .anyMatch(address -> Arrays.equals(address, voter.getBytes()));
+    }
 
+    public boolean isAuthorized(Transaction tx) {
         return isAuthorized(getVoter(tx));
     }
 
-    public boolean isAuthorized(ECKey key) {
-        return authorizedKeys.contains(key);
-    }
-
-    public boolean isSenderAuthorized(Transaction tx) {
-        byte[] sender = tx.getSender();
-
-        return authorizedKeys.stream()
-                .map(key -> key.getAddress())
-                .anyMatch(address -> Arrays.equals(address, sender));
-    }
-
-    public ECKey getVoter(Transaction tx) {
-        if (tx.getSignature() == null)
-            return null;
-
-        return tx.getKey();
+    public ABICallVoter getVoter(Transaction tx) {
+        return new ABICallVoter(tx.getSender());
     }
 
     public int getNumberOfAuthorizedKeys() {

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallElection.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallElection.java
@@ -67,7 +67,12 @@ public class ABICallElection {
         if (!authorizer.isAuthorized(voter))
             return false;
 
-        List<ECKey> callVotes = votes.getOrDefault(callSpec, new ArrayList<>());
+        if (!votes.containsKey(callSpec)) {
+            votes.put(callSpec, new ArrayList<>());
+        }
+
+        List<ECKey> callVotes = votes.get(callSpec);
+
         if (callVotes.contains(voter))
             return false;
 
@@ -90,6 +95,16 @@ public class ABICallElection {
         }
 
         return null;
+    }
+
+    /**
+     * Removes the entry votes for the current winner of the election
+     */
+    public void clearWinners() {
+        ABICallSpec winner = getWinner();
+        if (winner != null) {
+            votes.remove(winner);
+        }
     }
 
     private void validate() {

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallElection.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallElection.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+
+import java.util.*;
+
+/**
+ * Representation of a given state of the election
+ * of an ABI function call by a series of known
+ * and authorized electors.
+ *
+ * @author Ariel Mendelzon
+ */
+public class ABICallElection {
+    private ABICallAuthorizer authorizer;
+    private Map<ABICallSpec, List<BtcECKey>> votes;
+
+    public ABICallElection(ABICallAuthorizer authorizer, Map<ABICallSpec, List<BtcECKey>> votes) {
+        this.authorizer = authorizer;
+        this.votes = votes;
+        validate();
+    }
+
+    public ABICallElection(ABICallAuthorizer authorizer) {
+        this.authorizer = authorizer;
+        this.votes = new HashMap<>();
+    }
+
+    public Map<ABICallSpec, List<BtcECKey>> getVotes() {
+        return votes;
+    }
+
+    /**
+     * Register voter's vote for callSpec
+     * @param callSpec the call spec the voter is voting for
+     * @param voter the voter's key
+     * @return whether the voting succeeded
+     */
+    public boolean vote(ABICallSpec callSpec, BtcECKey voter) {
+        if (!authorizer.isAuthorized(voter))
+            return false;
+
+        List<BtcECKey> callVotes = votes.getOrDefault(callSpec, new ArrayList<>());
+        if (callVotes.contains(voter))
+            return false;
+
+        callVotes.add(voter);
+        return true;
+    }
+
+    /**
+     * Returns the election winner abi call spec, or null if there's none
+     * The vote authorizer determines the number of participants,
+     * whereas this class determines the number of votes that
+     * conforms a win
+     * @return the winner abi call spec
+     */
+    public ABICallSpec getWinner() {
+        for (Map.Entry<ABICallSpec, List<BtcECKey>> specVotes : votes.entrySet()) {
+            if (specVotes.getValue().size() >= getWinMinimumNumberOfVotes()) {
+                return specVotes.getKey();
+            }
+        }
+
+        return null;
+    }
+
+    private int getWinMinimumNumberOfVotes() {
+        return authorizer.getNumberOfAuthorizedKeys() / 2 + 1;
+    }
+
+    private void validate() {
+        // Make sure all the votes are authorized
+        for (Map.Entry<ABICallSpec, List<BtcECKey>> specVotes : votes.entrySet())
+            for (BtcECKey vote : specVotes.getValue())
+                if (!authorizer.isAuthorized(vote))
+                    throw new RuntimeException("Unauthorized voter");
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallElection.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallElection.java
@@ -18,14 +18,9 @@
 
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.BtcECKey;
-import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Representation of a given state of the election
@@ -36,9 +31,9 @@ import java.util.Map;
  */
 public class ABICallElection {
     private ABICallAuthorizer authorizer;
-    private Map<ABICallSpec, List<ECKey>> votes;
+    private Map<ABICallSpec, List<ABICallVoter>> votes;
 
-    public ABICallElection(ABICallAuthorizer authorizer, Map<ABICallSpec, List<ECKey>> votes) {
+    public ABICallElection(ABICallAuthorizer authorizer, Map<ABICallSpec, List<ABICallVoter>> votes) {
         this.authorizer = authorizer;
         this.votes = votes;
         validate();
@@ -49,7 +44,7 @@ public class ABICallElection {
         this.votes = new HashMap<>();
     }
 
-    public Map<ABICallSpec, List<ECKey>> getVotes() {
+    public Map<ABICallSpec, List<ABICallVoter>> getVotes() {
         return votes;
     }
 
@@ -63,7 +58,7 @@ public class ABICallElection {
      * @param voter the voter's key
      * @return whether the voting succeeded
      */
-    public boolean vote(ABICallSpec callSpec, ECKey voter) {
+    public boolean vote(ABICallSpec callSpec, ABICallVoter voter) {
         if (!authorizer.isAuthorized(voter))
             return false;
 
@@ -71,12 +66,12 @@ public class ABICallElection {
             votes.put(callSpec, new ArrayList<>());
         }
 
-        List<ECKey> callVotes = votes.get(callSpec);
+        List<ABICallVoter> callVoters = votes.get(callSpec);
 
-        if (callVotes.contains(voter))
+        if (callVoters.contains(voter))
             return false;
 
-        callVotes.add(voter);
+        callVoters.add(voter);
         return true;
     }
 
@@ -88,7 +83,7 @@ public class ABICallElection {
      * @return the winner abi call spec
      */
     public ABICallSpec getWinner() {
-        for (Map.Entry<ABICallSpec, List<ECKey>> specVotes : votes.entrySet()) {
+        for (Map.Entry<ABICallSpec, List<ABICallVoter>> specVotes : votes.entrySet()) {
             if (specVotes.getValue().size() >= authorizer.getRequiredAuthorizedKeys()) {
                 return specVotes.getKey();
             }
@@ -109,8 +104,8 @@ public class ABICallElection {
 
     private void validate() {
         // Make sure all the votes are authorized
-        for (Map.Entry<ABICallSpec, List<ECKey>> specVotes : votes.entrySet())
-            for (ECKey vote : specVotes.getValue())
+        for (Map.Entry<ABICallSpec, List<ABICallVoter>> specVotes : votes.entrySet())
+            for (ABICallVoter vote : specVotes.getValue())
                 if (!authorizer.isAuthorized(vote))
                     throw new RuntimeException("Unauthorized voter");
     }

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallSpec.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallSpec.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import com.google.common.primitives.SignedBytes;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Immutable representation of a function call
+ * spec to any given contract.
+ * For simplicity, each of the arguments is assumed to be a byte array.
+ * Encoding is up to the user.
+ *
+ * @author Ariel Mendelzon
+ */
+public final class ABICallSpec {
+    public static final Comparator<ABICallSpec> byBytesComparator = new Comparator<ABICallSpec>() {
+        @Override
+        public int compare(ABICallSpec specA, ABICallSpec specB) {
+            return SignedBytes.lexicographicalComparator().compare(
+                    specA.getEncoded(),
+                    specB.getEncoded()
+            );
+        }
+    };
+
+    private String function;
+    private byte[][] arguments;
+
+    public ABICallSpec(String function) {
+        this(function, new byte[][]{});
+    }
+
+    public ABICallSpec(String function, byte[][] arguments) {
+        this.function = function;
+        // Keep internal copies, so that the instance
+        // is immutable
+        this.arguments = copy(arguments);
+    }
+
+    public String getFunction() {
+        return function;
+    }
+
+    public byte[][] getArguments() {
+        return copy(arguments);
+    }
+
+    public byte[] getEncoded() {
+        byte[] functionBytes = function.getBytes(StandardCharsets.UTF_8);
+        int totalLength = functionBytes.length;
+        for (int i = 0; i < arguments.length; i++) {
+            totalLength += arguments[i].length;
+        }
+        byte[] result = new byte[totalLength];
+        System.arraycopy(functionBytes, 0, result, 0, functionBytes.length);
+        int offset = functionBytes.length;
+        for (int i = 0; i < arguments.length; i++) {
+            System.arraycopy(arguments[i], 0, result, offset, arguments[i].length);
+            offset += arguments[i].length;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Call to %s with %d arguments", function, arguments.length);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other instanceof ABICallSpec) {
+            ABICallSpec otherSpec = ((ABICallSpec) other);
+            return otherSpec.getFunction() == getFunction()
+                    && areEqual(arguments, otherSpec.arguments);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(function, arguments);
+    }
+
+    private boolean areEqual(byte[][] first, byte[][] second) {
+        if (first.length != second.length)
+            return false;
+
+        for (int i = 0; i < first.length; i++)
+            if (!Arrays.equals(first[i], second[i]))
+                return false;
+
+        return true;
+    }
+
+    private byte[][] copy(byte[][] array) {
+        byte[][] result = new byte[array.length][];
+        for (int i = 0; i < array.length; i++) {
+            result[i] = Arrays.copyOf(array[i], array[i].length);
+        }
+        return result;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallSpec.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallSpec.java
@@ -95,8 +95,8 @@ public final class ABICallSpec {
 
         if (other instanceof ABICallSpec) {
             ABICallSpec otherSpec = ((ABICallSpec) other);
-            return otherSpec.getFunction() == getFunction()
-                    && areEqual(arguments, otherSpec.arguments);
+            return otherSpec.getFunction().equals(getFunction()) &&
+                    areEqual(arguments, otherSpec.arguments);
         }
 
         return false;
@@ -104,7 +104,8 @@ public final class ABICallSpec {
 
     @Override
     public int hashCode() {
-        return Objects.hash(function, arguments);
+        int[] argumentsHashes = Arrays.stream(arguments).map(argument -> Arrays.hashCode(argument)).mapToInt(Integer::intValue).toArray();
+        return Objects.hash(function, Arrays.hashCode(argumentsHashes));
     }
 
     private boolean areEqual(byte[][] first, byte[][] second) {

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallSpec.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallSpec.java
@@ -47,10 +47,6 @@ public final class ABICallSpec {
     private String function;
     private byte[][] arguments;
 
-    public ABICallSpec(String function) {
-        this(function, new byte[][]{});
-    }
-
     public ABICallSpec(String function, byte[][] arguments) {
         this.function = function;
         // Keep internal copies, so that the instance
@@ -89,17 +85,15 @@ public final class ABICallSpec {
 
     @Override
     public boolean equals(Object other) {
-        if (this == other) {
+        if (this == other)
             return true;
-        }
 
-        if (other instanceof ABICallSpec) {
-            ABICallSpec otherSpec = ((ABICallSpec) other);
-            return otherSpec.getFunction().equals(getFunction()) &&
-                    areEqual(arguments, otherSpec.arguments);
-        }
+        if (other == null || this.getClass() != other.getClass())
+            return false;
 
-        return false;
+        ABICallSpec otherSpec = ((ABICallSpec) other);
+        return otherSpec.getFunction().equals(getFunction()) &&
+                areEqual(arguments, otherSpec.arguments);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallVoteResult.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallVoteResult.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import org.ethereum.crypto.ECKey;
+
+import java.util.List;
+
+/**
+ * Immutable representation of the result of a vote
+ * on a given ABI function call.
+ * Can either be successful or failed.
+ * Both successful and failed vote results
+ * can carry an associated result.
+ * @author Ariel Mendelzon
+ */
+public final class ABICallVoteResult {
+    private boolean successful;
+    private Object result;
+
+    public ABICallVoteResult(boolean successful, Object result) {
+        this.successful = successful;
+        this.result = result;
+    }
+
+    public boolean wasSuccessful() {
+        return successful;
+    }
+
+    public Object getResult() {
+        return result;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallVoter.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallVoter.java
@@ -40,19 +40,15 @@ public final class ABICallVoter {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
+    public boolean equals(Object other) {
+        if (this == other)
             return true;
 
-        if (this == null ^ o == null)
+        if (other == null || this.getClass() != other.getClass())
             return false;
 
-        if (o instanceof ABICallVoter) {
-            ABICallVoter otherVoter = (ABICallVoter) o;
-            return Arrays.equals(getBytes(), otherVoter.getBytes());
-        }
-
-        return false;
+        ABICallVoter otherVoter = (ABICallVoter) other;
+        return Arrays.equals(getBytes(), otherVoter.getBytes());
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/ABICallVoter.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ABICallVoter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import java.util.Arrays;
+
+/**
+ * Immutable representation of a voter
+ * for an ABICallElection. It is
+ * simple a byte[] wrapper.
+ * The byte[] is an RSK address.
+ *
+ * @author Ariel Mendelzon
+ */
+public final class ABICallVoter {
+    private byte[] voterBytes;
+
+    public ABICallVoter(byte[] voterBytes) {
+        this.voterBytes = voterBytes;
+    }
+
+    public byte[] getBytes() {
+        return voterBytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (this == null ^ o == null)
+            return false;
+
+        if (o instanceof ABICallVoter) {
+            ABICallVoter otherVoter = (ABICallVoter) o;
+            return Arrays.equals(getBytes(), otherVoter.getBytes());
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(voterBytes);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -119,9 +119,11 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     // Rolls back the currently pending federation
     public static final CallTransaction.Function ROLLBACK_FEDERATION = CallTransaction.Function.fromSignature("rollbackFederation", new String[]{}, new String[]{"int256"});
 
-    // Returns the number of federates in the currently active federation
+    // Returns the current pending federation's hash
+    public static final CallTransaction.Function GET_PENDING_FEDERATION_HASH = CallTransaction.Function.fromSignature("getPendingFederationHash", new String[]{}, new String[]{"bytes"});
+    // Returns the number of federates in the current pending federation
     public static final CallTransaction.Function GET_PENDING_FEDERATION_SIZE = CallTransaction.Function.fromSignature("getPendingFederationSize", new String[]{}, new String[]{"int256"});
-    // Returns the public key of the federator at the specified index
+    // Returns the public key of the federator at the specified index for the current pending federation
     public static final CallTransaction.Function GET_PENDING_FEDERATOR_PUBLIC_KEY = CallTransaction.Function.fromSignature("getPendingFederatorPublicKey", new String[]{"int256"}, new String[]{"bytes"});
 
     // Log topics used by the Bridge
@@ -184,6 +186,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
             ADD_FEDERATOR_PUBLIC_KEY,
             COMMIT_FEDERATION,
             ROLLBACK_FEDERATION,
+            GET_PENDING_FEDERATION_HASH,
             GET_PENDING_FEDERATION_SIZE,
             GET_PENDING_FEDERATOR_PUBLIC_KEY,
         }).forEach((CallTransaction.Function func) -> {
@@ -667,6 +670,20 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         logger.trace("rollbackFederation");
 
         return bridgeSupport.rollbackFederation();
+    }
+
+    public byte[] getPendingFederationHash(Object[] args)
+    {
+        logger.trace("getPendingFederationHash");
+
+        byte[] hash = bridgeSupport.getPendingFederationHash();
+
+        if (hash == null) {
+            // Empty array is returned when pending federation is not present
+            return new byte[]{};
+        }
+
+        return hash;
     }
 
     public Integer getPendingFederationSize(Object[] args)

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -624,52 +624,60 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return creationTime.toEpochMilli();
     }
 
-    public Long createFederation(Object[] args)
+    public Integer createFederation(Object[] args)
     {
         logger.trace("createFederation");
 
-        try {
-            return bridgeSupport.createFederation();
-        } catch (IOException e) {
-            logger.warn("Exception in createFederation", e);
-            throw new RuntimeException("Exception in createFederation", e);
-        }
-
+        return bridgeSupport.voteFederationChange(
+                rskTx,
+                new ABICallSpec("create", new byte[][]{})
+        );
     }
 
     public Integer addFederatorPublicKey(Object[] args)
     {
         logger.trace("addFederatorPublicKey");
 
-        byte[] publicKeyBytes = (byte[]) args[0];
-        BtcECKey publicKey;
+        byte[] publicKeyBytes;
         try {
-            publicKey = BtcECKey.fromPublicOnly(publicKeyBytes);
+            publicKeyBytes = (byte[]) args[0];
         } catch (Exception e) {
-            throw new BridgeIllegalArgumentException("Public key could not be parsed " + Hex.toHexString(publicKeyBytes), e);
+            logger.warn("Exception in addFederatorPublicKey: {}", e.getMessage());
+            return -10;
         }
 
-        return bridgeSupport.addFederatorPublicKey(publicKey);
+        return bridgeSupport.voteFederationChange(
+                rskTx,
+                new ABICallSpec("add", new byte[][]{ publicKeyBytes })
+        );
     }
 
     public Integer commitFederation(Object[] args)
     {
         logger.trace("commitFederation");
 
+        byte[] hash;
         try {
-            Sha3Hash hash = new Sha3Hash((byte[]) args[0]);
-            return bridgeSupport.commitFederation(hash);
-        } catch (IOException e) {
-            logger.warn("Exception in commitFederation", e);
-            throw new RuntimeException("Exception in commitFederation", e);
+            hash = (byte[]) args[0];
+        } catch (Exception e) {
+            logger.warn("Exception in commitFederation: {}", e.getMessage());
+            return -10;
         }
+
+        return bridgeSupport.voteFederationChange(
+                rskTx,
+                new ABICallSpec("commit", new byte[][]{ hash })
+        );
     }
 
     public Integer rollbackFederation(Object[] args)
     {
         logger.trace("rollbackFederation");
 
-        return bridgeSupport.rollbackFederation();
+        return bridgeSupport.voteFederationChange(
+                rskTx,
+                new ABICallSpec("rollback", new byte[][]{})
+        );
     }
 
     public byte[] getPendingFederationHash(Object[] args)

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -20,6 +20,7 @@ package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.crypto.Sha3Hash;
+import com.sun.xml.internal.bind.api.impl.NameConverter;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -29,6 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -265,26 +267,108 @@ public class BridgeSerializationUtils {
         return new Federation(numberOfSignaturesRequired, pubKeys, creationTime, btcContext.getParams());
     }
 
-    // A pending federation is serialized as a list of the public keys
-    // [pubkey1, pubkey2, ..., pubkeyn], sorted
-    // using the lexicographical order of the public keys
-    // (see BtcECKey.PUBKEY_COMPARATOR).
+    // A pending federation is serialized as the
+    // public keys conforming it.
+    // See BridgeSerializationUtils::serializePublicKeys
     public static byte[] serializePendingFederation(PendingFederation pendingFederation) {
-        List<byte[]> publicKeys = pendingFederation.getPublicKeys().stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(key -> RLP.encodeElement(key.getPubKey()))
-                .collect(Collectors.toList());
-        return RLP.encodeList((byte[][])publicKeys.toArray(new byte[publicKeys.size()][]));
+        return serializePublicKeys(pendingFederation.getPublicKeys());
     }
 
     // For the serialization format, see BridgeSerializationUtils::serializePendingFederation
+    // and serializePublicKeys::deserializePublicKeys
     public static PendingFederation deserializePendingFederation(byte[] data) {
+        return new PendingFederation(deserializePublicKeys(data));
+    }
+
+    // An ABI call spec is serialized as:
+    // function name encoded in UTF-8
+    // arg_1, ..., arg_n
+    public static byte[] serializeABICallSpec(ABICallSpec spec) {
+        byte[][] encodedArguments = (byte[][]) Arrays.stream(spec.getArguments())
+                .map(arg -> RLP.encodeElement(arg))
+                .toArray();
+        return RLP.encodeList(
+            RLP.encodeElement(spec.getFunction().getBytes(StandardCharsets.UTF_8)),
+            RLP.encodeList(encodedArguments)
+        );
+    }
+
+    // For the serialization format, see BridgeSerializationUtils::serializeABICallSpec
+    public static ABICallSpec deserializeABICallSpec(byte[] data) {
         RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
 
-        List<BtcECKey> pubKeys = rlpList.stream()
+        if (rlpList.size() != 2) {
+            throw new RuntimeException(String.format("Invalid serialized ABICallSpec. Expected 2 elements, but got %d", rlpList.size()));
+        }
+
+        String function = new String(rlpList.get(0).getRLPData(), StandardCharsets.UTF_8);
+        byte[][] arguments = (byte[][]) ((RLPList)rlpList.get(1)).stream().map(rlpElement -> rlpElement.getRLPData()).toArray();
+
+        return new ABICallSpec(function, arguments);
+    }
+
+    // A list of public keys is serialized as
+    // [pubkey1, pubkey2, ..., pubkeyn], sorted
+    // using the lexicographical order of the public keys
+    // (see BtcECKey.PUBKEY_COMPARATOR).
+    public static byte[] serializePublicKeys(List<BtcECKey> keys) {
+        List<byte[]> encodedKeys = keys.stream()
+                .sorted(BtcECKey.PUBKEY_COMPARATOR)
+                .map(key -> RLP.encodeElement(key.getPubKey()))
+                .collect(Collectors.toList());
+        return RLP.encodeList((byte[][])encodedKeys.toArray());
+    }
+
+    // For the serialization format, see BridgeSerializationUtils::serializePublicKeys
+    public static List<BtcECKey> deserializePublicKeys(byte[] data) {
+        RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
+
+        return rlpList.stream()
                 .map(pubKeyBytes -> BtcECKey.fromPublicOnly(pubKeyBytes.getRLPData()))
                 .collect(Collectors.toList());
+    }
 
-        return new PendingFederation(pubKeys);
+    // An ABI call election is serialized as a list of the votes, like so:
+    // spec_1, keys_1, ..., spec_n, keys_n
+    // Specs are sorted by their signed byte encoding lexicographically.
+    public static byte[] serializeElection(ABICallElection election) {
+        byte[][] bytes = new byte[election.getVotes().size() * 2][];
+        int n = 0;
+
+        Map<ABICallSpec, List<BtcECKey>> votes = election.getVotes();
+        ABICallSpec[] specs = votes.keySet().toArray(new ABICallSpec[votes.size()]);
+        Arrays.sort(specs, ABICallSpec.byBytesComparator);
+
+        for (ABICallSpec spec : specs) {
+            bytes[n++] = serializeABICallSpec(spec);
+            bytes[n++] = serializePublicKeys(votes.get(spec));
+        }
+
+        return RLP.encodeList(bytes);
+    }
+
+    // For the serialization format, see BridgeSerializationUtils::serializeElection
+    public static ABICallElection deserializeElection(byte[] data, ABICallAuthorizer authorizer) {
+        if (data == null || data.length == 0)
+            return new ABICallElection(authorizer);
+
+        RLPList rlpList = (RLPList) RLP.decode2(data).get(0);
+
+        // List size must be even - key, value pairs expected in sequence
+        if (rlpList.size() % 2 != 0) {
+            throw new RuntimeException("deserializeElection: expected an even number of entries, but odd given");
+        }
+
+        int numEntries = rlpList.size() / 2;
+
+        Map<ABICallSpec, List<BtcECKey>> votes = new HashMap<>();
+
+        for (int k = 0; k < numEntries; k++) {
+            ABICallSpec spec = deserializeABICallSpec(rlpList.get(k * 2).getRLPData());
+            List<BtcECKey> specVotes = deserializePublicKeys(rlpList.get(k * 2 + 1).getRLPData());
+            votes.put(spec, specVotes);
+        }
+
+        return new ABICallElection(authorizer, votes);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -285,9 +285,9 @@ public class BridgeSerializationUtils {
     // function name encoded in UTF-8
     // arg_1, ..., arg_n
     public static byte[] serializeABICallSpec(ABICallSpec spec) {
-        byte[][] encodedArguments = (byte[][]) Arrays.stream(spec.getArguments())
+        byte[][] encodedArguments = Arrays.stream(spec.getArguments())
                 .map(arg -> RLP.encodeElement(arg))
-                .toArray();
+                .toArray(byte[][]::new);
         return RLP.encodeList(
             RLP.encodeElement(spec.getFunction().getBytes(StandardCharsets.UTF_8)),
             RLP.encodeList(encodedArguments)
@@ -303,7 +303,7 @@ public class BridgeSerializationUtils {
         }
 
         String function = new String(rlpList.get(0).getRLPData(), StandardCharsets.UTF_8);
-        byte[][] arguments = (byte[][]) ((RLPList)rlpList.get(1)).stream().map(rlpElement -> rlpElement.getRLPData()).toArray();
+        byte[][] arguments = ((RLPList)rlpList.get(1)).stream().map(rlpElement -> rlpElement.getRLPData()).toArray(byte[][]::new);
 
         return new ABICallSpec(function, arguments);
     }
@@ -319,7 +319,7 @@ public class BridgeSerializationUtils {
                 )
                 .map(key -> RLP.encodeElement(key.getPubKey()))
                 .collect(Collectors.toList());
-        return RLP.encodeList((byte[][])encodedKeys.toArray());
+        return RLP.encodeList(encodedKeys.toArray(new byte[0][]));
     }
 
     // A list of btc public keys is serialized as
@@ -331,7 +331,7 @@ public class BridgeSerializationUtils {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .map(key -> RLP.encodeElement(key.getPubKey()))
                 .collect(Collectors.toList());
-        return RLP.encodeList((byte[][])encodedKeys.toArray());
+        return RLP.encodeList(encodedKeys.toArray(new byte[0][]));
     }
 
     // For the serialization format, see BridgeSerializationUtils::serializePublicKeys
@@ -360,7 +360,7 @@ public class BridgeSerializationUtils {
         int n = 0;
 
         Map<ABICallSpec, List<ECKey>> votes = election.getVotes();
-        ABICallSpec[] specs = votes.keySet().toArray(new ABICallSpec[votes.size()]);
+        ABICallSpec[] specs = votes.keySet().toArray(new ABICallSpec[0]);
         Arrays.sort(specs, ABICallSpec.byBytesComparator);
 
         for (ABICallSpec spec : specs) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -51,6 +51,7 @@ public class BridgeStorageProvider {
     private static final String BRIDGE_ACTIVE_FEDERATION_KEY = "bridgeActiveFederation";
     private static final String BRIDGE_RETIRING_FEDERATION_KEY = "bridgeRetiringFederation";
     private static final String BRIDGE_PENDING_FEDERATION_KEY = "bridgePendingFederation";
+    private static final String BRIDGE_FEDERATION_ELECTION_KEY = "bridgeFederationElection";
 
     private static final NetworkParameters networkParameters = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
 
@@ -74,6 +75,9 @@ public class BridgeStorageProvider {
     private boolean shouldSaveRetiringFederation = false;
     private PendingFederation pendingFederation;
     private boolean shouldSavePendingFederation = false;
+
+    private ABICallElection federationElection;
+    private boolean shouldSaveFederationElection = false;
 
     private BridgeConstants bridgeConstants;
     private Context btcContext;
@@ -277,8 +281,6 @@ public class BridgeStorageProvider {
         }
     }
 
-
-
     public PendingFederation getPendingFederation() {
         if (pendingFederation != null)
             return pendingFederation;
@@ -316,6 +318,43 @@ public class BridgeStorageProvider {
         }
     }
 
+    /**
+     * Save the federation election
+     */
+    public void saveFederationElection() {
+        if (shouldSaveFederationElection) {
+            DataWord address = new DataWord(BRIDGE_FEDERATION_ELECTION_KEY.getBytes(StandardCharsets.UTF_8));
+
+            byte[] data = null;
+            if (federationElection != null)
+                data = BridgeSerializationUtils.serializeElection(federationElection);
+
+            repository.addStorageBytes(Hex.decode(contractAddress), address, data);
+        }
+    }
+
+    public ABICallElection getFederationElection(ABICallAuthorizer authorizer) {
+        if (federationElection != null)
+            return federationElection;
+
+        DataWord address = new DataWord(BRIDGE_FEDERATION_ELECTION_KEY.getBytes(StandardCharsets.UTF_8));
+
+        byte[] data = repository.getStorageBytes(Hex.decode(contractAddress), address);
+
+        if (data == null) {
+            return null;
+        }
+
+        federationElection = BridgeSerializationUtils.deserializeElection(data, authorizer);
+
+        return federationElection;
+    }
+
+    public void setFederationElection(ABICallElection election) {
+        shouldSaveFederationElection = true;
+        federationElection = election;
+    }
+
     public void save() throws IOException {
         saveBtcTxHashesAlreadyProcessed();
 
@@ -329,5 +368,7 @@ public class BridgeStorageProvider {
         saveRetiringFederationBtcUTXOs();
 
         savePendingFederation();
+
+        saveFederationElection();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -77,7 +77,6 @@ public class BridgeStorageProvider {
     private boolean shouldSavePendingFederation = false;
 
     private ABICallElection federationElection;
-    private boolean shouldSaveFederationElection = false;
 
     private BridgeConstants bridgeConstants;
     private Context btcContext;
@@ -322,15 +321,14 @@ public class BridgeStorageProvider {
      * Save the federation election
      */
     public void saveFederationElection() {
-        if (shouldSaveFederationElection) {
-            DataWord address = new DataWord(BRIDGE_FEDERATION_ELECTION_KEY.getBytes(StandardCharsets.UTF_8));
+        if (federationElection == null)
+            return;
 
-            byte[] data = null;
-            if (federationElection != null)
-                data = BridgeSerializationUtils.serializeElection(federationElection);
+        DataWord address = new DataWord(BRIDGE_FEDERATION_ELECTION_KEY.getBytes(StandardCharsets.UTF_8));
 
-            repository.addStorageBytes(Hex.decode(contractAddress), address, data);
-        }
+        byte[] data = BridgeSerializationUtils.serializeElection(federationElection);
+
+        repository.addStorageBytes(Hex.decode(contractAddress), address, data);
     }
 
     public ABICallElection getFederationElection(ABICallAuthorizer authorizer) {
@@ -342,17 +340,13 @@ public class BridgeStorageProvider {
         byte[] data = repository.getStorageBytes(Hex.decode(contractAddress), address);
 
         if (data == null) {
-            return null;
+            federationElection = new ABICallElection(authorizer);
+            return federationElection;
         }
 
         federationElection = BridgeSerializationUtils.deserializeElection(data, authorizer);
 
         return federationElection;
-    }
-
-    public void setFederationElection(ABICallElection election) {
-        shouldSaveFederationElection = true;
-        federationElection = election;
     }
 
     public void save() throws IOException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -866,14 +866,13 @@ public class BridgeSupport {
         if (size == -1)
             return null;
 
-        int numberOfSignaturesRequired = getRetiringFederationThreshold();
         List<BtcECKey> publicKeys = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             publicKeys.add(BtcECKey.fromPublicOnly(getRetiringFederatorPublicKey(i)));
         }
         Instant creationTime = getRetiringFederationCreationTime();
 
-        return new Federation(numberOfSignaturesRequired, publicKeys, creationTime, bridgeConstants.getBtcParams());
+        return new Federation(publicKeys, creationTime, bridgeConstants.getBtcParams());
     }
 
     /**
@@ -1036,16 +1035,9 @@ public class BridgeSupport {
 
         ABICallAuthorizer authorizer = bridgeConstants.getFederationChangeAuthorizer();
 
-        if (tx.isOnReversibleExecution()) {
-            // Must be authorized (only checking for sender address)
-            if (!authorizer.isSenderAuthorized(tx)) {
-                return VOTE_GENERIC_ERROR_CODE;
-            }
-        } else {
-            // Must be authorized to vote (checking for signature)
-            if (!authorizer.isAuthorized(tx)) {
-                return VOTE_GENERIC_ERROR_CODE;
-            }
+        // Must be authorized to vote (checking for signature)
+        if (!authorizer.isAuthorized(tx)) {
+            return VOTE_GENERIC_ERROR_CODE;
         }
 
         // Try to do a dry-run and only register the vote if the
@@ -1058,7 +1050,7 @@ public class BridgeSupport {
         }
 
         // Return if the dry run failed or we are on a reversible execution
-        if (!result.wasSuccessful() || tx.isOnReversibleExecution()) {
+        if (!result.wasSuccessful()) {
             return (Integer) result.getResult();
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -64,9 +64,10 @@ import static org.ethereum.util.BIUtil.transfer;
  * @author Oscar Guindzberg
  */
 public class BridgeSupport {
+    public static final Integer VOTE_GENERIC_ERROR_CODE = -10;
+
     private static final Logger logger = LoggerFactory.getLogger("BridgeSupport");
     private static final PanicProcessor panicProcessor = new PanicProcessor();
-    private static final Integer VOTE_GENERIC_ERROR_CODE = -10;
 
     final List<String> FEDERATION_CHANGE_FUNCTIONS = Collections.unmodifiableList(Arrays.asList(new String[]{
             "create",
@@ -901,7 +902,7 @@ public class BridgeSupport {
      * @return 1 upon success, -1 when a pending federation is present, -2 when funds are still
      * to be moved between federations.
      */
-    public Integer createFederation(boolean dryRun) throws IOException {
+    private Integer createFederation(boolean dryRun) throws IOException {
         PendingFederation currentPendingFederation = provider.getPendingFederation();
 
         if (currentPendingFederation != null) {
@@ -931,7 +932,7 @@ public class BridgeSupport {
      * @param key the public key to add
      * @return 1 upon success, -1 if there was no pending federation, -2 if the key was already in the pending federation
      */
-    public Integer addFederatorPublicKey(boolean dryRun, BtcECKey key) {
+    private Integer addFederatorPublicKey(boolean dryRun, BtcECKey key) {
         PendingFederation currentPendingFederation = provider.getPendingFederation();
 
         if (currentPendingFederation == null) {
@@ -964,7 +965,7 @@ public class BridgeSupport {
      * @return 1 upon success, -1 if there was no pending federation, -2 if the pending federation was incomplete,
      * -3 if the given hash doesn't match the current pending federation's hash.
      */
-    public Integer commitFederation(boolean dryRun, Sha3Hash hash) throws IOException {
+    private Integer commitFederation(boolean dryRun, Sha3Hash hash) throws IOException {
         PendingFederation currentPendingFederation = provider.getPendingFederation();
 
         if (currentPendingFederation == null) {
@@ -1009,7 +1010,7 @@ public class BridgeSupport {
      * @param dryRun whether to just do a dry run
      * @return 1 upon success, 1 if there was no pending federation
      */
-    public Integer rollbackFederation(boolean dryRun) {
+    private Integer rollbackFederation(boolean dryRun) {
         PendingFederation currentPendingFederation = provider.getPendingFederation();
 
         if (currentPendingFederation == null) {
@@ -1046,6 +1047,8 @@ public class BridgeSupport {
         try {
             result = executeVoteFederationChangeFunction(true, callSpec);
         } catch (IOException e) {
+            result = new ABICallVoteResult(false, VOTE_GENERIC_ERROR_CODE);
+        } catch (BridgeIllegalArgumentException e) {
             result = new ABICallVoteResult(false, VOTE_GENERIC_ERROR_CODE);
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -993,6 +993,20 @@ public class BridgeSupport {
     }
 
     /**
+     * Returns the currently pending federation hash, or null if none exists
+     * @return the currently pending federation hash, or null if none exists
+     */
+    public byte[] getPendingFederationHash() {
+        PendingFederation currentPendingFederation = provider.getPendingFederation();
+
+        if (currentPendingFederation == null) {
+            return null;
+        }
+
+        return currentPendingFederation.getHash().getBytes();
+    }
+
+    /**
      * Returns the currently pending federation size, or -1 if none exists
      * @return the currently pending federation size, or -1 if none exists
      */

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -149,11 +149,26 @@ public class BridgeUtils {
         if (receiveAddress == null)
             return false;
 
+        BridgeConstants bridgeConstants = blockchainConfig.getCommonConstants().getBridgeConstants();
+
         // Temporary assumption: if areBridgeTxsFree() is true then the current federation
         // must be the genesis federation.
         // Once the original federation changes, txs are always paid.
         return StringUtils.equals(Hex.toHexString(receiveAddress), PrecompiledContracts.BRIDGE_ADDR) &&
                blockchainConfig.getConfigForBlock(blockNumber).areBridgeTxsFree() &&
-               rskTx.acceptTransactionSignature();
+               rskTx.acceptTransactionSignature() &&
+               (
+                       isFromFederateMember(rskTx) ||
+                       isFromFederationChangeAuthorizedVoter(rskTx, bridgeConstants)
+               );
+    }
+
+    private static boolean isFromFederateMember(org.ethereum.core.Transaction rskTx) {
+        return true;
+    }
+
+    private static boolean isFromFederationChangeAuthorizedVoter(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration) {
+        ABICallAuthorizer authorizer = bridgeConfiguration.getFederationChangeAuthorizer();
+        return authorizer.isAuthorized(rskTx);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
  * @author Ariel Mendelzon
  */
 public final class Federation {
-    private int numberOfSignaturesRequired;
     private List<BtcECKey> publicKeys;
     private Instant creationTime;
     private NetworkParameters btcParams;
@@ -49,15 +48,7 @@ public final class Federation {
     private Script p2shScript;
     private Address address;
 
-    public static Federation fromPrivateKeys(int numberOfSignaturesRequired, List<BtcECKey> privateKeys, Instant creationTime, NetworkParameters btcParams) {
-        List<BtcECKey> publicKeys = privateKeys.stream()
-                .map(key -> BtcECKey.fromPublicOnly(key.getPubKey()))
-                .collect(Collectors.toList());
-        return new Federation(numberOfSignaturesRequired, publicKeys, creationTime, btcParams);
-    }
-
-    public Federation(int numberOfSignaturesRequired, List<BtcECKey> publicKeys, Instant creationTime, NetworkParameters btcParams) {
-        this.numberOfSignaturesRequired = numberOfSignaturesRequired;
+    public Federation(List<BtcECKey> publicKeys, Instant creationTime, NetworkParameters btcParams) {
         // Sorting public keys ensures same order of federators for same public keys
         // Immutability provides protection unless unwanted modification, thus making the Federation instance
         // effectively immutable
@@ -75,7 +66,7 @@ public final class Federation {
     }
 
     public int getNumberOfSignaturesRequired() {
-        return this.numberOfSignaturesRequired;
+        return publicKeys.size() / 2 + 1;
     }
 
     public Instant getCreationTime() {
@@ -129,7 +120,7 @@ public final class Federation {
 
     @Override
     public String toString() {
-        return String.format("%d of %d signatures federation", numberOfSignaturesRequired, publicKeys.size());
+        return String.format("%d of %d signatures federation", getNumberOfSignaturesRequired(), publicKeys.size());
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -125,39 +125,27 @@ public final class Federation {
 
     @Override
     public boolean equals(Object other) {
-        if (this == other) {
+        if (this == other)
             return true;
-        }
 
-        if (other instanceof Federation) {
-            return this.equalsFederation((Federation) other);
-        }
-
-        return false;
-    }
-
-    private boolean equalsFederation(Federation other) {
-        if (other == null) {
+        if (other == null || this.getClass() != other.getClass())
             return false;
-        }
 
-        if (this == other) {
-            return true;
-        }
+        Federation otherFederation = (Federation) other;
 
         ByteArrayWrapper[] thisPublicKeys = this.getPublicKeys().stream()
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .map(k -> new ByteArrayWrapper(k.getPubKey()))
                 .toArray(ByteArrayWrapper[]::new);
-        ByteArrayWrapper[] otherPublicKeys = other.getPublicKeys().stream()
+        ByteArrayWrapper[] otherPublicKeys = otherFederation.getPublicKeys().stream()
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .map(k -> new ByteArrayWrapper(k.getPubKey()))
                 .toArray(ByteArrayWrapper[]::new);
 
-        return this.getNumberOfSignaturesRequired() == other.getNumberOfSignaturesRequired() &&
-                this.getSize() == other.getSize() &&
-                this.getCreationTime().equals(other.getCreationTime()) &&
-                this.btcParams.equals(other.btcParams) &&
+        return this.getNumberOfSignaturesRequired() == otherFederation.getNumberOfSignaturesRequired() &&
+                this.getSize() == otherFederation.getSize() &&
+                this.getCreationTime().equals(otherFederation.getCreationTime()) &&
+                this.btcParams.equals(otherFederation.btcParams) &&
                 Arrays.equals(thisPublicKeys, otherPublicKeys);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
@@ -79,20 +79,15 @@ public final class PendingFederation {
         }
 
         return new Federation(
-                calculateThreshold(),
                 publicKeys,
                 creationTime,
                 btcParams
         );
     }
 
-    private int calculateThreshold() {
-        return this.publicKeys.size() / 2 + 1;
-    }
-
     @Override
     public String toString() {
-        return String.format("%d of %d signatures pending federation (%s)", calculateThreshold(), publicKeys.size(), isComplete() ? "complete" : "incomplete");
+        return String.format("%d signatures pending federation (%s)", publicKeys.size(), isComplete() ? "complete" : "incomplete");
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
@@ -92,26 +92,24 @@ public final class PendingFederation {
 
     @Override
     public boolean equals(Object other) {
-        if (this == other) {
+        if (this == other)
             return true;
-        }
 
-        if (other instanceof PendingFederation) {
-            PendingFederation otherFederation = (PendingFederation) other;
-            ByteArrayWrapper[] thisPublicKeys = this.getPublicKeys().stream()
-                    .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                    .map(k -> new ByteArrayWrapper(k.getPubKey()))
-                    .toArray(ByteArrayWrapper[]::new);
-            ByteArrayWrapper[] otherPublicKeys = otherFederation.getPublicKeys().stream()
-                    .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                    .map(k -> new ByteArrayWrapper(k.getPubKey()))
-                    .toArray(ByteArrayWrapper[]::new);
+        if (other == null || this.getClass() != other.getClass())
+            return false;
 
-            return this.getPublicKeys().size() == otherFederation.getPublicKeys().size() &&
-                    Arrays.equals(thisPublicKeys, otherPublicKeys);
-        }
+        PendingFederation otherFederation = (PendingFederation) other;
+        ByteArrayWrapper[] thisPublicKeys = this.getPublicKeys().stream()
+                .sorted(BtcECKey.PUBKEY_COMPARATOR)
+                .map(k -> new ByteArrayWrapper(k.getPubKey()))
+                .toArray(ByteArrayWrapper[]::new);
+        ByteArrayWrapper[] otherPublicKeys = otherFederation.getPublicKeys().stream()
+                .sorted(BtcECKey.PUBKEY_COMPARATOR)
+                .map(k -> new ByteArrayWrapper(k.getPubKey()))
+                .toArray(ByteArrayWrapper[]::new);
 
-        return false;
+        return this.getPublicKeys().size() == otherFederation.getPublicKeys().size() &&
+                Arrays.equals(thisPublicKeys, otherPublicKeys);
     }
 
     public Sha3Hash getHash() {

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -499,6 +499,10 @@ public class Transaction implements SerializableObject {
         return (this.getNonce() == null) ? null : BigIntegers.fromUnsignedByteArray(this.getNonce());
     }
 
+    public boolean isOnReversibleExecution() {
+        return false;
+    }
+
     @Override
     public int hashCode() {
         return java.util.Arrays.hashCode(this.getHash());

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -499,10 +499,6 @@ public class Transaction implements SerializableObject {
         return (this.getNonce() == null) ? null : BigIntegers.fromUnsignedByteArray(this.getNonce());
     }
 
-    public boolean isOnReversibleExecution() {
-        return false;
-    }
-
     @Override
     public int hashCode() {
         return java.util.Arrays.hashCode(this.getHash());

--- a/rskj-core/src/test/java/co/rsk/peg/ABICallAuthorizerTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ABICallAuthorizerTest.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.junit.Assert;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ABICallAuthorizerTest {
+    @Test
+    public void numberOfKeys() {
+        ABICallAuthorizer auth = new ABICallAuthorizer(Arrays.asList(
+                mock(ECKey.class),
+                mock(ECKey.class),
+                mock(ECKey.class),
+                mock(ECKey.class)
+        ));
+
+        Assert.assertEquals(4, auth.getNumberOfAuthorizedKeys());
+        Assert.assertEquals(3, auth.getRequiredAuthorizedKeys());
+    }
+
+    @Test
+    public void getVoter() {
+        ABICallAuthorizer auth = new ABICallAuthorizer(Collections.emptyList());
+
+        Transaction mockedTx = mock(Transaction.class);
+        when(mockedTx.getSender()).thenReturn(Hex.decode("aabb"));
+
+        Assert.assertEquals(new ABICallVoter(Hex.decode("aabb")), auth.getVoter(mockedTx));
+    }
+
+    @Test
+    public void isAuthorized() {
+        ABICallAuthorizer auth = new ABICallAuthorizer(Arrays.asList(
+                ECKey.fromPrivate(BigInteger.valueOf(100L)),
+                ECKey.fromPrivate(BigInteger.valueOf(101L)),
+                ECKey.fromPrivate(BigInteger.valueOf(102L))
+        ));
+
+        for (long n = 100L; n <= 102L; n++) {
+            Transaction mockedTx = mock(Transaction.class);
+            when(mockedTx.getSender()).thenReturn(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress());
+            Assert.assertTrue(auth.isAuthorized(new ABICallVoter(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress())));
+            Assert.assertTrue(auth.isAuthorized(mockedTx));
+        }
+
+        Assert.assertFalse(auth.isAuthorized(new ABICallVoter(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress())));
+        Transaction mockedTx = mock(Transaction.class);
+        when(mockedTx.getSender()).thenReturn(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress());
+        Assert.assertFalse(auth.isAuthorized(mockedTx));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/ABICallElectionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ABICallElectionTest.java
@@ -1,0 +1,166 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import org.ethereum.crypto.ECKey;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.util.*;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ABICallElectionTest {
+    private ABICallSpec spec_fna, spec_fnb;
+    private ABICallElection election;
+    private ABICallAuthorizer authorizer;
+    private Map<ABICallSpec, List<ABICallVoter>> votes;
+
+    @Before
+    public void createVotesAuthorizerAndElection() {
+        authorizer = new ABICallAuthorizer(Arrays.asList(
+                createMockKeyForAddress("aa"),
+                createMockKeyForAddress("bb"),
+                createMockKeyForAddress("cc"),
+                createMockKeyForAddress("dd"),
+                createMockKeyForAddress("ee")
+        ));
+
+        spec_fna = new ABICallSpec("fn-a", new byte[][]{});
+        spec_fnb = new ABICallSpec("fn-b", new byte[][]{ Hex.decode("11"), Hex.decode("2233") });
+
+        votes = new HashMap<>();
+        votes.put(
+                spec_fna,
+                new ArrayList<>(Collections.emptyList())
+        );
+        votes.put(
+                spec_fnb,
+                new ArrayList<>(Arrays.asList(
+                        createVoter("aa"),
+                        createVoter("bb")
+                ))
+        );
+
+        election = new ABICallElection(authorizer, votes);
+    }
+
+    @Test
+    public void emptyVotesConstructor() {
+        ABICallElection electionBis = new ABICallElection(authorizer);
+        Assert.assertEquals(0, electionBis.getVotes().size());
+    }
+
+    @Test
+    public void getVotes() {
+        Assert.assertSame(votes, election.getVotes());
+    }
+
+    @Test
+    public void clear() {
+        election.clear();
+        Assert.assertEquals(0, election.getVotes().size());
+    }
+
+    @Test
+    public void vote_unauthorized() {
+        ABICallSpec spec_fnc = new ABICallSpec("fn-c", new byte[][]{});
+        Assert.assertFalse(election.vote(spec_fnc, createVoter("112233")));
+        Assert.assertEquals(2, election.getVotes().size());
+        Assert.assertEquals(0, election.getVotes().get(spec_fna).size());
+        Assert.assertEquals(2, election.getVotes().get(spec_fnb).size());
+        Assert.assertNull(election.getVotes().get(spec_fnc));
+    }
+
+    @Test
+    public void vote_alreadyVoted() {
+        Assert.assertFalse(election.vote(spec_fnb, createVoter("aa")));
+        Assert.assertFalse(election.vote(spec_fnb, createVoter("bb")));
+        Assert.assertEquals(2, election.getVotes().size());
+        Assert.assertEquals(0, election.getVotes().get(spec_fna).size());
+        Assert.assertEquals(2, election.getVotes().get(spec_fnb).size());
+    }
+
+    @Test
+    public void vote_newFn() {
+        ABICallSpec spec_fnc = new ABICallSpec("fn-c", new byte[][]{ Hex.decode("44") });
+        Assert.assertTrue(election.vote(spec_fnc, createVoter("dd")));
+        Assert.assertTrue(election.vote(spec_fnc, createVoter("ee")));
+        Assert.assertEquals(3, election.getVotes().size());
+        Assert.assertEquals(0, election.getVotes().get(spec_fna).size());
+        Assert.assertEquals(2, election.getVotes().get(spec_fnb).size());
+        Assert.assertEquals(Arrays.asList(createVoter("dd"), createVoter("ee")), election.getVotes().get(spec_fnc));
+    }
+
+    @Test
+    public void vote_existingFn() {
+        Assert.assertTrue(election.vote(spec_fna, createVoter("cc")));
+        Assert.assertTrue(election.vote(spec_fna, createVoter("dd")));
+        Assert.assertEquals(2, election.getVotes().size());
+        Assert.assertEquals(2, election.getVotes().get(spec_fna).size());
+        Assert.assertEquals(2, election.getVotes().get(spec_fnb).size());
+        Assert.assertEquals(Arrays.asList(createVoter("cc"), createVoter("dd")), election.getVotes().get(spec_fna));
+        Assert.assertEquals(Arrays.asList(createVoter("aa"), createVoter("bb")), election.getVotes().get(spec_fnb));
+    }
+
+    @Test
+    public void getWinnerAndClearWinners_existingFn() {
+        Assert.assertNull(election.getWinner());
+        Assert.assertTrue(election.vote(spec_fnb, createVoter("ee")));
+        Assert.assertEquals(spec_fnb, election.getWinner());
+
+        election.clearWinners();
+
+        Assert.assertNull(election.getWinner());
+        Assert.assertEquals(1, election.getVotes().size());
+        Assert.assertEquals(Collections.emptyList(), election.getVotes().get(spec_fna));
+    }
+
+    @Test
+    public void getWinnerAndClearWinners_newFn() {
+        ABICallSpec spec_fnc = new ABICallSpec("fn-c", new byte[][]{ Hex.decode("44") });
+        Assert.assertNull(election.getWinner());
+        Assert.assertTrue(election.vote(spec_fnc, createVoter("ee")));
+        Assert.assertNull(election.getWinner());
+        Assert.assertTrue(election.vote(spec_fnc, createVoter("cc")));
+        Assert.assertNull(election.getWinner());
+        Assert.assertTrue(election.vote(spec_fnc, createVoter("aa")));
+        Assert.assertEquals(spec_fnc, election.getWinner());
+
+        election.clearWinners();
+
+        Assert.assertNull(election.getWinner());
+        Assert.assertEquals(2, election.getVotes().size());
+        Assert.assertEquals(Collections.emptyList(), election.getVotes().get(spec_fna));
+        Assert.assertEquals(Arrays.asList(createVoter("aa"), createVoter("bb")), election.getVotes().get(spec_fnb));
+    }
+
+    private ABICallVoter createVoter(String hex) {
+        return new ABICallVoter(Hex.decode(hex));
+    }
+
+    private ECKey createMockKeyForAddress(String hex) {
+        ECKey mockedKey = mock(ECKey.class);
+        when(mockedKey.getAddress()).thenReturn(Hex.decode(hex));
+        return mockedKey;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/ABICallSpecTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ABICallSpecTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.spongycastle.util.encoders.Hex;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class ABICallSpecTest {
+    @Test
+    public void argumentsIsCopy() {
+        ABICallSpec spec = new ABICallSpec("a-function", new byte[][]{
+                Hex.decode("aabb"),
+                Hex.decode("ccddee")
+        });
+
+        byte[][] arguments = spec.getArguments();
+        Assert.assertNotSame(arguments, Whitebox.getInternalState(spec, "arguments"));
+        Assert.assertTrue(Arrays.equals(Hex.decode("aabb"), arguments[0]));
+        Assert.assertTrue(Arrays.equals(Hex.decode("ccddee"), arguments[1]));
+    }
+
+    @Test
+    public void getFunction() {
+        ABICallSpec spec = new ABICallSpec("a-function", new byte[][]{});
+        Assert.assertEquals("a-function", spec.getFunction());
+    }
+
+    @Test
+    public void getEncoded() {
+        ABICallSpec spec = new ABICallSpec("a-function", new byte[][]{
+                Hex.decode("1122"),
+                Hex.decode("334455"),
+        });
+
+        StringBuilder expectedBuilder = new StringBuilder();
+        expectedBuilder.append(Hex.toHexString("a-function".getBytes(StandardCharsets.UTF_8)));
+        expectedBuilder.append("1122334455");
+        Assert.assertTrue(Arrays.equals(Hex.decode(expectedBuilder.toString()), spec.getEncoded()));
+    }
+
+    @Test
+    public void testEquals() {
+        ABICallSpec specA = new ABICallSpec("function-a", new byte[][]{
+                Hex.decode("aabb"),
+                Hex.decode("ccddee")
+        });
+        ABICallSpec specB = new ABICallSpec("function-b", new byte[][]{
+                Hex.decode("aabb"),
+                Hex.decode("ccddee")
+        });
+        ABICallSpec specC = new ABICallSpec("function-a", new byte[][]{
+                Hex.decode("ccddee"),
+                Hex.decode("aabb")
+        });
+        ABICallSpec specD = new ABICallSpec("function-a", new byte[][]{
+                Hex.decode("aabb"),
+                Hex.decode("ccdd")
+        });
+        ABICallSpec specE = new ABICallSpec("function-a", new byte[][]{
+                Hex.decode("aabb")
+        });
+        ABICallSpec specF = new ABICallSpec("function-a", new byte[][]{
+                Hex.decode("aabb"),
+                Hex.decode("ccddee")
+        });
+
+        Assert.assertEquals(specA, specF);
+        Assert.assertNotEquals(specA, specB);
+        Assert.assertNotEquals(specA, specC);
+        Assert.assertNotEquals(specA, specD);
+        Assert.assertNotEquals(specA, specE);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/ABICallVoterTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ABICallVoterTest.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+public class ABICallVoterTest {
+    @Test
+    public void testEquals() {
+        ABICallVoter voterA = new ABICallVoter(Hex.decode("aabbccdd"));
+        ABICallVoter voterB = new ABICallVoter(Hex.decode("aabbccdd"));
+        ABICallVoter voterC = new ABICallVoter(Hex.decode("aabbccddee"));
+        ABICallVoter voterD = new ABICallVoter(Hex.decode(""));
+        ABICallVoter voterE = new ABICallVoter(Hex.decode("112233"));
+
+        Assert.assertEquals(voterA, voterB);
+        Assert.assertNotEquals(voterA, voterC);
+        Assert.assertNotEquals(voterA, voterD);
+        Assert.assertNotEquals(voterA, voterE);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -127,7 +127,6 @@ public class BridgeSerializationUtilsTest {
         };
 
         Federation federation = new Federation(
-            3,
             Arrays.asList(new BtcECKey[]{
                     BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[1]),

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -269,7 +269,7 @@ public class BridgeStorageProviderTest {
     public void getActiveFederation() throws IOException {
         List<Integer> calls = new ArrayList<>();
         Context contextMock = mock(Context.class);
-        Federation activeFederation = new Federation(1, Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation activeFederation = new Federation(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, "aabbccdd");
@@ -333,7 +333,7 @@ public class BridgeStorageProviderTest {
     @PrepareForTest({ BridgeSerializationUtils.class })
     @Test
     public void saveNewFederation() throws IOException {
-        Federation newFederation = new Federation(1, Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = new Federation(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         List<Integer> storageBytesCalls = new ArrayList<>();
         List<Integer> serializeCalls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -18,15 +18,14 @@
 
 package co.rsk.peg;
 
-import co.rsk.config.BridgeConstants;
-import co.rsk.config.RskSystemProperties;
-import co.rsk.crypto.Sha3Hash;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.ScriptBuilder;
-import co.rsk.bitcoinj.wallet.Wallet;
-import org.ethereum.core.Repository;
+import co.rsk.config.BridgeConstants;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.crypto.Sha3Hash;
 import co.rsk.db.RepositoryImpl;
+import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
@@ -364,6 +363,107 @@ public class BridgeStorageProviderTest {
         Assert.assertEquals(0, serializeCalls.size());
         storageProvider.setActiveFederation(newFederation);
         storageProvider.saveActiveFederation();
+        Assert.assertEquals(1, storageBytesCalls.size());
+        Assert.assertEquals(1, serializeCalls.size());
+    }
+
+    @PrepareForTest({ BridgeSerializationUtils.class })
+    @Test
+    public void getFederationElection_nonNullBytes() throws IOException {
+        List<Integer> calls = new ArrayList<>();
+        ABICallAuthorizer authorizerMock = mock(ABICallAuthorizer.class);
+        ABICallElection electionMock = mock(ABICallElection.class);
+        PowerMockito.mockStatic(BridgeSerializationUtils.class);
+        Repository repositoryMock = mock(Repository.class);
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, "aabbccdd");
+
+        when(repositoryMock.getStorageBytes(any(byte[].class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
+            calls.add(0);
+            byte[] contractAddress = invocation.getArgumentAt(0, byte[].class);
+            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            // Make sure the bytes are got from the correct address in the repo
+            Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress));
+            Assert.assertEquals(new DataWord("bridgeFederationElection".getBytes(StandardCharsets.UTF_8)), address);
+            return new byte[]{(byte)0xaa};
+        });
+        PowerMockito.when(BridgeSerializationUtils.deserializeElection(any(byte[].class), any(ABICallAuthorizer.class))).then((InvocationOnMock invocation) -> {
+            calls.add(0);
+            byte[] data = invocation.getArgumentAt(0, byte[].class);
+            ABICallAuthorizer authorizer = invocation.getArgumentAt(1, ABICallAuthorizer.class);
+            // Make sure we're deserializing what just came from the repo with the correct ABICallAuthorizer
+            Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa}, data));
+            Assert.assertEquals(authorizerMock, authorizer);
+            return electionMock;
+        });
+
+        Assert.assertSame(electionMock, storageProvider.getFederationElection(authorizerMock));
+        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes
+    }
+
+    @PrepareForTest({ BridgeSerializationUtils.class })
+    @Test
+    public void getFederationElection_nullBytes() throws IOException {
+        List<Integer> calls = new ArrayList<>();
+        ABICallAuthorizer authorizerMock = mock(ABICallAuthorizer.class);
+        ABICallElection electionMock = mock(ABICallElection.class);
+        PowerMockito.mockStatic(BridgeSerializationUtils.class);
+        Repository repositoryMock = mock(Repository.class);
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, "aabbccdd");
+
+        when(repositoryMock.getStorageBytes(any(byte[].class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
+            calls.add(0);
+            byte[] contractAddress = invocation.getArgumentAt(0, byte[].class);
+            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            // Make sure the bytes are got from the correct address in the repo
+            Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress));
+            Assert.assertEquals(new DataWord("bridgeFederationElection".getBytes(StandardCharsets.UTF_8)), address);
+            return null;
+        });
+        PowerMockito.when(BridgeSerializationUtils.deserializeElection(any(byte[].class), any(ABICallAuthorizer.class))).then((InvocationOnMock invocation) -> {
+            calls.add(0);
+            return null;
+        });
+
+        ABICallElection result = storageProvider.getFederationElection(authorizerMock);
+        Assert.assertSame(authorizerMock, Whitebox.getInternalState(result, "authorizer"));
+        Assert.assertEquals(0, result.getVotes().size());
+        Assert.assertEquals(1, calls.size()); // getStorageBytes is the only one called (can't be the other way around)
+    }
+
+    @PrepareForTest({ BridgeSerializationUtils.class })
+    @Test
+    public void saveFederationElection() throws IOException {
+        ABICallElection electionMock = mock(ABICallElection.class);
+        List<Integer> storageBytesCalls = new ArrayList<>();
+        List<Integer> serializeCalls = new ArrayList<>();
+        PowerMockito.mockStatic(BridgeSerializationUtils.class);
+        Repository repositoryMock = mock(Repository.class);
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, "aabbccdd");
+
+        PowerMockito.when(BridgeSerializationUtils.serializeElection(any(ABICallElection.class))).then((InvocationOnMock invocation) -> {
+            ABICallElection election = invocation.getArgumentAt(0, ABICallElection.class);
+            Assert.assertSame(electionMock, election);
+            serializeCalls.add(0);
+            return Hex.decode("aabb");
+        });
+        Mockito.doAnswer((InvocationOnMock invocation) -> {
+            storageBytesCalls.add(0);
+            byte[] contractAddress = invocation.getArgumentAt(0, byte[].class);
+            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            byte[] data = invocation.getArgumentAt(2, byte[].class);
+            // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
+            Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress));
+            Assert.assertEquals(new DataWord("bridgeFederationElection".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertTrue(Arrays.equals(Hex.decode("aabb"), data));
+            return null;
+        }).when(repositoryMock).addStorageBytes(any(byte[].class), any(DataWord.class), any(byte[].class));
+
+        storageProvider.saveFederationElection();
+        // Shouldn't have tried to save nor serialize anything
+        Assert.assertEquals(0, storageBytesCalls.size());
+        Assert.assertEquals(0, serializeCalls.size());
+        Whitebox.setInternalState(storageProvider, "federationElection", electionMock);
+        storageProvider.saveFederationElection();
         Assert.assertEquals(1, storageBytesCalls.size());
         Assert.assertEquals(1, serializeCalls.size());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1411,7 +1411,7 @@ public class BridgeSupportTest {
                 null
         );
 
-        Assert.assertEquals(1L, bridgeSupport.createFederation().longValue());
+        Assert.assertEquals(1L, bridgeSupport.createFederation(false).longValue());
         Assert.assertEquals(0, bridgeSupport.getPendingFederationSize().intValue());
     }
 
@@ -1426,7 +1426,7 @@ public class BridgeSupportTest {
                 null
         );
 
-        Assert.assertEquals(-1L, bridgeSupport.createFederation().longValue());
+        Assert.assertEquals(-1L, bridgeSupport.createFederation(false).longValue());
     }
 
     @Test
@@ -1441,7 +1441,7 @@ public class BridgeSupportTest {
         );
         ((BridgeStorageProvider) Whitebox.getInternalState(bridgeSupport, "provider")).getRetiringFederationBtcUTXOs().add(mock(UTXO.class));
 
-        Assert.assertEquals(-2L, bridgeSupport.createFederation().longValue());
+        Assert.assertEquals(-2L, bridgeSupport.createFederation(false).longValue());
     }
 
     @Test
@@ -1457,7 +1457,7 @@ public class BridgeSupportTest {
         );
 
         Assert.assertEquals(0, bridgeSupport.getPendingFederationSize().intValue());
-        Assert.assertEquals(1, bridgeSupport.addFederatorPublicKey(BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))).intValue());
+        Assert.assertEquals(1, bridgeSupport.addFederatorPublicKey(false, BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))).intValue());
         Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
     }
 
@@ -1476,7 +1476,7 @@ public class BridgeSupportTest {
         );
 
         Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
-        Assert.assertEquals(1, bridgeSupport.addFederatorPublicKey(BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"))).intValue());
+        Assert.assertEquals(1, bridgeSupport.addFederatorPublicKey(false, BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"))).intValue());
         Assert.assertEquals(2, bridgeSupport.getPendingFederationSize().intValue());
     }
 
@@ -1491,7 +1491,7 @@ public class BridgeSupportTest {
                 null
         );
 
-        Assert.assertEquals(-1, bridgeSupport.addFederatorPublicKey(BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"))).intValue());
+        Assert.assertEquals(-1, bridgeSupport.addFederatorPublicKey(false, BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"))).intValue());
     }
 
     @Test
@@ -1509,7 +1509,7 @@ public class BridgeSupportTest {
         );
 
         Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
-        Assert.assertEquals(-2, bridgeSupport.addFederatorPublicKey(BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))).intValue());
+        Assert.assertEquals(-2, bridgeSupport.addFederatorPublicKey(false, BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))).intValue());
         Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
     }
 
@@ -1530,7 +1530,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = (BridgeStorageProvider) Whitebox.getInternalState(bridgeSupport, "provider");
         Assert.assertNotNull(provider.getPendingFederation());
-        Assert.assertEquals(1, bridgeSupport.rollbackFederation().intValue());
+        Assert.assertEquals(1, bridgeSupport.rollbackFederation(false).intValue());
         Assert.assertNull(provider.getPendingFederation());
     }
 
@@ -1545,7 +1545,7 @@ public class BridgeSupportTest {
                 null
         );
 
-        Assert.assertEquals(-1, bridgeSupport.rollbackFederation().intValue());
+        Assert.assertEquals(-1, bridgeSupport.rollbackFederation(false).intValue());
     }
 
     @Test
@@ -1587,7 +1587,7 @@ public class BridgeSupportTest {
 
         Assert.assertNotNull(provider.getPendingFederation());
 
-        Assert.assertEquals(1, bridgeSupport.commitFederation(pendingFederation.getHash()).intValue());
+        Assert.assertEquals(1, bridgeSupport.commitFederation(false, pendingFederation.getHash()).intValue());
 
         Assert.assertNull(provider.getPendingFederation());
 
@@ -1617,7 +1617,7 @@ public class BridgeSupportTest {
         );
 
         Sha3Hash hash = new Sha3Hash(HashUtil.sha3(Hex.decode("aabbcc")));
-        Assert.assertEquals(-1, bridgeSupport.commitFederation(hash).intValue());
+        Assert.assertEquals(-1, bridgeSupport.commitFederation(false, hash).intValue());
     }
 
     @Test
@@ -1635,7 +1635,7 @@ public class BridgeSupportTest {
         );
 
         Sha3Hash hash = new Sha3Hash(HashUtil.sha3(Hex.decode("aabbcc")));
-        Assert.assertEquals(-2, bridgeSupport.commitFederation(hash).intValue());
+        Assert.assertEquals(-2, bridgeSupport.commitFederation(false, hash).intValue());
     }
 
     @Test
@@ -1654,7 +1654,7 @@ public class BridgeSupportTest {
         );
 
         Sha3Hash hash = new Sha3Hash(HashUtil.sha3(Hex.decode("aabbcc")));
-        Assert.assertEquals(-3, bridgeSupport.commitFederation(hash).intValue());
+        Assert.assertEquals(-3, bridgeSupport.commitFederation(false, hash).intValue());
     }
 
     @PrepareForTest({ BridgeUtils.class })

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1311,7 +1311,7 @@ public class BridgeSupportTest {
                 Instant.ofEpochMilli(1000),
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, activeFederation, genesisFederation, null, null, null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, activeFederation, genesisFederation, null, null, null, null);
 
         Assert.assertEquals(6, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(4, bridgeSupport.getFederationThreshold().intValue());
@@ -1334,7 +1334,7 @@ public class BridgeSupportTest {
                 Instant.ofEpochMilli(1000),
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, activeFederation, genesisFederation, null, null, null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, activeFederation, genesisFederation, null, null, null, null);
 
         Assert.assertEquals(3, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(2, bridgeSupport.getFederationThreshold().intValue());
@@ -1347,7 +1347,7 @@ public class BridgeSupportTest {
 
     @Test
     public void getRetiringFederationMethods_none() throws IOException {
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, null, null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, null, null, null);
 
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationSize().intValue());
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationThreshold().intValue());
@@ -1361,10 +1361,10 @@ public class BridgeSupportTest {
                 Instant.ofEpochMilli(2000),
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, mockedRetiringFederation, null, null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, mockedRetiringFederation, null, null, null);
 
         Assert.assertEquals(4, bridgeSupport.getRetiringFederationSize().intValue());
-        Assert.assertEquals(2, bridgeSupport.getRetiringFederationThreshold().intValue());
+        Assert.assertEquals(3, bridgeSupport.getRetiringFederationThreshold().intValue());
         Assert.assertEquals(2000, bridgeSupport.getRetiringFederationCreationTime().toEpochMilli());
         Assert.assertEquals(mockedRetiringFederation.getAddress().toString(), bridgeSupport.getRetiringFederationAddress().toString());
         List<BtcECKey> publicKeys = getTestFederationPublicKeys(4);
@@ -1375,7 +1375,7 @@ public class BridgeSupportTest {
 
     @Test
     public void getPendingFederationMethods_none() throws IOException {
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, null,  null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, null,  null, null);
 
         Assert.assertEquals(-1, bridgeSupport.getPendingFederationSize().intValue());
         Assert.assertNull(bridgeSupport.getPendingFederatorPublicKey(0));
@@ -1386,7 +1386,7 @@ public class BridgeSupportTest {
         PendingFederation mockedPendingFederation = new PendingFederation(
                 getTestFederationPublicKeys(5)
         );
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, mockedPendingFederation, null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, mockedPendingFederation, null, null);
 
         Assert.assertEquals(5, bridgeSupport.getPendingFederationSize().intValue());
         List<BtcECKey> publicKeys = getTestFederationPublicKeys(5);
@@ -1399,6 +1399,7 @@ public class BridgeSupportTest {
     public void createFederation_ok() throws IOException {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
+                null,
                 null,
                 null,
                 null,
@@ -1418,6 +1419,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 new PendingFederation(Collections.emptyList()),
+                null,
                 null
         );
 
@@ -1428,6 +1430,7 @@ public class BridgeSupportTest {
     public void createFederation_pendingUTXOs() throws IOException {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
+                null,
                 null,
                 null,
                 null,
@@ -1448,6 +1451,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 pendingFederation,
+                null,
                 null
         );
 
@@ -1467,6 +1471,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 pendingFederation,
+                null,
                 null
         );
 
@@ -1479,6 +1484,7 @@ public class BridgeSupportTest {
     public void addFederatorPublicKey_noPendingFederation() throws IOException {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
+                null,
                 null,
                 null,
                 null,
@@ -1500,6 +1506,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 pendingFederation,
+                null,
                 null
         );
 
@@ -1520,6 +1527,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 pendingFederation,
+                null,
                 null
         );
 
@@ -1533,6 +1541,7 @@ public class BridgeSupportTest {
     public void rollbackFederation_noPendingFederation() throws IOException {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
+                null,
                 null,
                 null,
                 null,
@@ -1565,6 +1574,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 pendingFederation,
+                null,
                 executionBlock
         );
         BridgeStorageProvider provider = (BridgeStorageProvider) Whitebox.getInternalState(bridgeSupport, "provider");
@@ -1608,6 +1618,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
 
@@ -1626,6 +1637,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 pendingFederation,
+                null,
                 null
         );
 
@@ -1645,6 +1657,7 @@ public class BridgeSupportTest {
                 null,
                 null,
                 pendingFederation,
+                null,
                 null
         );
 
@@ -1662,6 +1675,7 @@ public class BridgeSupportTest {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
                 expectedFederation,
+                null,
                 null,
                 null,
                 null,
@@ -1697,6 +1711,7 @@ public class BridgeSupportTest {
                 null,
                 expectedFederation,
                 null,
+                null,
                 null
         );
         Context expectedContext = mock(Context.class);
@@ -1728,7 +1743,7 @@ public class BridgeSupportTest {
         return providerMock;
     }
 
-    private BridgeSupport getBridgeSupportWithMocksForFederationTests(boolean genesis, Federation mockedActiveFederation, Federation mockedGenesisFederation, Federation mockedRetiringFederation, PendingFederation mockedPendingFederation, Block executionBlock) throws IOException {
+    private BridgeSupport getBridgeSupportWithMocksForFederationTests(boolean genesis, Federation mockedActiveFederation, Federation mockedGenesisFederation, Federation mockedRetiringFederation, PendingFederation mockedPendingFederation, ABICallElection mockedFederationElection, Block executionBlock) throws IOException {
         BridgeConstants constantsMock = mock(BridgeConstants.class);
         when(constantsMock.getGenesisFederation()).thenReturn(mockedGenesisFederation);
         when(constantsMock.getBtcParams()).thenReturn(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
@@ -1737,6 +1752,7 @@ public class BridgeSupportTest {
             private PendingFederation pendingFederation;
             private Federation activeFederation;
             private Federation retiringFederation;
+            private ABICallElection federationElection;
 
             public List<UTXO> retiringUTXOs = new ArrayList<>();
             public List<UTXO> activeUTXOs = new ArrayList<>();
@@ -1749,6 +1765,9 @@ public class BridgeSupportTest {
 
             Federation getRetiringFederation() { return retiringFederation; }
             void setRetiringFederation(Federation retiringFederation) { this.retiringFederation = retiringFederation; }
+
+            public ABICallElection getFederationElection() { return federationElection; }
+            public void setFederationElection(ABICallElection federationElection) { this.federationElection = federationElection; }
         }
 
         final FederationHolder holder = new FederationHolder();
@@ -1764,6 +1783,18 @@ public class BridgeSupportTest {
         when(providerMock.getActiveFederation()).then((InvocationOnMock m) -> holder.getActiveFederation());
         when(providerMock.getRetiringFederation()).then((InvocationOnMock m) -> holder.getRetiringFederation());
         when(providerMock.getPendingFederation()).then((InvocationOnMock m) -> holder.getPendingFederation());
+        when(providerMock.getFederationElection(any())).then((InvocationOnMock m) -> {
+            if (mockedFederationElection != null) {
+                holder.setFederationElection(mockedFederationElection);
+            }
+
+            if (holder.getFederationElection() == null) {
+                ABICallAuthorizer auth = m.getArgumentAt(0, ABICallAuthorizer.class);
+                holder.setFederationElection(new ABICallElection(auth));
+            }
+
+            return holder.getFederationElection();
+        });
         Mockito.doAnswer((InvocationOnMock m) -> {
             holder.setActiveFederation(m.getArgumentAt(0, Federation.class));
             return null;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1163,7 +1163,7 @@ public class BridgeSupportTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")),
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = new Federation(1, federation1Keys, Instant.ofEpochMilli(1000L), parameters);
+        Federation federation1 = new Federation(federation1Keys, Instant.ofEpochMilli(1000L), parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -1171,7 +1171,7 @@ public class BridgeSupportTest {
                 BtcECKey.fromPrivate(Hex.decode("fb03")),
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = new Federation(2, federation2Keys, Instant.ofEpochMilli(2000L), parameters);
+        Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), parameters);
 
         Repository repository = new RepositoryImpl();
         repository.addBalance(Hex.decode(PrecompiledContracts.BRIDGE_ADDR), BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
@@ -1302,13 +1302,11 @@ public class BridgeSupportTest {
     @Test
     public void getFederationMethods_genesis() throws IOException {
         Federation activeFederation = new Federation(
-                2,
                 getTestFederationPublicKeys(3),
                 Instant.ofEpochMilli(1000),
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = new Federation(
-                4,
                 getTestFederationPublicKeys(6),
                 Instant.ofEpochMilli(1000),
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1327,13 +1325,11 @@ public class BridgeSupportTest {
     @Test
     public void getFederationMethods_active() throws IOException {
         Federation activeFederation = new Federation(
-                2,
                 getTestFederationPublicKeys(3),
                 Instant.ofEpochMilli(1000),
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = new Federation(
-                4,
                 getTestFederationPublicKeys(6),
                 Instant.ofEpochMilli(1000),
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1361,7 +1357,6 @@ public class BridgeSupportTest {
     @Test
     public void getRetiringFederationMethods_present() throws IOException {
         Federation mockedRetiringFederation = new Federation(
-                2,
                 getTestFederationPublicKeys(4),
                 Instant.ofEpochMilli(2000),
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1558,7 +1553,7 @@ public class BridgeSupportTest {
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
                 BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49")),
         }));
-        Federation expectedFederation = new Federation(3, Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
@@ -1660,7 +1655,7 @@ public class BridgeSupportTest {
     @PrepareForTest({ BridgeUtils.class })
     @Test
     public void getActiveFederationWallet() throws IOException {
-        Federation expectedFederation = new Federation(1, Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         }), Instant.ofEpochMilli(5005L), NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
@@ -1692,7 +1687,7 @@ public class BridgeSupportTest {
     @PrepareForTest({ BridgeUtils.class })
     @Test
     public void getRetiringFederationWallet_nonEmpty() throws IOException {
-        Federation expectedFederation = new Federation(1, Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         }), Instant.ofEpochMilli(5005L), NetworkParameters.fromID(NetworkParameters.ID_REGTEST));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -801,9 +801,9 @@ public class BridgeTest {
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.createFederation()).thenReturn(123L);
+        when(bridgeSupportMock.createFederation(false)).thenReturn(123);
 
-        Assert.assertEquals(123L, bridge.createFederation(new Object[]{}).longValue());
+        Assert.assertEquals(123, bridge.createFederation(new Object[]{}).longValue());
     }
 
     @Test
@@ -812,7 +812,7 @@ public class BridgeTest {
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.createFederation()).thenThrow(new IOException("I am an exception"));
+        when(bridgeSupportMock.createFederation(false)).thenThrow(new IOException("I am an exception"));
 
         try {
             bridge.createFederation(new Object[]{});
@@ -829,7 +829,7 @@ public class BridgeTest {
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.addFederatorPublicKey(BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))))
+        when(bridgeSupportMock.addFederatorPublicKey(false, BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))))
                 .thenReturn(123);
 
         Assert.assertEquals(123, bridge.addFederatorPublicKey(new Object[]{Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")}).intValue());
@@ -841,7 +841,7 @@ public class BridgeTest {
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        verify(bridgeSupportMock, never()).addFederatorPublicKey(any());
+        verify(bridgeSupportMock, never()).addFederatorPublicKey(false, any());
 
         try {
             bridge.addFederatorPublicKey(new Object[]{Hex.decode("abcdef")});
@@ -865,7 +865,7 @@ public class BridgeTest {
         }
         Sha3Hash hash = new Sha3Hash(Hex.decode(hashHexBuilder.toString()));
 
-        when(bridgeSupportMock.commitFederation(hash)).thenReturn(123);
+        when(bridgeSupportMock.commitFederation(false, hash)).thenReturn(123);
 
         Assert.assertEquals(123, bridge.commitFederation(new Object[]{ hash.getBytes() }).intValue());
     }
@@ -883,7 +883,7 @@ public class BridgeTest {
         }
         Sha3Hash hash = new Sha3Hash(Hex.decode(hashHexBuilder.toString()));
 
-        when(bridgeSupportMock.commitFederation(hash)).thenThrow(new IOException("I am an exception"));
+        when(bridgeSupportMock.commitFederation(false, hash)).thenThrow(new IOException("I am an exception"));
 
         try {
             bridge.commitFederation(new Object[]{ hash.getBytes() });
@@ -900,7 +900,7 @@ public class BridgeTest {
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.commitFederation(any())).thenThrow(new IOException("I am an exception"));
+        when(bridgeSupportMock.commitFederation(false, any())).thenThrow(new IOException("I am an exception"));
 
         try {
             bridge.commitFederation(new Object[]{ new byte[]{ (byte) 0xab } });
@@ -915,7 +915,7 @@ public class BridgeTest {
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.rollbackFederation()).thenReturn(456);
+        when(bridgeSupportMock.rollbackFederation(false)).thenReturn(456);
 
         Assert.assertEquals(456, bridge.rollbackFederation(new Object[]{}).intValue());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -796,126 +796,73 @@ public class BridgeTest {
     }
 
     @Test
-    public void createFederation_ok() throws IOException {
+    public void createFederation() throws IOException {
+        Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.createFederation(false)).thenReturn(123);
+        when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("create", new byte[][]{}))).thenReturn(123);
 
-        Assert.assertEquals(123, bridge.createFederation(new Object[]{}).longValue());
-    }
-
-    @Test
-    public void createFederation_error() throws IOException {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
-        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.createFederation(false)).thenThrow(new IOException("I am an exception"));
-
-        try {
-            bridge.createFederation(new Object[]{});
-            Assert.fail();
-        }
-        catch (RuntimeException ex) {
-            Assert.assertEquals("Exception in createFederation", ex.getMessage());
-        }
+        Assert.assertEquals(123, bridge.createFederation(new Object[]{}).intValue());
     }
 
     @Test
     public void addFederatorPublicKey_ok() throws IOException {
+        Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.addFederatorPublicKey(false, BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))))
+        when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("add", new byte[][] { Hex.decode("aabbccdd") })))
                 .thenReturn(123);
 
-        Assert.assertEquals(123, bridge.addFederatorPublicKey(new Object[]{Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")}).intValue());
+        Assert.assertEquals(123, bridge.addFederatorPublicKey(new Object[]{Hex.decode("aabbccdd")}).intValue());
     }
 
     @Test
-    public void addFederatorPublicKey_error() throws IOException {
+    public void addFederatorPublicKey_wrongParameterType() throws IOException {
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        verify(bridgeSupportMock, never()).addFederatorPublicKey(false, any());
 
-        try {
-            bridge.addFederatorPublicKey(new Object[]{Hex.decode("abcdef")});
-            Assert.fail();
-        }
-        catch (RuntimeException ex) {
-            Assert.assertEquals("Public key could not be parsed abcdef", ex.getMessage());
-        }
+        Assert.assertEquals(-10, bridge.addFederatorPublicKey(new Object[]{ "i'm not a byte array" }).intValue());
+        verify(bridgeSupportMock, never()).voteFederationChange(any(), any());
     }
 
     @Test
     public void commitFederation_ok() throws IOException {
+        Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
 
-        StringBuilder hashHexBuilder = new StringBuilder(64);
-        for (int i = 0; i < 32; i++) {
-            hashHexBuilder.append("55");
-        }
-        Sha3Hash hash = new Sha3Hash(Hex.decode(hashHexBuilder.toString()));
+        when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("commit", new byte[][] { Hex.decode("01020304") }))).thenReturn(123);
 
-        when(bridgeSupportMock.commitFederation(false, hash)).thenReturn(123);
-
-        Assert.assertEquals(123, bridge.commitFederation(new Object[]{ hash.getBytes() }).intValue());
+        Assert.assertEquals(123, bridge.commitFederation(new Object[]{ Hex.decode("01020304") }).intValue());
     }
 
     @Test
-    public void commitFederation_error() throws IOException {
+    public void commitFederation_wrongParameterType() throws IOException {
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
 
-        StringBuilder hashHexBuilder = new StringBuilder(64);
-        for (int i = 0; i < 32; i++) {
-            hashHexBuilder.append("55");
-        }
-        Sha3Hash hash = new Sha3Hash(Hex.decode(hashHexBuilder.toString()));
-
-        when(bridgeSupportMock.commitFederation(false, hash)).thenThrow(new IOException("I am an exception"));
-
-        try {
-            bridge.commitFederation(new Object[]{ hash.getBytes() });
-            Assert.fail();
-        }
-        catch (RuntimeException ex) {
-            Assert.assertEquals("Exception in commitFederation", ex.getMessage());
-        }
-    }
-
-    @Test
-    public void commitFederation_invalidHash() throws IOException {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
-        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.commitFederation(false, any())).thenThrow(new IOException("I am an exception"));
-
-        try {
-            bridge.commitFederation(new Object[]{ new byte[]{ (byte) 0xab } });
-            Assert.fail();
-        }
-        catch (IllegalArgumentException ex) {}
+        Assert.assertEquals(-10, bridge.commitFederation(new Object[]{ "i'm not a byte array" }).intValue());
+        verify(bridgeSupportMock, never()).voteFederationChange(any(), any());
     }
 
     @Test
     public void rollbackFederation() throws IOException {
+        Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
-        when(bridgeSupportMock.rollbackFederation(false)).thenReturn(456);
+        when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("rollback", new byte[][]{}))).thenReturn(456);
 
         Assert.assertEquals(456, bridge.rollbackFederation(new Object[]{}).intValue());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -113,7 +113,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")),
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = new Federation(1, federation1Keys, Instant.ofEpochMilli(1000L), parameters);
+        Federation federation1 = new Federation(federation1Keys, Instant.ofEpochMilli(1000L), parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -121,7 +121,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fb03")),
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = new Federation(2, federation2Keys, Instant.ofEpochMilli(2000L), parameters);
+        Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), parameters);
 
         Address address1 = federation1.getAddress();
         Address address2 = federation2.getAddress();
@@ -299,7 +299,7 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationNoSpendWallet() {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(1, Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         }), Instant.ofEpochMilli(5005L), regTestParameters);
@@ -314,7 +314,7 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationSpendWallet() throws UTXOProviderException {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(1, Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         }), Instant.ofEpochMilli(5005L), regTestParameters);

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -106,7 +106,7 @@ public class FederationTest {
             calls.add(1);
             int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
             List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
-            Assert.assertEquals(3, numberOfSignaturesRequired);
+            Assert.assertEquals(4, numberOfSignaturesRequired);
             Assert.assertEquals(6, publicKeys.size());
             for (int i = 0; i < sortedPublicKeys.size(); i++) {
                 Assert.assertTrue(Arrays.equals(sortedPublicKeys.get(i).getPubKey(), publicKeys.get(i).getPubKey()));
@@ -128,7 +128,7 @@ public class FederationTest {
             calls.add(0);
             int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
             List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
-            Assert.assertEquals(3, numberOfSignaturesRequired);
+            Assert.assertEquals(4, numberOfSignaturesRequired);
             Assert.assertEquals(6, publicKeys.size());
             for (int i = 0; i < sortedPublicKeys.size();i ++) {
                 Assert.assertTrue(Arrays.equals(sortedPublicKeys.get(i).getPubKey(), publicKeys.get(i).getPubKey()));
@@ -154,7 +154,7 @@ public class FederationTest {
             calls.add(0);
             int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
             List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
-            Assert.assertEquals(3, numberOfSignaturesRequired);
+            Assert.assertEquals(4, numberOfSignaturesRequired);
             Assert.assertEquals(6, publicKeys.size());
             for (int i = 0; i < sortedPublicKeys.size();i ++) {
                 Assert.assertTrue(Arrays.equals(sortedPublicKeys.get(i).getPubKey(), publicKeys.get(i).getPubKey()));
@@ -175,23 +175,6 @@ public class FederationTest {
         Assert.assertFalse(federation.equals(null));
         Assert.assertFalse(federation.equals(new Object()));
         Assert.assertFalse(federation.equals("something else"));
-    }
-
-    @Test
-    public void testEquals_differentThreshold() {
-        Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
-                ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
-        Assert.assertFalse(federation.equals(otherFederation));
     }
 
     @Test
@@ -298,6 +281,6 @@ public class FederationTest {
 
     @Test
     public void testToString() {
-        Assert.assertEquals("3 of 6 signatures federation", federation.toString());
+        Assert.assertEquals("4 of 6 signatures federation", federation.toString());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -57,7 +57,6 @@ public class FederationTest {
     @Before
     public void createFederation() {
         federation = new Federation(
-                3,
                 Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -181,7 +180,6 @@ public class FederationTest {
     @Test
     public void testEquals_differentThreshold() {
         Federation otherFederation = new Federation(
-                2,
                 Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -199,7 +197,6 @@ public class FederationTest {
     @Test
     public void testEquals_differentNumberOfPublicKeys() {
         Federation otherFederation = new Federation(
-                3,
                 Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -218,7 +215,6 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationTime() {
         Federation otherFederation = new Federation(
-                3,
                 Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -236,7 +232,6 @@ public class FederationTest {
     @Test
     public void testEquals_differentNetworkParameters() {
         Federation otherFederation = new Federation(
-                3,
                 Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -254,7 +249,6 @@ public class FederationTest {
     @Test
     public void testEquals_differentPublicKeys() {
         Federation otherFederation = new Federation(
-                3,
                 Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -272,7 +266,6 @@ public class FederationTest {
     @Test
     public void testEquals_same() {
         Federation otherFederation = new Federation(
-                3,
                 Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -183,7 +183,7 @@ public class PendingFederationTest {
                 })
         );
 
-        Federation expectedFederation = new Federation(4, Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -217,7 +217,7 @@ public class PendingFederationTest {
                 })
         );
 
-        Federation expectedFederation = new Federation(5, Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(300)),

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -161,13 +161,13 @@ public class PendingFederationTest {
 
     @Test
     public void testToString() {
-        Assert.assertEquals("4 of 6 signatures pending federation (complete)", pendingFederation.toString());
+        Assert.assertEquals("6 signatures pending federation (complete)", pendingFederation.toString());
         PendingFederation otherPendingFederation = new PendingFederation(
                 Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 })
         );
-        Assert.assertEquals("1 of 1 signatures pending federation (incomplete)", otherPendingFederation.toString());
+        Assert.assertEquals("1 signatures pending federation (incomplete)", otherPendingFederation.toString());
     }
 
     @Test


### PR DESCRIPTION
Enhancing of federation change workflow by requiring a certain number of voters to vote on a federation change action (either `createFederation`, `addFederatorPublicKey`, `commitFederation` or `rollbackFederation`).

Added an `ABICallElection` to the `BridgeStorage`, which contains the status of the current "election" for which method to call on the bridge for the federation change (any of the aforementioned methods, that is). 

Upon voting, the underlying method is called in a "dry-run" fashion which allows for getting the result of the potential execution back, but doesn't actually impact the federation change workflow.

If the vote threshold is met in one of these calls (at least `n/2+1` votes, with n being the number of authorized keys - defined in `BridgeConstants` and customisable for each network), the actual underlying method is called and the original flow occurs. In addition, election is cleared for every method except for the `addFederatorPublicKey`.