### PR TITLE
Fixing decoding of integer in TransactionInfo and AccountState

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/AccountState.java
+++ b/rskj-core/src/main/java/org/ethereum/core/AccountState.java
@@ -93,9 +93,11 @@ public class AccountState {
                 : new BigInteger(1, items.get(1).getRLPData());
         this.stateRoot = items.get(2).getRLPData();
         this.codeHash = items.get(3).getRLPData();
-        if (items.size() > 4) {
-            this.stateFlags = RLP.decodeInt(items.get(4).getRLPData(), 0);
 
+        if (items.size() > 4) {
+            byte[] data = items.get(4).getRLPData();
+
+            this.stateFlags = data == null ? 0 : new BigInteger(1, data).intValue();
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/core/AccountState.java
+++ b/rskj-core/src/main/java/org/ethereum/core/AccountState.java
@@ -24,6 +24,7 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
+import org.spongycastle.util.BigIntegers;
 import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
@@ -97,7 +98,7 @@ public class AccountState {
         if (items.size() > 4) {
             byte[] data = items.get(4).getRLPData();
 
-            this.stateFlags = data == null ? 0 : new BigInteger(1, data).intValue();
+            this.stateFlags = data == null ? 0 : BigIntegers.fromUnsignedByteArray(data).intValue();
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/db/TransactionInfo.java
+++ b/rskj-core/src/main/java/org/ethereum/db/TransactionInfo.java
@@ -25,6 +25,7 @@ import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
+import org.spongycastle.util.BigIntegers;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -56,7 +57,7 @@ public class TransactionInfo {
         if (indexRLP.getRLPData() == null)
             index = 0;
         else
-            index = new BigInteger(1, indexRLP.getRLPData()).intValue();
+            index = BigIntegers.fromUnsignedByteArray(indexRLP.getRLPData()).intValue();
     }
 
     public void setTransaction(Transaction tx){

--- a/rskj-core/src/main/java/org/ethereum/db/TransactionInfo.java
+++ b/rskj-core/src/main/java/org/ethereum/db/TransactionInfo.java
@@ -26,6 +26,7 @@ import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 
 /**
@@ -55,7 +56,7 @@ public class TransactionInfo {
         if (indexRLP.getRLPData() == null)
             index = 0;
         else
-            index = RLP.decodeInt(indexRLP.getRLPData(), 0);
+            index = new BigInteger(1, indexRLP.getRLPData()).intValue();
     }
 
     public void setTransaction(Transaction tx){

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
@@ -17,7 +17,7 @@ public class RemascFederationProviderTest {
     @Test
     public void getDefaultFederationSize() throws IOException {
         RemascFederationProvider provider = getRemascFederationProvider();
-        Assert.assertEquals(15, provider.getFederationSize());
+        Assert.assertEquals(3, provider.getFederationSize());
     }
 
     @Test
@@ -31,7 +31,7 @@ public class RemascFederationProviderTest {
     }
 
     private static RemascFederationProvider getRemascFederationProvider() {
-        Genesis genesisBlock = BlockGenerator.getInstance().getGenesisBlock();
+        Genesis genesisBlock = new BlockGenerator().getGenesisBlock();
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setRsk(true).setGenesis(genesisBlock);
         Blockchain blockchain = builder.build();
 

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -67,7 +67,7 @@ public class RemascProcessMinerFeesTest {
         put(cowAddress, cowInitialBalance);
     }};
 
-    private Genesis genesisBlock = (Genesis) BlockGenerator.getInstance().getNewGenesisBlock(initialGasLimit, preMineMap);
+    private Genesis genesisBlock = (Genesis) (new BlockGenerator()).getNewGenesisBlock(initialGasLimit, preMineMap);
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {

--- a/rskj-core/src/test/java/co/rsk/util/RLPTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/RLPTest.java
@@ -831,4 +831,27 @@ public class RLPTest {
             Assert.assertEquals("The current implementation doesn't support lengths longer than Integer.MAX_VALUE because that is the largest number of elements an array can have", ex.getMessage());
         }
     }
+
+    @Test
+    public void encodeDecodeInteger() {
+        for (int k = 0; k < 2048; k++) {
+            Assert.assertEquals(k, RLP.decodeInt(RLP.encodeInt(k), 0));
+        }
+    }
+
+    @Test
+    public void encodeDecodeIntegerInList() {
+        for (int k = 1; k < 2048; k++) {
+            byte[] bytes = RLP.encodeList(RLP.encodeInt(k), new byte[0]);
+            byte[] bytes2 = ((RLPList)(RLP.decode2(bytes).get(0))).get(0).getRLPData();
+            Assert.assertEquals(k, RLP.decodeInt(bytes2, 0));
+        }
+    }
+
+    @Test
+    public void encodeDecodeInteger238InList() {
+        byte[] bytes = RLP.encodeList(RLP.encodeInt(238));
+        byte[] bytes2 = ((RLPList)(RLP.decode2(bytes).get(0))).get(0).getRLPData();
+        Assert.assertEquals(238, RLP.decodeInt(bytes2, 0));
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/util/RLPTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/RLPTest.java
@@ -4,7 +4,9 @@ import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.spongycastle.util.BigIntegers;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -840,6 +842,13 @@ public class RLPTest {
     }
 
     @Test
+    public void encodeDecodeInteger128() {
+        Assert.assertEquals(128, RLP.decodeInt(RLP.encodeInt(128), 0));
+    }
+
+    @Test
+    @Ignore
+    // Known issue, RLP.decodeInt should not be used in this case, to be reviewed
     public void encodeDecodeIntegerInList() {
         for (int k = 1; k < 2048; k++) {
             byte[] bytes = RLP.encodeList(RLP.encodeInt(k), new byte[0]);
@@ -849,9 +858,51 @@ public class RLPTest {
     }
 
     @Test
+    public void encodeDecodeIntegerInListUsingBigInteger() {
+        for (int k = 1; k < 2048; k++) {
+            byte[] bytes = RLP.encodeList(RLP.encodeInt(k), new byte[0]);
+            byte[] bytes2 = ((RLPList)(RLP.decode2(bytes).get(0))).get(0).getRLPData();
+            Assert.assertEquals(k, BigIntegers.fromUnsignedByteArray(bytes2).intValue());
+        }
+    }
+
+    @Test
+    public void encodeDecodeInteger0InList() {
+        byte[] bytes = RLP.encodeList(RLP.encodeInt(0));
+        byte[] bytes2 = ((RLPList)(RLP.decode2(bytes).get(0))).get(0).getRLPData();
+        // known issue, the byte array is null
+        Assert.assertNull(bytes2);
+    }
+
+    @Test
+    @Ignore
+    // Known issue, RLP.decodeInt should not be used in this case, to be reviewed
+    public void encodeDecodeInteger128InList() {
+        byte[] bytes = RLP.encodeList(RLP.encodeInt(128));
+        byte[] bytes2 = ((RLPList)(RLP.decode2(bytes).get(0))).get(0).getRLPData();
+        Assert.assertEquals(128, RLP.decodeInt(bytes2, 0));
+    }
+
+    @Test
+    public void encodeDecodeInteger128InListUsingBigInteger() {
+        byte[] bytes = RLP.encodeList(RLP.encodeInt(128));
+        byte[] bytes2 = ((RLPList)(RLP.decode2(bytes).get(0))).get(0).getRLPData();
+        Assert.assertEquals(128, BigIntegers.fromUnsignedByteArray(bytes2).intValue());
+    }
+
+    @Test
+    @Ignore
+    // Known issue, RLP.decodeInt should not be used in this case, to be reviewed
     public void encodeDecodeInteger238InList() {
         byte[] bytes = RLP.encodeList(RLP.encodeInt(238));
         byte[] bytes2 = ((RLPList)(RLP.decode2(bytes).get(0))).get(0).getRLPData();
         Assert.assertEquals(238, RLP.decodeInt(bytes2, 0));
+    }
+
+    @Test
+    public void encodeDecodeInteger238InListUsingBigInteger() {
+        byte[] bytes = RLP.encodeList(RLP.encodeInt(238));
+        byte[] bytes2 = ((RLPList)(RLP.decode2(bytes).get(0))).get(0).getRLPData();
+        Assert.assertEquals(238, BigIntegers.fromUnsignedByteArray(bytes2).intValue());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/core/AccountStateTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/AccountStateTest.java
@@ -39,4 +39,35 @@ public class AccountStateTest {
         assertEquals(expected, Hex.toHexString(acct.getEncoded()));
     }
 
+    @Test
+    public void encodeDecodeStateWithZeroInStateFlags() {
+        AccountState acct = new AccountState(BigInteger.ZERO, BigInteger.valueOf(2).pow(200));
+        AccountState result = new AccountState(acct.getEncoded());
+
+        assertEquals(BigInteger.ZERO, result.getNonce());
+        assertEquals(BigInteger.valueOf(2).pow(200), result.getBalance());
+        assertEquals(0, result.getStateFlags());
+    }
+
+    @Test
+    public void encodeDecodeStateWith128InStateFlags() {
+        AccountState acct = new AccountState(BigInteger.ZERO, BigInteger.valueOf(2).pow(200));
+        acct.setStateFlags(128);
+        AccountState result = new AccountState(acct.getEncoded());
+
+        assertEquals(BigInteger.ZERO, result.getNonce());
+        assertEquals(BigInteger.valueOf(2).pow(200), result.getBalance());
+        assertEquals(128, result.getStateFlags());
+    }
+
+    @Test
+    public void encodeDecodeStateWith238InStateFlags() {
+        AccountState acct = new AccountState(BigInteger.ZERO, BigInteger.valueOf(2).pow(200));
+        acct.setStateFlags(238);
+        AccountState result = new AccountState(acct.getEncoded());
+
+        assertEquals(BigInteger.ZERO, result.getNonce());
+        assertEquals(BigInteger.valueOf(2).pow(200), result.getBalance());
+        assertEquals(238, result.getStateFlags());
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/db/ReceiptStoreImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/ReceiptStoreImplTest.java
@@ -64,6 +64,42 @@ public class ReceiptStoreImplTest {
     }
 
     @Test
+    public void addAndGetTransactionWith128AsIndex() {
+        ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
+
+        TransactionReceipt receipt = createReceipt();
+        byte[] blockHash = Hex.decode("0102030405060708");
+
+        store.add(blockHash, 128, receipt);
+
+        TransactionInfo result = store.get(receipt.getTransaction().getHash());
+
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getBlockHash());
+        Assert.assertArrayEquals(blockHash, result.getBlockHash());
+        Assert.assertEquals(128, result.getIndex());
+        Assert.assertArrayEquals(receipt.getEncoded(), result.getReceipt().getEncoded());
+    }
+
+    @Test
+    public void addAndGetTransactionWith238AsIndex() {
+        ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
+
+        TransactionReceipt receipt = createReceipt();
+        byte[] blockHash = Hex.decode("0102030405060708");
+
+        store.add(blockHash, 238, receipt);
+
+        TransactionInfo result = store.get(receipt.getTransaction().getHash());
+
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getBlockHash());
+        Assert.assertArrayEquals(blockHash, result.getBlockHash());
+        Assert.assertEquals(238, result.getIndex());
+        Assert.assertArrayEquals(receipt.getEncoded(), result.getReceipt().getEncoded());
+    }
+
+    @Test
     public void addTwoTransactionsAndGetLastTransaction() {
         ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
 


### PR DESCRIPTION
RLP.decodeInt cannot be used over data obtained from a RLPList item

So, it was replaces by  BigIntegers.fromUnsignedByteArray

Some tests were added and marked as ignored, only to reveal the problem with RLP.decodeInt


