### PR TITLE
Changes in BlockGasPriceRange calculation and additional tiny changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ gradle/wrapper/gradle-wrapper.jar
 #Classes
 classes/
 
+#Infer
+infer-out/

--- a/rskj-core/src/main/java/co/rsk/mine/BlockGasPriceRange.java
+++ b/rskj-core/src/main/java/co/rsk/mine/BlockGasPriceRange.java
@@ -18,7 +18,6 @@
 
 package co.rsk.mine;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**

--- a/rskj-core/src/main/java/co/rsk/mine/BlockGasPriceRange.java
+++ b/rskj-core/src/main/java/co/rsk/mine/BlockGasPriceRange.java
@@ -26,13 +26,13 @@ import java.math.BigInteger;
  */
 public class BlockGasPriceRange {
 
-    private static final double VARIATION_PERCENTAGE_RANGE = 0.01;
+    private static final BigInteger VARIATION_PERCENTAGE_RANGE = BigInteger.ONE;
 
     private final BigInteger upperLimit;
     private final BigInteger lowerLimit;
 
     public BlockGasPriceRange(BigInteger center) {
-        BigInteger mgpDelta = BigDecimal.valueOf(center.doubleValue() * VARIATION_PERCENTAGE_RANGE).toBigInteger();
+        BigInteger mgpDelta = center.multiply(VARIATION_PERCENTAGE_RANGE).divide(BigInteger.valueOf(100));
         mgpDelta = (BigInteger.ZERO.compareTo(mgpDelta) == 0) ? BigInteger.ONE : mgpDelta;
         this.upperLimit = center.add(mgpDelta);
         this.lowerLimit = center.subtract(mgpDelta);

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -53,7 +53,7 @@ public class Constants {
 
     private int bestNumberDiffLimit = 100;
 
-    private int newBlockMaxMinInTheFuture = 540;
+    private int newBlockMaxSecondsInTheFuture = 540;
 
     private static final BigInteger SECP256K1N = new BigInteger("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16);
 
@@ -129,8 +129,8 @@ public class Constants {
         return targetGasLimit;
     }
 
-    public int getNewBlockMaxMinInTheFuture() {
-        return this.newBlockMaxMinInTheFuture;
+    public int getNewBlockMaxSecondsInTheFuture() {
+        return this.newBlockMaxSecondsInTheFuture;
     }
 
     public byte[] getBurnAddress() { return ByteUtils.clone(Constants.BURN_ADDRESS); }

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -177,7 +177,7 @@ public class DefaultConfig {
         Constants commonConstants = config.getBlockchainConfig().getCommonConstants();
         int uncleListLimit = commonConstants.getUncleListLimit();
         int uncleGenLimit = commonConstants.getUncleGenerationLimit();
-        int validPeriod = commonConstants.getNewBlockMaxMinInTheFuture();
+        int validPeriod = commonConstants.getNewBlockMaxSecondsInTheFuture();
         BlockTimeStampValidationRule blockTimeStampValidationRule = new BlockTimeStampValidationRule(validPeriod);
 
         BlockParentGasLimitRule parentGasLimitRule = new BlockParentGasLimitRule(commonConstants.getGasLimitBoundDivisor());
@@ -213,7 +213,7 @@ public class DefaultConfig {
         BlockParentGasLimitRule parentGasLimitRule = new BlockParentGasLimitRule(commonConstants.getGasLimitBoundDivisor());
         BlockParentCompositeRule unclesBlockParentHeaderValidator = new BlockParentCompositeRule(new PrevMinGasPriceRule(), new BlockParentNumberRule(), new BlockDifficultyRule(difficultyCalculator), parentGasLimitRule);
 
-        int validPeriod = commonConstants.getNewBlockMaxMinInTheFuture();
+        int validPeriod = commonConstants.getNewBlockMaxSecondsInTheFuture();
         BlockTimeStampValidationRule blockTimeStampValidationRule = new BlockTimeStampValidationRule(validPeriod);
         BlockCompositeRule unclesBlockHeaderValidator = new BlockCompositeRule(proofOfWorkRule, blockTimeStampValidationRule, new ValidGasUsedRule());
 

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/RegTestConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/RegTestConfig.java
@@ -48,7 +48,7 @@ public class RegTestConfig extends GenesisConfig {
         }
 
         @Override
-        public int getNewBlockMaxMinInTheFuture() {
+        public int getNewBlockMaxSecondsInTheFuture() {
             return 540;
         }
 

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/TestNetAfterBridgeSyncConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/TestNetAfterBridgeSyncConfig.java
@@ -50,7 +50,7 @@ public class TestNetAfterBridgeSyncConfig extends GenesisConfig {
         }
 
         @Override
-        public int getNewBlockMaxMinInTheFuture() {
+        public int getNewBlockMaxSecondsInTheFuture() {
             return 540;
         }
 

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -43,7 +43,7 @@ public class IndexedBlockStore extends AbstractBlockstore {
 
     private static final Logger logger = LoggerFactory.getLogger("general");
 
-    private BlockCache blockCache = new BlockCache(200);
+    private BlockCache blockCache = new BlockCache(5000);
     Map<Long, List<BlockInfo>> index;
     KeyValueDataSource blocks;
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -831,7 +831,7 @@ public class BlockValidatorTest {
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
 
-        int validPeriod = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getNewBlockMaxMinInTheFuture();
+        int validPeriod = RskSystemProperties.CONFIG.getBlockchainConfig().getCommonConstants().getNewBlockMaxSecondsInTheFuture();
 
         Block block = Mockito.mock(Block.class);
         Mockito.when(block.getTimestamp())


### PR DESCRIPTION
- Renamed NewBlockMaxMinInTheFuture to correctly specify it's in seconds
- Changed BlockGasPriceRange calculation to use BigInteger
- Increased IndexedBlockStore cache