### PR TITLE
Feature/rfs 61 add logs to bridge contract

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -143,8 +143,10 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     // Adds the given key to the current pending federation
     public static final CallTransaction.Function VOTE_FEE_PER_KB = CallTransaction.Function.fromSignature("voteFeePerKbChange", new String[]{"int256"}, new String[]{"int256"});
 
-    // Log topics used by the Bridge
+    // Log topics used by Bridge Contract
     public static final DataWord RELEASE_BTC_TOPIC = new DataWord("release_btc_topic".getBytes(StandardCharsets.UTF_8));
+
+    public static final DataWord UPDATE_COLLECTIONS_TOPIC = new DataWord("update_collections_topic".getBytes(StandardCharsets.UTF_8));
 
     private Map<ByteArrayWrapper, CallTransaction.Function> functions = new HashMap<>();
     private static Map<CallTransaction.Function, Long> functionCostMap = new HashMap<>();

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -148,6 +148,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
     public static final DataWord UPDATE_COLLECTIONS_TOPIC = new DataWord("update_collections_topic".getBytes(StandardCharsets.UTF_8));
 
+    public static final DataWord ADD_SIGNATURE_TOPIC = new DataWord("add_signature_topic".getBytes(StandardCharsets.UTF_8));
+
     private Map<ByteArrayWrapper, CallTransaction.Function> functions = new HashMap<>();
     private static Map<CallTransaction.Function, Long> functionCostMap = new HashMap<>();
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -39,6 +39,7 @@ import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.RLP;
+import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.Program;
@@ -759,7 +760,17 @@ public class BridgeSupport {
             logger.warn("Expected {} signatures but received {}.", btcTx.getInputs().size(), signatures.size());
             return;
         }
+        createAddSignatureEventLog(federatorPublicKey, btcTx);
         processSigning(executionBlockNumber, federatorPublicKey, signatures, rskTxHash, btcTx);
+    }
+
+    private void createAddSignatureEventLog(BtcECKey federatorPublicKey, BtcTransaction btcTx) {
+        byte[] loggerContractAddress = TypeConverter.stringToByteArray(contractAddress);
+        List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
+        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
+                                     RLP.encodeElement(federatorPublicKey.getPubKeyHash()));
+
+        logs.add(new LogInfo(loggerContractAddress, topics, data));
     }
 
     private void processSigning(long executionBlockNumber, BtcECKey federatorPublicKey, List<byte[]> signatures, byte[] rskTxHash, BtcTransaction btcTx) throws IOException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -493,11 +493,23 @@ public class BridgeSupport {
     public void updateCollections(Transaction rskTx) throws IOException {
         Context.propagate(btcContext);
 
+        createEventLog(rskTx);
+
         processFundsMigration();
 
         processReleaseRequests();
 
         processReleaseTransactions(rskTx);
+    }
+
+    private void createEventLog(Transaction rskTx) {
+        logs.add(
+                new LogInfo(
+                        TypeConverter.stringToByteArray(contractAddress),
+                        Collections.singletonList(Bridge.UPDATE_COLLECTIONS_TOPIC),
+                        RLP.encodeElement(rskTx.getSender())
+                )
+        );
     }
 
     private boolean federationIsInMigrationAge(Federation federation) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -760,15 +760,16 @@ public class BridgeSupport {
             logger.warn("Expected {} signatures but received {}.", btcTx.getInputs().size(), signatures.size());
             return;
         }
-        createAddSignatureEventLog(federatorPublicKey, btcTx);
+        createAddSignatureEventLog(federatorPublicKey, btcTx, rskTxHash);
         processSigning(executionBlockNumber, federatorPublicKey, signatures, rskTxHash, btcTx);
     }
 
