### PR TITLE
added coinbase.secret property

### DIFF
--- a/rskj-core/src/main/resources/config/rsk-sample.conf
+++ b/rskj-core/src/main/resources/config/rsk-sample.conf
@@ -61,6 +61,7 @@ peer {
     # Private key of the peer
     # nodeId = <NODE_ID> 
     privateKey = <PRIVATE_KEY>
+    coinbase.secret = <COINBASE_SECRET>
 
     # Network id
     networkId = 777


### PR DESCRIPTION
I was following the [tutorial](https://github.com/rsksmart/rskj/wiki/How-to-initialize-RSK-node-configuration-file-settings) but couldn't find the **<COINBASE_SECRET>** in this sample config. So I added it under **peer**-options and according to my local tests it seems to be working. However, still no sure, if this is the proper place for it. 