### PR TITLE
Validate block timestamp in comparison to parent timestamp

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -107,6 +107,7 @@ public class MinerServerImpl implements MinerServer {
     private final BlockProcessor nodeBlockProcessor;
 
     private long timeAdjustment;
+    private long minimumAcceptableTime;
 
     @Autowired
     public MinerServerImpl(Ethereum ethereum,
@@ -350,6 +351,7 @@ public class MinerServerImpl implements MinerServer {
 
         BigInteger minimumGasPrice = new MinimumGasPriceCalculator().calculate(newBlockParent.getMinGasPriceAsInteger(), minerMinGasPriceTarget);
         final List<Transaction> txs = getTransactions(txsToRemove, newBlockParent, minimumGasPrice);
+        minimumAcceptableTime = newBlockParent.getTimestamp() + 1;
 
         final Block newBlock = createBlock(newBlockParent, uncles, txs, minimumGasPrice);
 
@@ -400,7 +402,8 @@ public class MinerServerImpl implements MinerServer {
 
     @Override
     public long getCurrentTimeInSeconds() {
-        return System.currentTimeMillis() / 1000 + this.timeAdjustment;
+        long ret = System.currentTimeMillis() / 1000 + this.timeAdjustment;
+        return Long.max(ret, minimumAcceptableTime);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Created by mario on 23/01/17.
  */
-public class BlockTimeStampValidationRule implements BlockValidationRule{
+public class BlockTimeStampValidationRule implements BlockParentDependantValidationRule, BlockValidationRule{
 
     private static final Logger logger = LoggerFactory.getLogger("blockvalidator");
     private static final PanicProcessor panicProcessor = new PanicProcessor();
@@ -46,8 +46,22 @@ public class BlockTimeStampValidationRule implements BlockValidationRule{
         boolean result = blockTime - currentTime <= this.validPeriodLength;
         if(!result) {
             logger.warn("Error validating block. Invalid timestamp {}.", blockTime);
-            panicProcessor.panic("invalidtimestamp", String.format("Error validating block. Invalid timestamp %d.", blockTime));
         }
+        return result;
+    }
+
+    @Override
+    public boolean isValid(Block block, Block parent) {
+        boolean result = this.isValid(block);
+
+        final long blockTime = block.getTimestamp();
+        final long parentTime = parent.getTimestamp();
+        result = result && (blockTime > parentTime);
+
+        if (!result) {
+            logger.warn("Error validating block. Invalid timestamp {} for parent timestamp {}", blockTime, parentTime);
+        }
+
         return result;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -176,12 +176,12 @@ public class DefaultConfig {
         BlockStore blockStore = appCtx.getBean(BlockStore.class);
         int uncleListLimit = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getUncleListLimit();
         int uncleGenLimit = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getUncleGenerationLimit();
-
-        BlockParentGasLimitRule parentGasLimitRule = new BlockParentGasLimitRule(RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getGasLimitBoundDivisor());
-        BlockParentCompositeRule unclesBlockParentHeaderValidator = new BlockParentCompositeRule(new PrevMinGasPriceRule(), new BlockParentNumberRule(), new BlockDifficultyRule(), parentGasLimitRule);
-
         int validPeriod = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getNewBlockMaxMinInTheFuture();
         BlockTimeStampValidationRule blockTimeStampValidationRule = new BlockTimeStampValidationRule(validPeriod);
+
+        BlockParentGasLimitRule parentGasLimitRule = new BlockParentGasLimitRule(RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getGasLimitBoundDivisor());
+        BlockParentCompositeRule unclesBlockParentHeaderValidator = new BlockParentCompositeRule(new PrevMinGasPriceRule(), new BlockParentNumberRule(), blockTimeStampValidationRule, new BlockDifficultyRule(), parentGasLimitRule);
+
         BlockCompositeRule unclesBlockHeaderValidator = new BlockCompositeRule(new ProofOfWorkRule(), blockTimeStampValidationRule, new ValidGasUsedRule());
 
         BlockUnclesValidationRule blockUnclesValidationRule = new BlockUnclesValidationRule(blockStore, uncleListLimit, uncleGenLimit, unclesBlockHeaderValidator, unclesBlockParentHeaderValidator);

--- a/rskj-core/src/test/java/co/rsk/validators/BlockTimeStampValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockTimeStampValidationRuleTest.java
@@ -64,4 +64,54 @@ public class BlockTimeStampValidationRuleTest {
         Assert.assertFalse(validationRule.isValid(block));
     }
 
+    @Test
+    public void blockTimeLowerThanParentTime() {
+        int validPeriod = 540;
+        BlockTimeStampValidationRule validationRule = new BlockTimeStampValidationRule(validPeriod);
+
+        Block block = Mockito.mock(Block.class);
+        Block parent = Mockito.mock(Block.class);
+
+        Mockito.when(block.getTimestamp())
+                .thenReturn(System.currentTimeMillis() / 1000);
+
+        Mockito.when(parent.getTimestamp())
+                .thenReturn((System.currentTimeMillis() / 1000) + 1000);
+
+        Assert.assertFalse(validationRule.isValid(block, parent));
+    }
+
+    @Test
+    public void blockTimeGreaterThanParentTime() {
+        int validPeriod = 540;
+        BlockTimeStampValidationRule validationRule = new BlockTimeStampValidationRule(validPeriod);
+
+        Block block = Mockito.mock(Block.class);
+        Block parent = Mockito.mock(Block.class);
+
+        Mockito.when(block.getTimestamp())
+                .thenReturn(System.currentTimeMillis() / 1000);
+
+        Mockito.when(parent.getTimestamp())
+                .thenReturn((System.currentTimeMillis() / 1000) - 1000);
+
+        Assert.assertTrue(validationRule.isValid(block, parent));
+    }
+
+    @Test
+    public void blockTimeEqualsParentTime() {
+        int validPeriod = 540;
+        BlockTimeStampValidationRule validationRule = new BlockTimeStampValidationRule(validPeriod);
+
+        Block block = Mockito.mock(Block.class);
+        Block parent = Mockito.mock(Block.class);
+
+        Mockito.when(block.getTimestamp())
+                .thenReturn(System.currentTimeMillis() / 1000);
+
+        Mockito.when(parent.getTimestamp())
+                .thenReturn(System.currentTimeMillis() / 1000);
+
+        Assert.assertFalse(validationRule.isValid(block, parent));
+    }
 }


### PR DESCRIPTION
This PR replaces PR #102 since it was easier to create it again rather than fixing the other one after such a long time. Also some unit tests have been added.

@donequis shouldn't we consider validPeriodLength as in BlockTimeStampValidationRule ?

