### PR TITLE
Feature/rfs 49 defer federation activation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -40,8 +40,10 @@ public class BridgeConstants {
     protected Coin minimumLockTxValue;
     protected Coin minimumReleaseTxValue;
 
-    protected long fundsMigrationAgeBegin;
-    protected long fundsMigrationAgeEnd;
+    protected long federationActivationAge;
+
+    protected long fundsMigrationAgeSinceActivationBegin;
+    protected long fundsMigrationAgeSinceActivationEnd;
 
     protected AddressBasedAuthorizer federationChangeAuthorizer;
 
@@ -81,12 +83,14 @@ public class BridgeConstants {
 
     public Coin getMinimumReleaseTxValue() { return minimumReleaseTxValue; }
 
-    public long getFundsMigrationAgeBegin() {
-        return fundsMigrationAgeBegin;
+    public long getFederationActivationAge() { return federationActivationAge; }
+
+    public long getFundsMigrationAgeSinceActivationBegin() {
+        return fundsMigrationAgeSinceActivationBegin;
     }
 
-    public long getFundsMigrationAgeEnd() {
-        return fundsMigrationAgeEnd;
+    public long getFundsMigrationAgeSinceActivationEnd() {
+        return fundsMigrationAgeSinceActivationEnd;
     }
 
     public AddressBasedAuthorizer getFederationChangeAuthorizer() { return federationChangeAuthorizer; }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -96,8 +96,10 @@ public class BridgeDevNetConstants extends BridgeConstants {
                 AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
 
-        fundsMigrationAgeBegin = 15L;
-        fundsMigrationAgeEnd = 100L;
+        federationActivationAge = 10L;
+
+        fundsMigrationAgeSinceActivationBegin = 15L;
+        fundsMigrationAgeSinceActivationEnd = 100L;
     }
 
     public static BridgeDevNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -85,8 +85,10 @@ public class BridgeRegTestConstants extends BridgeConstants {
                 AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY
         );
 
-        fundsMigrationAgeBegin = 15L;
-        fundsMigrationAgeEnd = 150L;
+        federationActivationAge = 10L;
+
+        fundsMigrationAgeSinceActivationBegin = 15L;
+        fundsMigrationAgeSinceActivationEnd = 150L;
 
         // Key generated with GenNodeKey using generator 'auth-lock-whitelist'
         List<ECKey> lockWhitelistAuthorizedKeys = Arrays.stream(new String[]{

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -108,8 +108,10 @@ public class BridgeTestNetConstants extends BridgeConstants {
                 AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
 
-        fundsMigrationAgeBegin = 60L;
-        fundsMigrationAgeEnd = 900L;
+        federationActivationAge = 60L;
+
+        fundsMigrationAgeSinceActivationBegin = 60L;
+        fundsMigrationAgeSinceActivationEnd = 900L;
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -590,11 +590,6 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return bridgeSupport.getFederationCreationBlockNumber();
     }
 
-    public long getRetiringFederationCreationBlockNumber(Object[] args) {
-        logger.trace("getRetiringFederationCreationBlockNumber");
-        return bridgeSupport.getRetiringFederationCreationBlockNumber();
-    }
-
     public String getRetiringFederationAddress(Object[] args)
     {
         logger.trace("getRetiringFederationAddress");
@@ -651,6 +646,11 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
         // Return the creation time in milliseconds from the epoch
         return creationTime.toEpochMilli();
+    }
+
+    public long getRetiringFederationCreationBlockNumber(Object[] args) {
+        logger.trace("getRetiringFederationCreationBlockNumber");
+        return bridgeSupport.getRetiringFederationCreationBlockNumber();
     }
 
     public Integer createFederation(Object[] args)

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeState.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeState.java
@@ -61,7 +61,7 @@ public class BridgeState {
     public BridgeState(int btcBlockchainBestChainHeight, BridgeStorageProvider provider) throws IOException {
         this.btcBlockchainBestChainHeight = btcBlockchainBestChainHeight;
         this.btcTxHashesAlreadyProcessed = provider.getBtcTxHashesAlreadyProcessed();
-        this.activeFederationBtcUTXOs = provider.getActiveFederationBtcUTXOs();
+        this.activeFederationBtcUTXOs = provider.getNewFederationBtcUTXOs();
         this.rskTxsWaitingForSignatures = provider.getRskTxsWaitingForSignatures();
         this.releaseRequestQueue = provider.getReleaseRequestQueue();
         this.releaseTransactionSet = provider.getReleaseTransactionSet();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -40,17 +40,17 @@ import java.util.SortedMap;
  * @author Oscar Guindzberg
  */
 public class BridgeStorageProvider {
-    private static final DataWord ACTIVE_FEDERATION_BTC_UTXOS_KEY = new DataWord(TypeConverter.stringToByteArray("activeFederationBtcUTXOs"));
-    private static final DataWord RETIRING_FEDERATION_BTC_UTXOS_KEY = new DataWord(TypeConverter.stringToByteArray("retiringFederationBtcUTXOs"));
+    private static final DataWord NEW_FEDERATION_BTC_UTXOS_KEY = new DataWord(TypeConverter.stringToByteArray("newFederationBtcUTXOs"));
+    private static final DataWord OLD_FEDERATION_BTC_UTXOS_KEY = new DataWord(TypeConverter.stringToByteArray("oldFederationBtcUTXOs"));
     private static final DataWord BTC_TX_HASHES_ALREADY_PROCESSED_KEY = new DataWord(TypeConverter.stringToByteArray("btcTxHashesAP"));
     private static final DataWord RELEASE_REQUEST_QUEUE = new DataWord(TypeConverter.stringToByteArray("releaseRequestQueue"));
     private static final DataWord RELEASE_TX_SET = new DataWord(TypeConverter.stringToByteArray("releaseTransactionSet"));
     private static final DataWord RSK_TXS_WAITING_FOR_SIGNATURES_KEY = new DataWord(TypeConverter.stringToByteArray("rskTxsWaitingFS"));
-    private static final DataWord BRIDGE_ACTIVE_FEDERATION_KEY = new DataWord(TypeConverter.stringToByteArray("bridgeActiveFederation"));
-    private static final DataWord BRIDGE_RETIRING_FEDERATION_KEY = new DataWord(TypeConverter.stringToByteArray("bridgeRetiringFederation"));
-    private static final DataWord BRIDGE_PENDING_FEDERATION_KEY = new DataWord(TypeConverter.stringToByteArray("bridgePendingFederation"));
-    private static final DataWord BRIDGE_FEDERATION_ELECTION_KEY = new DataWord(TypeConverter.stringToByteArray("bridgeFederationElection"));
-    private static final DataWord LOCK_WHITELIST_KEY = new DataWord(TypeConverter.stringToByteArray("bridgeLockWhitelist"));
+    private static final DataWord NEW_FEDERATION_KEY = new DataWord(TypeConverter.stringToByteArray("newFederation"));
+    private static final DataWord OLD_FEDERATION_KEY = new DataWord(TypeConverter.stringToByteArray("oldFederation"));
+    private static final DataWord PENDING_FEDERATION_KEY = new DataWord(TypeConverter.stringToByteArray("pendingFederation"));
+    private static final DataWord FEDERATION_ELECTION_KEY = new DataWord(TypeConverter.stringToByteArray("federationElection"));
+    private static final DataWord LOCK_WHITELIST_KEY = new DataWord(TypeConverter.stringToByteArray("lockWhitelist"));
 
     private static final NetworkParameters networkParameters = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
 
@@ -69,12 +69,12 @@ public class BridgeStorageProvider {
     private ReleaseTransactionSet releaseTransactionSet;
     private SortedMap<Sha3Hash, BtcTransaction> rskTxsWaitingForSignatures;
 
-    private List<UTXO> activeFederationBtcUTXOs;
-    private List<UTXO> retiringFederationBtcUTXOs;
+    private List<UTXO> newFederationBtcUTXOs;
+    private List<UTXO> oldFederationBtcUTXOs;
 
-    private Federation activeFederation;
-    private Federation retiringFederation;
-    private boolean shouldSaveRetiringFederation = false;
+    private Federation newFederation;
+    private Federation oldFederation;
+    private boolean shouldSaveOldFederation = false;
     private PendingFederation pendingFederation;
     private boolean shouldSavePendingFederation = false;
 
@@ -92,38 +92,38 @@ public class BridgeStorageProvider {
         btcContext = new Context(bridgeConstants.getBtcParams());
     }
 
-    public List<UTXO> getActiveFederationBtcUTXOs() throws IOException {
-        if (activeFederationBtcUTXOs != null) {
-            return activeFederationBtcUTXOs;
+    public List<UTXO> getNewFederationBtcUTXOs() throws IOException {
+        if (newFederationBtcUTXOs != null) {
+            return newFederationBtcUTXOs;
         }
 
-        activeFederationBtcUTXOs = getFromRepository(ACTIVE_FEDERATION_BTC_UTXOS_KEY, BridgeSerializationUtils::deserializeUTXOList);
-        return activeFederationBtcUTXOs;
+        newFederationBtcUTXOs = getFromRepository(NEW_FEDERATION_BTC_UTXOS_KEY, BridgeSerializationUtils::deserializeUTXOList);
+        return newFederationBtcUTXOs;
     }
 
-    public void saveActiveFederationBtcUTXOs() throws IOException {
-        if (activeFederationBtcUTXOs == null) {
+    public void saveNewFederationBtcUTXOs() throws IOException {
+        if (newFederationBtcUTXOs == null) {
             return;
         }
 
-        saveToRepository(ACTIVE_FEDERATION_BTC_UTXOS_KEY, activeFederationBtcUTXOs, BridgeSerializationUtils::serializeUTXOList);
+        saveToRepository(NEW_FEDERATION_BTC_UTXOS_KEY, newFederationBtcUTXOs, BridgeSerializationUtils::serializeUTXOList);
     }
 
-    public List<UTXO> getRetiringFederationBtcUTXOs() throws IOException {
-        if (retiringFederationBtcUTXOs != null) {
-            return retiringFederationBtcUTXOs;
+    public List<UTXO> getOldFederationBtcUTXOs() throws IOException {
+        if (oldFederationBtcUTXOs != null) {
+            return oldFederationBtcUTXOs;
         }
 
-        retiringFederationBtcUTXOs = getFromRepository(RETIRING_FEDERATION_BTC_UTXOS_KEY, BridgeSerializationUtils::deserializeUTXOList);
-        return retiringFederationBtcUTXOs;
+        oldFederationBtcUTXOs = getFromRepository(OLD_FEDERATION_BTC_UTXOS_KEY, BridgeSerializationUtils::deserializeUTXOList);
+        return oldFederationBtcUTXOs;
     }
 
-    public void saveRetiringFederationBtcUTXOs() throws IOException {
-        if (retiringFederationBtcUTXOs == null) {
+    public void saveOldFederationBtcUTXOs() throws IOException {
+        if (oldFederationBtcUTXOs == null) {
             return;
         }
 
-        saveToRepository(RETIRING_FEDERATION_BTC_UTXOS_KEY, retiringFederationBtcUTXOs, BridgeSerializationUtils::serializeUTXOList);
+        saveToRepository(OLD_FEDERATION_BTC_UTXOS_KEY, oldFederationBtcUTXOs, BridgeSerializationUtils::serializeUTXOList);
     }
 
     public Map<Sha256Hash, Long> getBtcTxHashesAlreadyProcessed() throws IOException {
@@ -205,51 +205,60 @@ public class BridgeStorageProvider {
         safeSaveToRepository(RSK_TXS_WAITING_FOR_SIGNATURES_KEY, rskTxsWaitingForSignatures, BridgeSerializationUtils::serializeMap);
     }
 
-    public Federation getActiveFederation() {
-        if (activeFederation != null) {
-            return activeFederation;
+    public Federation getNewFederation() {
+        if (newFederation != null) {
+            return newFederation;
         }
 
-        activeFederation = safeGetFromRepository(BRIDGE_ACTIVE_FEDERATION_KEY, data -> (data == null)? null :BridgeSerializationUtils.deserializeFederation(data, btcContext));
-        return activeFederation;
+        newFederation = safeGetFromRepository(NEW_FEDERATION_KEY,
+                data ->
+                        data == null
+                                ? null
+                                : BridgeSerializationUtils.deserializeFederation(data, btcContext)
+        );
+        return newFederation;
     }
 
-    public void setActiveFederation(Federation federation) {
-        activeFederation = federation;
+    public void setNewFederation(Federation federation) {
+        newFederation = federation;
     }
 
     /**
-     * Save the active federation
-     * Only saved if a federation was set with BridgeStorageProvider::setActiveFederation
+     * Save the new federation
+     * Only saved if a federation was set with BridgeStorageProvider::setNewFederation
      */
-    public void saveActiveFederation() {
-        if (activeFederation == null) {
+    public void saveNewFederation() {
+        if (newFederation == null) {
             return;
         }
 
-        safeSaveToRepository(BRIDGE_ACTIVE_FEDERATION_KEY, activeFederation, BridgeSerializationUtils::serializeFederation);
+        safeSaveToRepository(NEW_FEDERATION_KEY, newFederation, BridgeSerializationUtils::serializeFederation);
     }
 
-    public Federation getRetiringFederation() {
-        if (retiringFederation != null) {
-            return retiringFederation;
+    public Federation getOldFederation() {
+        if (oldFederation != null) {
+            return oldFederation;
         }
 
-        retiringFederation = safeGetFromRepository(BRIDGE_RETIRING_FEDERATION_KEY, data -> (data == null)? null : BridgeSerializationUtils.deserializeFederation(data, btcContext));
-        return retiringFederation;
+        oldFederation = safeGetFromRepository(OLD_FEDERATION_KEY,
+                data -> data == null
+                        ? null
+                        : BridgeSerializationUtils.deserializeFederation(data, btcContext)
+        );
+        return oldFederation;
     }
 
-    public void setRetiringFederation(Federation federation) {
-        shouldSaveRetiringFederation = true;
-        retiringFederation = federation;
+    public void setOldFederation(Federation federation) {
+        shouldSaveOldFederation = true;
+        oldFederation = federation;
     }
 
     /**
-     * Save the retiring federation
+     * Save the old federation
      */
-    public void saveRetiringFederation() {
-        if (shouldSaveRetiringFederation) {
-            safeSaveToRepository(BRIDGE_RETIRING_FEDERATION_KEY, retiringFederation, BridgeSerializationUtils::serializeFederation);
+    public void saveOldFederation() {
+        if (shouldSaveOldFederation) {
+            safeSaveToRepository(OLD_FEDERATION_KEY, oldFederation, BridgeSerializationUtils::serializeFederation);
         }
     }
 
@@ -258,7 +267,11 @@ public class BridgeStorageProvider {
             return pendingFederation;
         }
 
-        pendingFederation = safeGetFromRepository(BRIDGE_PENDING_FEDERATION_KEY, data -> (data == null)? null : BridgeSerializationUtils.deserializePendingFederation(data));
+        pendingFederation = safeGetFromRepository(PENDING_FEDERATION_KEY,
+                data -> data == null
+                        ? null :
+                        BridgeSerializationUtils.deserializePendingFederation(data)
+        );
         return pendingFederation;
     }
 
@@ -272,7 +285,7 @@ public class BridgeStorageProvider {
      */
     public void savePendingFederation() {
         if (shouldSavePendingFederation) {
-            safeSaveToRepository(BRIDGE_PENDING_FEDERATION_KEY, pendingFederation, BridgeSerializationUtils::serializePendingFederation);
+            safeSaveToRepository(PENDING_FEDERATION_KEY, pendingFederation, BridgeSerializationUtils::serializePendingFederation);
         }
     }
 
@@ -284,7 +297,7 @@ public class BridgeStorageProvider {
             return;
         }
 
-        safeSaveToRepository(BRIDGE_FEDERATION_ELECTION_KEY, federationElection, BridgeSerializationUtils::serializeElection);
+        safeSaveToRepository(FEDERATION_ELECTION_KEY, federationElection, BridgeSerializationUtils::serializeElection);
     }
 
     public ABICallElection getFederationElection(AddressBasedAuthorizer authorizer) {
@@ -292,7 +305,7 @@ public class BridgeStorageProvider {
             return federationElection;
         }
 
-        federationElection = safeGetFromRepository(BRIDGE_FEDERATION_ELECTION_KEY, data -> (data == null)? new ABICallElection(authorizer) : BridgeSerializationUtils.deserializeElection(data, authorizer));
+        federationElection = safeGetFromRepository(FEDERATION_ELECTION_KEY, data -> (data == null)? new ABICallElection(authorizer) : BridgeSerializationUtils.deserializeElection(data, authorizer));
         return federationElection;
     }
 
@@ -328,11 +341,11 @@ public class BridgeStorageProvider {
         saveReleaseTransactionSet();
         saveRskTxsWaitingForSignatures();
 
-        saveActiveFederation();
-        saveActiveFederationBtcUTXOs();
+        saveNewFederation();
+        saveNewFederationBtcUTXOs();
 
-        saveRetiringFederation();
-        saveRetiringFederationBtcUTXOs();
+        saveOldFederation();
+        saveOldFederationBtcUTXOs();
 
         savePendingFederation();
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -213,8 +213,8 @@ public class BridgeStorageProvider {
         newFederation = safeGetFromRepository(NEW_FEDERATION_KEY,
                 data ->
                         data == null
-                                ? null
-                                : BridgeSerializationUtils.deserializeFederation(data, btcContext)
+                        ? null
+                        : BridgeSerializationUtils.deserializeFederation(data, btcContext)
         );
         return newFederation;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1233,7 +1233,8 @@ public class BridgeSupport {
 
     /**
      * Returns the retiring federation's creation block number
-     * @return the retiring federation creation block number, null if no retiring federation exists
+     * @return the retiring federation creation block number,
+     * -1 if no retiring federation exists
      */
     public long getRetiringFederationCreationBlockNumber() {
         Federation retiringFederation = getRetiringFederation();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -71,6 +71,8 @@ public class BridgeSupport {
     private static final PanicProcessor panicProcessor = new PanicProcessor();
     private static final Coin MINIMUM_FUNDS_TO_MIGRATE = Coin.CENT;
 
+    private enum StorageFederationReference { NONE, NEW, OLD, GENESIS }
+
     final List<String> FEDERATION_CHANGE_FUNCTIONS = Collections.unmodifiableList(Arrays.asList(new String[]{
             "create",
             "add",
@@ -190,7 +192,7 @@ public class BridgeSupport {
      */
     public Wallet getActiveFederationWallet() throws IOException {
         Federation federation = getActiveFederation();
-        List<UTXO> utxos = provider.getActiveFederationBtcUTXOs();
+        List<UTXO> utxos = getActiveFederationBtcUTXOs();
 
         return BridgeUtils.getFederationSpendWallet(btcContext, federation, utxos);
     }
@@ -208,7 +210,7 @@ public class BridgeSupport {
             return null;
         }
 
-        List<UTXO> utxos = provider.getRetiringFederationBtcUTXOs();
+        List<UTXO> utxos = getRetiringFederationBtcUTXOs();
 
         return BridgeUtils.getFederationSpendWallet(btcContext, federation, utxos);
     }
@@ -411,7 +413,7 @@ public class BridgeSupport {
         List<TransactionOutput> outputsToTheActiveFederation = btcTx.getWalletOutputs(getActiveFederationWallet());
         for (TransactionOutput output : outputsToTheActiveFederation) {
             UTXO utxo = new UTXO(btcTx.getHash(), output.getIndex(), output.getValue(), 0, btcTx.isCoinBase(), output.getScriptPubKey());
-            provider.getActiveFederationBtcUTXOs().add(utxo);
+            getActiveFederationBtcUTXOs().add(utxo);
         }
 
         // Outputs to the retiring federation (if any)
@@ -420,7 +422,7 @@ public class BridgeSupport {
             List<TransactionOutput> outputsToTheRetiringFederation = btcTx.getWalletOutputs(retiringFederationWallet);
             for (TransactionOutput output : outputsToTheRetiringFederation) {
                 UTXO utxo = new UTXO(btcTx.getHash(), output.getIndex(), output.getValue(), 0, btcTx.isCoinBase(), output.getScriptPubKey());
-                provider.getRetiringFederationBtcUTXOs().add(utxo);
+                getRetiringFederationBtcUTXOs().add(utxo);
             }
         }
     }
@@ -500,17 +502,32 @@ public class BridgeSupport {
         processReleaseTransactions(rskTx);
     }
 
-    private void processFundsMigration() throws IOException {
-        long activeFederationAge = rskExecutionBlock.getNumber() - getFederationCreationBlockNumber();
-        Wallet retiringFederationWallet = getRetiringFederationWallet();
-        List<UTXO> availableUTXOs = provider.getRetiringFederationBtcUTXOs();
-        ReleaseTransactionSet releaseTransactionSet = provider.getReleaseTransactionSet();
+    private boolean federationIsInMigrationAge(Federation federation) {
+        long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
+        long ageBegin = bridgeConstants.getFederationActivationAge() + bridgeConstants.getFundsMigrationAgeSinceActivationBegin();
+        long ageEnd = bridgeConstants.getFederationActivationAge() + bridgeConstants.getFundsMigrationAgeSinceActivationEnd();
 
-        if (activeFederationAge > bridgeConstants.getFundsMigrationAgeBegin() && activeFederationAge < bridgeConstants.getFundsMigrationAgeEnd()
+        return federationAge > ageBegin && federationAge < ageEnd;
+    }
+
+    private boolean federationIsPastMigrationAge(Federation federation) {
+        long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
+        long ageEnd = bridgeConstants.getFederationActivationAge() + bridgeConstants.getFundsMigrationAgeSinceActivationEnd();
+
+        return federationAge >= ageEnd;
+    }
+
+    private void processFundsMigration() throws IOException {
+        Wallet retiringFederationWallet = getRetiringFederationWallet();
+        List<UTXO> availableUTXOs = getRetiringFederationBtcUTXOs();
+        ReleaseTransactionSet releaseTransactionSet = provider.getReleaseTransactionSet();
+        Federation activeFederation = getActiveFederation();
+
+        if (federationIsInMigrationAge(activeFederation)
                 && retiringFederationWallet != null
                 && retiringFederationWallet.getBalance().isGreaterThan(MINIMUM_FUNDS_TO_MIGRATE)) {
 
-            Pair<BtcTransaction, List<UTXO>> createResult = createMigrationTransaction(retiringFederationWallet, getActiveFederation().getAddress());
+            Pair<BtcTransaction, List<UTXO>> createResult = createMigrationTransaction(retiringFederationWallet, activeFederation.getAddress());
             BtcTransaction btcTx = createResult.getLeft();
             List<UTXO> selectedUTXOs = createResult.getRight();
 
@@ -524,10 +541,10 @@ public class BridgeSupport {
             ));
         }
 
-        if (retiringFederationWallet != null && activeFederationAge >= bridgeConstants.getFundsMigrationAgeEnd()) {
+        if (retiringFederationWallet != null && federationIsPastMigrationAge(activeFederation)) {
             if (retiringFederationWallet.getBalance().isGreaterThan(Coin.ZERO)) {
                 try {
-                    Pair<BtcTransaction, List<UTXO>> createResult = createMigrationTransaction(retiringFederationWallet, getActiveFederation().getAddress());
+                    Pair<BtcTransaction, List<UTXO>> createResult = createMigrationTransaction(retiringFederationWallet, activeFederation.getAddress());
                     BtcTransaction btcTx = createResult.getLeft();
                     List<UTXO> selectedUTXOs = createResult.getRight();
 
@@ -544,7 +561,7 @@ public class BridgeSupport {
                     panicProcessor.panic("updateCollection", "Unable to complete retiring federation migration.");
                 }
             }
-            provider.setRetiringFederation(null);
+            provider.setOldFederation(null);
         }
     }
 
@@ -608,7 +625,7 @@ public class BridgeSupport {
             // (any of these could fail and would invalidate both
             // the tx build and utxo selection, so treat as atomic)
             try {
-                availableUTXOs = provider.getActiveFederationBtcUTXOs();
+                availableUTXOs = getActiveFederationBtcUTXOs();
                 releaseTransactionSet = provider.getReleaseTransactionSet();
             } catch (IOException exception) {
                 // Unexpected error accessing storage, log and fail
@@ -953,17 +970,131 @@ public class BridgeSupport {
     }
 
     /**
-     * Returns the active federation.
-     * @return the active federation.
+     * Returns the currently active federation reference.
+     * Logic is as follows:
+     * When no "new" federation is recorded in the blockchain, then return GENESIS
+     * When a "new" federation is present and no "old" federation is present, then return NEW
+     * When both "new" and "old" federations are present, then
+     * 1) If the "new" federation is at least bridgeConstants::getFederationActivationAge() blocks old,
+     * return the NEW
+     * 2) Otherwise, return OLD
+     * @return a reference to where the currently active federation is stored.
      */
-    public Federation getActiveFederation() {
-        Federation currentFederation = provider.getActiveFederation();
+    private StorageFederationReference getActiveFederationReference() {
+        Federation newFederation = provider.getNewFederation();
 
-        if (currentFederation == null) {
-            currentFederation = bridgeConstants.getGenesisFederation();
+        // No new federation in place, then the active federation
+        // is the genesis federation
+        if (newFederation == null) {
+            return StorageFederationReference.GENESIS;
         }
 
-        return currentFederation;
+        Federation oldFederation = provider.getOldFederation();
+
+        // No old federation in place, then the active federation
+        // is the new federation
+        if (oldFederation == null) {
+            return StorageFederationReference.NEW;
+        }
+
+        // Both new and old federations in place
+        // If the minimum age has gone by for the new federation's
+        // activation, then that federation is the currently active.
+        // Otherwise, the old federation is still the currently active.
+        if (shouldFederationBeActive(newFederation)) {
+            return StorageFederationReference.NEW;
+        }
+
+        return StorageFederationReference.OLD;
+    }
+
+    /**
+     * Returns the currently retiring federation reference.
+     * Logic is as follows:
+     * When no "new" or "old" federation is recorded in the blockchain, then return empty.
+     * When both "new" and "old" federations are present, then
+     * 1) If the "new" federation is at least bridgeConstants::getFederationActivationAge() blocks old,
+     * return OLD
+     * 2) Otherwise, return empty
+     * @return the retiring federation.
+     */
+    @Nullable
+    private StorageFederationReference getRetiringFederationReference() {
+        Federation newFederation = provider.getNewFederation();
+        Federation oldFederation = provider.getOldFederation();
+
+        if (oldFederation == null || newFederation == null) {
+            return StorageFederationReference.NONE;
+        }
+
+        // Both new and old federations in place
+        // If the minimum age has gone by for the new federation's
+        // activation, then the old federation is the currently retiring.
+        // Otherwise, there is no retiring federation.
+        if (shouldFederationBeActive(newFederation)) {
+            return StorageFederationReference.OLD;
+        }
+
+        return StorageFederationReference.NONE;
+    }
+
+    /**
+     * Returns the currently active federation.
+     * See getActiveFederationReference() for details.
+     * @return the currently active federation.
+     */
+    public Federation getActiveFederation() {
+        switch (getActiveFederationReference()) {
+            case NEW:
+                return provider.getNewFederation();
+            case OLD:
+                return provider.getOldFederation();
+            case GENESIS:
+            default:
+                return bridgeConstants.getGenesisFederation();
+        }
+    }
+
+    /**
+     * Returns the currently retiring federation.
+     * See getRetiringFederationReference() for details.
+     * @return the retiring federation.
+     */
+    @Nullable
+    private Federation getRetiringFederation() {
+        switch (getRetiringFederationReference()) {
+            case OLD:
+                return provider.getOldFederation();
+            case NONE:
+            default:
+                return null;
+        }
+    }
+
+    private List<UTXO> getActiveFederationBtcUTXOs() throws IOException {
+        switch (getActiveFederationReference()) {
+            case OLD:
+                return provider.getOldFederationBtcUTXOs();
+            case NEW:
+            case GENESIS:
+            default:
+                return provider.getNewFederationBtcUTXOs();
+        }
+    }
+
+    private List<UTXO> getRetiringFederationBtcUTXOs() throws IOException {
+        switch (getRetiringFederationReference()) {
+            case OLD:
+                return provider.getOldFederationBtcUTXOs();
+            case NONE:
+            default:
+                return Collections.emptyList();
+        }
+    }
+
+    private boolean shouldFederationBeActive(Federation federation) {
+        long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
+        return federationAge >= bridgeConstants.getFederationActivationAge();
     }
 
     /**
@@ -1014,16 +1145,12 @@ public class BridgeSupport {
     }
 
 
+    /**
+     * Returns the federation's creation block number
+     * @return the federation creation block number
+     */
     public long getFederationCreationBlockNumber() {
         return getActiveFederation().getCreationBlockNumber();
-    }
-
-    public long getRetiringFederationCreationBlockNumber() {
-        Federation retiringFederation = provider.getRetiringFederation();
-        if (retiringFederation == null) {
-            return -1L;
-        }
-        return retiringFederation.getCreationBlockNumber();
     }
 
     /**
@@ -1031,7 +1158,7 @@ public class BridgeSupport {
      * @return the retiring federation bitcoin address, null if no retiring federation exists
      */
     public Address getRetiringFederationAddress() {
-        Federation retiringFederation = provider.getRetiringFederation();
+        Federation retiringFederation = getRetiringFederation();
         if (retiringFederation == null) {
             return null;
         }
@@ -1044,7 +1171,7 @@ public class BridgeSupport {
      * @return the retiring federation size, -1 if no retiring federation exists
      */
     public Integer getRetiringFederationSize() {
-        Federation retiringFederation = provider.getRetiringFederation();
+        Federation retiringFederation = getRetiringFederation();
         if (retiringFederation == null) {
             return -1;
         }
@@ -1057,7 +1184,7 @@ public class BridgeSupport {
      * @return the retiring federation minimum required signatures, -1 if no retiring federation exists
      */
     public Integer getRetiringFederationThreshold() {
-        Federation retiringFederation = provider.getRetiringFederation();
+        Federation retiringFederation = getRetiringFederation();
         if (retiringFederation == null) {
             return -1;
         }
@@ -1071,7 +1198,7 @@ public class BridgeSupport {
      * @return the retiring federator's public key, null if no retiring federation exists
      */
     public byte[] getRetiringFederatorPublicKey(int index) {
-        Federation retiringFederation = provider.getRetiringFederation();
+        Federation retiringFederation = getRetiringFederation();
         if (retiringFederation == null) {
             return null;
         }
@@ -1090,7 +1217,7 @@ public class BridgeSupport {
      * @return the retiring federation creation time, null if no retiring federation exists
      */
     public Instant getRetiringFederationCreationTime() {
-        Federation retiringFederation = provider.getRetiringFederation();
+        Federation retiringFederation = getRetiringFederation();
         if (retiringFederation == null) {
             return null;
         }
@@ -1099,24 +1226,15 @@ public class BridgeSupport {
     }
 
     /**
-     * Builds and returns the retiring federation (if one exists)
-     * @return the retiring federation, null if none exists
+     * Returns the retiring federation's creation block number
+     * @return the retiring federation creation block number, null if no retiring federation exists
      */
-    @Nullable
-    private Federation getRetiringFederation() {
-        Integer size = getRetiringFederationSize();
-        if (size == -1) {
-            return null;
+    public long getRetiringFederationCreationBlockNumber() {
+        Federation retiringFederation = provider.getOldFederation();
+        if (retiringFederation == null) {
+            return -1L;
         }
-
-        List<BtcECKey> publicKeys = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            publicKeys.add(BtcECKey.fromPublicOnly(getRetiringFederatorPublicKey(i)));
-        }
-        Instant creationTime = getRetiringFederationCreationTime();
-        long creationBlockNumber = getRetiringFederationCreationBlockNumber();
-
-        return new Federation(publicKeys, creationTime, creationBlockNumber, bridgeConstants.getBtcParams());
+        return retiringFederation.getCreationBlockNumber();
     }
 
     /**
@@ -1152,7 +1270,7 @@ public class BridgeSupport {
             return -1;
         }
 
-        if (provider.getRetiringFederation() != null) {
+        if (getRetiringFederation() != null) {
             return -2;
         }
 
@@ -1229,19 +1347,19 @@ public class BridgeSupport {
             return 1;
         }
 
-        // Move UTXOs from the active federation into the retiring federation
-        // and clear the active federation's UTXOs
-        List<UTXO> utxosToMove = new ArrayList<>(provider.getActiveFederationBtcUTXOs());
-        provider.getActiveFederationBtcUTXOs().clear();
-        List<UTXO> retiringFederationUTXOs = provider.getRetiringFederationBtcUTXOs();
-        retiringFederationUTXOs.clear();
-        utxosToMove.forEach(utxo -> retiringFederationUTXOs.add(utxo));
+        // Move UTXOs from the new federation into the old federation
+        // and clear the new federation's UTXOs
+        List<UTXO> utxosToMove = new ArrayList<>(provider.getNewFederationBtcUTXOs());
+        provider.getNewFederationBtcUTXOs().clear();
+        List<UTXO> oldFederationUTXOs = provider.getOldFederationBtcUTXOs();
+        oldFederationUTXOs.clear();
+        utxosToMove.forEach(utxo -> oldFederationUTXOs.add(utxo));
 
         // Network parameters for the new federation are taken from the bridge constants.
         // Creation time is the block's timestamp.
         Instant creationTime = Instant.ofEpochMilli(rskExecutionBlock.getTimestamp());
-        provider.setRetiringFederation(getActiveFederation());
-        provider.setActiveFederation(currentPendingFederation.buildFederation(creationTime, rskExecutionBlock.getNumber(), bridgeConstants.getBtcParams()));
+        provider.setOldFederation(getActiveFederation());
+        provider.setNewFederation(currentPendingFederation.buildFederation(creationTime, rskExecutionBlock.getNumber(), bridgeConstants.getBtcParams()));
         provider.setPendingFederation(null);
 
         // Clear votes on election

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -277,7 +277,7 @@ public class BridgeSupportTest {
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(20,0));
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(10,0));
 
-        provider0.getActiveFederationBtcUTXOs().add(new UTXO(
+        provider0.getNewFederationBtcUTXOs().add(new UTXO(
                 PegTestUtils.createHash(),
                 1,
                 Coin.valueOf(12,0),
@@ -319,7 +319,7 @@ public class BridgeSupportTest {
         // Check value sent to user is 10 BTC minus fee
         Assert.assertEquals(Coin.valueOf(999962800l), provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction().getOutput(0).getValue());
         // Check the wallet has been emptied
-        Assert.assertTrue(provider.getActiveFederationBtcUTXOs().isEmpty());
+        Assert.assertTrue(provider.getNewFederationBtcUTXOs().isEmpty());
     }
 
     @Test
@@ -333,7 +333,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(37500));
-        provider0.getActiveFederationBtcUTXOs().add(new UTXO(
+        provider0.getNewFederationBtcUTXOs().add(new UTXO(
                 PegTestUtils.createHash(),
                 1,
                 Coin.valueOf(1000000),
@@ -376,7 +376,7 @@ public class BridgeSupportTest {
         Assert.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
         // Check the wallet has not been emptied
-        Assert.assertFalse(provider.getActiveFederationBtcUTXOs().isEmpty());
+        Assert.assertFalse(provider.getNewFederationBtcUTXOs().isEmpty());
     }
 
     @Test
@@ -391,7 +391,7 @@ public class BridgeSupportTest {
 
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.COIN.multiply(7));
         for (int i = 0; i < 2000; i++) {
-            provider0.getActiveFederationBtcUTXOs().add(new UTXO(
+            provider0.getNewFederationBtcUTXOs().add(new UTXO(
                     PegTestUtils.createHash(),
                     1,
                     Coin.CENT,
@@ -434,7 +434,7 @@ public class BridgeSupportTest {
         Assert.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
         // Check the wallet has not been emptied
-        Assert.assertFalse(provider.getActiveFederationBtcUTXOs().isEmpty());
+        Assert.assertFalse(provider.getNewFederationBtcUTXOs().isEmpty());
     }
 
     @Test
@@ -466,7 +466,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
 
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.COIN);
-        provider0.getActiveFederationBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.COIN.add(Coin.valueOf(100)), 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
+        provider0.getNewFederationBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.COIN.add(Coin.valueOf(100)), 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
 
         provider0.save();
 
@@ -491,7 +491,7 @@ public class BridgeSupportTest {
         Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(21000000-2600)), repository.getBalance(Hex.decode(PrecompiledContracts.BRIDGE_ADDR)));
         Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(2600)), repository.getBalance(RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBurnAddress()));
         // Check the wallet has been emptied
-        Assert.assertTrue(provider.getActiveFederationBtcUTXOs().isEmpty());
+        Assert.assertTrue(provider.getNewFederationBtcUTXOs().isEmpty());
     }
 
     @PrepareForTest({ BridgeUtils.class })
@@ -714,8 +714,6 @@ public class BridgeSupportTest {
         BtcTransaction prevTx = new BtcTransaction(btcParams);
         TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, federation.getAddress());
         prevTx.addOutput(prevOut);
-//        UTXO utxo = new UTXO(prevTx.getHash(), 0, prevOut.getValue(), 0, false, prevOut.getScriptPubKey());
-//        provider.getActiveFederationBtcUTXOs().add(utxo);
 
         BtcTransaction t = new BtcTransaction(btcParams);
         TransactionOutput output = new TransactionOutput(btcParams, t, Coin.COIN, new BtcECKey().toAddress(btcParams));
@@ -889,7 +887,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertTrue(provider2.getActiveFederationBtcUTXOs().isEmpty());
+        Assert.assertTrue(provider2.getNewFederationBtcUTXOs().isEmpty());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
@@ -920,7 +918,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertTrue(provider2.getActiveFederationBtcUTXOs().isEmpty());
+        Assert.assertTrue(provider2.getNewFederationBtcUTXOs().isEmpty());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
@@ -951,7 +949,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertTrue(provider2.getActiveFederationBtcUTXOs().isEmpty());
+        Assert.assertTrue(provider2.getNewFederationBtcUTXOs().isEmpty());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
@@ -986,7 +984,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertTrue(provider2.getActiveFederationBtcUTXOs().isEmpty());
+        Assert.assertTrue(provider2.getNewFederationBtcUTXOs().isEmpty());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
@@ -1036,7 +1034,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(0, provider2.getActiveFederationBtcUTXOs().size());
+        Assert.assertEquals(0, provider2.getNewFederationBtcUTXOs().size());
 
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
@@ -1118,8 +1116,8 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(1, provider2.getActiveFederationBtcUTXOs().size());
-        Assert.assertEquals(Coin.COIN, provider2.getActiveFederationBtcUTXOs().get(0).getValue());
+        Assert.assertEquals(1, provider2.getNewFederationBtcUTXOs().size());
+        Assert.assertEquals(Coin.COIN, provider2.getNewFederationBtcUTXOs().get(0).getValue());
 
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
@@ -1185,8 +1183,8 @@ public class BridgeSupportTest {
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress);
-        provider.setActiveFederation(activeFederation);
-        provider.setRetiringFederation(retiringFederation);
+        provider.setNewFederation(activeFederation);
+        provider.setOldFederation(retiringFederation);
         BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
 
@@ -1209,7 +1207,7 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        List<UTXO> activeFederationBtcUTXOs = provider.getActiveFederationBtcUTXOs();
+        List<UTXO> activeFederationBtcUTXOs = provider.getNewFederationBtcUTXOs();
         List<Coin> activeFederationBtcCoins = activeFederationBtcUTXOs.stream().map(UTXO::getValue).collect(Collectors.toList());
         Assert.assertThat(activeFederationBtcUTXOs, hasSize(1));
         Assert.assertThat(activeFederationBtcCoins, hasItem(Coin.COIN));
@@ -1267,8 +1265,8 @@ public class BridgeSupportTest {
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress);
-        provider.setActiveFederation(federation1);
-        provider.setRetiringFederation(federation2);
+        provider.setNewFederation(federation1);
+        provider.setOldFederation(federation2);
 
         // Whitelist the addresses
         LockWhitelist whitelist = provider.getLockWhitelist();
@@ -1319,12 +1317,12 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(2, provider2.getActiveFederationBtcUTXOs().size());
-        Assert.assertEquals(2, provider2.getRetiringFederationBtcUTXOs().size());
-        Assert.assertEquals(Coin.COIN.multiply(5), provider2.getActiveFederationBtcUTXOs().get(0).getValue());
-        Assert.assertEquals(Coin.COIN.multiply(2), provider2.getActiveFederationBtcUTXOs().get(1).getValue());
-        Assert.assertEquals(Coin.COIN.multiply(10), provider2.getRetiringFederationBtcUTXOs().get(0).getValue());
-        Assert.assertEquals(Coin.COIN.multiply(3), provider2.getRetiringFederationBtcUTXOs().get(1).getValue());
+        Assert.assertEquals(2, provider2.getNewFederationBtcUTXOs().size());
+        Assert.assertEquals(2, provider2.getOldFederationBtcUTXOs().size());
+        Assert.assertEquals(Coin.COIN.multiply(5), provider2.getNewFederationBtcUTXOs().get(0).getValue());
+        Assert.assertEquals(Coin.COIN.multiply(2), provider2.getNewFederationBtcUTXOs().get(1).getValue());
+        Assert.assertEquals(Coin.COIN.multiply(10), provider2.getOldFederationBtcUTXOs().get(0).getValue());
+        Assert.assertEquals(Coin.COIN.multiply(3), provider2.getOldFederationBtcUTXOs().get(1).getValue());
 
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
@@ -1384,8 +1382,8 @@ public class BridgeSupportTest {
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress);
-        provider.setActiveFederation(federation1);
-        provider.setRetiringFederation(federation2);
+        provider.setNewFederation(federation1);
+        provider.setOldFederation(federation2);
 
         BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
@@ -1428,8 +1426,16 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(0, provider2.getActiveFederationBtcUTXOs().size());
-        Assert.assertEquals(0, provider2.getRetiringFederationBtcUTXOs().size());
+        Assert.assertEquals(2, provider2.getNewFederationBtcUTXOs().size());
+        Assert.assertEquals(2, provider2.getOldFederationBtcUTXOs().size());
+        Assert.assertEquals(Coin.COIN.multiply(5), provider2.getNewFederationBtcUTXOs().get(0).getValue());
+        Assert.assertEquals(Coin.COIN.multiply(3), provider2.getNewFederationBtcUTXOs().get(1).getValue());
+        Assert.assertEquals(Coin.COIN.multiply(10), provider2.getOldFederationBtcUTXOs().get(0).getValue());
+        Assert.assertEquals(Coin.COIN.multiply(4), provider2.getOldFederationBtcUTXOs().get(1).getValue());
+
+        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
+
+        List<ReleaseRequestQueue.Entry> releaseReqQueueEntries = provider2.getReleaseRequestQueue().getEntries();
 
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(3, provider2.getReleaseTransactionSet().getEntries().size());
@@ -1759,7 +1765,7 @@ public class BridgeSupportTest {
                 mocksProvider.getElection(),
                 null
         );
-        ((BridgeStorageProvider) Whitebox.getInternalState(bridgeSupport, "provider")).getRetiringFederationBtcUTXOs().add(mock(UTXO.class));
+        ((BridgeStorageProvider) Whitebox.getInternalState(bridgeSupport, "provider")).getOldFederationBtcUTXOs().add(mock(UTXO.class));
 
         Assert.assertNull(bridgeSupport.getPendingFederationHash());
         Assert.assertEquals(-2, mocksProvider.execute(bridgeSupport));
@@ -2007,11 +2013,11 @@ public class BridgeSupportTest {
             UTXO utxoMock = mock(UTXO.class);
             when(utxoMock.getIndex()).thenReturn((long)i);
             when(utxoMock.getValue()).thenReturn(Coin.valueOf((i+1)*1000));
-            provider.getActiveFederationBtcUTXOs().add(utxoMock);
+            provider.getNewFederationBtcUTXOs().add(utxoMock);
         }
 
         // Currently active federation
-        Federation oldActiveFederation = provider.getActiveFederation();
+        Federation oldActiveFederation = provider.getNewFederation();
 
         // Vote with no winner
         Assert.assertNotNull(provider.getPendingFederation());
@@ -2024,17 +2030,17 @@ public class BridgeSupportTest {
 
         Assert.assertNull(provider.getPendingFederation());
 
-        Federation retiringFederation = provider.getRetiringFederation();
-        Federation activeFederation = provider.getActiveFederation();
+        Federation retiringFederation = provider.getOldFederation();
+        Federation activeFederation = provider.getNewFederation();
 
         Assert.assertEquals(expectedFederation, activeFederation);
         Assert.assertEquals(retiringFederation, oldActiveFederation);
 
-        Assert.assertEquals(0, provider.getActiveFederationBtcUTXOs().size());
-        Assert.assertEquals(5, provider.getRetiringFederationBtcUTXOs().size());
+        Assert.assertEquals(0, provider.getNewFederationBtcUTXOs().size());
+        Assert.assertEquals(5, provider.getOldFederationBtcUTXOs().size());
         for (int i = 0; i < 5; i++) {
-            Assert.assertEquals((long) i, provider.getRetiringFederationBtcUTXOs().get(i).getIndex());
-            Assert.assertEquals(Coin.valueOf((i+1)*1000), provider.getRetiringFederationBtcUTXOs().get(i).getValue());
+            Assert.assertEquals((long) i, provider.getOldFederationBtcUTXOs().get(i).getIndex());
+            Assert.assertEquals(Coin.valueOf((i+1)*1000), provider.getOldFederationBtcUTXOs().get(i).getValue());
         }
         verify(mocksProvider.getElection(), times(1)).clearWinners();
         verify(mocksProvider.getElection(), times(1)).clear();
@@ -2139,7 +2145,7 @@ public class BridgeSupportTest {
         Context expectedContext = mock(Context.class);
         Whitebox.setInternalState(bridgeSupport, "btcContext", expectedContext);
         BridgeStorageProvider provider = (BridgeStorageProvider) Whitebox.getInternalState(bridgeSupport, "provider");
-        Object expectedUtxos = provider.getActiveFederationBtcUTXOs();
+        Object expectedUtxos = provider.getNewFederationBtcUTXOs();
 
         final Wallet expectedWallet = mock(Wallet.class);
         PowerMockito.mockStatic(BridgeUtils.class);
@@ -2172,7 +2178,7 @@ public class BridgeSupportTest {
         Context expectedContext = mock(Context.class);
         Whitebox.setInternalState(bridgeSupport, "btcContext", expectedContext);
         BridgeStorageProvider provider = (BridgeStorageProvider) Whitebox.getInternalState(bridgeSupport, "provider");
-        Object expectedUtxos = provider.getRetiringFederationBtcUTXOs();
+        Object expectedUtxos = provider.getOldFederationBtcUTXOs();
 
         final Wallet expectedWallet = mock(Wallet.class);
         PowerMockito.mockStatic(BridgeUtils.class);
@@ -2385,13 +2391,13 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider providerMock = mock(BridgeStorageProvider.class);
 
-        when(providerMock.getRetiringFederationBtcUTXOs()).then((InvocationOnMock m) -> holder.retiringUTXOs);
-        when(providerMock.getActiveFederationBtcUTXOs()).then((InvocationOnMock m) -> holder.activeUTXOs);
+        when(providerMock.getOldFederationBtcUTXOs()).then((InvocationOnMock m) -> holder.retiringUTXOs);
+        when(providerMock.getNewFederationBtcUTXOs()).then((InvocationOnMock m) -> holder.activeUTXOs);
 
         holder.setActiveFederation(genesis ? null : mockedActiveFederation);
         holder.setRetiringFederation(mockedRetiringFederation);
-        when(providerMock.getActiveFederation()).then((InvocationOnMock m) -> holder.getActiveFederation());
-        when(providerMock.getRetiringFederation()).then((InvocationOnMock m) -> holder.getRetiringFederation());
+        when(providerMock.getNewFederation()).then((InvocationOnMock m) -> holder.getActiveFederation());
+        when(providerMock.getOldFederation()).then((InvocationOnMock m) -> holder.getRetiringFederation());
         when(providerMock.getPendingFederation()).then((InvocationOnMock m) -> holder.getPendingFederation());
         when(providerMock.getFederationElection(any())).then((InvocationOnMock m) -> {
             if (mockedFederationElection != null) {
@@ -2408,11 +2414,11 @@ public class BridgeSupportTest {
         Mockito.doAnswer((InvocationOnMock m) -> {
             holder.setActiveFederation(m.getArgumentAt(0, Federation.class));
             return null;
-        }).when(providerMock).setActiveFederation(any());
+        }).when(providerMock).setNewFederation(any());
         Mockito.doAnswer((InvocationOnMock m) -> {
             holder.setRetiringFederation(m.getArgumentAt(0, Federation.class));
             return null;
-        }).when(providerMock).setRetiringFederation(any());
+        }).when(providerMock).setOldFederation(any());
         Mockito.doAnswer((InvocationOnMock m) -> {
             holder.setPendingFederation(m.getArgumentAt(0, PendingFederation.class));
             return null;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1426,16 +1426,8 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR);
 
-        Assert.assertEquals(2, provider2.getNewFederationBtcUTXOs().size());
-        Assert.assertEquals(2, provider2.getOldFederationBtcUTXOs().size());
-        Assert.assertEquals(Coin.COIN.multiply(5), provider2.getNewFederationBtcUTXOs().get(0).getValue());
-        Assert.assertEquals(Coin.COIN.multiply(3), provider2.getNewFederationBtcUTXOs().get(1).getValue());
-        Assert.assertEquals(Coin.COIN.multiply(10), provider2.getOldFederationBtcUTXOs().get(0).getValue());
-        Assert.assertEquals(Coin.COIN.multiply(4), provider2.getOldFederationBtcUTXOs().get(1).getValue());
-
-        Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
-
-        List<ReleaseRequestQueue.Entry> releaseReqQueueEntries = provider2.getReleaseRequestQueue().getEntries();
+        Assert.assertEquals(0, provider2.getNewFederationBtcUTXOs().size());
+        Assert.assertEquals(0, provider2.getOldFederationBtcUTXOs().size());
 
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(3, provider2.getReleaseTransactionSet().getEntries().size());


### PR DESCRIPTION
Implemented deferred federation activation by means of:

- Active and retiring federation in storage are now named new and old, respectively. This is to prevent confusion with active and retiring federations, which are now a top-level bridge-only concept.
- Methods in the bridge that use or retrieve either the currently active or currently retiring federation are now dependent on the current block number and the age of the new federation that is stored. According to that and to a new bridge constant (defined in `BridgeConstants`), the active and retiring federations are determined.

Therefore there is no need for a tx to happen in order to activate new federations and retire old ones. This will automatically happen once the commit of a new federation reachs a certain age.