### PR TITLE
Fix duplicated logs

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -988,18 +988,6 @@ public class Web3Impl implements Web3 {
             add(new LogFilterEvent(new LogFilterElement(logInfo, b, txIndex, tx, logIdx)));
         }
 
-        void onTransactionReceipt(TransactionReceipt receipt, Block b, int txIndex) {
-            if (logFilter.matchBloom(receipt.getBloomFilter())) {
-                int logIdx = 0;
-                for (LogInfo logInfo : receipt.getLogInfoList()) {
-                    if (logFilter.matchBloom(logInfo.getBloom()) && logFilter.matchesExactly(logInfo)) {
-                        onLogMatch(logInfo, b, txIndex, receipt.getTransaction(), logIdx);
-                    }
-                    logIdx++;
-                }
-            }
-        }
-
         void onTransaction(Transaction tx, Block b, int txIndex) {
             TransactionInfo txInfo = blockchain.getTransactionInfo(tx.getHash());
             TransactionReceipt receipt = txInfo.getReceipt();

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -1008,7 +1008,7 @@ public class Web3Impl implements Web3 {
             for (int i = 0; i < logs.length; i++) {
                 LogInfo logInfo = receipt.getLogInfoList().get(i);
                 if (logFilter.matchesContractAddress(logInfo.getAddress())) {
-                    onTransactionReceipt(receipt, b, txIndex);
+                    onLogMatch(logInfo, b, txIndex, receipt.getTransaction(), i);
                 }
             }
         }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -391,6 +391,7 @@ public class Web3ImplLogsTest {
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
+        String callerAddress = Hex.toHexString(tx2.getContractAddress());
 
         List<Transaction> txs2 = new ArrayList<>();
         txs2.add(tx2);
@@ -403,10 +404,8 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(2, logs.length);
 
-        for (int k = 0; k < 2; k++) {
-            LogFilterElement log = (LogFilterElement)logs[0];
-            Assert.assertEquals("0x" + mainAddress, log.address);
-        }
+        Assert.assertEquals("0x" + mainAddress, ((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + callerAddress, ((LogFilterElement)logs[1]).address);
     }
 
     @Test
@@ -447,6 +446,7 @@ public class Web3ImplLogsTest {
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
+        String callerAddress = Hex.toHexString(tx2.getContractAddress());
 
         List<Transaction> txs2 = new ArrayList<>();
         txs2.add(tx2);
@@ -467,10 +467,9 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(3, logs.length);
 
-        for (int k = 0; k < 3; k++) {
-            LogFilterElement log = (LogFilterElement)logs[0];
-            Assert.assertEquals("0x" + mainAddress, log.address);
-        }
+        Assert.assertEquals("0x" + mainAddress, ((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + callerAddress, ((LogFilterElement)logs[1]).address);
+        Assert.assertEquals("0x" + mainAddress, ((LogFilterElement)logs[2]).address);
     }
 
     private Web3Impl createWeb3(SimpleWorldManager worldManager) {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -401,12 +401,11 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(id);
         Assert.assertNotNull(logs);
-        Assert.assertEquals(4, logs.length);
+        Assert.assertEquals(2, logs.length);
 
-        for (int k = 0; k < 4; k++) {
+        for (int k = 0; k < 2; k++) {
             LogFilterElement log = (LogFilterElement)logs[0];
-            if (k % 2 == 0)
-                Assert.assertEquals("0x" + mainAddress, ((LogFilterElement)log).address);
+            Assert.assertEquals("0x" + mainAddress, log.address);
         }
     }
 
@@ -466,12 +465,11 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(id);
         Assert.assertNotNull(logs);
-        Assert.assertEquals(5, logs.length);
+        Assert.assertEquals(3, logs.length);
 
-        for (int k = 0; k < 5; k++) {
+        for (int k = 0; k < 3; k++) {
             LogFilterElement log = (LogFilterElement)logs[0];
-            if (k % 2 == 0 || k == 4)
-                Assert.assertEquals("0x" + mainAddress, ((LogFilterElement)log).address);
+            Assert.assertEquals("0x" + mainAddress, log.address);
         }
     }
 


### PR DESCRIPTION
The generation of logs in Web3 was fixed. The expected log output was specified using two tests. It was validated againts a TestRPC instance

