### PR TITLE
Simplify ethereum impl construction

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -92,32 +92,30 @@ public class RskFactory {
                       ChannelManager channelManager,
                       PeerServer peerServer,
                       ProgramInvokeFactory programInvokeFactory,
-                      PendingState pendingState,
                       SystemProperties config,
                       CompositeEthereumListener compositeEthereumListener,
-                      ReceiptStore receiptStore,
-                      PeerScoringManager peerScoringManager,
                       NodeBlockProcessor nodeBlockProcessor,
-                      NodeMessageHandler nodeMessageHandler,
-                      RskSystemProperties rskSystemProperties,
-                      org.ethereum.core.Repository repository) {
+                      RskSystemProperties rskSystemProperties) {
 
         logger.info("Running {},  core version: {}-{}", config.genesisInfo(), config.projectVersion(), config.projectVersionModifier());
         BuildInfo.printInfo();
 
         RskImpl rsk = new RskImpl(worldManager, channelManager, peerServer, programInvokeFactory,
-                pendingState, config, compositeEthereumListener, receiptStore, nodeBlockProcessor, repository);
+                config, compositeEthereumListener, nodeBlockProcessor);
 
         rsk.init();
         rsk.getBlockchain().setRsk(true);  //TODO: check if we can remove this field from org.ethereum.facade.Blockchain
+
         if (logger.isInfoEnabled()) {
             String versions = EthVersion.supported().stream().map(EthVersion::name).collect(Collectors.joining(", "));
             logger.info("Capability eth version: [{}]", versions);
         }
+
         if (rskSystemProperties.isBlocksEnabled()) {
             setupRecorder(rsk, rskSystemProperties.blocksRecorder());
             setupPlayer(rsk, channelManager, blockchain, rskSystemProperties.blocksPlayer());
         }
+
         return rsk;
     }
 

