### PR TITLE
RFS-55 improve blockchain block locator and RFS-90 call bridge from contract

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -190,55 +190,6 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         this.config = config;
         this.blockchainNetConfig = config.getBlockchainConfig();
         this.bridgeConstants = blockchainNetConfig.getCommonConstants().getBridgeConstants();
-
-        Arrays.stream(new Object[]{
-            Pair.of(UPDATE_COLLECTIONS, 48000L),
-            Pair.of(RECEIVE_HEADERS, 22000L),
-            Pair.of(REGISTER_BTC_TRANSACTION, 22000L),
-            Pair.of(RELEASE_BTC, 23000L),
-            Pair.of(ADD_SIGNATURE, 70000L),
-            Pair.of(GET_STATE_FOR_BTC_RELEASE_CLIENT, 4000L),
-            Pair.of(GET_STATE_FOR_DEBUGGING, 3_000_000L),
-            Pair.of(GET_BTC_BLOCKCHAIN_BEST_CHAIN_HEIGHT, 19000L),
-            Pair.of(GET_BTC_BLOCKCHAIN_INITIAL_BLOCK_HEIGHT, 19000L), // TODO: estimate cost
-            Pair.of(GET_BTC_BLOCKCHAIN_BLOCK_LOCATOR, 76000L),
-            Pair.of(GET_BTC_BLOCKCHAIN_BLOCK_HASH_AT_DEPTH, 76000L), // TODO: estimate cost
-            Pair.of(GET_MINIMUM_LOCK_TX_VALUE, 2000L),
-            Pair.of(IS_BTC_TX_HASH_ALREADY_PROCESSED, 23000L),
-            Pair.of(GET_BTC_TX_HASH_PROCESSED_HEIGHT, 22000L),
-            Pair.of(GET_FEDERATION_ADDRESS, 11000L),
-            Pair.of(GET_FEDERATION_SIZE, 10000L),
-            Pair.of(GET_FEDERATION_THRESHOLD, 11000L),
-            Pair.of(GET_FEDERATOR_PUBLIC_KEY, 10000L),
-            Pair.of(GET_FEDERATION_CREATION_TIME, 10000L),
-            Pair.of(GET_FEDERATION_CREATION_BLOCK_NUMBER, 10000L),
-            Pair.of(GET_RETIRING_FEDERATION_ADDRESS, 3000L),
-            Pair.of(GET_RETIRING_FEDERATION_SIZE, 3000L),
-            Pair.of(GET_RETIRING_FEDERATION_THRESHOLD, 3000L),
-            Pair.of(GET_RETIRING_FEDERATOR_PUBLIC_KEY, 3000L),
-            Pair.of(GET_RETIRING_FEDERATION_CREATION_TIME, 3000L),
-            Pair.of(GET_RETIRING_FEDERATION_CREATION_BLOCK_NUMBER, 3000L),
-            Pair.of(CREATE_FEDERATION, 11000L),
-            Pair.of(ADD_FEDERATOR_PUBLIC_KEY, 13000L),
-            Pair.of(COMMIT_FEDERATION, 38000L),
-            Pair.of(ROLLBACK_FEDERATION, 12000L),
-            Pair.of(GET_PENDING_FEDERATION_HASH, 3000L),
-            Pair.of(GET_PENDING_FEDERATION_SIZE, 3000L),
-            Pair.of(GET_PENDING_FEDERATOR_PUBLIC_KEY, 3000L),
-            Pair.of(GET_LOCK_WHITELIST_SIZE, 16000L),
-            Pair.of(GET_LOCK_WHITELIST_ADDRESS, 16000L),
-            Pair.of(ADD_LOCK_WHITELIST_ADDRESS, 25000L),
-            Pair.of(REMOVE_LOCK_WHITELIST_ADDRESS, 24000L),
-            Pair.of(SET_LOCK_WHITELIST_DISABLE_BLOCK_DELAY, 24000L),
-            Pair.of(GET_FEE_PER_KB, 2000L),
-            Pair.of(VOTE_FEE_PER_KB, 10000L)
-        }).forEach((Object obj) -> {
-            Pair<CallTransaction.Function, Long> spec = (Pair<CallTransaction.Function, Long>) obj;
-            CallTransaction.Function func = spec.getLeft();
-            Long cost = spec.getRight();
-            this.functions.put(new ByteArrayWrapper(func.encodeSignature()),  func);
-            functionCostMap.put(func, cost);
-        });
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -366,8 +366,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         ));
 
         if (blockchainConfig.isRfs55()) {
-            functionsAndCosts.add(Pair.of(GET_BTC_BLOCKCHAIN_INITIAL_BLOCK_HEIGHT, 19000L)); // TODO: estimate cost
-            functionsAndCosts.add(Pair.of(GET_BTC_BLOCKCHAIN_BLOCK_HASH_AT_DEPTH, 76000L)); // TODO: estimate cost
+            functionsAndCosts.add(Pair.of(GET_BTC_BLOCKCHAIN_INITIAL_BLOCK_HEIGHT, 20000L));
+            functionsAndCosts.add(Pair.of(GET_BTC_BLOCKCHAIN_BLOCK_HASH_AT_DEPTH, 20000L));
         }
 
         functionsAndCosts.stream().forEach((Object obj) -> {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -922,9 +922,18 @@ public class BridgeSupport {
     }
 
     /**
-     * Returns an array of block hashes known by the bridge contract. Federators can use this to find what is the latest block in the mainchain the bridge has.
+     * Returns the bitcoin blockchain initial stored block height
+     */
+    public int getBtcBlockchainInitialBlockHeight() {
+        return initialBtcStoredBlock.getHeight();
+    }
+
+    /**
+     * Returns an array of block hashes known by the bridge contract.
+     * Federators can use this to find what is the latest block in the mainchain the bridge has.
      * @return a List of bitcoin block hashes
      */
+    @Deprecated
     public List<Sha256Hash> getBtcBlockchainBlockLocator() throws IOException {
         final int maxHashesToInform = 100;
         List<Sha256Hash> blockLocator = new ArrayList<>();
@@ -956,6 +965,24 @@ public class BridgeSupport {
             }
         }
         return blockLocator;
+    }
+
+    public Sha256Hash getBtcBlockchainBlockHashAtDepth(int depth) throws BlockStoreException {
+        StoredBlock head = btcBlockChain.getChainHead();
+
+        int maxDepth = head.getHeight() - initialBtcStoredBlock.getHeight();
+
+        if (depth < 0 || depth > maxDepth) {
+            throw new IndexOutOfBoundsException(String.format("Depth must be between 0 and %d", maxDepth));
+        }
+
+        int currentDepth = 0;
+        StoredBlock current = head;
+        while (currentDepth < depth) {
+            current = current.getPrev(btcBlockStore);
+            currentDepth++;
+        }
+        return current.getHeader().getHash();
     }
 
     private StoredBlock getPrevBlockAtHeight(StoredBlock cursor, int height) throws BlockStoreException {

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -40,4 +40,8 @@ public interface BlockchainConfig {
     BlockDifficulty calcDifficulty(BlockHeader curBlock, BlockHeader parent);
 
     boolean areBridgeTxsFree();
+
+    boolean isRfs55();
+
+    boolean isRfs90();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
@@ -129,4 +129,14 @@ public abstract class AbstractConfig implements BlockchainConfig, BlockchainNetC
     public boolean areBridgeTxsFree() {
         return false;
     }
+
+    @Override
+    public boolean isRfs55() {
+        return false;
+    }
+
+    @Override
+    public boolean isRfs90() {
+        return false;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/DevNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/DevNetConfig.java
@@ -21,6 +21,7 @@ package org.ethereum.config.blockchain;
 
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeDevNetConstants;
+import org.ethereum.config.blockchain.testnet.TestNetAfterBridgeSyncConfig;
 
 /**
  * Created by Oscar Guindzberg on 25.10.2016.
@@ -49,4 +50,13 @@ public class DevNetConfig extends TestNetAfterBridgeSyncConfig {
         return true;
     }
 
+    @Override
+    public boolean isRfs55() {
+        return true;
+    }
+
+    @Override
+    public boolean isRfs90() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/FallbackMainNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/FallbackMainNetConfig.java
@@ -1,6 +1,7 @@
 package org.ethereum.config.blockchain;
 
 import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.mainnet.MainNetAfterBridgeSyncConfig;
 import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/RegTestConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/RegTestConfig.java
@@ -70,4 +70,14 @@ public class RegTestConfig extends GenesisConfig {
     public boolean areBridgeTxsFree() {
         return true;
     }
+
+    @Override
+    public boolean isRfs55() {
+        return true;
+    }
+
+    @Override
+    public boolean isRfs90() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetAfterBridgeSyncConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetAfterBridgeSyncConfig.java
@@ -1,9 +1,10 @@
-package org.ethereum.config.blockchain;
+package org.ethereum.config.blockchain.mainnet;
 
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.core.BlockDifficulty;
 import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.core.BlockHeader;
 
 import java.math.BigInteger;
@@ -36,13 +37,13 @@ public class MainNetAfterBridgeSyncConfig extends GenesisConfig {
 
         @Override
         public byte getChainId() {
-            return org.ethereum.config.blockchain.MainNetAfterBridgeSyncConfig.MainNetConstants.CHAIN_ID;
+            return MainNetAfterBridgeSyncConfig.MainNetConstants.CHAIN_ID;
         }
 
     }
 
     public MainNetAfterBridgeSyncConfig() {
-        super(new org.ethereum.config.blockchain.MainNetAfterBridgeSyncConfig.MainNetConstants());
+        super(new MainNetAfterBridgeSyncConfig.MainNetConstants());
     }
 
     protected MainNetAfterBridgeSyncConfig(Constants constants) {

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetBeforeBridgeSyncConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetBeforeBridgeSyncConfig.java
@@ -1,6 +1,7 @@
-package org.ethereum.config.blockchain;
+package org.ethereum.config.blockchain.mainnet;
 
 import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.mainnet.MainNetAfterBridgeSyncConfig;
 
 public class MainNetBeforeBridgeSyncConfig extends MainNetAfterBridgeSyncConfig {
 

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetFirstForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetFirstForkConfig.java
@@ -1,0 +1,13 @@
+package org.ethereum.config.blockchain.mainnet;
+
+public class MainNetFirstForkConfig extends MainNetAfterBridgeSyncConfig {
+    @Override
+    public boolean isRfs55() {
+        return true;
+    }
+
+    @Override
+    public boolean isRfs90() {
+        return true;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetFirstForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetFirstForkConfig.java
@@ -1,5 +1,6 @@
 package org.ethereum.config.blockchain.mainnet;
 
+// TODO: find a proper name for the "FirstFork"
 public class MainNetFirstForkConfig extends MainNetAfterBridgeSyncConfig {
     @Override
     public boolean isRfs55() {

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetAfterBridgeSyncConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetAfterBridgeSyncConfig.java
@@ -17,12 +17,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.ethereum.config.blockchain;
+package org.ethereum.config.blockchain.testnet;
 
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.core.BlockDifficulty;
 import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.core.BlockHeader;
 
 import java.math.BigInteger;

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetBeforeBridgeSyncConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetBeforeBridgeSyncConfig.java
@@ -17,10 +17,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.ethereum.config.blockchain;
+package org.ethereum.config.blockchain.testnet;
 
 
 import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.testnet.TestNetAfterBridgeSyncConfig;
 
 public class TestNetBeforeBridgeSyncConfig extends TestNetAfterBridgeSyncConfig {
 

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetFirstForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetFirstForkConfig.java
@@ -1,0 +1,13 @@
+package org.ethereum.config.blockchain.testnet;
+
+public class TestNetFirstForkConfig extends TestNetAfterBridgeSyncConfig {
+    @Override
+    public boolean isRfs55() {
+        return true;
+    }
+
+    @Override
+    public boolean isRfs90() {
+        return true;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetFirstForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetFirstForkConfig.java
@@ -1,5 +1,6 @@
 package org.ethereum.config.blockchain.testnet;
 
+// TODO: find a proper name for the "FirstFork"
 public class TestNetFirstForkConfig extends TestNetAfterBridgeSyncConfig {
     @Override
     public boolean isRfs55() {

--- a/rskj-core/src/main/java/org/ethereum/config/net/MainNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/net/MainNetConfig.java
@@ -19,8 +19,9 @@
 
 package org.ethereum.config.net;
 
-import org.ethereum.config.blockchain.MainNetAfterBridgeSyncConfig;
-import org.ethereum.config.blockchain.MainNetBeforeBridgeSyncConfig;
+import org.ethereum.config.blockchain.mainnet.MainNetAfterBridgeSyncConfig;
+import org.ethereum.config.blockchain.mainnet.MainNetBeforeBridgeSyncConfig;
+import org.ethereum.config.blockchain.mainnet.MainNetFirstForkConfig;
 
 
 /**
@@ -31,6 +32,8 @@ public class MainNetConfig extends AbstractNetConfig {
         add(0, new MainNetBeforeBridgeSyncConfig());
         // 60 days of 1 block every 14 seconds.
         // On blockchain launch blocks will be faster until difficulty is adjusted to available hashing power.
-        add(370000, new MainNetAfterBridgeSyncConfig());
+        add(370_000, new MainNetAfterBridgeSyncConfig());
+        // TODO: establish when to apply this fork. 500_000 is just a made up figure.
+        add(500_000, new MainNetFirstForkConfig());
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/net/TestNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/net/TestNetConfig.java
@@ -20,8 +20,9 @@
 package org.ethereum.config.net;
 
 
-import org.ethereum.config.blockchain.TestNetAfterBridgeSyncConfig;
-import org.ethereum.config.blockchain.TestNetBeforeBridgeSyncConfig;
+import org.ethereum.config.blockchain.testnet.TestNetAfterBridgeSyncConfig;
+import org.ethereum.config.blockchain.testnet.TestNetBeforeBridgeSyncConfig;
+import org.ethereum.config.blockchain.testnet.TestNetFirstForkConfig;
 
 public class TestNetConfig extends AbstractNetConfig {
     public static final TestNetConfig INSTANCE = new TestNetConfig();
@@ -31,5 +32,7 @@ public class TestNetConfig extends AbstractNetConfig {
         // 21 days of 1 block every 14 seconds.
         // On blockchain launch blocks will be faster until difficulty is adjusted to available hashing power.
         add(129600, new TestNetAfterBridgeSyncConfig());
+        // TODO: establish when to apply this fork. 500_000 is just a made up figure.
+        add(500_000, new TestNetFirstForkConfig());
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1549,7 +1549,7 @@ public class Program {
         }
 
         // Special initialization for Bridge and Remasc contracts
-        if (contract.getClass() == Bridge.class || contract.getClass() == RemascContract.class) {
+        if (contract instanceof Bridge || contract instanceof RemascContract) {
             // CREATE CALL INTERNAL TRANSACTION
             InternalTransaction internalTx = addInternalTx(null, getGasLimit(), senderAddress, contextAddress, endowment, EMPTY_BYTE_ARRAY, "call");
 

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1553,7 +1553,7 @@ public class Program {
             // CREATE CALL INTERNAL TRANSACTION
             InternalTransaction internalTx = addInternalTx(null, getGasLimit(), senderAddress, contextAddress, endowment, EMPTY_BYTE_ARRAY, "call");
 
-            Block executionBlock = new Block(getPrevHash().getData(), EMPTY_BYTE_ARRAY, getCoinbase().getData(), EMPTY_BYTE_ARRAY,
+            Block executionBlock = new Block(getPrevHash().getData(), EMPTY_BYTE_ARRAY, getCoinbase().getLast20Bytes(), EMPTY_BYTE_ARRAY,
                     getDifficulty().getData(), getNumber().longValue(), getGasLimit().getData(), 0, getTimestamp().longValue(),
                     EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, new ArrayList<>(), new ArrayList<>(), null);
 

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1548,6 +1548,18 @@ public class Program {
             return;
         }
 
+        // Special initialization for Bridge and Remasc contracts
+        if (contract.getClass() == Bridge.class || contract.getClass() == RemascContract.class) {
+            // CREATE CALL INTERNAL TRANSACTION
+            InternalTransaction internalTx = addInternalTx(null, getGasLimit(), senderAddress, contextAddress, endowment, EMPTY_BYTE_ARRAY, "call");
+
+            Block executionBlock = new Block(getPrevHash().getData(), EMPTY_BYTE_ARRAY, getCoinbase().getData(), EMPTY_BYTE_ARRAY,
+                    getDifficulty().getData(), getNumber().longValue(), getGasLimit().getData(), 0, getTimestamp().longValue(),
+                    EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, new ArrayList<>(), new ArrayList<>(), null);
+
+            contract.init(internalTx, executionBlock, track, this.invoke.getBlockStore(), null, null);
+        }
+
 
         long requiredGas = contract.getGasForData(data);
         if (requiredGas > msg.getGas().longValue()) {
@@ -1559,16 +1571,6 @@ public class Program {
 
             this.refundGas(msg.getGas().longValue() - requiredGas, "call pre-compiled");
 
-            if (contract instanceof Bridge || contract instanceof RemascContract) {
-                // CREATE CALL INTERNAL TRANSACTION
-                InternalTransaction internalTx = addInternalTx(null, getGasLimit(), senderAddress, contextAddress, endowment, EMPTY_BYTE_ARRAY, "call");
-
-                Block executionBlock = new Block(getPrevHash().getData(), EMPTY_BYTE_ARRAY, getCoinbase().getData(), EMPTY_BYTE_ARRAY,
-                        getDifficulty().getData(), getNumber().longValue(), getGasLimit().getData(), 0, getTimestamp().longValue(),
-                        EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, new ArrayList<>(), new ArrayList<>(), null);
-
-                contract.init(internalTx, executionBlock, track, this.invoke.getBlockStore(), null, null);
-            }
             byte[] out = contract.execute(data);
 
             this.memorySave(msg.getOutDataOffs().intValue(), out);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeFromVMTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeFromVMTest.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.asm.EVMAssembler;
+import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.RskAddress;
+import org.ethereum.config.BlockchainConfig;
+import org.ethereum.config.BlockchainNetConfig;
+import org.ethereum.config.blockchain.RegTestConfig;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.vm.VM;
+import org.ethereum.vm.program.Program;
+import org.ethereum.vm.program.invoke.ProgramInvoke;
+import org.ethereum.vm.program.invoke.ProgramInvokeMockImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+import java.util.Collections;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class BridgeFromVMTest {
+    private static RskSystemProperties config = new RskSystemProperties();
+    private BlockchainNetConfig oldConfig;
+    private BlockchainNetConfig testConfig;
+
+    @Test
+    public void testCallFromContract_preRfs90() {
+        try {
+            runBridgeCallFromContract(false);
+            Assert.fail();
+        } catch (RuntimeException e) {}
+    }
+
+    @Test
+    public void testCallFromContract() {
+        Program result = runBridgeCallFromContract(true);
+        long output = new BigInteger(result.memoryChunk(0x30, 0x20)).longValue();
+        Assert.assertEquals(BridgeRegTestConstants.getInstance().getMinimumLockTxValue().value, output);
+    }
+
+    private Program runBridgeCallFromContract(boolean isRfs90) {
+        simulateConfig(isRfs90);
+        config.setBlockchainConfig(testConfig);
+
+        EVMAssembler assembler = new EVMAssembler();
+        ProgramInvoke invoke = new ProgramInvokeMockImpl();
+
+        // Save code on the sender's address so that the bridge
+        // thinks its being called by a contract
+        byte[] callerCode = assembler.assemble("0xaabb 0xccdd 0xeeff");
+        invoke.getRepository().saveCode(new RskAddress(invoke.getOwnerAddress().getLast20Bytes()), callerCode);
+
+        VM vm = new VM(config);
+            
+        // Encode a call to the bridge's getMinimumLockTxValue function
+        // That means first pushing the corresponding encoded ABI storage to memory (MSTORE)
+        // and then doing a CALL to the corresponding address with the correct parameters
+        String bridgeFunctionHex = Hex.toHexString(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode());
+        bridgeFunctionHex = String.format("0x%s%s", bridgeFunctionHex, String.join("", Collections.nCopies(32*2 - bridgeFunctionHex.length(), "0")));
+        String asm = String.format("%s 0x00 MSTORE 0x20 0x30 0x20 0x00 0x00 0x0000000000000000000000000000000001000006 0x1000 CALL", bridgeFunctionHex);
+        int numOps = asm.split(" ").length;
+        byte[] code = assembler.assemble(asm);
+
+        // Mock a transaction, all we really need is a hash
+        Transaction tx = mock(Transaction.class);
+        when(tx.getHash()).thenReturn(HashUtil.sha3(Hex.decode("aabbccdd")));
+
+        // Run the program on the VM
+        Program program = new Program(config, code, invoke, tx);
+        for (int i = 0; i < numOps; i++) {
+            vm.step(program);
+        }
+        restoreConfig();
+
+        // Return the resulting program (and its state)
+        return program;
+    }
+
+    private void simulateConfig(boolean isRfs90) {
+        oldConfig = config.getBlockchainConfig();
+        testConfig = spy(RegTestConfig.class);
+        BlockchainConfig preRfs90Config = spy(RegTestConfig.class);
+        when(preRfs90Config.isRfs90()).thenReturn(isRfs90);
+        when(testConfig.getConfigForBlock(any(Long.class))).thenReturn(preRfs90Config);
+        Assert.assertEquals(isRfs90, testConfig.getConfigForBlock(1L).isRfs90());
+    }
+
+    private void restoreConfig() {
+        config.setBlockchainConfig(oldConfig);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -41,6 +41,7 @@ import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.utils.BridgeEventLoggerImpl;
 import co.rsk.test.builders.BlockChainBuilder;
 import com.google.common.collect.Lists;
+import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.config.net.TestNetConfig;
 import org.ethereum.core.*;
@@ -191,7 +192,6 @@ public class BridgeSupportTest {
         Assert.assertEquals(blocks.get(1).getHash(), locator.get(4));
         Assert.assertEquals(_networkParameters.getGenesisBlock().getHash(), locator.get(5));
     }
-
 
     @Test
     public void testGetBtcBlockchainBlockLocatorWithBtcCheckpoints() throws Exception {
@@ -2928,6 +2928,47 @@ public class BridgeSupportTest {
         BridgeSupport bridgeSupport = new BridgeSupport(config, repositoryMock, null, constants, provider, null, null);
         assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
         verify(provider).setFeePerKb(Coin.CENT);
+    }
+
+    @Test
+    public void getBtcBlockchainInitialBlockHeight() {
+        BridgeSupport bridgeSupport = new BridgeSupport(config, null, null, BridgeRegTestConstants.getInstance(), null, null, null);
+        StoredBlock initialBlockMock = mock(StoredBlock.class);
+        when(initialBlockMock.getHeight()).thenReturn(123);
+        Whitebox.setInternalState(bridgeSupport, "initialBtcStoredBlock", initialBlockMock);
+
+        Assert.assertEquals(123, bridgeSupport.getBtcBlockchainInitialBlockHeight());
+    }
+
+    @Test
+    public void getBtcBlockchainBlockHashAtDepth() throws Exception {
+        BlockchainNetConfig blockchainNetConfigOriginal = config.getBlockchainConfig();
+        config.setBlockchainConfig(new RegTestConfig());
+        NetworkParameters networkParameters = config.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
+
+        Repository repository = new RepositoryImpl(config);
+        Repository track = repository.startTracking();
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
+        Assert.assertEquals(0, bridgeSupport.getBtcBlockStore().getChainHead().getHeight());
+        Assert.assertEquals(networkParameters.getGenesisBlock(), bridgeSupport.getBtcBlockStore().getChainHead().getHeader());
+
+        Assert.assertEquals(networkParameters.getGenesisBlock().getHash(), bridgeSupport.getBtcBlockchainBlockHashAtDepth(0));
+        try { bridgeSupport.getBtcBlockchainBlockHashAtDepth(-1); Assert.fail(); } catch (IndexOutOfBoundsException e) {}
+        try { bridgeSupport.getBtcBlockchainBlockHashAtDepth(1); Assert.fail(); } catch (IndexOutOfBoundsException e) {}
+
+        List<BtcBlock> blocks = createBtcBlocks(networkParameters, networkParameters.getGenesisBlock(), 10);
+        bridgeSupport.receiveHeaders(blocks.toArray(new BtcBlock[]{}));
+
+        Assert.assertEquals(networkParameters.getGenesisBlock().getHash(), bridgeSupport.getBtcBlockchainBlockHashAtDepth(10));
+        try { bridgeSupport.getBtcBlockchainBlockHashAtDepth(-1); Assert.fail(); } catch (IndexOutOfBoundsException e) {}
+        try { bridgeSupport.getBtcBlockchainBlockHashAtDepth(11); Assert.fail(); } catch (IndexOutOfBoundsException e) {}
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(blocks.get(i).getHash(), bridgeSupport.getBtcBlockchainBlockHashAtDepth(9-i));
+        }
+
+        config.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     private BridgeStorageProvider getBridgeStorageProviderMockWithProcessedHashes() throws IOException {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
@@ -158,7 +159,7 @@ public class BridgeTest {
         Repository track = repository.startTracking();
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         bridge.execute(Bridge.RECEIVE_HEADERS.encode());
 
@@ -171,7 +172,7 @@ public class BridgeTest {
         Repository track = repository.startTracking();
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         co.rsk.bitcoinj.core.BtcBlock block = new co.rsk.bitcoinj.core.BtcBlock(networkParameters, 1, PegTestUtils.createHash(), PegTestUtils.createHash(), 1, Utils.encodeCompactBits(networkParameters.getMaxTarget()), 1, new ArrayList<>());
         co.rsk.bitcoinj.core.BtcBlock[] headers = new co.rsk.bitcoinj.core.BtcBlock[1];
@@ -207,7 +208,7 @@ public class BridgeTest {
         Repository track = repository.startTracking();
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         Object[] objectArray = new Object[1];
         objectArray[0] = new byte[60];
@@ -224,7 +225,7 @@ public class BridgeTest {
         Repository track = repository.startTracking();
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
 
         byte[] data = Bridge.REGISTER_BTC_TRANSACTION.encode(new byte[3], 1, new byte[30]);
@@ -238,7 +239,7 @@ public class BridgeTest {
         Repository track = repository.startTracking();
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         NetworkParameters btcParams = RegTestParams.get();
         BtcTransaction tx = new BtcTransaction(btcParams);
@@ -256,7 +257,7 @@ public class BridgeTest {
         Repository track = repository.startTracking();
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         NetworkParameters btcParams = RegTestParams.get();
         BtcTransaction tx = new BtcTransaction(btcParams);
@@ -276,7 +277,7 @@ public class BridgeTest {
         Repository track = repository.startTracking();
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         byte[] data = Bridge.GET_FEDERATION_ADDRESS.encode();
 
@@ -290,7 +291,7 @@ public class BridgeTest {
 
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         byte[] data = Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode();
 
@@ -302,7 +303,7 @@ public class BridgeTest {
         Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new byte[3];
         Object[] signaturesObjectArray = new Object[0];
@@ -317,7 +318,7 @@ public class BridgeTest {
         Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, track, null, null, null);
+        bridge.init(null, getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new BtcECKey().getPubKey();
         Object[] signaturesObjectArray = new Object[0];
@@ -564,7 +565,7 @@ public class BridgeTest {
     @Test
     public void isBtcTxHashAlreadyProcessed_normalFlow() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         Set<Sha256Hash> hashes = new HashSet<>();
@@ -586,7 +587,7 @@ public class BridgeTest {
     @Test
     public void isBtcTxHashAlreadyProcessed_exception() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
 
@@ -603,7 +604,7 @@ public class BridgeTest {
     @Test
     public void getBtcTxHashProcessedHeight_normalFlow() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         Map<Sha256Hash, Long> hashes = new HashMap<>();
@@ -624,7 +625,7 @@ public class BridgeTest {
     @Test
     public void getBtcTxHashProcessedHeight_exception() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
 
@@ -641,7 +642,7 @@ public class BridgeTest {
     @Test
     public void getFederationSize() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getFederationSize()).thenReturn(1234);
@@ -652,7 +653,7 @@ public class BridgeTest {
     @Test
     public void getFederationThreshold() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getFederationThreshold()).thenReturn(5678);
@@ -663,7 +664,7 @@ public class BridgeTest {
     @Test
     public void getFederationCreationTime() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getFederationCreationTime()).thenReturn(Instant.ofEpochMilli(5000));
@@ -684,7 +685,7 @@ public class BridgeTest {
     @Test
     public void getFederatorPublicKey() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
@@ -698,7 +699,7 @@ public class BridgeTest {
     @Test
     public void getRetiringFederationSize() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getRetiringFederationSize()).thenReturn(1234);
@@ -709,7 +710,7 @@ public class BridgeTest {
     @Test
     public void getRetiringFederationThreshold() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getRetiringFederationThreshold()).thenReturn(5678);
@@ -720,7 +721,7 @@ public class BridgeTest {
     @Test
     public void getRetiringFederationCreationTime() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getRetiringFederationCreationTime()).thenReturn(Instant.ofEpochMilli(5000));
@@ -741,7 +742,7 @@ public class BridgeTest {
     @Test
     public void getRetiringFederatorPublicKey() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getRetiringFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
@@ -755,7 +756,7 @@ public class BridgeTest {
     @Test
     public void getPendingFederationSize() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getPendingFederationSize()).thenReturn(1234);
@@ -766,7 +767,7 @@ public class BridgeTest {
     @Test
     public void getPendingFederatorPublicKey() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getPendingFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
@@ -781,7 +782,7 @@ public class BridgeTest {
     public void createFederation() throws IOException {
         Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(txMock, null, null, null, null, null);
+        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("create", new byte[][]{}))).thenReturn(123);
@@ -793,7 +794,7 @@ public class BridgeTest {
     public void addFederatorPublicKey_ok() throws IOException {
         Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(txMock, null, null, null, null, null);
+        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("add", new byte[][] { Hex.decode("aabbccdd") })))
@@ -805,7 +806,7 @@ public class BridgeTest {
     @Test
     public void addFederatorPublicKey_wrongParameterType() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
 
@@ -817,7 +818,7 @@ public class BridgeTest {
     public void commitFederation_ok() throws IOException {
         Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(txMock, null, null, null, null, null);
+        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
 
@@ -829,7 +830,7 @@ public class BridgeTest {
     @Test
     public void commitFederation_wrongParameterType() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
 
@@ -841,7 +842,7 @@ public class BridgeTest {
     public void rollbackFederation() throws IOException {
         Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(txMock, null, null, null, null, null);
+        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("rollback", new byte[][]{}))).thenReturn(456);
@@ -852,7 +853,7 @@ public class BridgeTest {
     @Test
     public void getLockWhitelistSize() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getLockWhitelistSize()).thenReturn(1234);
@@ -863,7 +864,7 @@ public class BridgeTest {
     @Test
     public void getLockWhitelistAddress() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getLockWhitelistAddress(any(int.class))).then((InvocationOnMock invocation) ->
@@ -877,7 +878,7 @@ public class BridgeTest {
     public void addLockWhitelistAddress() throws IOException {
         Transaction mockedTransaction = mock(Transaction.class);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(mockedTransaction, null, null, null, null, null);
+        bridge.init(mockedTransaction, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.addLockWhitelistAddress(mockedTransaction, "i-am-an-address", BigInteger.valueOf(Coin.COIN.getValue()))).thenReturn(1234);
@@ -889,7 +890,7 @@ public class BridgeTest {
     public void removeLockWhitelistAddress() throws IOException {
         Transaction mockedTransaction = mock(Transaction.class);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(mockedTransaction, null, null, null, null, null);
+        bridge.init(mockedTransaction, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.removeLockWhitelistAddress(mockedTransaction, "i-am-an-address")).thenReturn(1234);
@@ -912,7 +913,7 @@ public class BridgeTest {
     public void voteFeePerKb_ok() throws IOException {
         Transaction txMock = mock(Transaction.class);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(txMock, null, null, null, null, null);
+        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.voteFeePerKbChange(txMock, Coin.valueOf(2)))
@@ -924,7 +925,7 @@ public class BridgeTest {
     @Test
     public void voteFeePerKb_wrongParameterType() throws IOException {
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, null, null, null, null, null);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
 
@@ -940,5 +941,32 @@ public class BridgeTest {
         Assert.assertArrayEquals(
                 PrecompiledContracts.BRIDGE_ADDR.getBytes(),
                 TypeConverter.stringHexToByteArray(PrecompiledContracts.BRIDGE_ADDR_STR));
+    }
+
+    @Test
+    public void getBtcBlockchainInitialBlockHeight() {
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        when(bridgeSupportMock.getBtcBlockchainInitialBlockHeight()).thenReturn(1234);
+
+        Assert.assertEquals(1234, bridge.getBtcBlockchainInitialBlockHeight(new Object[]{}).intValue());
+    }
+
+    @Test
+    public void getBtcBlockchainBlockHashAtDepth() throws BlockStoreException {
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
+        bridge.init(null, getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        Sha256Hash mockedResult = Sha256Hash.of(Hex.decode("aabbcc"));
+        when(bridgeSupportMock.getBtcBlockchainBlockHashAtDepth(555)).thenReturn(mockedResult);
+
+        Assert.assertEquals(mockedResult, Sha256Hash.wrap(bridge.getBtcBlockchainBlockHashAtDepth(new Object[]{BigInteger.valueOf(555)})));
+    }
+
+    private Block getGenesisBlock() {
+        return new BlockGenerator().getGenesisBlock();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.peg;
 
+import co.rsk.asm.EVMAssembler;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.ScriptBuilder;
@@ -27,15 +28,22 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.BlockDifficulty;
+import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.peg.bitcoin.SimpleBtcTransaction;
 import co.rsk.test.World;
+import org.ethereum.config.BlockchainConfig;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.vm.PrecompiledContracts;
+import org.ethereum.vm.VM;
+import org.ethereum.vm.program.Program;
+import org.ethereum.vm.program.invoke.ProgramInvoke;
+import org.ethereum.vm.program.invoke.ProgramInvokeMockImpl;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -56,7 +64,6 @@ import static org.mockito.Mockito.*;
  * Created by ajlopez on 6/8/2016.
  */
 public class BridgeTest {
-
     private static NetworkParameters networkParameters;
     private static BridgeConstants bridgeConstants;
 
@@ -66,6 +73,9 @@ public class BridgeTest {
     private static final BigInteger GAS_LIMIT = new BigInteger("1000");
     private static final String DATA = "80af2871";
     private static RskSystemProperties config = new RskSystemProperties();
+
+    private BlockchainNetConfig oldConfig;
+    private BlockchainNetConfig testConfig;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
@@ -968,5 +978,77 @@ public class BridgeTest {
 
     private Block getGenesisBlock() {
         return new BlockGenerator().getGenesisBlock();
+    }
+
+    // These are more sort of "integration" tests, in the sense that they test the behavior of the bridge in a
+    // certain context and with a more real-world-like runtime environment.
+    //
+    // In this case, in the context of a call from another contract within an actual VM execution environment,
+    // pre and post the RFS-90 fork.
+
+    @Test
+    public void testCallFromContract_preRfs90() {
+        try {
+            runBridgeCallFromContract(false);
+            Assert.fail();
+        } catch (RuntimeException e) {}
+    }
+
+    @Test
+    public void testCallFromContract() {
+        Program result = runBridgeCallFromContract(true);
+        long output = new BigInteger(result.memoryChunk(0x30, 0x20)).longValue();
+        Assert.assertEquals(BridgeRegTestConstants.getInstance().getMinimumLockTxValue().value, output);
+    }
+
+    private Program runBridgeCallFromContract(boolean isRfs90) {
+        simulateConfig(isRfs90);
+        config.setBlockchainConfig(testConfig);
+
+        EVMAssembler assembler = new EVMAssembler();
+        ProgramInvoke invoke = new ProgramInvokeMockImpl();
+
+        // Save code on the sender's address so that the bridge
+        // thinks its being called by a contract
+        byte[] callerCode = assembler.assemble("0xaabb 0xccdd 0xeeff");
+        invoke.getRepository().saveCode(new RskAddress(invoke.getOwnerAddress().getLast20Bytes()), callerCode);
+
+        VM vm = new VM(config);
+            
+        // Encode a call to the bridge's getMinimumLockTxValue function
+        // That means first pushing the corresponding encoded ABI storage to memory (MSTORE)
+        // and then doing a DELEGATECALL to the corresponding address with the correct parameters
+        String bridgeFunctionHex = Hex.toHexString(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode());
+        bridgeFunctionHex = String.format("0x%s%s", bridgeFunctionHex, String.join("", Collections.nCopies(32*2 - bridgeFunctionHex.length(), "0")));
+        String asm = String.format("%s 0x00 MSTORE 0x20 0x30 0x20 0x00 0x0000000000000000000000000000000001000006 0x6000 DELEGATECALL", bridgeFunctionHex);
+        int numOps = asm.split(" ").length;
+        byte[] code = assembler.assemble(asm);
+
+        // Mock a transaction, all we really need is a hash
+        Transaction tx = mock(Transaction.class);
+        when(tx.getHash()).thenReturn(HashUtil.sha3(Hex.decode("aabbccdd")));
+
+        // Run the program on the VM
+        Program program = new Program(config, code, invoke, tx);
+        for (int i = 0; i < numOps; i++) {
+            vm.step(program);
+        }
+        restoreConfig();
+
+        // Return the resulting program (and its state)
+        return program;
+    }
+
+    private void simulateConfig(boolean isRfs90) {
+        oldConfig = config.getBlockchainConfig();
+        testConfig = spy(RegTestConfig.class);
+        BlockchainConfig preRfs90Config = spy(RegTestConfig.class);
+        when(preRfs90Config.isRfs90()).thenReturn(isRfs90);
+        when(testConfig.getConfigForBlock(any(Long.class))).thenReturn(preRfs90Config);
+        Assert.assertEquals(isRfs90, testConfig.getConfigForBlock(1L).isRfs90());
+    }
+
+    private void restoreConfig() {
+        config.setBlockchainConfig(oldConfig);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BtcBlockchainTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BtcBlockchainTest.java
@@ -32,6 +32,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.math.BigInteger;
 
 @Ignore
 public class BtcBlockchainTest extends BridgePerformanceTestCase {
@@ -40,6 +41,22 @@ public class BtcBlockchainTest extends BridgePerformanceTestCase {
         ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_BTC_BLOCKCHAIN_BEST_CHAIN_HEIGHT.encode();
         ExecutionStats stats = new ExecutionStats("getBtcBlockchainBestChainHeight");
         executeAndAverage("getBtcBlockchainBestChainHeight", 200, abiEncoder, buildInitializer(), Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
+        BridgePerformanceTest.addStats(stats);
+    }
+
+    @Test
+    public void getBtcBlockchainInitialBlockHeight() throws IOException {
+        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_BTC_BLOCKCHAIN_INITIAL_BLOCK_HEIGHT.encode();
+        ExecutionStats stats = new ExecutionStats("getBtcBlockchainInitialBlockHeight");
+        executeAndAverage("getBtcBlockchainInitialBlockHeight", 200, abiEncoder, buildInitializer(), Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
+        BridgePerformanceTest.addStats(stats);
+    }
+
+    @Test
+    public void getBtcBlockchainBlockHashAtDepth() throws IOException {
+        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_BTC_BLOCKCHAIN_BLOCK_HASH_AT_DEPTH.encode(new Object[]{BigInteger.ZERO});
+        ExecutionStats stats = new ExecutionStats("getBtcBlockchainBlockHashAtDepth");
+        executeAndAverage("getBtcBlockchainBlockHashAtDepth", 200, abiEncoder, buildInitializer(), Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
         BridgePerformanceTest.addStats(stats);
     }
 


### PR DESCRIPTION
Two main issues are addressed in this PR:

RFS-55: two new bridge methods were added: `getBtcBlockchainInitialBlockHeight` and `getBtcBlockchainBlockHashAtDepth`. This allows for the federate node to update the bridge's btc blockchain without using the -now deprecated- `getBtcBlockchainBlockLocator`. A special configuration was added to the blockchain constants to determine from which block the fork for rfs-55 applies.

RFS-90: fix to allow calling any bridge method from another contract. This is also treated as a hard fork, adding an analogue constant in the bridge constants. Essentially, if the fork has not been reached, the error condition (a `RuntimeException`) is simulated.