### PR TITLE
Get bridge status using BridgeSupport

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -82,7 +82,7 @@ public class EthModule
 
         byte[] result = bridgeSupport.getStateForDebugging();
 
-        BridgeState state = BridgeStateReader.readSate(TypeConverter.removeZeroX(toJsonHex(result)));
+        BridgeState state = BridgeState.create(result);
 
         return state.stateToMap();
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -1330,7 +1330,7 @@ public class Web3Impl implements Web3 {
 
     @Override
     public Map<String, Object> eth_bridgeState() throws Exception {
-        return ethModule.bridgeState();
+        return ethModule.bridgeState(blockchain);
     }
 
     @Override


### PR DESCRIPTION
Proposal: from web3 et_hbridgeState, in EthModule, use BridgeSupport instead of use the Bridge contract with call.

This new implementation avoid:

- Using Call, create a constant call, with gas, instantiate a Bridge contract, call the execute, convert the result to HRESULT, then parse the result again, etc..

And, if needed, the get state for debugging method in Bridge could be removed, avoiding to put a high cost only to avoid its call.