--- a/rskj-core/src/main/java/co/rsk/core/RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskImpl.java
@@ -39,13 +39,10 @@ public class RskImpl extends EthereumImpl implements Rsk {
                    ChannelManager channelManager,
                    PeerServer peerServer,
                    ProgramInvokeFactory programInvokeFactory,
-                   PendingState pendingState,
                    SystemProperties config,
                    CompositeEthereumListener compositeEthereumListener,
-                   ReceiptStore receiptStore,
-                   NodeBlockProcessor nodeBlockProcessor,
-                   Repository repository) {
-        super(worldManager, channelManager, peerServer, programInvokeFactory, pendingState, config, compositeEthereumListener, receiptStore, repository);
+                   NodeBlockProcessor nodeBlockProcessor) {
+        super(worldManager, channelManager, peerServer, programInvokeFactory, config, compositeEthereumListener);
         this.nodeBlockProcessor = nodeBlockProcessor;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -79,11 +79,13 @@ public class EthereumImpl implements Ethereum {
         this.channelManager = channelManager;
         this.peerServer = peerServer;
         this.programInvokeFactory = programInvokeFactory;
-        this.pendingState = pendingState;
         this.config = config;
         this.compositeEthereumListener = compositeEthereumListener;
-        this.receiptStore = receiptStore;
-        this.repository = repository;
+
+        // WorldManager derived fields
+        this.pendingState = this.worldManager.getBlockchain().getPendingState();
+        this.receiptStore = this.worldManager.getBlockchain().getReceiptStore();
+        this.repository = this.worldManager.getBlockchain().getRepository();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -50,8 +50,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 public class EthereumImpl implements Ethereum {
-
-    private static final Logger logger = LoggerFactory.getLogger("facade");
     private static final Logger gLogger = LoggerFactory.getLogger("general");
 
     private final WorldManager worldManager;
@@ -70,11 +68,8 @@ public class EthereumImpl implements Ethereum {
                         ChannelManager channelManager,
                         PeerServer peerServer,
                         ProgramInvokeFactory programInvokeFactory,
-                        PendingState pendingState,
                         SystemProperties config,
-                        CompositeEthereumListener compositeEthereumListener,
-                        ReceiptStore receiptStore,
-                        Repository repository) {
+                        CompositeEthereumListener compositeEthereumListener) {
         this.worldManager = worldManager;
         this.channelManager = channelManager;
         this.peerServer = peerServer;

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -30,6 +30,7 @@ import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
+import org.ethereum.manager.WorldManager;
 import org.ethereum.rpc.Simples.SimpleEthereum;
 import org.ethereum.rpc.Simples.SimpleWorldManager;
 import org.junit.Assert;
@@ -51,7 +52,7 @@ public class MinerManagerTest {
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         minerClient.stop();
         Assert.assertFalse(minerClient.mineBlock());
@@ -65,7 +66,7 @@ public class MinerManagerTest {
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         MinerClientImpl.RefreshWork refreshWork = minerClient.createRefreshWork();
 
@@ -86,7 +87,7 @@ public class MinerManagerTest {
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         MinerClientImpl.RefreshWork refreshWork = minerClient.createRefreshWork();
 
@@ -111,7 +112,7 @@ public class MinerManagerTest {
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
 
@@ -147,7 +148,10 @@ public class MinerManagerTest {
 
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
-        RskImplForTest rsk = new RskImplForTest() {
+        SimpleWorldManager worldManager = new SimpleWorldManager();
+        worldManager.setBlockchain(blockchain);
+
+        RskImplForTest rsk = new RskImplForTest(worldManager) {
             @Override
             public boolean hasBetterBlockToSync() {
                 return true;
@@ -170,7 +174,10 @@ public class MinerManagerTest {
 
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
-        RskImplForTest rsk = new RskImplForTest() {
+        SimpleWorldManager worldManager = new SimpleWorldManager();
+        worldManager.setBlockchain(blockchain);
+
+        RskImplForTest rsk = new RskImplForTest(worldManager) {
             @Override
             public boolean hasBetterBlockToSync() {
                 return false;
@@ -199,7 +206,7 @@ public class MinerManagerTest {
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
         minerClient.doWork();
@@ -215,7 +222,7 @@ public class MinerManagerTest {
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         Assert.assertNull(minerServer.getWork());
 
@@ -232,7 +239,7 @@ public class MinerManagerTest {
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(null);
+        MinerClientImpl minerClient = getMinerClient(null, blockchain);
 
         minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
         minerClient.doWork();
@@ -248,7 +255,7 @@ public class MinerManagerTest {
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
         Thread thread = minerClient.createDoWorkThread();
@@ -276,7 +283,7 @@ public class MinerManagerTest {
         MinerManager manager = new MinerManager();
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         manager.mineBlock(blockchain, minerClient, minerServer);
 
@@ -312,7 +319,7 @@ public class MinerManagerTest {
         MinerManager manager = new MinerManager();
 
         MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
+        MinerClientImpl minerClient = getMinerClient(minerServer, blockchain);
 
         long currentTime = minerServer.getCurrentTimeInSeconds();
 
@@ -327,8 +334,11 @@ public class MinerManagerTest {
         Assert.assertTrue(currentTime + 11 > block.getTimestamp());
     }
 
-    private static MinerClientImpl getMinerClient(MinerServerImpl minerServer) {
-        return getMinerClient(new RskImplForTest() {
+    private static MinerClientImpl getMinerClient(MinerServerImpl minerServer, Blockchain blockchain) {
+        SimpleWorldManager worldManager = new SimpleWorldManager();
+        worldManager.setBlockchain(blockchain);
+
+        return getMinerClient(new RskImplForTest(worldManager) {
             @Override
             public boolean hasBetterBlockToSync() {
                 return false;
@@ -363,9 +373,9 @@ public class MinerManagerTest {
     }
 
     private static class RskImplForTest extends RskImpl {
-        public RskImplForTest() {
-            super(null, null, null,
-                    null, null, null, null, null, null, null);
+        public RskImplForTest(WorldManager worldManager) {
+            super(worldManager, null, null,
+                    null, null, null, null);
         }
     }
 }


### PR DESCRIPTION
Some redundant arguments were removed from EthereumImpl constructor. The additional objects now can be obtained using WorldManager, and there is no use case to have different objects, even in tests.

Some tests were refactored.

Tested on devnet, and quick test on testnet (until block 345, then hard fork)

THIS IS A BABY STEP, in order to refactor many other objects. Since the last year, we were working untangled the objects graphs of the original implementation. One step did in that direction: Blockchain interface extended, to put visibility on the helper objects.

Some things to consider:

- WorldManager has now few responsabilities. Candidate to be removed.
- Blockchain facade could be replaced.
- Spring Framework remove, at least where there is no use case for its use.

This pull request is an step towards future refactors. 
