### PR TITLE
Feature/rfs 83 add event logs for commit federation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -147,10 +147,9 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
     // Log topics used by Bridge Contract
     public static final DataWord RELEASE_BTC_TOPIC = new DataWord("release_btc_topic".getBytes(StandardCharsets.UTF_8));
-
     public static final DataWord UPDATE_COLLECTIONS_TOPIC = new DataWord("update_collections_topic".getBytes(StandardCharsets.UTF_8));
-
     public static final DataWord ADD_SIGNATURE_TOPIC = new DataWord("add_signature_topic".getBytes(StandardCharsets.UTF_8));
+    public static final DataWord COMMIT_FEDERATION_TOPIC = new DataWord("commit_federation_topic".getBytes(StandardCharsets.UTF_8));
 
     private Map<ByteArrayWrapper, CallTransaction.Function> functions = new HashMap<>();
     private static Map<CallTransaction.Function, Long> functionCostMap = new HashMap<>();
@@ -342,7 +341,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     }
 
     private BridgeSupport setup() throws Exception {
-        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(this.logs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(this.bridgeConstants, this.logs);
         return new BridgeSupport(repository, contractAddress, rskExecutionBlock, bridgeConstants, eventLogger);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -22,6 +22,8 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.panic.PanicProcessor;
+import co.rsk.peg.utils.BridgeEventLogger;
+import co.rsk.peg.utils.BridgeEventLoggerImpl;
 import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
@@ -340,7 +342,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     }
 
     private BridgeSupport setup() throws Exception {
-        return new BridgeSupport(repository, contractAddress, rskExecutionBlock, bridgeConstants, logs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(this.logs);
+        return new BridgeSupport(repository, contractAddress, rskExecutionBlock, bridgeConstants, eventLogger);
     }
 
     private void teardown() throws IOException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -754,18 +754,8 @@ public class BridgeSupport {
             logger.warn("Expected {} signatures but received {}.", btcTx.getInputs().size(), signatures.size());
             return;
         }
-        createAddSignatureEventLog(federatorPublicKey, btcTx, rskTxHash);
+        eventLogger.losAddSignature(federatorPublicKey, btcTx, rskTxHash);
         processSigning(executionBlockNumber, federatorPublicKey, signatures, rskTxHash, btcTx);
-    }
-
-    private void createAddSignatureEventLog(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
-        byte[] loggerContractAddress = TypeConverter.stringToByteArray(contractAddress);
-        List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
-        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
-                                     RLP.encodeElement(federatorPublicKey.getPubKeyHash()),
-                                     RLP.encodeElement(rskTxHash));
-
-        eventLogger.getLogs().add(new LogInfo(loggerContractAddress, topics, data));
     }
 
     private void processSigning(long executionBlockNumber, BtcECKey federatorPublicKey, List<byte[]> signatures, byte[] rskTxHash, BtcTransaction btcTx) throws IOException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -117,13 +117,14 @@ public class BridgeSupport {
 
 
     // Used by unit tests
-    public BridgeSupport(Repository repository, String contractAddress, BridgeStorageProvider provider, BtcBlockStore btcBlockStore, BtcBlockChain btcBlockChain, BridgeConstants bridgeConstants) {
+    public BridgeSupport(Repository repository, String contractAddress, BridgeStorageProvider provider, BtcBlockStore btcBlockStore, BtcBlockChain btcBlockChain, BridgeConstants bridgeConstants, BridgeEventLogger eventLogger) {
         this.provider = provider;
         this.bridgeConstants = bridgeConstants;
         this.btcContext = new Context(bridgeConstants.getBtcParams());
         this.btcBlockStore = btcBlockStore;
         this.btcBlockChain = btcBlockChain;
         this.rskRepository = repository;
+        this.eventLogger = eventLogger;
     }
 
     @VisibleForTesting
@@ -1400,6 +1401,8 @@ public class BridgeSupport {
 
         // Clear votes on election
         provider.getFederationElection(bridgeConstants.getFederationChangeAuthorizer()).clear();
+
+        eventLogger.logCommitFederation(rskExecutionBlock, provider.getOldFederation(), provider.getNewFederation());
 
         return 1;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -838,19 +838,10 @@ public class BridgeSupport {
         if (hasEnoughSignatures(btcTx)) {
             logger.info("Tx fully signed {}. Hex: {}", btcTx, Hex.toHexString(btcTx.bitcoinSerialize()));
             provider.getRskTxsWaitingForSignatures().remove(new Sha3Hash(rskTxHash));
-            createReleaseBtcEventLog(btcTx);
+            eventLogger.logReleaseBtc(btcTx);
         } else {
             logger.debug("Tx not yet fully signed {}.", new Sha3Hash(rskTxHash));
         }
-    }
-
-    private void createReleaseBtcEventLog(BtcTransaction btcTx) {
-        byte[] loggerContractAddress = TypeConverter.stringToByteArray(contractAddress);
-        List<DataWord> topics = Collections.singletonList(Bridge.RELEASE_BTC_TOPIC);
-        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
-                                     RLP.encodeElement(btcTx.bitcoinSerialize()));
-
-        eventLogger.getLogs().add(new LogInfo(loggerContractAddress, topics, data));
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -38,10 +38,6 @@ import org.ethereum.core.Block;
 import org.ethereum.core.Denomination;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
-import org.ethereum.rpc.TypeConverter;
-import org.ethereum.util.RLP;
-import org.ethereum.vm.DataWord;
-import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.Program;
 import org.slf4j.Logger;
@@ -79,7 +75,6 @@ public class BridgeSupport {
             "commit",
             "rollback"));
 
-    private final String contractAddress;
     private final BridgeConstants bridgeConstants;
     private final Context btcContext;
     private final BtcBlockStore btcBlockStore;
@@ -98,8 +93,7 @@ public class BridgeSupport {
 
     // Used by unit tests
     public BridgeSupport(Repository repository, String contractAddress, BridgeStorageProvider provider, Block rskExecutionBlock, BridgeConstants bridgeConstants, BridgeEventLogger eventLogger) throws IOException, BlockStoreException {
-    this.rskRepository = repository;
-        this.contractAddress = contractAddress;
+        this.rskRepository = repository;
         this.provider = provider;
         this.rskExecutionBlock = rskExecutionBlock;
         this.bridgeConstants = bridgeConstants;
@@ -129,7 +123,6 @@ public class BridgeSupport {
         this.btcContext = new Context(bridgeConstants.getBtcParams());
         this.btcBlockStore = btcBlockStore;
         this.btcBlockChain = btcBlockChain;
-        this.contractAddress = contractAddress;
         this.rskRepository = repository;
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -492,23 +492,13 @@ public class BridgeSupport {
     public void updateCollections(Transaction rskTx) throws IOException {
         Context.propagate(btcContext);
 
-        createUpdateSignatureEventLog(rskTx);
+        eventLogger.logUpdateCollections(rskTx);
 
         processFundsMigration();
 
         processReleaseRequests();
 
         processReleaseTransactions(rskTx);
-    }
-
-    private void createUpdateSignatureEventLog(Transaction rskTx) {
-        eventLogger.getLogs().add(
-                new LogInfo(
-                        TypeConverter.stringToByteArray(contractAddress),
-                        Collections.singletonList(Bridge.UPDATE_COLLECTIONS_TOPIC),
-                        RLP.encodeElement(rskTx.getSender())
-                )
-        );
     }
 
     private boolean federationIsInMigrationAge(Federation federation) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -748,7 +748,7 @@ public class BridgeSupport {
             logger.warn("Expected {} signatures but received {}.", btcTx.getInputs().size(), signatures.size());
             return;
         }
-        eventLogger.losAddSignature(federatorPublicKey, btcTx, rskTxHash);
+        eventLogger.logAddSignature(federatorPublicKey, btcTx, rskTxHash);
         processSigning(executionBlockNumber, federatorPublicKey, signatures, rskTxHash, btcTx);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -94,8 +94,7 @@ public class BridgeSupport {
     public BridgeSupport(Repository repository, String contractAddress, Block rskExecutionBlock, BridgeConstants bridgeConstants, List<LogInfo> logs) throws IOException, BlockStoreException {
         this(repository, contractAddress, new BridgeStorageProvider(repository, contractAddress, bridgeConstants), rskExecutionBlock, bridgeConstants, logs);
     }
-
-
+    
     // Used by unit tests
     public BridgeSupport(Repository repository, String contractAddress, BridgeStorageProvider provider, Block rskExecutionBlock, BridgeConstants bridgeConstants, List<LogInfo> logs) throws IOException, BlockStoreException {
         this.rskRepository = repository;
@@ -121,16 +120,6 @@ public class BridgeSupport {
         this.initialBtcStoredBlock = this.getLowestBlock();
     }
 
-    @VisibleForTesting
-    InputStream getCheckPoints() {
-        InputStream checkpoints = BridgeSupport.class.getResourceAsStream("/rskbitcoincheckpoints/" + bridgeConstants.getBtcParams().getId() + ".checkpoints");
-        if (checkpoints == null) {
-            // If we don't have a custom checkpoints file, try to use bitcoinj's default checkpoints for that network
-            checkpoints = BridgeSupport.class.getResourceAsStream("/" + bridgeConstants.getBtcParams().getId() + ".checkpoints");
-        }
-        return checkpoints;
-    }
-
     // Used by unit tests
     public BridgeSupport(Repository repository, String contractAddress, BridgeStorageProvider provider, BtcBlockStore btcBlockStore, BtcBlockChain btcBlockChain, BridgeConstants bridgeConstants) {
         this.provider = provider;
@@ -140,6 +129,16 @@ public class BridgeSupport {
         this.btcBlockChain = btcBlockChain;
         this.contractAddress = contractAddress;
         this.rskRepository = repository;
+    }
+
+    @VisibleForTesting
+    InputStream getCheckPoints() {
+        InputStream checkpoints = BridgeSupport.class.getResourceAsStream("/rskbitcoincheckpoints/" + bridgeConstants.getBtcParams().getId() + ".checkpoints");
+        if (checkpoints == null) {
+            // If we don't have a custom checkpoints file, try to use bitcoinj's default checkpoints for that network
+            checkpoints = BridgeSupport.class.getResourceAsStream("/" + bridgeConstants.getBtcParams().getId() + ".checkpoints");
+        }
+        return checkpoints;
     }
 
     public void save() throws IOException {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -20,6 +20,8 @@ package co.rsk.peg.utils;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.peg.Federation;
+import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 import org.ethereum.vm.LogInfo;
 
@@ -39,4 +41,6 @@ public interface BridgeEventLogger {
     void losAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash);
 
     void logReleaseBtc(BtcTransaction btcTx);
+
+    void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation);
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.peg.utils;
 
 import co.rsk.bitcoinj.core.BtcECKey;

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -1,5 +1,6 @@
 package co.rsk.peg.utils;
 
+import org.ethereum.core.Transaction;
 import org.ethereum.vm.LogInfo;
 
 import java.util.List;

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -1,0 +1,15 @@
+package co.rsk.peg.utils;
+
+import org.ethereum.vm.LogInfo;
+
+import java.util.List;
+
+/**
+ * Responsible for logging events triggered by BridgeContract.
+ *
+ * @author martin.medina
+ */
+public interface BridgeEventLogger {
+
+    List<LogInfo> getLogs();
+}

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -1,5 +1,7 @@
 package co.rsk.peg.utils;
 
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
 import org.ethereum.core.Transaction;
 import org.ethereum.vm.LogInfo;
 
@@ -13,4 +15,8 @@ import java.util.List;
 public interface BridgeEventLogger {
 
     List<LogInfo> getLogs();
+
+    void logUpdateCollections(Transaction rskTx);
+
+    void losAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash);
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -38,7 +38,7 @@ public interface BridgeEventLogger {
 
     void logUpdateCollections(Transaction rskTx);
 
-    void losAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash);
+    void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash);
 
     void logReleaseBtc(BtcTransaction btcTx);
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -19,4 +19,6 @@ public interface BridgeEventLogger {
     void logUpdateCollections(Transaction rskTx);
 
     void losAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash);
+
+    void logReleaseBtc(BtcTransaction btcTx);
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.peg.utils;
 
 import co.rsk.bitcoinj.core.BtcECKey;

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -66,7 +66,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
         );
     }
 
-    public void losAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
+    public void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
         List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
         byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
                                     RLP.encodeElement(federatorPublicKey.getPubKeyHash()),

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -1,9 +1,12 @@
 package co.rsk.peg.utils;
 
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.peg.Bridge;
 import org.ethereum.core.Transaction;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.RLP;
+import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 
@@ -17,6 +20,8 @@ import java.util.List;
  */
 public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
+    private static final byte[] BRIDGE_CONTRACT_ADDRESS = TypeConverter.stringToByteArray(PrecompiledContracts.BRIDGE_ADDR);
+
     private List<LogInfo> logs;
 
     public BridgeEventLoggerImpl(List<LogInfo> logs) {
@@ -25,5 +30,23 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     public List<LogInfo> getLogs() {
         return logs;
+    }
+
+    public void logUpdateCollections(Transaction rskTx) {
+        this.logs.add(
+                new LogInfo(BRIDGE_CONTRACT_ADDRESS,
+                            Collections.singletonList(Bridge.UPDATE_COLLECTIONS_TOPIC),
+                            RLP.encodeElement(rskTx.getSender())
+                )
+        );
+    }
+
+    public void losAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
+        List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
+        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
+                RLP.encodeElement(federatorPublicKey.getPubKeyHash()),
+                RLP.encodeElement(rskTxHash));
+
+        this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -1,0 +1,23 @@
+package co.rsk.peg.utils;
+
+import org.ethereum.vm.LogInfo;
+
+import java.util.List;
+
+/**
+ * Responsible for logging events triggered by BridgeContract.
+ *
+ * @author martin.medina
+ */
+public class BridgeEventLoggerImpl implements BridgeEventLogger {
+
+    private List<LogInfo> logs;
+
+    public BridgeEventLoggerImpl(List<LogInfo> logs) {
+        this.logs = logs;
+    }
+
+    public List<LogInfo> getLogs() {
+        return logs;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -49,4 +49,12 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
         this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
     }
+
+    public void logReleaseBtc(BtcTransaction btcTx) {
+        List<DataWord> topics = Collections.singletonList(Bridge.RELEASE_BTC_TOPIC);
+        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
+                RLP.encodeElement(btcTx.bitcoinSerialize()));
+
+        this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -1,7 +1,13 @@
 package co.rsk.peg.utils;
 
+import co.rsk.peg.Bridge;
+import org.ethereum.core.Transaction;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.util.RLP;
 import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
 
+import java.util.Collections;
 import java.util.List;
 
 /**

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -20,7 +20,10 @@ package co.rsk.peg.utils;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.config.BridgeConstants;
 import co.rsk.peg.Bridge;
+import co.rsk.peg.Federation;
+import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.RLP;
@@ -30,6 +33,7 @@ import org.ethereum.vm.PrecompiledContracts;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Responsible for logging events triggered by BridgeContract.
@@ -40,9 +44,12 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     private static final byte[] BRIDGE_CONTRACT_ADDRESS = TypeConverter.stringToByteArray(PrecompiledContracts.BRIDGE_ADDR);
 
+    private final BridgeConstants bridgeConstants;
+
     private List<LogInfo> logs;
 
-    public BridgeEventLoggerImpl(List<LogInfo> logs) {
+    public BridgeEventLoggerImpl(BridgeConstants bridgeConstants, List<LogInfo> logs) {
+        this.bridgeConstants = bridgeConstants;
         this.logs = logs;
     }
 
@@ -62,17 +69,48 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     public void losAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
         List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
         byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
-                RLP.encodeElement(federatorPublicKey.getPubKeyHash()),
-                RLP.encodeElement(rskTxHash));
+                                    RLP.encodeElement(federatorPublicKey.getPubKeyHash()),
+                                    RLP.encodeElement(rskTxHash));
 
         this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
     }
 
     public void logReleaseBtc(BtcTransaction btcTx) {
         List<DataWord> topics = Collections.singletonList(Bridge.RELEASE_BTC_TOPIC);
-        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
-                RLP.encodeElement(btcTx.bitcoinSerialize()));
+        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()), RLP.encodeElement(btcTx.bitcoinSerialize()));
 
         this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
+    }
+
+    public void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation) {
+        List<DataWord> topics = Collections.singletonList(Bridge.COMMIT_FEDERATION_TOPIC);
+
+        byte[] oldFedFlatPubKeys = flatKeysAsRlpCollection(oldFederation.getPublicKeys());
+        byte[] oldFedData = RLP.encodeList(RLP.encodeElement(oldFederation.getAddress().getHash160()), RLP.encodeList(oldFedFlatPubKeys));
+
+        byte[] newFedFlatPubKeys = flatKeysAsRlpCollection(newFederation.getPublicKeys());
+        byte[] newFedData = RLP.encodeList(RLP.encodeElement(newFederation.getAddress().getHash160()), RLP.encodeList(newFedFlatPubKeys));
+
+        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge();
+
+        byte[] data = RLP.encodeList(oldFedData, newFedData, RLP.encodeString(Long.toString(newFedActivationBlockNumber)));
+
+        this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
+    }
+
+    private byte[] flatKeysAsRlpCollection(List<BtcECKey> keys) {
+        List<byte[]> pubKeys = keys.stream()
+                                    .map(k -> RLP.encodeElement(k.getPubKey()))
+                                    .collect(Collectors.toList());
+        int pubKeysLength = pubKeys.stream().mapToInt(key -> key.length).sum();
+
+        byte[] flatPubKeys = new byte[pubKeysLength];
+        int copyPos = 0;
+        for(byte[] key : pubKeys) {
+            System.arraycopy(key, 0, flatPubKeys, copyPos, key.length);
+            copyPos += key.length;
+        }
+
+        return flatPubKeys;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -698,7 +698,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
 
         co.rsk.bitcoinj.core.BtcBlock block = new co.rsk.bitcoinj.core.BtcBlock(btcParams, 1, PegTestUtils.createHash(), PegTestUtils.createHash(), 1, 1, 1, new ArrayList<BtcTransaction>());
         co.rsk.bitcoinj.core.BtcBlock[] headers = new co.rsk.bitcoinj.core.BtcBlock[1];
@@ -724,7 +724,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
 
         co.rsk.bitcoinj.core.BtcBlock block = new co.rsk.bitcoinj.core.BtcBlock(btcParams, 1, PegTestUtils.createHash(), PegTestUtils.createHash(), 1, 1, 1, new ArrayList<BtcTransaction>());
         co.rsk.bitcoinj.core.BtcBlock[] headers = new co.rsk.bitcoinj.core.BtcBlock[1];
@@ -1305,7 +1305,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1383,7 +1383,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
 
         byte[] bits = new byte[1];
@@ -1478,7 +1478,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         provider.setNewFederation(activeFederation);
         provider.setOldFederation(retiringFederation);
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
 
         byte[] bits = new byte[1];
@@ -1570,7 +1570,7 @@ public class BridgeSupportTest {
         whitelist.put(address2, Coin.COIN.multiply(10));
         whitelist.put(address3, Coin.COIN.multiply(2).add(Coin.COIN.multiply(3)));
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
         byte[] bits = new byte[1];
         bits[0] = 0x3f;
@@ -1684,7 +1684,7 @@ public class BridgeSupportTest {
         provider.setNewFederation(federation1);
         provider.setOldFederation(federation2);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, provider, btcBlockStore, btcBlockChain, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
         byte[] bits = new byte[1];
         bits[0] = 0x3f;
@@ -1773,7 +1773,7 @@ public class BridgeSupportTest {
 
     @Test
     public void isBtcTxHashAlreadyProcessed() throws IOException, BlockStoreException {
-        BridgeSupport bridgeSupport = new BridgeSupport(null, null, getBridgeStorageProviderMockWithProcessedHashes(), null, null, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(null, null, getBridgeStorageProviderMockWithProcessedHashes(), null, null, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
 
         for (int i = 0; i < 10; i++) {
             Assert.assertTrue(bridgeSupport.isBtcTxHashAlreadyProcessed(Sha256Hash.of(("hash_" + i).getBytes())));
@@ -1783,7 +1783,7 @@ public class BridgeSupportTest {
 
     @Test
     public void getBtcTxHashProcessedHeight() throws IOException, BlockStoreException {
-        BridgeSupport bridgeSupport = new BridgeSupport(null, null, getBridgeStorageProviderMockWithProcessedHashes(), null, null, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(null, null, getBridgeStorageProviderMockWithProcessedHashes(), null, null, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
 
         for (int i = 0; i < 10; i++) {
             Assert.assertEquals((long) i, bridgeSupport.getBtcTxHashProcessedHeight(Sha256Hash.of(("hash_" + i).getBytes())).longValue());
@@ -2471,6 +2471,8 @@ public class BridgeSupportTest {
                 BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))),
                 Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
+        BridgeEventLogger eventLoggerMock = mock(BridgeEventLogger.class);
+
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
                 newFederation,
@@ -2478,7 +2480,8 @@ public class BridgeSupportTest {
                 null,
                 pendingFederation,
                 mocksProvider.getElection(),
-                executionBlock
+                executionBlock,
+                eventLoggerMock
         );
         BridgeStorageProvider provider = (BridgeStorageProvider) Whitebox.getInternalState(bridgeSupport, "provider");
 
@@ -2522,6 +2525,9 @@ public class BridgeSupportTest {
         }
         verify(mocksProvider.getElection(), times(1)).clearWinners();
         verify(mocksProvider.getElection(), times(1)).clear();
+
+        // Check logs are made
+        verify(eventLoggerMock, times(1)).logCommitFederation(executionBlock, newFederation, expectedFederation);
     }
 
     @Test
@@ -2849,7 +2855,7 @@ public class BridgeSupportTest {
         when(authorizer.isAuthorized(tx))
                 .thenReturn(true);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(repositoryMock, "aabbccdd", provider, null, null, constants);
+        BridgeSupport bridgeSupport = new BridgeSupport(repositoryMock, "aabbccdd", provider, null, null, constants, null);
         bridgeSupport.voteFeePerKbChange(tx, null);
         verify(provider, never()).setFeePerKb(any());
     }
@@ -2872,7 +2878,7 @@ public class BridgeSupportTest {
         when(authorizer.isAuthorized(tx))
                 .thenReturn(false);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(repositoryMock, "aabbccdd", provider, null, null, constants);
+        BridgeSupport bridgeSupport = new BridgeSupport(repositoryMock, "aabbccdd", provider, null, null, constants, null);
         assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(-10));
         verify(provider, never()).setFeePerKb(any());
     }
@@ -2899,7 +2905,7 @@ public class BridgeSupportTest {
         when(authorizer.getRequiredAuthorizedKeys())
                 .thenReturn(2);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(repositoryMock, "aabbccdd", provider, null, null, constants);
+        BridgeSupport bridgeSupport = new BridgeSupport(repositoryMock, "aabbccdd", provider, null, null, constants, null);
         assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
         verify(provider, never()).setFeePerKb(any());
     }
@@ -2926,7 +2932,7 @@ public class BridgeSupportTest {
         when(authorizer.getRequiredAuthorizedKeys())
                 .thenReturn(1);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(repositoryMock, "aabbccdd", provider, null, null, constants);
+        BridgeSupport bridgeSupport = new BridgeSupport(repositoryMock, "aabbccdd", provider, null, null, constants, null);
         assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
         verify(provider).setFeePerKb(Coin.CENT);
     }
@@ -2951,6 +2957,19 @@ public class BridgeSupportTest {
             PendingFederation mockedPendingFederation,
             ABICallElection mockedFederationElection,
             Block executionBlock) throws IOException {
+            return this.getBridgeSupportWithMocksForFederationTests(genesis, mockedNewFederation, mockedGenesisFederation,
+                            mockedOldFederation, mockedPendingFederation, mockedFederationElection, executionBlock, null);
+    }
+
+    private BridgeSupport getBridgeSupportWithMocksForFederationTests(
+            boolean genesis,
+            Federation mockedNewFederation,
+            Federation mockedGenesisFederation,
+            Federation mockedOldFederation,
+            PendingFederation mockedPendingFederation,
+            ABICallElection mockedFederationElection,
+            Block executionBlock,
+            BridgeEventLogger eventLogger) throws IOException {
 
         BridgeConstants constantsMock = mock(BridgeConstants.class);
         when(constantsMock.getGenesisFederation()).thenReturn(mockedGenesisFederation);
@@ -3018,7 +3037,7 @@ public class BridgeSupportTest {
             return null;
         }).when(providerMock).setPendingFederation(any());
 
-        BridgeSupport result = new BridgeSupport(null, null, providerMock, null, null, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport result = new BridgeSupport(null, null, providerMock, null, null, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), eventLogger);
 
         Whitebox.setInternalState(result, "bridgeConstants", constantsMock);
         Whitebox.setInternalState(result, "rskExecutionBlock", executionBlock);
@@ -3034,7 +3053,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider providerMock = mock(BridgeStorageProvider.class);
         when(providerMock.getLockWhitelist()).thenReturn(mockedWhitelist);
 
-        BridgeSupport result = new BridgeSupport(null, null, providerMock, null, null, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport result = new BridgeSupport(null, null, providerMock, null, null, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), null);
 
         Whitebox.setInternalState(result, "bridgeConstants", constantsMock);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -520,7 +520,7 @@ public class BridgeSupportTest {
 
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, bridgeConstants, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, bridgeConstants, mock(BridgeEventLogger.class));
 
         // One MICROCOIN is less than half the fee per kb, which is the minimum funds to migrate,
         // and so it won't be removed from the old federation UTXOs list for migration.

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -2444,12 +2444,11 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_ok() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
-                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49")),
-        }));
+                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))));
 
         VotingMocksProvider mocksProvider = new VotingMocksProvider("commit", new byte[][]{
                 pendingFederation.getHash().getBytes()
@@ -2459,18 +2458,18 @@ public class BridgeSupportTest {
         when(executionBlock.getTimestamp()).thenReturn(15005L);
         when(executionBlock.getNumber()).thenReturn(15L);
 
-        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
-                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49")),
-        }), Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))),
+                Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
-        Federation newFederation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation newFederation = new Federation(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
                 BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
-                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338")),
-        }), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))),
+                Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -296,7 +296,7 @@ public class BridgeSupportTest {
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
 
         List<LogInfo> eventLogs = new LinkedList<>();
-        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(eventLogs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, eventLogs);
         BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), eventLogger);
 
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
@@ -823,7 +823,7 @@ public class BridgeSupportTest {
 
         // Setup BridgeSupport
         List<LogInfo> eventLogs = new ArrayList<>();
-        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(eventLogs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, eventLogs);
         BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, null, BridgeRegTestConstants.getInstance(), eventLogger);
 
         // Create signed hash of Btc tx
@@ -913,7 +913,7 @@ public class BridgeSupportTest {
 
         track = repository.startTracking();
         List<LogInfo> logs = new ArrayList<>();
-        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(logs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, logs);
         BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, (Block) null, BridgeRegTestConstants.getInstance(), eventLogger);
 
         // Generate valid signatures for inputs
@@ -1017,7 +1017,7 @@ public class BridgeSupportTest {
 
         track = repository.startTracking();
         List<LogInfo> logs = new ArrayList<>();
-        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(logs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, logs);
         BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, (Block) null, BridgeRegTestConstants.getInstance(), eventLogger);
 
         Script inputScript = t.getInputs().get(0).getScriptSig();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -36,6 +36,8 @@ import co.rsk.db.RepositoryImpl;
 import co.rsk.peg.simples.SimpleBlockChain;
 import co.rsk.peg.simples.SimpleRskTransaction;
 import co.rsk.peg.simples.SimpleWallet;
+import co.rsk.peg.utils.BridgeEventLogger;
+import co.rsk.peg.utils.BridgeEventLoggerImpl;
 import co.rsk.test.builders.BlockChainBuilder;
 import com.google.common.collect.Lists;
 import org.ethereum.config.BlockchainNetConfig;
@@ -133,7 +135,7 @@ public class BridgeSupportTest {
         Repository track = repository.startTracking();
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
         Assert.assertEquals(0, bridgeSupport.getBtcBlockStore().getChainHead().getHeight());
         Assert.assertEquals(_networkParameters.getGenesisBlock(), bridgeSupport.getBtcBlockStore().getChainHead().getHeader());
 
@@ -149,7 +151,7 @@ public class BridgeSupportTest {
         Repository track = repository.startTracking();
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeTestNetConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeTestNetConstants.getInstance(), mock(BridgeEventLogger.class));
         Assert.assertEquals(1229760, bridgeSupport.getBtcBlockStore().getChainHead().getHeight());
 
         RskSystemProperties.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
@@ -166,7 +168,7 @@ public class BridgeSupportTest {
         provider.setFeePerKb(expected);
         provider.saveFeePerKb();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         Assert.assertEquals(expected, bridgeSupport.getFeePerKb());
     }
@@ -181,7 +183,7 @@ public class BridgeSupportTest {
         Repository track = repository.startTracking();
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
         Assert.assertEquals(0, bridgeSupport.getBtcBlockStore().getChainHead().getHeight());
         Assert.assertEquals(_networkParameters.getGenesisBlock(), bridgeSupport.getBtcBlockStore().getChainHead().getHeader());
 
@@ -215,7 +217,7 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         List<BtcBlock> checkpoints = createBtcBlocks(_networkParameters, _networkParameters.getGenesisBlock(), 10);
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList()) {
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class)) {
             @Override
             InputStream getCheckPoints() {
                 return getCheckpoints(_networkParameters, checkpoints);
@@ -294,8 +296,8 @@ public class BridgeSupportTest {
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
 
         List<LogInfo> eventLogs = new LinkedList<>();
-
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), eventLogs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(eventLogs);
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), eventLogger);
 
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         ECKey key = new ECKey();
@@ -353,7 +355,7 @@ public class BridgeSupportTest {
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.updateCollections(tx);
 
@@ -412,7 +414,7 @@ public class BridgeSupportTest {
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.updateCollections(tx);
 
@@ -471,7 +473,7 @@ public class BridgeSupportTest {
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.updateCollections(tx);
 
@@ -518,7 +520,7 @@ public class BridgeSupportTest {
 
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, bridgeConstants, Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, bridgeConstants, null);
 
         // One MICROCOIN is less than half the fee per kb, which is the minimum funds to migrate,
         // and so it won't be removed from the old federation UTXOs list for migration.
@@ -598,7 +600,7 @@ public class BridgeSupportTest {
         Transaction tx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.updateCollections(tx);
 
@@ -670,7 +672,7 @@ public class BridgeSupportTest {
         Transaction rskTx = Transaction.create(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, BridgeRegTestConstants.getInstance(), new LinkedList<>());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, rskCurrentBlock, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.updateCollections(rskTx);
         bridgeSupport.save();
@@ -743,7 +745,7 @@ public class BridgeSupportTest {
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, (Block) null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, (Block) null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.addSignature(1, federation.getPublicKeys().get(0), null, PegTestUtils.createHash().getBytes());
         bridgeSupport.save();
@@ -760,7 +762,7 @@ public class BridgeSupportTest {
         Repository repository = new RepositoryImpl();
         Repository track = repository.startTracking();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, (Block) null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, (Block) null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.addSignature(1, new BtcECKey(), null, PegTestUtils.createHash().getBytes());
         bridgeSupport.save();
@@ -821,7 +823,8 @@ public class BridgeSupportTest {
 
         // Setup BridgeSupport
         List<LogInfo> eventLogs = new ArrayList<>();
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, null, BridgeRegTestConstants.getInstance(), eventLogs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(eventLogs);
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, null, BridgeRegTestConstants.getInstance(), eventLogger);
 
         // Create signed hash of Btc tx
         Script inputScript = btcTx.getInputs().get(0).getScriptSig();
@@ -910,7 +913,8 @@ public class BridgeSupportTest {
 
         track = repository.startTracking();
         List<LogInfo> logs = new ArrayList<>();
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, (Block) null, BridgeRegTestConstants.getInstance(), logs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(logs);
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, (Block) null, BridgeRegTestConstants.getInstance(), eventLogger);
 
         // Generate valid signatures for inputs
         List<byte[]> derEncodedSigsFirstFed = new ArrayList<>();
@@ -1013,7 +1017,8 @@ public class BridgeSupportTest {
 
         track = repository.startTracking();
         List<LogInfo> logs = new ArrayList<>();
-        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, (Block) null, BridgeRegTestConstants.getInstance(), logs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(logs);
+        BridgeSupport bridgeSupport = new BridgeSupport(track, contractAddress, (Block) null, BridgeRegTestConstants.getInstance(), eventLogger);
 
         Script inputScript = t.getInputs().get(0).getScriptSig();
         List<ScriptChunk> chunks = inputScript.getChunks();
@@ -1098,7 +1103,7 @@ public class BridgeSupportTest {
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.releaseBtc(tx);
         bridgeSupport.save();
@@ -1122,7 +1127,7 @@ public class BridgeSupportTest {
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.releaseBtc(tx);
         bridgeSupport.save();
@@ -1146,7 +1151,7 @@ public class BridgeSupportTest {
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
         track.saveCode(tx.getSender(), new byte[] {0x1});
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         try {
             bridgeSupport.releaseBtc(tx);
@@ -1166,7 +1171,7 @@ public class BridgeSupportTest {
 
         provider.getBtcTxHashesAlreadyProcessed().put(tx.getHash(), 1L);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx, 0, null);
         bridgeSupport.save();
@@ -1190,7 +1195,7 @@ public class BridgeSupportTest {
         BtcTransaction tx = createTransaction();
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1221,7 +1226,7 @@ public class BridgeSupportTest {
         BtcTransaction tx = createTransaction();
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1256,7 +1261,7 @@ public class BridgeSupportTest {
         BtcTransaction tx = createTransaction();
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), Collections.emptyList());
+        BridgeSupport bridgeSupport = new BridgeSupport(track, PrecompiledContracts.BRIDGE_ADDR, provider, null, BridgeRegTestConstants.getInstance(), mock(BridgeEventLogger.class));
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -2451,18 +2451,25 @@ public class BridgeSupportTest {
         }, true);
 
         Block executionBlock = mock(Block.class);
-        when(executionBlock.getTimestamp()).thenReturn(5005L);
+        when(executionBlock.getTimestamp()).thenReturn(15005L);
+        when(executionBlock.getNumber()).thenReturn(15L);
 
         Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
                 BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49")),
+        }), Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+
+        Federation newFederation = new Federation(Arrays.asList(new BtcECKey[]{
+                BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
+                BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
+                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338")),
         }), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
-                null,
+                newFederation,
                 null,
                 null,
                 pendingFederation,
@@ -2481,11 +2488,15 @@ public class BridgeSupportTest {
 
         // Currently active federation
         Federation oldActiveFederation = provider.getNewFederation();
+        Assert.assertNotNull(oldActiveFederation);
 
         // Vote with no winner
         Assert.assertNotNull(provider.getPendingFederation());
         Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
         Assert.assertNotNull(provider.getPendingFederation());
+
+        Assert.assertEquals(oldActiveFederation, provider.getNewFederation());
+        Assert.assertNull(provider.getOldFederation());
 
         // Vote with winner
         mocksProvider.setWinner(mocksProvider.getSpec());

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg.utils;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.config.BridgeConstants;
+import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.peg.Bridge;
+import co.rsk.peg.Federation;
+import org.ethereum.core.Block;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPElement;
+import org.ethereum.util.RLPList;
+import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Test class for BridgeEventLoggerImpl.
+ *
+ * @author martin.medina
+ */
+public class BridgeEventLoggerImplTest {
+
+    @Test
+    public void logCommitFederation() {
+        // Setup event logger
+        BridgeConstants constantsMock = mock(BridgeConstants.class);
+        when(constantsMock.getFederationActivationAge()).thenReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge());
+        List<LogInfo> eventLogs = new LinkedList<>();
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(constantsMock, eventLogs);
+
+        // Setup parameters for test method call
+        Block executionBlock = mock(Block.class);
+        when(executionBlock.getTimestamp()).thenReturn(15005L);
+        when(executionBlock.getNumber()).thenReturn(15L);
+
+        Federation oldFederation = new Federation(Arrays.asList(
+                BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
+                BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
+                BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
+                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))),
+                Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+
+        Federation newFederation = new Federation(Arrays.asList(
+                BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
+                BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
+                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))),
+                Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+
+        // Do method call
+        eventLogger.logCommitFederation(executionBlock, oldFederation, newFederation);
+
+        // Assert
+        Assert.assertEquals(1, eventLogs.size());
+
+        // Assert address that made the log
+        LogInfo result = eventLogs.get(0);
+        Assert.assertArrayEquals(TypeConverter.stringToByteArray(PrecompiledContracts.BRIDGE_ADDR), result.getAddress());
+
+        // Assert log topics
+        Assert.assertEquals(1, result.getTopics().size());
+        Assert.assertEquals(Bridge.COMMIT_FEDERATION_TOPIC, result.getTopics().get(0));
+
+        // Assert log data
+        Assert.assertNotNull(result.getData());
+        List<RLPElement> rlpData = RLP.decode2(result.getData());
+        Assert.assertEquals(1 , rlpData.size());
+        RLPList dataList = (RLPList)rlpData.get(0);
+        Assert.assertEquals(3, dataList.size());
+
+        // Assert old federation data
+        RLPList oldFedData = (RLPList) dataList.get(0);
+        Assert.assertEquals(2, oldFedData.size());
+        Assert.assertArrayEquals(oldFederation.getAddress().getHash160(), oldFedData.get(0).getRLPData());
+
+        RLPList oldFedPubKeys = (RLPList) oldFedData.get(1);
+        Assert.assertEquals(4, oldFedPubKeys.size());
+        for(int i = 0; i < 4; i++) {
+            Assert.assertEquals(oldFederation.getPublicKeys().get(i), BtcECKey.fromPublicOnly(oldFedPubKeys.get(i).getRLPData()));
+        }
+
+        // Assert new federation data
+        RLPList newFedData = (RLPList) dataList.get(1);
+        Assert.assertEquals(2, newFedData.size());
+        Assert.assertArrayEquals(newFederation.getAddress().getHash160(), newFedData.get(0).getRLPData());
+
+        RLPList newFedPubKeys = (RLPList) newFedData.get(1);
+        Assert.assertEquals(3, newFedPubKeys.size());
+        for(int i = 0; i < 3; i++) {
+            Assert.assertEquals(newFederation.getPublicKeys().get(i), BtcECKey.fromPublicOnly(newFedPubKeys.get(i).getRLPData()));
+        }
+
+        // Assert new federation activation block number
+        Assert.assertEquals(15L + BridgeRegTestConstants.getInstance().getFederationActivationAge(), Long.valueOf(new String(dataList.get(2).getRLPData(), StandardCharsets.UTF_8)).longValue());
+    }
+}


### PR DESCRIPTION
## Log added for commit federation event
There is a need to know when a new federation is committed.

### Data to include in event log
- Old federation address 
- Old federation public keys
- New federation address
- New federation public keys
- Block number when new federation will be activated
