### PR TITLE
Specify the Remasc sender as currently in mainnet so we don't hardfork

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/RskAddress.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskAddress.java
@@ -32,7 +32,7 @@ import java.util.Comparator;
  *
  * @author Ariel Mendelzon
  */
-public final class RskAddress {
+public class RskAddress {
 
     /**
      * This is the size of an RSK address in bytes.

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
@@ -32,6 +32,19 @@ import org.ethereum.vm.PrecompiledContracts;
 public class RemascTransaction extends Transaction {
     private static final byte[] ZERO_BYTE_ARRAY = new byte[]{0};
 
+    /**
+     * The Remasc transaction is not signed so it has no sender.
+     * Due to a bug in the implementation before mainnet release, this address has a special encoding.
+     * Instead of the empty array, it is encoded as the array with just one zero.
+     * This instance should not be used for any other reason.
+     */
+    public static final RskAddress REMASC_ADDRESS = new RskAddress(RskAddress.nullAddress().getBytes()) {
+        @Override
+        public byte[] getBytes() {
+            return ZERO_BYTE_ARRAY;
+        }
+    };
+
     public RemascTransaction(byte[] rawData) {
         super(rawData);
     }
@@ -54,8 +67,7 @@ public class RemascTransaction extends Transaction {
 
     @Override
     public RskAddress getSender() {
-        // RemascTransaction is not signed so has no sender
-        return RskAddress.nullAddress();
+        return REMASC_ADDRESS;
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -24,7 +24,6 @@ import co.rsk.bitcoinj.core.VerificationException;
 import co.rsk.config.ConfigHelper;
 import co.rsk.config.ConfigUtils;
 import co.rsk.core.DifficultyCalculator;
-import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.remasc.RemascTransaction;
 import co.rsk.test.World;
@@ -79,9 +78,9 @@ public class MinerServerTest {
         Mockito.when(tx1.getEncoded()).thenReturn(new byte[32]);
 
         Mockito.when(repository.getNonce(tx1.getSender())).thenReturn(BigInteger.ZERO);
-        Mockito.when(repository.getNonce(RskAddress.nullAddress())).thenReturn(BigInteger.ZERO);
+        Mockito.when(repository.getNonce(RemascTransaction.REMASC_ADDRESS)).thenReturn(BigInteger.ZERO);
         Mockito.when(repository.getBalance(tx1.getSender())).thenReturn(BigInteger.valueOf(4200000L));
-        Mockito.when(repository.getBalance(RskAddress.nullAddress())).thenReturn(BigInteger.valueOf(4200000L));
+        Mockito.when(repository.getBalance(RemascTransaction.REMASC_ADDRESS)).thenReturn(BigInteger.valueOf(4200000L));
 
         List<Transaction> txs = new ArrayList<>(Arrays.asList(tx1));
 


### PR DESCRIPTION
In mainnet we are encoding the Remasc transaction sender as the byte array with just one zero instead of the empty byte array. This prevents us from using the `RskAddress.nullAddress()` object.

@ajlopezrsk has an alternative solution which is also worth considering, but this one maintains strict checks in the `RskAddress` class.