-    private void createAddSignatureEventLog(BtcECKey federatorPublicKey, BtcTransaction btcTx) {
+    private void createAddSignatureEventLog(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
         byte[] loggerContractAddress = TypeConverter.stringToByteArray(contractAddress);
         List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
         byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
-                                     RLP.encodeElement(federatorPublicKey.getPubKeyHash()));
+                                     RLP.encodeElement(federatorPublicKey.getPubKeyHash()),
+                                     RLP.encodeElement(rskTxHash));
 
         logs.add(new LogInfo(loggerContractAddress, topics, data));
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -854,16 +854,19 @@ public class BridgeSupport {
         if (hasEnoughSignatures(btcTx)) {
             logger.info("Tx fully signed {}. Hex: {}", btcTx, Hex.toHexString(btcTx.bitcoinSerialize()));
             provider.getRskTxsWaitingForSignatures().remove(new Sha3Hash(rskTxHash));
-            logs.add(
-                new LogInfo(
-                    TypeConverter.stringToByteArray(contractAddress),
-                    Collections.singletonList(Bridge.RELEASE_BTC_TOPIC),
-                    RLP.encodeElement(btcTx.bitcoinSerialize())
-                )
-            );
+            createReleaseBtcEventLog(btcTx);
         } else {
             logger.debug("Tx not yet fully signed {}.", new Sha3Hash(rskTxHash));
         }
+    }
+
+    private void createReleaseBtcEventLog(BtcTransaction btcTx) {
+        byte[] loggerContractAddress = TypeConverter.stringToByteArray(contractAddress);
+        List<DataWord> topics = Collections.singletonList(Bridge.RELEASE_BTC_TOPIC);
+        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
+                                     RLP.encodeElement(btcTx.bitcoinSerialize()));
+
+        logs.add(new LogInfo(loggerContractAddress, topics, data));
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -494,7 +494,7 @@ public class BridgeSupport {
     public void updateCollections(Transaction rskTx) throws IOException {
         Context.propagate(btcContext);
 
-        createEventLog(rskTx);
+        createUpdateSignatureEventLog(rskTx);
 
         processFundsMigration();
 
@@ -503,7 +503,7 @@ public class BridgeSupport {
         processReleaseTransactions(rskTx);
     }
 
-    private void createEventLog(Transaction rskTx) {
+    private void createUpdateSignatureEventLog(Transaction rskTx) {
         logs.add(
                 new LogInfo(
                         TypeConverter.stringToByteArray(contractAddress),

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -292,13 +292,9 @@ public class BridgeSupportTest {
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
 
-        Blockchain blockchain = new BlockChainBuilder().setTesting(true).setRsk(true).setGenesis(BlockGenerator.getInstance().getGenesisBlock()).build();
-        ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
-        org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
-
         List<LogInfo> eventLogs = new LinkedList<>();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), eventLogs);
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), eventLogs);
 
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         ECKey key = new ECKey();
@@ -352,17 +348,11 @@ public class BridgeSupportTest {
 
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
 
-        BlockChainBuilder builder = new BlockChainBuilder();
-
-        Blockchain blockchain = builder.setTesting(true).setRsk(true).setGenesis(BlockGenerator.getInstance().getGenesisBlock()).build();
-
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
-        org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(tx);
 
@@ -418,12 +408,10 @@ public class BridgeSupportTest {
             blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
-        org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(tx);
 
@@ -482,7 +470,7 @@ public class BridgeSupportTest {
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(tx);
 
@@ -519,8 +507,6 @@ public class BridgeSupportTest {
             blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
-        org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
 
         Repository repository = blockchain.getRepository();
         Repository track = repository.startTracking();
@@ -538,7 +524,7 @@ public class BridgeSupportTest {
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(tx);
 
@@ -607,12 +593,10 @@ public class BridgeSupportTest {
             blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
-        org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
         Transaction rskTx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(rskTx);
         bridgeSupport.save();
@@ -742,7 +726,7 @@ public class BridgeSupportTest {
         // Setup
         Federation federation = bridgeConstants.getGenesisFederation();
         Repository track = new RepositoryImpl().startTracking();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants);
 
         // Build prev btc tx
         BtcTransaction prevTx = new BtcTransaction(btcParams);
@@ -763,7 +747,7 @@ public class BridgeSupportTest {
 
         // Setup BridgeSupport
         List<LogInfo> eventLogs = new ArrayList<>();
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, null, null, null, BridgeRegTestConstants.getInstance(), eventLogs);
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, null, BridgeRegTestConstants.getInstance(), eventLogs);
 
         // Create signed hash of Btc tx
         Script inputScript = btcTx.getInputs().get(0).getScriptSig();
@@ -909,11 +893,11 @@ public class BridgeSupportTest {
 
         Assert.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertThat(logs, is(not(empty())));
-        Assert.assertThat(logs, hasSize(1));
-        LogInfo releaseTxEvent = logs.get(0);
+        Assert.assertThat(logs, hasSize(5));
+        LogInfo releaseTxEvent = logs.get(4);
         Assert.assertThat(releaseTxEvent.getTopics(), hasSize(1));
         Assert.assertThat(releaseTxEvent.getTopics(), hasItem(Bridge.RELEASE_BTC_TOPIC));
-        BtcTransaction releaseTx = new BtcTransaction(bridgeConstants.getBtcParams(), RLP.decode2(releaseTxEvent.getData()).get(0).getRLPData());
+        BtcTransaction releaseTx = new BtcTransaction(bridgeConstants.getBtcParams(), ((RLPList)RLP.decode2(releaseTxEvent.getData()).get(0)).get(1).getRLPData());
         // Verify all inputs fully signed
         for (int i = 0; i < releaseTx.getInputs().size(); i++) {
             Script retrievedScriptSig = releaseTx.getInput(i).getScriptSig();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -794,9 +794,10 @@ public class BridgeSupportTest {
         List<RLPElement> rlpData = RLP.decode2(result.getData());
         Assert.assertEquals(1 , rlpData.size());
         RLPList dataList = (RLPList)rlpData.get(0);
-        Assert.assertEquals(2, dataList.size());
+        Assert.assertEquals(3, dataList.size());
         Assert.assertArrayEquals(btcTx.getHashAsString().getBytes(), dataList.get(0).getRLPData());
         Assert.assertArrayEquals(federatorPubKey.getPubKeyHash(), dataList.get(1).getRLPData());
+        Assert.assertArrayEquals(rskTxHash.getBytes(), dataList.get(2).getRLPData());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1004,7 +1004,7 @@ public class BridgeSupportTest {
             LogInfo releaseTxEvent = logs.get(2);
             Assert.assertThat(releaseTxEvent.getTopics(), hasSize(1));
             Assert.assertThat(releaseTxEvent.getTopics(), hasItem(Bridge.RELEASE_BTC_TOPIC));
-            BtcTransaction releaseTx = new BtcTransaction(bridgeConstants.getBtcParams(), RLP.decode2(releaseTxEvent.getData()).get(0).getRLPData());
+            BtcTransaction releaseTx = new BtcTransaction(bridgeConstants.getBtcParams(), ((RLPList)RLP.decode2(releaseTxEvent.getData()).get(0)).get(1).getRLPData());
             Script retrievedScriptSig = releaseTx.getInput(0).getScriptSig();
             Assert.assertEquals(4, retrievedScriptSig.getChunks().size());
             Assert.assertEquals(true, retrievedScriptSig.getChunks().get(1).data.length > 0);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -46,6 +46,7 @@ import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.db.ReceiptStore;
+import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.RLP;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
@@ -283,6 +284,41 @@ public class BridgeSupportTest {
     }
 
     @Test
+    public void callUpdateCollectionsGenerateEventLog() throws IOException, BlockStoreException {
+        Repository track = new RepositoryImpl().startTracking();
+
+        List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
+        org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
+
+        Blockchain blockchain = new BlockChainBuilder().setTesting(true).setRsk(true).setGenesis(BlockGenerator.getInstance().getGenesisBlock()).build();
+        ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
+        org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
+
+        List<LogInfo> eventLogs = new LinkedList<>();
+
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), eventLogs);
+
+        Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        ECKey key = new ECKey();
+        tx.sign(key.getPrivKeyBytes());
+
+        bridgeSupport.updateCollections(tx);
+
+        Assert.assertEquals(1, eventLogs.size());
+
+        // Assert address that made the log
+        LogInfo result = eventLogs.get(0);
+        Assert.assertArrayEquals(TypeConverter.stringToByteArray(PrecompiledContracts.BRIDGE_ADDR), result.getAddress());
+
+        // Assert log topics
+        Assert.assertEquals(1, result.getTopics().size());
+        Assert.assertEquals(Bridge.UPDATE_COLLECTIONS_TOPIC, result.getTopics().get(0));
+
+        // Assert log data
+        Assert.assertArrayEquals(key.getAddress(), RLP.decode2(result.getData()).get(0).getRLPData());
+    }
+
+    @Test
     public void callUpdateCollectionsFundsEnoughForJustTheSmallerTx() throws IOException, BlockStoreException {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
@@ -322,8 +358,9 @@ public class BridgeSupportTest {
         ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
         org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(tx);
 
@@ -382,8 +419,9 @@ public class BridgeSupportTest {
         ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
         org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(tx);
 
@@ -440,8 +478,9 @@ public class BridgeSupportTest {
         ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
         org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(tx);
 
@@ -495,8 +534,9 @@ public class BridgeSupportTest {
 
         track = repository.startTracking();
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(tx);
 
@@ -568,8 +608,9 @@ public class BridgeSupportTest {
         ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
         org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
         Transaction rskTx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        rskTx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, rskReceiptStore, rskBlockStore, BridgeRegTestConstants.getInstance(), new LinkedList<>());
 
         bridgeSupport.updateCollections(rskTx);
         bridgeSupport.save();


### PR DESCRIPTION
# Logs added

## Sign Tx
There is a need to know when a federate node signs a BTC tx. 
This helps monitoring the status (ie. number of signatures) of txs released to BTC.

### Candidate data to include in event log
- Federate member public key
	It is an instance of class BtcECKey. It can be summarized for logging purposes using:
		- PubKeyHash or ---> this one is used for implementation
		- toString() method which provides public key as hex
- Hash id of BTC tx
	It is an instance of class BtcTransaction. Use of getHashAsString() method seems like the best option because is the hash that
	can then be used in an explorer to track the tx.
- RskTxHash
- Signatures
	There is one signature per BTC tx input. Anyway, this does not seem necessary for monitoring purposes.

## Update Collections
A task on each federate node is responsible for calling updateCollections() method of Bridge contract. 
To check if a federate node is doing it's job there must be a way to know that it is calling the updateCollections() method.
An approach to identify who calls the updateCollections() method is to save in an event log the address of the caller.

### Candidate data to include in event log
- RSK tx sender address

## Release BTC
After a BTC tx is fully signed it needs to be released to the network. 
There is an existing event log whose topic is called "RELEASE_BTC_TOPIC" and stores the whole BTC tx that is going to be released in hex.
There is a need to store an id for that tx so that it can be tracked on BTC network

### Candidate data to include in event log
- Hash id of BTC tx
	It is an instance of class BtcTransaction. Use of getHashAsString() method seems like the best option.
	It can be added as the first parameter of a collection that can then include as second the whole BTC tx in hex (current data saved by log)