### PR TITLE
Change Trie Serialization/Deserialization

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -61,4 +61,10 @@ public interface Trie {
     byte[] serialize();
 
     boolean hasStore();
+
+    boolean hasLongValue();
+
+    byte[] getValueHash();
+
+    byte[] getValue();
 }

--- a/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.trie;
 
 import co.rsk.panic.PanicProcessor;
@@ -26,7 +44,7 @@ import static org.ethereum.crypto.SHA3Helper.sha3;
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
 
 /**
- * NewTrie is the trie node.
+ * TrieImpl is the trie node.
  *
  * Each node have 2, 4 or 16 subnodes (depending on arity variable value)
  * and an optional associated value (a byte array)

--- a/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
@@ -253,8 +253,9 @@ public class TrieImpl implements Trie {
             if (hasLongVal) {
                 byte[] valueHash = new byte[SHA3Helper.DEFAULT_SIZE_BYTES];
 
-                if (istream.read(valueHash) != SHA3Helper.DEFAULT_SIZE_BYTES)
+                if (istream.read(valueHash) != SHA3Helper.DEFAULT_SIZE_BYTES) {
                     throw new EOFException();
+                }
 
                 value = store.retrieveValue(valueHash);
             }
@@ -263,8 +264,9 @@ public class TrieImpl implements Trie {
 
                 if (lvalue > 0) {
                     value = new byte[lvalue];
-                    if (istream.read(value) != lvalue)
+                    if (istream.read(value) != lvalue) {
                         throw new EOFException();
+                    }
                 }
             }
 
@@ -946,7 +948,8 @@ public class TrieImpl implements Trie {
 
         if (trie.sharedPathLength == 0) {
             trieSharedPath = positionPath;
-        } else {
+        }
+        else {
             trieSharedPath = ByteUtils.concatenate(decodePath(trie.encodedSharedPath, trie.arity, trie.sharedPathLength), positionPath);
         }
 
@@ -954,7 +957,8 @@ public class TrieImpl implements Trie {
 
         if (firstChild.sharedPathLength == 0) {
             newSharedPath = trieSharedPath;
-        } else {
+        }
+        else {
             byte[] childSharedPath = decodePath(firstChild.encodedSharedPath, firstChild.arity, firstChild.sharedPathLength);
             newSharedPath = ByteUtils.concatenate(trieSharedPath, childSharedPath);
         }
@@ -976,7 +980,8 @@ public class TrieImpl implements Trie {
 
             if (k >= sharedPath.length) {
                 position += sharedPath.length;
-            } else {
+            }
+            else {
                 return this.split(k).put(key, length, position, value);
             }
         }
@@ -1201,7 +1206,6 @@ public class TrieImpl implements Trie {
             return new TrieImpl(this.store, this.isSecure);
         }
 
-
         Trie newTrie = this.store.retrieve(hash);
 
         if (newTrie == null) {
@@ -1290,6 +1294,7 @@ public class TrieImpl implements Trie {
 
         for (int k = 0; k < lpath; k++) {
             int offset = k % 8;
+
             if (k > 0 && offset == 0) {
                 nbyte++;
             }

--- a/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
@@ -439,6 +439,7 @@ public class TrieImpl implements Trie {
         int nnodes = this.getNodeCount();
         int lshared = this.sharedPathLength;
         int lencoded = getEncodedPathLength(lshared, this.arity);
+        boolean hasLongVal = this.hasLongValue();
 
         int bits = 0;
 
@@ -452,10 +453,10 @@ public class TrieImpl implements Trie {
             bits |= 1 << k;
         }
 
-        ByteBuffer buffer = ByteBuffer.allocate(MESSAGE_HEADER_LENGTH + lencoded + nnodes * SHA3Helper.DEFAULT_SIZE_BYTES + lvalue);
+        ByteBuffer buffer = ByteBuffer.allocate(MESSAGE_HEADER_LENGTH + lencoded + nnodes * SHA3Helper.DEFAULT_SIZE_BYTES + (hasLongVal ? SHA3Helper.DEFAULT_SIZE_BYTES : lvalue));
 
         buffer.put((byte) this.arity);
-        buffer.put((byte) (this.isSecure ? 1 : 0));
+        buffer.put((byte) ((this.isSecure ? 1 : 0) + (hasLongVal ? 2 : 0)));
         buffer.putShort((short) bits);
         buffer.putShort((short) lshared);
 
@@ -474,7 +475,12 @@ public class TrieImpl implements Trie {
         }
 
         if (lvalue > 0) {
-            buffer.put(this.value);
+            if (hasLongVal) {
+                buffer.put(this.getValueHash());
+            }
+            else {
+                buffer.put(this.value);
+            }
         }
 
         return buffer.array();

--- a/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
@@ -488,7 +488,16 @@ public class TrieImpl implements Trie {
         ByteBuffer buffer = ByteBuffer.allocate(MESSAGE_HEADER_LENGTH + lencoded + nnodes * SHA3Helper.DEFAULT_SIZE_BYTES + (hasLongVal ? SHA3Helper.DEFAULT_SIZE_BYTES : lvalue));
 
         buffer.put((byte) this.arity);
-        buffer.put((byte) ((this.isSecure ? 1 : 0) + (hasLongVal ? 2 : 0)));
+
+        byte flags = 0;
+
+        if (this.isSecure)
+            flags |= 1;
+
+        if (hasLongVal)
+            flags |= 2;
+
+        buffer.put(flags);
         buffer.putShort((short) bits);
         buffer.putShort((short) lshared);
 

--- a/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
@@ -1182,6 +1182,20 @@ public class TrieImpl implements Trie {
         return this.store;
     }
 
+    public boolean hasLongValue() {
+        return this.value != null && this.value.length > 32;
+    }
+
+    public byte[] getValueHash() {
+        if (this.hasLongValue()) {
+            return sha3(this.value);
+        }
+
+        return null;
+    }
+
+    public byte[] getValue() { return this.value; }
+
     private static int getEncodedPathLength(int length, int arity) {
         if (arity == 2) {
             return length / 8 + (length % 8 == 0 ? 0 : 1);

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStore.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStore.java
@@ -31,4 +31,6 @@ public interface TrieStore {
     int getRetrieveCount();
 
     byte[] serialize();
+
+    byte[] retrieveValue(byte[] hash);
 }

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -66,6 +66,11 @@ public class TrieStoreImpl implements TrieStore {
     public void save(Trie trie) {
         this.saveCount++;
         this.store.put(trie.getHash(), trie.toMessage());
+
+        if (trie.hasLongValue()) {
+            this.saveCount++;
+            this.store.put(trie.getValueHash(), trie.getValue());
+        }
     }
 
     @Override
@@ -85,6 +90,10 @@ public class TrieStoreImpl implements TrieStore {
         byte[] message = this.store.get(hash);
 
         return TrieImpl.fromMessage(message, this);
+    }
+
+    public byte[] retrieveValue(byte[] hash) {
+        return this.store.get(hash);
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplHashTest.java
@@ -77,33 +77,70 @@ public class SecureTrieImplHashTest {
 
     @Test
     public void triesWithSameKeyValuesHaveSameHash() {
-        Trie trie1 = new TrieImpl(true).put("foo", "bar".getBytes())
+        Trie trie1 = new TrieImpl(true)
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes());
-        Trie trie2 = new TrieImpl(true).put("foo", "bar".getBytes())
+        Trie trie2 = new TrieImpl(true)
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes());
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+    }
+
+    @Test
+    public void triesWithSameKeyLongValuesHaveSameHash() {
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        Trie trie1 = new TrieImpl(true)
+                .put("foo", value1)
+                .put("bar", value2);
+        Trie trie2 = new TrieImpl(true)
+                .put("foo", value1)
+                .put("bar", value2);
 
         Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
     }
 
     @Test
     public void triesWithSameKeyValuesInsertedInDifferentOrderHaveSameHash() {
-        Trie trie1 = new TrieImpl(true).put("foo", "bar".getBytes())
+        Trie trie1 = new TrieImpl(true)
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes());
-        Trie trie2 = new TrieImpl(true).put("bar", "baz".getBytes())
+        Trie trie2 = new TrieImpl(true)
+                .put("bar", "baz".getBytes())
                 .put("foo", "bar".getBytes());
 
         Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
     }
 
     @Test
+    public void triesWithSameKeyLongValuesInsertedInDifferentOrderHaveSameHash() {
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        Trie trie1 = new TrieImpl(true)
+                .put("foo", value1)
+                .put("bar", value2);
+        Trie trie2 = new TrieImpl(true)
+                .put("bar", value2)
+                .put("foo", value1);
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+    }
+
+    @Test
     public void threeTriesWithSameKeyValuesInsertedInDifferentOrderHaveSameHash() {
-        Trie trie1 = new TrieImpl(true).put("foo".getBytes(), "bar".getBytes())
+        Trie trie1 = new TrieImpl(true)
+                .put("foo".getBytes(), "bar".getBytes())
                 .put("bar".getBytes(), "baz".getBytes())
                 .put("baz".getBytes(), "foo".getBytes());
-        Trie trie2 = new TrieImpl(true).put("bar".getBytes(), "baz".getBytes())
+        Trie trie2 = new TrieImpl(true)
+                .put("bar".getBytes(), "baz".getBytes())
                 .put("baz".getBytes(), "foo".getBytes())
                 .put("foo".getBytes(), "bar".getBytes());
-        Trie trie3 = new TrieImpl(true).put("baz".getBytes(), "foo".getBytes())
+        Trie trie3 = new TrieImpl(true)
+                .put("baz".getBytes(), "foo".getBytes())
                 .put("bar".getBytes(), "baz".getBytes())
                 .put("foo".getBytes(), "bar".getBytes());
 
@@ -112,11 +149,48 @@ public class SecureTrieImplHashTest {
     }
 
     @Test
+    public void threeTriesWithSameKeyLongValuesInsertedInDifferentOrderHaveSameHash() {
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(150);
+        byte[] value3 = TrieImplValueTest.makeValue(200);
+
+        Trie trie1 = new TrieImpl(true)
+                .put("foo".getBytes(), value1)
+                .put("bar".getBytes(), value2)
+                .put("baz".getBytes(), value3);
+        Trie trie2 = new TrieImpl(true)
+                .put("bar".getBytes(), value2)
+                .put("baz".getBytes(), value3)
+                .put("foo".getBytes(), value1);
+        Trie trie3 = new TrieImpl(true)
+                .put("baz".getBytes(), value3)
+                .put("bar".getBytes(), value2)
+                .put("foo".getBytes(), value1);
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+        Assert.assertArrayEquals(trie3.getHash(), trie2.getHash());
+    }
+
+    @Test
     public void triesWithDifferentKeyValuesHaveDifferentHashes() {
-        Trie trie1 = new TrieImpl(true).put("foo", "bar".getBytes())
+        Trie trie1 = new TrieImpl(true)
+                .put("foo", "bar".getBytes())
                 .put("bar", "42".getBytes());
-        Trie trie2 = new TrieImpl(true).put("foo", "bar".getBytes())
+        Trie trie2 = new TrieImpl(true)
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes());
+
+        Assert.assertFalse(Arrays.equals(trie1.getHash(), trie2.getHash()));
+    }
+
+    @Test
+    public void triesWithDifferentKeyLongValuesHaveDifferentHashes() {
+        Trie trie1 = new TrieImpl(true)
+                .put("foo", TrieImplValueTest.makeValue(100))
+                .put("bar", TrieImplValueTest.makeValue(110));
+        Trie trie2 = new TrieImpl(true)
+                .put("foo", TrieImplValueTest.makeValue(120))
+                .put("bar", TrieImplValueTest.makeValue(130));
 
         Assert.assertFalse(Arrays.equals(trie1.getHash(), trie2.getHash()));
     }

--- a/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplKeyValueTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplKeyValueTest.java
@@ -43,10 +43,29 @@ public class SecureTrieImplKeyValueTest {
     }
 
     @Test
+    public void putAndGetKeyLongValue() {
+        Trie trie = new TrieImpl(true);
+        byte[] value = TrieImplValueTest.makeValue(100);
+
+        trie = trie.put("foo", value);
+        Assert.assertNotNull(trie.get("foo"));
+        Assert.assertArrayEquals(value, trie.get("foo"));
+    }
+
+    @Test
     public void putKeyValueAndDeleteKey() {
         Trie trie = new TrieImpl(true);
 
         trie = trie.put("foo", "bar".getBytes()).delete("foo");
+        Assert.assertNull(trie.get("foo"));
+    }
+
+    @Test
+    public void putKeyLongValueAndDeleteKey() {
+        Trie trie = new TrieImpl(true);
+        byte[] value = TrieImplValueTest.makeValue(100);
+
+        trie = trie.put("foo", value).delete("foo");
         Assert.assertNull(trie.get("foo"));
     }
 
@@ -57,6 +76,16 @@ public class SecureTrieImplKeyValueTest {
         trie = trie.put("", "bar".getBytes());
         Assert.assertNotNull(trie.get(""));
         Assert.assertArrayEquals("bar".getBytes(), trie.get(""));
+    }
+
+    @Test
+    public void putAndGetEmptyKeyLongValue() {
+        Trie trie = new TrieImpl(true);
+        byte[] value = TrieImplValueTest.makeValue(100);
+
+        trie = trie.put("", value);
+        Assert.assertNotNull(trie.get(""));
+        Assert.assertArrayEquals(value, trie.get(""));
     }
 
     @Test
@@ -74,6 +103,22 @@ public class SecureTrieImplKeyValueTest {
     }
 
     @Test
+    public void putAndGetTwoKeyLongValues() {
+        Trie trie = new TrieImpl(true);
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        trie = trie.put("foo", value1);
+        trie = trie.put("bar", value2);
+
+        Assert.assertNotNull(trie.get("foo"));
+        Assert.assertArrayEquals(value1, trie.get("foo"));
+
+        Assert.assertNotNull(trie.get("bar"));
+        Assert.assertArrayEquals(value2, trie.get("bar"));
+    }
+
+    @Test
     public void putAndGetKeyAndSubKeyValues() {
         Trie trie = new TrieImpl(true);
 
@@ -88,10 +133,27 @@ public class SecureTrieImplKeyValueTest {
     }
 
     @Test
+    public void putAndGetKeyAndSubKeyLongValues() {
+        Trie trie = new TrieImpl(true);
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        trie = trie.put("foo", value1);
+        trie = trie.put("f", value2);
+
+        Assert.assertNotNull(trie.get("foo"));
+        Assert.assertArrayEquals(value1, trie.get("foo"));
+
+        Assert.assertNotNull(trie.get("f"));
+        Assert.assertArrayEquals(value2, trie.get("f"));
+    }
+
+    @Test
     public void putAndGetKeyAndSubKeyValuesInverse() {
         Trie trie = new TrieImpl(true);
 
-        trie = trie.put("f", "42".getBytes())
+        trie = trie
+                .put("f", "42".getBytes())
                 .put("fo", "bar".getBytes());
 
         Assert.assertNotNull(trie.get("fo"));
@@ -99,6 +161,23 @@ public class SecureTrieImplKeyValueTest {
 
         Assert.assertNotNull(trie.get("f"));
         Assert.assertArrayEquals("42".getBytes(), trie.get("f"));
+    }
+
+    @Test
+    public void putAndGetKeyAndSubKeyLongValuesInverse() {
+        Trie trie = new TrieImpl(true);
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        trie = trie
+                .put("f", value1)
+                .put("fo", value2);
+
+        Assert.assertNotNull(trie.get("fo"));
+        Assert.assertArrayEquals(value2, trie.get("fo"));
+
+        Assert.assertNotNull(trie.get("f"));
+        Assert.assertArrayEquals(value1, trie.get("f"));
     }
 
     @Test
@@ -117,6 +196,21 @@ public class SecureTrieImplKeyValueTest {
     }
 
     @Test
+    public void putAndGetOneHundredKeyLongValues() {
+        Trie trie = new TrieImpl(16, true);
+
+        for (int k = 0; k < 100; k++)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 100));
+
+        for (int k = 0; k < 100; k++) {
+            String key = k + "";
+            byte[] expected = TrieImplValueTest.makeValue(k + 100);
+            byte[] value = trie.get(key);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
+    @Test
     public void putAndGetOneHundredKeyValuesUsingBinaryTree() {
         Trie trie = new TrieImpl(true);
 
@@ -128,6 +222,21 @@ public class SecureTrieImplKeyValueTest {
             byte[] expected = key.getBytes();
             byte[] value = trie.get(key);
             Assert.assertArrayEquals(key, value, expected);
+        }
+    }
+
+    @Test
+    public void putAndGetOneHundredKeyLongValuesUsingBinaryTree() {
+        Trie trie = new TrieImpl(true);
+
+        for (int k = 0; k < 100; k++)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 100));
+
+        for (int k = 0; k < 100; k++) {
+            String key = k + "";
+            byte[] expected = TrieImplValueTest.makeValue(k + 100);
+            byte[] value = trie.get(key);
+            Assert.assertArrayEquals(expected, value);
         }
     }
 }

--- a/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplMessageTest.java
@@ -74,6 +74,34 @@ public class SecureTrieImplMessageTest {
     }
 
     @Test
+    public void trieWithLongValueToMessage() {
+        byte[] key = new byte[0];
+        byte[] newKey = sha3(key);
+
+        Trie trie = new TrieImpl(true).put(key, TrieImplValueTest.makeValue(33));
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(70, message.length);
+        Assert.assertEquals(2, message[0]);
+        Assert.assertEquals(3, message[1]);
+        Assert.assertEquals(0, message[2]);
+        Assert.assertEquals(0, message[3]);
+        Assert.assertEquals(1, message[4]);
+        Assert.assertEquals(0, message[5]);
+
+        for (int k = 0; k < newKey.length; k++)
+            Assert.assertEquals(newKey[k], message[6 + k]);
+
+        byte[] valueHash = trie.getValueHash();
+
+        for (int k = 0; k < valueHash.length; k++) {
+            Assert.assertEquals(valueHash[k], message[k + 38]);
+        }
+    }
+
+    @Test
     public void trieWithSubtrieAndNoValueToMessage() {
         byte[] key = new byte[] { 0x02 };
         byte[] newKey = sha3(key);

--- a/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplSaveRetrieveTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplSaveRetrieveTest.java
@@ -49,9 +49,36 @@ public class SecureTrieImplSaveRetrieveTest {
 
         for (int k = 0; k < 1000; k++) {
             String key = k + "";
-            byte[] expected = key.getBytes();
+            byte[] expected = trie.get(key);
             byte[] value = trie2.get(key);
-            Assert.assertArrayEquals(key, value, expected);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
+    @Test
+    public void updateSaveRetrieveAndGetOneThousandKeyLongValues() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(16, store, true);
+
+        for (int k = 0; k < 1000; k++)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertEquals(16, trie2.getArity());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        for (int k = 0; k < 1000; k++) {
+            String key = k + "";
+            byte[] expectedValue = trie.get(key);
+            byte[] value = trie2.get(key);
+            Assert.assertArrayEquals(expectedValue, value);
         }
     }
 
@@ -76,9 +103,36 @@ public class SecureTrieImplSaveRetrieveTest {
 
         for (int k = 0; k < 1000; k++) {
             String key = k + "";
-            byte[] expected = key.getBytes();
+            byte[] expected = trie.get(key);
             byte[] value = trie2.get(key);
-            Assert.assertArrayEquals(key, value, expected);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
+    @Test
+    public void updateSaveRetrieveAndGetOneThousandKeyLongValuesUsingBinaryTree() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true);
+
+        for (int k = 0; k < 1000; k++)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertEquals(2, trie2.getArity());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        for (int k = 0; k < 1000; k++) {
+            String key = k + "";
+            byte[] expected = trie.get(key);
+            byte[] value = trie2.get(key);
+            Assert.assertArrayEquals(expected, value);
         }
     }
 
@@ -101,9 +155,34 @@ public class SecureTrieImplSaveRetrieveTest {
 
         for (int k = 1000; k > 0; k--) {
             String key = k + "";
-            byte[] expected = key.getBytes();
+            byte[] expected = trie.get(key);
             byte[] value = trie2.get(key);
-            Assert.assertArrayEquals(key, value, expected);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
+    @Test
+    public void updateSaveRetrieveAndGetOneThousandKeyLongValuesInverseOrder() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(16, store, true);
+
+        for (int k = 1000; k > 0; k--)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        for (int k = 1000; k > 0; k--) {
+            String key = k + "";
+            byte[] expected = trie.get(key);
+            byte[] value = trie2.get(key);
+            Assert.assertArrayEquals(expected, value);
         }
     }
 
@@ -126,17 +205,44 @@ public class SecureTrieImplSaveRetrieveTest {
 
         for (int k = 1000; k > 0; k--) {
             String key = k + "";
-            byte[] expected = key.getBytes();
+            byte[] expected = trie.get(key);
             byte[] value = trie2.get(key);
-            Assert.assertArrayEquals(key, value, expected);
+            Assert.assertArrayEquals(expected, value);
         }
     }
+
+    @Test
+    public void updateSaveRetrieveAndGetOneThousandKeyLongValuesInverseOrderUsingBinaryTree() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true);
+
+        for (int k = 1000; k > 0; k--)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        for (int k = 1000; k > 0; k--) {
+            String key = k + "";
+            byte[] expected = trie.get(key);
+            byte[] value = trie2.get(key);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
     @Test
     public void saveTrieWithKeyValues() {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(store, true).put("foo", "bar".getBytes())
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes())
                 .put("answer", "42".getBytes());
 
@@ -147,11 +253,28 @@ public class SecureTrieImplSaveRetrieveTest {
     }
 
     @Test
-    public void retrieveTrieWithHash() {
+    public void saveTrieWithKeyLongValues() {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(16, store, true).put("foo", "bar".getBytes())
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", "bar".getBytes())
+                .put("bar", TrieImplValueTest.makeValue(100))
+                .put("answer", TrieImplValueTest.makeValue(200));
+
+        trie.save();
+
+        Assert.assertNotEquals(0, trie.trieSize());
+        Assert.assertEquals(trie.trieSize() + 2, map.keys().size());
+    }
+
+    @Test
+    public void retrieveTrieUsingHash() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(16, store, true)
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes())
                 .put("answer", "42".getBytes());
 
@@ -170,13 +293,62 @@ public class SecureTrieImplSaveRetrieveTest {
     }
 
     @Test
-    public void retrieveTrieWithHashUsingBinaryTree() {
+    public void retrieveTrieWithLongValuesUsingHash() {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(store, true).put("foo", "bar".getBytes())
+        Trie trie = new TrieImpl(16, store, true)
+                .put("foo", "bar".getBytes())
+                .put("bar", TrieImplValueTest.makeValue(100))
+                .put("answer", TrieImplValueTest.makeValue(200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertEquals(16, trie2.getArity());
+        Assert.assertEquals(trie.trieSize(), trie2.trieSize());
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        Assert.assertArrayEquals(trie.get("foo"), trie2.get("foo"));
+        Assert.assertArrayEquals(trie.get("bar"), trie2.get("bar"));
+        Assert.assertArrayEquals(trie.get("answer"), trie2.get("answer"));
+    }
+
+    @Test
+    public void retrieveTrieUsingHashUsingBinaryTree() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes())
                 .put("answer", "42".getBytes());
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertEquals(2, trie2.getArity());
+        Assert.assertEquals(trie.trieSize(), trie2.trieSize());
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        Assert.assertArrayEquals(trie.get("foo"), trie2.get("foo"));
+        Assert.assertArrayEquals(trie.get("bar"), trie2.get("bar"));
+        Assert.assertArrayEquals(trie.get("answer"), trie2.get("answer"));
+    }
+
+    @Test
+    public void retrieveTrieWithLongValuesUsingHashUsingBinaryTree() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", TrieImplValueTest.makeValue(100))
+                .put("bar", TrieImplValueTest.makeValue(200))
+                .put("answer", TrieImplValueTest.makeValue(300));
 
         trie.save();
 

--- a/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplStoreTest.java
@@ -93,7 +93,8 @@ public class SecureTrieImplStoreTest {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(store, true).put("foo", new byte[100]);
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", TrieImplValueTest.makeValue(100));
 
         trie.save();
 
@@ -110,8 +111,8 @@ public class SecureTrieImplStoreTest {
         TrieStoreImpl store = new TrieStoreImpl(map);
 
         Trie trie = new TrieImpl(store, true)
-                .put("foo", new byte[100])
-                .put("bar", new byte[200]);
+                .put("foo", TrieImplValueTest.makeValue(100))
+                .put("bar", TrieImplValueTest.makeValue(200));
 
         trie.save();
 
@@ -127,7 +128,8 @@ public class SecureTrieImplStoreTest {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(store, true).put("foo", "bar".getBytes());
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", "bar".getBytes());
 
         trie.save();
 
@@ -136,6 +138,23 @@ public class SecureTrieImplStoreTest {
         trie.save();
 
         Assert.assertEquals(trie.trieSize(), store.getSaveCount());
+    }
+
+    @Test
+    public void saveFullTrieWithLongValueTwice() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", TrieImplValueTest.makeValue(100));
+
+        trie.save();
+
+        Assert.assertEquals(2, store.getSaveCount());
+
+        trie.save();
+
+        Assert.assertEquals(2, store.getSaveCount());
     }
 
     @Test
@@ -143,7 +162,8 @@ public class SecureTrieImplStoreTest {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(store, true).put("foo", "bar".getBytes());
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", "bar".getBytes());
 
         trie.save();
 
@@ -157,11 +177,31 @@ public class SecureTrieImplStoreTest {
     }
 
     @Test
+    public void saveFullTrieWithLongValueUpdateAndSaveAgainUsingBinaryTrie() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", TrieImplValueTest.makeValue(100));
+
+        trie.save();
+
+        Assert.assertEquals(2, store.getSaveCount());
+
+        trie = trie.put("foo", TrieImplValueTest.makeValue(200));
+
+        trie.save();
+
+        Assert.assertEquals(4, store.getSaveCount());
+    }
+
+    @Test
     public void saveFullTrieUpdateAndSaveAgainUsingArity16() {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(16, store, true).put("foo", "bar".getBytes());
+        Trie trie = new TrieImpl(16, store, true)
+                .put("foo", "bar".getBytes());
 
         trie.save();
 
@@ -172,6 +212,25 @@ public class SecureTrieImplStoreTest {
         trie.save();
 
         Assert.assertEquals(trie.trieSize() + 1, store.getSaveCount());
+    }
+
+    @Test
+    public void saveFullTrieWithLongValueUpdateAndSaveAgainUsingArity16() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(16, store, true)
+                .put("foo", TrieImplValueTest.makeValue(100));
+
+        trie.save();
+
+        Assert.assertEquals(2, store.getSaveCount());
+
+        trie = trie.put("foo", TrieImplValueTest.makeValue(200));
+
+        trie.save();
+
+        Assert.assertEquals(4, store.getSaveCount());
     }
 
     @Test
@@ -187,9 +246,31 @@ public class SecureTrieImplStoreTest {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(store, true).put("bar", "foo".getBytes())
+        Trie trie = new TrieImpl(store, true)
+                .put("bar", "foo".getBytes())
                 .put("foo", "bar".getBytes());
 
+
+        trie.save();
+        int size = trie.trieSize();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertEquals(1, store.getRetrieveCount());
+
+        Assert.assertEquals(size, trie2.trieSize());
+
+        Assert.assertEquals(size, store.getRetrieveCount());
+    }
+
+    @Test
+    public void retrieveTrieWithLongValuesByHash() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true)
+                .put("bar", TrieImplValueTest.makeValue(100))
+                .put("foo", TrieImplValueTest.makeValue(200));
 
         trie.save();
         int size = trie.trieSize();

--- a/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/SecureTrieImplStoreTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.ethereum.crypto.SHA3Helper.sha3;
+
 /**
  * Created by ajlopez on 03/04/2017.
  */
