### PR TITLE
Feature/rfs 63 whitelist return same utxos

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -226,6 +226,16 @@ public class BridgeSupport {
     }
 
     /**
+     * Get a no spend wallet for the currently live federations
+     * @return A no spend BTC wallet for the currently live federation(s)
+     *
+     * @throws IOException
+     */
+    public Wallet getNoSpendWalletForLiveFederations() throws IOException {
+        return BridgeUtils.getFederationsNoSpendWallet(btcContext, getLiveFederations());
+    }
+
+    /**
      * In case of a lock tx: Transfers some SBTCs to the sender of the btc tx and keeps track of the new UTXOs available for spending.
      * In case of a release tx: Keeps track of the change UTXOs, now available for spending.
      * @param btcTx The bitcoin transaction
@@ -283,6 +293,8 @@ public class BridgeSupport {
             return;
         }
 
+        boolean locked = true;
+
         // Specific code for lock/release/none txs
         if (BridgeUtils.isLockTx(btcTx, getLiveFederations(), btcContext, bridgeConstants)) {
             logger.debug("This is a lock tx {}", btcTx);
@@ -312,16 +324,40 @@ public class BridgeSupport {
             Address senderBtcAddress = new Address(btcContext.getParams(), senderBtcKey.getPubKeyHash());
 
             // If the address is not whitelisted, then return the funds
-            // That is, get them in the release cycle
-            // otherwise, transfer SBTC to the sender of the BTC
+            // using the exact same utxos sent to us.
+            // That is, build a release transaction and get it in the release transaction set.
+            // Otherwise, transfer SBTC to the sender of the BTC
             // The RSK account to update is the one that matches the pubkey "spent" on the first bitcoin tx input
             if (!provider.getLockWhitelist().isWhitelisted(senderBtcAddress)) {
-                boolean addResult = requestRelease(senderBtcAddress, totalAmount);
-
-                if (addResult) {
-                    logger.info("whitelist money return succesful to {}. Tx {}. Value {}.", senderBtcAddress, rskTx, totalAmount);
+                locked = false;
+                // Build the list of UTXOs in the BTC transaction sent to either the active
+                // or retiring federation
+                List<UTXO> utxosToUs = btcTx.getWalletOutputs(getNoSpendWalletForLiveFederations()).stream()
+                        .map(output ->
+                                new UTXO(
+                                        btcTx.getHash(),
+                                        output.getIndex(),
+                                        output.getValue(),
+                                        0,
+                                        btcTx.isCoinBase(),
+                                        output.getScriptPubKey()
+                                )
+                        ).collect(Collectors.toList());
+                // Use the list of UTXOs to build a transaction builder
+                // for the return btc transaction generation
+                ReleaseTransactionBuilder txBuilder = new ReleaseTransactionBuilder(
+                        btcContext.getParams(),
+                        getUTXOBasedWalletForLiveFederations(utxosToUs),
+                        senderBtcAddress,
+                        getFeePerKb()
+                );
+                Optional<ReleaseTransactionBuilder.BuildResult> buildReturnResult = txBuilder.buildEmptyWalletTo(senderBtcAddress);
+                if (buildReturnResult.isPresent()) {
+                    provider.getReleaseTransactionSet().add(buildReturnResult.get().getBtcTx(), rskExecutionBlock.getNumber());
+                    logger.info("whitelist money return tx build successful to {}. Tx {}. Value {}.", senderBtcAddress, rskTx, totalAmount);
                 } else {
-                    logger.warn("whitelist money return ignored because value is considered dust. To {}. Tx {}. Value {}.", senderBtcAddress, rskTx, totalAmount);
+                    logger.warn("whitelist money return tx build for btc tx {} error. Return was to {}. Tx {}. Value {}", btcTx.getHash(), senderBtcAddress, rskTx, totalAmount);
+                    panicProcessor.panic("whitelist-return-funds", String.format("whitelist money return tx build for btc tx {} error. Return was to {}. Tx {}. Value {}", btcTx.getHash(), senderBtcAddress, rskTx, totalAmount));
                 }
             } else {
                 org.ethereum.crypto.ECKey key = org.ethereum.crypto.ECKey.fromPublicOnly(data);
@@ -359,8 +395,11 @@ public class BridgeSupport {
         // Mark tx as processed on this block
         provider.getBtcTxHashesAlreadyProcessed().put(btcTxHash, rskExecutionBlock.getNumber());
 
-        // Save UTXOs from the federation(s)
-        saveNewUTXOs(btcTx);
+        // Save UTXOs from the federation(s) only if we actually
+        // locked the funds.
+        if (locked) {
+            saveNewUTXOs(btcTx);
+        }
         logger.info("BTC Tx {} processed in RSK", btcTxHash);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -214,6 +214,18 @@ public class BridgeSupport {
     }
 
     /**
+     * Get the wallet for the currently live federations
+     * but limited to a specific list of UTXOs
+     * @return A BTC wallet for the currently live federation(s)
+     * limited to the given list of UTXOs
+     *
+     * @throws IOException
+     */
+    public Wallet getUTXOBasedWalletForLiveFederations(List<UTXO> utxos) throws IOException {
+        return BridgeUtils.getFederationsSpendWallet(btcContext, getLiveFederations(), utxos);
+    }
+
+    /**
      * In case of a lock tx: Transfers some SBTCs to the sender of the btc tx and keeps track of the new UTXOs available for spending.
      * In case of a release tx: Keeps track of the change UTXOs, now available for spending.
      * @param btcTx The bitcoin transaction
@@ -520,13 +532,14 @@ public class BridgeSupport {
         // Releases are attempted using the currently active federation
         // wallet.
         final ReleaseTransactionBuilder txBuilder = new ReleaseTransactionBuilder(
+                btcContext.getParams(),
                 activeFederationWallet,
                 getFederationAddress(),
                 getFeePerKb()
         );
 
         releaseRequestQueue.process((ReleaseRequestQueue.Entry releaseRequest) -> {
-            Optional<ReleaseTransactionBuilder.BuildResult> result = txBuilder.build(
+            Optional<ReleaseTransactionBuilder.BuildResult> result = txBuilder.buildAmountTo(
                     releaseRequest.getDestination(),
                     releaseRequest.getAmount()
             );

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -78,11 +78,17 @@ public class BridgeUtils {
     }
 
     public static Wallet getFederationSpendWallet(Context btcContext, Federation federation, List<UTXO> utxos) {
-        Wallet wallet = new BridgeBtcWallet(btcContext, Arrays.asList(federation));
+        return getFederationsSpendWallet(btcContext, Arrays.asList(federation), utxos);
+    }
+
+    public static Wallet getFederationsSpendWallet(Context btcContext, List<Federation> federations, List<UTXO> utxos) {
+        Wallet wallet = new BridgeBtcWallet(btcContext, federations);
 
         RskUTXOProvider utxoProvider = new RskUTXOProvider(btcContext.getParams(), utxos);
         wallet.setUTXOProvider(utxoProvider);
-        wallet.addWatchedAddress(federation.getAddress(), federation.getCreationTime().toEpochMilli());
+        federations.stream().forEach(federation -> {
+            wallet.addWatchedAddress(federation.getAddress(), federation.getCreationTime().toEpochMilli());
+        });
         wallet.setCoinSelector(new RskAllowUnconfirmedCoinSelector());
         return wallet;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -55,13 +55,19 @@ public class ReleaseTransactionBuilder {
         }
     }
 
+    private interface SendRequestConfigurator {
+        void configure(SendRequest sr);
+    }
+
     private static final Logger logger = LoggerFactory.getLogger("ReleaseTransactionBuilder");
 
+    private final NetworkParameters params;
     private final Wallet wallet;
     private final Address changeAddress;
     private final Coin feePerKb;
 
-    public ReleaseTransactionBuilder(Wallet wallet, Address changeAddress, Coin feePerKb) {
+    public ReleaseTransactionBuilder(NetworkParameters params, Wallet wallet, Address changeAddress, Coin feePerKb) {
+        this.params = params;
         this.wallet = wallet;
         this.changeAddress = changeAddress;
         this.feePerKb = feePerKb;
@@ -79,16 +85,32 @@ public class ReleaseTransactionBuilder {
         return feePerKb;
     }
 
-    public Optional<BuildResult> build(Address to, Coin amount) {
-        BtcTransaction btcTx = new BtcTransaction(to.getParameters());
-        btcTx.addOutput(amount, to);
+    public Optional<BuildResult> buildAmountTo(Address to, Coin amount) {
+        return buildWithConfiguration((SendRequest sr) -> {
+            sr.tx.addOutput(amount, to);
+            sr.changeAddress = changeAddress;
+        }, String.format("sending %s to %s", amount, to));
+    }
 
+    public Optional<BuildResult> buildEmptyWalletTo(Address to) {
+        return buildWithConfiguration((SendRequest sr) -> {
+            sr.tx.addOutput(Coin.ZERO, to);
+            sr.changeAddress = to;
+            sr.emptyWallet = true;
+        }, String.format("emptying wallet to %s", to));
+    }
+
+    private Optional<BuildResult> buildWithConfiguration(
+            SendRequestConfigurator sendRequestConfigurator,
+            String operationDescription) {
+
+        // Build a tx and send request and configure it
+        BtcTransaction btcTx = new BtcTransaction(params);
         SendRequest sr = SendRequest.forTx(btcTx);
-        sr.feePerKb = feePerKb;
-        sr.missingSigsMode = Wallet.MissingSigsMode.USE_OP_ZERO;
-        sr.changeAddress = changeAddress;
-        sr.shuffleOutputs = false;
-        sr.recipientsPayFees = true;
+        // Default settings
+        defaultSettingsConfigurator.configure(sr);
+        // Specific settings
+        sendRequestConfigurator.configure(sr);
 
         try {
             wallet.completeTx(sr);
@@ -110,25 +132,32 @@ public class ReleaseTransactionBuilder {
 
             return Optional.of(new BuildResult(btcTx, selectedUTXOs));
         } catch (InsufficientMoneyException e) {
-            logger.warn(String.format("Not enough BTC in the wallet to complete sending %s to %s", amount, to), e);
+            logger.warn(String.format("Not enough BTC in the wallet to complete %s", operationDescription), e);
             // Comment out panic logging for now
             // panicProcessor.panic("nomoney", "Not enough confirmed BTC in the federation wallet to complete " + rskTxHash + " " + btcTx);
             return Optional.empty();
         } catch (Wallet.CouldNotAdjustDownwards e) {
-            logger.warn(String.format("A user output could not be adjusted downwards to pay tx fees sending %s to %s", amount, to), e);
+            logger.warn(String.format("A user output could not be adjusted downwards to pay tx fees %s", operationDescription), e);
             // Comment out panic logging for now
             // panicProcessor.panic("couldnotadjustdownwards", "A user output could not be adjusted downwards to pay tx fees " + rskTxHash + " " + btcTx);
             return Optional.empty();
         } catch (Wallet.ExceededMaxTransactionSize e) {
-            logger.warn(String.format("Tx size too big sending %s to %s", amount, to), e);
+            logger.warn(String.format("Tx size too big %s", operationDescription), e);
             // Comment out panic logging for now
             // panicProcessor.panic("exceededmaxtransactionsize", "Tx size too big " + rskTxHash + " " + btcTx);
             return Optional.empty();
         } catch (UTXOProviderException e) {
-            logger.warn(String.format("UTXO provider exception sending %s to %s", amount, to), e);
+            logger.warn(String.format("UTXO provider exception sending %s", operationDescription), e);
             // Comment out panic logging for now
             // panicProcessor.panic("utxoprovider", "UTXO provider exception " + rskTxHash + " " + btcTx);
             return Optional.empty();
         }
     }
+
+    private final SendRequestConfigurator defaultSettingsConfigurator = (SendRequest sr) -> {
+        sr.missingSigsMode = Wallet.MissingSigsMode.USE_OP_ZERO;
+        sr.feePerKb = getFeePerKb();
+        sr.shuffleOutputs = false;
+        sr.recipientsPayFees = true;
+    };
 }

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -19,12 +19,9 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.*;
-import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.Script;
-import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.wallet.SendRequest;
 import co.rsk.bitcoinj.wallet.Wallet;
-import org.ethereum.core.CallTransaction;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +49,7 @@ public class ReleaseTransactionBuilderTest {
     public void createBuilder() {
         wallet = mock(Wallet.class);
         changeAddress = mockAddress(1000);
-        builder = new ReleaseTransactionBuilder(wallet, changeAddress, Coin.MILLICOIN.multiply(2));
+        builder = new ReleaseTransactionBuilder(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), wallet, changeAddress, Coin.MILLICOIN.multiply(2));
     }
 
     @Test
@@ -63,7 +60,7 @@ public class ReleaseTransactionBuilderTest {
     }
 
     @Test
-    public void build_ok() throws InsufficientMoneyException, UTXOProviderException {
+    public void buildAmountTo_ok() throws InsufficientMoneyException, UTXOProviderException {
         Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Address to = mockAddress(123);
         Coin amount = Coin.CENT.multiply(3);
@@ -107,7 +104,7 @@ public class ReleaseTransactionBuilderTest {
             return null;
         }).when(wallet).completeTx(any(SendRequest.class));
 
-        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.build(to, amount);
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
 
         Assert.assertTrue(result.isPresent());
 
@@ -132,14 +129,14 @@ public class ReleaseTransactionBuilderTest {
     }
 
     @Test
-    public void build_insufficientMoneyException() throws InsufficientMoneyException, UTXOProviderException {
+    public void buildAmountTo_insufficientMoneyException() throws InsufficientMoneyException, UTXOProviderException {
         Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Address to = mockAddress(123);
         Coin amount = Coin.CENT.multiply(3);
 
         mockCompleteTxWithThrow(wallet, amount, to, new InsufficientMoneyException(Coin.valueOf(1234)));
 
-        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.build(to, amount);
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
 
         Assert.assertFalse(result.isPresent());
         verify(wallet, never()).getWatchedAddresses();
@@ -147,14 +144,14 @@ public class ReleaseTransactionBuilderTest {
     }
 
     @Test
-    public void build_walletCouldNotAdjustDownwards() throws InsufficientMoneyException, UTXOProviderException {
+    public void buildAmountTo_walletCouldNotAdjustDownwards() throws InsufficientMoneyException, UTXOProviderException {
         Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Address to = mockAddress(123);
         Coin amount = Coin.CENT.multiply(3);
 
         mockCompleteTxWithThrow(wallet, amount, to, new Wallet.CouldNotAdjustDownwards());
 
-        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.build(to, amount);
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
 
         Assert.assertFalse(result.isPresent());
         verify(wallet, never()).getWatchedAddresses();
@@ -162,14 +159,14 @@ public class ReleaseTransactionBuilderTest {
     }
 
     @Test
-    public void build_walletExceededMaxTransactionSize() throws InsufficientMoneyException, UTXOProviderException {
+    public void buildAmountTo_walletExceededMaxTransactionSize() throws InsufficientMoneyException, UTXOProviderException {
         Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Address to = mockAddress(123);
         Coin amount = Coin.CENT.multiply(3);
 
         mockCompleteTxWithThrow(wallet, amount, to, new Wallet.ExceededMaxTransactionSize());
 
-        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.build(to, amount);
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
 
         Assert.assertFalse(result.isPresent());
         verify(wallet, never()).getWatchedAddresses();
@@ -177,7 +174,7 @@ public class ReleaseTransactionBuilderTest {
     }
 
     @Test
-    public void build_utxoProviderException() throws InsufficientMoneyException, UTXOProviderException {
+    public void buildAmountTo_utxoProviderException() throws InsufficientMoneyException, UTXOProviderException {
         Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Address to = mockAddress(123);
         Coin amount = Coin.CENT.multiply(3);
@@ -221,7 +218,7 @@ public class ReleaseTransactionBuilderTest {
             return null;
         }).when(wallet).completeTx(any(SendRequest.class));
 
-        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.build(to, amount);
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
 
         Assert.assertFalse(result.isPresent());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -134,7 +134,7 @@ public class ReleaseTransactionBuilderTest {
         Address to = mockAddress(123);
         Coin amount = Coin.CENT.multiply(3);
 
-        mockCompleteTxWithThrow(wallet, amount, to, new InsufficientMoneyException(Coin.valueOf(1234)));
+        mockCompleteTxWithThrowForBuildToAmount(wallet, amount, to, new InsufficientMoneyException(Coin.valueOf(1234)));
 
         Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
 
@@ -149,7 +149,7 @@ public class ReleaseTransactionBuilderTest {
         Address to = mockAddress(123);
         Coin amount = Coin.CENT.multiply(3);
 
-        mockCompleteTxWithThrow(wallet, amount, to, new Wallet.CouldNotAdjustDownwards());
+        mockCompleteTxWithThrowForBuildToAmount(wallet, amount, to, new Wallet.CouldNotAdjustDownwards());
 
         Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
 
@@ -164,7 +164,7 @@ public class ReleaseTransactionBuilderTest {
         Address to = mockAddress(123);
         Coin amount = Coin.CENT.multiply(3);
 
-        mockCompleteTxWithThrow(wallet, amount, to, new Wallet.ExceededMaxTransactionSize());
+        mockCompleteTxWithThrowForBuildToAmount(wallet, amount, to, new Wallet.ExceededMaxTransactionSize());
 
         Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
 
@@ -219,11 +219,180 @@ public class ReleaseTransactionBuilderTest {
         }).when(wallet).completeTx(any(SendRequest.class));
 
         Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildAmountTo(to, amount);
+        verify(wallet, times(1)).completeTx(any(SendRequest.class));
 
         Assert.assertFalse(result.isPresent());
     }
 
-    private void mockCompleteTxWithThrow(Wallet wallet, Coin expectedAmount, Address expectedAddress, Throwable t) throws InsufficientMoneyException {
+    @Test
+    public void buildEmptyWalletTo_ok() throws InsufficientMoneyException, UTXOProviderException {
+        Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Address to = mockAddress(123);
+
+        List<UTXO> availableUTXOs = Arrays.asList(
+                mockUTXO("one", 0, Coin.COIN),
+                mockUTXO("two", 2, Coin.FIFTY_COINS),
+                mockUTXO("two", 0, Coin.COIN.times(7)),
+                mockUTXO("three", 0, Coin.CENT.times(3))
+        );
+
+        UTXOProvider utxoProvider = mock(UTXOProvider.class);
+        when(wallet.getUTXOProvider()).thenReturn(utxoProvider);
+        when(wallet.getWatchedAddresses()).thenReturn(Arrays.asList(to));
+        when(utxoProvider.getOpenTransactionOutputs(any(List.class))).then((InvocationOnMock m) -> {
+            List<Address> addresses = m.getArgumentAt(0, List.class);
+            Assert.assertEquals(Arrays.asList(to), addresses);
+            return availableUTXOs;
+        });
+
+        Mockito.doAnswer((InvocationOnMock m) -> {
+            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+
+            Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
+            Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
+            Assert.assertEquals(to, sr.changeAddress);
+            Assert.assertFalse(sr.shuffleOutputs);
+            Assert.assertTrue(sr.recipientsPayFees);
+            Assert.assertTrue(sr.emptyWallet);
+
+            BtcTransaction tx = sr.tx;
+
+            Assert.assertEquals(1, tx.getOutputs().size());
+            Assert.assertEquals(Coin.ZERO, tx.getOutput(0).getValue());
+            Assert.assertEquals(to, tx.getOutput(0).getAddressFromP2PKHScript(NetworkParameters.fromID(NetworkParameters.ID_REGTEST)));
+
+            tx.addInput(mockUTXOHash("one"), 0, mock(Script.class));
+            tx.addInput(mockUTXOHash("two"), 2, mock(Script.class));
+            tx.addInput(mockUTXOHash("two"), 0, mock(Script.class));
+            tx.addInput(mockUTXOHash("three"), 0, mock(Script.class));
+            tx.getOutput(0).setValue(Coin.FIFTY_COINS);
+
+            return null;
+        }).when(wallet).completeTx(any(SendRequest.class));
+
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildEmptyWalletTo(to);
+
+        Assert.assertTrue(result.isPresent());
+
+        BtcTransaction tx = result.get().getBtcTx();
+        List<UTXO> selectedUTXOs = result.get().getSelectedUTXOs();
+
+        Assert.assertEquals(1, tx.getOutputs().size());
+        Assert.assertEquals(Coin.FIFTY_COINS, tx.getOutput(0).getValue());
+        Assert.assertEquals(to, tx.getOutput(0).getAddressFromP2PKHScript(NetworkParameters.fromID(NetworkParameters.ID_REGTEST)));
+
+        Assert.assertEquals(4, tx.getInputs().size());
+        Assert.assertEquals(mockUTXOHash("one"), tx.getInput(0).getOutpoint().getHash());
+        Assert.assertEquals(0, tx.getInput(0).getOutpoint().getIndex());
+        Assert.assertEquals(mockUTXOHash("two"), tx.getInput(1).getOutpoint().getHash());
+        Assert.assertEquals(2, tx.getInput(1).getOutpoint().getIndex());
+        Assert.assertEquals(mockUTXOHash("two"), tx.getInput(2).getOutpoint().getHash());
+        Assert.assertEquals(0, tx.getInput(2).getOutpoint().getIndex());
+        Assert.assertEquals(mockUTXOHash("three"), tx.getInput(3).getOutpoint().getHash());
+        Assert.assertEquals(0, tx.getInput(3).getOutpoint().getIndex());
+
+        Assert.assertEquals(4, selectedUTXOs.size());
+        Assert.assertEquals(mockUTXOHash("one"), selectedUTXOs.get(0).getHash());
+        Assert.assertEquals(0, selectedUTXOs.get(0).getIndex());
+        Assert.assertEquals(mockUTXOHash("two"), selectedUTXOs.get(1).getHash());
+        Assert.assertEquals(2, selectedUTXOs.get(1).getIndex());
+        Assert.assertEquals(mockUTXOHash("two"), selectedUTXOs.get(2).getHash());
+        Assert.assertEquals(0, selectedUTXOs.get(2).getIndex());
+        Assert.assertEquals(mockUTXOHash("three"), selectedUTXOs.get(3).getHash());
+        Assert.assertEquals(0, selectedUTXOs.get(3).getIndex());
+    }
+
+    @Test
+    public void buildEmptyWalletTo_insufficientMoneyException() throws InsufficientMoneyException, UTXOProviderException {
+        Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Address to = mockAddress(123);
+
+        mockCompleteTxWithThrowForEmptying(wallet, to, new InsufficientMoneyException(Coin.valueOf(1234)));
+
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildEmptyWalletTo(to);
+
+        Assert.assertFalse(result.isPresent());
+        verify(wallet, never()).getWatchedAddresses();
+        verify(wallet, never()).getUTXOProvider();
+    }
+
+    @Test
+    public void buildEmptyWalletTo_walletCouldNotAdjustDownwards() throws InsufficientMoneyException, UTXOProviderException {
+        Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Address to = mockAddress(123);
+
+        mockCompleteTxWithThrowForEmptying(wallet, to, new Wallet.CouldNotAdjustDownwards());
+
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildEmptyWalletTo(to);
+
+        Assert.assertFalse(result.isPresent());
+        verify(wallet, never()).getWatchedAddresses();
+        verify(wallet, never()).getUTXOProvider();
+    }
+
+    @Test
+    public void buildEmptyWalletTo_walletExceededMaxTransactionSize() throws InsufficientMoneyException, UTXOProviderException {
+        Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Address to = mockAddress(123);
+
+        mockCompleteTxWithThrowForEmptying(wallet, to, new Wallet.ExceededMaxTransactionSize());
+
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildEmptyWalletTo(to);
+
+        Assert.assertFalse(result.isPresent());
+        verify(wallet, never()).getWatchedAddresses();
+        verify(wallet, never()).getUTXOProvider();
+    }
+
+    @Test
+    public void buildEmptyWalletTo_utxoProviderException() throws InsufficientMoneyException, UTXOProviderException {
+        Context btcContext = new Context(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Address to = mockAddress(123);
+
+        List<UTXO> availableUTXOs = Arrays.asList(
+                mockUTXO("two", 2, Coin.FIFTY_COINS),
+                mockUTXO("three", 0, Coin.CENT.times(3))
+        );
+
+        UTXOProvider utxoProvider = mock(UTXOProvider.class);
+        when(wallet.getUTXOProvider()).thenReturn(utxoProvider);
+        when(wallet.getWatchedAddresses()).thenReturn(Arrays.asList(to));
+        when(utxoProvider.getOpenTransactionOutputs(any(List.class))).then((InvocationOnMock m) -> {
+            List<Address> addresses = m.getArgumentAt(0, List.class);
+            Assert.assertEquals(Arrays.asList(to), addresses);
+            throw new UTXOProviderException();
+        });
+
+        Mockito.doAnswer((InvocationOnMock m) -> {
+            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+
+            Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
+            Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
+            Assert.assertEquals(to, sr.changeAddress);
+            Assert.assertFalse(sr.shuffleOutputs);
+            Assert.assertTrue(sr.recipientsPayFees);
+            Assert.assertTrue(sr.emptyWallet);
+
+            BtcTransaction tx = sr.tx;
+
+            Assert.assertEquals(1, tx.getOutputs().size());
+            Assert.assertEquals(Coin.ZERO, tx.getOutput(0).getValue());
+            Assert.assertEquals(to, tx.getOutput(0).getAddressFromP2PKHScript(NetworkParameters.fromID(NetworkParameters.ID_REGTEST)));
+
+            tx.addInput(mockUTXOHash("two"), 2, mock(Script.class));
+            tx.addInput(mockUTXOHash("three"), 0, mock(Script.class));
+            tx.getOutput(0).setValue(Coin.FIFTY_COINS);
+
+            return null;
+        }).when(wallet).completeTx(any(SendRequest.class));
+
+        Optional<ReleaseTransactionBuilder.BuildResult> result = builder.buildEmptyWalletTo(to);
+        verify(wallet, times(1)).completeTx(any(SendRequest.class));
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    private void mockCompleteTxWithThrowForBuildToAmount(Wallet wallet, Coin expectedAmount, Address expectedAddress, Throwable t) throws InsufficientMoneyException {
         Mockito.doAnswer((InvocationOnMock m) -> {
             SendRequest sr = m.getArgumentAt(0, SendRequest.class);
 
@@ -237,6 +406,27 @@ public class ReleaseTransactionBuilderTest {
 
             Assert.assertEquals(1, tx.getOutputs().size());
             Assert.assertEquals(expectedAmount, tx.getOutput(0).getValue());
+            Assert.assertEquals(expectedAddress, tx.getOutput(0).getAddressFromP2PKHScript(NetworkParameters.fromID(NetworkParameters.ID_REGTEST)));
+
+            throw t;
+        }).when(wallet).completeTx(any(SendRequest.class));
+    }
+
+    private void mockCompleteTxWithThrowForEmptying(Wallet wallet, Address expectedAddress, Throwable t) throws InsufficientMoneyException {
+        Mockito.doAnswer((InvocationOnMock m) -> {
+            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+
+            Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
+            Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
+            Assert.assertEquals(expectedAddress, sr.changeAddress);
+            Assert.assertFalse(sr.shuffleOutputs);
+            Assert.assertTrue(sr.recipientsPayFees);
+            Assert.assertTrue(sr.emptyWallet);
+
+            BtcTransaction tx = sr.tx;
+
+            Assert.assertEquals(1, tx.getOutputs().size());
+            Assert.assertEquals(Coin.ZERO, tx.getOutput(0).getValue());
             Assert.assertEquals(expectedAddress, tx.getOutput(0).getAddressFromP2PKHScript(NetworkParameters.fromID(NetworkParameters.ID_REGTEST)));
 
             throw t;


### PR DESCRIPTION
When funds a returned to a non-whitelisted addresses, build the BTC transaction that returns the funds using the UTXOs of the BTC transaction that corresponds to the lock attempt.