### PR TITLE
Feature/rfs 62 multiple release btc (plus rfs 43 & 54)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -21,7 +21,6 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.crypto.Sha3Hash;
 import com.google.common.primitives.UnsignedBytes;
-import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.spongycastle.util.BigIntegers;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -309,13 +309,10 @@ public class BridgeSerializationUtils {
     // [address_1, amount_1, ..., address_n, amount_n]
     // with address_i being the encoded bytes of each btc address
     // and amount_i the RLP-encoded biginteger corresponding to each amount
-    // To preserve order amongst different implementations of lists,
-    // entries are first sorted on the lexicographical order of the
-    // address bytes and then by the amount ascending
-    // (see ReleaseTransactionSet.Entry.DESTINATION_AMOUNT_COMPARATOR)
+    // Order of entries in serialized output is order of the request queue entries
+    // so that we enforce a FIFO policy on release requests.
     public static byte[] serializeReleaseRequestQueue(ReleaseRequestQueue queue) {
         List<ReleaseRequestQueue.Entry> entries = queue.getEntries();
-        entries.sort(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR);
 
         byte[][] bytes = new byte[entries.size() * 2][];
         int n = 0;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -329,8 +329,9 @@ public class BridgeSerializationUtils {
     public static ReleaseRequestQueue deserializeReleaseRequestQueue(byte[] data, NetworkParameters networkParameters) {
         List<ReleaseRequestQueue.Entry> entries = new ArrayList<>();
 
-        if (data == null || data.length == 0)
+        if (data == null || data.length == 0) {
             return new ReleaseRequestQueue(entries);
+        }
 
         RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
 
@@ -379,8 +380,9 @@ public class BridgeSerializationUtils {
     public static ReleaseTransactionSet deserializeReleaseTransactionSet(byte[] data, NetworkParameters networkParameters) {
         Set<ReleaseTransactionSet.Entry> entries = new HashSet<>();
 
-        if (data == null || data.length == 0)
+        if (data == null || data.length == 0) {
             return new ReleaseTransactionSet(entries);
+        }
 
         RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -144,8 +144,9 @@ public class BridgeStorageProvider {
     }
 
     public ReleaseRequestQueue getReleaseRequestQueue() throws IOException {
-        if (releaseRequestQueue != null)
+        if (releaseRequestQueue != null) {
             return releaseRequestQueue;
+        }
 
         releaseRequestQueue = getFromRepository(
                 RELEASE_REQUEST_QUEUE,
@@ -156,15 +157,17 @@ public class BridgeStorageProvider {
     }
 
     public void saveReleaseRequestQueue() {
-        if (releaseRequestQueue == null)
+        if (releaseRequestQueue == null) {
             return;
+        }
 
         safeSaveToRepository(RELEASE_REQUEST_QUEUE, releaseRequestQueue, BridgeSerializationUtils::serializeReleaseRequestQueue);
     }
 
     public ReleaseTransactionSet getReleaseTransactionSet() throws IOException {
-        if (releaseTransactionSet != null)
+        if (releaseTransactionSet != null) {
             return releaseTransactionSet;
+        }
 
         releaseTransactionSet = getFromRepository(
                 RELEASE_TX_SET,
@@ -175,8 +178,9 @@ public class BridgeStorageProvider {
     }
 
     public void saveReleaseTransactionSet() {
-        if (releaseTransactionSet == null)
+        if (releaseTransactionSet == null) {
             return;
+        }
 
         safeSaveToRepository(RELEASE_TX_SET, releaseTransactionSet, BridgeSerializationUtils::serializeReleaseTransactionSet);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1519,7 +1519,7 @@ public class BridgeSupport {
         return btcBlockStore;
     }
 
-    private static Pair<BtcTransaction, List<UTXO>> createMigrationTransaction(Wallet originWallet, Address destinationAddress) {
+    private Pair<BtcTransaction, List<UTXO>> createMigrationTransaction(Wallet originWallet, Address destinationAddress) {
         Coin expectedMigrationValue = originWallet.getBalance();
         for(;;) {
             BtcTransaction migrationBtcTx = new BtcTransaction(originWallet.getParams());
@@ -1527,7 +1527,7 @@ public class BridgeSupport {
 
             SendRequest sr = SendRequest.forTx(migrationBtcTx);
             sr.changeAddress = destinationAddress;
-            sr.feePerKb = Coin.MILLICOIN;
+            sr.feePerKb = getFeePerKb();
             sr.missingSigsMode = Wallet.MissingSigsMode.USE_OP_ZERO;
             sr.recipientsPayFees = true;
             try {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -37,10 +37,8 @@ import org.ethereum.core.Block;
 import org.ethereum.core.Denomination;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
-import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
-import org.ethereum.db.TransactionInfo;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.RLP;
 import org.ethereum.vm.LogInfo;
@@ -57,7 +55,6 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.ethereum.util.BIUtil.toBI;
 import static org.ethereum.util.BIUtil.transfer;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -467,14 +467,14 @@ public class BridgeSupport {
     public void updateCollections(Transaction rskTx) throws IOException {
         Context.propagate(btcContext);
 
-        processFundsMigration(rskTx);
+        processFundsMigration();
 
         processReleaseRequests();
 
         processReleaseTransactions(rskTx);
     }
 
-    private void processFundsMigration(Transaction rskTx) throws IOException {
+    private void processFundsMigration() throws IOException {
         long activeFederationAge = rskExecutionBlock.getNumber() - getFederationCreationBlockNumber();
         Wallet retiringFederationWallet = getRetiringFederationWallet();
         List<UTXO> availableUTXOs = provider.getRetiringFederationBtcUTXOs();

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseRequestQueue.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseRequestQueue.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import com.google.common.primitives.UnsignedBytes;
+import org.ethereum.core.Block;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Representation of a queue of btc release
+ * requests waiting to be processed by the bridge.
+ *
+ * @author Ariel Mendelzon
+ */
+public class ReleaseRequestQueue {
+    public static class Entry {
+        // Compares entries using destination address and then amount order
+        // (address compared on the lexicographical order of its bytes, amount ascending)
+        public static final Comparator<Entry> DESTINATION_AMOUNT_COMPARATOR = new Comparator<Entry>() {
+            private Comparator<byte[]> comparator = UnsignedBytes.lexicographicalComparator();
+
+            @Override
+            public int compare(Entry e1, Entry e2) {
+                int addressComparison = comparator.compare(e1.getDestination().getHash160(), e2.getDestination().getHash160());
+
+                if (addressComparison != 0) {
+                    return addressComparison;
+                }
+
+                return e1.getAmount().compareTo(e2.getAmount());
+            }
+        };
+
+        private Address destination;
+        private Coin amount;
+
+        public Entry(Address destination, Coin amount) {
+            this.destination = destination;
+            this.amount = amount;
+        }
+
+        public Address getDestination() {
+            return destination;
+        }
+
+        public Coin getAmount() {
+            return amount;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || this.getClass() != o.getClass()) {
+                return false;
+            }
+
+            Entry otherEntry = (Entry) o;
+
+            return otherEntry.getDestination().equals(getDestination()) &&
+                    otherEntry.getAmount().equals(getAmount());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.getDestination(), this.getAmount());
+        }
+    }
+
+    public interface Processor {
+        boolean process(Entry entry);
+    }
+
+    private List<Entry> entries;
+
+    public ReleaseRequestQueue(List<Entry> entries) {
+        this.entries = new ArrayList<>(entries);
+    }
+
+    public List<Entry> getEntries() {
+        return new ArrayList<>(entries);
+    }
+
+    public void add(Address destination, Coin amount) {
+        entries.add(new Entry(destination, amount));
+    }
+
+    /**
+     * This methods iterates the requests in the queue
+     * and calls the processor for each. If the
+     * processor returns true, then the item is removed
+     * (i.e., processing was successful). Otherwise
+     * it is kept for future processing.
+     */
+    public void process(Processor processor) {
+        ListIterator<Entry> iterator = entries.listIterator();
+        while (iterator.hasNext()) {
+            boolean result = processor.process(iterator.next());
+            if (result) {
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseRequestQueue.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseRequestQueue.java
@@ -20,9 +20,11 @@ package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.Coin;
-import com.google.common.primitives.UnsignedBytes;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
 
 /**
  * Representation of a queue of btc release

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseRequestQueue.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseRequestQueue.java
@@ -19,13 +19,10 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.Address;
-import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.Coin;
 import com.google.common.primitives.UnsignedBytes;
-import org.ethereum.core.Block;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Representation of a queue of btc release

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseRequestQueue.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseRequestQueue.java
@@ -32,23 +32,6 @@ import java.util.*;
  */
 public class ReleaseRequestQueue {
     public static class Entry {
-        // Compares entries using destination address and then amount order
-        // (address compared on the lexicographical order of its bytes, amount ascending)
-        public static final Comparator<Entry> DESTINATION_AMOUNT_COMPARATOR = new Comparator<Entry>() {
-            private Comparator<byte[]> comparator = UnsignedBytes.lexicographicalComparator();
-
-            @Override
-            public int compare(Entry e1, Entry e2) {
-                int addressComparison = comparator.compare(e1.getDestination().getHash160(), e2.getDestination().getHash160());
-
-                if (addressComparison != 0) {
-                    return addressComparison;
-                }
-
-                return e1.getAmount().compareTo(e2.getAmount());
-            }
-        };
-
         private Address destination;
         private Coin amount;
 

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.wallet.SendRequest;
+import co.rsk.bitcoinj.wallet.Wallet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Given a set of UTXOs, a ReleaseTransactionBuilder
+ * knows how to build a release transaction
+ * of a certain amount to a certain address,
+ * and how to signal the used UTXOs so they
+ * can be invalidated.
+ *
+ * @author Ariel Mendelzon
+ */
+public class ReleaseTransactionBuilder {
+    public class BuildResult {
+        private final BtcTransaction btcTx;
+        private final List<UTXO> selectedUTXOs;
+
+        public BuildResult(BtcTransaction btcTx, List<UTXO> selectedUTXOs) {
+            this.btcTx = btcTx;
+            this.selectedUTXOs = selectedUTXOs;
+        }
+
+        public BtcTransaction getBtcTx() {
+            return btcTx;
+        }
+
+        public List<UTXO> getSelectedUTXOs() {
+            return selectedUTXOs;
+        }
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger("ReleaseTransactionBuilder");
+
+    private final Wallet wallet;
+    private final Address changeAddress;
+    private final Coin feePerKb;
+
+    public ReleaseTransactionBuilder(Wallet wallet, Address changeAddress, Coin feePerKb) {
+        this.wallet = wallet;
+        this.changeAddress = changeAddress;
+        this.feePerKb = feePerKb;
+    }
+
+    public Wallet getWallet() {
+        return wallet;
+    }
+
+    public Address getChangeAddress() {
+        return changeAddress;
+    }
+
+    public Coin getFeePerKb() {
+        return feePerKb;
+    }
+
+    public Optional<BuildResult> build(Address to, Coin amount) {
+        BtcTransaction btcTx = new BtcTransaction(to.getParameters());
+        btcTx.addOutput(amount, to);
+
+        SendRequest sr = SendRequest.forTx(btcTx);
+        sr.feePerKb = feePerKb;
+        sr.missingSigsMode = Wallet.MissingSigsMode.USE_OP_ZERO;
+        sr.changeAddress = changeAddress;
+        sr.shuffleOutputs = false;
+        sr.recipientsPayFees = true;
+
+        try {
+            wallet.completeTx(sr);
+
+            // Disconnect input from output because we don't need the reference and it interferes serialization
+            for (TransactionInput transactionInput : btcTx.getInputs()) {
+                transactionInput.disconnect();
+            }
+
+            List<UTXO> selectedUTXOs = wallet
+                .getUTXOProvider().getOpenTransactionOutputs(wallet.getWatchedAddresses()).stream()
+                .filter(utxo ->
+                    btcTx.getInputs().stream().anyMatch(input ->
+                        input.getOutpoint().getHash().equals(utxo.getHash()) &&
+                        input.getOutpoint().getIndex() == utxo.getIndex()
+                    )
+                )
+                .collect(Collectors.toList());
+
+            return Optional.of(new BuildResult(btcTx, selectedUTXOs));
+        } catch (InsufficientMoneyException e) {
+            logger.warn(String.format("Not enough BTC in the wallet to complete sending %s to %s", amount, to), e);
+            // Comment out panic logging for now
+            // panicProcessor.panic("nomoney", "Not enough confirmed BTC in the federation wallet to complete " + rskTxHash + " " + btcTx);
+            return Optional.empty();
+        } catch (Wallet.CouldNotAdjustDownwards e) {
+            logger.warn(String.format("A user output could not be adjusted downwards to pay tx fees sending %s to %s", amount, to), e);
+            // Comment out panic logging for now
+            // panicProcessor.panic("couldnotadjustdownwards", "A user output could not be adjusted downwards to pay tx fees " + rskTxHash + " " + btcTx);
+            return Optional.empty();
+        } catch (Wallet.ExceededMaxTransactionSize e) {
+            logger.warn(String.format("Tx size too big sending %s to %s", amount, to), e);
+            // Comment out panic logging for now
+            // panicProcessor.panic("exceededmaxtransactionsize", "Tx size too big " + rskTxHash + " " + btcTx);
+            return Optional.empty();
+        } catch (UTXOProviderException e) {
+            logger.warn(String.format("UTXO provider exception sending %s to %s", amount, to), e);
+            // Comment out panic logging for now
+            // panicProcessor.panic("utxoprovider", "UTXO provider exception " + rskTxHash + " " + btcTx);
+            return Optional.empty();
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcTransaction;
+import com.google.common.primitives.UnsignedBytes;
+import org.ethereum.core.Block;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Representation of a queue of BTC release
+ * transactions waiting for confirmations
+ * on the rsk network.
+ *
+ * @author Ariel Mendelzon
+ */
+public class ReleaseTransactionSet {
+    public static class Entry {
+        // Compares entries using the lexicographical order of the btc tx's serialized bytes
+        public static final Comparator<Entry> BTC_TX_COMPARATOR = new Comparator<Entry>() {
+            private Comparator<byte[]> comparator = UnsignedBytes.lexicographicalComparator();
+
+            @Override
+            public int compare(Entry e1, Entry e2) {
+                return comparator.compare(e1.getTransaction().bitcoinSerialize(), e2.getTransaction().bitcoinSerialize());
+            }
+        };
+
+        private BtcTransaction transaction;
+        private Long rskBlockNumber;
+
+        public Entry(BtcTransaction transaction, Long rskBlockNumber) {
+            this.transaction = transaction;
+            this.rskBlockNumber = rskBlockNumber;
+        }
+
+        public BtcTransaction getTransaction() {
+            return transaction;
+        }
+
+        public Long getRskBlockNumber() {
+            return rskBlockNumber;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || this.getClass() != o.getClass()) {
+                return false;
+            }
+
+            Entry otherEntry = (Entry) o;
+            return otherEntry.getTransaction().equals(getTransaction()) &&
+                    otherEntry.getRskBlockNumber().equals(getRskBlockNumber());
+         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getTransaction(), getRskBlockNumber());
+        }
+    }
+
+    private Set<Entry> entries;
+
+    public ReleaseTransactionSet(Set<Entry> entries) {
+        this.entries = new HashSet<>(entries);
+    }
+
+    public Set<Entry> getEntries() {
+        return new HashSet<>(entries);
+    }
+
+    public void add(BtcTransaction transaction, Block rskBlock) {
+        entries.add(new Entry(transaction, rskBlock.getNumber()));
+    }
+
+    public Set<BtcTransaction> sliceWithConfirmations(Block rskBlock, Long minimumConfirmations) {
+        Set<BtcTransaction> output = entries.stream()
+            .filter(e -> hasEnoughConfirmations(e, rskBlock, minimumConfirmations))
+            .map(e -> e.getTransaction())
+            .collect(Collectors.toSet());
+
+        entries.removeIf(e -> hasEnoughConfirmations(e, rskBlock, minimumConfirmations));
+
+        return output;
+    }
+
+    private boolean hasEnoughConfirmations(Entry entry, Block rskBlock, Long minimumConfirmations) {
+        return (rskBlock.getNumber() - entry.getRskBlockNumber()) >= minimumConfirmations;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
@@ -89,7 +89,10 @@ public class ReleaseTransactionSet {
     }
 
     public void add(BtcTransaction transaction, Long blockNumber) {
-        entries.add(new Entry(transaction, blockNumber));
+        // Disallow duplicate transactions
+        if (!entries.stream().anyMatch(e -> e.getTransaction().equals(transaction))) {
+            entries.add(new Entry(transaction, blockNumber));
+        }
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
@@ -20,11 +20,8 @@ package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
 import com.google.common.primitives.UnsignedBytes;
-import org.ethereum.core.Block;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Representation of a queue of BTC release

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -595,14 +595,14 @@ public class BridgeSerializationUtilsTest {
         byte[] result = BridgeSerializationUtils.serializeReleaseRequestQueue(sample);
         String hexResult = Hex.toHexString(result);
         StringBuilder expectedBuilder = new StringBuilder();
-        expectedBuilder.append("ddaa");
-        expectedBuilder.append("ff1e");
-        expectedBuilder.append("ddbb");
-        expectedBuilder.append("ff14");
-        expectedBuilder.append("ddbb");
-        expectedBuilder.append("ff32");
         expectedBuilder.append("ddccdd");
         expectedBuilder.append("ff0a");
+        expectedBuilder.append("ddbb");
+        expectedBuilder.append("ff32");
+        expectedBuilder.append("ddbb");
+        expectedBuilder.append("ff14");
+        expectedBuilder.append("ddaa");
+        expectedBuilder.append("ff1e");
         assertEquals(expectedBuilder.toString(), hexResult);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStateTest.java
@@ -45,7 +45,6 @@ public class BridgeStateTest {
         Assert.assertEquals(42, clone.getBtcBlockchainBestChainHeight());
         Assert.assertTrue(clone.getBtcTxHashesAlreadyProcessed().isEmpty());
         Assert.assertTrue(clone.getActiveFederationBtcUTXOs().isEmpty());
-        Assert.assertTrue(clone.getRskTxsWaitingForConfirmations().isEmpty());
         Assert.assertTrue(clone.getRskTxsWaitingForSignatures().isEmpty());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -67,10 +67,15 @@ public class BridgeStorageProviderTest {
         Assert.assertNotNull(processed);
         Assert.assertTrue(processed.isEmpty());
 
-        SortedMap<Sha3Hash, BtcTransaction> confirmations = provider.getRskTxsWaitingForConfirmations();
+        ReleaseRequestQueue releaseRequestQueue = provider.getReleaseRequestQueue();
 
-        Assert.assertNotNull(confirmations);
-        Assert.assertTrue(confirmations.isEmpty());
+        Assert.assertNotNull(releaseRequestQueue);
+        Assert.assertEquals(0, releaseRequestQueue.getEntries().size());
+
+        ReleaseTransactionSet releaseTransactionSet = provider.getReleaseTransactionSet();
+
+        Assert.assertNotNull(releaseTransactionSet);
+        Assert.assertEquals(0, releaseTransactionSet.getEntries().size());
 
         SortedMap<Sha3Hash, BtcTransaction> signatures = provider.getRskTxsWaitingForSignatures();
 
@@ -90,7 +95,8 @@ public class BridgeStorageProviderTest {
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
         provider0.getBtcTxHashesAlreadyProcessed();
-        provider0.getRskTxsWaitingForConfirmations();
+        provider0.getReleaseRequestQueue();
+        provider0.getReleaseTransactionSet();
         provider0.getRskTxsWaitingForSignatures();
         provider0.getActiveFederationBtcUTXOs();
         provider0.getRetiringFederationBtcUTXOs();
@@ -103,7 +109,8 @@ public class BridgeStorageProviderTest {
 
         Assert.assertNotNull(repository.getContractDetails(contractAddress));
         Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("btcTxHashesAP".getBytes())));
-        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("rskTxsWaitingFC".getBytes())));
+        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("releaseRequestQueue".getBytes())));
+        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("releaseTransactionSet".getBytes())));
         Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("rskTxsWaitingFS".getBytes())));
         Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("activeFederationBtcUTXOs".getBytes())));
         Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("retiringFederationBtcUTXOs".getBytes())));
@@ -115,10 +122,15 @@ public class BridgeStorageProviderTest {
         Assert.assertNotNull(processed);
         Assert.assertTrue(processed.isEmpty());
 
-        SortedMap<Sha3Hash, BtcTransaction> confirmations = provider.getRskTxsWaitingForConfirmations();
+        ReleaseRequestQueue releaseRequestQueue = provider.getReleaseRequestQueue();
 
-        Assert.assertNotNull(confirmations);
-        Assert.assertTrue(confirmations.isEmpty());
+        Assert.assertNotNull(releaseRequestQueue);
+        Assert.assertEquals(0, releaseRequestQueue.getEntries().size());
+
+        ReleaseTransactionSet releaseTransactionSet = provider.getReleaseTransactionSet();
+
+        Assert.assertNotNull(releaseTransactionSet);
+        Assert.assertEquals(0, releaseTransactionSet.getEntries().size());
 
         SortedMap<Sha3Hash, BtcTransaction> signatures = provider.getRskTxsWaitingForSignatures();
 
@@ -159,43 +171,6 @@ public class BridgeStorageProviderTest {
 
         Assert.assertTrue(processedHashes.contains(hash1));
         Assert.assertTrue(processedHashes.contains(hash2));
-    }
-
-    @Test
-    public void createSaveAndRecreateInstanceWithTxsWaitingForConfirmations() throws IOException {
-        BtcTransaction tx1 = createTransaction();
-        BtcTransaction tx2 = createTransaction();
-        BtcTransaction tx3 = createTransaction();
-        Sha3Hash hash1 = PegTestUtils.createHash3();
-        Sha3Hash hash2 = PegTestUtils.createHash3();
-        Sha3Hash hash3 = PegTestUtils.createHash3();
-
-        Repository repository = new RepositoryImpl();
-        Repository track = repository.startTracking();
-
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
-        provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
-        provider0.getRskTxsWaitingForConfirmations().put(hash2, tx2);
-        provider0.getRskTxsWaitingForConfirmations().put(hash3, tx3);
-
-        provider0.save();
-        track.commit();
-
-        track = repository.startTracking();
-
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
-
-        SortedMap<Sha3Hash, BtcTransaction> confirmations = provider.getRskTxsWaitingForConfirmations();
-
-        Assert.assertNotNull(confirmations);
-
-        Assert.assertTrue(confirmations.containsKey(hash1));
-        Assert.assertTrue(confirmations.containsKey(hash2));
-        Assert.assertTrue(confirmations.containsKey(hash3));
-
-        Assert.assertEquals(tx1.getHash(), confirmations.get(hash1).getHash());
-        Assert.assertEquals(tx2.getHash(), confirmations.get(hash2).getHash());
-        Assert.assertEquals(tx3.getHash(), confirmations.get(hash3).getHash());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -547,6 +547,70 @@ public class BridgeStorageProviderTest {
         Assert.assertEquals(1, serializeCalls.size());
     }
 
+    @PrepareForTest({ BridgeSerializationUtils.class })
+    @Test
+    public void getReleaseRequestQueue() throws IOException {
+        List<Integer> calls = new ArrayList<>();
+        ReleaseRequestQueue requestQueueMock = mock(ReleaseRequestQueue.class);
+        PowerMockito.mockStatic(BridgeSerializationUtils.class);
+        Repository repositoryMock = mock(Repository.class);
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, "aabbccdd");
+
+        when(repositoryMock.getStorageBytes(any(byte[].class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
+            calls.add(0);
+            byte[] contractAddress = invocation.getArgumentAt(0, byte[].class);
+            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            // Make sure the bytes are got from the correct address in the repo
+            Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress));
+            Assert.assertEquals(new DataWord("releaseRequestQueue".getBytes(StandardCharsets.UTF_8)), address);
+            return new byte[]{(byte)0xaa};
+        });
+        PowerMockito.when(BridgeSerializationUtils.deserializeReleaseRequestQueue(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
+            calls.add(0);
+            byte[] data = invocation.getArgumentAt(0, byte[].class);
+            NetworkParameters parameters = invocation.getArgumentAt(1, NetworkParameters.class);
+            Assert.assertEquals(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), parameters);
+            // Make sure we're deserializing what just came from the repo
+            Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa}, data));
+            return requestQueueMock;
+        });
+
+        Assert.assertSame(requestQueueMock, storageProvider.getReleaseRequestQueue());
+        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes
+    }
+
+    @PrepareForTest({ BridgeSerializationUtils.class })
+    @Test
+    public void getReleaseTransactionSet() throws IOException {
+        List<Integer> calls = new ArrayList<>();
+        ReleaseTransactionSet transactionSetMock = mock(ReleaseTransactionSet.class);
+        PowerMockito.mockStatic(BridgeSerializationUtils.class);
+        Repository repositoryMock = mock(Repository.class);
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, "aabbccdd");
+
+        when(repositoryMock.getStorageBytes(any(byte[].class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
+            calls.add(0);
+            byte[] contractAddress = invocation.getArgumentAt(0, byte[].class);
+            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            // Make sure the bytes are got from the correct address in the repo
+            Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress));
+            Assert.assertEquals(new DataWord("releaseTransactionSet".getBytes(StandardCharsets.UTF_8)), address);
+            return new byte[]{(byte)0xaa};
+        });
+        PowerMockito.when(BridgeSerializationUtils.deserializeReleaseTransactionSet(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
+            calls.add(0);
+            byte[] data = invocation.getArgumentAt(0, byte[].class);
+            NetworkParameters parameters = invocation.getArgumentAt(1, NetworkParameters.class);
+            Assert.assertEquals(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), parameters);
+            // Make sure we're deserializing what just came from the repo
+            Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa}, data));
+            return transactionSetMock;
+        });
+
+        Assert.assertSame(transactionSetMock, storageProvider.getReleaseTransactionSet());
+        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes
+    }
+
     private BtcTransaction createTransaction() {
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addInput(PegTestUtils.createHash(), transactionOffset++, ScriptBuilder.createInputScript(new TransactionSignature(BigInteger.ONE, BigInteger.TEN)));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -268,24 +268,16 @@ public class BridgeSupportTest {
     public void callUpdateCollectionsFundsEnoughForJustTheSmallerTx() throws IOException, BlockStoreException {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        BtcTransaction tx1 = new BtcTransaction(btcParams);
-        tx1.addOutput(Coin.valueOf(30,0), new BtcECKey().toAddress(btcParams));
-        BtcTransaction tx2 = new BtcTransaction(btcParams);
-        tx2.addOutput(Coin.valueOf(20,0), new BtcECKey().toAddress(btcParams));
-        BtcTransaction tx3 = new BtcTransaction(btcParams);
-        tx3.addOutput(Coin.valueOf(10,0), new BtcECKey().toAddress(btcParams));
-        Sha3Hash hash1 = PegTestUtils.createHash3();
-        Sha3Hash hash2 = PegTestUtils.createHash3();
-        Sha3Hash hash3 = PegTestUtils.createHash3();
 
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
-        provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
-        provider0.getRskTxsWaitingForConfirmations().put(hash2, tx2);
-        provider0.getRskTxsWaitingForConfirmations().put(hash3, tx3);
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(30,0));
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(20,0));
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(10,0));
+
         provider0.getActiveFederationBtcUTXOs().add(new UTXO(
                 PegTestUtils.createHash(),
                 1,
@@ -302,27 +294,10 @@ public class BridgeSupportTest {
         track = repository.startTracking();
 
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
-        TransactionReceipt receipt1 = new TransactionReceipt();
-        org.ethereum.core.Transaction rskTx1 = new SimpleRskTransaction(hash1.getBytes());
-        receipt1.setTransaction(rskTx1);
-        TransactionInfo ti1 = new TransactionInfo(receipt1, blocks.get(1).getHash(), 0);
-        TransactionReceipt receipt2 = new TransactionReceipt();
-        org.ethereum.core.Transaction rskTx2 = new SimpleRskTransaction(hash2.getBytes());
-        receipt2.setTransaction(rskTx2);
-        TransactionInfo ti2 = new TransactionInfo(receipt2, blocks.get(1).getHash(), 1);
-        TransactionReceipt receipt3 = new TransactionReceipt();
-        org.ethereum.core.Transaction rskTx3 = new SimpleRskTransaction(hash3.getBytes());
-        receipt3.setTransaction(rskTx3);
-        TransactionInfo ti3 = new TransactionInfo(receipt3, blocks.get(1).getHash(), 2);
-
-        List<TransactionInfo> tis = Lists.newArrayList(ti1, ti2, ti3);
 
         BlockChainBuilder builder = new BlockChainBuilder();
 
-        Blockchain blockchain = builder.setTesting(true).setRsk(true).setTransactionInfos(tis).setGenesis(BlockGenerator.getInstance().getGenesisBlock()).build();
-
-        for (Block block : blocks)
-            blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
+        Blockchain blockchain = builder.setTesting(true).setRsk(true).setGenesis(BlockGenerator.getInstance().getGenesisBlock()).build();
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
         ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
@@ -339,26 +314,24 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(2, provider.getRskTxsWaitingForConfirmations().size());
-        Assert.assertEquals(1, provider.getRskTxsWaitingForSignatures().size());
+        Assert.assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
         // Check value sent to user is 10 BTC minus fee
-        Assert.assertEquals(Coin.valueOf(999962800l), provider.getRskTxsWaitingForSignatures().values().iterator().next().getOutput(0).getValue());
+        Assert.assertEquals(Coin.valueOf(999962800l), provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction().getOutput(0).getValue());
     }
 
     @Test
     public void callUpdateCollectionsThrowsCouldNotAdjustDownwards() throws IOException, BlockStoreException {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        BtcTransaction tx1 = new BtcTransaction(btcParams);
-        tx1.addOutput(Coin.valueOf(37500), new BtcECKey().toAddress(btcParams));
-        Sha3Hash hash1 = PegTestUtils.createHash3();
 
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
-        provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(37500));
         provider0.getActiveFederationBtcUTXOs().add(new UTXO(
                 PegTestUtils.createHash(),
                 1,
@@ -375,15 +348,9 @@ public class BridgeSupportTest {
         track = repository.startTracking();
 
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
-        TransactionReceipt receipt1 = new TransactionReceipt();
-        org.ethereum.core.Transaction rskTx1 = new SimpleRskTransaction(hash1.getBytes());
-        receipt1.setTransaction(rskTx1);
-        TransactionInfo ti1 = new TransactionInfo(receipt1, blocks.get(1).getHash(), 0);
-
-        List<TransactionInfo> tis = Lists.newArrayList(ti1);
         BlockChainBuilder builder = new BlockChainBuilder();
 
-        Blockchain blockchain = builder.setTesting(true).setRsk(true).setTransactionInfos(tis).build();
+        Blockchain blockchain = builder.setTesting(true).setRsk(true).build();
 
 
         for (Block block : blocks)
@@ -404,7 +371,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(1, provider.getRskTxsWaitingForConfirmations().size());
+        Assert.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
     }
 
@@ -412,16 +379,13 @@ public class BridgeSupportTest {
     public void callUpdateCollectionsThrowsExceededMaxTransactionSize() throws IOException, BlockStoreException {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        BtcTransaction tx1 = new BtcTransaction(btcParams);
-        tx1.addOutput(Coin.COIN.multiply(7), new BtcECKey().toAddress(btcParams));
-        Sha3Hash hash1 = PegTestUtils.createHash3();
 
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
-        provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.COIN.multiply(7));
         for (int i = 0; i < 2000; i++) {
             provider0.getActiveFederationBtcUTXOs().add(new UTXO(
                     PegTestUtils.createHash(),
@@ -440,15 +404,9 @@ public class BridgeSupportTest {
         track = repository.startTracking();
 
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
-        TransactionReceipt receipt1 = new TransactionReceipt();
-        org.ethereum.core.Transaction rskTx1 = new SimpleRskTransaction(hash1.getBytes());
-        receipt1.setTransaction(rskTx1);
-        TransactionInfo ti1 = new TransactionInfo(receipt1, blocks.get(1).getHash(), 0);
-
-        List<TransactionInfo> tis = Lists.newArrayList(ti1);
         BlockChainBuilder builder = new BlockChainBuilder();
 
-        Blockchain blockchain = builder.setTesting(true).setRsk(true).setTransactionInfos(tis).build();
+        Blockchain blockchain = builder.setTesting(true).setRsk(true).build();
 
         for (Block block : blocks)
             blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
@@ -468,7 +426,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(1, provider.getRskTxsWaitingForConfirmations().size());
+        Assert.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
     }
 
@@ -476,9 +434,6 @@ public class BridgeSupportTest {
     public void callUpdateCollectionsChangeGetsOutOfDust() throws IOException, BlockStoreException {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        BtcTransaction tx1 = new BtcTransaction(btcParams);
-        tx1.addOutput(Coin.COIN, new BtcECKey().toAddress(btcParams));
-        Sha3Hash hash1 = PegTestUtils.createHash3();
 
         Map<byte[], BigInteger> preMineMap = new HashMap<byte[], BigInteger>();
         preMineMap.put(Hex.decode(PrecompiledContracts.BRIDGE_ADDR), Denomination.satoshisToWeis(BigInteger.valueOf(21000000)));
@@ -487,15 +442,9 @@ public class BridgeSupportTest {
 
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(genesisBlock, 10);
 
-        TransactionReceipt receipt1 = new TransactionReceipt();
-        org.ethereum.core.Transaction rskTx1 = new SimpleRskTransaction(hash1.getBytes());
-        receipt1.setTransaction(rskTx1);
-        TransactionInfo ti1 = new TransactionInfo(receipt1, blocks.get(1).getHash(), 0);
-
-        List<TransactionInfo> tis = Lists.newArrayList(ti1);
         BlockChainBuilder builder = new BlockChainBuilder();
 
-        Blockchain blockchain = builder.setTesting(true).setRsk(true).setTransactionInfos(tis).setGenesis(genesisBlock).build();
+        Blockchain blockchain = builder.setTesting(true).setRsk(true).setGenesis(genesisBlock).build();
 
         for (Block block : blocks)
             blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
@@ -509,7 +458,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
-        provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.COIN);
         provider0.getActiveFederationBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.COIN.add(Coin.valueOf(100)), 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
 
         provider0.save();
@@ -529,15 +478,16 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(0, provider.getRskTxsWaitingForConfirmations().size());
-        Assert.assertEquals(1, provider.getRskTxsWaitingForSignatures().size());
+        Assert.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
         Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(21000000-2600)), repository.getBalance(Hex.decode(PrecompiledContracts.BRIDGE_ADDR)));
         Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(2600)), repository.getBalance(RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBurnAddress()));
     }
 
     @PrepareForTest({ BridgeUtils.class })
     @Test
-    public void callUpdateCollectionsWithTransactionsWaitingForConfirmationWithEnoughConfirmationsAndFunds() throws IOException, BlockStoreException {
+    public void callUpdateCollectionsWithTransactionsWaitingForConfirmationWithEnoughConfirmations() throws IOException, BlockStoreException {
         // Bridge constants and btc context
         BridgeConstants bridgeConstants = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         Context context = new Context(bridgeConstants.getBtcParams());
@@ -546,21 +496,29 @@ public class BridgeSupportTest {
         PowerMockito.mockStatic(BridgeUtils.class);
         PowerMockito.when(BridgeUtils.getFederationSpendWallet(any(Context.class), any(Federation.class), any(List.class))).thenReturn(new SimpleWallet(context));
 
-        BtcTransaction tx1 = createTransaction();
-        BtcTransaction tx2 = createTransaction();
-        BtcTransaction tx3 = createTransaction();
-        Sha3Hash hash1 = PegTestUtils.createHash3();
-        Sha3Hash hash2 = PegTestUtils.createHash3();
-        Sha3Hash hash3 = PegTestUtils.createHash3();
-
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
-        provider0.getRskTxsWaitingForConfirmations().put(hash1, tx1);
-        provider0.getRskTxsWaitingForConfirmations().put(hash2, tx2);
-        provider0.getRskTxsWaitingForConfirmations().put(hash3, tx3);
+        BtcTransaction txs = new BtcTransaction(btcParams);
+        txs.addOutput(Coin.FIFTY_COINS, new BtcECKey());
+
+        BtcTransaction tx1 = new BtcTransaction(btcParams);
+        tx1.addInput(txs.getOutput(0));
+        tx1.getInput(0).disconnect();
+        tx1.addOutput(Coin.COIN, new BtcECKey());
+        BtcTransaction tx2 = new BtcTransaction(btcParams);
+        tx2.addInput(txs.getOutput(0));
+        tx2.getInput(0).disconnect();
+        tx2.addOutput(Coin.COIN, new BtcECKey());
+        BtcTransaction tx3 = new BtcTransaction(btcParams);
+        tx3.addInput(txs.getOutput(0));
+        tx3.getInput(0).disconnect();
+        tx3.addOutput(Coin.COIN, new BtcECKey());
+        provider0.getReleaseTransactionSet().add(tx1, 1L);
+        provider0.getReleaseTransactionSet().add(tx2, 1L);
+        provider0.getReleaseTransactionSet().add(tx3, 1L);
 
         provider0.save();
 
@@ -570,15 +528,9 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
-        TransactionReceipt receipt = new TransactionReceipt();
-        org.ethereum.core.Transaction tx = new SimpleRskTransaction(hash1.getBytes());
-        receipt.setTransaction(tx);
-        TransactionInfo ti = new TransactionInfo(receipt, blocks.get(1).getHash(), 0);
-        List<TransactionInfo> tis = new ArrayList<>();
-        tis.add(ti);
 
         BlockChainBuilder builder = new BlockChainBuilder();
-        Blockchain blockchain = builder.setTesting(true).setRsk(true).setTransactionInfos(tis).build();
+        Blockchain blockchain = builder.setTesting(true).setRsk(true).build();
 
         for (Block block : blocks)
             blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
@@ -597,9 +549,8 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertFalse(provider2.getRskTxsWaitingForConfirmations().isEmpty());
-        Assert.assertEquals(2, provider2.getRskTxsWaitingForConfirmations().size());
-        Assert.assertFalse(provider2.getRskTxsWaitingForSignatures().isEmpty());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(2, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertEquals(1, provider2.getRskTxsWaitingForSignatures().size());
     }
 
@@ -863,8 +814,8 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertTrue(provider.getRskTxsWaitingForConfirmations().isEmpty());
-        Assert.assertTrue(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
     }
 
@@ -887,8 +838,8 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertFalse(provider.getRskTxsWaitingForConfirmations().isEmpty());
-        Assert.assertFalse(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(1, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
     }
 
@@ -932,7 +883,8 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
         Assert.assertTrue(provider2.getActiveFederationBtcUTXOs().isEmpty());
-        Assert.assertTrue(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertFalse(provider2.getBtcTxHashesAlreadyProcessed().isEmpty());
     }
@@ -962,7 +914,8 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
         Assert.assertTrue(provider2.getActiveFederationBtcUTXOs().isEmpty());
-        Assert.assertTrue(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertTrue(provider2.getBtcTxHashesAlreadyProcessed().isEmpty());
     }
@@ -992,7 +945,8 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
         Assert.assertTrue(provider2.getActiveFederationBtcUTXOs().isEmpty());
-        Assert.assertTrue(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertTrue(provider2.getBtcTxHashesAlreadyProcessed().isEmpty());
     }
@@ -1026,7 +980,8 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
         Assert.assertTrue(provider2.getActiveFederationBtcUTXOs().isEmpty());
-        Assert.assertTrue(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertTrue(provider2.getBtcTxHashesAlreadyProcessed().isEmpty());
 
@@ -1076,7 +1031,8 @@ public class BridgeSupportTest {
 
         Assert.assertEquals(0, provider2.getActiveFederationBtcUTXOs().size());
 
-        Assert.assertTrue(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertTrue(provider2.getBtcTxHashesAlreadyProcessed().isEmpty());
     }
@@ -1158,7 +1114,8 @@ public class BridgeSupportTest {
         Assert.assertEquals(1, provider2.getActiveFederationBtcUTXOs().size());
         Assert.assertEquals(Coin.COIN, provider2.getActiveFederationBtcUTXOs().get(0).getValue());
 
-        Assert.assertTrue(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertEquals(1, provider2.getBtcTxHashesAlreadyProcessed().size());
     }
@@ -1362,7 +1319,8 @@ public class BridgeSupportTest {
         Assert.assertEquals(Coin.COIN.multiply(10), provider2.getRetiringFederationBtcUTXOs().get(0).getValue());
         Assert.assertEquals(Coin.COIN.multiply(3), provider2.getRetiringFederationBtcUTXOs().get(1).getValue());
 
-        Assert.assertTrue(provider2.getRskTxsWaitingForConfirmations().isEmpty());
+        Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertEquals(3, provider2.getBtcTxHashesAlreadyProcessed().size());
     }
@@ -1470,19 +1428,19 @@ public class BridgeSupportTest {
         Assert.assertEquals(Coin.COIN.multiply(10), provider2.getRetiringFederationBtcUTXOs().get(0).getValue());
         Assert.assertEquals(Coin.COIN.multiply(4), provider2.getRetiringFederationBtcUTXOs().get(1).getValue());
 
-        Assert.assertEquals(3, provider2.getRskTxsWaitingForConfirmations().size());
-        BtcTransaction tx;
-        TransactionOutput output;
-        Address outputAddress;
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
 
-        tx = provider2.getRskTxsWaitingForConfirmations().get(new Sha3Hash(rskTx1.getHash()));
-        assertTxIsOfValueToSpecificAddress(tx, srcKey1, 5);
+        List<ReleaseRequestQueue.Entry> releaseReqQueueEntries = provider2.getReleaseRequestQueue().getEntries();
 
-        tx = provider2.getRskTxsWaitingForConfirmations().get(new Sha3Hash(rskTx2.getHash()));
-        assertTxIsOfValueToSpecificAddress(tx, srcKey2, 10);
-
-        tx = provider2.getRskTxsWaitingForConfirmations().get(new Sha3Hash(rskTx3.getHash()));
-        assertTxIsOfValueToSpecificAddress(tx, srcKey3, 7);
+        Assert.assertTrue(releaseReqQueueEntries.stream().anyMatch(e ->
+                e.getDestination().equals(srcKey1.toAddress(btcParams)) && e.getAmount().equals(Coin.COIN.multiply(5))
+        ));
+        Assert.assertTrue(releaseReqQueueEntries.stream().anyMatch(e ->
+                e.getDestination().equals(srcKey2.toAddress(btcParams)) && e.getAmount().equals(Coin.COIN.multiply(10))
+        ));
+        Assert.assertTrue(releaseReqQueueEntries.stream().anyMatch(e ->
+                e.getDestination().equals(srcKey3.toAddress(btcParams)) && e.getAmount().equals(Coin.COIN.multiply(7))
+        ));
 
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertEquals(3, provider2.getBtcTxHashesAlreadyProcessed().size());
@@ -1497,12 +1455,6 @@ public class BridgeSupportTest {
         Address outputAddress = new Script(output.getScriptBytes()).getToAddress(params);
         Assert.assertEquals(outputAddress, key.toAddress(params));
         Assert.assertEquals(output.getValue(), Coin.COIN.multiply(value));
-    }
-
-    @Test
-    public void testHasEnoughConfirmations() throws Exception {
-        Assert.assertFalse(hasEnoughConfirmations(10));
-        Assert.assertTrue(hasEnoughConfirmations(20));
     }
 
     @Test
@@ -2150,26 +2102,6 @@ public class BridgeSupportTest {
         verify(mocksProvider.getElection(), never()).clear();
         verify(mocksProvider.getElection(), never()).vote(mocksProvider.getSpec(), mocksProvider.getVoter());
     }
-//
-//    @Test
-//    public void commitFederation_hashMismatch() throws IOException {
-//        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new BtcECKey[]{
-//                BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
-//                BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
-//        }));
-//        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
-//                false,
-//                null,
-//                null,
-//                null,
-//                pendingFederation,
-//                null,
-//                null
-//        );
-//
-//        Sha3Hash hash = new Sha3Hash(HashUtil.sha3(Hex.decode("aabbcc")));
-//        Assert.assertEquals(-3, bridgeSupport.commitFederation(false, hash).intValue());
-//    }
 
     @PrepareForTest({ BridgeUtils.class })
     @Test
@@ -2512,36 +2444,7 @@ public class BridgeSupportTest {
         result.sort(BtcECKey.PUBKEY_COMPARATOR);
         return result;
     }
-
-    public boolean hasEnoughConfirmations(long currentBlockNumber) throws Exception{
-        Repository repository = new RepositoryImpl();
-        Repository track = repository.startTracking();
-
-        byte[] blockHash = new byte[32];
-        new SecureRandom().nextBytes(blockHash);
-        TransactionInfo transactionInfo = mock(TransactionInfo.class);
-        when(transactionInfo.getBlockHash()).thenReturn(blockHash);
-
-        ReceiptStore receiptStore = mock(ReceiptStore.class);
-        when(receiptStore.get(any(), any(), any())).thenReturn(transactionInfo);
-
-        org.ethereum.core.Block includedBlock = mock(org.ethereum.core.Block.class);
-        when(includedBlock.getNumber()).thenReturn(Long.valueOf(10));
-
-        org.ethereum.db.BlockStore blockStore = mock(org.ethereum.db.BlockStore.class);
-        when(blockStore.getBlockByHash(any())).thenReturn(includedBlock);
-
-        org.ethereum.core.Block currentBlock = mock(org.ethereum.core.Block.class);
-        when(currentBlock.getNumber()).thenReturn(Long.valueOf(currentBlockNumber));
-
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, currentBlock, receiptStore, blockStore, BridgeRegTestConstants.getInstance(), Collections.emptyList());
-
-        Sha3Hash txHash = Sha3Hash.ZERO_HASH;
-
-        return bridgeSupport.hasEnoughConfirmations(txHash);
-    }
-
+    
     private BtcTransaction createTransaction() {
         BtcTransaction btcTx = new BtcTransaction(btcParams);
         btcTx.addInput(new TransactionInput(btcParams, btcTx, new byte[0]));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -319,6 +319,8 @@ public class BridgeSupportTest {
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
         // Check value sent to user is 10 BTC minus fee
         Assert.assertEquals(Coin.valueOf(999962800l), provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction().getOutput(0).getValue());
+        // Check the wallet has been emptied
+        Assert.assertTrue(provider.getActiveFederationBtcUTXOs().isEmpty());
     }
 
     @Test
@@ -372,7 +374,10 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
         Assert.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
+        // Check the wallet has not been emptied
+        Assert.assertFalse(provider.getActiveFederationBtcUTXOs().isEmpty());
     }
 
     @Test
@@ -427,7 +432,10 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
         Assert.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        Assert.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
+        // Check the wallet has not been emptied
+        Assert.assertFalse(provider.getActiveFederationBtcUTXOs().isEmpty());
     }
 
     @Test
@@ -483,6 +491,8 @@ public class BridgeSupportTest {
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
         Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(21000000-2600)), repository.getBalance(Hex.decode(PrecompiledContracts.BRIDGE_ADDR)));
         Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(2600)), repository.getBalance(RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBurnAddress()));
+        // Check the wallet has been emptied
+        Assert.assertTrue(provider.getActiveFederationBtcUTXOs().isEmpty());
     }
 
     @PrepareForTest({ BridgeUtils.class })
@@ -705,8 +715,8 @@ public class BridgeSupportTest {
         BtcTransaction prevTx = new BtcTransaction(btcParams);
         TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, federation.getAddress());
         prevTx.addOutput(prevOut);
-        UTXO utxo = new UTXO(prevTx.getHash(), 0, prevOut.getValue(), 0, false, prevOut.getScriptPubKey());
-        provider.getActiveFederationBtcUTXOs().add(utxo);
+//        UTXO utxo = new UTXO(prevTx.getHash(), 0, prevOut.getValue(), 0, false, prevOut.getScriptPubKey());
+//        provider.getActiveFederationBtcUTXOs().add(utxo);
 
         BtcTransaction t = new BtcTransaction(btcParams);
         TransactionOutput output = new TransactionOutput(btcParams, t, Coin.COIN, new BtcECKey().toAddress(btcParams));
@@ -772,7 +782,6 @@ public class BridgeSupportTest {
             Assert.assertEquals(4, retrievedScriptSig.getChunks().size());
             Assert.assertEquals(true, retrievedScriptSig.getChunks().get(1).data.length > 0);
             Assert.assertEquals(true, retrievedScriptSig.getChunks().get(2).data.length > 0);
-            Assert.assertTrue(provider.getActiveFederationBtcUTXOs().isEmpty());
         } else {
             Script retrievedScriptSig = provider.getRskTxsWaitingForSignatures().get(sha3Hash).getInput(0).getScriptSig();
             Assert.assertEquals(4, retrievedScriptSig.getChunks().size());
@@ -782,7 +791,6 @@ public class BridgeSupportTest {
             }
             Assert.assertEquals(expectSignatureToBePersisted, retrievedScriptSig.getChunks().get(1).data.length > 0);
             Assert.assertEquals(false, retrievedScriptSig.getChunks().get(2).data.length > 0);
-            Assert.assertFalse(provider.getActiveFederationBtcUTXOs().isEmpty());
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseRequestQueueTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseRequestQueueTest.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class ReleaseRequestQueueTest {
+    private List<ReleaseRequestQueue.Entry> queueEntries;
+    private ReleaseRequestQueue queue;
+
+    @Before
+    public void createQueue() {
+        queueEntries = Arrays.asList(
+            new ReleaseRequestQueue.Entry(mockAddress(2), Coin.valueOf(150)),
+            new ReleaseRequestQueue.Entry(mockAddress(5), Coin.COIN),
+            new ReleaseRequestQueue.Entry(mockAddress(4), Coin.FIFTY_COINS),
+            new ReleaseRequestQueue.Entry(mockAddress(3), Coin.MILLICOIN),
+            new ReleaseRequestQueue.Entry(mockAddress(8), Coin.CENT.times(5))
+        );
+        queue = new ReleaseRequestQueue(queueEntries);
+    }
+
+    @Test
+    public void entryEquals() {
+        ReleaseRequestQueue.Entry e1 = new ReleaseRequestQueue.Entry(mockAddress(2), Coin.valueOf(150));
+        ReleaseRequestQueue.Entry e2 = new ReleaseRequestQueue.Entry(mockAddress(2), Coin.valueOf(150));
+        ReleaseRequestQueue.Entry e3 = new ReleaseRequestQueue.Entry(mockAddress(2), Coin.valueOf(149));
+        ReleaseRequestQueue.Entry e4 = new ReleaseRequestQueue.Entry(mockAddress(5), Coin.valueOf(150));
+        ReleaseRequestQueue.Entry e5 = new ReleaseRequestQueue.Entry(mockAddress(5), Coin.valueOf(151));
+
+        Assert.assertEquals(e1, e2);
+        Assert.assertNotEquals(e1, e3);
+        Assert.assertNotEquals(e1, e4);
+        Assert.assertNotEquals(e1, e5);
+    }
+
+    @Test
+    public void entryGetters() {
+        ReleaseRequestQueue.Entry entry = new ReleaseRequestQueue.Entry(mockAddress(5), Coin.valueOf(100));
+
+        Assert.assertEquals(mockAddress(5), entry.getDestination());
+        Assert.assertEquals(Coin.valueOf(100), entry.getAmount());
+    }
+
+    @Test
+    public void entryComparators() {
+        NetworkParameters params = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+        ReleaseRequestQueue.Entry e1 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("6891f76b9261d8abb82171f5380d710a2d173aef")), Coin.valueOf(150));
+        ReleaseRequestQueue.Entry e2 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("6891f76b9261d8abb82171f5380d710a2d173aef")), Coin.valueOf(150));
+        ReleaseRequestQueue.Entry e3 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("6891f76b9261d8abb82171f5380d710a2d173aef")), Coin.valueOf(151));
+        ReleaseRequestQueue.Entry e4 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("6891f76b9261d8abb82171f5380d710a2d173aef")), Coin.valueOf(149));
+        ReleaseRequestQueue.Entry e5 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("3607136cb67e1ef78794620b39d6f0bdc27b3721")), Coin.valueOf(1));
+        ReleaseRequestQueue.Entry e6 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("eaa41ef07e9ba0c8657a5f94a32b7bedce193df5")), Coin.valueOf(1));
+
+        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e2) == 0);
+        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e3) < 0);
+        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e4) > 0);
+        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e5) > 0);
+        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e6) < 0);
+    }
+
+    @Test
+    public void entriesCopy() {
+        Assert.assertNotSame(queueEntries, queue.getEntries());
+        Assert.assertEquals(queueEntries, queue.getEntries());
+    }
+
+    @Test
+    public void add() {
+        Assert.assertFalse(queue.getEntries().contains(new ReleaseRequestQueue.Entry(mockAddress(10), Coin.valueOf(10))));
+        queue.add(mockAddress(10), Coin.valueOf(10));
+        Assert.assertTrue(queue.getEntries().contains(new ReleaseRequestQueue.Entry(mockAddress(10), Coin.valueOf(10))));
+    }
+
+    @Test
+    public void process() {
+        class Indexer {
+            public int index = 0;
+        }
+
+        Indexer idx = new Indexer();
+        queue.process(entry -> {
+            Assert.assertEquals(entry, queueEntries.get(idx.index));
+            return idx.index++ % 2 == 0;
+        });
+        Assert.assertEquals(5, idx.index);
+        Assert.assertEquals(Arrays.asList(
+            new ReleaseRequestQueue.Entry(mockAddress(5), Coin.COIN),
+            new ReleaseRequestQueue.Entry(mockAddress(3), Coin.MILLICOIN)
+        ), queue.getEntries());
+    }
+
+    private Address mockAddress(int pk) {
+        return BtcECKey.fromPrivate(BigInteger.valueOf(pk)).toAddress(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseRequestQueueTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseRequestQueueTest.java
@@ -79,23 +79,6 @@ public class ReleaseRequestQueueTest {
     }
 
     @Test
-    public void entryComparators() {
-        NetworkParameters params = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        ReleaseRequestQueue.Entry e1 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("6891f76b9261d8abb82171f5380d710a2d173aef")), Coin.valueOf(150));
-        ReleaseRequestQueue.Entry e2 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("6891f76b9261d8abb82171f5380d710a2d173aef")), Coin.valueOf(150));
-        ReleaseRequestQueue.Entry e3 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("6891f76b9261d8abb82171f5380d710a2d173aef")), Coin.valueOf(151));
-        ReleaseRequestQueue.Entry e4 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("6891f76b9261d8abb82171f5380d710a2d173aef")), Coin.valueOf(149));
-        ReleaseRequestQueue.Entry e5 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("3607136cb67e1ef78794620b39d6f0bdc27b3721")), Coin.valueOf(1));
-        ReleaseRequestQueue.Entry e6 = new ReleaseRequestQueue.Entry(new Address(params, Hex.decode("eaa41ef07e9ba0c8657a5f94a32b7bedce193df5")), Coin.valueOf(1));
-
-        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e2) == 0);
-        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e3) < 0);
-        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e4) > 0);
-        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e5) > 0);
-        Assert.assertTrue(ReleaseRequestQueue.Entry.DESTINATION_AMOUNT_COMPARATOR.compare(e1, e6) < 0);
-    }
-
-    @Test
     public void entriesCopy() {
         Assert.assertNotSame(queueEntries, queue.getEntries());
         Assert.assertEquals(queueEntries, queue.getEntries());

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.wallet.SendRequest;
+import co.rsk.bitcoinj.wallet.Wallet;
+import org.ethereum.core.CallTransaction;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class ReleaseTransactionBuilderTest {
+    private Wallet wallet;
+    private Address changeAddress;
+    private ReleaseTransactionBuilder builder;
+
+    @Before
+    public void createBuilder() {
+        wallet = mock(Wallet.class);
+        changeAddress = mockAddress(1000);
+        builder = new ReleaseTransactionBuilder(wallet, changeAddress, Coin.MILLICOIN.multiply(2));
+    }
+
+    @Test
+    public void getters() {
+        Assert.assertSame(wallet, builder.getWallet());
+        Assert.assertSame(changeAddress, builder.getChangeAddress());
+        Assert.assertEquals(Coin.MILLICOIN.multiply(2), builder.getFeePerKb());
+    }
+
+    @Test
+    public void build_ok() throws InsufficientMoneyException, UTXOProviderException {
+        Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Address to = mockAddress(123);
+        Coin amount = Coin.CENT.multiply(3);
+
+        UTXOProvider utxoProvider = mock(UTXOProvider.class);
+        when(wallet.getUTXOProvider()).thenReturn(utxoProvider);
+        when(wallet.getWatchedAddresses()).thenReturn(Arrays.asList(changeAddress));
+        when(utxoProvider.getOpenTransactionOutputs(any(List.class))).then((InvocationOnMock m) -> {
+            List<Address> addresses = m.getArgumentAt(0, List.class);
+            Assert.assertEquals(Arrays.asList(changeAddress), addresses);
+        });
+
+        Mockito.doAnswer((InvocationOnMock m) -> {
+            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+
+            Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
+            Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
+            Assert.assertEquals(changeAddress, sr.changeAddress);
+            Assert.assertFalse(sr.shuffleOutputs);
+            Assert.assertTrue(sr.recipientsPayFees);
+
+            BtcTransaction tx = sr.tx;
+
+            Assert.assertEquals(1, tx.getOutputs().size());
+            Assert.assertEquals(amount, tx.getOutput(0).getValue());
+            Assert.assertEquals(to, tx.getOutput(0).getAddressFromP2PKHScript(NetworkParameters.fromID(NetworkParameters.ID_REGTEST)));
+
+            return null;
+        }).when(wallet).completeTx(any(SendRequest.class));
+
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.build(to, amount);
+    }
+
+    private Address mockAddress(int pk) {
+        return BtcECKey.fromPrivate(BigInteger.valueOf(pk)).toAddress(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionSetTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionSetTest.java
@@ -1,0 +1,190 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.spongycastle.util.encoders.Hex;
+
+import javax.swing.text.html.Option;
+import java.math.BigInteger;
+import java.util.*;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class ReleaseTransactionSetTest {
+    private Set<ReleaseTransactionSet.Entry> setEntries;
+    private ReleaseTransactionSet set;
+
+    @Before
+    public void createSet() {
+        setEntries = new HashSet<>(Arrays.asList(
+            new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 32L),
+            new ReleaseTransactionSet.Entry(createTransaction(5, Coin.COIN), 100L),
+            new ReleaseTransactionSet.Entry(createTransaction(4, Coin.FIFTY_COINS), 7L),
+            new ReleaseTransactionSet.Entry(createTransaction(3, Coin.MILLICOIN), 10L),
+            new ReleaseTransactionSet.Entry(createTransaction(8, Coin.CENT.times(5)), 5L)
+        ));
+        set = new ReleaseTransactionSet(setEntries);
+    }
+
+    @Test
+    public void entryEquals() {
+        ReleaseTransactionSet.Entry e1 = new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 15L);
+        ReleaseTransactionSet.Entry e2 = new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 15L);
+        ReleaseTransactionSet.Entry e3 = new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(149)), 14L);
+        ReleaseTransactionSet.Entry e4 = new ReleaseTransactionSet.Entry(createTransaction(5, Coin.valueOf(230)), 15L);
+
+        Assert.assertEquals(e1, e2);
+        Assert.assertNotEquals(e1, e3);
+        Assert.assertNotEquals(e1, e4);
+    }
+
+    @Test
+    public void entryGetters() {
+        ReleaseTransactionSet.Entry entry = new ReleaseTransactionSet.Entry(createTransaction(5, Coin.valueOf(100)), 7L);
+
+        Assert.assertEquals(createTransaction(5, Coin.valueOf(100)), entry.getTransaction());
+        Assert.assertEquals(7L, entry.getRskBlockNumber().longValue());
+    }
+
+    @Test
+    public void entryComparators() {
+        NetworkParameters params = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+        ReleaseTransactionSet.Entry e1 = new ReleaseTransactionSet.Entry(mockTxSerialize("aa"), 7L);
+        ReleaseTransactionSet.Entry e2 = new ReleaseTransactionSet.Entry(mockTxSerialize("aa"), 7L);
+        ReleaseTransactionSet.Entry e3 = new ReleaseTransactionSet.Entry(mockTxSerialize("aa"), 8L);
+        ReleaseTransactionSet.Entry e4 = new ReleaseTransactionSet.Entry(mockTxSerialize("bb"), 7L);
+        ReleaseTransactionSet.Entry e5 = new ReleaseTransactionSet.Entry(mockTxSerialize("99"), 7L);
+
+        Assert.assertTrue(ReleaseTransactionSet.Entry.BTC_TX_COMPARATOR.compare(e1, e2) == 0);
+        Assert.assertTrue(ReleaseTransactionSet.Entry.BTC_TX_COMPARATOR.compare(e1, e3) == 0);
+        Assert.assertTrue(ReleaseTransactionSet.Entry.BTC_TX_COMPARATOR.compare(e1, e4) < 0);
+        Assert.assertTrue(ReleaseTransactionSet.Entry.BTC_TX_COMPARATOR.compare(e1, e5) > 0);
+    }
+
+    @Test
+    public void entriesCopy() {
+        Assert.assertNotSame(setEntries, set.getEntries());
+        Assert.assertEquals(setEntries, set.getEntries());
+    }
+
+    @Test
+    public void add_nonExisting() {
+        Assert.assertFalse(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(123, Coin.COIN.multiply(3)), 34L)));
+        set.add(createTransaction(123, Coin.COIN.multiply(3)), 34L);
+        Assert.assertTrue(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(123, Coin.COIN.multiply(3)), 34L)));
+    }
+
+    @Test
+    public void add_existing() {
+        Assert.assertTrue(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 32L)));
+        Assert.assertEquals(1, set.getEntries().stream().filter(e -> e.getTransaction().equals(createTransaction(2, Coin.valueOf(150)))).count());
+        set.add(createTransaction(2, Coin.valueOf(150)), 23L);
+        Assert.assertTrue(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 32L)));
+        Assert.assertFalse(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 23L)));
+        Assert.assertEquals(1, set.getEntries().stream().filter(e -> e.getTransaction().equals(createTransaction(2, Coin.valueOf(150)))).count());
+    }
+
+    @Test
+    public void sliceWithConfirmations_withLimit_none() {
+        Set<BtcTransaction> result = set.sliceWithConfirmations(9L, 5, Optional.of(1));
+        Assert.assertEquals(0, result.size());
+        Assert.assertEquals(setEntries, set.getEntries());
+    }
+
+    @Test
+    public void sliceWithConfirmations_withLimit_singleMatch() {
+        Set<BtcTransaction> result = set.sliceWithConfirmations(10L, 5, Optional.of(2));
+        Assert.assertEquals(1, result.size());
+        setEntries.remove(new ReleaseTransactionSet.Entry(createTransaction(8, Coin.CENT.times(5)), 5L));
+        Assert.assertEquals(setEntries, set.getEntries());
+    }
+
+    @Test
+    public void sliceWithConfirmations_withLimit_multipleMatch() {
+        Set<BtcTransaction> result = set.sliceWithConfirmations(15L, 5, Optional.of(2));
+        Assert.assertEquals(2, result.size());
+        Iterator<BtcTransaction> resultIterator = result.iterator();
+        while (resultIterator.hasNext()) {
+            BtcTransaction itemTx = resultIterator.next();
+            ReleaseTransactionSet.Entry item = setEntries.stream().filter(e -> e.getTransaction().equals(itemTx)).findFirst().get();
+            Assert.assertTrue(15L - item.getRskBlockNumber() >= 5);
+            setEntries.remove(item);
+        }
+        Assert.assertEquals(3, set.getEntries().size());
+        Assert.assertEquals(setEntries, set.getEntries());
+    }
+
+    @Test
+    public void sliceWithConfirmations_noLimit_none() {
+        Set<BtcTransaction> result = set.sliceWithConfirmations(9L, 5, Optional.empty());
+        Assert.assertEquals(0, result.size());
+        Assert.assertEquals(setEntries, set.getEntries());
+    }
+
+    @Test
+    public void sliceWithConfirmations_noLimit_singleMatch() {
+        Set<BtcTransaction> result = set.sliceWithConfirmations(10L, 5, Optional.empty());
+        Assert.assertEquals(1, result.size());
+        setEntries.remove(new ReleaseTransactionSet.Entry(createTransaction(8, Coin.CENT.times(5)), 5L));
+        Assert.assertEquals(setEntries, set.getEntries());
+    }
+
+    @Test
+    public void sliceWithConfirmations_noLimit_multipleMatch() {
+        Set<BtcTransaction> result = set.sliceWithConfirmations(15L, 5, Optional.empty());
+        Assert.assertEquals(3, result.size());
+        Iterator<BtcTransaction> resultIterator = result.iterator();
+        while (resultIterator.hasNext()) {
+            BtcTransaction itemTx = resultIterator.next();
+            ReleaseTransactionSet.Entry item = setEntries.stream().filter(e -> e.getTransaction().equals(itemTx)).findFirst().get();
+            Assert.assertTrue(15L - item.getRskBlockNumber() >= 5);
+            setEntries.remove(item);
+        }
+        Assert.assertEquals(2, set.getEntries().size());
+        Assert.assertEquals(setEntries, set.getEntries());
+    }
+
+    private BtcTransaction createTransaction(int toPk, Coin value) {
+        NetworkParameters params = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+        BtcTransaction input = new BtcTransaction(params);
+        input.addOutput(Coin.FIFTY_COINS, BtcECKey.fromPrivate(BigInteger.valueOf(123456)).toAddress(params));
+
+        Address to = BtcECKey.fromPrivate(BigInteger.valueOf(toPk)).toAddress(params);
+
+        BtcTransaction result = new BtcTransaction(params);
+        result.addInput(input.getOutput(0));
+        result.getInput(0).disconnect();
+        result.addOutput(value, to);
+        return result;
+    }
+
+    private BtcTransaction mockTxSerialize(String serializationHex) {
+        BtcTransaction result = mock(BtcTransaction.class);
+        when(result.bitcoinSerialize()).thenReturn(Hex.decode(serializationHex));
+        return result;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -40,7 +40,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -97,16 +96,16 @@ public class RskForksBridgeTest {
         Transaction releaseTx = buildReleaseTx();
         Block blockB1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB1));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB2 = buildBlock(blockB1);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB2));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SIGNATURES);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
     @Test