@@ -45,6 +47,32 @@ public class SecureTrieImplStoreTest {
     }
 
     @Test
+    public void saveAndRetrieveTrieNodeWith33BytesValue() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        byte[] key = "foo".getBytes();
+        byte[] value = new byte[33];
+
+        Trie trie = new TrieImpl(store, true).put(key, value);
+
+        store.save(trie);
+
+        Assert.assertEquals(2, map.keys().size());
+        Assert.assertNotNull(map.get(trie.getHash()));
+        Assert.assertArrayEquals(trie.toMessage(), map.get(trie.getHash()));
+
+        Assert.assertEquals(2, store.getSaveCount());
+
+        Trie newTrie = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(newTrie);
+        Assert.assertEquals(1, newTrie.trieSize());
+        Assert.assertNotNull(newTrie.get(key));
+        Assert.assertArrayEquals(value, newTrie.get(key));
+    }
+
+    @Test
     public void saveFullTrie() {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
@@ -58,6 +86,40 @@ public class SecureTrieImplStoreTest {
         Assert.assertArrayEquals(trie.toMessage(), map.get(trie.getHash()));
 
         Assert.assertEquals(trie.trieSize(), store.getSaveCount());
+    }
+
+    @Test
+    public void saveFullTrieWithLongValue() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true).put("foo", new byte[100]);
+
+        trie.save();
+
+        Assert.assertEquals(trie.trieSize() + 1, map.keys().size());
+        Assert.assertNotNull(map.get(trie.getHash()));
+        Assert.assertArrayEquals(trie.toMessage(), map.get(trie.getHash()));
+
+        Assert.assertEquals(trie.trieSize() + 1, store.getSaveCount());
+    }
+
+    @Test
+    public void saveFullTrieWithTwoLongValues() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, true)
+                .put("foo", new byte[100])
+                .put("bar", new byte[200]);
+
+        trie.save();
+
+        Assert.assertEquals(trie.trieSize() + 2, map.keys().size());
+        Assert.assertNotNull(map.get(trie.getHash()));
+        Assert.assertArrayEquals(trie.toMessage(), map.get(trie.getHash()));
+
+        Assert.assertEquals(trie.trieSize() + 2, store.getSaveCount());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplDeleteTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplDeleteTest.java
@@ -22,7 +22,8 @@ public class TrieImplDeleteTest {
 
     @Test
     public void deleteOneValueGivesTheSameHash() {
-        Trie trie1 = new TrieImpl().put("key1", "value1".getBytes())
+        Trie trie1 = new TrieImpl()
+                .put("key1", "value1".getBytes())
                 .put("key2", "value2".getBytes())
                 .delete("key1");
 
@@ -33,7 +34,8 @@ public class TrieImplDeleteTest {
 
     @Test
     public void deleteOneLongValueGivesTheSameHash() {
-        Trie trie1 = new TrieImpl().put("key1", TrieImplValueTest.makeValue(1024))
+        Trie trie1 = new TrieImpl()
+                .put("key1", TrieImplValueTest.makeValue(1024))
                 .put("key2", "value2".getBytes())
                 .delete("key1");
 
@@ -44,7 +46,8 @@ public class TrieImplDeleteTest {
 
     @Test
     public void deleteOneValueTwiceGivesTheSameHash() {
-        Trie trie1 = new TrieImpl().put("key1", "value1".getBytes())
+        Trie trie1 = new TrieImpl()
+                .put("key1", "value1".getBytes())
                 .put("key2", "value2".getBytes())
                 .put("key2", "value2".getBytes())
                 .delete("key1");

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplDeleteTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplDeleteTest.java
@@ -32,6 +32,17 @@ public class TrieImplDeleteTest {
     }
 
     @Test
+    public void deleteOneLongValueGivesTheSameHash() {
+        Trie trie1 = new TrieImpl().put("key1", TrieImplValueTest.makeValue(1024))
+                .put("key2", "value2".getBytes())
+                .delete("key1");
+
+        Trie trie2 = new TrieImpl().put("key2", "value2".getBytes());
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+    }
+
+    @Test
     public void deleteOneValueTwiceGivesTheSameHash() {
         Trie trie1 = new TrieImpl().put("key1", "value1".getBytes())
                 .put("key2", "value2".getBytes())
@@ -62,6 +73,24 @@ public class TrieImplDeleteTest {
     }
 
     @Test
+    public void deleteOneHundredLongValuesGivesTheSameHash() {
+        Trie trie1 = new TrieImpl();
+
+        for (int k = 0; k < 200; k++)
+            trie1 = trie1.put("key" + k, TrieImplValueTest.makeValue(k + 100));
+
+        for (int k = 1; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        Trie trie2 = new TrieImpl();
+
+        for (int k = 0; k < 200; k += 2)
+            trie2 = trie2.put("key" + k, TrieImplValueTest.makeValue(k + 100));
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+    }
+
+    @Test
     public void deleteOneHundredValuesGivesTheSameHashUsingArity16() {
         Trie trie1 = new TrieImpl(16, false);
 
@@ -75,6 +104,24 @@ public class TrieImplDeleteTest {
 
         for (int k = 0; k < 200; k += 2)
             trie2 = trie2.put("key" + k, ("value" + k).getBytes());
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+    }
+
+    @Test
+    public void deleteOneHundredLongValuesGivesTheSameHashUsingArity16() {
+        Trie trie1 = new TrieImpl(16, false);
+
+        for (int k = 0; k < 200; k++)
+            trie1 = trie1.put("key" + k, TrieImplValueTest.makeValue(k + 200));
+
+        for (int k = 1; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        Trie trie2 = new TrieImpl(16, false);
+
+        for (int k = 0; k < 200; k += 2)
+            trie2 = trie2.put("key" + k, TrieImplValueTest.makeValue(k + 200));
 
         Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
     }
@@ -98,6 +145,24 @@ public class TrieImplDeleteTest {
     }
 
     @Test
+    public void deleteOneHundredLongValuesGivesTheSameHashUsingArity16AndSecureKeys() {
+        Trie trie1 = new TrieImpl(16, true);
+
+        for (int k = 0; k < 200; k++)
+            trie1 = trie1.put("key" + k, TrieImplValueTest.makeValue(k + 200));
+
+        for (int k = 1; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        Trie trie2 = new TrieImpl(16, true);
+
+        for (int k = 0; k < 200; k += 2)
+            trie2 = trie2.put("key" + k, TrieImplValueTest.makeValue(k + 200));
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+    }
+
+    @Test
     public void deleteTwoHundredValuesGivesTheEmptyHash() {
         Trie trie1 = new TrieImpl();
 
@@ -111,7 +176,20 @@ public class TrieImplDeleteTest {
     }
 
     @Test
-    public void deleteOneHundredAndOneHundrerValuesGivesTheEmptyHash() {
+    public void deleteTwoHundredLongValuesGivesTheEmptyHash() {
+        Trie trie1 = new TrieImpl();
+
+        for (int k = 0; k < 200; k++)
+            trie1 = trie1.put("key" + k, TrieImplValueTest.makeValue(k + 200));
+
+        for (int k = 0; k < 200; k++)
+            trie1 = trie1.delete("key" + k);
+
+        Assert.assertArrayEquals(makeEmptyHash(), trie1.getHash());
+    }
+
+    @Test
+    public void deleteOneHundredAndOneHundredValuesGivesTheEmptyHash() {
         Trie trie1 = new TrieImpl();
 
         for (int k = 0; k < 200; k++)
@@ -127,7 +205,23 @@ public class TrieImplDeleteTest {
     }
 
     @Test
-    public void deleteOneHundredAndOneHundrerValuesGivesTheEmptyHashUsingArity16() {
+    public void deleteOneHundredAndOneHundredLongValuesGivesTheEmptyHash() {
+        Trie trie1 = new TrieImpl();
+
+        for (int k = 0; k < 200; k++)
+            trie1 = trie1.put("key" + k, TrieImplValueTest.makeValue(k + 200));
+
+        for (int k = 0; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        for (int k = 1; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        Assert.assertArrayEquals(makeEmptyHash(), trie1.getHash());
+    }
+
+    @Test
+    public void deleteOneHundredAndOneHundredValuesGivesTheEmptyHashUsingArity16() {
         Trie trie1 = new TrieImpl(16, false);
 
         for (int k = 0; k < 200; k++)
@@ -143,11 +237,43 @@ public class TrieImplDeleteTest {
     }
 
     @Test
-    public void deleteOneHundredAndOneHundrerValuesGivesTheEmptyHashUsingArity16AndSecureKeys() {
+    public void deleteOneHundredAndOneHundredLongValuesGivesTheEmptyHashUsingArity16() {
+        Trie trie1 = new TrieImpl(16, false);
+
+        for (int k = 0; k < 200; k++)
+            trie1 = trie1.put("key" + k, TrieImplValueTest.makeValue(k + 200));
+
+        for (int k = 0; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        for (int k = 1; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        Assert.assertArrayEquals(makeEmptyHash(), trie1.getHash());
+    }
+
+    @Test
+    public void deleteOneHundredAndOneHundredValuesGivesTheEmptyHashUsingArity16AndSecureKeys() {
         Trie trie1 = new TrieImpl(16, true);
 
         for (int k = 0; k < 200; k++)
             trie1 = trie1.put("key" + k, ("value" + k).getBytes());
+
+        for (int k = 0; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        for (int k = 1; k < 200; k += 2)
+            trie1 = trie1.delete("key" + k);
+
+        Assert.assertArrayEquals(makeEmptyHash(), trie1.getHash());
+    }
+
+    @Test
+    public void deleteOneHundredAndOneHundredLongValuesGivesTheEmptyHashUsingArity16AndSecureKeys() {
+        Trie trie1 = new TrieImpl(16, true);
+
+        for (int k = 0; k < 200; k++)
+            trie1 = trie1.put("key" + k, TrieImplValueTest.makeValue(k + 200));
 
         for (int k = 0; k < 200; k += 2)
             trie1 = trie1.delete("key" + k);

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplHashTest.java
@@ -75,6 +75,15 @@ public class TrieImplHashTest {
     }
 
     @Test
+    public void nonEmptyHashForNonEmptyTrieWithLongValue() {
+        Trie trie = new TrieImpl();
+
+        trie = trie.put("foo".getBytes(), TrieImplValueTest.makeValue(100));
+
+        Assert.assertFalse(Arrays.equals(emptyHash, trie.getHash()));
+    }
+
+    @Test
     public void triesWithSameKeyValuesHaveSameHash() {
         Trie trie1 = new TrieImpl().put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes());
@@ -85,24 +94,51 @@ public class TrieImplHashTest {
     }
 
     @Test
-    public void triesWithSameKeyValuesInsertedInDifferentOrderHaveSameHash() {
+    public void triesWithSameKeyLongValuesHaveSameHash() {
         Trie trie1 = new TrieImpl().put("foo", "bar".getBytes())
+                .put("bar", TrieImplValueTest.makeValue(100));
+        Trie trie2 = new TrieImpl().put("foo", "bar".getBytes())
+                .put("bar", TrieImplValueTest.makeValue(100));
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+    }
+
+    @Test
+    public void triesWithSameKeyValuesInsertedInDifferentOrderHaveSameHash() {
+        Trie trie1 = new TrieImpl()
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes());
-        Trie trie2 = new TrieImpl().put("bar", "baz".getBytes())
+        Trie trie2 = new TrieImpl()
+                .put("bar", "baz".getBytes())
                 .put("foo", "bar".getBytes());
 
         Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
     }
 
     @Test
+    public void triesWithSameKeyLongValuesInsertedInDifferentOrderHaveSameHash() {
+        Trie trie1 = new TrieImpl()
+                .put("foo", TrieImplValueTest.makeValue(100))
+                .put("bar", TrieImplValueTest.makeValue(200));
+        Trie trie2 = new TrieImpl()
+                .put("bar", TrieImplValueTest.makeValue(200))
+                .put("foo", TrieImplValueTest.makeValue(100));
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+    }
+
+    @Test
     public void threeTriesWithSameKeyValuesInsertedInDifferentOrderHaveSameHash() {
-        Trie trie1 = new TrieImpl().put("foo", "bar".getBytes())
+        Trie trie1 = new TrieImpl()
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes())
                 .put("baz", "foo".getBytes());
-        Trie trie2 = new TrieImpl().put("bar", "baz".getBytes())
+        Trie trie2 = new TrieImpl()
+                .put("bar", "baz".getBytes())
                 .put("baz", "foo".getBytes())
                 .put("foo", "bar".getBytes());
-        Trie trie3 = new TrieImpl().put("baz", "foo".getBytes())
+        Trie trie3 = new TrieImpl()
+                .put("baz", "foo".getBytes())
                 .put("bar", "baz".getBytes())
                 .put("foo", "bar".getBytes());
 
@@ -111,11 +147,44 @@ public class TrieImplHashTest {
     }
 
     @Test
+    public void threeTriesWithSameKeyLongValuesInsertedInDifferentOrderHaveSameHash() {
+        Trie trie1 = new TrieImpl()
+                .put("foo", TrieImplValueTest.makeValue(100))
+                .put("bar", TrieImplValueTest.makeValue(200))
+                .put("baz", TrieImplValueTest.makeValue(300));
+        Trie trie2 = new TrieImpl()
+                .put("bar", TrieImplValueTest.makeValue(200))
+                .put("baz", TrieImplValueTest.makeValue(300))
+                .put("foo", TrieImplValueTest.makeValue(100));
+        Trie trie3 = new TrieImpl()
+                .put("baz", TrieImplValueTest.makeValue(300))
+                .put("bar", TrieImplValueTest.makeValue(200))
+                .put("foo", TrieImplValueTest.makeValue(100));
+
+        Assert.assertArrayEquals(trie1.getHash(), trie2.getHash());
+        Assert.assertArrayEquals(trie3.getHash(), trie2.getHash());
+    }
+
+    @Test
     public void triesWithDifferentKeyValuesHaveDifferentHashes() {
-        Trie trie1 = new TrieImpl().put("foo", "bar".getBytes())
+        Trie trie1 = new TrieImpl()
+                .put("foo", "bar".getBytes())
                 .put("bar", "42".getBytes());
-        Trie trie2 = new TrieImpl().put("foo", "bar".getBytes())
+        Trie trie2 = new TrieImpl()
+                .put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes());
+
+        Assert.assertFalse(Arrays.equals(trie1.getHash(), trie2.getHash()));
+    }
+
+    @Test
+    public void triesWithDifferentKeyLongValuesHaveDifferentHashes() {
+        Trie trie1 = new TrieImpl()
+                .put("foo", TrieImplValueTest.makeValue(100))
+                .put("bar", TrieImplValueTest.makeValue(200));
+        Trie trie2 = new TrieImpl()
+                .put("foo", TrieImplValueTest.makeValue(150))
+                .put("bar", TrieImplValueTest.makeValue(250));
 
         Assert.assertFalse(Arrays.equals(trie1.getHash(), trie2.getHash()));
     }

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplKeyValueTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplKeyValueTest.java
@@ -43,10 +43,28 @@ public class TrieImplKeyValueTest {
     }
 
     @Test
+    public void putAndGetKeyLongValue() {
+        Trie trie = new TrieImpl();
+        byte[] value = TrieImplValueTest.makeValue(100);
+
+        trie = trie.put("foo", value);
+        Assert.assertNotNull(trie.get("foo"));
+        Assert.assertArrayEquals(value, trie.get("foo"));
+    }
+
+    @Test
     public void putKeyValueAndDeleteKey() {
         Trie trie = new TrieImpl();
 
         trie = trie.put("foo", "bar".getBytes()).delete("foo");
+        Assert.assertNull(trie.get("foo"));
+    }
+
+    @Test
+    public void putKeyLongValueAndDeleteKey() {
+        Trie trie = new TrieImpl();
+
+        trie = trie.put("foo", TrieImplValueTest.makeValue(100)).delete("foo");
         Assert.assertNull(trie.get("foo"));
     }
 
@@ -57,6 +75,16 @@ public class TrieImplKeyValueTest {
         trie = trie.put("", "bar".getBytes());
         Assert.assertNotNull(trie.get(""));
         Assert.assertArrayEquals("bar".getBytes(), trie.get(""));
+    }
+
+    @Test
+    public void putAndGetEmptyKeyLongValue() {
+        Trie trie = new TrieImpl();
+        byte[] value = TrieImplValueTest.makeValue(100);
+
+        trie = trie.put("", value);
+        Assert.assertNotNull(trie.get(""));
+        Assert.assertArrayEquals(value, trie.get(""));
     }
 
     @Test
@@ -74,6 +102,22 @@ public class TrieImplKeyValueTest {
     }
 
     @Test
+    public void putAndGetTwoKeyLongValues() {
+        Trie trie = new TrieImpl();
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        trie = trie.put("foo", value1);
+        trie = trie.put("bar", value2);
+
+        Assert.assertNotNull(trie.get("foo"));
+        Assert.assertArrayEquals(value1, trie.get("foo"));
+
+        Assert.assertNotNull(trie.get("bar"));
+        Assert.assertArrayEquals(value2, trie.get("bar"));
+    }
+
+    @Test
     public void putAndGetKeyAndSubKeyValues() {
         Trie trie = new TrieImpl();
 
@@ -88,6 +132,22 @@ public class TrieImplKeyValueTest {
     }
 
     @Test
+    public void putAndGetKeyAndSubKeyLongValues() {
+        Trie trie = new TrieImpl();
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        trie = trie.put("foo", value1);
+        trie = trie.put("f", value2);
+
+        Assert.assertNotNull(trie.get("foo"));
+        Assert.assertArrayEquals(value1, trie.get("foo"));
+
+        Assert.assertNotNull(trie.get("f"));
+        Assert.assertArrayEquals(value2, trie.get("f"));
+    }
+
+    @Test
     public void putAndGetKeyAndSubKeyValuesInverse() {
         Trie trie = new TrieImpl();
 
@@ -99,6 +159,22 @@ public class TrieImplKeyValueTest {
 
         Assert.assertNotNull(trie.get("f"));
         Assert.assertArrayEquals("42".getBytes(), trie.get("f"));
+    }
+
+    @Test
+    public void putAndGetKeyAndSubKeyLongValuesInverse() {
+        Trie trie = new TrieImpl();
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        trie = trie.put("f", value1)
+                .put("fo", value2);
+
+        Assert.assertNotNull(trie.get("fo"));
+        Assert.assertArrayEquals(value2, trie.get("fo"));
+
+        Assert.assertNotNull(trie.get("f"));
+        Assert.assertArrayEquals(value1, trie.get("f"));
     }
 
     @Test
@@ -117,6 +193,21 @@ public class TrieImplKeyValueTest {
     }
 
     @Test
+    public void putAndGetOneHundredKeyLongValues() {
+        Trie trie = new TrieImpl(16, false);
+
+        for (int k = 0; k < 100; k++)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 100));
+
+        for (int k = 0; k < 100; k++) {
+            String key = k + "";
+            byte[] expected = TrieImplValueTest.makeValue(k + 100);
+            byte[] value = trie.get(key);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
+    @Test
     public void putAndGetOneHundredKeyValuesUsingBinaryTree() {
         Trie trie = new TrieImpl();
 
@@ -128,6 +219,21 @@ public class TrieImplKeyValueTest {
             byte[] expected = key.getBytes();
             byte[] value = trie.get(key);
             Assert.assertArrayEquals(key, value, expected);
+        }
+    }
+
+    @Test
+    public void putAndGetOneHundredKeyLongValuesUsingBinaryTree() {
+        Trie trie = new TrieImpl();
+
+        for (int k = 0; k < 100; k++)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 100));
+
+        for (int k = 0; k < 100; k++) {
+            String key = k + "";
+            byte[] expected = TrieImplValueTest.makeValue(k + 100);
+            byte[] value = trie.get(key);
+            Assert.assertArrayEquals(expected, value);
         }
     }
 }

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplMessageTest.java
@@ -65,6 +65,28 @@ public class TrieImplMessageTest {
     }
 
     @Test
+    public void trieWithLongValueToMessage() {
+        Trie trie = new TrieImpl().put(new byte[0], new byte[33]);
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(38, message.length);
+        Assert.assertEquals(2, message[0]);
+        Assert.assertEquals(2, message[1]);
+        Assert.assertEquals(0, message[2]);
+        Assert.assertEquals(0, message[3]);
+        Assert.assertEquals(0, message[4]);
+        Assert.assertEquals(0, message[5]);
+
+        byte[] valueHash = trie.getValueHash();
+
+        for (int k = 0; k < valueHash.length; k++) {
+            Assert.assertEquals(valueHash[k], message[k + 6]);
+        }
+    }
+
+    @Test
     public void trieWithSubtrieAndNoValueToMessage() {
         Trie trie = new TrieImpl().put(new byte[] { 0x2 }, new byte[] { 1, 2, 3, 4 });
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplMessageTest.java
@@ -66,7 +66,7 @@ public class TrieImplMessageTest {
 
     @Test
     public void trieWithLongValueToMessage() {
-        Trie trie = new TrieImpl().put(new byte[0], new byte[33]);
+        Trie trie = new TrieImpl().put(new byte[0], TrieImplValueTest.makeValue(33));
 
         byte[] message = trie.toMessage();
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplSaveRetrieveTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplSaveRetrieveTest.java
@@ -49,9 +49,36 @@ public class TrieImplSaveRetrieveTest {
 
         for (int k = 0; k < 1000; k++) {
             String key = k + "";
-            byte[] expected = key.getBytes();
+            byte[] expected = trie.get(key);
             byte[] value = trie2.get(key);
-            Assert.assertArrayEquals(key, value, expected);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
+    @Test
+    public void updateSaveRetrieveAndGetOneThousandKeyLongValues() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(16, store, false);
+
+        for (int k = 0; k < 1000; k++)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertEquals(16, trie2.getArity());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        for (int k = 0; k < 1000; k++) {
+            String key = k + "";
+            byte[] expectedValue = trie.get(key);
+            byte[] value = trie2.get(key);
+            Assert.assertArrayEquals(expectedValue, value);
         }
     }
 
@@ -76,9 +103,36 @@ public class TrieImplSaveRetrieveTest {
 
         for (int k = 0; k < 1000; k++) {
             String key = k + "";
-            byte[] expected = key.getBytes();
+            byte[] expected = trie.get(key);
             byte[] value = trie2.get(key);
-            Assert.assertArrayEquals(key, value, expected);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
+    @Test
+    public void updateSaveRetrieveAndGetOneThousandKeyLongValuesUsingBinaryTree() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, false);
+
+        for (int k = 0; k < 1000; k++)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertEquals(2, trie2.getArity());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        for (int k = 0; k < 1000; k++) {
+            String key = k + "";
+            byte[] expected = trie.get(key);
+            byte[] value = trie2.get(key);
+            Assert.assertArrayEquals(expected, value);
         }
     }
 
@@ -101,9 +155,34 @@ public class TrieImplSaveRetrieveTest {
 
         for (int k = 1000; k > 0; k--) {
             String key = k + "";
-            byte[] expected = key.getBytes();
+            byte[] expected = trie.get(key);
             byte[] value = trie2.get(key);
-            Assert.assertArrayEquals(key, value, expected);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
+    @Test
+    public void updateSaveRetrieveAndGetOneThousandKeyLongValuesInverseOrder() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(16, store, false);
+
+        for (int k = 1000; k > 0; k--)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        for (int k = 1000; k > 0; k--) {
+            String key = k + "";
+            byte[] expected = trie.get(key);
+            byte[] value = trie2.get(key);
+            Assert.assertArrayEquals(expected, value);
         }
     }
 
@@ -126,11 +205,37 @@ public class TrieImplSaveRetrieveTest {
 
         for (int k = 1000; k > 0; k--) {
             String key = k + "";
-            byte[] expected = key.getBytes();
+            byte[] expected = trie.get(key);
             byte[] value = trie2.get(key);
-            Assert.assertArrayEquals(key, value, expected);
+            Assert.assertArrayEquals(expected, value);
         }
     }
+
+    @Test
+    public void updateSaveRetrieveAndGetOneThousandKeyLongValuesInverseOrderUsingBinaryTree() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, false);
+
+        for (int k = 1000; k > 0; k--)
+            trie = trie.put(k + "", TrieImplValueTest.makeValue(k + 200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        for (int k = 1000; k > 0; k--) {
+            String key = k + "";
+            byte[] expected = trie.get(key);
+            byte[] value = trie2.get(key);
+            Assert.assertArrayEquals(expected, value);
+        }
+    }
+
     @Test
     public void saveTrieWithKeyValues() {
         HashMapDB map = new HashMapDB();
@@ -147,7 +252,22 @@ public class TrieImplSaveRetrieveTest {
     }
 
     @Test
-    public void retrieveTrieWithHash() {
+    public void saveTrieWithKeyLongValues() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, false).put("foo", "bar".getBytes())
+                .put("bar", TrieImplValueTest.makeValue(100))
+                .put("answer", TrieImplValueTest.makeValue(200));
+
+        trie.save();
+
+        Assert.assertNotEquals(0, trie.trieSize());
+        Assert.assertEquals(trie.trieSize() + 2, map.keys().size());
+    }
+
+    @Test
+    public void retrieveTrieUsingHash() {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
@@ -170,13 +290,60 @@ public class TrieImplSaveRetrieveTest {
     }
 
     @Test
-    public void retrieveTrieWithHashUsingBinaryTree() {
+    public void retrieveTrieWithLongValuesUsingHash() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(16, store, false).put("foo", "bar".getBytes())
+                .put("bar", TrieImplValueTest.makeValue(100))
+                .put("answer", TrieImplValueTest.makeValue(200));
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertEquals(16, trie2.getArity());
+        Assert.assertEquals(trie.trieSize(), trie2.trieSize());
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        Assert.assertArrayEquals(trie.get("foo"), trie2.get("foo"));
+        Assert.assertArrayEquals(trie.get("bar"), trie2.get("bar"));
+        Assert.assertArrayEquals(trie.get("answer"), trie2.get("answer"));
+    }
+
+    @Test
+    public void retrieveTrieUsingHashUsingBinaryTree() {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
         Trie trie = new TrieImpl(store, false).put("foo", "bar".getBytes())
                 .put("bar", "baz".getBytes())
                 .put("answer", "42".getBytes());
+
+        trie.save();
+
+        Trie trie2 = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(trie2);
+        Assert.assertEquals(2, trie2.getArity());
+        Assert.assertEquals(trie.trieSize(), trie2.trieSize());
+        Assert.assertArrayEquals(trie.getHash(), trie2.getHash());
+
+        Assert.assertArrayEquals(trie.get("foo"), trie2.get("foo"));
+        Assert.assertArrayEquals(trie.get("bar"), trie2.get("bar"));
+        Assert.assertArrayEquals(trie.get("answer"), trie2.get("answer"));
+    }
+
+    @Test
+    public void retrieveTrieWithLongValuesUsingHashUsingBinaryTree() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, false)
+                .put("foo", TrieImplValueTest.makeValue(100))
+                .put("bar", TrieImplValueTest.makeValue(200))
+                .put("answer", TrieImplValueTest.makeValue(300));
 
         trie.save();
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplSerializationTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplSerializationTest.java
@@ -46,8 +46,6 @@ public class TrieImplSerializationTest {
 
         Assert.assertNotNull(bytes);
 
-        byte[] message = trie.toMessage();
-
         ByteArrayInputStream bstream = new ByteArrayInputStream(bytes);
         DataInputStream ostream = new DataInputStream(bstream);
 
@@ -68,8 +66,6 @@ public class TrieImplSerializationTest {
         byte[] bytes = trie.serialize();
 
         Assert.assertNotNull(bytes);
-
-        byte[] message = trie.toMessage();
 
         ByteArrayInputStream bstream = new ByteArrayInputStream(bytes);
         DataInputStream ostream = new DataInputStream(bstream);

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplSerializationTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplSerializationTest.java
@@ -79,6 +79,30 @@ public class TrieImplSerializationTest {
     }
 
     @Test
+    public void serializeTrieWithTwoLongValues() throws IOException {
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        Trie trie = new TrieImpl(new TrieStoreImpl(new HashMapDB()), false)
+                .put("foo".getBytes(), value1)
+                .put("bar".getBytes(), value2);
+
+        byte[] bytes = trie.serialize();
+
+        Assert.assertNotNull(bytes);
+
+        ByteArrayInputStream bstream = new ByteArrayInputStream(bytes);
+        DataInputStream ostream = new DataInputStream(bstream);
+
+        Assert.assertEquals(0, ostream.readShort());
+
+        byte[] root = new byte[SHA3Helper.DEFAULT_SIZE_BYTES];
+        ostream.read(root);
+
+        Assert.assertArrayEquals(trie.getHash(), root);
+    }
+
+    @Test
     public void deserializeEmptyTrie() {
         Trie trie = new TrieImpl(new TrieStoreImpl(new HashMapDB()), false);
 
@@ -110,6 +134,27 @@ public class TrieImplSerializationTest {
     }
 
     @Test
+    public void deserializeTrieWithTwoLongValues() {
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        Trie trie = new TrieImpl(new TrieStoreImpl(new HashMapDB()), false)
+                .put("foo".getBytes(), value1)
+                .put("bar".getBytes(), value2);
+
+        byte[] bytes = trie.serialize();
+
+        Trie result = TrieImpl.deserialize(bytes);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(3, result.trieSize());
+        Assert.assertFalse(Arrays.equals(emptyHash, result.getHash()));
+
+        Assert.assertArrayEquals(value1, result.get("foo".getBytes()));
+        Assert.assertArrayEquals(value2, result.get("bar".getBytes()));
+    }
+
+    @Test
     public void deserializeSecureTrieWithTwoValues() {
         Trie trie = new TrieImpl(new TrieStoreImpl(new HashMapDB()), false)
                 .put("foo".getBytes(), "bar".getBytes())
@@ -125,6 +170,27 @@ public class TrieImplSerializationTest {
 
         Assert.assertArrayEquals("bar".getBytes(), result.get("foo".getBytes()));
         Assert.assertArrayEquals("foo".getBytes(), result.get("bar".getBytes()));
+    }
+
+    @Test
+    public void deserializeSecureTrieWithTwoLongValues() {
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        Trie trie = new TrieImpl(new TrieStoreImpl(new HashMapDB()), false)
+                .put("foo".getBytes(), value1)
+                .put("bar".getBytes(), value2);
+
+        byte[] bytes = trie.serialize();
+
+        Trie result = TrieImpl.deserialize(bytes);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(3, result.trieSize());
+        Assert.assertFalse(Arrays.equals(emptyHash, result.getHash()));
+
+        Assert.assertArrayEquals(value1, result.get("foo".getBytes()));
+        Assert.assertArrayEquals(value2, result.get("bar".getBytes()));
     }
 
     @Test
@@ -147,6 +213,25 @@ public class TrieImplSerializationTest {
     }
 
     @Test
+    public void deserializeTrieWithOneHundredLongValues() {
+        Trie trie = new TrieImpl(new TrieStoreImpl(new HashMapDB()), false);
+
+        for (int k = 0; k < 100; k++)
+            trie = trie.put(("foo" + k).getBytes(), TrieImplValueTest.makeValue(k + 200));
+
+        byte[] bytes = trie.serialize();
+
+        Trie result = TrieImpl.deserialize(bytes);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(trie.trieSize(), result.trieSize());
+        Assert.assertFalse(Arrays.equals(emptyHash, result.getHash()));
+
+        for (int k = 0; k < 100; k++)
+            Assert.assertArrayEquals(TrieImplValueTest.makeValue(k + 200), result.get(("foo" + k).getBytes()));
+    }
+
+    @Test
     public void deserializeSecureTrieWithOneHundredValues() {
         Trie trie = new TrieImpl(new TrieStoreImpl(new HashMapDB()), true);
 
@@ -163,6 +248,25 @@ public class TrieImplSerializationTest {
 
         for (int k = 0; k < 100; k++)
             Assert.assertArrayEquals(("bar" + k).getBytes(), result.get(("foo" + k).getBytes()));
+    }
+
+    @Test
+    public void deserializeSecureTrieWithOneHundredLongValues() {
+        Trie trie = new TrieImpl(new TrieStoreImpl(new HashMapDB()), true);
+
+        for (int k = 0; k < 100; k++)
+            trie = trie.put(("foo" + k).getBytes(), TrieImplValueTest.makeValue(k + 200));
+
+        byte[] bytes = trie.serialize();
+
+        Trie result = TrieImpl.deserialize(bytes);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(trie.trieSize(), result.trieSize());
+        Assert.assertFalse(Arrays.equals(emptyHash, result.getHash()));
+
+        for (int k = 0; k < 100; k++)
+            Assert.assertArrayEquals(TrieImplValueTest.makeValue(k + 200), result.get(("foo" + k).getBytes()));
     }
 
     public static byte[] makeEmptyHash() {

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplSnapshotTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplSnapshotTest.java
@@ -71,6 +71,31 @@ public class TrieImplSnapshotTest {
 
 
     @Test
+    public void getSnapshotToTrieWithLongValues() {
+        TrieStore store = new TrieStoreImpl(new HashMapDB());
+        Trie trie = new TrieImpl(store, false);
+
+        trie = trie.put("foo".getBytes(), TrieImplValueTest.makeValue(100));
+
+        byte[] hash = trie.getHash();
+
+        trie.save();
+
+        trie = trie.put("bar".getBytes(), TrieImplValueTest.makeValue(200));
+
+        Assert.assertNotNull(trie.get("foo".getBytes()));
+        Assert.assertNotNull(trie.get("bar".getBytes()));
+
+        Trie snapshot = trie.getSnapshotTo(hash);
+
+        Assert.assertNotNull(snapshot);
+        Assert.assertArrayEquals(hash, snapshot.getHash());
+
+        Assert.assertNotNull(snapshot.get("foo".getBytes()));
+        Assert.assertNull(snapshot.get("bar".getBytes()));
+    }
+
+    @Test
     public void getSnapshotToTrieUsingDeserializedTrie() {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
         Trie trie = new TrieImpl(store, false);
@@ -92,6 +117,37 @@ public class TrieImplSnapshotTest {
         Assert.assertArrayEquals(hash, snapshot.getHash());
 
         Assert.assertNotNull(snapshot.get("foo".getBytes()));
+        Assert.assertNull(snapshot.get("bar".getBytes()));
+    }
+
+    @Test
+    public void getSnapshotToTrieUsingDeserializedTrieWithLongValues() {
+        byte[] value1 = TrieImplValueTest.makeValue(100);
+        byte[] value2 = TrieImplValueTest.makeValue(200);
+
+        TrieStore store = new TrieStoreImpl(new HashMapDB());
+        Trie trie = new TrieImpl(store, false);
+
+        trie = trie.put("foo".getBytes(), value1);
+
+        byte[] hash = trie.getHash();
+
+        trie.save();
+
+        trie = trie.put("bar".getBytes(), value2);
+
+        Assert.assertNotNull(trie.get("foo".getBytes()));
+        Assert.assertArrayEquals(value1, trie.get("foo".getBytes()));
+        Assert.assertNotNull(trie.get("bar".getBytes()));
+        Assert.assertArrayEquals(value2, trie.get("bar".getBytes()));
+
+        Trie snapshot = TrieImpl.deserialize(trie.serialize()).getSnapshotTo(hash);
+
+        Assert.assertNotNull(snapshot);
+        Assert.assertArrayEquals(hash, snapshot.getHash());
+
+        Assert.assertNotNull(snapshot.get("foo".getBytes()));
+        Assert.assertArrayEquals(value1, snapshot.get("foo".getBytes()));
         Assert.assertNull(snapshot.get("bar".getBytes()));
     }
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplValueTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplValueTest.java
@@ -72,6 +72,7 @@ public class TrieImplValueTest {
 
         Assert.assertTrue(trie.hasLongValue());
         Assert.assertNotNull(trie.getValueHash());
+        Assert.assertEquals(32, trie.getValueHash().length);
         Assert.assertArrayEquals(value, trie.getValue());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplValueTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplValueTest.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.trie;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by ajlopez on 04/12/2017.
+ */
+public class TrieImplValueTest {
+    @Test
+    public void noLongValueInEmptyTrie() {
+        Trie trie = new TrieImpl();
+
+        Assert.assertFalse(trie.hasLongValue());
+        Assert.assertNull(trie.getValueHash());
+        Assert.assertNull(trie.getValue());
+    }
+
+    @Test
+    public void noLongValueInTrieWithShortValue() {
+        byte[] value = new byte[] { 0x01, 0x02, 0x03 };
+        byte[] key = new byte[] { 0x04, 0x05 };
+        Trie trie = new TrieImpl().put(key, value);
+
+        Assert.assertFalse(trie.hasLongValue());
+        Assert.assertNull(trie.getValueHash());
+        Assert.assertArrayEquals(value, trie.getValue());
+    }
+
+    @Test
+    public void noValueInTrieWith32BytesValue() {
+        byte[] value = new byte[32];
+
+        for (int k = 0; k < value.length; k++)
+            value[k] = (byte)(k + 1);
+
+        byte[] key = new byte[] { 0x04, 0x05 };
+        Trie trie = new TrieImpl().put(key, value);
+
+        Assert.assertFalse(trie.hasLongValue());
+        Assert.assertNull(trie.getValueHash());
+        Assert.assertArrayEquals(value, trie.getValue());
+    }
+
+    @Test
+    public void longValueInTrieWith33BytesValue() {
+        byte[] value = new byte[33];
+
+        for (int k = 0; k < value.length; k++)
+            value[k] = (byte)(k + 1);
+
+        byte[] key = new byte[] { 0x04, 0x05 };
+        Trie trie = new TrieImpl().put(key, value);
+
+        Assert.assertTrue(trie.hasLongValue());
+        Assert.assertNotNull(trie.getValueHash());
+        Assert.assertArrayEquals(value, trie.getValue());
+    }
+}
+

--- a/rskj-core/src/test/java/co/rsk/trie/TrieImplValueTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieImplValueTest.java
@@ -47,7 +47,7 @@ public class TrieImplValueTest {
 
     @Test
     public void noValueInTrieWith32BytesValue() {
-        byte[] value = new byte[32];
+        byte[] value = makeValue(32);
 
         for (int k = 0; k < value.length; k++)
             value[k] = (byte)(k + 1);
@@ -62,7 +62,7 @@ public class TrieImplValueTest {
 
     @Test
     public void longValueInTrieWith33BytesValue() {
-        byte[] value = new byte[33];
+        byte[] value = makeValue(33);
 
         for (int k = 0; k < value.length; k++)
             value[k] = (byte)(k + 1);
@@ -74,6 +74,16 @@ public class TrieImplValueTest {
         Assert.assertNotNull(trie.getValueHash());
         Assert.assertEquals(32, trie.getValueHash().length);
         Assert.assertArrayEquals(value, trie.getValue());
+    }
+
+    public static byte[] makeValue(int length) {
+        byte[] value = new byte[length];
+
+        for (int k = 0; k < length; k++) {
+            value[k] = (byte)((k + 1) % 256);
+        }
+
+        return value;
     }
 }
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -130,7 +130,7 @@ public class TrieStoreImplTest {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
 
-        Trie trie = new TrieImpl(store, false).put("foo", new byte[100]);
+        Trie trie = new TrieImpl(store, false).put("foo", TrieImplValueTest.makeValue(100));
 
         trie.save();
 
@@ -147,8 +147,8 @@ public class TrieStoreImplTest {
         TrieStoreImpl store = new TrieStoreImpl(map);
 
         Trie trie = new TrieImpl(store, false)
-                .put("foo", new byte[100])
-                .put("bar", new byte[200]);
+                .put("foo", TrieImplValueTest.makeValue(100))
+                .put("bar", TrieImplValueTest.makeValue(200));
 
         trie.save();
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -84,6 +84,32 @@ public class TrieStoreImplTest {
     }
 
     @Test
+    public void saveAndRetrieveTrieNodeWith33BytesValue() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        byte[] key = sha3("foo".getBytes());
+        byte[] value = new byte[33];
+
+        Trie trie = new TrieImpl(store, false).put(key, value);
+
+        store.save(trie);
+
+        Assert.assertEquals(2, map.keys().size());
+        Assert.assertNotNull(map.get(trie.getHash()));
+        Assert.assertArrayEquals(trie.toMessage(), map.get(trie.getHash()));
+
+        Assert.assertEquals(2, store.getSaveCount());
+
+        Trie newTrie = store.retrieve(trie.getHash());
+
+        Assert.assertNotNull(newTrie);
+        Assert.assertEquals(1, newTrie.trieSize());
+        Assert.assertNotNull(newTrie.get(key));
+        Assert.assertArrayEquals(value, newTrie.get(key));
+    }
+
+    @Test
     public void saveFullTrie() {
         HashMapDB map = new HashMapDB();
         TrieStoreImpl store = new TrieStoreImpl(map);
@@ -97,6 +123,40 @@ public class TrieStoreImplTest {
         Assert.assertArrayEquals(trie.toMessage(), map.get(trie.getHash()));
 
         Assert.assertEquals(trie.trieSize(), store.getSaveCount());
+    }
+
+    @Test
+    public void saveFullTrieWithLongValue() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, false).put("foo", new byte[100]);
+
+        trie.save();
+
+        Assert.assertEquals(trie.trieSize() + 1, map.keys().size());
+        Assert.assertNotNull(map.get(trie.getHash()));
+        Assert.assertArrayEquals(trie.toMessage(), map.get(trie.getHash()));
+
+        Assert.assertEquals(trie.trieSize() + 1, store.getSaveCount());
+    }
+
+    @Test
+    public void saveFullTrieWithTwoLongValues() {
+        HashMapDB map = new HashMapDB();
+        TrieStoreImpl store = new TrieStoreImpl(map);
+
+        Trie trie = new TrieImpl(store, false)
+                .put("foo", new byte[100])
+                .put("bar", new byte[200]);
+
+        trie.save();
+
+        Assert.assertEquals(trie.trieSize() + 2, map.keys().size());
+        Assert.assertNotNull(map.get(trie.getHash()));
+        Assert.assertArrayEquals(trie.toMessage(), map.get(trie.getHash()));
+
+        Assert.assertEquals(trie.trieSize() + 2, store.getSaveCount());
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/core/BlockTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockTest.java
@@ -46,7 +46,7 @@ public class BlockTest {
 
     private static final Logger logger = LoggerFactory.getLogger("test");
 
-    private String GENESIS_STATE_ROOT = "d37ff1381258582a6f793b59a97391324f1a3c555588313d30c8c1dfcc288d32";
+    private String GENESIS_STATE_ROOT = "59c6704f11a243a47899e79ea038c5da46965a81ae75b710d57fab10f82c086f";
 
     static String TEST_GENESIS =
             "{" +
@@ -86,8 +86,11 @@ public class BlockTest {
 
             BigInteger wei = Denomination.valueOf(denom.toUpperCase()).value().multiply(new BigInteger(value));
 
-            AccountState acctState = new AccountState(BigInteger.ZERO, wei);
-            state = state.put(Hex.decode(key.toString()), acctState.getEncoded());
+            AccountState accountState = new AccountState(BigInteger.ZERO, wei);
+            byte[] encodedAccountState = accountState.getEncoded();
+            byte[] accountKey = Hex.decode(key.toString());
+            state = state.put(accountKey, encodedAccountState);
+            Assert.assertArrayEquals(encodedAccountState, state.get(accountKey));
         }
 
         logger.info("root: " + Hex.toHexString(state.getHash()));

--- a/rskj-core/src/test/java/org/ethereum/core/BlockTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockTest.java
@@ -46,8 +46,6 @@ public class BlockTest {
 
     private static final Logger logger = LoggerFactory.getLogger("test");
 
-    private String GENESIS_STATE_ROOT = "59c6704f11a243a47899e79ea038c5da46965a81ae75b710d57fab10f82c086f";
-
     static String TEST_GENESIS =
             "{" +
                     "'0000000000000000000000000000000000000001': { 'wei': '1' }" +
@@ -63,6 +61,8 @@ public class BlockTest {
                     "'6c386a4b26f73c802f34673f7248bb118f97424a': { 'wei': '1606938044258990275541962092341162602522202993782792835301376' }" +
                     "'e4157b34ea9615cfbde6b4fda419828124b70c78': { 'wei': '1606938044258990275541962092341162602522202993782792835301376' }" +
                     "}";
+
+    private String GENESIS_STATE_ROOT = "59c6704f11a243a47899e79ea038c5da46965a81ae75b710d57fab10f82c086f";
 
     static {
         TEST_GENESIS = TEST_GENESIS.replace("'", "\"");


### PR DESCRIPTION
These changes are motivated by issue #265 

Now, long values (with MORE than 32 bytes) are serialized and deserialized using their hashes.

The changes alter the root hashes of the states, and they are oriented only to prevent a future hard fork. The use of a Partial Merkled Tree should be improved, but after planning meeting discussion, it was posponed: they is no use of that class, yet.

Any change out the initial scope, was avoided.

Additional tests was added, and local manual tests were executed, with success. A full devnet test cycle is still pending.



