### PR TITLE
Channnel manager now takes block identifiers to broadcast block hash

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
@@ -22,6 +22,7 @@ package org.ethereum.net.server;
 import co.rsk.net.NodeID;
 import co.rsk.net.Status;
 import org.ethereum.core.Block;
+import org.ethereum.core.BlockIdentifier;
 import org.ethereum.core.Transaction;
 
 import javax.annotation.Nonnull;
@@ -66,7 +67,7 @@ public interface ChannelManager {
     Set<NodeID> broadcastBlock(@Nonnull final Block block, @Nullable final Set<NodeID> skip);
 
     @Nonnull
-    Set<NodeID> broadcastBlockHash(@Nonnull final byte[] hash, @Nullable final Set<NodeID> targets);
+    Set<NodeID> broadcastBlockHash(@Nonnull final List<BlockIdentifier> identifiers, @Nullable final Set<NodeID> targets);
 
     /**
      * broadcastTransaction Propagates a transaction message across active peers with exclusion of

--- a/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
@@ -216,9 +216,9 @@ public class ChannelManagerImpl implements ChannelManager {
     }
 
     @Nonnull
-    public Set<NodeID> broadcastBlockHash(@Nonnull final byte[] hash, @Nullable final Set<NodeID> targets) {
+    public Set<NodeID> broadcastBlockHash(@Nonnull final List<BlockIdentifier> identifiers, @Nullable final Set<NodeID> targets) {
         final Set<NodeID> res = new HashSet<>();
-        final EthMessage newBlockHash = new RskMessage(new NewBlockHashesMessage(hash));
+        final EthMessage newBlockHash = new RskMessage(new NewBlockHashesMessage(identifiers));
 
         synchronized (activePeers) {
             activePeers.values().forEach(c -> logger.trace("RSK activePeers: {}", c));

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleChannelManager.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleChannelManager.java
@@ -21,6 +21,7 @@ package org.ethereum.rpc.Simples;
 import co.rsk.net.NodeID;
 import co.rsk.net.Status;
 import org.ethereum.core.Block;
+import org.ethereum.core.BlockIdentifier;
 import org.ethereum.core.Transaction;
 import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
@@ -60,7 +61,7 @@ public class SimpleChannelManager implements ChannelManager {
 
     @Nonnull
     @Override
-    public Set<NodeID> broadcastBlockHash(@Nonnull byte[] hash, @Nullable Set<NodeID> skip) {
+    public Set<NodeID> broadcastBlockHash(@Nonnull List<BlockIdentifier> identifiers, @Nullable Set<NodeID> targets) {
         return new HashSet<>();
     }
 


### PR DESCRIPTION
Fix problem where block hashes where not relayed when a new block arrived