### PR TITLE
Fix issue in bridge free transaction

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -166,8 +166,9 @@ public class BridgeUtils {
     }
 
     private static boolean isFromFederateMember(org.ethereum.core.Transaction rskTx, Federation federation) {
-        BtcECKey btcKey = BtcECKey.fromPublicOnly(rskTx.getKey().getPubKeyPoint());
-        return federation.hasPublicKey(btcKey);
+        byte[] sender = rskTx.getSender();
+        return federation.getRskPublicKeys().stream()
+                .anyMatch(k -> Arrays.equals(k.getAddress(), sender));
     }
 
     private static boolean isFromFederationChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -166,9 +166,7 @@ public class BridgeUtils {
     }
 
     private static boolean isFromFederateMember(org.ethereum.core.Transaction rskTx, Federation federation) {
-        byte[] sender = rskTx.getSender();
-        return federation.getRskPublicKeys().stream()
-                .anyMatch(k -> Arrays.equals(k.getAddress(), sender));
+        return federation.hasMemberWithRskAddress(rskTx.getSender());
     }
 
     private static boolean isFromFederationChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration) {

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -55,10 +55,11 @@ public final class Federation {
         // Immutability provides protection unless unwanted modification, thus making the Federation instance
         // effectively immutable
         this.publicKeys = Collections.unmodifiableList(publicKeys.stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList()));
-        this.rskPublicKeys = publicKeys.stream()
+        // using this.publicKeys ensures order in rskPublicKeys
+        this.rskPublicKeys = Collections.unmodifiableList(this.publicKeys.stream()
                 .map(BtcECKey::getPubKey)
                 .map(ECKey::fromPublicOnly)
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
         this.creationTime = creationTime;
         this.creationBlockNumber = creationBlockNumber;
         this.btcParams = btcParams;

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -73,10 +73,6 @@ public final class Federation {
         return publicKeys;
     }
 
-    public List<ECKey> getRskPublicKeys() {
-        return rskPublicKeys;
-    }
-
     public int getNumberOfSignaturesRequired() {
         return publicKeys.size() / 2 + 1;
     }
@@ -135,6 +131,11 @@ public final class Federation {
 
     public boolean hasPublicKey(BtcECKey key) {
         return getPublicKeyIndex(key) != null;
+    }
+
+    public boolean hasMemberWithRskAddress(byte[] address) {
+        return rskPublicKeys.stream()
+                .anyMatch(k -> Arrays.equals(k.getAddress(), address));
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
+import org.ethereum.crypto.ECKey;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +47,7 @@ import static org.mockito.Matchers.any;
 public class FederationTest {
     private Federation federation;
     private List<BtcECKey> sortedPublicKeys;
+    private List<byte[]> rskAddresses;
 
     @Before
     public void createFederation() {
@@ -70,6 +72,9 @@ public class FederationTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)),
         }).stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        rskAddresses = sortedPublicKeys.stream()
+                .map(FederationTest::getRskAddressFromBtcKey)
+                .collect(Collectors.toList());
     }
 
     @Test
@@ -297,7 +302,22 @@ public class FederationTest {
     }
 
     @Test
+    public void hasMemberWithRskAddress() {
+        for (int i = 0; i < federation.getPublicKeys().size(); i++) {
+            Assert.assertTrue(federation.hasMemberWithRskAddress(rskAddresses.get(i)));
+        }
+
+        BtcECKey nonFederateKey = BtcECKey.fromPrivate(BigInteger.valueOf(1234));
+        byte[] nonFederateRskAddress = getRskAddressFromBtcKey(nonFederateKey);
+        Assert.assertFalse(federation.hasMemberWithRskAddress(nonFederateRskAddress));
+    }
+
+    @Test
     public void testToString() {
         Assert.assertEquals("4 of 6 signatures federation", federation.toString());
+    }
+
+    private static byte[] getRskAddressFromBtcKey(BtcECKey btcECKey) {
+        return ECKey.fromPublicOnly(btcECKey.getPubKey()).getAddress();
     }
 }


### PR DESCRIPTION
1. Undo a change in `getPublicKeyIndex` because we didn't take into account that the new method also compared the private key.
2. Check sender instead of public key in `isFromFederateMember` because it is more reliable. `ReversibleTransactionExecutor` creates a transaction without signature and that would throw an `NPE` here.
3. Create `Federation.getRskPublicKeys`, which we use to verify federate member's RSK addresses.