### PR TITLE
Modify bindIp and externalIp

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -223,7 +223,7 @@ public class DefaultConfig {
     @Bean
     public PeerExplorer peerExplorer(RskSystemProperties rskConfig) {
         ECKey key = rskConfig.getMyKey();
-        Node localNode = new Node(key.getNodeId(), rskConfig.externalIp(), rskConfig.listenPort());
+        Node localNode = new Node(key.getNodeId(), rskConfig.getExternalIp(), rskConfig.listenPort());
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, localNode);
         long msgTimeOut = rskConfig.peerDiscoveryMessageTimeOut();
         long refreshPeriod = rskConfig.peerDiscoveryRefreshPeriod();
@@ -240,6 +240,6 @@ public class DefaultConfig {
 
     @Bean
     public UDPServer udpServer(PeerExplorer peerExplorer, RskSystemProperties rskConfig) {
-        return new UDPServer(rskConfig.bindIp(), rskConfig.listenPort(), peerExplorer);
+        return new UDPServer(rskConfig.getPeerDiscoveryBindAddress(), rskConfig.listenPort(), peerExplorer);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -43,7 +43,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
-import java.net.Socket;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -554,37 +553,47 @@ public abstract class SystemProperties {
     /**
      * This can be a blocking call with long timeout (thus no ValidateMe)
      */
-    public String bindIp() {
-        if (!configFromFiles.hasPath("peer.discovery.bind.ip") || configFromFiles.getString("peer.discovery.bind.ip").trim().isEmpty()) {
-            if (bindIp == null) {
-                logger.info("Bind address wasn't set, Punching to identify it...");
-                try(Socket s = new Socket("www.google.com", 80)) {
-                    bindIp = s.getLocalAddress().getHostAddress();
-                    logger.info("UDP local bound to: {}", bindIp);
-                } catch (IOException e) {
-                    logger.warn("Can't get bind IP. Fall back to 0.0.0.0: ", e);
-                    bindIp = DEFAULT_BIND_IP;
-                }
-            }
-            return bindIp;
-        } else {
-            return configFromFiles.getString("peer.discovery.bind.ip").trim();
+    public String getPeerDiscoveryBindAddress() {
+        if (bindIp == null) {
+            bindIp = DEFAULT_BIND_IP;
         }
+
+        if (configFromFiles.hasPath("peer.discovery.bind.ip") &&
+                !configFromFiles.getString("peer.discovery.bind.ip").trim().isEmpty()) {
+            bindIp = configFromFiles.getString("peer.discovery.bind.ip").trim();
+        }
+
+        logger.info("Binding peer discovery on {}", bindIp);
+        return bindIp;
     }
 
     /**
      * This can be a blocking call with long timeout (thus no ValidateMe)
      */
-    public String externalIp() {
-        if (configFromFiles.hasPath("peer.discovery.external.ip") && !configFromFiles.getString("peer.discovery.external.ip").trim().isEmpty()) {
-            return configFromFiles.getString("peer.discovery.external.ip").trim();
-        }
-
+    public synchronized String getExternalIp() {
         if (externalIp != null) {
             return externalIp;
         }
 
-        logger.info("External IP wasn't set, using checkip.amazonaws.com to identify it...");
+        if (configFromFiles.hasPath("peer.discovery.external.ip") &&
+                !configFromFiles.getString("peer.discovery.external.ip").trim().isEmpty()) {
+            try {
+                InetAddress addr = InetAddress.getByName(configFromFiles.getString("peer.discovery.external.ip").trim());
+                externalIp = addr.getHostAddress();
+                logger.info("External address identified {}", externalIp);
+                return externalIp;
+            } catch (IOException e) {
+                externalIp = null;
+                logger.warn("Can't resolve external address");
+            }
+        }
+
+        externalIp = getMyPublicIpFromRemoteService();
+        return externalIp;
+    }
+
+    public String getMyPublicIpFromRemoteService(){
+        logger.info("External IP wasn't set or resolved, using checkip.amazonaws.com to identify it...");
         try {
             try (BufferedReader in = new BufferedReader(new InputStreamReader(new URL("http://checkip.amazonaws.com").openStream()))) {
                 externalIp = in.readLine();
@@ -597,11 +606,9 @@ public abstract class SystemProperties {
             tryParseIpOrThrow();
             logger.info("External address identified: {}", externalIp);
         } catch (IOException e) {
-            externalIp = bindIp();
-            logger.warn("Can't get external IP. Fall back to peer.bind.ip: " + externalIp + " :" + e);
+            logger.warn("Can't get external IP. " + e);
         }
         return externalIp;
-
     }
 
     @ValidateMe

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -99,7 +99,7 @@ public class EthereumImpl implements Ethereum {
         }
         compositeEthereumListener.addListener(gasPriceTracker);
 
-        gLogger.info("RskJ node started: enode://" + Hex.toHexString(config.nodeId()) + "@" + config.getExternalIp() + ":" + config.listenPort());
+        gLogger.info("RskJ node started: enode://{}@{}:{}" , Hex.toHexString(config.nodeId()), config.getExternalIp(), config.listenPort());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -99,7 +99,7 @@ public class EthereumImpl implements Ethereum {
         }
         compositeEthereumListener.addListener(gasPriceTracker);
 
-        gLogger.info("RskJ node started: enode://" + Hex.toHexString(config.nodeId()) + "@" + config.externalIp() + ":" + config.listenPort());
+        gLogger.info("RskJ node started: enode://" + Hex.toHexString(config.nodeId()) + "@" + config.getExternalIp() + ":" + config.listenPort());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/net/NodeManager.java
+++ b/rskj-core/src/main/java/org/ethereum/net/NodeManager.java
@@ -70,7 +70,7 @@ public class NodeManager {
     void init() {
         discoveryEnabled = config.peerDiscovery();
 
-        homeNode = new Node(config.nodeId(), config.externalIp(), config.listenPort());
+        homeNode = new Node(config.nodeId(), config.getExternalIp(), config.listenPort());
 
         for (Node node : config.peerActive()) {
             NodeHandler handler = new NodeHandler(node, this);

--- a/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
@@ -31,7 +31,7 @@ public class SystemPropertiesTest {
     public void punchBindIpTest() {
         RskSystemProperties.CONFIG.overrideParams("peer.bind.ip", "");
         long st = System.currentTimeMillis();
-        String ip = RskSystemProperties.CONFIG.bindIp();
+        String ip = RskSystemProperties.CONFIG.getPeerDiscoveryBindAddress();
         long t = System.currentTimeMillis() - st;
         System.out.println(ip + " in " + t + " msec");
         Assert.assertTrue(t < 10 * 1000);
@@ -42,7 +42,7 @@ public class SystemPropertiesTest {
     public void externalIpTest() {
         RskSystemProperties.CONFIG.overrideParams("peer.discovery.external.ip", "");
         long st = System.currentTimeMillis();
-        String ip = RskSystemProperties.CONFIG.externalIp();
+        String ip = RskSystemProperties.CONFIG.getExternalIp();
         long t = System.currentTimeMillis() - st;
         System.out.println(ip + " in " + t + " msec");
         Assert.assertTrue(t < 10 * 1000);

--- a/rskj-core/src/test/java/org/ethereum/net/NodeManagerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/NodeManagerTest.java
@@ -63,7 +63,7 @@ public class NodeManagerTest {
         MockitoAnnotations.initMocks(this);
 
         Mockito.when(config.nodeId()).thenReturn(Hex.decode(NODE_ID_1));
-        Mockito.when(config.externalIp()).thenReturn("127.0.0.1");
+        Mockito.when(config.getExternalIp()).thenReturn("127.0.0.1");
         Mockito.when(config.listenPort()).thenReturn(8080);
     }
 


### PR DESCRIPTION
Rename bindIp method to getPeerDiscoveryBindAddress. 
Rename externalIp method to getExternalIp.
Remove socket implementation to get the ip if not configured. 
Reorder logger. 
Modify log message. 
Syncronize getExternalIp method to avoid double excecution. 
Try to resolve peer.discovery.external.ip to avoid exception in peer discovery when is not propertly configured. 
Add getMyPublicIpFromRemoteService as a separated method to resolve public ip using a remote service.