### PR TITLE
Add creation gas cost when a contract is created from an transaction

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -195,7 +195,7 @@ public class Transaction implements SerializableObject {
         long nonZeroes = this.nonZeroDataBytes();
         long zeroVals  = ArrayUtils.getLength(this.getData()) - nonZeroes;
 
-        return GasCost.TRANSACTION + zeroVals * GasCost.TX_ZERO_DATA + nonZeroes * GasCost.TX_NO_ZERO_DATA;
+        return (this.isContractCreation() ? GasCost.TRANSACTION_CREATE_CONTRACT : GasCost.TRANSACTION) + zeroVals * GasCost.TX_ZERO_DATA + nonZeroes * GasCost.TX_NO_ZERO_DATA;
     }
 
     public void verify() {

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -345,7 +345,7 @@ public class TransactionExecutor {
 
             if (tx.isContractCreation() && !result.isRevert()) {
                 int createdContractSize = getLength(program.getResult().getHReturn());
-                int returnDataGasValue = createdContractSize * GasCost.CREATE_DATA;
+                int returnDataGasValue = createdContractSize * GasCost.CREATE_DATA + GasCost.CREATE;
                 if (mEndGas.compareTo(BigInteger.valueOf(returnDataGasValue)) < 0) {
                     program.setRuntimeFailure(
                             Program.ExceptionHelper.notEnoughSpendingGas(

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -345,7 +345,7 @@ public class TransactionExecutor {
 
             if (tx.isContractCreation() && !result.isRevert()) {
                 int createdContractSize = getLength(program.getResult().getHReturn());
-                int returnDataGasValue = createdContractSize * GasCost.CREATE_DATA + GasCost.CREATE;
+                int returnDataGasValue = createdContractSize * GasCost.CREATE_DATA;
                 if (mEndGas.compareTo(BigInteger.valueOf(returnDataGasValue)) < 0) {
                     program.setRuntimeFailure(
                             Program.ExceptionHelper.notEnoughSpendingGas(

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -658,6 +658,7 @@ public class RemascProcessMinerFeesTest {
 
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock());
+            b.seal();
             blockchain.tryToConnect(b);
         }
 
@@ -684,7 +685,7 @@ public class RemascProcessMinerFeesTest {
 //                remasc.call();
 //            }
 //        }
-        long txCreateContractGasLimit = 53755;
+        long txCreateContractGasLimit = 53755 + 32000;
         Transaction txCreateContract = new Transaction(
                 BigInteger.valueOf(1).toByteArray(),
                 BigInteger.ONE.toByteArray(),
@@ -709,6 +710,7 @@ public class RemascProcessMinerFeesTest {
                 PegTestUtils.createHash3(), PegTestUtils.createHash3(), null, null,
                 txCreateContract, txCallRemasc);
         blockExecutor.executeAndFillAll(newblock, blockchain.getBestBlock());
+        newblock.seal();
         blockchain.tryToConnect(newblock);
 
         repository = blockchain.getRepository();

--- a/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
@@ -23,12 +23,16 @@ import co.rsk.test.dsl.DslParser;
 import co.rsk.test.dsl.DslProcessorException;
 import co.rsk.test.dsl.WorldDslProcessor;
 import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.vm.DataWord;
 import org.junit.Assert;
 import org.junit.Test;
+import org.spongycastle.util.BigIntegers;
+import org.spongycastle.util.encoders.Hex;
 
 import java.io.FileNotFoundException;
+import java.math.BigInteger;
 import java.util.Arrays;
 
 /**
@@ -56,6 +60,27 @@ public class DslFilesTest {
         Assert.assertNotNull(world.getAccountByName("acc2"));
         Assert.assertNotNull(world.getTransactionByName("tx01"));
         Assert.assertNotNull(world.getBlockByName("b01"));
+    }
+
+    @Test
+    public void runCreate01Resource() throws FileNotFoundException, DslProcessorException {
+        DslParser parser = DslParser.fromResource("dsl/create01.txt");
+        World world = new World();
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        Transaction transaction = world.getTransactionByName("tx01");
+
+        Assert.assertNotNull(transaction);
+
+        TransactionInfo txinfo = world.getBlockChain().getTransactionInfo(transaction.getHash());
+
+        Assert.assertNotNull(txinfo);
+        BigInteger gasUsed = BigIntegers.fromUnsignedByteArray(txinfo.getReceipt().getGasUsed());
+
+        Assert.assertNotEquals(BigInteger.ZERO, gasUsed);
+        // According to TestRPC and geth, the gas used is 0x010c2d
+        Assert.assertEquals(BigIntegers.fromUnsignedByteArray(Hex.decode("010c2d")), gasUsed);
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -728,7 +728,7 @@ contract main {
 
         return new TransactionBuilder()
                 .sender(acc1)
-                .gasLimit(BigInteger.valueOf(100000))
+                .gasLimit(BigInteger.valueOf(1000000))
                 .gasPrice(BigInteger.ONE)
                 .data(compiledLogExample)
                 .build();

--- a/rskj-core/src/test/resources/dsl/contracts03.txt
+++ b/rskj-core/src/test/resources/dsl/contracts03.txt
@@ -86,7 +86,7 @@ assert_best b04
 assert_balance tx01 10000
 
 # check sender balance, before next transaction
-assert_balance acc1 8589429
+assert_balance acc1 8557429
 
 transaction_build tx05
     sender acc1
@@ -112,7 +112,7 @@ assert_best b05
 assert_balance tx01 10000
 
 # check sender balance, it should pay the total cost (8589589 - 25000)
-assert_balance acc1 8564429
+assert_balance acc1 8532429
 
 transaction_build tx06
     sender acc1

--- a/rskj-core/src/test/resources/dsl/create01.txt
+++ b/rskj-core/src/test/resources/dsl/create01.txt
@@ -1,5 +1,7 @@
 account_new acc1 10000000
 
+# Create empty.sol contract
+
 transaction_build tx01
     sender acc1
     receiverAddress 00
@@ -18,3 +20,4 @@ block_connect b01
 # Assert best block
 assert_best b01
 
+# The code test checks the gas used

--- a/rskj-core/src/test/resources/dsl/create01.txt
+++ b/rskj-core/src/test/resources/dsl/create01.txt
@@ -1,0 +1,20 @@
+account_new acc1 10000000
+
+transaction_build tx01
+    sender acc1
+    receiverAddress 00
+    value 0
+    data 60606040523415600e57600080fd5b603580601b6000396000f3006060604052600080fd00a165627a7a72305820b25edb28bec763685838b8044760e105b5385638276b4768c8045237b8fc6bf10029
+    gas 1200000
+    build
+
+block_build b01
+    parent g00
+    transactions tx01
+    build
+
+block_connect b01
+
+# Assert best block
+assert_best b01
+

--- a/rskj-core/src/test/resources/dsl/empty.sol
+++ b/rskj-core/src/test/resources/dsl/empty.sol
@@ -1,0 +1,5 @@
+// Simple empty contract
+
+contract Empty {
+}
+

--- a/rskj-core/src/test/resources/dsl/opcode_revert1.txt
+++ b/rskj-core/src/test/resources/dsl/opcode_revert1.txt
@@ -18,7 +18,7 @@ block_connect b01
 # Assert best block
 assert_best b01
 
-assert_balance acc1 9889039
+assert_balance acc1 9857039
 
 transaction_build tx02
     sender acc1
@@ -40,7 +40,7 @@ block_connect b02
 assert_best b02
 
 # spend 99527 gas running the contract
-assert_balance acc1 9788792
+assert_balance acc1 9756792
 
 transaction_build tx03
     sender acc1
@@ -62,4 +62,4 @@ block_connect b03
 assert_best b03
 
 # spend only 21424 because the contract uses the revert OPCODE
-assert_balance acc1 9767368
+assert_balance acc1 9735368

--- a/rskj-core/src/test/resources/dsl/opcode_revert2.txt
+++ b/rskj-core/src/test/resources/dsl/opcode_revert2.txt
@@ -18,7 +18,7 @@ block_connect b01
 # Assert best block
 assert_best b01
 
-assert_balance acc1 9889039
+assert_balance acc1 9857039
 
 transaction_build tx02
     sender acc1
@@ -40,7 +40,7 @@ block_connect b02
 assert_best b02
 
 # spend only 21424 because the contract uses the revert OPCODE
-assert_balance acc1 9867615
+assert_balance acc1 9835615
 
 transaction_build tx03
     sender acc1
@@ -62,4 +62,4 @@ block_connect b03
 assert_best b03
 
 # spend 99527 gas running the contract
-assert_balance acc1 9767368
+assert_balance acc1 9735368


### PR DESCRIPTION
After checking the gas used in TestRPC and local geth nodes, we discovered our node produces a different gas used in those cases. The difference was 32000, in many tests. So, we added that gas amount in TransactionExecutor logic.

Some test had been modified, because the expected gas used is now different (in the same amount, 32000 gas units).

We don't find the corresponding logic in current EthereumJ.
