### PR TITLE
Bugfix/old federation cleanup

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -59,7 +59,8 @@ public class BridgeDevNetConstants extends BridgeConstants {
                 getBtcParams()
         );
 
-        btc2RskMinimumAcceptableConfirmations = 10;
+        btc2RskMinimumAcceptableConfirmations = 3;
+        btc2RskMinimumAcceptableConfirmationsOnRsk = 10;
         rsk2BtcMinimumAcceptableConfirmations = 10;
         btcBroadcastingMinimumAcceptableBlocks = 30;
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -234,7 +234,7 @@ public class BridgeStorageProvider {
     }
 
     public Federation getOldFederation() {
-        if (oldFederation != null) {
+        if (oldFederation != null || shouldSaveOldFederation) {
             return oldFederation;
         }
 
@@ -261,7 +261,7 @@ public class BridgeStorageProvider {
     }
 
     public PendingFederation getPendingFederation() {
-        if (pendingFederation != null) {
+        if (pendingFederation != null || shouldSavePendingFederation) {
             return pendingFederation;
         }
 


### PR DESCRIPTION
Upon setting the old (or pending) federation to null in the bridge storage provider, if the getter was called again, then the subsequent save wouldn't set the storage to null, but rather keep the same value.