### PR TITLE
Reduce logging messages on info level

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
@@ -180,12 +180,12 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
         }
 
         try {
-            logger.info("Try connect block hash: {}, number: {}",
+            logger.trace("Try connect block hash: {}, number: {}",
                     Hex.toHexString(block.getHash()).substring(0, 6),
                     block.getNumber());
 
             synchronized (connectLock) {
-                logger.info("Start try connect");
+                logger.trace("Start try connect");
                 long saveTime = System.nanoTime();
                 ImportResult result = internalTryToConnect(block);
                 long totalTime = System.nanoTime() - saveTime;
@@ -211,7 +211,7 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
         Block bestBlock;
         BigInteger bestTotalDifficulty;
 
-        logger.info("get current state");
+        logger.trace("get current state");
 
         // get current state
         synchronized (accessLock) {
@@ -229,7 +229,7 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
         }
         // else, Get parent AND total difficulty
         else {
-            logger.info("get parent and total difficulty");
+            logger.trace("get parent and total difficulty");
             parent = blockStore.getBlockByHash(block.getParentHash());
 
             if (parent == null) {
@@ -255,7 +255,7 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
 
         if (parent != null) {
             long saveTime = System.nanoTime();
-            logger.info("execute start");
+            logger.trace("execute start");
 
             if (this.noValidation) {
                 result = blockExecutor.executeAll(block, parent.getStateRoot());
@@ -263,11 +263,11 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
                 result = blockExecutor.execute(block, parent.getStateRoot(), false);
             }
 
-            logger.info("execute done");
+            logger.trace("execute done");
 
             boolean isValid = noValidation ? true : blockExecutor.validate(block, result);
 
-            logger.info("validate done");
+            logger.trace("validate done");
 
             if (!isValid) {
                 return ImportResult.INVALID_BLOCK;
@@ -279,17 +279,17 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
                 adminInfo.addBlockExecTime(totalTime);
             }
 
-            logger.info("block: num: [{}] hash: [{}], executed after: [{}]nano", block.getNumber(), block.getShortHash(), totalTime);
+            logger.trace("block: num: [{}] hash: [{}], executed after: [{}]nano", block.getNumber(), block.getShortHash(), totalTime);
         }
 
         // the new accumulated difficulty
         BigInteger totalDifficulty = parentTotalDifficulty.add(block.getCumulativeDifficulty());
-        logger.info("TD: updated to {}", totalDifficulty);
+        logger.trace("TD: updated to {}", totalDifficulty);
 
         // It is the new best block
         if (SelectionRule.shouldWeAddThisBlock(totalDifficulty, status.getTotalDifficulty(),block, bestBlock)) {
             if (bestBlock != null && !bestBlock.isParentOf(block)) {
-                logger.info("Rebranching: {} ~> {} From block {} ~> {} Difficulty {} Challenger difficulty {}",
+                logger.trace("Rebranching: {} ~> {} From block {} ~> {} Difficulty {} Challenger difficulty {}",
                         bestBlock.getShortHash(), block.getShortHash(), bestBlock.getNumber(), block.getNumber(),
                         status.getTotalDifficulty().toString(), totalDifficulty.toString());
                 BlockFork fork = new BlockFork();
@@ -321,7 +321,7 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
         // It is not the new best block
         else {
             if (bestBlock != null && !bestBlock.isParentOf(block)) {
-                logger.info("No rebranch: {} ~> {} From block {} ~> {} Difficulty {} Challenger difficulty {}",
+                logger.trace("No rebranch: {} ~> {} From block {} ~> {} Difficulty {} Challenger difficulty {}",
                         bestBlock.getShortHash(), block.getShortHash(), bestBlock.getNumber(), block.getNumber(),
                         status.getTotalDifficulty().toString(), totalDifficulty.toString());
             }
@@ -509,7 +509,7 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
 
     private void storeBlock(Block block, BigInteger totalDifficulty, boolean inBlockChain) {
         blockStore.saveBlock(block, totalDifficulty, inBlockChain);
-        logger.info("Block saved: number: {}, hash: {}, TD: {}",
+        logger.trace("Block saved: number: {}, hash: {}, TD: {}",
                 block.getNumber(), block.getShortHash(), totalDifficulty);
     }
 
@@ -553,11 +553,11 @@ public class BlockChainImpl implements Blockchain, org.ethereum.facade.Blockchai
             long saveTime = System.nanoTime();
             repository.flush();
             long totalTime = System.nanoTime() - saveTime;
-            logger.info("repository flush: [{}]nano", totalTime);
+            logger.trace("repository flush: [{}]nano", totalTime);
             saveTime = System.nanoTime();
             blockStore.flush();
             totalTime = System.nanoTime() - saveTime;
-            logger.info("blockstore flush: [{}]nano", totalTime);
+            logger.trace("blockstore flush: [{}]nano", totalTime);
         }
         nFlush++;
         nFlush = nFlush % config.flushNumberOfBlocks();

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -186,7 +186,7 @@ public class BlockExecutor {
     }
 
     private BlockResult execute(Block block, byte[] stateRoot, boolean discardInvalidTxs, boolean ignoreReadyToExecute) {
-        logger.info("applyBlock: block: [{}] tx.list: [{}]", block.getNumber(), block.getTransactionsList().size());
+        logger.trace("applyBlock: block: [{}] tx.list: [{}]", block.getNumber(), block.getTransactionsList().size());
 
         Repository initialRepository = repository.getSnapshotTo(stateRoot);
 
@@ -202,7 +202,7 @@ public class BlockExecutor {
         int txindex = 0;
 
         for (Transaction tx : block.getTransactionsList()) {
-            logger.info("apply block: [{}] tx: [{}] ", block.getNumber(), i);
+            logger.trace("apply block: [{}] tx: [{}] ", block.getNumber(), i);
 
             TransactionExecutor txExecutor = new TransactionExecutor(config, tx, txindex++, block.getCoinbase(), track, blockStore, blockChain.getReceiptStore(), programInvokeFactory, block, listener, totalGasUsed);
 
@@ -224,11 +224,11 @@ public class BlockExecutor {
             txExecutor.go();
             txExecutor.finalization();
 
-            logger.info("tx executed");
+            logger.trace("tx executed");
 
             track.commit();
 
-            logger.info("track commit");
+            logger.trace("track commit");
 
             long gasUsed = txExecutor.getGasUsed();
             totalGasUsed += gasUsed;
@@ -246,16 +246,16 @@ public class BlockExecutor {
             receipt.setLogInfoList(txExecutor.getVMLogs());
             receipt.setStatus(txExecutor.getReceipt().getStatus());
 
-            logger.info("block: [{}] executed tx: [{}] state: [{}]", block.getNumber(), Hex.toHexString(tx.getHash()),
+            logger.trace("block: [{}] executed tx: [{}] state: [{}]", block.getNumber(), Hex.toHexString(tx.getHash()),
                     Hex.toHexString(lastStateRootHash));
 
-            logger.info("tx[{}].receipt", i);
+            logger.trace("tx[{}].receipt", i);
 
             i++;
 
             receipts.add(receipt);
 
-            logger.info("tx done");
+            logger.trace("tx done");
         }
 
         return new BlockResult(executedTransactions, receipts, lastStateRootHash, totalGasUsed, totalPaidFees);

--- a/rskj-core/src/main/java/co/rsk/core/bc/PendingStateImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/PendingStateImpl.java
@@ -166,19 +166,19 @@ public class PendingStateImpl implements PendingState {
         List<Transaction> added = new ArrayList<>();
         Long bnumber = Long.valueOf(getCurrentBestBlockNumber());
 
-        logger.info("Trying add {} wire transactions using block {} {}", transactions.size(), bnumber, getBestBlock().getShortHash());
+        logger.trace("Trying add {} wire transactions using block {} {}", transactions.size(), bnumber, getBestBlock().getShortHash());
 
         for (Transaction tx : transactions) {
             if (!shouldAcceptTx(tx)) {
                 continue;
             }
 
-            logger.info("Trying add wire transaction nonce {} hash {}", tx.getHash(), toBI(tx.getNonce()));
+            logger.trace("Trying add wire transaction nonce {} hash {}", tx.getHash(), toBI(tx.getNonce()));
 
             ByteArrayWrapper hash = new ByteArrayWrapper(tx.getHash());
 
             if (pendingTransactions.containsKey(hash) || wireTransactions.containsKey(hash)) {
-                logger.info("TX already exists: {} ", tx);
+                logger.trace("TX already exists: {} ", tx);
                 continue;
             }
 
@@ -197,7 +197,7 @@ public class PendingStateImpl implements PendingState {
             });
         }
 
-        logger.info("Wire transaction list added: {} new, {} valid of received {}, #of known txs: {}", added.size(), added.size(), transactions.size(), transactions.size());
+        logger.trace("Wire transaction list added: {} new, {} valid of received {}, #of known txs: {}", added.size(), added.size(), transactions.size(), transactions.size());
 
         return added;
     }
@@ -301,7 +301,7 @@ public class PendingStateImpl implements PendingState {
 
             if (block < currentBlock - depth) {
                 toremove.add(entry.getKey());
-                logger.info(
+                logger.trace(
                         "Clear outdated transaction, block.number: [{}] hash: [{}]",
                         block,
                         entry.getKey().toString());
@@ -324,7 +324,7 @@ public class PendingStateImpl implements PendingState {
 
             if (txtime <= timeSeconds) {
                 toremove.add(entry.getKey());
-                logger.info(
+                logger.trace(
                         "Clear outdated transaction, hash: [{}]",
                         entry.getKey().toString());
             }
@@ -348,7 +348,7 @@ public class PendingStateImpl implements PendingState {
             byte[] bhash = tx.getHash();
             ByteArrayWrapper hash = new ByteArrayWrapper(bhash);
             pendingTransactions.remove(hash);
-            logger.info("Clear pending transaction, hash: [{}]", Hex.toHexString(bhash));
+            logger.trace("Clear pending transaction, hash: [{}]", Hex.toHexString(bhash));
         }
     }
 
@@ -358,7 +358,7 @@ public class PendingStateImpl implements PendingState {
             byte[] bhash = tx.getHash();
             ByteArrayWrapper hash = new ByteArrayWrapper(bhash);
             wireTransactions.remove(hash);
-            logger.info("Clear wire transaction, hash: [{}]", Hex.toHexString(bhash));
+            logger.trace("Clear wire transaction, hash: [{}]", Hex.toHexString(bhash));
         }
     }
 
@@ -384,7 +384,7 @@ public class PendingStateImpl implements PendingState {
     }
 
     private void executeTransaction(Transaction tx) {
-        logger.info("Apply pending state tx: {} {}", toBI(tx.getNonce()), Hex.toHexString(tx.getHash()));
+        logger.trace("Apply pending state tx: {} {}", toBI(tx.getNonce()), Hex.toHexString(tx.getHash()));
 
         Block best = blockChain.getBestBlock();
 

--- a/rskj-core/src/main/java/co/rsk/db/RepositoryImpl.java
+++ b/rskj-core/src/main/java/co/rsk/db/RepositoryImpl.java
@@ -320,7 +320,7 @@ public class RepositoryImpl implements Repository {
     @Override
     public synchronized void updateBatch(Map<RskAddress, AccountState> stateCache,
                                          Map<RskAddress, ContractDetails> detailsCache) {
-        logger.info("updatingBatch: detailsCache.size: {}", detailsCache.size());
+        logger.debug("updatingBatch: detailsCache.size: {}", detailsCache.size());
 
         for (Map.Entry<RskAddress, AccountState> entry : stateCache.entrySet()) {
             RskAddress addr = entry.getKey();
@@ -357,7 +357,7 @@ public class RepositoryImpl implements Repository {
             }
         }
 
-        logger.info("updated: detailsCache.size: {}", detailsCache.size());
+        logger.debug("updated: detailsCache.size: {}", detailsCache.size());
 
         stateCache.clear();
         detailsCache.clear();

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -469,14 +469,11 @@ public class MinerServerImpl implements MinerServer {
 
     private boolean isValid(Block block) {
         try {
-            if (!powRule.isValid(block)) {
-                return false;
-            }
+            return powRule.isValid(block);
         } catch (Exception e) {
             logger.error("Failed to validate PoW from block {}: {}", block.getShortHash(), e);
             return false;
         }
-        return true;
     }
 
     public static byte[] compressCoinbase(byte[] bitcoinMergedMiningCoinbaseTransactionSerialized) {
@@ -607,7 +604,7 @@ public class MinerServerImpl implements MinerServer {
             newBlockParent = blockchain.getBlockByHash(newBlockParent.getParentHash());
         }
 
-        logger.info("Starting block to mine from parent {}", newBlockParent.getNumber() + " " + Hex.toHexString(newBlockParent.getHash()));
+        logger.info("Starting block to mine from parent {} {}", newBlockParent.getNumber(), Hex.toHexString(newBlockParent.getHash()));
 
         List<BlockHeader> uncles;
         if (blockStore != null) {
@@ -711,7 +708,7 @@ public class MinerServerImpl implements MinerServer {
     private void removePendingTransactions(List<Transaction> transactions) {
         if (transactions != null) {
             for (Transaction tx : transactions) {
-                logger.info("Removing transaction {}", Hex.toHexString(tx.getHash()));
+                logger.debug("Removing transaction {}", Hex.toHexString(tx.getHash()));
             }
         }
 
@@ -721,7 +718,7 @@ public class MinerServerImpl implements MinerServer {
 
     private List<Transaction> getTransactions(List<Transaction> txsToRemove, Block parent, BigInteger minGasPrice) {
 
-        logger.info("Starting getTransactions");
+        logger.debug("Starting getTransactions");
 
         List<Transaction> txs = new MinerUtils().getAllTransactions(pendingState);
         logger.debug("txsList size {}", txs.size());

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -154,10 +154,10 @@ public class MinerUtils {
         List<org.ethereum.core.Transaction> txsResult = new ArrayList<>();
         for (org.ethereum.core.Transaction tx : txs) {
             try {
-                logger.info("Pending transaction {} {}", toBI(tx.getNonce()), Hex.toHexString(tx.getHash()));
+                logger.debug("Pending transaction {} {}", toBI(tx.getNonce()), Hex.toHexString(tx.getHash()));
                 RskAddress txSender = tx.getSender();
 
-                logger.info("Examining transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), txSender, Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
+                logger.debug("Examining transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), txSender, Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
 
                 BigInteger txNonce = new BigInteger(1, tx.getNonce());
 
@@ -183,7 +183,7 @@ public class MinerUtils {
 
                 accountNonces.put(txSender, txNonce);
 
-                logger.info("Accepted transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), txSender, Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
+                logger.debug("Accepted transaction {} sender: {} value: {} nonce: {}", Hex.toHexString(tx.getHash()), txSender, Hex.toHexString(tx.getValue()), Hex.toHexString(tx.getNonce()));
             } catch (Exception e) {
                 // Txs that can't be selected by any reason should be removed from pending state
                 String hash = null == tx.getHash() ? "" : Hex.toHexString(tx.getHash());
@@ -199,7 +199,7 @@ public class MinerUtils {
             txsResult.add(tx);
         }
 
-        logger.info("Ending getTransactions {}", txsResult.size());
+        logger.debug("Ending getTransactions {}", txsResult.size());
 
         return txsResult;
     }

--- a/rskj-core/src/main/java/co/rsk/net/Metrics.java
+++ b/rskj-core/src/main/java/co/rsk/net/Metrics.java
@@ -153,7 +153,7 @@ public class Metrics {
     }
 
     private static void logEvent(@Nonnull final String event) {
-        logger.info("{} at: {} nano: {} | {} ", nodeID, currentTimeMillis(), nanoTime(), event);
+        logger.debug("{} at: {} nano: {} | {} ", nodeID, currentTimeMillis(), nanoTime(), event);
     }
 
     public static void registerNodeID(byte[] bytes) {

--- a/rskj-core/src/main/java/co/rsk/net/eth/RskWireProtocol.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/RskWireProtocol.java
@@ -157,6 +157,11 @@ public class RskWireProtocol extends EthHandler {
             if (!Arrays.equals(msg.getGenesisHash(), genesis.getHash())
                     || msg.getProtocolVersion() != version.getCode()) {
                 loggerNet.info("Removing EthHandler for {} due to protocol incompatibility", ctx.channel().remoteAddress());
+                if (msg.getProtocolVersion() != version.getCode()){
+                    loggerNet.info("Protocol version {} - message protocol version {}", version.getCode(), msg.getProtocolVersion());
+                } else {
+                    loggerNet.info("Config genesis hash {} - message genesis hash {}", genesis.getHash(), msg.getGenesisHash());
+                }
                 ethState = EthState.STATUS_FAILED;
                 recordEvent(EventType.INCOMPATIBLE_PROTOCOL);
                 disconnect(ReasonCode.INCOMPATIBLE_PROTOCOL);
@@ -164,7 +169,8 @@ public class RskWireProtocol extends EthHandler {
                 return;
             }
 
-            if (msg.getNetworkId() != config.networkId()) {
+            if (config.networkId() != msg.getNetworkId()) {
+                loggerNet.info("Different network received: config network ID {} - message network ID {}", config.networkId(), msg.getNetworkId());
                 ethState = EthState.STATUS_FAILED;
                 recordEvent(EventType.INVALID_NETWORK);
                 disconnect(ReasonCode.NULL_IDENTITY);

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -248,8 +248,6 @@ public class Transaction implements SerializableObject {
             byte[] r = transaction.get(7).getRLPData();
             byte[] s = transaction.get(8).getRLPData();
             this.signature = ECDSASignature.fromComponents(r, s, getRealV(v));
-        } else {
-            logger.debug("RLP encoded tx is not signed!");
         }
         this.parsed = true;
         this.hash = getHash();

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -248,6 +248,8 @@ public class Transaction implements SerializableObject {
             byte[] r = transaction.get(7).getRLPData();
             byte[] s = transaction.get(8).getRLPData();
             this.signature = ECDSASignature.fromComponents(r, s, getRealV(v));
+        } else {
+            logger.trace("RLP encoded tx is not signed!");
         }
         this.parsed = true;
         this.hash = getHash();

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -191,9 +191,9 @@ public class TransactionExecutor {
         }
 
         if (!tx.acceptTransactionSignature(config.getBlockchainConfig().getCommonConstants().getChainId())) {
-                logger.warn("Transaction {} signature not accepted: {}", Hex.toHexString(tx.getHash()), tx.getSignature());
-                logger.warn("Transaction Data: {}", tx);
-                logger.warn("Tx Included in the following block: {}", this.executionBlock);
+            logger.warn("Transaction {} signature not accepted: {}", Hex.toHexString(tx.getHash()), tx.getSignature());
+            logger.warn("Transaction Data: {}", tx);
+            logger.warn("Tx Included in the following block: {}", this.executionBlock);
 
             panicProcessor.panic("invalidsignature", String.format("Transaction %s signature not accepted: %s", Hex.toHexString(tx.getHash()), tx.getSignature().toString()));
             execError(String.format("Transaction signature not accepted: %s", tx.getSignature().toString()));
@@ -221,7 +221,9 @@ public class TransactionExecutor {
             BigInteger txGasCost = toBI(tx.getGasPrice()).multiply(txGasLimit);
             track.addBalance(tx.getSender(), txGasCost.negate());
 
-            logger.trace("Paying: txGasCost: [{}], gasPrice: [{}], gasLimit: [{}]", txGasCost, toBI(tx.getGasPrice()), txGasLimit);
+            if (logger.isTraceEnabled()){
+                logger.trace("Paying: txGasCost: [{}], gasPrice: [{}], gasLimit: [{}]", txGasCost, toBI(tx.getGasPrice()), txGasLimit);
+            }
         }
 
         if (tx.isContractCreation()) {
@@ -315,6 +317,11 @@ public class TransactionExecutor {
         transfer(cacheTrack, tx.getSender(), newContractAddress, endowment);
     }
 
+    private void execError(Throwable err) {
+        logger.warn("execError: ", err);
+        executionError = err.getMessage();
+    }
+
     private void execError(String err) {
         logger.warn(err);
         executionError = err;
@@ -389,7 +396,7 @@ public class TransactionExecutor {
 //            https://github.com/ethereum/cpp-ethereum/blob/develop/libethereum/Executive.cpp#L241
             cacheTrack.rollback();
             mEndGas = BigInteger.ZERO;
-            execError(e.getMessage());
+            execError(e);
 
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -65,7 +65,7 @@ public class LevelDbDataSource implements KeyValueDataSource {
     public LevelDbDataSource(RskSystemProperties config, String name) {
         this.config = config;
         this.name = name;
-        logger.info("New LevelDbDataSource: {}", name);
+        logger.debug("New LevelDbDataSource: {}", name);
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/FrameCodecHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/FrameCodecHandler.java
@@ -85,8 +85,7 @@ public class FrameCodecHandler extends ByteToMessageCodec<FrameCodec.Frame> {
             loggerNet.debug("FrameCodec failed: ", cause);
         } else {
             if (cause instanceof IOException) {
-                loggerNet.info("FrameCodec failed: " + ctx.channel().remoteAddress() + "(" + cause.getMessage() + ")");
-                loggerNet.debug("FrameCodec failed: " + ctx.channel().remoteAddress(), cause);
+                loggerNet.info("FrameCodec failed: {} ({})", ctx.channel().remoteAddress(), cause);
             } else {
                 loggerNet.error("FrameCodec failed: ", cause);
             }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/FrameCodecHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/FrameCodecHandler.java
@@ -39,8 +39,8 @@ public class FrameCodecHandler extends ByteToMessageCodec<FrameCodec.Frame> {
     private static final Logger loggerWire = LoggerFactory.getLogger("wire");
     private static final Logger loggerNet = LoggerFactory.getLogger("net");
 
-    public FrameCodec frameCodec;
-    public Channel channel;
+    protected final FrameCodec frameCodec;
+    protected final Channel channel;
 
     public FrameCodecHandler(FrameCodec frameCodec, Channel channel) {
         this.frameCodec = frameCodec;
@@ -63,8 +63,7 @@ public class FrameCodecHandler extends ByteToMessageCodec<FrameCodec.Frame> {
         }
 
         for (int i = 0; i < frames.size(); i++) {
-            FrameCodec.Frame frame = frames.get(i);
-
+            frames.get(i);
             channel.getNodeStatistics().rlpxInMessages.add();
         }
 
@@ -85,7 +84,7 @@ public class FrameCodecHandler extends ByteToMessageCodec<FrameCodec.Frame> {
             loggerNet.debug("FrameCodec failed: ", cause);
         } else {
             if (cause instanceof IOException) {
-                loggerNet.info("FrameCodec failed: {} ({})", ctx.channel().remoteAddress(), cause);
+                loggerNet.info(String.format("FrameCodec failed: %s", ctx.channel().remoteAddress()), cause);
             } else {
                 loggerNet.error("FrameCodec failed: ", cause);
             }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -336,14 +336,13 @@ public class HandshakeHandler extends ByteToMessageDecoder {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         recordFailedHandshake(ctx);
-        String exceptionLog = String.format("Handshake failed: {} ({})", ctx.channel().remoteAddress(), cause.getMessage());
         if (channel.isDiscoveryMode()) {
-            loggerNet.debug(exceptionLog);
+            loggerNet.debug(String.format("Handshake failed: %s (%s)", ctx.channel().remoteAddress(), cause.getMessage()));
         } else {
             if (cause instanceof IOException) {
-                loggerNet.info(exceptionLog);
+                loggerNet.info(String.format("Handshake failed: %s", ctx.channel().remoteAddress(), cause));
             } else {
-                loggerNet.error(exceptionLog);
+                loggerNet.error("Handshake failed: ", cause);
             }
         }
         ctx.close();

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/MessageCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/MessageCodec.java
@@ -141,9 +141,7 @@ public class MessageCodec extends MessageToMessageCodec<Frame, Message> {
 
         Message msg = createMessage((byte) frameType, payload);
 
-        if (loggerNet.isInfoEnabled()) {
-            loggerNet.info("From: \t{} \tRecv: \t{}", channel, msg.toString());
-        }
+        loggerNet.trace("From: \t{} \tRecv: \t{}", channel, msg.toString());
 
         ethereumListener.onRecvMessage(channel, msg);
 
@@ -156,9 +154,7 @@ public class MessageCodec extends MessageToMessageCodec<Frame, Message> {
         String output = String.format("To: \t%s \tSend: \t%s", ctx.channel().remoteAddress(), msg);
         ethereumListener.trace(output);
 
-        if (loggerNet.isInfoEnabled()) {
-            loggerNet.info("To: \t{} \tSend: \t{}", channel, msg);
-        }
+        loggerNet.trace("To: \t{} \tSend: \t{}", channel, msg);
 
         byte[] encoded = msg.getEncoded();
 

--- a/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
@@ -59,7 +59,6 @@ import java.util.stream.Collectors;
 public class ChannelManagerImpl implements ChannelManager {
 
     private static final Logger logger = LoggerFactory.getLogger("net");
-    private static final Logger mlogger = LoggerFactory.getLogger("metrics");
 
     // If the inbound peer connection was dropped by us with a reason message
     // then we ban that peer IP on any connections for some time to protect from
@@ -327,8 +326,7 @@ public class ChannelManagerImpl implements ChannelManager {
         syncPool.onDisconnect(channel);
         activePeers.values().remove(channel);
         if(newPeers.remove(channel)) {
-            logger.debug("Peer removed from active peers: {}", channel);
-            mlogger.info("Peer removed from active peers: {}", channel);
+            logger.info("Peer removed from active peers: {}", channel.getPeerId());
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/net/submit/TransactionTask.java
+++ b/rskj-core/src/main/java/org/ethereum/net/submit/TransactionTask.java
@@ -59,7 +59,7 @@ public class TransactionTask implements Callable<List<Transaction>> {
     public List<Transaction> call() throws Exception {
 
         try {
-            logger.info("submit tx: {}", tx.toString());
+            logger.trace("submit tx: {}", tx.toString());
             channelManager.sendTransaction(tx, receivedFrom);
             return tx;
 


### PR DESCRIPTION
Many logs were throw on info level and it makes hard to get what's happening on the node by reading logs.
Most of them were kept and demoted to trace so still can be used for debugging but are not useful for the regular user. 
Still there are some logs coming from external libraries that should be turned off or silenced from logback.
There are some minor fixes on string formats or incompatible protocol.