### PR TITLE
Use TxSender instead of byte[] for Transaction.getSender()

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -19,6 +19,7 @@
 
 package co.rsk.core;
 
+import co.rsk.peg.TxSender;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -86,12 +87,7 @@ public final class ReversibleTransactionExecutor extends TransactionExecutor {
 
         private UnsignedTransaction(byte[] nonce, byte[] gasPrice, byte[] gasLimit, byte[] receiveAddress, byte[] value, byte[] data, byte[] fromAddress) {
             super(nonce, gasPrice, gasLimit, receiveAddress, value, data);
-            this.sendAddress = fromAddress;
-        }
-
-        @Override
-        public byte[] getSender() {
-            return sendAddress;
+            this.sender = new TxSender(fromAddress);
         }
 
         @Override

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -26,6 +26,7 @@ import co.rsk.core.bc.FamilyUtils;
 import co.rsk.crypto.Sha3Hash;
 import co.rsk.net.BlockProcessor;
 import co.rsk.panic.PanicProcessor;
+import co.rsk.peg.TxSender;
 import co.rsk.remasc.RemascTransaction;
 import co.rsk.util.DifficultyUtils;
 import co.rsk.validators.BlockValidationRule;
@@ -36,7 +37,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.rpc.TypeConverter;
@@ -451,7 +451,7 @@ public class MinerServerImpl implements MinerServer {
         Transaction remascTx = new RemascTransaction(parent.getNumber() + 1);
         txs.add(remascTx);
 
-        Map<ByteArrayWrapper, BigInteger> accountNonces = new HashMap<>();
+        Map<TxSender, BigInteger> accountNonces = new HashMap<>();
 
         Repository originalRepo = blockchain.getRepository().getSnapshotTo(parent.getStateRoot());
 

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -18,15 +18,15 @@
 
 package co.rsk.mine;
 
-import com.google.common.collect.Lists;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.config.RskMiningConstants;
 import co.rsk.core.bc.PendingStateImpl;
+import co.rsk.peg.TxSender;
 import co.rsk.remasc.RemascTransaction;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.BtcTransaction;
+import com.google.common.collect.Lists;
 import org.ethereum.core.PendingState;
 import org.ethereum.core.Repository;
-import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.rpc.TypeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +37,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 import static org.ethereum.util.BIUtil.toBI;
-import static org.ethereum.util.ByteUtil.wrap;
 
 /**
  * Created by oscar on 26/09/2016.
@@ -97,28 +99,27 @@ public class MinerUtils {
         return new LinkedList<>(ret);
     }
 
-    public List<org.ethereum.core.Transaction> filterTransactions(List<org.ethereum.core.Transaction> txsToRemove, List<org.ethereum.core.Transaction> txs, Map<ByteArrayWrapper, BigInteger> accountNonces, Repository originalRepo, BigInteger minGasPrice) {
+    public List<org.ethereum.core.Transaction> filterTransactions(List<org.ethereum.core.Transaction> txsToRemove, List<org.ethereum.core.Transaction> txs, Map<TxSender, BigInteger> accountNonces, Repository originalRepo, BigInteger minGasPrice) {
         List<org.ethereum.core.Transaction> txsResult = new ArrayList<>();
         for (org.ethereum.core.Transaction tx : txs) {
             try {
                 logger.info("Pending transaction {} {}", toBI(tx.getNonce()), Hex.toHexString(tx.getHash()));
-                byte[] txSender = tx.getSender().getBytes();
+                TxSender txSender = tx.getSender();
 
-                logger.info("Examining transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), Hex.toHexString(txSender), Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
+                logger.info("Examining transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), txSender, Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
 
-                ByteArrayWrapper wrappedSender = wrap(txSender);
                 BigInteger txNonce = new BigInteger(1, tx.getNonce());
 
                 BigInteger expectedNonce;
 
-                if (accountNonces.containsKey(wrappedSender)) {
-                    expectedNonce = new BigInteger(1, accountNonces.get(wrappedSender).toByteArray()).add(BigInteger.ONE);
+                if (accountNonces.containsKey(txSender)) {
+                    expectedNonce = new BigInteger(1, accountNonces.get(txSender).toByteArray()).add(BigInteger.ONE);
                 } else {
-                    expectedNonce = originalRepo.getNonce(txSender);
+                    expectedNonce = originalRepo.getNonce(txSender.getBytes());
                 }
 
                 if (!(tx instanceof RemascTransaction) && tx.getGasPriceAsInteger().compareTo(minGasPrice) < 0) {
-                    logger.warn("Rejected transaction {} because of low gas account {}, removing tx from pending state.", Hex.toHexString(tx.getHash()), Hex.toHexString(txSender));
+                    logger.warn("Rejected transaction {} because of low gas account {}, removing tx from pending state.", Hex.toHexString(tx.getHash()), txSender);
 
                     txsToRemove.add(tx);
                     continue;
@@ -129,9 +130,9 @@ public class MinerUtils {
                     continue;
                 }
 
-                accountNonces.put(wrappedSender, txNonce);
+                accountNonces.put(txSender, txNonce);
 
-                logger.info("Accepted transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), Hex.toHexString(txSender), Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
+                logger.info("Accepted transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), txSender, Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
             } catch (Exception e) {
                 // Txs that can't be selected by any reason should be removed from pending state
                 String hash = null == tx.getHash() ? "" : Hex.toHexString(tx.getHash());

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -102,7 +102,7 @@ public class MinerUtils {
         for (org.ethereum.core.Transaction tx : txs) {
             try {
                 logger.info("Pending transaction {} {}", toBI(tx.getNonce()), Hex.toHexString(tx.getHash()));
-                byte[] txSender = tx.getSender();
+                byte[] txSender = tx.getSender().getBytes();
 
                 logger.info("Examining transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), Hex.toHexString(txSender), Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
 

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxHandlerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxHandlerImpl.java
@@ -99,7 +99,7 @@ public class TxHandlerImpl implements TxHandler {
             TxTimestamp txt = entry.getValue();
 
             if (time - txt.timestamp > oldTxThresholdInMS) {
-                String accountId = TypeConverter.toJsonHex(txt.tx.getSender());
+                String accountId = TypeConverter.toJsonHex(txt.tx.getSender().getBytes());
                 TxsPerAccount txsPerAccount = txsPerAccounts.get(accountId);
 
                 if (txsPerAccount != null) {
@@ -132,7 +132,7 @@ public class TxHandlerImpl implements TxHandler {
                         continue;
                     }
 
-                    String accountId = TypeConverter.toJsonHex(tx.getSender());
+                    String accountId = TypeConverter.toJsonHex(tx.getSender().getBytes());
 
                     TxsPerAccount txsPerAccount = txsPerAccounts.get(accountId);
 

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxValidator.java
@@ -74,7 +74,7 @@ class TxValidator {
             }
             knownTxs.put(hash, new TxTimestamp(tx, System.currentTimeMillis()));
 
-            AccountState state = repository.getAccountState(tx.getSender());
+            AccountState state = repository.getAccountState(tx.getSender().getBytes());
             if (state == null) {
                 state = new AccountState(BigInteger.ZERO, BigInteger.ZERO);
             }
@@ -94,7 +94,7 @@ class TxValidator {
                 continue;
             }
 
-            String addr = TypeConverter.toJsonHex(tx.getSender());
+            String addr = TypeConverter.toJsonHex(tx.getSender().getBytes());
 
             txsPerAccounts.computeIfAbsent(addr, key -> new TxsPerAccount());
 

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler;
 
 import co.rsk.net.handler.txvalidator.*;
+import co.rsk.peg.TxSender;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Repository;
@@ -59,7 +60,7 @@ class TxValidator {
                                 Blockchain blockchain,
                                 List<Transaction> txs,
                                 Map<String, TxTimestamp> knownTxs,
-                                Map<String, TxsPerAccount> txsPerAccounts) {
+                                Map<TxSender, TxsPerAccount> txsPerAccounts) {
         //FIXME(mmarquez): this method is quite coupled with TxHandlerImpl
         // but it should be fixed when NodeMessageHandler stops managing the wire txs
         // and related stuff
@@ -94,7 +95,7 @@ class TxValidator {
                 continue;
             }
 
-            String addr = TypeConverter.toJsonHex(tx.getSender().getBytes());
+            TxSender addr = tx.getSender();
 
             txsPerAccounts.computeIfAbsent(addr, key -> new TxsPerAccount());
 

--- a/rskj-core/src/main/java/co/rsk/peg/AddressBasedAuthorizer.java
+++ b/rskj-core/src/main/java/co/rsk/peg/AddressBasedAuthorizer.java
@@ -48,7 +48,7 @@ public class AddressBasedAuthorizer {
     }
 
     public boolean isAuthorized(Transaction tx) {
-        return isAuthorized(TxSender.fromTx(tx));
+        return isAuthorized(tx.getSender());
     }
 
     public int getNumberOfAuthorizedKeys() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -20,7 +20,6 @@ package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.crypto.Sha3Hash;
-import com.google.common.primitives.UnsignedBytes;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.spongycastle.util.BigIntegers;
@@ -488,9 +487,7 @@ public class BridgeSerializationUtils {
     // using the lexicographical order of the voters' unsigned bytes
     private static byte[] serializeVoters(List<TxSender> voters) {
         List<byte[]> encodedKeys = voters.stream()
-                .sorted((TxSender v1, TxSender v2) ->
-                        UnsignedBytes.lexicographicalComparator().compare(v1.getBytes(), v2.getBytes())
-                )
+                .sorted(TxSender.COMPARATOR)
                 .map(key -> RLP.encodeElement(key.getBytes()))
                 .collect(Collectors.toList());
         return RLP.encodeList(encodedKeys.toArray(new byte[0][]));

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -425,11 +425,11 @@ public class BridgeSupport {
      * @throws IOException
      */
     public void releaseBtc(Transaction rskTx) throws IOException {
-        byte[] senderCode = rskRepository.getCode(rskTx.getSender());
+        byte[] senderCode = rskRepository.getCode(rskTx.getSender().getBytes());
 
         //as we can't send btc from contracts we want to send them back to the sender
         if (senderCode != null && senderCode.length > 0) {
-            logger.trace("Contract {} tried to release funds. Release is just allowed from standard accounts.", Hex.toHexString(rskTx.getSender()));
+            logger.trace("Contract {} tried to release funds. Release is just allowed from standard accounts.", rskTx.toString());
             throw new Program.OutOfGasException("Contract calling releaseBTC");
         }
 
@@ -1465,7 +1465,7 @@ public class BridgeSupport {
 
         ABICallElection election = provider.getFederationElection(authorizer);
         // Register the vote. It is expected to succeed, since all previous checks succeeded
-        if (!election.vote(callSpec, TxSender.fromTx(tx))) {
+        if (!election.vote(callSpec, tx.getSender())) {
             logger.warn("Unexpected federation change vote failure");
             return FEDERATION_CHANGE_GENERIC_ERROR_CODE;
         }
@@ -1693,10 +1693,9 @@ public class BridgeSupport {
             return FEE_PER_KB_GENERIC_ERROR_CODE;
         }
 
-        TxSender voter = TxSender.fromTx(tx);
         ABICallElection feePerKbElection = provider.getFeePerKbElection(authorizer);
         ABICallSpec feeVote = new ABICallSpec("setFeePerKb", new byte[][]{BridgeSerializationUtils.serializeCoin(feePerKb)});
-        boolean successfulVote = feePerKbElection.vote(feeVote, voter);
+        boolean successfulVote = feePerKbElection.vote(feeVote, tx.getSender());
         if (!successfulVote) {
             return -1;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -182,7 +182,7 @@ public class BridgeUtils {
     }
 
     private static boolean isFromFederateMember(org.ethereum.core.Transaction rskTx, Federation federation) {
-        return federation.hasMemberWithRskAddress(rskTx.getSender());
+        return federation.hasMemberWithRskAddress(rskTx.getSender().getBytes());
     }
 
     private static boolean isFromFederationChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration) {

--- a/rskj-core/src/main/java/co/rsk/peg/TxSender.java
+++ b/rskj-core/src/main/java/co/rsk/peg/TxSender.java
@@ -18,7 +18,7 @@
 
 package co.rsk.peg;
 
-import org.ethereum.core.Transaction;
+import org.spongycastle.util.encoders.Hex;
 
 import java.util.Arrays;
 
@@ -32,18 +32,14 @@ import java.util.Arrays;
  */
 public final class TxSender {
 
-    public static TxSender fromTx(Transaction tx) {
-        return new TxSender(tx.getSender());
-    }
-    
-    private byte[] senderBytes;
+    private final byte[] bytes;
 
-    public TxSender(byte[] senderBytes) {
-        this.senderBytes = senderBytes;
+    public TxSender(byte[] bytes) {
+        this.bytes = bytes;
     }
 
     public byte[] getBytes() {
-        return senderBytes;
+        return bytes;
     }
 
     @Override
@@ -57,11 +53,16 @@ public final class TxSender {
         }
 
         TxSender otherSender = (TxSender) other;
-        return Arrays.equals(getBytes(), otherSender.getBytes());
+        return Arrays.equals(bytes, otherSender.bytes);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(senderBytes);
+        return Arrays.hashCode(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return Hex.toHexString(bytes);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/TxSender.java
+++ b/rskj-core/src/main/java/co/rsk/peg/TxSender.java
@@ -18,9 +18,11 @@
 
 package co.rsk.peg;
 
+import com.google.common.primitives.UnsignedBytes;
 import org.spongycastle.util.encoders.Hex;
 
 import java.util.Arrays;
+import java.util.Comparator;
 
 /**
  * Immutable representation of a tx
@@ -31,6 +33,13 @@ import java.util.Arrays;
  * @author Ariel Mendelzon
  */
 public final class TxSender {
+
+    /**
+     * This compares using the lexicographical order of the sender unsigned bytes.
+     */
+    public static final Comparator<TxSender> COMPARATOR = Comparator.comparing(
+            TxSender::getBytes,
+            UnsignedBytes.lexicographicalComparator());
 
     private final byte[] bytes;
 

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
@@ -18,6 +18,7 @@
 
 package co.rsk.remasc;
 
+import co.rsk.peg.TxSender;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 import org.ethereum.util.ByteUtil;
@@ -52,9 +53,9 @@ public class RemascTransaction extends Transaction {
     }
 
     @Override
-    public byte[] getSender() {
+    public TxSender getSender() {
         // RemascTransaction is not signed so has no sender
-        return new byte[]{0};
+        return new TxSender(new byte[]{0});
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
@@ -19,10 +19,10 @@
 package co.rsk.validators;
 
 import co.rsk.panic.PanicProcessor;
+import co.rsk.peg.TxSender;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
-import org.ethereum.db.ByteArrayWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
@@ -66,7 +66,7 @@ public class BlockTxsValidationRule implements BlockParentDependantValidationRul
 
         Repository parentRepo = repository.getSnapshotTo(parent.getStateRoot());
 
-        Map<ByteArrayWrapper, BigInteger> curNonce = new HashMap<>();
+        Map<TxSender, BigInteger> curNonce = new HashMap<>();
 
         for (Transaction tx : txs) {
             try {
@@ -76,21 +76,20 @@ public class BlockTxsValidationRule implements BlockParentDependantValidationRul
                 return false;
             }
 
-            byte[] txSender = tx.getSender().getBytes();
-            ByteArrayWrapper key = new ByteArrayWrapper(txSender);
-            BigInteger expectedNonce = curNonce.get(key);
+            TxSender sender = tx.getSender();
+            BigInteger expectedNonce = curNonce.get(sender);
             if (expectedNonce == null) {
-                expectedNonce = parentRepo.getNonce(txSender);
+                expectedNonce = parentRepo.getNonce(sender.getBytes());
             }
-            curNonce.put(key, expectedNonce.add(ONE));
+            curNonce.put(sender, expectedNonce.add(ONE));
             BigInteger txNonce = new BigInteger(1, tx.getNonce());
 
             if (!expectedNonce.equals(txNonce)) {
                 logger.warn("Invalid transaction: Tx nonce {} != expected nonce {} (parent nonce: {}): {}",
-                        txNonce, expectedNonce, parentRepo.getNonce(txSender), tx);
+                        txNonce, expectedNonce, parentRepo.getNonce(sender.getBytes()), tx);
 
                 panicProcessor.panic("invalidtransaction", String.format("Invalid transaction: Tx nonce %s != expected nonce %s (parent nonce: %s): %s",
-                        txNonce.toString(), expectedNonce.toString(), parentRepo.getNonce(txSender).toString(), Hex.toHexString(tx.getHash())));
+                        txNonce.toString(), expectedNonce.toString(), parentRepo.getNonce(sender.getBytes()).toString(), Hex.toHexString(tx.getHash())));
 
                 return false;
             }

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
@@ -76,7 +76,7 @@ public class BlockTxsValidationRule implements BlockParentDependantValidationRul
                 return false;
             }
 
-            byte[] txSender = tx.getSender();
+            byte[] txSender = tx.getSender().getBytes();
             ByteArrayWrapper key = new ByteArrayWrapper(txSender);
             BigInteger expectedNonce = curNonce.get(key);
             if (expectedNonce == null) {

--- a/rskj-core/src/main/java/org/ethereum/core/PendingTransaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/PendingTransaction.java
@@ -64,7 +64,7 @@ public class PendingTransaction {
 
     public byte[] getSender() {
         if (sender == null) {
-            sender = transaction.getSender();
+            sender = transaction.getSender().getBytes();
         }
         return sender;
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -55,7 +55,7 @@ public class TransactionReceiptDTO {
         }
 
         cumulativeGasUsed = toJsonHex(receipt.getCumulativeGas());
-        from = toJsonHex(receipt.getTransaction().getSender());
+        from = toJsonHex(receipt.getTransaction().getSender().getBytes());
         gasUsed = toJsonHex(receipt.getGasUsed());
 
         logs = new LogFilterElement[receipt.getLogInfoList().size()];

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -55,7 +55,7 @@ public class TransactionResultDTO {
         blockHash = b != null ? TypeConverter.toJsonHex(b.getHash()) : null;
         blockNumber = b != null ? TypeConverter.toJsonHex(b.getNumber()) : null;
         transactionIndex = index != null ? TypeConverter.toJsonHex(index) : null;
-        from= TypeConverter.toJsonHex(tx.getSender());
+        from= TypeConverter.toJsonHex(tx.getSender().getBytes());
         to = TypeConverter.toJsonHex(tx.getReceiveAddress());
         gas = TypeConverter.toJsonHex(tx.getGasLimit()); // Todo: unclear if it's the gas limit or gas consumed what is asked
 

--- a/rskj-core/src/main/java/org/ethereum/vm/program/InternalTransaction.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/InternalTransaction.java
@@ -19,6 +19,7 @@
 
 package org.ethereum.vm.program;
 
+import co.rsk.peg.TxSender;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
@@ -45,7 +46,7 @@ public class InternalTransaction extends Transaction {
         this.parentHash = parentHash;
         this.deep = deep;
         this.index = index;
-        this.sendAddress = nullToEmpty(sendAddress);
+        this.sender = new TxSender(nullToEmpty(sendAddress));
         this.note = note;
     }
 
@@ -74,11 +75,6 @@ public class InternalTransaction extends Transaction {
         return note;
     }
 
-    @Override
-    public byte[] getSender() {
-        return sendAddress;
-    }
-
     public byte[] getParentHash() {
         return parentHash;
     }
@@ -95,7 +91,7 @@ public class InternalTransaction extends Transaction {
         } else {
             nonce = RLP.encodeElement(nonce);
         }
-        byte[] senderAddress = RLP.encodeElement(getSender());
+        byte[] senderAddress = RLP.encodeElement(getSender().getBytes());
         byte[] receiveAddress = RLP.encodeElement(getReceiveAddress());
         byte[] value = RLP.encodeElement(getValue());
         byte[] gasPrice = RLP.encodeElement(getGasPrice());

--- a/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
@@ -55,11 +55,11 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
 
         /***         ORIGIN op       ***/
         // YP: This is the sender of original transaction; it is never a contract.
-        byte[] origin = tx.getSender();
+        byte[] origin = tx.getSender().getBytes();
 
         /***         CALLER op       ***/
         // YP: This is the address of the account that is directly responsible for this execution.
-        byte[] caller = tx.getSender();
+        byte[] caller = tx.getSender().getBytes();
 
         /***         BALANCE op       ***/
         byte[] balance = repository.getBalance(address).toByteArray();

--- a/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
+++ b/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
@@ -24,7 +24,6 @@ import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Random;
 
 import static org.mockito.Matchers.any;
@@ -49,7 +48,7 @@ public class Tx {
         byte[] returnReceiveAddress = new byte[20];
         r.nextBytes(returnReceiveAddress);
 
-        Mockito.when(transaction.getSender()).thenReturn(returnSender);
+        Mockito.when(transaction.getSender().getBytes()).thenReturn(returnSender);
         Mockito.when(transaction.getHash()).thenReturn(BigInteger.valueOf(hashes.nextLong()).toByteArray());
         Mockito.when(transaction.acceptTransactionSignature()).thenReturn(Boolean.TRUE);
         Mockito.when(transaction.getReceiveAddress()).thenReturn(returnReceiveAddress);

--- a/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
+++ b/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
@@ -18,6 +18,7 @@
 
 package co.rsk.TestHelpers;
 
+import co.rsk.peg.TxSender;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 import org.mockito.Mockito;
@@ -42,13 +43,14 @@ public class Tx {
         Mockito.when(transaction.getNonce()).thenReturn(BigInteger.valueOf(nonce).toByteArray());
         Mockito.when(transaction.getNonceAsInteger()).thenReturn(BigInteger.valueOf(nonce));
 
-        byte[] returnSender = new byte[20];
-        r.nextBytes(returnSender);
+        byte[] returnSenderBytes = new byte[20];
+        r.nextBytes(returnSenderBytes);
+        TxSender returnSender = new TxSender(returnSenderBytes);
 
         byte[] returnReceiveAddress = new byte[20];
         r.nextBytes(returnReceiveAddress);
 
-        Mockito.when(transaction.getSender().getBytes()).thenReturn(returnSender);
+        Mockito.when(transaction.getSender()).thenReturn(returnSender);
         Mockito.when(transaction.getHash()).thenReturn(BigInteger.valueOf(hashes.nextLong()).toByteArray());
         Mockito.when(transaction.acceptTransactionSignature()).thenReturn(Boolean.TRUE);
         Mockito.when(transaction.getReceiveAddress()).thenReturn(returnReceiveAddress);

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -78,9 +78,9 @@ public class MinerServerTest {
         Mockito.when(tx1.getHash()).thenReturn(s1);
         Mockito.when(tx1.getEncoded()).thenReturn(new byte[32]);
 
-        Mockito.when(repository.getNonce(tx1.getSender())).thenReturn(BigInteger.ZERO);
+        Mockito.when(repository.getNonce(tx1.getSender().getBytes())).thenReturn(BigInteger.ZERO);
         Mockito.when(repository.getNonce(new byte[]{0})).thenReturn(BigInteger.ZERO);
-        Mockito.when(repository.getBalance(tx1.getSender())).thenReturn(BigInteger.valueOf(4200000L));
+        Mockito.when(repository.getBalance(tx1.getSender().getBytes())).thenReturn(BigInteger.valueOf(4200000L));
         Mockito.when(repository.getBalance(new byte[]{0})).thenReturn(BigInteger.valueOf(4200000L));
 
         List<Transaction> txs = new ArrayList<>(Arrays.asList(tx1));

--- a/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
@@ -72,7 +72,7 @@ public class MinerUtilsTest {
         txs.add(tx);
         Map<ByteArrayWrapper, BigInteger> accountNounces = new HashMap();
         Repository repository = Mockito.mock(Repository.class);
-        Mockito.when(repository.getNonce(tx.getSender())).thenReturn(BigInteger.valueOf(0));
+        Mockito.when(repository.getNonce(tx.getSender().getBytes())).thenReturn(BigInteger.valueOf(0));
         BigInteger minGasPrice = BigInteger.valueOf(1);
 
         List<Transaction> res = new MinerUtils().filterTransactions(new LinkedList<>(), txs, accountNounces, repository, minGasPrice);
@@ -86,7 +86,7 @@ public class MinerUtilsTest {
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Map<ByteArrayWrapper, BigInteger> accountNounces = new HashMap();
-        accountNounces.put(wrap(tx.getSender()), BigInteger.valueOf(0));
+        accountNounces.put(wrap(tx.getSender().getBytes()), BigInteger.valueOf(0));
         Repository repository = Mockito.mock(Repository.class);
         BigInteger minGasPrice = BigInteger.valueOf(1);
 
@@ -100,7 +100,7 @@ public class MinerUtilsTest {
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Map<ByteArrayWrapper, BigInteger> accountNounces = new HashMap();
-        accountNounces.put(wrap(tx.getSender()), BigInteger.valueOf(0));
+        accountNounces.put(wrap(tx.getSender().getBytes()), BigInteger.valueOf(0));
         Repository repository = Mockito.mock(Repository.class);
         BigInteger minGasPrice = BigInteger.valueOf(1);
 

--- a/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
@@ -19,18 +19,16 @@
 package co.rsk.mine;
 
 import co.rsk.TestHelpers.Tx;
+import co.rsk.peg.TxSender;
 import org.ethereum.core.PendingState;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
-import org.ethereum.db.ByteArrayWrapper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.util.*;
-
-import static org.ethereum.util.ByteUtil.wrap;
 
 public class MinerUtilsTest {
 
@@ -70,7 +68,7 @@ public class MinerUtilsTest {
         //Mockito.when(tx.checkGasPrice(Mockito.any(BigInteger.class))).thenReturn(true);
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
-        Map<ByteArrayWrapper, BigInteger> accountNounces = new HashMap();
+        Map<TxSender, BigInteger> accountNounces = new HashMap();
         Repository repository = Mockito.mock(Repository.class);
         Mockito.when(repository.getNonce(tx.getSender().getBytes())).thenReturn(BigInteger.valueOf(0));
         BigInteger minGasPrice = BigInteger.valueOf(1);
@@ -85,8 +83,8 @@ public class MinerUtilsTest {
         //Mockito.when(tx.checkGasPrice(Mockito.any(BigInteger.class))).thenReturn(true);
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
-        Map<ByteArrayWrapper, BigInteger> accountNounces = new HashMap();
-        accountNounces.put(wrap(tx.getSender().getBytes()), BigInteger.valueOf(0));
+        Map<TxSender, BigInteger> accountNounces = new HashMap();
+        accountNounces.put(tx.getSender(), BigInteger.valueOf(0));
         Repository repository = Mockito.mock(Repository.class);
         BigInteger minGasPrice = BigInteger.valueOf(1);
 
@@ -99,8 +97,8 @@ public class MinerUtilsTest {
         Transaction tx = Tx.create(0, 50000, 2, 0, 0, 0, new Random(0));
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
-        Map<ByteArrayWrapper, BigInteger> accountNounces = new HashMap();
-        accountNounces.put(wrap(tx.getSender().getBytes()), BigInteger.valueOf(0));
+        Map<TxSender, BigInteger> accountNounces = new HashMap();
+        accountNounces.put(tx.getSender(), BigInteger.valueOf(0));
         Repository repository = Mockito.mock(Repository.class);
         BigInteger minGasPrice = BigInteger.valueOf(1);
 
@@ -115,8 +113,8 @@ public class MinerUtilsTest {
         Transaction tx = Tx.create(0, 50000, 1, 0, 0, 0, new Random(0));
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
-        Map<ByteArrayWrapper, BigInteger> accountNounces = new HashMap();
-        accountNounces.put(wrap(BigInteger.valueOf(new Random(0).nextLong()).toByteArray()), BigInteger.valueOf(0));
+        Map<TxSender, BigInteger> accountNounces = new HashMap();
+        accountNounces.put(new TxSender(BigInteger.valueOf(new Random(0).nextLong()).toByteArray()), BigInteger.valueOf(0));
         Repository repository = Mockito.mock(Repository.class);
         BigInteger minGasPrice = BigInteger.valueOf(2);
 
@@ -132,8 +130,8 @@ public class MinerUtilsTest {
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Mockito.when(tx.getGasPrice()).thenReturn(null);
-        Map<ByteArrayWrapper, BigInteger> accountNounces = new HashMap();
-        accountNounces.put(wrap(BigInteger.valueOf(new Random(0).nextLong()).toByteArray()), BigInteger.valueOf(0));
+        Map<TxSender, BigInteger> accountNounces = new HashMap();
+        accountNounces.put(new TxSender(BigInteger.valueOf(new Random(0).nextLong()).toByteArray()), BigInteger.valueOf(0));
         Repository repository = Mockito.mock(Repository.class);
         BigInteger minGasPrice = BigInteger.valueOf(2);
 

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxHandlerTest.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler;
 
 import co.rsk.TestHelpers.Tx;
+import co.rsk.peg.TxSender;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.rpc.TypeConverter;
@@ -41,7 +42,7 @@ public class TxHandlerTest {
         Transaction tx2 = Tx.create(0, 0, 0, 1, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
-        Map<String, TxsPerAccount> txsPerAccounts = new HashMap<>();
+        Map<TxSender, TxsPerAccount> txsPerAccounts = new HashMap<>();
 
         knownTxs.put("1", new TxTimestamp(tx1, time));
         knownTxs.put("2", new TxTimestamp(tx1, time - threshold));
@@ -49,7 +50,7 @@ public class TxHandlerTest {
         TxsPerAccount tpa = new TxsPerAccount();
         tpa.getTransactions().add(tx1);
         tpa.getTransactions().add(tx2);
-        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender().getBytes()), tpa);
+        txsPerAccounts.put(tx1.getSender(), tpa);
 
         TxHandlerImpl txHandler = new TxHandlerImpl();
         txHandler.setKnownTxs(knownTxs);
@@ -70,13 +71,13 @@ public class TxHandlerTest {
         Transaction tx1 = Tx.create(0, 0, 0, 0, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
-        Map<String, TxsPerAccount> txsPerAccounts = new HashMap<>();
+        Map<TxSender, TxsPerAccount> txsPerAccounts = new HashMap<>();
 
         knownTxs.put("2", new TxTimestamp(tx1, time - threshold));
 
         TxsPerAccount tpa = new TxsPerAccount();
         tpa.getTransactions().add(tx1);
-        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender().getBytes()), tpa);
+        txsPerAccounts.put(tx1.getSender(), tpa);
 
         TxHandlerImpl txHandler = new TxHandlerImpl();
         txHandler.setKnownTxs(knownTxs);
@@ -97,7 +98,7 @@ public class TxHandlerTest {
         Transaction tx2 = Tx.create(0, 0, 0, 1, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
-        Map<String, TxsPerAccount> txsPerAccounts = new HashMap<>();
+        Map<TxSender, TxsPerAccount> txsPerAccounts = new HashMap<>();
 
         random = new Random(0);
         String hash1 = TypeConverter.toJsonHex(BigInteger.valueOf(random.nextLong()).toByteArray());
@@ -109,7 +110,7 @@ public class TxHandlerTest {
         TxsPerAccount tpa = new TxsPerAccount();
         tpa.getTransactions().add(tx1);
         tpa.getTransactions().add(tx2);
-        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender().getBytes()), tpa);
+        txsPerAccounts.put(tx1.getSender(), tpa);
 
         TransactionReceipt receipt = Mockito.mock(TransactionReceipt.class);
         Mockito.when(receipt.getTransaction()).thenReturn(tx1);

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxHandlerTest.java
@@ -49,7 +49,7 @@ public class TxHandlerTest {
         TxsPerAccount tpa = new TxsPerAccount();
         tpa.getTransactions().add(tx1);
         tpa.getTransactions().add(tx2);
-        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender()), tpa);
+        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender().getBytes()), tpa);
 
         TxHandlerImpl txHandler = new TxHandlerImpl();
         txHandler.setKnownTxs(knownTxs);
@@ -76,7 +76,7 @@ public class TxHandlerTest {
 
         TxsPerAccount tpa = new TxsPerAccount();
         tpa.getTransactions().add(tx1);
-        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender()), tpa);
+        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender().getBytes()), tpa);
 
         TxHandlerImpl txHandler = new TxHandlerImpl();
         txHandler.setKnownTxs(knownTxs);
@@ -109,7 +109,7 @@ public class TxHandlerTest {
         TxsPerAccount tpa = new TxsPerAccount();
         tpa.getTransactions().add(tx1);
         tpa.getTransactions().add(tx2);
-        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender()), tpa);
+        txsPerAccounts.put(TypeConverter.toJsonHex(tx1.getSender().getBytes()), tpa);
 
         TransactionReceipt receipt = Mockito.mock(TransactionReceipt.class);
         Mockito.when(receipt.getTransaction()).thenReturn(tx1);

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
@@ -21,6 +21,7 @@ package co.rsk.net.handler;
 import co.rsk.TestHelpers.Tx;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.peg.Federation;
+import co.rsk.peg.TxSender;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.*;
@@ -46,7 +47,7 @@ public class TxValidatorTest {
         List<Transaction> result;
         TxValidator txValidator = new TxValidator();
         Map<String, TxTimestamp> times;
-        Map<String, TxsPerAccount> txmap;
+        Map<TxSender, TxsPerAccount> txmap;
         Repository repository = Mockito.mock(Repository.class);
         final long blockGasLimit = 100000;
         WorldManager worldManager = Mockito.mock(WorldManager.class);
@@ -136,7 +137,7 @@ public class TxValidatorTest {
         txs.add(createBridgeTx(1, 0, 1, 0, 0, 6, hashes));
 
         Map<String, TxTimestamp> times;
-        Map<String, TxsPerAccount> txmap;
+        Map<TxSender, TxsPerAccount> txmap;
         Repository repository = Mockito.mock(Repository.class);
         final long blockGasLimit = 100000;
         WorldManager worldManager = Mockito.mock(WorldManager.class);

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
@@ -165,7 +165,7 @@ public class TxValidatorTest {
         AccountState as = Mockito.mock(AccountState.class);
         Mockito.when(as.getBalance()).thenReturn(BigInteger.valueOf(balance));
         Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(nonce));
-        Mockito.when(repository.getAccountState(tx.getSender())).thenReturn(as);
+        Mockito.when(repository.getAccountState(tx.getSender().getBytes())).thenReturn(as);
     }
 
     public static Transaction createBridgeTx(long value, long gaslimit, long gasprice, long nonce, long data, long sender, Random hashes) {

--- a/rskj-core/src/test/java/co/rsk/peg/AddressBasedAuthorizerTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/AddressBasedAuthorizerTest.java
@@ -22,11 +22,9 @@ import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.junit.Assert;
 import org.junit.Test;
-import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -81,14 +79,14 @@ public class AddressBasedAuthorizerTest {
 
         for (long n = 100L; n <= 102L; n++) {
             Transaction mockedTx = mock(Transaction.class);
-            when(mockedTx.getSender()).thenReturn(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress());
+            when(mockedTx.getSender()).thenReturn(new TxSender(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress()));
             Assert.assertTrue(auth.isAuthorized(new TxSender(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress())));
             Assert.assertTrue(auth.isAuthorized(mockedTx));
         }
 
         Assert.assertFalse(auth.isAuthorized(new TxSender(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress())));
         Transaction mockedTx = mock(Transaction.class);
-        when(mockedTx.getSender()).thenReturn(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress());
+        when(mockedTx.getSender()).thenReturn(new TxSender(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress()));
         Assert.assertFalse(auth.isAuthorized(mockedTx));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -980,7 +980,7 @@ public class BridgeSupportTest {
         org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
 
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
-        track.saveCode(tx.getSender(), new byte[] {0x1});
+        track.saveCode(tx.getSender().getBytes(), new byte[] {0x1});
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
 
@@ -1886,7 +1886,7 @@ public class BridgeSupportTest {
         );
         ABICallSpec spec = new ABICallSpec("create", new byte[][]{});
         Transaction mockedTx = mock(Transaction.class);
-        when(mockedTx.getSender()).thenReturn(ECKey.fromPrivate(BigInteger.valueOf(12L)).getAddress());
+        when(mockedTx.getSender()).thenReturn(new TxSender(ECKey.fromPrivate(BigInteger.valueOf(12L)).getAddress()));
         Assert.assertEquals(BridgeSupport.FEDERATION_CHANGE_GENERIC_ERROR_CODE, bridgeSupport.voteFederationChange(mockedTx, spec));
     }
 
@@ -1905,7 +1905,7 @@ public class BridgeSupportTest {
             voter = new TxSender(voterBytes);
 
             tx = mock(Transaction.class);
-            when(tx.getSender()).thenReturn(voterBytes);
+            when(tx.getSender()).thenReturn(voter);
 
             spec = new ABICallSpec(function, arguments);
 
@@ -2527,7 +2527,8 @@ public class BridgeSupportTest {
             // Public key hex of the authorized whitelist admin in regtest, taken from BridgeRegTestConstants
             "04641fb250d7ca7a1cb4f530588e978013038ec4294d084d248869dd54d98873e45c61d00ceeaeeb9e35eab19fa5fbd8f07cb8a5f0ddba26b4d4b18349c09199ad"
         )).getAddress();
-        when(mockedTx.getSender()).thenReturn(senderBytes);
+        TxSender sender = new TxSender(senderBytes);
+        when(mockedTx.getSender()).thenReturn(sender);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
@@ -2547,7 +2548,8 @@ public class BridgeSupportTest {
                 // Public key hex of the authorized whitelist admin in regtest, taken from BridgeRegTestConstants
                 "04641fb250d7ca7a1cb4f530588e978013038ec4294d084d248869dd54d98873e45c61d00ceeaeeb9e35eab19fa5fbd8f07cb8a5f0ddba26b4d4b18349c09199ad"
         )).getAddress();
-        when(mockedTx.getSender()).thenReturn(senderBytes);
+        TxSender sender = new TxSender(senderBytes);
+        when(mockedTx.getSender()).thenReturn(sender);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
@@ -2563,7 +2565,8 @@ public class BridgeSupportTest {
     public void addLockWhitelistAddress_notAuthorized() throws IOException {
         Transaction mockedTx = mock(Transaction.class);
         byte[] senderBytes = Hex.decode("aabbcc");
-        when(mockedTx.getSender()).thenReturn(senderBytes);
+        TxSender sender = new TxSender(senderBytes);
+        when(mockedTx.getSender()).thenReturn(sender);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
@@ -2578,7 +2581,8 @@ public class BridgeSupportTest {
             // Public key hex of the authorized whitelist admin in regtest, taken from BridgeRegTestConstants
             "04641fb250d7ca7a1cb4f530588e978013038ec4294d084d248869dd54d98873e45c61d00ceeaeeb9e35eab19fa5fbd8f07cb8a5f0ddba26b4d4b18349c09199ad"
         )).getAddress();
-        when(mockedTx.getSender()).thenReturn(senderBytes);
+        TxSender sender = new TxSender(senderBytes);
+        when(mockedTx.getSender()).thenReturn(sender);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
@@ -2593,7 +2597,8 @@ public class BridgeSupportTest {
                 // Public key hex of the authorized whitelist admin in regtest, taken from BridgeRegTestConstants
                 "04641fb250d7ca7a1cb4f530588e978013038ec4294d084d248869dd54d98873e45c61d00ceeaeeb9e35eab19fa5fbd8f07cb8a5f0ddba26b4d4b18349c09199ad"
         )).getAddress();
-        when(mockedTx.getSender()).thenReturn(senderBytes);
+        TxSender sender = new TxSender(senderBytes);
+        when(mockedTx.getSender()).thenReturn(sender);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
@@ -2613,7 +2618,8 @@ public class BridgeSupportTest {
                 // Public key hex of the authorized whitelist admin in regtest, taken from BridgeRegTestConstants
                 "04641fb250d7ca7a1cb4f530588e978013038ec4294d084d248869dd54d98873e45c61d00ceeaeeb9e35eab19fa5fbd8f07cb8a5f0ddba26b4d4b18349c09199ad"
         )).getAddress();
-        when(mockedTx.getSender()).thenReturn(senderBytes);
+        TxSender sender = new TxSender(senderBytes);
+        when(mockedTx.getSender()).thenReturn(sender);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
@@ -2630,7 +2636,8 @@ public class BridgeSupportTest {
     public void removeLockWhitelistAddress_notAuthorized() throws IOException {
         Transaction mockedTx = mock(Transaction.class);
         byte[] senderBytes = Hex.decode("aabbcc");
-        when(mockedTx.getSender()).thenReturn(senderBytes);
+        TxSender sender = new TxSender(senderBytes);
+        when(mockedTx.getSender()).thenReturn(sender);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
@@ -2645,7 +2652,8 @@ public class BridgeSupportTest {
             // Public key hex of the authorized whitelist admin in regtest, taken from BridgeRegTestConstants
             "04641fb250d7ca7a1cb4f530588e978013038ec4294d084d248869dd54d98873e45c61d00ceeaeeb9e35eab19fa5fbd8f07cb8a5f0ddba26b4d4b18349c09199ad"
         )).getAddress();
-        when(mockedTx.getSender()).thenReturn(senderBytes);
+        TxSender sender = new TxSender(senderBytes);
+        when(mockedTx.getSender()).thenReturn(sender);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
@@ -2664,7 +2672,7 @@ public class BridgeSupportTest {
         when(provider.getFeePerKbElection(any()))
                 .thenReturn(new ABICallElection(null));
         when(tx.getSender())
-                .thenReturn(new byte[] {0x43});
+                .thenReturn(new TxSender(new byte[] {0x43}));
         when(constants.getFeePerKbChangeAuthorizer())
                 .thenReturn(authorizer);
         when(authorizer.isAuthorized(tx))
@@ -2687,7 +2695,7 @@ public class BridgeSupportTest {
         when(provider.getFeePerKbElection(any()))
                 .thenReturn(new ABICallElection(authorizer));
         when(tx.getSender())
-                .thenReturn(senderBytes);
+                .thenReturn(new TxSender(senderBytes));
         when(constants.getFeePerKbChangeAuthorizer())
                 .thenReturn(authorizer);
         when(authorizer.isAuthorized(tx))
@@ -2710,12 +2718,12 @@ public class BridgeSupportTest {
         when(provider.getFeePerKbElection(any()))
                 .thenReturn(new ABICallElection(authorizer));
         when(tx.getSender())
-                .thenReturn(senderBytes);
+                .thenReturn(new TxSender(senderBytes));
         when(constants.getFeePerKbChangeAuthorizer())
                 .thenReturn(authorizer);
         when(authorizer.isAuthorized(tx))
                 .thenReturn(true);
-        when(authorizer.isAuthorized(TxSender.fromTx(tx)))
+        when(authorizer.isAuthorized(tx.getSender()))
                 .thenReturn(true);
         when(authorizer.getRequiredAuthorizedKeys())
                 .thenReturn(2);
@@ -2737,12 +2745,12 @@ public class BridgeSupportTest {
         when(provider.getFeePerKbElection(any()))
                 .thenReturn(new ABICallElection(authorizer));
         when(tx.getSender())
-                .thenReturn(senderBytes);
+                .thenReturn(new TxSender(senderBytes));
         when(constants.getFeePerKbChangeAuthorizer())
                 .thenReturn(authorizer);
         when(authorizer.isAuthorized(tx))
                 .thenReturn(true);
-        when(authorizer.isAuthorized(TxSender.fromTx(tx)))
+        when(authorizer.isAuthorized(tx.getSender()))
                 .thenReturn(true);
         when(authorizer.getRequiredAuthorizedKeys())
                 .thenReturn(1);

--- a/rskj-core/src/test/java/co/rsk/peg/TxSenderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/TxSenderTest.java
@@ -18,15 +18,9 @@
 
 package co.rsk.peg;
 
-import org.ethereum.core.Transaction;
 import org.junit.Assert;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
-
-import java.util.Collections;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TxSenderTest {
     @Test
@@ -41,14 +35,6 @@ public class TxSenderTest {
         Assert.assertNotEquals(senderA, senderC);
         Assert.assertNotEquals(senderA, senderD);
         Assert.assertNotEquals(senderA, senderE);
-    }
-
-    @Test
-    public void fromTx() {
-        Transaction mockedTx = mock(Transaction.class);
-        when(mockedTx.getSender()).thenReturn(Hex.decode("aabb"));
-
-        Assert.assertEquals(new TxSender(Hex.decode("aabb")), TxSender.fromTx(mockedTx));
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/peg/simples/SimpleRskTransaction.java
+++ b/rskj-core/src/test/java/co/rsk/peg/simples/SimpleRskTransaction.java
@@ -18,6 +18,7 @@
 
 package co.rsk.peg.simples;
 
+import co.rsk.peg.TxSender;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.SHA3Helper;
@@ -33,6 +34,7 @@ public class SimpleRskTransaction extends Transaction {
     public SimpleRskTransaction(byte[] hash) {
         super(null);
         this.hash = hash;
+        this.sender = new TxSender(ECKey.fromPrivate(SHA3Helper.sha3("cow".getBytes())).getAddress());
     }
 
     @Override
@@ -43,9 +45,4 @@ public class SimpleRskTransaction extends Transaction {
 
     @Override
     public String toString() { return "Tx " + this.getHash().toString(); }
-
-    @Override
-    public synchronized byte[] getSender() {
-        return ECKey.fromPrivate(SHA3Helper.sha3("cow".getBytes())).getAddress();
-    }
 }

--- a/rskj-core/src/test/java/co/rsk/test/builderstest/TransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/builderstest/TransactionBuilderTest.java
@@ -44,7 +44,7 @@ public class TransactionBuilderTest {
                 .build();
 
         Assert.assertNotNull(tx);
-        Assert.assertArrayEquals(sender.getAddress(), tx.getSender());
+        Assert.assertArrayEquals(sender.getAddress(), tx.getSender().getBytes());
         Assert.assertArrayEquals(receiver.getAddress(), tx.getReceiveAddress());
         Assert.assertEquals(BigInteger.TEN, new BigInteger(1, tx.getValue()));
         Assert.assertEquals(BigInteger.ONE, new BigInteger(1, tx.getGasPrice()));

--- a/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
@@ -340,7 +340,7 @@ public class WorldDslProcessorTest {
 
         Assert.assertNotNull(tx01);
 
-        Assert.assertArrayEquals(acc1.getAddress(), tx01.getSender());
+        Assert.assertArrayEquals(acc1.getAddress(), tx01.getSender().getBytes());
         Assert.assertArrayEquals(acc2.getAddress(), tx01.getReceiveAddress());
         Assert.assertEquals(new BigInteger("1000"), new BigInteger(1, tx01.getValue()));
         Assert.assertNotNull(tx01.getData());
@@ -367,7 +367,7 @@ public class WorldDslProcessorTest {
 
         Assert.assertNotNull(tx01);
 
-        Assert.assertArrayEquals(acc1.getAddress(), tx01.getSender());
+        Assert.assertArrayEquals(acc1.getAddress(), tx01.getSender().getBytes());
         Assert.assertArrayEquals(acc2.getAddress(), tx01.getReceiveAddress());
         Assert.assertEquals(new BigInteger("1000"), new BigInteger(1, tx01.getValue()));
         Assert.assertNotNull(tx01.getData());
@@ -394,7 +394,7 @@ public class WorldDslProcessorTest {
 
         Assert.assertNotNull(tx01);
 
-        Assert.assertArrayEquals(acc1.getAddress(), tx01.getSender());
+        Assert.assertArrayEquals(acc1.getAddress(), tx01.getSender().getBytes());
         Assert.assertArrayEquals(acc2.getAddress(), tx01.getReceiveAddress());
         Assert.assertEquals(new BigInteger("1000"), new BigInteger(1, tx01.getValue()));
         Assert.assertNotNull(tx01.getData());
@@ -423,7 +423,7 @@ public class WorldDslProcessorTest {
 
         Assert.assertNotNull(tx01);
 
-        Assert.assertArrayEquals(acc1.getAddress(), tx01.getSender());
+        Assert.assertArrayEquals(acc1.getAddress(), tx01.getSender().getBytes());
         Assert.assertArrayEquals(acc2.getAddress(), tx01.getReceiveAddress());
         Assert.assertEquals(new BigInteger("1000"), new BigInteger(1, tx01.getValue()));
         Assert.assertNotNull(tx01.getData());

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -303,7 +303,7 @@ public class TransactionTest {
         System.out.println("plainTx1: " + plainTx1);
         System.out.println("plainTx2: " + plainTx2);
 
-        System.out.println(Hex.toHexString(tx2.getSender()));
+        System.out.println(tx2.getSender().toString());
     }
 
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestProgramInvokeFactory.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestProgramInvokeFactory.java
@@ -66,11 +66,11 @@ public class TestProgramInvokeFactory implements ProgramInvokeFactory {
 
         /***         ORIGIN op       ***/
         // YP: This is the sender of original transaction; it is never a contract.
-        byte[] origin = tx.getSender();
+        byte[] origin = tx.getSender().getBytes();
 
         /***         CALLER op       ***/
         // YP: This is the address of the account that is directly responsible for this execution.
-        byte[] caller = tx.getSender();
+        byte[] caller = tx.getSender().getBytes();
 
         /***         BALANCE op       ***/
         byte[] balance = repository.getBalance(address).toByteArray();

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -290,7 +290,7 @@ public class Web3ImplTest {
 
         org.junit.Assert.assertNotNull(trxHash);
         org.junit.Assert.assertNotNull(eth.tx);
-        org.junit.Assert.assertArrayEquals(acc1.getAddress(), eth.tx.getSender());
+        org.junit.Assert.assertArrayEquals(acc1.getAddress(), eth.tx.getSender().getBytes());
         org.junit.Assert.assertArrayEquals(acc2.getAddress(), eth.tx.getReceiveAddress());
         org.junit.Assert.assertEquals(BigInteger.valueOf(1000000), new BigInteger(1, eth.tx.getValue()));
     }
@@ -335,7 +335,7 @@ public class Web3ImplTest {
 
         org.junit.Assert.assertNotNull(tr);
         org.junit.Assert.assertEquals("0x" + hashString, tr.transactionHash);
-        String trxFrom = TypeConverter.toJsonHex(tx.getSender());
+        String trxFrom = TypeConverter.toJsonHex(tx.getSender().getBytes());
         org.junit.Assert.assertEquals(trxFrom, tr.from);
         String trxTo = TypeConverter.toJsonHex(tx.getReceiveAddress());
         org.junit.Assert.assertEquals(trxTo, tr.to);


### PR DESCRIPTION
As part of the effort to strongly-type our codebase and stop relying on basic types like `byte[]`, let's return `TxSender` from `Transaction.getSender()`.