@@ -119,20 +118,20 @@ public class RskForksBridgeTest {
 
         Block blockA2 = buildBlock(blockA1, 6l, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA2));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB1 = buildBlock(blockBase, 1l, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, blockChain.tryToConnect(blockB1));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB2 = buildBlock(blockB1, 2l);
         Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, blockChain.tryToConnect(blockB2));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, 10l, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SIGNATURES);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
 
@@ -142,24 +141,24 @@ public class RskForksBridgeTest {
 
         Block blockB1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB1));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB2 = buildBlock(blockB1,6l);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB2));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockA1 = buildBlock(blockBase,1);
         Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, blockChain.tryToConnect(blockA1));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockA2 = buildBlock(blockA1,1, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, blockChain.tryToConnect(blockA2));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2,12, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SIGNATURES);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
     @Test
@@ -168,19 +167,19 @@ public class RskForksBridgeTest {
 
         Block blockA1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA1));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockA2 = buildBlock(blockA1,3);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA2));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB1 = buildBlock(blockBase,2);
         Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, blockChain.tryToConnect(blockB1));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB2 = buildBlock(blockB1,1);
         Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, blockChain.tryToConnect(blockB2));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2,6l, updateCollectionsTx);
@@ -211,7 +210,7 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, 10l, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SIGNATURES);
+        assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
     private Block buildBlock(Block parent, long difficulty) {
@@ -311,20 +310,27 @@ public class RskForksBridgeTest {
 
     private void assertReleaseTransactionState(ReleaseTransactionState state) throws IOException, ClassNotFoundException {
         BridgeState stateForDebugging = callGetStateForDebuggingTx();
-        if (ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS.equals(state)) {
-            Assert.assertEquals(1, stateForDebugging.getRskTxsWaitingForConfirmations().size());
+        if (ReleaseTransactionState.WAITING_FOR_SELECTION.equals(state)) {
+            Assert.assertEquals(1, stateForDebugging.getReleaseRequestQueue().getEntries().size());
+            Assert.assertEquals(0, stateForDebugging.getReleaseTransactionSet().getEntries().size());
             Assert.assertEquals(0, stateForDebugging.getRskTxsWaitingForSignatures().size());
         } else if (ReleaseTransactionState.WAITING_FOR_SIGNATURES.equals(state)) {
-            Assert.assertEquals(0, stateForDebugging.getRskTxsWaitingForConfirmations().size());
+            Assert.assertEquals(0, stateForDebugging.getReleaseRequestQueue().getEntries().size());
+            Assert.assertEquals(0, stateForDebugging.getReleaseTransactionSet().getEntries().size());
             Assert.assertEquals(1, stateForDebugging.getRskTxsWaitingForSignatures().size());
+        } else if (ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS.equals(state)) {
+            Assert.assertEquals(0, stateForDebugging.getReleaseRequestQueue().getEntries().size());
+            Assert.assertEquals(1, stateForDebugging.getReleaseTransactionSet().getEntries().size());
+            Assert.assertEquals(0, stateForDebugging.getRskTxsWaitingForSignatures().size());
         } else if (ReleaseTransactionState.NO_TX.equals(state)) {
-            Assert.assertEquals(0, stateForDebugging.getRskTxsWaitingForConfirmations().size());
+            Assert.assertEquals(0, stateForDebugging.getReleaseRequestQueue().getEntries().size());
+            Assert.assertEquals(0, stateForDebugging.getReleaseTransactionSet().getEntries().size());
             Assert.assertEquals(0, stateForDebugging.getRskTxsWaitingForSignatures().size());
         }
     }
 
     private enum ReleaseTransactionState {
-        NO_TX, WAITING_FOR_SIGNATURES, WAITING_FOR_CONFIRMATIONS
+        NO_TX, WAITING_FOR_SIGNATURES, WAITING_FOR_SELECTION, WAITING_FOR_CONFIRMATIONS
     }
 
     private BridgeState callGetStateForDebuggingTx() throws IOException, ClassNotFoundException {


### PR DESCRIPTION
Release BTC workflow was refactored so that several release BTC transactions can be signed simultaneously.

The idea is that we now wait for confirmations on the coin selection when releasing btc, thus being able to mark UTXOs as used early and do several coin selections without the need for signing and releasing first.

For this, the bridge has now got two new objects stored: a `ReleaseRequestQueue` and a `ReleaseTransactionSet`.

Flow is as follows: when requesting a release, an entry is added to the release request queue. 

Upon `updateCollections`, the release request queue is processed and coins are selected. Successful selections turn into BTC transactions that get into the release transaction set, where they will be waiting for enough confirmations. 

When enough confirmations are reached, transactions from the release transaction set are moved to the already existing `txsWaitingForSignatures` and the rest of the flow remains.

This last bit implies that, given that the last part of the flow is dependent upon `txsWaitingForSignatures`, which uses RSK transaction hashes as keys, moving of transactions from the release transaction set to `txsWaitingForSignatures` happens one RSK tx at a time. This is due for a future refactor.