### PR TITLE
Reworked some tests to remove ConfigHelper usage with setters

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -83,6 +83,7 @@ public abstract class SystemProperties {
 
     private static final String YES = "yes";
     private static final String NO = "no";
+    private static Config configDataFromFile;
 
     /**
      * Marks config accessor methods which need to be called (for value validation)
@@ -113,11 +114,15 @@ public abstract class SystemProperties {
     
     protected SystemProperties() {
         try {
-            configFromFiles = getConfigFromFiles();
-            validateConfig();
-
-            logger.debug("Config trace: " + configFromFiles.root().render(ConfigRenderOptions.defaults().
-                    setComments(false).setJson(false)));
+            // could be locked but the result should be the same if there is no race condition
+            if (configDataFromFile == null){
+                configDataFromFile = getConfigFromFiles();
+                logger.debug("Config trace: " + configDataFromFile.root().render(ConfigRenderOptions.defaults().
+                        setComments(false).setJson(false)));
+                configFromFiles = configDataFromFile;
+                validateConfig();
+            }
+            configFromFiles = configDataFromFile;
 
             Properties props = new Properties();
             InputStream is = getClass().getResourceAsStream("/version.properties");
@@ -414,11 +419,6 @@ public abstract class SystemProperties {
 
     public void setDataBaseDir(String dataBaseDir) {
         this.databaseDir = dataBaseDir;
-    }
-
-    @ValidateMe
-    public boolean dumpCleanOnRestart() {
-        return configFromFiles.getBoolean("dump.clean.on.restart");
     }
 
     @ValidateMe

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -83,7 +83,6 @@ public abstract class SystemProperties {
 
     private static final String YES = "yes";
     private static final String NO = "no";
-    private static Config configDataFromFile;
 
     /**
      * Marks config accessor methods which need to be called (for value validation)
@@ -93,7 +92,7 @@ public abstract class SystemProperties {
     @Retention(RetentionPolicy.RUNTIME)
     private @interface ValidateMe {}
 
-    protected Config configFromFiles;
+    protected static Config configFromFiles;
 
     // mutable options for tests
     private String databaseDir = null;
@@ -115,14 +114,12 @@ public abstract class SystemProperties {
     protected SystemProperties() {
         try {
             // could be locked but the result should be the same if there is no race condition
-            if (configDataFromFile == null){
-                configDataFromFile = getConfigFromFiles();
-                logger.debug("Config trace: " + configDataFromFile.root().render(ConfigRenderOptions.defaults().
+            if (configFromFiles == null){
+                configFromFiles = getConfigFromFiles();
+                logger.debug("Config trace: " + configFromFiles.root().render(ConfigRenderOptions.defaults().
                         setComments(false).setJson(false)));
-                configFromFiles = configDataFromFile;
                 validateConfig();
             }
-            configFromFiles = configDataFromFile;
 
             Properties props = new Properties();
             InputStream is = getClass().getResourceAsStream("/version.properties");

--- a/rskj-core/src/main/java/org/ethereum/config/net/MainNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/net/MainNetConfig.java
@@ -27,8 +27,6 @@ import org.ethereum.config.blockchain.MainNetBeforeBridgeSyncConfig;
  * Created by Anton Nashatyrev on 25.02.2016.
  */
 public class MainNetConfig extends AbstractNetConfig {
-    public static final MainNetConfig INSTANCE = new MainNetConfig();
-
     public MainNetConfig() {
         add(0, new MainNetBeforeBridgeSyncConfig());
         // 60 days of 1 block every 14 seconds.

--- a/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
+++ b/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
@@ -18,7 +18,7 @@
 
 package co.rsk.TestHelpers;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
@@ -34,7 +34,7 @@ import static org.mockito.Matchers.eq;
 
 public class Tx {
 
-    public static Transaction create(long value, long gaslimit, long gasprice, long nonce, long data, long sender, Random hashes) {
+    public static Transaction create(RskSystemProperties config, long value, long gaslimit, long gasprice, long nonce, long data, long sender, Random hashes) {
         Random r = new Random(sender);
         Transaction transaction = Mockito.mock(Transaction.class);
         Mockito.when(transaction.getValue()).thenReturn(BigInteger.valueOf(value).toByteArray());
@@ -55,7 +55,7 @@ public class Tx {
 
         Mockito.when(transaction.getSender()).thenReturn(returnSender);
         Mockito.when(transaction.getHash()).thenReturn(BigInteger.valueOf(hashes.nextLong()).toByteArray());
-        Mockito.when(transaction.acceptTransactionSignature(ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId())).thenReturn(Boolean.TRUE);
+        Mockito.when(transaction.acceptTransactionSignature(config.getBlockchainConfig().getCommonConstants().getChainId())).thenReturn(Boolean.TRUE);
         Mockito.when(transaction.getReceiveAddress()).thenReturn(returnReceiveAddress);
         ArrayList<Byte> bytes = new ArrayList();
         long amount = 21000;
@@ -76,7 +76,7 @@ public class Tx {
             b[i] = bytes.get(i);
         }
         Mockito.when(transaction.getData()).thenReturn(b);
-        Mockito.when(transaction.transactionCost(eq(ConfigHelper.CONFIG), any(Block.class))).thenReturn(amount);
+        Mockito.when(transaction.transactionCost(eq(config), any(Block.class))).thenReturn(amount);
 
         return transaction;
     }

--- a/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
+++ b/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
@@ -18,7 +18,7 @@
 
 package co.rsk.blockchain.utils;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.mine.MinimumGasPriceCalculator;
@@ -71,7 +71,7 @@ public class BlockGenerator {
         return INSTANCE;
     }
 
-    private final DifficultyCalculator difficultyCalculator = new DifficultyCalculator(ConfigHelper.CONFIG);
+    private final DifficultyCalculator difficultyCalculator = new DifficultyCalculator(new RskSystemProperties());
     private int count = 0;
 
     public Genesis getGenesisBlock() {

--- a/rskj-core/src/test/java/co/rsk/blocks/FileBlockPlayerTest.java
+++ b/rskj-core/src/test/java/co/rsk/blocks/FileBlockPlayerTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.blocks;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,7 +33,7 @@ public class FileBlockPlayerTest {
         FileBlockRecorder recorder = new FileBlockRecorder("testblocks.txt");
         recorder.close();
 
-        FileBlockPlayer player = new FileBlockPlayer(ConfigHelper.CONFIG, "testblocks.txt");
+        FileBlockPlayer player = new FileBlockPlayer(new RskSystemProperties(), "testblocks.txt");
 
         File file = new File("testblocks.txt");
         Assert.assertTrue(file.exists());

--- a/rskj-core/src/test/java/co/rsk/config/CommonConfigTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/CommonConfigTest.java
@@ -33,11 +33,14 @@ import java.util.List;
  * Created by ajlopez on 10/04/2017.
  */
 public class CommonConfigTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void createRepositoryUsingNewRepository() {
         CommonConfig config = new CommonConfig();
 
-        Repository repository = config.repository(ConfigHelper.CONFIG);
+        Repository repository = config.repository(this.config);
 
         Assert.assertNotNull(repository);
         Assert.assertTrue(repository instanceof RepositoryImpl);
@@ -57,7 +60,7 @@ public class CommonConfigTest {
     public void createParentHeaderValidator() {
         CommonConfig config = new CommonConfig();
 
-        ParentBlockHeaderValidator result = config.parentHeaderValidator(ConfigHelper.CONFIG, new DifficultyCalculator(ConfigHelper.CONFIG));
+        ParentBlockHeaderValidator result = config.parentHeaderValidator(this.config, new DifficultyCalculator(this.config));
 
         Assert.assertNotNull(result);
     }

--- a/rskj-core/src/test/java/co/rsk/config/ConfigHelper.java
+++ b/rskj-core/src/test/java/co/rsk/config/ConfigHelper.java
@@ -1,5 +1,0 @@
-package co.rsk.config;
-
-public class ConfigHelper {
-    public static final RskSystemProperties CONFIG = new RskSystemProperties();
-}

--- a/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
@@ -27,21 +27,24 @@ import java.util.List;
  * Created by ajlopez on 3/16/2016.
  */
 public class RskSystemPropertiesTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void defaultValues() {
-        Assert.assertEquals(false, ConfigHelper.CONFIG.minerClientEnabled());
-        Assert.assertEquals(false, ConfigHelper.CONFIG.minerServerEnabled());
-        Assert.assertEquals(0, ConfigHelper.CONFIG.minerMinGasPrice());
-        Assert.assertEquals(0, ConfigHelper.CONFIG.minerGasUnitInDollars(), 0.001);
-        Assert.assertEquals(0, ConfigHelper.CONFIG.minerMinFeesNotifyInDollars(), 0.001);
-        Assert.assertTrue(ConfigHelper.CONFIG.isFlushEnabled());
+        Assert.assertEquals(false, config.minerClientEnabled());
+        Assert.assertEquals(false, config.minerServerEnabled());
+        Assert.assertEquals(0, config.minerMinGasPrice());
+        Assert.assertEquals(0, config.minerGasUnitInDollars(), 0.001);
+        Assert.assertEquals(0, config.minerMinFeesNotifyInDollars(), 0.001);
+        Assert.assertTrue(config.isFlushEnabled());
     }
 
     @Test
     public void hasMessagesConfiguredInTestConfig() {
-        Assert.assertTrue(ConfigHelper.CONFIG.hasMessageRecorderEnabled());
+        Assert.assertTrue(config.hasMessageRecorderEnabled());
 
-        List<String> commands = ConfigHelper.CONFIG.getMessageRecorderCommands();
+        List<String> commands = config.getMessageRecorderCommands();
         Assert.assertNotNull(commands);
         Assert.assertEquals(2, commands.size());
         Assert.assertTrue(commands.contains("TRANSACTIONS"));

--- a/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.test.World;
 import co.rsk.test.builders.AccountBuilder;
 import org.ethereum.core.*;
@@ -33,6 +33,9 @@ import java.math.BigInteger;
  * Created by ajlopez on 07/05/2017.
  */
 public class CallContractTest {
+
+    private static final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void callContractReturningOne() {
         World world = new World();
@@ -51,7 +54,7 @@ public class CallContractTest {
     }
 
     private static ProgramResult callContract(World world, RskAddress receiveAddress, byte[] data) {
-        Transaction tx = CallTransaction.createRawTransaction(ConfigHelper.CONFIG, 0, 0, 100000000000000L,
+        Transaction tx = CallTransaction.createRawTransaction(config, 0, 0, 100000000000000L,
                 receiveAddress, 0, data);
         tx.sign(new byte[32]);
 
@@ -61,7 +64,7 @@ public class CallContractTest {
 
         try {
             org.ethereum.core.TransactionExecutor executor = new org.ethereum.core.TransactionExecutor
-                    (ConfigHelper.CONFIG, tx, 0, bestBlock.getCoinbase(), repository, world.getBlockChain().getBlockStore(), world.getBlockChain().getReceiptStore(),
+                    (config, tx, 0, bestBlock.getCoinbase(), repository, world.getBlockChain().getBlockStore(), world.getBlockChain().getReceiptStore(),
                             new ProgramInvokeFactoryImpl(), bestBlock)
                     .setLocalCall(true);
 

--- a/rskj-core/src/test/java/co/rsk/core/CodeReplaceTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CodeReplaceTest.java
@@ -19,9 +19,11 @@
 package co.rsk.core;
 
 import co.rsk.asm.EVMAssembler;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
-import org.ethereum.core.*;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionExecutor;
 import org.ethereum.core.genesis.GenesisLoader;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
@@ -38,11 +40,14 @@ import java.util.Arrays;
  * Created by Sergio on 26/02/2017.
  */
 public class CodeReplaceTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void replaceCodeTest1() throws IOException, InterruptedException {
 
-        BigInteger nonce = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getInitialNonce();
-        BlockChainImpl blockchain = org.ethereum.core.ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(ConfigHelper.CONFIG, nonce,
+        BigInteger nonce = config.getBlockchainConfig().getCommonConstants().getInitialNonce();
+        BlockChainImpl blockchain = org.ethereum.core.ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(config, nonce,
                 getClass().getResourceAsStream("/genesis/genesis-light.json"), false));
 
         ECKey sender = ECKey.fromPrivate(Hex.decode("3ec771c31cac8c0dba77a69e503765701d3c2bb62435888d4ffa38fed60c445c"));
@@ -99,8 +104,8 @@ public class CodeReplaceTest {
     public void replaceCodeTest2() throws IOException, InterruptedException {
         // We test code replacement during initialization: this is forbitten.
 
-        BigInteger nonce = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getInitialNonce();
-        BlockChainImpl blockchain = org.ethereum.core.ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(ConfigHelper.CONFIG, nonce,
+        BigInteger nonce = config.getBlockchainConfig().getCommonConstants().getInitialNonce();
+        BlockChainImpl blockchain = org.ethereum.core.ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(config, nonce,
                 getClass().getResourceAsStream("/genesis/genesis-light.json"), false));
 
         ECKey sender = ECKey.fromPrivate(Hex.decode("3ec771c31cac8c0dba77a69e503765701d3c2bb62435888d4ffa38fed60c445c"));
@@ -137,14 +142,14 @@ public class CodeReplaceTest {
                 receiveAddress,
                 ByteUtil.longToBytesNoLeadZeroes(value),
                 data,
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         tx.sign(sender.getPrivKeyBytes());
         return tx;
     }
 
     public TransactionExecutor executeTransaction(BlockChainImpl blockchain, Transaction tx) {
         Repository track = blockchain.getRepository().startTracking();
-        TransactionExecutor executor = new TransactionExecutor(ConfigHelper.CONFIG, tx, 0, RskAddress.nullAddress(), blockchain.getRepository(),
+        TransactionExecutor executor = new TransactionExecutor(config, tx, 0, RskAddress.nullAddress(), blockchain.getRepository(),
                 blockchain.getBlockStore(), blockchain.getReceiptStore(), new ProgramInvokeFactoryImpl(), blockchain.getBestBlock());
 
         executor.init();

--- a/rskj-core/src/test/java/co/rsk/core/NetworkStateExporterTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/NetworkStateExporterTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.trie.TrieStoreImpl;
 import com.fasterxml.jackson.databind.JavaType;
@@ -33,6 +33,7 @@ import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
@@ -50,6 +51,12 @@ public class NetworkStateExporterTest {
     private static final byte[] ZERO_BYTE_ARRAY = new byte[]{0};
 
     static String jsonFileName = "networkStateExporterTest.json";
+    private RskSystemProperties config;
+
+    @Before
+    public void setup(){
+        config = new RskSystemProperties();
+    }
 
     @AfterClass
     public static void cleanup(){
@@ -58,7 +65,7 @@ public class NetworkStateExporterTest {
 
     @Test
     public void testEmptyRepo() throws Exception {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
         Map result = writeAndReadJson(repository);
 
@@ -67,7 +74,7 @@ public class NetworkStateExporterTest {
 
     @Test
     public void testNoContracts() throws Exception {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
         String address1String = "1000000000000000000000000000000000000000";
         RskAddress address1 = new RskAddress(address1String);
         repository.createAccount(address1);
@@ -110,13 +117,13 @@ public class NetworkStateExporterTest {
 
     @Test
     public void testContracts() throws Exception {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
         String address1String = "1000000000000000000000000000000000000000";
         RskAddress address1 = new RskAddress(address1String);
         repository.createAccount(address1);
         repository.addBalance(address1, BigInteger.ONE);
         repository.increaseNonce(address1);
-        ContractDetails contractDetails = new co.rsk.db.ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetails contractDetails = new co.rsk.db.ContractDetailsImpl(config);
         contractDetails.setCode(new byte[] {1, 2, 3, 4});
         contractDetails.put(DataWord.ZERO, DataWord.ONE);
         contractDetails.putBytes(DataWord.ONE, new byte[] {5, 6, 7, 8});

--- a/rskj-core/src/test/java/co/rsk/core/ReversibleTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/ReversibleTransactionExecutorTest.java
@@ -19,7 +19,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.util.TestContract;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
@@ -34,6 +34,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ReversibleTransactionExecutorTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void executeTransactionHello() {
         RskTestFactory factory = new RskTestFactory();
@@ -52,7 +55,7 @@ public class ReversibleTransactionExecutorTest {
 
         Block bestBlock = factory.getBlockchain().getBestBlock();
         TransactionExecutor executor = ReversibleTransactionExecutor.executeTransaction(
-                ConfigHelper.CONFIG, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
+                config, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
                 args);
 
         Assert.assertNull(executor.getResult().getException());
@@ -80,7 +83,7 @@ public class ReversibleTransactionExecutorTest {
 
         Block bestBlock = factory.getBlockchain().getBestBlock();
         TransactionExecutor executor = ReversibleTransactionExecutor.executeTransaction(
-                ConfigHelper.CONFIG, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
+                config, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
                 args);
 
         Assert.assertNull(executor.getResult().getException());
@@ -108,7 +111,7 @@ public class ReversibleTransactionExecutorTest {
 
         Block bestBlock = factory.getBlockchain().getBestBlock();
         TransactionExecutor executor = ReversibleTransactionExecutor.executeTransaction(
-                ConfigHelper.CONFIG, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
+                config, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
                 args);
 
         Assert.assertTrue(executor.getResult().isRevert());
@@ -133,7 +136,7 @@ public class ReversibleTransactionExecutorTest {
 
         Block bestBlock = factory.getBlockchain().getBestBlock();
         TransactionExecutor executor = ReversibleTransactionExecutor.executeTransaction(
-                ConfigHelper.CONFIG, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
+                config, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
                 args);
 
         Assert.assertNull(executor.getResult().getException());
@@ -142,7 +145,7 @@ public class ReversibleTransactionExecutorTest {
                 callsFn.decodeResult(executor.getResult().getHReturn()));
 
         TransactionExecutor executor2 = ReversibleTransactionExecutor.executeTransaction(
-                ConfigHelper.CONFIG, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
+                config, factory.getRepository(), factory.getBlockStore(), factory.getReceiptStore(), new ProgramInvokeFactoryImpl(), bestBlock, bestBlock.getCoinbase(),
                 args);
 
         Assert.assertNull(executor2.getResult().getException());

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -36,13 +36,14 @@ import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class TransactionTest {
 
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test  /* achieve public key of the sender */
     public void test2() throws Exception {
-        if (ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId() != 0)
+        if (config.getBlockchainConfig().getCommonConstants().getChainId() != 0)
             return;
 
         // cat --> 79b08ad8787060333663d19704909ee7b1903e58
@@ -181,7 +182,7 @@ public class TransactionTest {
                 {
                     Repository track = repository.startTracking();
 
-                    Transaction txConst = CallTransaction.createCallTransaction(ConfigHelper.CONFIG, 0, 0, 100000000000000L,
+                    Transaction txConst = CallTransaction.createCallTransaction(config, 0, 0, 100000000000000L,
                             new RskAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), 0,
                             CallTransaction.Function.fromSignature("get"));
                     txConst.sign(new byte[32]);
@@ -189,7 +190,7 @@ public class TransactionTest {
                     Block bestBlock = block;
 
                     TransactionExecutor executor = new TransactionExecutor
-                            (ConfigHelper.CONFIG, txConst, 0, bestBlock.getCoinbase(), track, new BlockStoreDummy(), null,
+                            (config, txConst, 0, bestBlock.getCoinbase(), track, new BlockStoreDummy(), null,
                                     invokeFactory, bestBlock)
                             .setLocalCall(true);
 
@@ -234,37 +235,37 @@ public class TransactionTest {
 
     @Test
     public void isContractCreationWhenReceiveAddressIsNull() {
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, null, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = Transaction.create(config, null, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertTrue(tx.isContractCreation());
     }
 
     @Test
     public void isContractCreationWhenReceiveAddressIsEmptyString() {
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = Transaction.create(config, "", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertTrue(tx.isContractCreation());
     }
 
     @Test
     public void isContractCreationWhenReceiveAddressIs00() {
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "00", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = Transaction.create(config, "00", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertTrue(tx.isContractCreation());
     }
 
     @Test
     public void isContractCreationWhenReceiveAddressIsFortyZeroes() {
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000000", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000000", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertTrue(tx.isContractCreation());
     }
 
     @Test
     public void isNotContractCreationWhenReceiveAddressIsCowAddress() {
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "cd2a3d9f938e13cd947ec05abc7fe734df8dd826", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = Transaction.create(config, "cd2a3d9f938e13cd947ec05abc7fe734df8dd826", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertFalse(tx.isContractCreation());
     }
 
     @Test
     public void isNotContractCreationWhenReceiveAddressIsBridgeAddress() {
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR_STR, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertFalse(tx.isContractCreation());
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/WalletFactory.java
+++ b/rskj-core/src/test/java/co/rsk/core/WalletFactory.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.LevelDbDataSource;
@@ -26,7 +26,7 @@ import org.ethereum.datasource.LevelDbDataSource;
 public class WalletFactory {
 
     public static Wallet createPersistentWallet(String storeName) {
-        KeyValueDataSource ds = new LevelDbDataSource(ConfigHelper.CONFIG, storeName);
+        KeyValueDataSource ds = new LevelDbDataSource(new RskSystemProperties(), storeName);
         ds.init();
         return new Wallet(ds);
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
@@ -20,7 +20,7 @@ package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.blocks.DummyBlockRecorder;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.test.builders.BlockBuilder;
@@ -56,6 +56,9 @@ import java.util.List;
  */
 
 public class BlockChainImplTest {
+
+    private static final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void addGenesisBlock() {
         BlockChainImpl blockChain = createBlockChain();
@@ -777,7 +780,7 @@ public class BlockChainImplTest {
 
     @Test
     public void createWithoutArgumentsAndUnusedMethods() {
-        BlockChainImpl blockChain = new BlockChainImpl(ConfigHelper.CONFIG, null, null, null, null, null, null, new DummyBlockValidator());
+        BlockChainImpl blockChain = new BlockChainImpl(config, null, null, null, null, null, null, new DummyBlockValidator());
         blockChain.setExitOn(0);
         blockChain.close();
     }
@@ -797,9 +800,9 @@ public class BlockChainImplTest {
 
     @Test
     public void addInvalidMGPBlock() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
-        IndexedBlockStore blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore blockStore = new IndexedBlockStore(config);
         blockStore.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockValidatorBuilder validatorBuilder = new BlockValidatorBuilder();
@@ -817,7 +820,7 @@ public class BlockChainImplTest {
         Assert.assertEquals(ImportResult.INVALID_BLOCK, blockChain.tryToConnect(block));
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(1L), BigInteger.TEN);
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(1L), BigInteger.TEN);
         tx.sign(new byte[]{22, 11, 00});
         txs.add(tx);
 
@@ -829,9 +832,9 @@ public class BlockChainImplTest {
 
     @Test
     public void addValidMGPBlock() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
-        IndexedBlockStore blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore blockStore = new IndexedBlockStore(config);
         blockStore.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockValidatorBuilder validatorBuilder = new BlockValidatorBuilder();
@@ -847,7 +850,7 @@ public class BlockChainImplTest {
         track.commit();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000100", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.valueOf(22000L));
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000100", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.valueOf(22000L));
         tx.sign(account.getEcKey().getPrivKeyBytes());
         txs.add(tx);
 
@@ -858,7 +861,7 @@ public class BlockChainImplTest {
         Block block = new BlockBuilder().minGasPrice(BigInteger.ZERO).transactions(txs)
                 .parent(genesis).build();
 
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, repository, blockChain, null, null);
+        BlockExecutor executor = new BlockExecutor(config, repository, blockChain, null, null);
         executor.executeAndFill(block, genesis);
 
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(genesis));
@@ -870,7 +873,7 @@ public class BlockChainImplTest {
     }
 
     public static BlockChainImpl createBlockChain(Repository repository) {
-        IndexedBlockStore blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore blockStore = new IndexedBlockStore(config);
         blockStore.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockValidatorBuilder validatorBuilder = new BlockValidatorBuilder();
@@ -891,8 +894,8 @@ public class BlockChainImplTest {
 
         EthereumListener listener = new BlockExecutorTest.SimpleEthereumListener();
 
-        BlockChainImpl blockChain = new BlockChainImpl(ConfigHelper.CONFIG, repository, blockStore, receiptStore, null, listener, adminInfo, blockValidator);
-        PendingStateImpl pendingState = new PendingStateImpl(ConfigHelper.CONFIG, blockChain, repository, null, null, listener, 10, 100);
+        BlockChainImpl blockChain = new BlockChainImpl(config, repository, blockStore, receiptStore, null, listener, adminInfo, blockValidator);
+        PendingStateImpl pendingState = new PendingStateImpl(config, blockChain, repository, null, null, listener, 10, 100);
         blockChain.setPendingState(pendingState);
 
         return blockChain;
@@ -901,7 +904,7 @@ public class BlockChainImplTest {
     public static Block getGenesisBlock(BlockChainImpl blockChain) {
         Repository repository = blockChain.getRepository();
 
-        Genesis genesis = GenesisLoader.loadGenesis(ConfigHelper.CONFIG, "rsk-unittests.json", BigInteger.ZERO, true);
+        Genesis genesis = GenesisLoader.loadGenesis(config, "rsk-unittests.json", BigInteger.ZERO, true);
 
         for (ByteArrayWrapper key : genesis.getPremine().keySet()) {
             repository.createAccount(new RskAddress(key.getData()));
@@ -915,7 +918,7 @@ public class BlockChainImplTest {
     }
 
     private static BlockExecutor createExecutor(BlockChainImpl blockChain) {
-        return new BlockExecutor(ConfigHelper.CONFIG, blockChain.getRepository(), blockChain, blockChain.getBlockStore(), blockChain.getListener());
+        return new BlockExecutor(config, blockChain.getRepository(), blockChain, blockChain.getBlockStore(), blockChain.getListener());
     }
 
     private static void alterBytes(byte[] bytes) {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.BlockchainDummy;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.test.builders.BlockChainBuilder;
@@ -55,12 +55,13 @@ import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
  */
 public class BlockExecutorTest {
     public static final byte[] EMPTY_TRIE_HASH = sha3(RLP.encodeElement(EMPTY_BYTE_ARRAY));
+    private static final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void executeBlockWithoutTransaction() {
         Block block = BlockGenerator.getInstance().createChildBlock(BlockGenerator.getInstance().getGenesisBlock());
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
         Repository track = repository.startTracking();
 
@@ -70,7 +71,7 @@ public class BlockExecutorTest {
 
         Assert.assertFalse(Arrays.equals(EMPTY_TRIE_HASH, repository.getRoot()));
 
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, repository, null, null, null);
+        BlockExecutor executor = new BlockExecutor(config, repository, null, null, null);
 
         BlockResult result = executor.execute(block, repository.getRoot(), false);
 
@@ -91,7 +92,7 @@ public class BlockExecutorTest {
         SimpleEthereumListener listener = new SimpleEthereumListener();
         TestObjects objects = generateBlockWithOneTransaction();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, listener);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, listener);
         Repository repository = objects.getRepository();
         Transaction tx = objects.getTransaction();
         Account account = objects.getAccount();
@@ -141,7 +142,7 @@ public class BlockExecutorTest {
 
     @Test
     public void executeBlockWithTwoTransactions() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
         Repository track = repository.startTracking();
 
@@ -152,7 +153,7 @@ public class BlockExecutorTest {
 
         Assert.assertFalse(Arrays.equals(EMPTY_TRIE_HASH, repository.getRoot()));
 
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, repository, new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, repository, new BlockchainDummy(), null, null);
 
         Transaction tx1 = createTransaction(account, account2, BigInteger.TEN, repository.getNonce(account.getAddress()));
         Transaction tx2 = createTransaction(account, account2, BigInteger.TEN, repository.getNonce(account.getAddress()).add(BigInteger.ONE));
@@ -214,7 +215,7 @@ public class BlockExecutorTest {
         TestObjects objects = generateBlockWithOneTransaction();
         Block parent = objects.getParent();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, null);
 
         BlockResult result = executor.execute(block, parent.getStateRoot(), false);
         executor.executeAndFill(block, parent);
@@ -230,7 +231,7 @@ public class BlockExecutorTest {
 
     @Test
     public void executeAndFillBlockWithTxToExcludeBecauseSenderHasNoBalance() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
         Repository track = repository.startTracking();
 
@@ -242,7 +243,7 @@ public class BlockExecutorTest {
 
         Assert.assertFalse(Arrays.equals(EMPTY_TRIE_HASH, repository.getRoot()));
 
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, repository, new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, repository, new BlockchainDummy(), null, null);
 
         Transaction tx = createTransaction(account, account2, BigInteger.TEN, repository.getNonce(account.getAddress()));
         Transaction tx2 = createTransaction(account3, account2, BigInteger.TEN, repository.getNonce(account3.getAddress()));
@@ -268,7 +269,7 @@ public class BlockExecutorTest {
 
     @Test
     public void executeBlockWithTxThatMakesBlockInvalidSenderHasNoBalance() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
         Repository track = repository.startTracking();
 
@@ -280,7 +281,7 @@ public class BlockExecutorTest {
 
         Assert.assertFalse(Arrays.equals(EMPTY_TRIE_HASH, repository.getRoot()));
 
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, repository, new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, repository, new BlockchainDummy(), null, null);
 
         Transaction tx = createTransaction(account, account2, BigInteger.TEN, repository.getNonce(account.getAddress()));
         Transaction tx2 = createTransaction(account3, account2, BigInteger.TEN, repository.getNonce(account3.getAddress()));
@@ -304,7 +305,7 @@ public class BlockExecutorTest {
         TestObjects objects = generateBlockWithOneTransaction();
         Block parent = objects.getParent();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, null);
 
         Assert.assertTrue(executor.executeAndValidate(block, parent));
     }
@@ -314,7 +315,7 @@ public class BlockExecutorTest {
         TestObjects objects = generateBlockWithOneTransaction();
         Block parent = objects.getParent();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, null);
 
         byte[] stateRoot = block.getStateRoot();
         stateRoot[0] = (byte)((stateRoot[0] + 1) % 256);
@@ -327,7 +328,7 @@ public class BlockExecutorTest {
         TestObjects objects = generateBlockWithOneTransaction();
         Block parent = objects.getParent();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, null);
 
         byte[] receiptsRoot = block.getReceiptsRoot();
         receiptsRoot[0] = (byte)((receiptsRoot[0] + 1) % 256);
@@ -340,7 +341,7 @@ public class BlockExecutorTest {
         TestObjects objects = generateBlockWithOneTransaction();
         Block parent = objects.getParent();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, null);
 
         block.getHeader().setGasUsed(0);
 
@@ -352,7 +353,7 @@ public class BlockExecutorTest {
         TestObjects objects = generateBlockWithOneTransaction();
         Block parent = objects.getParent();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, null);
 
         block.getHeader().setPaidFees(BigInteger.ZERO);
 
@@ -364,7 +365,7 @@ public class BlockExecutorTest {
         TestObjects objects = generateBlockWithOneTransaction();
         Block parent = objects.getParent();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, null);
 
         byte[] logBloom = block.getLogBloom();
         logBloom[0] = (byte)((logBloom[0] + 1) % 256);
@@ -385,7 +386,7 @@ public class BlockExecutorTest {
 
         Assert.assertFalse(Arrays.equals(EMPTY_TRIE_HASH, repository.getRoot()));
 
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, repository, new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, repository, new BlockchainDummy(), null, null);
 
         Transaction tx = createTransaction(account, account2, BigInteger.TEN, repository.getNonce(account.getAddress()));
         List<Transaction> txs = new ArrayList<>();
@@ -405,7 +406,7 @@ public class BlockExecutorTest {
     private static Transaction createTransaction(Account sender, Account receiver, BigInteger value, BigInteger nonce) {
         String toAddress = Hex.toHexString(receiver.getAddress().getBytes());
         byte[] privateKeyBytes = sender.getEcKey().getPrivKeyBytes();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
+        Transaction tx = Transaction.create(config, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
         tx.sign(privateKeyBytes);
         return tx;
     }
@@ -447,7 +448,7 @@ public class BlockExecutorTest {
     public void executeBlockWithOneStrangeTransaction(boolean mustFailValidation, boolean mustFailExecution, TestObjects objects) {
         SimpleEthereumListener listener = new SimpleEthereumListener();
         Block block = objects.getBlock();
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, objects.getRepository(), new BlockchainDummy(), null, listener);
+        BlockExecutor executor = new BlockExecutor(config, objects.getRepository(), new BlockchainDummy(), null, listener);
         Repository repository = objects.getRepository();
         Transaction tx = objects.getTransaction();
         Account account = objects.getAccount();
@@ -523,7 +524,7 @@ public class BlockExecutorTest {
 
         Assert.assertFalse(Arrays.equals(EMPTY_TRIE_HASH, repository.getRoot()));
 
-        BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, repository, new BlockchainDummy(), null, null);
+        BlockExecutor executor = new BlockExecutor(config, repository, new BlockchainDummy(), null, null);
 
         List<Transaction> txs = new ArrayList<>();
         Transaction tx = createStrangeTransaction(account, account2, BigInteger.TEN, repository.getNonce(account.getAddress()), strangeTransactionType);

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockForkTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockForkTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.Block;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
@@ -36,6 +36,7 @@ import java.util.List;
  * Created by ajlopez on 09/08/2016.
  */
 public class BlockForkTest {
+
     @Test
     public void calculateParentChild() {
         BlockStore store = createBlockStore();
@@ -159,7 +160,7 @@ public class BlockForkTest {
     }
 
     private static BlockStore createBlockStore() {
-        IndexedBlockStore blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore blockStore = new IndexedBlockStore(new RskSystemProperties());
         blockStore.init(new HashMap<>(), new HashMapDB(), null);
         return blockStore;
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core.bc;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.validators.*;
 import org.ethereum.core.Repository;
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
  */
 public class BlockValidatorBuilder {
 
+    private final RskSystemProperties config = new RskSystemProperties();
     private BlockTxsValidationRule blockTxsValidationRule;
 
     private BlockTxsFieldsValidationRule blockTxsFieldsValidationRule;
@@ -95,9 +96,9 @@ public class BlockValidatorBuilder {
     }
 
     public BlockValidatorBuilder addBlockUnclesValidationRule(BlockStore blockStore, BlockValidationRule validationRule, BlockParentDependantValidationRule parentValidationRule) {
-        int uncleListLimit = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getUncleListLimit();
-        int uncleGenLimit = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getUncleGenerationLimit();
-        this.blockUnclesValidationRule = new BlockUnclesValidationRule(ConfigHelper.CONFIG, blockStore, uncleListLimit, uncleGenLimit, validationRule, parentValidationRule);
+        int uncleListLimit = config.getBlockchainConfig().getCommonConstants().getUncleListLimit();
+        int uncleGenLimit = config.getBlockchainConfig().getCommonConstants().getUncleGenerationLimit();
+        this.blockUnclesValidationRule = new BlockUnclesValidationRule(config, blockStore, uncleListLimit, uncleGenLimit, validationRule, parentValidationRule);
         return this;
     }
 
@@ -117,12 +118,12 @@ public class BlockValidatorBuilder {
     }
 
     public BlockValidatorBuilder addDifficultyRule() {
-        this.difficultyRule = new BlockDifficultyRule(new DifficultyCalculator(ConfigHelper.CONFIG));
+        this.difficultyRule = new BlockDifficultyRule(new DifficultyCalculator(config));
         return this;
     }
 
     public BlockValidatorBuilder addParentGasLimitRule() {
-        parentGasLimitRule = new BlockParentGasLimitRule(ConfigHelper.CONFIG.getBlockchainConfig().
+        parentGasLimitRule = new BlockParentGasLimitRule(config.getBlockchainConfig().
                         getCommonConstants().getGasLimitBoundDivisor());
         return this;
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.peg.simples.SimpleBlock;
 import co.rsk.remasc.RemascTransaction;
 import co.rsk.test.builders.BlockBuilder;
@@ -48,6 +48,9 @@ import java.util.Set;
  * Created by ajlopez on 04/08/2016.
  */
 public class BlockValidatorTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void validateGenesisBlock() {
         BlockValidatorImpl validator = new BlockValidatorBuilder().build();
@@ -58,7 +61,7 @@ public class BlockValidatorTest {
 
     @Test
     public void validateEmptyBlock() {
-        IndexedBlockStore blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore blockStore = new IndexedBlockStore(config);
         blockStore.init(new HashMap<>(), new HashMapDB(), null);
         Block genesis = new BlockGenerator().getGenesisBlock();
         blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
@@ -71,7 +74,7 @@ public class BlockValidatorTest {
 
     @Test
     public void validateChildBlock() {
-        IndexedBlockStore blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore blockStore = new IndexedBlockStore(config);
         blockStore.init(new HashMap<>(), new HashMapDB(), null);
         Block genesis = new BlockGenerator().getGenesisBlock();
         blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
@@ -185,7 +188,7 @@ public class BlockValidatorTest {
 
     @Test
     public void validateHeader() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -207,7 +210,7 @@ public class BlockValidatorTest {
 
     @Test
     public void getGenesisEmptyAncestorSet() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
@@ -216,7 +219,7 @@ public class BlockValidatorTest {
 
     @Test
     public void getBlockOneAncestorSet() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
@@ -231,7 +234,7 @@ public class BlockValidatorTest {
 
     @Test
     public void getThreeAncestorSet() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
@@ -261,7 +264,7 @@ public class BlockValidatorTest {
 
     @Test
     public void getUsedUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
@@ -320,7 +323,7 @@ public class BlockValidatorTest {
 
     @Test
     public void validUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -351,7 +354,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidSiblingUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -379,7 +382,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUnclesUncleIncludedMultipeTimes () {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -405,7 +408,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidPOWUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -425,7 +428,7 @@ public class BlockValidatorTest {
         Mockito.when(parentValidationRule.isValid(Mockito.any(), Mockito.any())).thenReturn(true);
       
         BlockValidatorImpl validator = new BlockValidatorBuilder()
-                .addBlockUnclesValidationRule(store, new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), parentValidationRule)
+                .addBlockUnclesValidationRule(store, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), parentValidationRule)
                 .blockStore(store)
                 .build();
 
@@ -434,7 +437,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleIsAncestor() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -460,7 +463,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleHasNoSavedParent() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -484,7 +487,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleHasNoCommonAncestor() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -511,7 +514,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleHasParentThatIsNotAncestor() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -544,7 +547,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleAlreadyUsed() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -583,7 +586,7 @@ public class BlockValidatorTest {
 
     @Test
     public void tooManyUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -655,7 +658,7 @@ public class BlockValidatorTest {
                 .parent(new BlockGenerator().getGenesisBlock()).build();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN);
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN);
         tx.sign(new byte[]{22, 11, 00});
         txs.add(tx);
         Block block = new BlockBuilder().minGasPrice(BigInteger.TEN).transactions(txs)
@@ -707,7 +710,7 @@ public class BlockValidatorTest {
                 .parent(new BlockGenerator().getGenesisBlock()).build();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{22, 11, 00});
         txs.add(tx);
 
@@ -727,7 +730,7 @@ public class BlockValidatorTest {
 
     @Test
     public void parentInvalidNumber() {
-        IndexedBlockStore store = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore store = new IndexedBlockStore(config);
         store.init(new HashMap<>(), new HashMapDB(), null);
 
         BlockGenerator blockGenerator = new BlockGenerator();
@@ -751,7 +754,7 @@ public class BlockValidatorTest {
         Block genesis = BlockChainImplTest.getGenesisBlock(blockChain);
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.TEN, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.TEN, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{});
         txs.add(tx);
         Block block = new BlockBuilder().parent(genesis).transactions(txs).build();
@@ -770,7 +773,7 @@ public class BlockValidatorTest {
         Block genesis = blockGenerator.getGenesisBlock();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{});
         txs.add(tx);
         Block block = new BlockBuilder().parent(genesis).transactions(txs).build();
@@ -794,7 +797,7 @@ public class BlockValidatorTest {
         Block genesis = blockGenerator.getGenesisBlock();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{});
         txs.add(new RemascTransaction(BigInteger.ONE.longValue()));
         txs.add(tx);
@@ -814,7 +817,7 @@ public class BlockValidatorTest {
         Block genesis = blockGenerator.getGenesisBlock();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{});
         txs.add(tx);
         txs.add(new RemascTransaction(BigInteger.ONE.longValue()));
@@ -832,7 +835,7 @@ public class BlockValidatorTest {
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
 
-        int validPeriod = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getNewBlockMaxSecondsInTheFuture();
+        int validPeriod = config.getBlockchainConfig().getCommonConstants().getNewBlockMaxSecondsInTheFuture();
 
         Block block = Mockito.mock(Block.class);
         Mockito.when(block.getTimestamp())

--- a/rskj-core/src/test/java/co/rsk/core/bc/FamilyUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/FamilyUtilsTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.datasource.HashMapDB;
@@ -246,7 +246,7 @@ public class FamilyUtilsTest {
     }
 
     private static BlockStore createBlockStore() {
-        IndexedBlockStore blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore blockStore = new IndexedBlockStore(new RskSystemProperties());
         blockStore.init(new HashMap<>(), new HashMapDB(), null);
 
         return blockStore;

--- a/rskj-core/src/test/java/co/rsk/core/bc/PendingStateImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/PendingStateImplTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.BlockChainBuilder;
@@ -42,6 +42,9 @@ import java.util.List;
  * Created by ajlopez on 08/08/2016.
  */
 public class PendingStateImplTest {
+
+    private static final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void usingRepository() {
         PendingStateImpl pendingState = createSampleNewPendingState();
@@ -458,7 +461,7 @@ public class PendingStateImplTest {
     private static PendingStateImpl createSampleNewPendingState() {
         BlockChainImpl blockChain = createBlockchain();
 
-        return new PendingStateImpl(ConfigHelper.CONFIG, blockChain, blockChain.getRepository(), blockChain.getBlockStore(), new ProgramInvokeFactoryImpl(), new BlockExecutorTest.SimpleEthereumListener(), 10, 100);
+        return new PendingStateImpl(config, blockChain, blockChain.getRepository(), blockChain.getBlockStore(), new ProgramInvokeFactoryImpl(), new BlockExecutorTest.SimpleEthereumListener(), 10, 100);
     }
 
     private static PendingStateImpl createSampleNewPendingStateWithAccounts(int naccounts, BigInteger balance) {
@@ -480,7 +483,7 @@ public class PendingStateImplTest {
         best.setStateRoot(repository.getRoot());
         best.flushRLP();
 
-        PendingStateImpl pendingState = new PendingStateImpl(ConfigHelper.CONFIG, blockChain, blockChain.getRepository(), blockChain.getBlockStore(), new ProgramInvokeFactoryImpl(), new BlockExecutorTest.SimpleEthereumListener(), 10, 100);
+        PendingStateImpl pendingState = new PendingStateImpl(config, blockChain, blockChain.getRepository(), blockChain.getBlockStore(), new ProgramInvokeFactoryImpl(), new BlockExecutorTest.SimpleEthereumListener(), 10, 100);
         blockChain.setPendingState(pendingState);
 
         return pendingState;

--- a/rskj-core/src/test/java/co/rsk/datasource/DataSourcePoolTest.java
+++ b/rskj-core/src/test/java/co/rsk/datasource/DataSourcePoolTest.java
@@ -18,28 +18,37 @@
 
 package co.rsk.datasource;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.datasource.DataSourcePool;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Created by ajlopez on 26/07/2016.
  */
 public class DataSourcePoolTest {
+
+    private RskSystemProperties config;
+
+    @Before
+    public void setup(){
+        config = new RskSystemProperties();
+    }
+
     @Test
     public void openAndCloseDataSource() {
-        KeyValueDataSource dataSource = DataSourcePool.levelDbByName(ConfigHelper.CONFIG, "test1");
+        KeyValueDataSource dataSource = DataSourcePool.levelDbByName(config, "test1");
         dataSource.close();
     }
 
     @Test
     public void openUseAndCloseDataSource() {
-        KeyValueDataSource dataSource = DataSourcePool.levelDbByName(ConfigHelper.CONFIG, "test2");
+        KeyValueDataSource dataSource = DataSourcePool.levelDbByName(config, "test2");
         dataSource.put(new byte[] { 0x01 }, new byte[] { 0x02 });
         dataSource.close();
-        KeyValueDataSource dataSource2 = DataSourcePool.levelDbByName(ConfigHelper.CONFIG, "test2");
+        KeyValueDataSource dataSource2 = DataSourcePool.levelDbByName(config, "test2");
         byte[] result = dataSource2.get(new byte[] { 0x01 });
         Assert.assertNotNull(result);
         Assert.assertEquals(1, result.length);
@@ -49,8 +58,8 @@ public class DataSourcePoolTest {
 
     @Test
     public void openUseAndCloseDataSourceTwice() {
-        KeyValueDataSource dataSource = DataSourcePool.levelDbByName(ConfigHelper.CONFIG, "test3");
-        KeyValueDataSource dataSource2 = DataSourcePool.levelDbByName(ConfigHelper.CONFIG, "test3");
+        KeyValueDataSource dataSource = DataSourcePool.levelDbByName(config, "test3");
+        KeyValueDataSource dataSource2 = DataSourcePool.levelDbByName(config, "test3");
 
         Assert.assertSame(dataSource, dataSource2);
 
@@ -68,7 +77,7 @@ public class DataSourcePoolTest {
     @Test
     public void openAndCloseTenTimes() {
         for (int k = 0; k < 10; k++) {
-            KeyValueDataSource dataSource = DataSourcePool.levelDbByName(ConfigHelper.CONFIG, "test4");
+            KeyValueDataSource dataSource = DataSourcePool.levelDbByName(config, "test4");
             dataSource.put(new byte[] { (byte) k }, new byte[] { (byte) k });
             byte[] result = dataSource.get(new byte[] { (byte) k });
 

--- a/rskj-core/src/test/java/co/rsk/db/ContractDetailsImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/ContractDetailsImplTest.java
@@ -18,8 +18,11 @@
 
 package co.rsk.db;
 
-import co.rsk.config.ConfigHelper;
-import co.rsk.trie.*;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieImpl;
+import co.rsk.trie.TrieStore;
+import co.rsk.trie.TrieStoreImpl;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.ContractDetails;
 import org.ethereum.vm.DataWord;
@@ -37,32 +40,33 @@ import static org.ethereum.util.ByteUtil.toHexString;
  * Created by ajlopez on 05/04/2017.
  */
 public class ContractDetailsImplTest {
-    private static final int IN_MEMORY_STORAGE_LIMIT = ConfigHelper.CONFIG.detailsInMemoryStorageLimit();
+    private final RskSystemProperties config = new RskSystemProperties();
+    private final int IN_MEMORY_STORAGE_LIMIT = config.detailsInMemoryStorageLimit();
 
     @Test
     public void getNullFromUnusedAddress() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertEquals(null, details.get(DataWord.ONE));
     }
 
     @Test
     public void newContractDetailsIsClean() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertFalse(details.isDirty());
     }
 
     @Test
     public void hasNoExternalStorage() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertFalse(details.hasExternalStorage());
     }
 
     @Test
     public void hasExternalStorageIfHasEnoughtKeys() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
@@ -74,7 +78,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void hasExternalStorageIfHasEnoughtBytesKeys() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
@@ -86,7 +90,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void setDirty() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.setDirty(true);
         Assert.assertTrue(details.isDirty());
@@ -94,14 +98,14 @@ public class ContractDetailsImplTest {
 
     @Test
     public void newContractDetailsIsNotDeleted() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertFalse(details.isDeleted());
     }
 
     @Test
     public void setDeleted() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.setDeleted(true);
         Assert.assertTrue(details.isDeleted());
@@ -109,7 +113,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void putAndGetDataWord() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ONE, new DataWord(42));
 
@@ -120,7 +124,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void putDataWordWithoutLeadingZeroes() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ONE, new DataWord(42));
 
@@ -136,7 +140,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void putDataWordZeroAsDeleteValue() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ONE, new DataWord(42));
         details.put(DataWord.ONE, DataWord.ZERO);
@@ -151,7 +155,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getNullBytesFromUnusedAddress() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertNull(details.getBytes(DataWord.ONE));
     }
@@ -160,7 +164,7 @@ public class ContractDetailsImplTest {
     public void putAndGetBytes() {
         byte[] value = new byte[] { 0x01, 0x02, 0x03 };
 
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.putBytes(DataWord.ONE, value);
 
@@ -171,7 +175,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void putNullValueAsDeleteValue() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.putBytes(DataWord.ONE, new byte[] { 0x01, 0x02, 0x03 });
         details.putBytes(DataWord.ONE, null);
@@ -186,7 +190,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getStorageRoot() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ONE, new DataWord(42));
         details.put(DataWord.ZERO, new DataWord(1));
@@ -200,7 +204,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getNullCode() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertNull(details.getCode());
     }
@@ -209,7 +213,7 @@ public class ContractDetailsImplTest {
     public void setAndGetCode() {
         byte[] code = new byte[] { 0x01, 0x02, 0x03 };
 
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.setCode(code);
 
@@ -218,14 +222,14 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getStorageSizeInEmptyDetails() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertEquals(0, details.getStorageSize());
     }
 
     @Test
     public void getStorageSizeInNonEmptyDetails() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ZERO, DataWord.ONE);
         details.put(DataWord.ONE, new DataWord(42));
@@ -235,7 +239,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getStorageKeysInNonEmptyDetails() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ZERO, DataWord.ONE);
         details.put(DataWord.ONE, new DataWord(42));
@@ -250,7 +254,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getStorageKeysAfterDelete() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ZERO, DataWord.ONE);
         details.put(DataWord.ONE, new DataWord(42));
@@ -265,7 +269,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getStorageFromEmptyDetails() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Map<DataWord, DataWord> map = details.getStorage();
 
@@ -275,7 +279,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getStorageUsingNullFromEmptyDetails() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Map<DataWord, DataWord> map = details.getStorage(null);
 
@@ -285,7 +289,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getStorageFromNonEmptyDetails() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ZERO, DataWord.ONE);
         details.put(DataWord.ONE, new DataWord(42));
@@ -304,7 +308,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getStorageFromNonEmptyDetailsUsingKeys() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ZERO, DataWord.ONE);
         details.put(DataWord.ONE, new DataWord(42));
@@ -331,7 +335,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getNullAddress() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertNull(details.getAddress());
     }
@@ -340,7 +344,7 @@ public class ContractDetailsImplTest {
     public void setAndGetAddress() {
         byte[] address = new byte[] { 0x01, 0x02, 0x03 };
 
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.setAddress(address);
 
@@ -352,14 +356,14 @@ public class ContractDetailsImplTest {
 
     @Test
     public void newContractDetailsIsNullObject() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Assert.assertTrue(details.isNullObject());
     }
 
     @Test
     public void newContractDetailsWithEmptyCodeIsNullObject() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.setCode(new byte[0]);
 
@@ -368,7 +372,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void contractDetailsWithNonEmptyCodeIsNotNullObject() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.setCode(new byte[] { 0x01, 0x02, 0x03 });
 
@@ -377,7 +381,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void contractDetailsWithStorageDataIsNotNullObject() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.put(DataWord.ONE, new DataWord(42));
 
@@ -386,7 +390,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void setStorageUsingKeysAndValues() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         List<DataWord> keys = new ArrayList<>();
 
@@ -406,7 +410,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void setStorageUsingMap() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         Map<DataWord, DataWord> map = new HashMap<>();
 
@@ -421,7 +425,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getSnapshot() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         byte[] initialRoot = details.getStorageHash();
 
@@ -468,7 +472,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void getEncodedAndCreateClone() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         List<DataWord> keys = new ArrayList<>();
 
@@ -488,7 +492,7 @@ public class ContractDetailsImplTest {
 
         Assert.assertNotNull(encoded);
 
-        ContractDetailsImpl result = new ContractDetailsImpl(ConfigHelper.CONFIG, encoded);
+        ContractDetailsImpl result = new ContractDetailsImpl(config, encoded);
 
         Assert.assertEquals(new DataWord(42), result.get(DataWord.ZERO));
         Assert.assertEquals(new DataWord(144), result.get(DataWord.ONE));
@@ -498,7 +502,7 @@ public class ContractDetailsImplTest {
 
     @Test
     public void syncStorageInEmptyDetails() {
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(config);
 
         details.syncStorage();
     }
@@ -508,7 +512,7 @@ public class ContractDetailsImplTest {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
         Trie trie = new TrieImpl(store, false);
         byte[] accountAddress = randomAddress();
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG, accountAddress, trie, null);
+        ContractDetailsImpl details = new ContractDetailsImpl(config, accountAddress, trie, null);
 
         details.put(new DataWord(42), DataWord.ONE);
 
@@ -522,7 +526,7 @@ public class ContractDetailsImplTest {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
         Trie trie = new TrieImpl(store, false);
         byte[] accountAddress = randomAddress();
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG, accountAddress, trie, null);
+        ContractDetailsImpl details = new ContractDetailsImpl(config, accountAddress, trie, null);
 
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
@@ -533,8 +537,8 @@ public class ContractDetailsImplTest {
 
         details.syncStorage();
 
-        ContractDetailsImpl details1 = new ContractDetailsImpl(ConfigHelper.CONFIG, details.getEncoded());
-        ContractDetailsImpl details2 = new ContractDetailsImpl(ConfigHelper.CONFIG, details.getEncoded());
+        ContractDetailsImpl details1 = new ContractDetailsImpl(config, details.getEncoded());
+        ContractDetailsImpl details2 = new ContractDetailsImpl(config, details.getEncoded());
 
         Assert.assertTrue(details1.hasExternalStorage());
         Assert.assertTrue(details2.hasExternalStorage());
@@ -553,7 +557,7 @@ public class ContractDetailsImplTest {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
         Trie trie = new TrieImpl(store, false);
         byte[] accountAddress = randomAddress();
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG, accountAddress, trie, null);
+        ContractDetailsImpl details = new ContractDetailsImpl(config, accountAddress, trie, null);
 
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
@@ -566,14 +570,14 @@ public class ContractDetailsImplTest {
 
         int ssize = details.getStorageSize();
 
-        details = new ContractDetailsImpl(ConfigHelper.CONFIG, details.getEncoded());
+        details = new ContractDetailsImpl(config, details.getEncoded());
 
         Assert.assertEquals(ssize, details.getStorageSize());
 
         for (int k = 1; k <= nkeys + 1; k++)
             Assert.assertNotNull(details.get(new DataWord(k)));
 
-        ContractDetailsImpl clone = new ContractDetailsImpl(ConfigHelper.CONFIG, details.getEncoded());
+        ContractDetailsImpl clone = new ContractDetailsImpl(config, details.getEncoded());
 
         Assert.assertNotNull(clone);
         Assert.assertTrue(clone.hasExternalStorage());
@@ -598,7 +602,7 @@ public class ContractDetailsImplTest {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
         Trie trie = new TrieImpl(store, false);
         byte[] accountAddress = randomAddress();
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG, accountAddress, trie, null);
+        ContractDetailsImpl details = new ContractDetailsImpl(config, accountAddress, trie, null);
 
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
@@ -612,7 +616,7 @@ public class ContractDetailsImplTest {
         for (int k = 1; k <= nkeys + 1; k++)
             Assert.assertNotNull(details.get(new DataWord(k)));
 
-        ContractDetailsImpl clone = new ContractDetailsImpl(ConfigHelper.CONFIG, details.getEncoded());
+        ContractDetailsImpl clone = new ContractDetailsImpl(config, details.getEncoded());
 
         Assert.assertNotNull(clone);
         Assert.assertTrue(clone.hasExternalStorage());
@@ -640,7 +644,7 @@ public class ContractDetailsImplTest {
 
         HashMapDB externalStorage = new HashMapDB();
 
-        ContractDetailsImpl original = new ContractDetailsImpl(ConfigHelper.CONFIG, address, new TrieImpl(new TrieStoreImpl(externalStorage), true), code);
+        ContractDetailsImpl original = new ContractDetailsImpl(config, address, new TrieImpl(new TrieStoreImpl(externalStorage), true), code);
 
         for (int i = 0; i < IN_MEMORY_STORAGE_LIMIT + 10; i++) {
             DataWord key = randomDataWord();
@@ -654,7 +658,7 @@ public class ContractDetailsImplTest {
 
         byte[] rlp = original.getEncoded();
 
-        ContractDetailsImpl deserialized = new ContractDetailsImpl(ConfigHelper.CONFIG, rlp);
+        ContractDetailsImpl deserialized = new ContractDetailsImpl(config, rlp);
 
         Assert.assertEquals(toHexString(address), toHexString(deserialized.getAddress()));
         Assert.assertEquals(toHexString(code), toHexString(deserialized.getCode()));
@@ -679,7 +683,7 @@ public class ContractDetailsImplTest {
 
         HashMapDB externalStorage = new HashMapDB();
 
-        ContractDetailsImpl original = new ContractDetailsImpl(ConfigHelper.CONFIG, address, new TrieImpl(new TrieStoreImpl(externalStorage), true), code);
+        ContractDetailsImpl original = new ContractDetailsImpl(config, address, new TrieImpl(new TrieStoreImpl(externalStorage), true), code);
 
         for (int i = 0; i < IN_MEMORY_STORAGE_LIMIT - 1; i++) {
             DataWord key = randomDataWord();
@@ -691,7 +695,7 @@ public class ContractDetailsImplTest {
 
         original.syncStorage();
 
-        ContractDetails deserialized = new ContractDetailsImpl(ConfigHelper.CONFIG, original.getEncoded());
+        ContractDetails deserialized = new ContractDetailsImpl(config, original.getEncoded());
 
         // adds keys for in-memory storage limit overflow
         for (int i = 0; i < 10; i++) {
@@ -704,7 +708,7 @@ public class ContractDetailsImplTest {
 
         deserialized.syncStorage();
 
-        deserialized = new ContractDetailsImpl(ConfigHelper.CONFIG, deserialized.getEncoded());
+        deserialized = new ContractDetailsImpl(config, deserialized.getEncoded());
 
         Map<DataWord, DataWord> storage = deserialized.getStorage();
         Assert.assertEquals(elements.size(), storage.size());
@@ -724,14 +728,14 @@ public class ContractDetailsImplTest {
         byte[] key_2 = Hex.decode("222222");
         byte[] val_2 = Hex.decode("bbbbbb");
 
-        ContractDetailsImpl contractDetails = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl contractDetails = new ContractDetailsImpl(config);
         contractDetails.setCode(code);
         contractDetails.put(new DataWord(key_1), new DataWord(val_1));
         contractDetails.put(new DataWord(key_2), new DataWord(val_2));
 
         byte[] data = contractDetails.getEncoded();
 
-        ContractDetailsImpl contractDetails_ = new ContractDetailsImpl(ConfigHelper.CONFIG, data);
+        ContractDetailsImpl contractDetails_ = new ContractDetailsImpl(config, data);
 
         Assert.assertEquals(Hex.toHexString(code),
                 Hex.toHexString(contractDetails_.getCode()));
@@ -792,7 +796,7 @@ public class ContractDetailsImplTest {
         byte[] val_13 = Hex.decode("0000000000000000000000000c6686f3d6ee27e285f2de7b68e8db25cf1b1063");
 
 
-        ContractDetailsImpl contractDetails = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl contractDetails = new ContractDetailsImpl(config);
         contractDetails.setCode(code);
         contractDetails.setAddress(address);
         contractDetails.put(new DataWord(key_0), new DataWord(val_0));
@@ -812,7 +816,7 @@ public class ContractDetailsImplTest {
 
         byte[] data = contractDetails.getEncoded();
 
-        ContractDetailsImpl contractDetails_ = new ContractDetailsImpl(ConfigHelper.CONFIG, data);
+        ContractDetailsImpl contractDetails_ = new ContractDetailsImpl(config, data);
 
         Assert.assertEquals(Hex.toHexString(code),
                 Hex.toHexString(contractDetails_.getCode()));

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplForTesting.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplForTesting.java
@@ -18,7 +18,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.AccountState;
 import org.ethereum.db.ContractDetails;
@@ -29,7 +29,7 @@ import org.ethereum.vm.DataWord;
  */
 public class RepositoryImplForTesting extends RepositoryImpl {
     public RepositoryImplForTesting() {
-        super(ConfigHelper.CONFIG);
+        super(new RskSystemProperties());
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
@@ -19,7 +19,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
@@ -53,10 +53,11 @@ public class RepositoryImplOriginalTest {
 
     public static final RskAddress COW = new RskAddress("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
     public static final RskAddress HORSE = new RskAddress("13978AEE95F38490E9769C39B2773ED763D9CD5F");
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void test1() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         repository.increaseNonce(COW);
         repository.increaseNonce(HORSE);
@@ -70,7 +71,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test2() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         repository.addBalance(COW, BigInteger.TEN);
         repository.addBalance(HORSE, BigInteger.ONE);
@@ -83,7 +84,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test3() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cowCode = Hex.decode("A1A2A3");
         byte[] horseCode = Hex.decode("B1B2B3");
@@ -99,7 +100,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test4() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         byte[] cowKey = Hex.decode("A1A2A3");
@@ -120,7 +121,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test5() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         Repository track = repository.startTracking();
 
@@ -147,7 +148,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test6() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         track.increaseNonce(COW);
@@ -176,7 +177,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test7() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         track.addBalance(COW, BigInteger.TEN);
@@ -195,7 +196,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test8() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         track.addBalance(COW, BigInteger.TEN);
@@ -214,7 +215,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test7_1() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track1 = repository.startTracking();
 
         track1.addBalance(COW, BigInteger.TEN);
@@ -244,7 +245,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test7_2() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track1 = repository.startTracking();
 
         track1.addBalance(COW, BigInteger.TEN);
@@ -274,7 +275,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test9() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         DataWord cowKey = new DataWord(Hex.decode("A1A2A3"));
@@ -299,7 +300,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test10() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         DataWord cowKey = new DataWord(Hex.decode("A1A2A3"));
@@ -325,7 +326,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test11() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         byte[] cowCode = Hex.decode("A1A2A3");
@@ -347,7 +348,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test12() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         byte[] cowCode = Hex.decode("A1A2A3");
@@ -369,10 +370,10 @@ public class RepositoryImplOriginalTest {
 
     @Test  // Let's upload genesis pre-mine just like in the real world
     public void test13() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Genesis genesis = (Genesis)Genesis.getInstance(ConfigHelper.CONFIG);
+        Genesis genesis = (Genesis)Genesis.getInstance(config);
         for (ByteArrayWrapper key : genesis.getPremine().keySet()) {
             repository.createAccount(new RskAddress(key.getData()));
             repository.addBalance(new RskAddress(key.getData()), genesis.getPremine().get(key).getAccountState().getBalance());
@@ -388,7 +389,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test14() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         final BigInteger ELEVEN = BigInteger.TEN.add(BigInteger.ONE);
 
@@ -421,7 +422,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test15() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         final BigInteger ELEVEN = BigInteger.TEN.add(BigInteger.ONE);
 
@@ -453,7 +454,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test16() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cowKey1 = "key-c-1".getBytes();
         byte[] cowValue1 = "val-c-1".getBytes();
@@ -509,7 +510,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test16_2() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cowKey1 = "key-c-1".getBytes();
         byte[] cowValue1 = "val-c-1".getBytes();
@@ -560,7 +561,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test16_3() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cowKey1 = "key-c-1".getBytes();
         byte[] cowValue1 = "val-c-1".getBytes();
@@ -611,7 +612,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test16_4() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cowKey1 = "key-c-1".getBytes();
         byte[] cowValue1 = "val-c-1".getBytes();
@@ -652,7 +653,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test16_5() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cowKey1 = "key-c-1".getBytes();
         byte[] cowValue1 = "val-c-1".getBytes();
@@ -689,7 +690,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test17() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cowKey1 = "key-c-1".getBytes();
         byte[] cowValue1 = "val-c-1".getBytes();
@@ -713,7 +714,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test18() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository repoTrack2 = repository.startTracking(); //track
 
         RskAddress pig = new RskAddress("F0B8C9D84DD2B877E0B952130B73E218106FEC04");
@@ -735,7 +736,7 @@ public class RepositoryImplOriginalTest {
 
     @Test
     public void test19() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         DataWord cowKey1 = new DataWord("c1");
@@ -777,7 +778,7 @@ public class RepositoryImplOriginalTest {
     @Test // testing for snapshot
     public void test20() {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, store);
+        Repository repository = new RepositoryImpl(config, store);
         byte[] root = repository.getRoot();
 
         DataWord cowKey1 = new DataWord("c1");
@@ -834,7 +835,7 @@ public class RepositoryImplOriginalTest {
     @Test // testing for snapshot
     public void testMultiThread() throws InterruptedException {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
-        final Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, store);
+        final Repository repository = new RepositoryImpl(config, store);
 
         final DataWord cowKey1 = new DataWord("c1");
         final DataWord cowKey2 = new DataWord("c2");

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.trie.TrieImplHashTest;
 import co.rsk.trie.TrieStore;
@@ -40,10 +40,11 @@ import java.util.Set;
  */
 public class RepositoryImplTest {
     private static byte[] emptyHash = TrieImplHashTest.makeEmptyHash();
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void getNonceUnknownAccount() {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
         BigInteger nonce = repository.getNonce(randomAccountAddress());
 
         Assert.assertEquals(BigInteger.ZERO, nonce);
@@ -51,21 +52,21 @@ public class RepositoryImplTest {
 
     @Test
     public void isNotClosedWhenCreated() {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Assert.assertFalse(repository.isClosed());
     }
 
     @Test
     public void hasEmptyHashAsRootWhenCreated() {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Assert.assertArrayEquals(emptyHash, repository.getRoot());
     }
 
     @Test
     public void createAccount() {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         AccountState accState = repository.createAccount(randomAccountAddress());
 
@@ -79,7 +80,7 @@ public class RepositoryImplTest {
     @Test
     public void syncToRootAfterCreatingAnAccount() {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG, store);
+        RepositoryImpl repository = new RepositoryImpl(config, store);
 
         repository.flush();
 
@@ -106,7 +107,7 @@ public class RepositoryImplTest {
     public void updateAccountState() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         AccountState accState = repository.createAccount(accAddress);
 
@@ -125,7 +126,7 @@ public class RepositoryImplTest {
     public void incrementAccountNonceForNewAccount() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.increaseNonce(accAddress);
 
@@ -136,7 +137,7 @@ public class RepositoryImplTest {
     public void incrementAccountNonceForAlreadyCreatedAccount() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
         repository.increaseNonce(accAddress);
@@ -148,7 +149,7 @@ public class RepositoryImplTest {
     public void incrementAccountNonceTwiceForAlreadyCreatedAccount() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
         repository.increaseNonce(accAddress);
@@ -161,7 +162,7 @@ public class RepositoryImplTest {
     public void incrementAccountBalanceForNewAccount() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Assert.assertEquals(BigInteger.ONE, repository.addBalance(accAddress, BigInteger.ONE));
 
@@ -172,7 +173,7 @@ public class RepositoryImplTest {
     public void incrementAccountBalanceForAlreadyCreatedAccount() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
         Assert.assertEquals(BigInteger.ONE, repository.addBalance(accAddress, BigInteger.ONE));
@@ -184,7 +185,7 @@ public class RepositoryImplTest {
     public void incrementAccountBalanceTwiceForAlreadyCreatedAccount() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
         Assert.assertEquals(BigInteger.ONE, repository.addBalance(accAddress, BigInteger.ONE));
@@ -195,7 +196,7 @@ public class RepositoryImplTest {
 
     @Test
     public void isExistReturnsFalseForUnknownAccount() {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Assert.assertFalse(repository.isExist(randomAccountAddress()));
     }
@@ -204,7 +205,7 @@ public class RepositoryImplTest {
     public void isExistReturnsTrueForCreatedAccount() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
 
@@ -213,7 +214,7 @@ public class RepositoryImplTest {
 
     @Test
     public void getCodeFromUnknownAccount() {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         byte[] code = repository.getCode(randomAccountAddress());
 
@@ -225,7 +226,7 @@ public class RepositoryImplTest {
     public void getCodeFromAccountWithoutCode() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
 
@@ -240,7 +241,7 @@ public class RepositoryImplTest {
         RskAddress accAddress = randomAccountAddress();
         byte[] accCode = new byte[] { 0x01, 0x02, 0x03 };
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
 
@@ -256,7 +257,7 @@ public class RepositoryImplTest {
     public void hibernateAccount() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
         repository.hibernate(accAddress);
@@ -272,7 +273,7 @@ public class RepositoryImplTest {
         RskAddress accAddress = randomAccountAddress();
         byte[] accCode = new byte[] { 0x01, 0x02, 0x03 };
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
 
@@ -287,7 +288,7 @@ public class RepositoryImplTest {
 
     @Test
     public void startTracking() {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Repository track = repository.startTracking();
 
@@ -297,7 +298,7 @@ public class RepositoryImplTest {
     @Test
     public void createAccountInTrackAndCommit() {
         RskAddress accAddress = randomAccountAddress();
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Repository track = repository.startTracking();
 
@@ -311,7 +312,7 @@ public class RepositoryImplTest {
     @Test
     public void createAccountInTrackAndRollback() {
         RskAddress accAddress = randomAccountAddress();
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Repository track = repository.startTracking();
 
@@ -326,7 +327,7 @@ public class RepositoryImplTest {
     public void getEmptyStorageValue() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress);
         DataWord value = repository.getStorageValue(accAddress, DataWord.ONE);
@@ -338,7 +339,7 @@ public class RepositoryImplTest {
     public void setAndGetStorageValue() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.addStorageRow(accAddress, DataWord.ONE, DataWord.ONE);
 
@@ -366,7 +367,7 @@ public class RepositoryImplTest {
     public void setAndGetStorageValueUsingTrack() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Repository track = repository.startTracking();
 
@@ -383,7 +384,7 @@ public class RepositoryImplTest {
     public void getEmptyStorageBytes() {
         RskAddress accAddress = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         byte[] bytes = repository.getStorageBytes(accAddress, DataWord.ONE);
 
@@ -395,7 +396,7 @@ public class RepositoryImplTest {
         RskAddress accAddress = randomAccountAddress();
         byte[] bytes = new byte[] { 0x01, 0x02, 0x03 };
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Repository track = repository.startTracking();
         track.addStorageBytes(accAddress, DataWord.ONE, bytes);
@@ -410,7 +411,7 @@ public class RepositoryImplTest {
     @Test
     public void emptyAccountsKeysOnNonExistentAccount()
     {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Set<RskAddress> keys = repository.getAccountsKeys();
 
@@ -424,7 +425,7 @@ public class RepositoryImplTest {
         RskAddress accAddress1 = randomAccountAddress();
         RskAddress accAddress2 = randomAccountAddress();
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         repository.createAccount(accAddress1);
         repository.createAccount(accAddress2);
@@ -443,7 +444,7 @@ public class RepositoryImplTest {
         RskAddress accAddress2 = randomAccountAddress();
 
         TrieStore store = new TrieStoreImpl(new HashMapDB());
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG, store);
+        RepositoryImpl repository = new RepositoryImpl(config, store);
 
         repository.createAccount(accAddress1);
         repository.flush();
@@ -463,7 +464,7 @@ public class RepositoryImplTest {
 
     @Test
     public void getDetailsDataStore() {
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
 
         Assert.assertNotNull(repository.getDetailsDataStore());
     }
@@ -471,7 +472,7 @@ public class RepositoryImplTest {
     @Test
     public void flushNoReconnect() {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG, store);
+        RepositoryImpl repository = new RepositoryImpl(config, store);
 
         RskAddress accAddress = randomAccountAddress();
         byte[] initialRoot = repository.getRoot();

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
@@ -48,11 +48,12 @@ public class RepositoryTest {
 
     public static final RskAddress COW = new RskAddress("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
     public static final RskAddress HORSE = new RskAddress("13978AEE95F38490E9769C39B2773ED763D9CD5F");
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void test4() {
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         byte[] cowKey = Hex.decode("A1A2A3");
@@ -74,7 +75,7 @@ public class RepositoryTest {
     @Test
     public void test9() {
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -103,7 +104,7 @@ public class RepositoryTest {
     @Test
     public void test10() {
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -131,7 +132,7 @@ public class RepositoryTest {
 
     @Test
     public void test16() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -190,7 +191,7 @@ public class RepositoryTest {
 
     @Test
     public void test16_2() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -255,7 +256,7 @@ public class RepositoryTest {
 
     @Test
     public void test16_3() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -309,7 +310,7 @@ public class RepositoryTest {
 
     @Test
     public void test16_4() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -351,7 +352,7 @@ public class RepositoryTest {
 
     @Test
     public void test16_5() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
@@ -391,7 +392,7 @@ public class RepositoryTest {
 
     @Test
     public void test17() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
 
@@ -417,7 +418,7 @@ public class RepositoryTest {
 
     @Test
     public void test19() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -461,7 +462,7 @@ public class RepositoryTest {
 
     @Test
     public void test19b() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
@@ -506,7 +507,7 @@ public class RepositoryTest {
     @Test // testing for snapshot
     public void testMultiThread() throws InterruptedException {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
-        final Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, store);
+        final Repository repository = new RepositoryImpl(config, store);
 
         final byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
 

--- a/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
+++ b/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
@@ -26,10 +26,7 @@ import org.ethereum.jsontestsuite.DifficultyTestCase;
 import org.ethereum.jsontestsuite.DifficultyTestSuite;
 import org.ethereum.jsontestsuite.JSONReader;
 import org.json.simple.parser.ParseException;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,23 +39,15 @@ import static org.junit.Assert.assertEquals;
  * @author Angel J Lopez
  * @since 02.23.2016
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class LocalBasicTest {
 
     private static final Logger logger = LoggerFactory.getLogger("TCK-Test");
-    private RskSystemProperties config;
-
-    @Before
-    public void setup() {
-        // if not set explicitly
-        // this test fails being run by Gradle
-        config = new RskSystemProperties();
-        config.setGenesisInfo("frontier.json");
-        config.setBlockchainConfig(new MainNetConfig());
-    }
+    private RskSystemProperties config = new RskSystemProperties();;
 
     @Test
     public void runDifficultyTest() throws IOException, ParseException {
+        config.setGenesisInfo("frontier.json");
+        config.setBlockchainConfig(new MainNetConfig());
 
         String json = getJSON("difficulty");
 

--- a/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
+++ b/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
@@ -18,16 +18,14 @@
 
 package co.rsk.jsontestsuite;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
-import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.net.MainNetConfig;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.jsontestsuite.DifficultyTestCase;
 import org.ethereum.jsontestsuite.DifficultyTestSuite;
 import org.ethereum.jsontestsuite.JSONReader;
 import org.json.simple.parser.ParseException;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -48,23 +46,16 @@ import static org.junit.Assert.assertEquals;
 public class LocalBasicTest {
 
     private static final Logger logger = LoggerFactory.getLogger("TCK-Test");
-    private BlockchainNetConfig originalBlockchainConfig;
+    private RskSystemProperties config;
 
     @Before
     public void setup() {
         // if not set explicitly
         // this test fails being run by Gradle
-        ConfigHelper.CONFIG.setGenesisInfo("frontier.json");
-
-        originalBlockchainConfig = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
+        config = new RskSystemProperties();
+        config.setGenesisInfo("frontier.json");
+        config.setBlockchainConfig(new MainNetConfig());
     }
-
-    @After
-    public void tearDown() {
-        ConfigHelper.CONFIG.setBlockchainConfig(originalBlockchainConfig);
-    }
-
 
     @Test
     public void runDifficultyTest() throws IOException, ParseException {
@@ -79,7 +70,7 @@ public class LocalBasicTest {
 
             BlockHeader current = testCase.getCurrent();
             BlockHeader parent = testCase.getParent();
-            BigInteger calc = new DifficultyCalculator(ConfigHelper.CONFIG).calcDifficulty(current, parent);
+            BigInteger calc = new DifficultyCalculator(config).calcDifficulty(current, parent);
             int c = calc.compareTo(parent.getDifficultyBI());
             if (c>0)
                 logger.info(" Difficulty increase test\n");

--- a/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBlockTest.java
@@ -18,11 +18,14 @@
 
 package co.rsk.jsontestsuite;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.jsontestsuite.GitHubJSONTestSuite;
 import org.ethereum.jsontestsuite.JSONReader;
 import org.json.simple.parser.ParseException;
-import org.junit.*;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
@@ -35,10 +38,11 @@ import java.util.Collections;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class LocalBlockTest {
     private ClassLoader loader = LocalBlockTest.class.getClassLoader();
+    private static RskSystemProperties config = new RskSystemProperties();
 
     @BeforeClass
     public static void init() {
-        ConfigHelper.CONFIG.disableRemasc();
+        config.disableRemasc();
     }
 
     private void run(String name) throws IOException, ParseException {
@@ -49,7 +53,7 @@ public class LocalBlockTest {
     @Ignore // to fix after adding prefix to tx raw encode
     @Test
     public void runSingleTest() throws ParseException, IOException {
-        ConfigHelper.CONFIG.setGenesisInfo("frontier.json");
+        config.setGenesisInfo("frontier.json");
 
         String json = JSONReader.loadJSONFromResource("json/BlockchainTests/bcValidBlockTest.json", loader);
         GitHubJSONTestSuite.runGitHubJsonSingleBlockTest(json, "RecallSuicidedContractInOneBlock");
@@ -88,7 +92,7 @@ public class LocalBlockTest {
     @Test
     @Ignore
     public void runBCValidBlockTest() throws ParseException, IOException {
-        ConfigHelper.CONFIG.setGenesisInfo("frontier.json");
+        config.setGenesisInfo("frontier.json");
         run("bcValidBlockTest");
     }
 
@@ -145,11 +149,4 @@ public class LocalBlockTest {
     public void runBCMultiChainTest() throws ParseException, IOException {
         run("bcMultiChainTest");
     }
-
-    @AfterClass
-    public static void destroy() {
-        ConfigHelper.CONFIG.enableRemasc();
-    }
-
-
 }

--- a/rskj-core/src/test/java/co/rsk/mine/GasLimitCalculatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/GasLimitCalculatorTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.mine;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.config.Constants;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.validator.ParentGasLimitRule;
@@ -34,15 +34,16 @@ import static org.ethereum.validator.ParentGasLimitRuleTest.getHeader;
  */
 public class GasLimitCalculatorTest {
 
+    private final RskSystemProperties config = new RskSystemProperties();
     private Constants constants = new Constants();
     private ParentGasLimitRule rule = new ParentGasLimitRule(1024);
 
     @Test
     public void NextBlockGasLimitIsDecreasedByAFactor() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger minGasLimit = BigInteger.valueOf(constants.getMinGasLimit());
         BigInteger parentGasLimit = minGasLimit.add(BigInteger.valueOf(21000));
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
 
         BigInteger newGasLimit = calc.calculateBlockGasLimit(parentGasLimit, BigInteger.ZERO, minGasLimit, targetGasLimit, false);
 
@@ -53,9 +54,9 @@ public class GasLimitCalculatorTest {
 
     @Test
     public void NextBlockGasLimitIsNotDecreasedLowerThanMinGasLimit() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger minGasLimit = BigInteger.valueOf(constants.getMinGasLimit());
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
         BigInteger newGasLimit = calc.calculateBlockGasLimit(minGasLimit, BigInteger.ZERO, minGasLimit, targetGasLimit, false);
 
         Assert.assertTrue(newGasLimit.compareTo(minGasLimit) == 0);
@@ -63,10 +64,10 @@ public class GasLimitCalculatorTest {
 
     @Test
     public void NextBlockGasLimitIsIncreasedBasedOnGasUsed() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger parentGas = BigInteger.valueOf(3500000);
         BigInteger gasUsed = BigInteger.valueOf(3000000);
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
 
         BigInteger newGasLimit = calc.calculateBlockGasLimit(parentGas, gasUsed, BigInteger.ZERO, targetGasLimit, false);
 
@@ -77,10 +78,10 @@ public class GasLimitCalculatorTest {
 
     @Test
     public void NextBlockGasLimitIsIncreasedBasedOnFullGasUsed() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger parentGas = BigInteger.valueOf(3500000);
         BigInteger gasUsed = BigInteger.valueOf(3500000);
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
 
         BigInteger newGasLimit = calc.calculateBlockGasLimit(parentGas, gasUsed, BigInteger.ZERO, targetGasLimit, false);
 
@@ -90,8 +91,8 @@ public class GasLimitCalculatorTest {
     }
     @Test
     public void NextBlockGasLimitIsNotIncreasedMoreThanTargetGasLimit() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        GasLimitCalculator calc = new GasLimitCalculator(config);
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
         BigInteger gasUsed = targetGasLimit;
 
         BigInteger newGasLimit = calc.calculateBlockGasLimit(targetGasLimit, gasUsed, BigInteger.ZERO, targetGasLimit, false);
@@ -101,9 +102,9 @@ public class GasLimitCalculatorTest {
 
     @Test
     public void NextBlockGasLimitRemainsTheSame() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
-        BigInteger minGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        GasLimitCalculator calc = new GasLimitCalculator(config);
+        BigInteger minGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
         BigInteger newGasLimit = calc.calculateBlockGasLimit(targetGasLimit, BigInteger.ZERO, minGasLimit, targetGasLimit, true);
         Assert.assertTrue(newGasLimit.compareTo(targetGasLimit) == 0);
         Assert.assertTrue(validByConsensus(newGasLimit, targetGasLimit));
@@ -111,9 +112,9 @@ public class GasLimitCalculatorTest {
 
     @Test
     public void NextBlockGasLimitIsIncreasedByMaximumValue() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger minGasLimit = BigInteger.valueOf(constants.getMinGasLimit());
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
         BigInteger newGasLimit = calc.calculateBlockGasLimit(minGasLimit, BigInteger.ZERO, minGasLimit, targetGasLimit, true);
         BigInteger newGasLimit2 = calc.calculateBlockGasLimit(minGasLimit, minGasLimit, minGasLimit, targetGasLimit, true);
         Assert.assertTrue(newGasLimit.compareTo(newGasLimit2) == 0);
@@ -125,7 +126,7 @@ public class GasLimitCalculatorTest {
 
     @Test
     public void NextBlockGasLimitIsIncreasedToTarget() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger minGasLimit = BigInteger.valueOf(constants.getMinGasLimit());
         BigInteger targetGasLimit = minGasLimit.add(BigInteger.ONE);
         BigInteger newGasLimit = calc.calculateBlockGasLimit(minGasLimit, BigInteger.ZERO, minGasLimit, targetGasLimit, true);
@@ -138,7 +139,7 @@ public class GasLimitCalculatorTest {
 
     @Test
     public void NextBlockGasLimitIsDecreasedToTarget() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger minGasLimit = BigInteger.valueOf(constants.getMinGasLimit());
         BigInteger targetGasLimit = minGasLimit.add(BigInteger.ONE);
         BigInteger usedGas = targetGasLimit.add(BigInteger.ONE);
@@ -152,7 +153,7 @@ public class GasLimitCalculatorTest {
 
     @Test
     public void NextBlockGasLimitIsDecreasedToMinimum() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger minGasLimit = BigInteger.valueOf(constants.getMinGasLimit());
         BigInteger targetGasLimit = minGasLimit.subtract(BigInteger.ONE);
         BigInteger usedGas = minGasLimit.add(BigInteger.ONE);
@@ -165,9 +166,9 @@ public class GasLimitCalculatorTest {
     }
     @Test
     public void NextBlockGasLimitIsDecreasedByMaximumValue() {
-        GasLimitCalculator calc = new GasLimitCalculator(ConfigHelper.CONFIG);
+        GasLimitCalculator calc = new GasLimitCalculator(config);
         BigInteger minGasLimit = BigInteger.valueOf(constants.getMinGasLimit());
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
         BigInteger usedGas = targetGasLimit.multiply(BigInteger.valueOf(2));
         BigInteger newGasLimit = calc.calculateBlockGasLimit(usedGas, BigInteger.ZERO, minGasLimit, targetGasLimit, true);
         BigInteger newGasLimit2 = calc.calculateBlockGasLimit(usedGas, usedGas, minGasLimit, targetGasLimit, true);

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -2,7 +2,6 @@ package co.rsk.mine;
 
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.VerificationException;
-import co.rsk.config.ConfigHelper;
 import co.rsk.config.ConfigUtils;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
@@ -21,7 +20,10 @@ import org.ethereum.core.ImportResult;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.facade.EthereumImpl;
 import org.ethereum.rpc.TypeConverter;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
@@ -40,21 +42,18 @@ public class MainNetMinerTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
+    private RskSystemProperties config;
 
     @Before
     public void setup() {
-        oldConfig = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new FallbackMainNetConfig());
-        DIFFICULTY_CALCULATOR = new DifficultyCalculator(ConfigHelper.CONFIG);
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new FallbackMainNetConfig());
+        DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
         World world = new World();
         blockchain = world.getBlockChain();
 
     }
 
-    @After
-    public void clean() {
-        ConfigHelper.CONFIG.setBlockchainConfig(oldConfig);
-    }
     /*
      * This test is probabilistic, but it has a really high chance to pass. We will generate
      * a random block that it is unlikely to pass the Long.MAX_VALUE difficulty, though
@@ -74,9 +73,9 @@ public class MainNetMinerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, world.getBlockProcessor(), DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, world.getBlockProcessor(), DIFFICULTY_CALCULATOR,
+                new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         try {
             minerServer.start();
             MinerWork work = minerServer.getWork();
@@ -121,7 +120,7 @@ public class MainNetMinerTest {
 
         RskSystemProperties tempConfig = new RskSystemProperties() {
 
-            BlockchainNetConfig blockchainNetConfig = ConfigHelper.CONFIG.getBlockchainConfig();
+            BlockchainNetConfig blockchainNetConfig = config.getBlockchainConfig();
 
             @Override
             public String fallbackMiningKeysDir() {
@@ -166,7 +165,7 @@ public class MainNetMinerTest {
         MinerServer minerServer = new MinerServerImpl(tempConfig, ethereumImpl, blockchain, null,
                 blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
                 unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(ConfigHelper.CONFIG),
+                new GasLimitCalculator(config),
                 new ProofOfWorkRule(tempConfig).setFallbackMiningEnabled(true)
         );
         try {
@@ -236,12 +235,12 @@ public class MainNetMinerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, this.blockchain, null,
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, this.blockchain, null,
                 this.blockchain.getPendingState(), blockchain.getRepository(),
                 ConfigUtils.getDefaultMiningConfig(), unclesValidationRule,
                 world.getBlockProcessor(), DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         try {
         minerServer.start();
         MinerWork work = minerServer.getWork();

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -18,8 +18,8 @@
 
 package co.rsk.mine;
 
-import co.rsk.config.ConfigHelper;
 import co.rsk.config.ConfigUtils;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.RskImpl;
 import co.rsk.core.SnapshotManager;
@@ -43,6 +43,9 @@ import java.util.concurrent.Callable;
  * Created by ajlopez on 15/04/2017.
  */
 public class MinerManagerTest {
+
+    private static final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void mineBlockWhenStopped() {
         World world = new World();
@@ -352,7 +355,7 @@ public class MinerManagerTest {
     }
 
     private static MinerClientImpl getMinerClient(RskImplForTest rsk, MinerServerImpl minerServer) {
-        return new MinerClientImpl(rsk, minerServer, ConfigHelper.CONFIG);
+        return new MinerClientImpl(rsk, minerServer, config);
     }
 
     private static MinerServerImpl getMinerServer(Blockchain blockchain) {
@@ -361,12 +364,12 @@ public class MinerManagerTest {
         worldManager.setBlockchain(blockchain);
         ethereum.repository = blockchain.getRepository();
         ethereum.worldManager = worldManager;
-        DifficultyCalculator difficultyCalculator = new DifficultyCalculator(ConfigHelper.CONFIG);
-        return new MinerServerImpl(ConfigHelper.CONFIG, ethereum, blockchain, blockchain.getBlockStore(), blockchain.getPendingState(),
+        DifficultyCalculator difficultyCalculator = new DifficultyCalculator(config);
+        return new MinerServerImpl(config, ethereum, blockchain, blockchain.getBlockStore(), blockchain.getPendingState(),
                 blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
                 new BlockValidationRuleDummy(), worldManager.getNodeBlockProcessor(),
-                difficultyCalculator, new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                difficultyCalculator, new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
     }
 
     public static class BlockValidationRuleDummy implements BlockValidationRule {

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -69,7 +69,7 @@ public class MinerServerTest {
         Mockito.when(repository.getRoot()).thenReturn(blockchain.getRepository().getRoot());
         Mockito.when(repository.startTracking()).thenReturn(repository);
 
-        Transaction tx1 = Tx.create(0, 21000, 100, 0, 0, 0, new Random(0));
+        Transaction tx1 = Tx.create(ConfigHelper.CONFIG, 0, 21000, 100, 0, 0, 0, new Random(0));
         byte[] s1 = new byte[32];
         byte[] s2 = new byte[32];
         s1[0] = 0;

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -21,8 +21,8 @@ package co.rsk.mine;
 import co.rsk.TestHelpers.Tx;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.VerificationException;
-import co.rsk.config.ConfigHelper;
 import co.rsk.config.ConfigUtils;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.remasc.RemascTransaction;
@@ -51,7 +51,8 @@ import static org.junit.Assert.*;
  * Created by adrian.eidelman on 3/16/2016.
  */
 public class MinerServerTest {
-    public static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(ConfigHelper.CONFIG);
+    private static final RskSystemProperties config = new RskSystemProperties();
+    public static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
 
     private BlockChainImpl blockchain;
 
@@ -69,7 +70,7 @@ public class MinerServerTest {
         Mockito.when(repository.getRoot()).thenReturn(blockchain.getRepository().getRoot());
         Mockito.when(repository.startTracking()).thenReturn(repository);
 
-        Transaction tx1 = Tx.create(ConfigHelper.CONFIG, 0, 21000, 100, 0, 0, 0, new Random(0));
+        Transaction tx1 = Tx.create(config, 0, 21000, 100, 0, 0, 0, new Random(0));
         byte[] s1 = new byte[32];
         byte[] s2 = new byte[32];
         s1[0] = 0;
@@ -89,10 +90,10 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServerImpl minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, this.blockchain, null, localPendingState,
+        MinerServerImpl minerServer = new MinerServerImpl(config, ethereumImpl, this.blockchain, null, localPendingState,
                 repository, ConfigUtils.getDefaultMiningConfig(), unclesValidationRule,
-                null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
         Block blockAtHeightOne = minerServer.getBlocksWaitingforPoW().entrySet().iterator().next().getValue();
@@ -114,11 +115,11 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, blockchain, null,
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null,
                 blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
                 unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         try {
         byte[] extraData = ByteBuffer.allocate(4).putInt(1).array();
         minerServer.setExtraData(extraData);
@@ -161,11 +162,11 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, blockchain, null,
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null,
                 blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
                 unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         try {
         minerServer.start();
         MinerWork work = minerServer.getWork();
@@ -195,9 +196,9 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null, DIFFICULTY_CALCULATOR,
+                new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         minerServer.start();
         try {
@@ -215,9 +216,9 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null, DIFFICULTY_CALCULATOR,
+                new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         try {
         minerServer.start();
 
@@ -235,8 +236,8 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, this.blockchain, null, this.blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         minerServer.start();
         try {
@@ -258,8 +259,8 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(ConfigHelper.CONFIG, ethereumImpl, this.blockchain, null, blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, this.blockchain, null, blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(), unclesValidationRule, null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         try {
         minerServer.start();
 
@@ -281,9 +282,9 @@ public class MinerServerTest {
     public void getCurrentTimeInMilliseconds() {
         long current = System.currentTimeMillis() / 1000;
 
-        MinerServer server = new MinerServerImpl(ConfigHelper.CONFIG, null, null, null, null,
+        MinerServer server = new MinerServerImpl(config, null, null, null, null,
                 null, ConfigUtils.getDefaultMiningConfig(), null, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(ConfigHelper.CONFIG), new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new GasLimitCalculator(config), new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         long result = server.getCurrentTimeInSeconds();
 
@@ -295,10 +296,10 @@ public class MinerServerTest {
     public void increaseTime() {
         long current = System.currentTimeMillis() / 1000;
 
-        MinerServer server = new MinerServerImpl(ConfigHelper.CONFIG, null, null, null, null,
+        MinerServer server = new MinerServerImpl(config, null, null, null, null,
                 null, ConfigUtils.getDefaultMiningConfig(), null, null,
-                DIFFICULTY_CALCULATOR, new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                DIFFICULTY_CALCULATOR, new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         Assert.assertEquals(10, server.increaseTime(10));
 
@@ -312,8 +313,8 @@ public class MinerServerTest {
     public void increaseTimeUsingNegativeNumberHasNoEffect() {
         long current = System.currentTimeMillis() / 1000;
 
-        MinerServer server = new MinerServerImpl(ConfigHelper.CONFIG, null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null, null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        MinerServer server = new MinerServerImpl(config, null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null, null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         Assert.assertEquals(0, server.increaseTime(-10));
 
@@ -326,8 +327,8 @@ public class MinerServerTest {
     public void increaseTimeTwice() {
         long current = System.currentTimeMillis() / 1000;
 
-        MinerServer server = new MinerServerImpl(ConfigHelper.CONFIG, null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null, null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        MinerServer server = new MinerServerImpl(config, null, null, null, null, null, ConfigUtils.getDefaultMiningConfig(), null, null, DIFFICULTY_CALCULATOR, new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         Assert.assertEquals(5, server.increaseTime(5));
         Assert.assertEquals(10, server.increaseTime(5));

--- a/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
@@ -19,6 +19,7 @@
 package co.rsk.mine;
 
 import co.rsk.TestHelpers.Tx;
+import co.rsk.config.ConfigHelper;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.PendingState;
 import org.ethereum.core.Repository;
@@ -65,7 +66,7 @@ public class MinerUtilsTest {
 
     @Test
     public void validTransactionRepositoryNonceTest() {
-        Transaction tx = Tx.create(0, 50000, 5, 0, 0, 0, new Random(0));
+        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 5, 0, 0, 0, new Random(0));
         //Mockito.when(tx.checkGasPrice(Mockito.any(BigInteger.class))).thenReturn(true);
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
@@ -80,7 +81,7 @@ public class MinerUtilsTest {
 
     @Test
     public void validTransactionAccWrapNonceTest() {
-        Transaction tx = Tx.create(0, 50000, 5, 1, 0, 0, new Random(0));
+        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 5, 1, 0, 0, new Random(0));
         //Mockito.when(tx.checkGasPrice(Mockito.any(BigInteger.class))).thenReturn(true);
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
@@ -95,7 +96,7 @@ public class MinerUtilsTest {
 
     @Test
     public void invalidNonceTransactionTest() {
-        Transaction tx = Tx.create(0, 50000, 2, 0, 0, 0, new Random(0));
+        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 2, 0, 0, 0, new Random(0));
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Map<RskAddress, BigInteger> accountNounces = new HashMap();
@@ -111,7 +112,7 @@ public class MinerUtilsTest {
 
     @Test
     public void invalidGasPriceTransactionTest() {
-        Transaction tx = Tx.create(0, 50000, 1, 0, 0, 0, new Random(0));
+        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 1, 0, 0, 0, new Random(0));
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Map<RskAddress, BigInteger> accountNounces = new HashMap();
@@ -128,7 +129,7 @@ public class MinerUtilsTest {
 
     @Test
     public void harmfulTransactionTest() {
-        Transaction tx = Tx.create(0, 50000, 1, 0, 0, 0, new Random(0));
+        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 1, 0, 0, 0, new Random(0));
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Mockito.when(tx.getGasPrice()).thenReturn(null);

--- a/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
@@ -19,7 +19,7 @@
 package co.rsk.mine;
 
 import co.rsk.TestHelpers.Tx;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.PendingState;
 import org.ethereum.core.Repository;
@@ -33,6 +33,8 @@ import java.math.BigInteger;
 import java.util.*;
 
 public class MinerUtilsTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void getAllTransactionsTest() {
@@ -66,7 +68,7 @@ public class MinerUtilsTest {
 
     @Test
     public void validTransactionRepositoryNonceTest() {
-        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 5, 0, 0, 0, new Random(0));
+        Transaction tx = Tx.create(config, 0, 50000, 5, 0, 0, 0, new Random(0));
         //Mockito.when(tx.checkGasPrice(Mockito.any(BigInteger.class))).thenReturn(true);
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
@@ -81,7 +83,7 @@ public class MinerUtilsTest {
 
     @Test
     public void validTransactionAccWrapNonceTest() {
-        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 5, 1, 0, 0, new Random(0));
+        Transaction tx = Tx.create(config, 0, 50000, 5, 1, 0, 0, new Random(0));
         //Mockito.when(tx.checkGasPrice(Mockito.any(BigInteger.class))).thenReturn(true);
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
@@ -96,7 +98,7 @@ public class MinerUtilsTest {
 
     @Test
     public void invalidNonceTransactionTest() {
-        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 2, 0, 0, 0, new Random(0));
+        Transaction tx = Tx.create(config, 0, 50000, 2, 0, 0, 0, new Random(0));
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Map<RskAddress, BigInteger> accountNounces = new HashMap();
@@ -112,7 +114,7 @@ public class MinerUtilsTest {
 
     @Test
     public void invalidGasPriceTransactionTest() {
-        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 1, 0, 0, 0, new Random(0));
+        Transaction tx = Tx.create(config, 0, 50000, 1, 0, 0, 0, new Random(0));
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Map<RskAddress, BigInteger> accountNounces = new HashMap();
@@ -129,7 +131,7 @@ public class MinerUtilsTest {
 
     @Test
     public void harmfulTransactionTest() {
-        Transaction tx = Tx.create(ConfigHelper.CONFIG, 0, 50000, 1, 0, 0, 0, new Random(0));
+        Transaction tx = Tx.create(config, 0, 50000, 1, 0, 0, 0, new Random(0));
         List<Transaction> txs = new LinkedList<>();
         txs.add(tx);
         Mockito.when(tx.getGasPrice()).thenReturn(null);

--- a/rskj-core/src/test/java/co/rsk/mine/TxBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TxBuilderTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.mine;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.net.BlockProcessor;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -31,10 +31,12 @@ import java.math.BigInteger;
 
 public class TxBuilderTest {
 
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void createBasicTransaction() {
         SimpleEthereum rsk = new SimpleEthereum();
-        TxBuilder builder = new TxBuilder(ConfigHelper.CONFIG, rsk, null, (Repository) rsk.repository);
+        TxBuilder builder = new TxBuilder(config, rsk, null, (Repository) rsk.repository);
 
         BigInteger gasPrice = BigInteger.ONE;
         BigInteger gasLimit = BigInteger.valueOf(21000);
@@ -51,7 +53,7 @@ public class TxBuilderTest {
     public void createAndBroadcastTransaction() {
         SimpleEthereum rsk = new SimpleEthereum();
         BlockProcessor blockProcessor = Mockito.mock(BlockProcessor.class);
-        TxBuilder builder = new TxBuilder(ConfigHelper.CONFIG, rsk, blockProcessor, (Repository) rsk.repository);
+        TxBuilder builder = new TxBuilder(config, rsk, blockProcessor, (Repository) rsk.repository);
 
         BigInteger nonce = BigInteger.TEN;
 

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.net.handler.TxHandler;
 import co.rsk.net.handler.TxHandlerImpl;
@@ -46,7 +46,10 @@ import org.ethereum.manager.WorldManager;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
 import org.ethereum.util.RskMockFactory;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
@@ -64,16 +67,12 @@ import static org.mockito.Mockito.*;
  */
 public class NodeMessageHandlerTest {
     private static BlockchainNetConfig blockchainNetConfigOriginal;
+    private static RskSystemProperties config;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new RegTestConfig());
     }
 
     @Test
@@ -81,7 +80,7 @@ public class NodeMessageHandlerTest {
         SimpleMessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null, null, scoring, new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null, scoring, new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         Block block = BlockChainBuilder.ofSize(1, true).getBestBlock();
         Message message = new BlockMessage(block);
 
@@ -113,7 +112,7 @@ public class NodeMessageHandlerTest {
         SimpleMessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null,null, scoring, new DummyBlockValidationRule());
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null,null, scoring, new DummyBlockValidationRule());
         Block block = BlockGenerator.getInstance().getGenesisBlock();
         Message message = new BlockMessage(block);
 
@@ -134,8 +133,8 @@ public class NodeMessageHandlerTest {
         MessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null, null, scoring,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         Block block = BlockChainBuilder.ofSize(1, true).getBestBlock();
         Message message = new BlockMessage(block);
 
@@ -153,9 +152,9 @@ public class NodeMessageHandlerTest {
     @Test
     public void postBlockMessageUsingProcessor() throws InterruptedException, UnknownHostException {
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null, null,
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null,
                 null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         Block block = BlockChainBuilder.ofSize(1, true).getBestBlock();
         Message message = new BlockMessage(block);
 
@@ -178,9 +177,9 @@ public class NodeMessageHandlerTest {
         SimpleMessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null,
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null,
                 null, scoring,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         Block block = BlockChainBuilder.ofSize(1, true).getBestBlock();
         byte[] mergedMiningHeader = block.getBitcoinMergedMiningHeader();
         mergedMiningHeader[76] += 3; //change merged mining nonce.
@@ -206,7 +205,7 @@ public class NodeMessageHandlerTest {
         SimpleMessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null, null, scoring, new DummyBlockValidationRule());
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null, scoring, new DummyBlockValidationRule());
         Block block = BlockGenerator.getInstance().getGenesisBlock();
 
         for (int i = 0; i < 50; i++) {
@@ -233,8 +232,8 @@ public class NodeMessageHandlerTest {
     @Test
     public void processFutureBlockMessageUsingProcessor() throws UnknownHostException {
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null, null, null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         Block block = BlockGenerator.getInstance().getGenesisBlock();
         Message message = new BlockMessage(block);
         SimpleMessageChannel sender = new SimpleMessageChannel();
@@ -254,8 +253,8 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         final SimpleMessageChannel sender = new SimpleMessageChannel();
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null, null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         final Block block = BlockGenerator.getInstance().createChildBlock(BlockGenerator.getInstance().getGenesisBlock());
         final Status status = new Status(block.getNumber(), block.getHash());
@@ -308,9 +307,9 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         final SimpleMessageChannel sender = new SimpleMessageChannel();
-        final SyncProcessor syncProcessor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), null);
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, syncProcessor, null, null, null, null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), null);
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, syncProcessor, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         final Block block = BlockGenerator.getInstance().createChildBlock(BlockGenerator.getInstance().getGenesisBlock());
         final Status status = new Status(block.getNumber(), block.getHash(), block.getParentHash(), blockchain.getTotalDifficulty());
@@ -338,8 +337,8 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null,
-                null, new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
+                null, new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -373,9 +372,9 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null,
+        NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
                 null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -406,7 +405,7 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null, null, new DummyBlockValidationRule());
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null, null, new DummyBlockValidationRule());
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -430,9 +429,9 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null,
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
                 null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -466,9 +465,9 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null,
+        NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
                 null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -502,8 +501,8 @@ public class NodeMessageHandlerTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null, null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         class TestCase {
             protected final NewBlockHashesMessage message;
@@ -612,8 +611,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(true);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, blockProcessor, null, null, null, txHandler, null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, null, null, txHandler, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         Message message = mock(Message.class);
         Mockito.when(message.getMessageType()).thenReturn(MessageType.NEW_BLOCK_HASHES);
@@ -641,8 +640,8 @@ public class NodeMessageHandlerTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null, null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         int baseBlock = 9;
 
@@ -751,7 +750,7 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, bp, null, null, null, null, null, new DummyBlockValidationRule());
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null, null, new DummyBlockValidationRule());
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -770,8 +769,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, blockProcessor, null, channelManager, state, txmock, scoring,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, channelManager, state, txmock, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
         sender.setPeerNodeID(new byte[] {1});
@@ -827,8 +826,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, blockProcessor, null, channelManager, state, txmock, scoring,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, channelManager, state, txmock, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -860,10 +859,10 @@ public class NodeMessageHandlerTest {
         PendingState state = mock(PendingState.class);
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
-        TxHandler txHandler = new TxHandlerImpl(ConfigHelper.CONFIG, mock(WorldManager.class), mock(RepositoryImpl.class), blockchain);
+        TxHandler txHandler = new TxHandlerImpl(config, mock(WorldManager.class), mock(RepositoryImpl.class), blockchain);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, blockProcessor, null, channelManager, state, txHandler, scoring,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, channelManager, state, txHandler, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -899,8 +898,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(true);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, blockProcessor, null, channelManager, null, txHandler, null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, channelManager, null, txHandler, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         Message message = mock(Message.class);
         Mockito.when(message.getMessageType()).thenReturn(MessageType.TRANSACTIONS);
@@ -918,8 +917,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, blockProcessor, null, channelManager, pendingState, txmock, RskMockFactory.getPeerScoringManager(),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, channelManager, pendingState, txmock, RskMockFactory.getPeerScoringManager(),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
         sender.setPeerNodeID(new byte[] {1});
@@ -951,9 +950,9 @@ public class NodeMessageHandlerTest {
     @Test
     public void processBlockByHashRequestMessageUsingProcessor() throws UnknownHostException {
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null, null,
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null,
                 null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         Block block = BlockChainBuilder.ofSize(1, true).getBestBlock();
         Message message = new BlockRequestMessage(100, block.getHash());
 
@@ -967,8 +966,8 @@ public class NodeMessageHandlerTest {
     public void processBlockHeadersRequestMessageUsingProcessor() throws UnknownHostException {
         byte[] hash = HashUtil.randomHash();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(ConfigHelper.CONFIG, sbp, null, null, null, null, null,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
         Message message = new BlockHeadersRequestMessage(100, hash, 50);
 
         processor.processMessage(new SimpleMessageChannel(), message);

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
@@ -1,6 +1,6 @@
 package co.rsk.net;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.net.sync.SyncConfiguration;
 import co.rsk.scoring.PeerScoringManager;
@@ -17,7 +17,8 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 
 public class NodeMessageHandlerUtil {
-    private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(ConfigHelper.CONFIG);
+    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
 
     public static NodeMessageHandler createHandler(BlockValidationRule validationRule) {
         final World world = new World();
@@ -27,10 +28,10 @@ public class NodeMessageHandlerUtil {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
-        SyncProcessor syncProcessor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        return new NodeMessageHandler(ConfigHelper.CONFIG, processor, syncProcessor, new SimpleChannelManager(), null, null, RskMockFactory.getPeerScoringManager(), validationRule);
+        return new NodeMessageHandler(config, processor, syncProcessor, new SimpleChannelManager(), null, null, RskMockFactory.getPeerScoringManager(), validationRule);
     }
 
     public static NodeMessageHandler createHandlerWithSyncProcessor() {
@@ -49,10 +50,10 @@ public class NodeMessageHandlerUtil {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        ProofOfWorkRule blockValidationRule = new ProofOfWorkRule(ConfigHelper.CONFIG);
+        ProofOfWorkRule blockValidationRule = new ProofOfWorkRule(config);
         PeerScoringManager peerScoringManager = mock(PeerScoringManager.class);
         Mockito.when(peerScoringManager.hasGoodReputation(isA(NodeID.class))).thenReturn(true);
-        SyncProcessor syncProcessor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, peerScoringManager, syncConfiguration, blockValidationRule, DIFFICULTY_CALCULATOR);
-        return new NodeMessageHandler(ConfigHelper.CONFIG, processor, syncProcessor, null, null, null, null, blockValidationRule);
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, peerScoringManager, syncConfiguration, blockValidationRule, DIFFICULTY_CALCULATOR);
+        return new NodeMessageHandler(config, processor, syncProcessor, null, null, null, null, blockValidationRule);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.net.messages.BlockMessage;
 import co.rsk.net.simples.SimpleAsyncNode;
@@ -45,12 +45,13 @@ public class OneAsyncNodeTest {
         final BlockStore store = new BlockStore();
         final Blockchain blockchain = world.getBlockChain();
 
+        RskSystemProperties config = new RskSystemProperties();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        SyncProcessor syncProcessor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), new DifficultyCalculator(ConfigHelper.CONFIG));
-        NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, processor, syncProcessor, new SimpleChannelManager(), null, null, RskMockFactory.getPeerScoringManager(), new DummyBlockValidationRule());
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), new DifficultyCalculator(config));
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, new SimpleChannelManager(), null, null, RskMockFactory.getPeerScoringManager(), new DummyBlockValidationRule());
 
         return new SimpleAsyncNode(handler);
     }

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -1,7 +1,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.net.messages.*;
@@ -36,7 +36,8 @@ import static org.mockito.Mockito.when;
  */
 public class SyncProcessorTest {
 
-    public static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(ConfigHelper.CONFIG);
+    private static final RskSystemProperties config = new RskSystemProperties();
+    public static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
 
     @Test
     public void noPeers() {
@@ -44,9 +45,9 @@ public class SyncProcessorTest {
         Blockchain blockchain = BlockChainBuilder.ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, getPeerScoringManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, getPeerScoringManager(),
                 SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         Assert.assertEquals(0, processor.getPeersCount());
         Assert.assertEquals(0, processor.getNoAdvancedPeers());
@@ -66,8 +67,8 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[]{0x01});
         processor.processStatus(sender, status);
 
@@ -103,8 +104,8 @@ public class SyncProcessorTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[]{0x01});
         processor.processStatus(sender, status);
 
@@ -144,9 +145,9 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(),
                 SyncConfiguration.DEFAULT,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[]{0x01});
         processor.processStatus(sender, status);
 
@@ -177,8 +178,8 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.DEFAULT,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.DEFAULT,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         List<SimpleMessageChannel> senders = new ArrayList<SimpleMessageChannel>();
 
@@ -237,8 +238,8 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.processStatus(sender, status);
 
         Assert.assertEquals(1, processor.getPeersCount());
@@ -257,8 +258,8 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, null, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, null, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
         processor.sendSkeletonRequest(sender, 0);
@@ -286,8 +287,8 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, null, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, null, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
         Assert.assertFalse(processor.isPeerSyncing(sender.getPeerNodeID()));
@@ -316,9 +317,9 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, null, RskMockFactory.getPeerScoringManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, null, RskMockFactory.getPeerScoringManager(),
                 SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.processStatus(sender, new Status(100, null));
     }
 
@@ -328,9 +329,9 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(),
                 syncConfiguration,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         List<BlockHeader> headers = new ArrayList<>();
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
@@ -350,9 +351,9 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(),
                 syncConfiguration,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
 
         List<BlockHeader> headers = new ArrayList<>();
@@ -373,8 +374,8 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
 
         List<BlockHeader> headers = new ArrayList<>();
@@ -398,8 +399,8 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
 
         List<BlockHeader> headers = new ArrayList<>();
@@ -419,8 +420,8 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
 
         BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), null, null);
@@ -447,8 +448,8 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
@@ -491,8 +492,8 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
@@ -546,9 +547,9 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(),
                 SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
@@ -607,7 +608,7 @@ public class SyncProcessorTest {
 
         Block block = BlockGenerator.getInstance().createChildBlock(genesis, txs, blockchain.getRepository().getRoot());
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
         Assert.assertEquals(1, block.getTransactionsList().size());
         blockExecutor.executeAndFillAll(block, genesis);
         Assert.assertEquals(21000, block.getFeesPaidToMiner().intValueExact());
@@ -619,8 +620,8 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
         List<Transaction> transactions = block.getTransactionsList();
         List<BlockHeader> uncles = block.getUncleList();
@@ -663,8 +664,8 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
         BlockResponseMessage response = new BlockResponseMessage(new Random().nextLong(), block);
         processor.registerExpectedMessage(response);
@@ -687,7 +688,7 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
 
         processor.processStatus(sender, StatusUtils.fromBlockchain(advancedBlockchain));
         BlockHeadersRequestMessage requestMessage = (BlockHeadersRequestMessage)sender.getMessages().get(0);
@@ -731,7 +732,7 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
 
         Status status = StatusUtils.fromBlockchain(advancedBlockchain);
         processor.processStatus(sender, status);
@@ -774,8 +775,8 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
 
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         int connectionPoint = 0;
         int step = 10;
@@ -815,8 +816,8 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
 
         List<BlockIdentifier> blockIdentifiers = new ArrayList<>();
@@ -839,8 +840,8 @@ public class SyncProcessorTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
-        SyncProcessor processor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         int connectionPoint = 25;
         int step = 10;
@@ -891,7 +892,7 @@ public class SyncProcessorTest {
     private static Transaction createTransaction(Account sender, Account receiver, BigInteger value, BigInteger nonce) {
         String toAddress = Hex.toHexString(receiver.getAddress().getBytes());
         byte[] privateKeyBytes = sender.getEcKey().getPrivKeyBytes();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
+        Transaction tx = Transaction.create(new RskSystemProperties(), toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
         tx.sign(privateKeyBytes);
         return tx;
     }

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -892,7 +892,7 @@ public class SyncProcessorTest {
     private static Transaction createTransaction(Account sender, Account receiver, BigInteger value, BigInteger nonce) {
         String toAddress = Hex.toHexString(receiver.getAddress().getBytes());
         byte[] privateKeyBytes = sender.getEcKey().getPrivKeyBytes();
-        Transaction tx = Transaction.create(new RskSystemProperties(), toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
+        Transaction tx = Transaction.create(config, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
         tx.sign(privateKeyBytes);
         return tx;
     }

--- a/rskj-core/src/test/java/co/rsk/net/TwoAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TwoAsyncNodeTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.net.messages.BlockMessage;
 import co.rsk.net.simples.SimpleAsyncNode;
 import co.rsk.net.sync.SyncConfiguration;
@@ -37,6 +37,9 @@ import java.util.List;
  * Created by ajlopez on 5/14/2016.
  */
 public class TwoAsyncNodeTest {
+
+    private static final RskSystemProperties config = new RskSystemProperties();
+
     private static SimpleAsyncNode createNode(int size) {
         final World world = new World();
         final BlockStore store = new BlockStore();
@@ -51,7 +54,7 @@ public class TwoAsyncNodeTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, processor, null, null, null, null, null, new DummyBlockValidationRule());
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, null, null, null, null, null, new DummyBlockValidationRule());
 
         return new SimpleAsyncNode(handler);
     }
@@ -70,7 +73,7 @@ public class TwoAsyncNodeTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, processor, null, null, null, null, null, new DummyBlockValidationRule());
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, null, null, null, null, null, new DummyBlockValidationRule());
 
         return new SimpleAsyncNode(handler);
     }

--- a/rskj-core/src/test/java/co/rsk/net/TwoNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TwoNodeTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.net.messages.BlockMessage;
 import co.rsk.net.simples.SimpleNode;
 import co.rsk.net.sync.SyncConfiguration;
@@ -51,7 +51,7 @@ public class TwoNodeTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, processor, null, null, null, null, null, new DummyBlockValidationRule());
+        NodeMessageHandler handler = new NodeMessageHandler(new RskSystemProperties(), processor, null, null, null, null, null, new DummyBlockValidationRule());
 
         return new SimpleNode(handler);
     }

--- a/rskj-core/src/test/java/co/rsk/net/eth/RskMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/eth/RskMessageTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net.eth;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.net.Status;
 import co.rsk.net.messages.*;
 import org.ethereum.core.Block;
@@ -33,15 +33,18 @@ import org.junit.Test;
  * Created by ajlopez on 5/14/2016.
  */
 public class RskMessageTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void encodeDecodeGetBlockMessage() {
         Block block = BlockGenerator.getInstance().getBlock(1);
         GetBlockMessage message = new GetBlockMessage(block.getHash());
-        RskMessage rskmessage = new RskMessage(ConfigHelper.CONFIG, message);
+        RskMessage rskmessage = new RskMessage(config, message);
 
         byte[] encoded = rskmessage.getEncoded();
 
-        Eth62MessageFactory factory = new Eth62MessageFactory(ConfigHelper.CONFIG);
+        Eth62MessageFactory factory = new Eth62MessageFactory(config);
 
         EthMessage ethmessage = (EthMessage)factory.create((byte)0x08, encoded);
 
@@ -63,11 +66,11 @@ public class RskMessageTest {
         Block block = BlockGenerator.getInstance().getBlock(1);
         Status status = new Status(block.getNumber(), block.getHash());
         StatusMessage message = new StatusMessage(status);
-        RskMessage rskmessage = new RskMessage(ConfigHelper.CONFIG, message);
+        RskMessage rskmessage = new RskMessage(config, message);
 
         byte[] encoded = rskmessage.getEncoded();
 
-        Eth62MessageFactory factory = new Eth62MessageFactory(ConfigHelper.CONFIG);
+        Eth62MessageFactory factory = new Eth62MessageFactory(config);
 
         EthMessage ethmessage = (EthMessage)factory.create((byte)0x08, encoded);
 
@@ -89,11 +92,11 @@ public class RskMessageTest {
     public void encodeDecodeBlockMessage() {
         Block block = BlockGenerator.getInstance().getBlock(1);
         BlockMessage message = new BlockMessage(block);
-        RskMessage rskmessage = new RskMessage(ConfigHelper.CONFIG, message);
+        RskMessage rskmessage = new RskMessage(config, message);
 
         byte[] encoded = rskmessage.getEncoded();
 
-        Eth62MessageFactory factory = new Eth62MessageFactory(ConfigHelper.CONFIG);
+        Eth62MessageFactory factory = new Eth62MessageFactory(config);
 
         EthMessage ethmessage = (EthMessage)factory.create((byte)0x08, encoded);
 

--- a/rskj-core/src/test/java/co/rsk/net/eth/WriterMessageRecorderTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/eth/WriterMessageRecorderTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net.eth;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.net.NodeID;
 import co.rsk.net.messages.GetBlockMessage;
 import co.rsk.test.builders.AccountBuilder;
@@ -44,6 +44,9 @@ import java.util.Random;
  * Created by ajlopez on 26/04/2017.
  */
 public class WriterMessageRecorderTest {
+
+    private static final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void recordRskMessage() throws IOException {
         Message message = createRskMessage();
@@ -138,13 +141,13 @@ public class WriterMessageRecorderTest {
     public static Message createRskMessage() {
         Block block = BlockGenerator.getInstance().getBlock(1);
         GetBlockMessage message = new GetBlockMessage(block.getHash());
-        return new RskMessage(ConfigHelper.CONFIG, message);
+        return new RskMessage(config, message);
     }
 
     public static Message createEthMessage() {
         Account acc1 = new AccountBuilder().name("acc1").build();
         Account acc2 = new AccountBuilder().name("acc2").build();
         Transaction tx = new co.rsk.test.builders.TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
-        return new TransactionsMessage(ConfigHelper.CONFIG, tx);
+        return new TransactionsMessage(config, tx);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxHandlerTest.java
@@ -19,19 +19,21 @@
 package co.rsk.net.handler;
 
 import co.rsk.TestHelpers.Tx;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.rpc.TypeConverter;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.junit.Assert;
 
 import java.math.BigInteger;
 import java.util.*;
 
 public class TxHandlerTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void cleanOldTxsTest() {
@@ -39,8 +41,8 @@ public class TxHandlerTest {
         final long threshold = 300001;
         Random random = new Random(0);
 
-        Transaction tx1 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 0, 0, 0, random);
-        Transaction tx2 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 1, 0, 0, random);
+        Transaction tx1 = Tx.create(config, 0, 0, 0, 0, 0, 0, random);
+        Transaction tx2 = Tx.create(config, 0, 0, 0, 1, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
         Map<RskAddress, TxsPerAccount> txsPerAccounts = new HashMap<>();
@@ -53,7 +55,7 @@ public class TxHandlerTest {
         tpa.getTransactions().add(tx2);
         txsPerAccounts.put(tx1.getSender(), tpa);
 
-        TxHandlerImpl txHandler = new TxHandlerImpl(ConfigHelper.CONFIG);
+        TxHandlerImpl txHandler = new TxHandlerImpl(config);
         txHandler.setKnownTxs(knownTxs);
         txHandler.setTxsPerAccounts(txsPerAccounts);
 
@@ -69,7 +71,7 @@ public class TxHandlerTest {
         final long threshold = 300001;
         Random random = new Random(0);
 
-        Transaction tx1 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 0, 0, 0, random);
+        Transaction tx1 = Tx.create(config, 0, 0, 0, 0, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
         Map<RskAddress, TxsPerAccount> txsPerAccounts = new HashMap<>();
@@ -80,7 +82,7 @@ public class TxHandlerTest {
         tpa.getTransactions().add(tx1);
         txsPerAccounts.put(tx1.getSender(), tpa);
 
-        TxHandlerImpl txHandler = new TxHandlerImpl(ConfigHelper.CONFIG);
+        TxHandlerImpl txHandler = new TxHandlerImpl(config);
         txHandler.setKnownTxs(knownTxs);
         txHandler.setTxsPerAccounts(txsPerAccounts);
 
@@ -95,8 +97,8 @@ public class TxHandlerTest {
         long time = System.currentTimeMillis();
         Random random = new Random(0);
 
-        Transaction tx1 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 0, 0, 0, random);
-        Transaction tx2 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 1, 0, 0, random);
+        Transaction tx1 = Tx.create(config, 0, 0, 0, 0, 0, 0, random);
+        Transaction tx2 = Tx.create(config, 0, 0, 0, 1, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
         Map<RskAddress, TxsPerAccount> txsPerAccounts = new HashMap<>();
@@ -118,7 +120,7 @@ public class TxHandlerTest {
         List<TransactionReceipt> receiptList = new LinkedList<>();
         receiptList.add(receipt);
 
-        TxHandlerImpl txHandler = new TxHandlerImpl(ConfigHelper.CONFIG);
+        TxHandlerImpl txHandler = new TxHandlerImpl(config);
         txHandler.setTxsPerAccounts(txsPerAccounts);
         txHandler.setKnownTxs(knownTxs);
 

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxHandlerTest.java
@@ -39,8 +39,8 @@ public class TxHandlerTest {
         final long threshold = 300001;
         Random random = new Random(0);
 
-        Transaction tx1 = Tx.create(0, 0, 0, 0, 0, 0, random);
-        Transaction tx2 = Tx.create(0, 0, 0, 1, 0, 0, random);
+        Transaction tx1 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 0, 0, 0, random);
+        Transaction tx2 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 1, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
         Map<RskAddress, TxsPerAccount> txsPerAccounts = new HashMap<>();
@@ -69,7 +69,7 @@ public class TxHandlerTest {
         final long threshold = 300001;
         Random random = new Random(0);
 
-        Transaction tx1 = Tx.create(0, 0, 0, 0, 0, 0, random);
+        Transaction tx1 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 0, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
         Map<RskAddress, TxsPerAccount> txsPerAccounts = new HashMap<>();
@@ -95,8 +95,8 @@ public class TxHandlerTest {
         long time = System.currentTimeMillis();
         Random random = new Random(0);
 
-        Transaction tx1 = Tx.create(0, 0, 0, 0, 0, 0, random);
-        Transaction tx2 = Tx.create(0, 0, 0, 1, 0, 0, random);
+        Transaction tx1 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 0, 0, 0, random);
+        Transaction tx2 = Tx.create(ConfigHelper.CONFIG, 0, 0, 0, 1, 0, 0, random);
 
         Map<String, TxTimestamp> knownTxs = new HashMap<>();
         Map<RskAddress, TxsPerAccount> txsPerAccounts = new HashMap<>();

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net.handler;
 
 import co.rsk.TestHelpers.Tx;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Transaction;
 import org.junit.Assert;
@@ -62,7 +62,7 @@ public class TxPendingValidatorTest {
     }
 
     private Transaction createTransaction(long value, long gaslimit, long gasprice, long nonce, long data, long sender) {
-        return Tx.create(ConfigHelper.CONFIG, value, gaslimit, gasprice, nonce, data, sender, hashes);
+        return Tx.create(new RskSystemProperties(), value, gaslimit, gasprice, nonce, data, sender, hashes);
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler;
 
 import co.rsk.TestHelpers.Tx;
+import co.rsk.config.ConfigHelper;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Transaction;
 import org.junit.Assert;
@@ -61,7 +62,7 @@ public class TxPendingValidatorTest {
     }
 
     private Transaction createTransaction(long value, long gaslimit, long gasprice, long nonce, long data, long sender) {
-        return Tx.create(value, gaslimit, gasprice, nonce, data, sender, hashes);
+        return Tx.create(ConfigHelper.CONFIG, value, gaslimit, gasprice, nonce, data, sender, hashes);
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxFilterAccumCostFilterTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxFilterAccumCostFilterTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net.handler.txvalidator;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.net.handler.TxsPerAccount;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
@@ -30,6 +30,8 @@ import java.math.BigInteger;
 import java.util.LinkedList;
 
 public class TxFilterAccumCostFilterTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void twoTxsValidAccumGasPrice() {
@@ -59,7 +61,7 @@ public class TxFilterAccumCostFilterTest {
         Mockito.when(as2.getNonce()).thenReturn(BigInteger.valueOf(0));
         Mockito.when(as3.getNonce()).thenReturn(BigInteger.valueOf(0));
 
-        TxFilterAccumCostFilter tfacf = new TxFilterAccumCostFilter(ConfigHelper.CONFIG);
+        TxFilterAccumCostFilter tfacf = new TxFilterAccumCostFilter(config);
 
         tpa1.setTransactions(new LinkedList<>());
         tpa1.getTransactions().add(tx1);
@@ -115,7 +117,7 @@ public class TxFilterAccumCostFilterTest {
         Mockito.when(as2.getNonce()).thenReturn(BigInteger.valueOf(0));
         Mockito.when(as3.getNonce()).thenReturn(BigInteger.valueOf(0));
 
-        TxFilterAccumCostFilter tfacf = new TxFilterAccumCostFilter(ConfigHelper.CONFIG);
+        TxFilterAccumCostFilter tfacf = new TxFilterAccumCostFilter(config);
 
         tpa1.setTransactions(new LinkedList<>());
         tpa1.getTransactions().add(tx1);

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidatorTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net.handler.txvalidator;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
@@ -79,7 +79,7 @@ public class TxValidatorAccountBalanceValidatorTest {
                 new ECKey().getAddress(),
                 BigInteger.ZERO.toByteArray(),
                 Hex.decode("0001"),
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                new RskSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
 
         tx.sign(new ECKey().getPrivKeyBytes());
 

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
@@ -19,34 +19,29 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.config.BridgeRegTestConstants;
-import co.rsk.config.ConfigHelper;
-import org.spongycastle.util.encoders.Hex;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
 public class TxValidatorIntrinsicGasLimitValidatorTest {
 
     BlockchainNetConfig originalConfig;
+    private RskSystemProperties config;
 
     @Before
     public void setUp() {
-        originalConfig = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-    }
-
-    @After
-    public void tearDown() {
-        ConfigHelper.CONFIG.setBlockchainConfig(originalConfig);
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new RegTestConfig());
     }
 
     @Test
@@ -57,7 +52,7 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                             new ECKey().getAddress(),
                             BigInteger.ZERO.toByteArray(),
                             null,
-                            ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                            config.getBlockchainConfig().getCommonConstants().getChainId());
         tx1.sign(new ECKey().getPrivKeyBytes());
 
         Transaction tx2 = new Transaction(BigInteger.ZERO.toByteArray(),
@@ -66,7 +61,7 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                 new ECKey().getAddress(),
                 BigInteger.ZERO.toByteArray(),
                 Hex.decode("0001"),
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         tx2.sign(new ECKey().getPrivKeyBytes());
 
         Transaction tx3 = new Transaction(BigInteger.ZERO.toByteArray(),
@@ -75,7 +70,7 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                 new ECKey().getAddress(),
                 BigInteger.ZERO.toByteArray(),
                 Hex.decode("0001"),
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         tx3.sign(new ECKey().getPrivKeyBytes());
 
         Transaction tx4 = new Transaction(BigInteger.ZERO.toByteArray(),
@@ -84,11 +79,11 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                 PrecompiledContracts.BRIDGE_ADDR.getBytes(),
                 BigInteger.ZERO.toByteArray(),
                 null,
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         BridgeRegTestConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
         tx4.sign(bridgeRegTestConstants.getFederatorPrivateKeys().get(0).getPrivKeyBytes());
 
-        TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(ConfigHelper.CONFIG);
+        TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(config);
 
         Assert.assertTrue(tvigpv.validate(tx1, new AccountState(BigInteger.ZERO, BigInteger.ZERO), null, null, Long.MAX_VALUE, false));
         Assert.assertTrue(tvigpv.validate(tx2, new AccountState(BigInteger.ZERO, BigInteger.ZERO), null, null, Long.MAX_VALUE, false));
@@ -106,7 +101,7 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                 new ECKey().getAddress(),
                 BigInteger.ZERO.toByteArray(),
                 Hex.decode("0001"),
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         tx1.sign(new ECKey().getPrivKeyBytes());
 
         Transaction tx2 = new Transaction(BigInteger.ZERO.toByteArray(),
@@ -115,7 +110,7 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                 new ECKey().getAddress(),
                 BigInteger.ZERO.toByteArray(),
                 null,
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         tx2.sign(new ECKey().getPrivKeyBytes());
 
         Transaction tx3 = new Transaction(BigInteger.ZERO.toByteArray(),
@@ -124,7 +119,7 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                 new ECKey().getAddress(),
                 BigInteger.ZERO.toByteArray(),
                 Hex.decode("0001"),
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         tx3.sign(new ECKey().getPrivKeyBytes());
 
         Transaction tx4 = new Transaction(BigInteger.ZERO.toByteArray(),
@@ -133,10 +128,10 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                 new ECKey().getAddress(),
                 BigInteger.ZERO.toByteArray(),
                 null,
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         tx4.sign(new ECKey().getPrivKeyBytes());
 
-        TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(ConfigHelper.CONFIG);
+        TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(config);
 
         Assert.assertFalse(tvigpv.validate(tx1, new AccountState(BigInteger.ZERO, BigInteger.ZERO), null, null, Long.MAX_VALUE, false));
         Assert.assertFalse(tvigpv.validate(tx2, new AccountState(BigInteger.ZERO, BigInteger.ZERO), null, null, Long.MAX_VALUE, false));

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net.simples;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.net.*;
 import co.rsk.net.messages.Message;
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.when;
  * Created by ajlopez on 5/15/2016.
  */
 public class SimpleAsyncNode extends SimpleNode {
+    private static final RskSystemProperties config = new RskSystemProperties();
     private ExecutorService executor = Executors.newSingleThreadExecutor();
     private LinkedBlockingQueue<Future> futures = new LinkedBlockingQueue<>(5000);
     private SyncProcessor syncProcessor;
@@ -118,8 +119,8 @@ public class SimpleAsyncNode extends SimpleNode {
         PeerScoringManager peerScoringManager = Mockito.mock(PeerScoringManager.class);
         when(peerScoringManager.hasGoodReputation(isA(NodeID.class))).thenReturn(true);
         when(peerScoringManager.getPeerScoring(isA(NodeID.class))).thenReturn(new PeerScoring());
-        SyncProcessor syncProcessor = new SyncProcessor(ConfigHelper.CONFIG, blockchain, blockSyncService, peerScoringManager, syncConfiguration, blockValidationRule, new DifficultyCalculator(ConfigHelper.CONFIG));
-        NodeMessageHandler handler = new NodeMessageHandler(ConfigHelper.CONFIG, processor, syncProcessor, new SimpleChannelManager(), null, null, peerScoringManager, blockValidationRule);
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, peerScoringManager, syncConfiguration, blockValidationRule, new DifficultyCalculator(config));
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, new SimpleChannelManager(), null, null, peerScoringManager, blockValidationRule);
         return new SimpleAsyncNode(handler, syncProcessor);
     }
 

--- a/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net.utils;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
@@ -57,7 +57,7 @@ public class TransactionUtils {
     }
 
     public static Transaction createTransaction(byte[] privateKey, String toAddress, BigInteger value, BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit) {
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, toAddress, value, nonce, gasPrice, gasLimit);
+        Transaction tx = Transaction.create(new RskSystemProperties(), toAddress, value, nonce, gasPrice, gasLimit);
         tx.sign(privateKey);
         return tx;
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStateTest.java
@@ -19,11 +19,11 @@
 package co.rsk.peg;
 
 import co.rsk.config.BridgeConstants;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.db.RepositoryImpl;
 import co.rsk.trie.TrieStoreImpl;
 import org.ethereum.core.Repository;
 import org.ethereum.datasource.HashMapDB;
-import co.rsk.db.RepositoryImpl;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,8 +36,9 @@ import java.io.IOException;
 public class BridgeStateTest {
     @Test
     public void recreateFromEmptyStorageProvider() throws IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
-        BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        RskSystemProperties config = new RskSystemProperties();
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants);
 
         BridgeState state = new BridgeState(42, provider);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.config.BridgeConstants;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Sha3Hash;
 import co.rsk.db.RepositoryImpl;
@@ -59,13 +59,14 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ BridgeSerializationUtils.class, RskAddress.class })
 public class BridgeStorageProviderTest {
-    private NetworkParameters networkParameters = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
+    private final RskSystemProperties config = new RskSystemProperties();
+    private final NetworkParameters networkParameters = config.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
     private int transactionOffset;
 
     @Test
     public void createInstance() throws IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        Repository repository = new RepositoryImpl(config);
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Map<Sha256Hash, Long> processed = provider.getBtcTxHashesAlreadyProcessed();
 
@@ -95,10 +96,10 @@ public class BridgeStorageProviderTest {
 
     @Test
     public void createSaveAndRecreateInstance() throws IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         provider0.getBtcTxHashesAlreadyProcessed();
         provider0.getReleaseRequestQueue();
         provider0.getReleaseTransactionSet();
@@ -120,7 +121,7 @@ public class BridgeStorageProviderTest {
         Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("newFederationBtcUTXOs".getBytes())));
         Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("oldFederationBtcUTXOs".getBytes())));
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Map<Sha256Hash, Long> processed = provider.getBtcTxHashesAlreadyProcessed();
 
@@ -158,10 +159,10 @@ public class BridgeStorageProviderTest {
         Sha256Hash hash1 = PegTestUtils.createHash();
         Sha256Hash hash2 = PegTestUtils.createHash();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         provider0.getBtcTxHashesAlreadyProcessed().put(hash1, 1L);
         provider0.getBtcTxHashesAlreadyProcessed().put(hash2, 1L);
         provider0.save();
@@ -169,7 +170,7 @@ public class BridgeStorageProviderTest {
 
         track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Map<Sha256Hash, Long> processed = provider.getBtcTxHashesAlreadyProcessed();
         Set<Sha256Hash> processedHashes = processed.keySet();
@@ -187,10 +188,10 @@ public class BridgeStorageProviderTest {
         Sha3Hash hash2 = PegTestUtils.createHash3();
         Sha3Hash hash3 = PegTestUtils.createHash3();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         provider0.getRskTxsWaitingForSignatures().put(hash1, tx1);
         provider0.getRskTxsWaitingForSignatures().put(hash2, tx2);
         provider0.getRskTxsWaitingForSignatures().put(hash3, tx3);
@@ -200,7 +201,7 @@ public class BridgeStorageProviderTest {
 
         track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         SortedMap<Sha3Hash, BtcTransaction> signatures = provider.getRskTxsWaitingForSignatures();
 
@@ -220,14 +221,14 @@ public class BridgeStorageProviderTest {
         Sha256Hash hash1 = PegTestUtils.createHash();
         Sha256Hash hash2 = PegTestUtils.createHash();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         provider0.getNewFederationBtcUTXOs().add(new UTXO(hash1, 1, Coin.COIN, 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
         provider0.getNewFederationBtcUTXOs().add(new UTXO(hash2, 2, Coin.FIFTY_COINS, 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
         provider0.save();
@@ -235,7 +236,7 @@ public class BridgeStorageProviderTest {
 
         track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         List<UTXO> utxos = provider.getNewFederationBtcUTXOs();
 
@@ -250,7 +251,7 @@ public class BridgeStorageProviderTest {
         Federation newFederation = new Federation(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         Whitebox.setInternalState(storageProvider, "btcContext", contextMock);
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
@@ -284,7 +285,7 @@ public class BridgeStorageProviderTest {
         Context contextMock = mock(Context.class);
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         Whitebox.setInternalState(storageProvider, "btcContext", contextMock);
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
@@ -314,7 +315,7 @@ public class BridgeStorageProviderTest {
         List<Integer> serializeCalls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         PowerMockito.when(BridgeSerializationUtils.serializeFederation(any(Federation.class))).then((InvocationOnMock invocation) -> {
             Federation federation = invocation.getArgumentAt(0, Federation.class);
@@ -351,7 +352,7 @@ public class BridgeStorageProviderTest {
         ABICallElection electionMock = mock(ABICallElection.class);
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
@@ -383,7 +384,7 @@ public class BridgeStorageProviderTest {
         ABICallElection electionMock = mock(ABICallElection.class);
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
@@ -412,7 +413,7 @@ public class BridgeStorageProviderTest {
         List<Integer> serializeCalls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         PowerMockito.when(BridgeSerializationUtils.serializeElection(any(ABICallElection.class))).then((InvocationOnMock invocation) -> {
             ABICallElection election = invocation.getArgumentAt(0, ABICallElection.class);
@@ -448,7 +449,7 @@ public class BridgeStorageProviderTest {
         LockWhitelist whitelistMock = mock(LockWhitelist.class);
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         Context contextMock = mock(Context.class);
         when(contextMock.getParams()).thenReturn(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Whitebox.setInternalState(storageProvider, "btcContext", contextMock);
@@ -481,7 +482,7 @@ public class BridgeStorageProviderTest {
         List<Integer> calls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         Context contextMock = mock(Context.class);
         when(contextMock.getParams()).thenReturn(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Whitebox.setInternalState(storageProvider, "btcContext", contextMock);
@@ -513,7 +514,7 @@ public class BridgeStorageProviderTest {
         List<Integer> serializeCalls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         PowerMockito.when(BridgeSerializationUtils.serializeLockWhitelist(any(LockWhitelist.class))).then((InvocationOnMock invocation) -> {
             LockWhitelist whitelist = invocation.getArgumentAt(0, LockWhitelist.class);
@@ -549,7 +550,7 @@ public class BridgeStorageProviderTest {
         ReleaseRequestQueue requestQueueMock = mock(ReleaseRequestQueue.class);
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
@@ -580,7 +581,7 @@ public class BridgeStorageProviderTest {
         ReleaseTransactionSet transactionSetMock = mock(ReleaseTransactionSet.class);
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
@@ -607,10 +608,10 @@ public class BridgeStorageProviderTest {
 
     @Test
     public void setFeePerKb_savedAndRecreated() {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Coin expectedCoin = Coin.valueOf(5325);
         provider0.setFeePerKb(expectedCoin);
@@ -619,7 +620,7 @@ public class BridgeStorageProviderTest {
 
         track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         assertThat(provider.getFeePerKb(), is(expectedCoin));
     }
@@ -628,7 +629,7 @@ public class BridgeStorageProviderTest {
     public void getFeePerKbElection_emptyVotes() {
         AddressBasedAuthorizer authorizerMock = mock(AddressBasedAuthorizer.class);
         Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         HashMap<ABICallSpec, List<RskAddress>> electionVotes = new HashMap<>();
         byte[] serializedElection = BridgeSerializationUtils.serializeElection(
@@ -651,7 +652,7 @@ public class BridgeStorageProviderTest {
                 .thenReturn(1);
         when(authorizerMock.isAuthorized(any(RskAddress.class)))
                 .thenReturn(true);
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         byte[] electionFee = new byte[] {0x43, 0x19};
         ABICallSpec expectedWinner = new ABICallSpec("setFeePerKb", new byte[][]{electionFee});

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -100,7 +100,7 @@ public class BridgeSupportTest {
 
     private static BridgeConstants bridgeConstants;
     private static NetworkParameters btcParams;
-    private static RskSystemProperties config;
+    private RskSystemProperties config;
 
     private static final String TO_ADDRESS = "0000000000000000000000000000000000000006";
     private static final BigInteger DUST_AMOUNT = new BigInteger("1");

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -27,7 +27,9 @@ import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.*;
+import co.rsk.config.BridgeConstants;
+import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Sha3Hash;
 import co.rsk.db.RepositoryImpl;
@@ -38,7 +40,6 @@ import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.utils.BridgeEventLoggerImpl;
 import co.rsk.test.builders.BlockChainBuilder;
 import com.google.common.collect.Lists;
-import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.config.net.TestNetConfig;
 import org.ethereum.core.*;
@@ -53,9 +54,8 @@ import org.ethereum.util.RLPList;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.Program;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -98,9 +98,9 @@ import static org.mockito.Mockito.*;
 public class BridgeSupportTest {
     private static final RskAddress contractAddress = PrecompiledContracts.BRIDGE_ADDR;
 
-    private static BlockchainNetConfig blockchainNetConfigOriginal;
     private static BridgeConstants bridgeConstants;
     private static NetworkParameters btcParams;
+    private static RskSystemProperties config;
 
     private static final String TO_ADDRESS = "0000000000000000000000000000000000000006";
     private static final BigInteger DUST_AMOUNT = new BigInteger("1");
@@ -110,78 +110,66 @@ public class BridgeSupportTest {
     private static final BigInteger GAS_LIMIT = new BigInteger("1000");
     private static final String DATA = "80af2871";
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-        bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+    @Before
+    public void setUpOnEachTest(){
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new RegTestConfig());
+        bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         btcParams = bridgeConstants.getBtcParams();
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test
     public void testInitialChainHeadWithoutBtcCheckpoints() throws Exception {
-        BlockchainNetConfig blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-        NetworkParameters _networkParameters = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
-
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        NetworkParameters _networkParameters = btcParams;
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
         Assert.assertEquals(0, bridgeSupport.getBtcBlockStore().getChainHead().getHeight());
         Assert.assertEquals(_networkParameters.getGenesisBlock(), bridgeSupport.getBtcBlockStore().getChainHead().getHeader());
-
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test
     public void testInitialChainHeadWithBtcCheckpoints() throws Exception {
-        BlockchainNetConfig blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new TestNetConfig());
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new TestNetConfig());
+        bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        btcParams = bridgeConstants.getBtcParams();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
         Assert.assertEquals(1229760, bridgeSupport.getBtcBlockStore().getChainHead().getHeight());
-
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test
     public void feePerKbFromStorageProvider() throws Exception {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Coin expected = Coin.MILLICOIN;
         provider.setFeePerKb(expected);
         provider.saveFeePerKb();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
 
         Assert.assertEquals(expected, bridgeSupport.getFeePerKb());
     }
 
     @Test
     public void testGetBtcBlockchainBlockLocatorWithoutBtcCheckpoints() throws Exception {
-        BlockchainNetConfig blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-        NetworkParameters _networkParameters = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
+        NetworkParameters _networkParameters = btcParams;
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
         Assert.assertEquals(0, bridgeSupport.getBtcBlockStore().getChainHead().getHeight());
         Assert.assertEquals(_networkParameters.getGenesisBlock(), bridgeSupport.getBtcBlockStore().getChainHead().getHeader());
 
@@ -199,23 +187,19 @@ public class BridgeSupportTest {
         Assert.assertEquals(blocks.get(5).getHash(), locator.get(3));
         Assert.assertEquals(blocks.get(1).getHash(), locator.get(4));
         Assert.assertEquals(_networkParameters.getGenesisBlock().getHash(), locator.get(5));
-
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
 
     @Test
     public void testGetBtcBlockchainBlockLocatorWithBtcCheckpoints() throws Exception {
-        BlockchainNetConfig blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-        NetworkParameters _networkParameters = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
+        NetworkParameters _networkParameters = btcParams;
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         List<BtcBlock> checkpoints = createBtcBlocks(_networkParameters, _networkParameters.getGenesisBlock(), 10);
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null) {
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null) {
             @Override
             InputStream getCheckPoints() {
                 return getCheckpoints(_networkParameters, checkpoints);
@@ -238,8 +222,6 @@ public class BridgeSupportTest {
         Assert.assertEquals(blocks.get(5).getHash(), locator.get(3));
         Assert.assertEquals(blocks.get(1).getHash(), locator.get(4));
         Assert.assertEquals(checkpoints.get(9).getHash(), locator.get(5));
-
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     private List<BtcBlock> createBtcBlocks(NetworkParameters _networkParameters, BtcBlock parent, int numberOfBlocksToCreate) {
@@ -288,16 +270,16 @@ public class BridgeSupportTest {
 
     @Test
     public void callUpdateCollectionsGenerateEventLog() throws IOException, BlockStoreException {
-        Repository track = new RepositoryImpl(ConfigHelper.CONFIG).startTracking();
+        Repository track = new RepositoryImpl(config).startTracking();
 
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
 
         List<LogInfo> eventLogs = new LinkedList<>();
         BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, eventLogs);
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, eventLogger, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, eventLogger, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
 
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         ECKey key = new ECKey();
         tx.sign(key.getPrivKeyBytes());
 
@@ -322,10 +304,10 @@ public class BridgeSupportTest {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(30,0));
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(20,0));
@@ -350,10 +332,10 @@ public class BridgeSupportTest {
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
 
         bridgeSupport.updateCollections(tx);
 
@@ -361,7 +343,7 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
@@ -377,10 +359,10 @@ public class BridgeSupportTest {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(37500));
         provider0.setFeePerKb(Coin.MILLICOIN);
@@ -409,10 +391,10 @@ public class BridgeSupportTest {
             blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
 
         bridgeSupport.updateCollections(tx);
 
@@ -420,7 +402,7 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
@@ -434,10 +416,10 @@ public class BridgeSupportTest {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.COIN.multiply(7));
         for (int i = 0; i < 2000; i++) {
@@ -468,10 +450,10 @@ public class BridgeSupportTest {
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
         ReceiptStore rskReceiptStore = blockchain.getReceiptStore();
         org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
 
         bridgeSupport.updateCollections(tx);
 
@@ -479,7 +461,7 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
@@ -514,11 +496,11 @@ public class BridgeSupportTest {
         BlockGenerator blockGenerator = new BlockGenerator();
         // Old federation will be in migration age at block 35
         org.ethereum.core.Block rskCurrentBlock = blockGenerator.createBlock(35, 1);
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, rskCurrentBlock);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, rskCurrentBlock);
 
         // One MICROCOIN is less than half the fee per kb, which is the minimum funds to migrate,
         // and so it won't be removed from the old federation UTXOs list for migration.
@@ -585,7 +567,7 @@ public class BridgeSupportTest {
         Repository repository = blockchain.getRepository();
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.COIN);
         provider0.getNewFederationBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.COIN.add(Coin.valueOf(100)), 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
@@ -595,10 +577,10 @@ public class BridgeSupportTest {
         track.commit();
 
         track = repository.startTracking();
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
 
         bridgeSupport.updateCollections(tx);
 
@@ -606,13 +588,13 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
         Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(21000000-2600)), repository.getBalance(PrecompiledContracts.BRIDGE_ADDR));
-        Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(2600)), repository.getBalance(ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBurnAddress()));
+        Assert.assertEquals(Denomination.satoshisToWeis(BigInteger.valueOf(2600)), repository.getBalance(config.getBlockchainConfig().getCommonConstants().getBurnAddress()));
         // Check the wallet has been emptied
         Assert.assertTrue(provider.getNewFederationBtcUTXOs().isEmpty());
     }
@@ -620,17 +602,17 @@ public class BridgeSupportTest {
     @Test
     public void callUpdateCollectionsWithTransactionsWaitingForConfirmationWithEnoughConfirmations() throws IOException, BlockStoreException {
         // Bridge constants and btc context
-        BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         Context context = new Context(bridgeConstants.getBtcParams());
 
         // Fake wallet returned every time
         PowerMockito.mockStatic(BridgeUtils.class);
         PowerMockito.when(BridgeUtils.getFederationSpendWallet(any(Context.class), any(Federation.class), any(List.class))).thenReturn(new SimpleWallet(context));
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         BtcTransaction txs = new BtcTransaction(btcParams);
         txs.addOutput(Coin.FIFTY_COINS, new BtcECKey());
@@ -656,7 +638,7 @@ public class BridgeSupportTest {
         track.commit();
 
         track = repository.startTracking();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(BlockGenerator.getInstance().getGenesisBlock(), 10);
 
@@ -667,17 +649,17 @@ public class BridgeSupportTest {
             blockchain.getBlockStore().saveBlock(block, BigInteger.ONE, true);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        Transaction rskTx = Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, rskCurrentBlock);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, rskCurrentBlock);
 
         bridgeSupport.updateCollections(rskTx);
         bridgeSupport.save();
 
         track.commit();
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(2, provider2.getReleaseTransactionSet().getEntries().size());
@@ -686,17 +668,17 @@ public class BridgeSupportTest {
 
     @Test
     public void sendOrphanBlockHeader() throws IOException, BlockStoreException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         Context btcContext = new Context(bridgeConstants.getBtcParams());
-        BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, track, PrecompiledContracts.BRIDGE_ADDR);
+        BtcBlockStore btcBlockStore = new RepositoryBlockStore(config, track, PrecompiledContracts.BRIDGE_ADDR);
         BtcBlockChain btcBlockChain = new BtcBlockChain(btcContext, btcBlockStore);
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
 
         co.rsk.bitcoinj.core.BtcBlock block = new co.rsk.bitcoinj.core.BtcBlock(btcParams, 1, PegTestUtils.createHash(), PegTestUtils.createHash(), 1, 1, 1, new ArrayList<BtcTransaction>());
         co.rsk.bitcoinj.core.BtcBlock[] headers = new co.rsk.bitcoinj.core.BtcBlock[1];
@@ -712,17 +694,17 @@ public class BridgeSupportTest {
 
     @Test
     public void addBlockHeaderToBlockchain() throws IOException, BlockStoreException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         Context btcContext = new Context(bridgeConstants.getBtcParams());
-        BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, track, PrecompiledContracts.BRIDGE_ADDR);
+        BtcBlockStore btcBlockStore = new RepositoryBlockStore(config, track, PrecompiledContracts.BRIDGE_ADDR);
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
 
         co.rsk.bitcoinj.core.BtcBlock block = new co.rsk.bitcoinj.core.BtcBlock(btcParams, 1, PegTestUtils.createHash(), PegTestUtils.createHash(), 1, 1, 1, new ArrayList<BtcTransaction>());
         co.rsk.bitcoinj.core.BtcBlock[] headers = new co.rsk.bitcoinj.core.BtcBlock[1];
@@ -740,34 +722,34 @@ public class BridgeSupportTest {
     public void addSignatureToMissingTransaction() throws Exception {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, (Block) null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, (Block) null);
 
         bridgeSupport.addSignature(1, federation.getPublicKeys().get(0), null, PegTestUtils.createHash().getBytes());
         bridgeSupport.save();
 
         track.commit();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
     }
 
     @Test
     public void addSignatureFromInvalidFederator() throws Exception {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, (Block) null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, (Block) null);
 
         bridgeSupport.addSignature(1, new BtcECKey(), null, PegTestUtils.createHash().getBytes());
         bridgeSupport.save();
 
         track.commit();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
     }
@@ -799,7 +781,7 @@ public class BridgeSupportTest {
     public void addSignatureCreateEventLog() throws Exception {
         // Setup
         Federation federation = bridgeConstants.getGenesisFederation();
-        Repository track = new RepositoryImpl(ConfigHelper.CONFIG).startTracking();
+        Repository track = new RepositoryImpl(config).startTracking();
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants);
 
         // Build prev btc tx
@@ -822,7 +804,7 @@ public class BridgeSupportTest {
         // Setup BridgeSupport
         List<LogInfo> eventLogs = new ArrayList<>();
         BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, eventLogs);
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, eventLogger, contractAddress, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, eventLogger, contractAddress, null);
 
         // Create signed hash of Btc tx
         Script inputScript = btcTx.getInputs().get(0).getScriptSig();
@@ -882,7 +864,7 @@ public class BridgeSupportTest {
     public void addSignatureMultipleInputsPartiallyValid() throws Exception {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         final Sha3Hash sha3Hash = PegTestUtils.createHash3();
 
@@ -912,7 +894,7 @@ public class BridgeSupportTest {
         track = repository.startTracking();
         List<LogInfo> logs = new ArrayList<>();
         BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, logs);
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, eventLogger, contractAddress, (Block) null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, eventLogger, contractAddress, (Block) null);
 
         // Generate valid signatures for inputs
         List<byte[]> derEncodedSigsFirstFed = new ArrayList<>();
@@ -994,12 +976,12 @@ public class BridgeSupportTest {
     private void addSignatureFromValidFederator(List<BtcECKey> privateKeysToSignWith, int numberOfInputsToSign, boolean signatureCanonical, boolean signTwice, String expectedResult) throws Exception {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         final Sha3Hash sha3Hash = PegTestUtils.createHash3();
 
         Repository track = repository.startTracking();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         BtcTransaction prevTx = new BtcTransaction(btcParams);
         TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, federation.getAddress());
@@ -1016,7 +998,7 @@ public class BridgeSupportTest {
         track = repository.startTracking();
         List<LogInfo> logs = new ArrayList<>();
         BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, logs);
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, eventLogger, contractAddress, (Block) null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, eventLogger, contractAddress, (Block) null);
 
         Script inputScript = t.getInputs().get(0).getScriptSig();
         List<ScriptChunk> chunks = inputScript.getChunks();
@@ -1056,7 +1038,7 @@ public class BridgeSupportTest {
         bridgeSupport.save();
         track.commit();
 
-        provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         if ("FullySigned".equals(expectedResult)) {
             Assert.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
@@ -1093,22 +1075,22 @@ public class BridgeSupportTest {
 
     @Test
     public void releaseBtcWithDustOutput() throws BlockStoreException, AddressFormatException, IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
+        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
 
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
 
         bridgeSupport.releaseBtc(tx);
         bridgeSupport.save();
 
         track.commit();
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
@@ -1117,22 +1099,22 @@ public class BridgeSupportTest {
 
     @Test
     public void releaseBtc() throws BlockStoreException, AddressFormatException, IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
+        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
 
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
 
         bridgeSupport.releaseBtc(tx);
         bridgeSupport.save();
 
         track.commit();
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(1, provider2.getReleaseRequestQueue().getEntries().size());
@@ -1141,15 +1123,15 @@ public class BridgeSupportTest {
 
     @Test
     public void releaseBtcFromContract() throws BlockStoreException, AddressFormatException, IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
+        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
 
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
         track.saveCode(tx.getSender(), new byte[] {0x1});
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
 
         try {
             bridgeSupport.releaseBtc(tx);
@@ -1161,22 +1143,22 @@ public class BridgeSupportTest {
 
     @Test
     public void registerBtcTransactionOfAlreadyProcessedTransaction() throws BlockStoreException, AddressFormatException, IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         BtcTransaction tx = createTransaction();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         provider.getBtcTxHashesAlreadyProcessed().put(tx.getHash(), 1L);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
 
         bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx, 0, null);
         bridgeSupport.save();
 
         track.commit();
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertTrue(provider2.getNewFederationBtcUTXOs().isEmpty());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
@@ -1187,13 +1169,13 @@ public class BridgeSupportTest {
 
     @Test
     public void registerBtcTransactionOfTransactionNotInMerkleTree() throws BlockStoreException, AddressFormatException, IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         BtcTransaction tx = createTransaction();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1207,7 +1189,7 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertTrue(provider2.getNewFederationBtcUTXOs().isEmpty());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
@@ -1218,13 +1200,13 @@ public class BridgeSupportTest {
 
     @Test
     public void registerBtcTransactionOfTransactionInMerkleTreeWithNegativeHeight() throws BlockStoreException, AddressFormatException, IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         BtcTransaction tx = createTransaction();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1238,7 +1220,7 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertTrue(provider2.getNewFederationBtcUTXOs().isEmpty());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
@@ -1249,17 +1231,15 @@ public class BridgeSupportTest {
 
     @Test
     public void registerBtcTransactionOfTransactionInMerkleTreeWithNotEnoughtHeight() throws BlockStoreException, AddressFormatException, IOException {
-        BlockchainNetConfig blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-        NetworkParameters _networkParameters = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
+        NetworkParameters _networkParameters = btcParams;
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
         BtcTransaction tx = createTransaction();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, mock(BridgeEventLogger.class), provider, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, null);
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1273,23 +1253,21 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertTrue(provider2.getNewFederationBtcUTXOs().isEmpty());
         Assert.assertEquals(0, provider2.getReleaseRequestQueue().getEntries().size());
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertTrue(provider2.getBtcTxHashesAlreadyProcessed().isEmpty());
-
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test
     public void registerBtcTransactionTxNotLockNorReleaseTx() throws BlockStoreException, AddressFormatException, IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
 
         BtcTransaction tx = new BtcTransaction(this.btcParams);
         Address address = ScriptBuilder.createP2SHOutputScript(2, Lists.newArrayList(new BtcECKey(), new BtcECKey(), new BtcECKey())).getToAddress(bridgeConstants.getBtcParams());
@@ -1298,12 +1276,12 @@ public class BridgeSupportTest {
 
 
         Context btcContext = new Context(bridgeConstants.getBtcParams());
-        BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, track, PrecompiledContracts.BRIDGE_ADDR);
+        BtcBlockStore btcBlockStore = new RepositoryBlockStore(config, track, PrecompiledContracts.BRIDGE_ADDR);
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1323,7 +1301,7 @@ public class BridgeSupportTest {
 
         track.commit();
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(0, provider2.getNewFederationBtcUTXOs().size());
 
@@ -1337,7 +1315,7 @@ public class BridgeSupportTest {
     public void registerBtcTransactionReleaseTx() throws BlockStoreException, AddressFormatException, IOException {
         // Federation is the genesis federation ATM
         Federation federation = bridgeConstants.getGenesisFederation();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
         Repository track = repository.startTracking();
         Block executionBlock = Mockito.mock(Block.class);
@@ -1376,12 +1354,12 @@ public class BridgeSupportTest {
         tx.getInput(0).setScriptSig(scriptSig);
 
         Context btcContext = new Context(bridgeConstants.getBtcParams());
-        BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, track, PrecompiledContracts.BRIDGE_ADDR);
+        BtcBlockStore btcBlockStore = new RepositoryBlockStore(config, track, PrecompiledContracts.BRIDGE_ADDR);
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
 
         byte[] bits = new byte[1];
@@ -1405,7 +1383,7 @@ public class BridgeSupportTest {
 
         Assert.assertEquals(BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()), repository.getBalance(PrecompiledContracts.BRIDGE_ADDR));
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(1, provider2.getNewFederationBtcUTXOs().size());
         Assert.assertEquals(Coin.COIN, provider2.getNewFederationBtcUTXOs().get(0).getValue());
@@ -1433,7 +1411,7 @@ public class BridgeSupportTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
         Federation retiringFederation = new Federation(retiringFederationKeys, Instant.ofEpochMilli(1000L), 1L, parameters);
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
         Block executionBlock = Mockito.mock(Block.class);
         Mockito.when(executionBlock.getNumber()).thenReturn(15L);
@@ -1470,13 +1448,13 @@ public class BridgeSupportTest {
 
 
         Context btcContext = new Context(bridgeConstants.getBtcParams());
-        BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, track, PrecompiledContracts.BRIDGE_ADDR);
+        BtcBlockStore btcBlockStore = new RepositoryBlockStore(config, track, PrecompiledContracts.BRIDGE_ADDR);
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         provider.setNewFederation(activeFederation);
         provider.setOldFederation(retiringFederation);
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
 
         byte[] bits = new byte[1];
@@ -1506,7 +1484,7 @@ public class BridgeSupportTest {
 
     @Test
     public void registerBtcTransactionLockTxWhitelisted() throws BlockStoreException, AddressFormatException, IOException {
-        BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         NetworkParameters parameters = bridgeConstants.getBtcParams();
 
         List<BtcECKey> federation1Keys = Arrays.asList(new BtcECKey[]{
@@ -1524,7 +1502,7 @@ public class BridgeSupportTest {
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
         Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), 0L, parameters);
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
         Block executionBlock = Mockito.mock(Block.class);
         Mockito.when(executionBlock.getNumber()).thenReturn(10L);
@@ -1552,10 +1530,10 @@ public class BridgeSupportTest {
         tx3.addInput(PegTestUtils.createHash(), 0, ScriptBuilder.createInputScript(null, srcKey3));
 
         Context btcContext = new Context(bridgeConstants.getBtcParams());
-        BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, track, PrecompiledContracts.BRIDGE_ADDR);
+        BtcBlockStore btcBlockStore = new RepositoryBlockStore(config, track, PrecompiledContracts.BRIDGE_ADDR);
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         provider.setNewFederation(federation1);
         provider.setOldFederation(federation2);
 
@@ -1568,7 +1546,7 @@ public class BridgeSupportTest {
         whitelist.put(address2, Coin.COIN.multiply(10));
         whitelist.put(address3, Coin.COIN.multiply(2).add(Coin.COIN.multiply(3)));
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
         byte[] bits = new byte[1];
         bits[0] = 0x3f;
@@ -1612,7 +1590,7 @@ public class BridgeSupportTest {
         Assert.assertEquals(amountToHaveBeenCreditedToSrc3, repository.getBalance(srcKey3RskAddress));
         Assert.assertEquals(BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()).subtract(totalAmountExpectedToHaveBeenLocked), repository.getBalance(PrecompiledContracts.BRIDGE_ADDR));
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(2, provider2.getNewFederationBtcUTXOs().size());
         Assert.assertEquals(2, provider2.getOldFederationBtcUTXOs().size());
@@ -1629,7 +1607,7 @@ public class BridgeSupportTest {
 
     @Test
     public void registerBtcTransactionLockTxNotWhitelisted() throws BlockStoreException, AddressFormatException, IOException {
-        BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         NetworkParameters parameters = bridgeConstants.getBtcParams();
 
         List<BtcECKey> federation1Keys = Arrays.asList(new BtcECKey[]{
@@ -1647,7 +1625,7 @@ public class BridgeSupportTest {
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
         Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), 0L, parameters);
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()));
         Block executionBlock = Mockito.mock(Block.class);
         Mockito.when(executionBlock.getNumber()).thenReturn(10L);
@@ -1675,14 +1653,14 @@ public class BridgeSupportTest {
         tx3.addInput(PegTestUtils.createHash(), 0, ScriptBuilder.createInputScript(null, srcKey3));
 
         Context btcContext = new Context(bridgeConstants.getBtcParams());
-        BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, track, PrecompiledContracts.BRIDGE_ADDR);
+        BtcBlockStore btcBlockStore = new RepositoryBlockStore(config, track, PrecompiledContracts.BRIDGE_ADDR);
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
         provider.setNewFederation(federation1);
         provider.setOldFederation(federation2);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, track, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, btcBlockStore, btcBlockChain);
         Whitebox.setInternalState(bridgeSupport, "rskExecutionBlock", executionBlock);
         byte[] bits = new byte[1];
         bits[0] = 0x3f;
@@ -1721,7 +1699,7 @@ public class BridgeSupportTest {
         Assert.assertEquals(0, repository.getBalance(srcKey3RskAddress).intValue());
         Assert.assertEquals(BigInteger.valueOf(21000000).multiply(Denomination.SBTC.value()), repository.getBalance(PrecompiledContracts.BRIDGE_ADDR));
 
-        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(0, provider2.getNewFederationBtcUTXOs().size());
         Assert.assertEquals(0, provider2.getOldFederationBtcUTXOs().size());
@@ -1771,7 +1749,7 @@ public class BridgeSupportTest {
 
     @Test
     public void isBtcTxHashAlreadyProcessed() throws IOException, BlockStoreException {
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, null, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), getBridgeStorageProviderMockWithProcessedHashes(), null, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, null, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), getBridgeStorageProviderMockWithProcessedHashes(), null, null);
 
         for (int i = 0; i < 10; i++) {
             Assert.assertTrue(bridgeSupport.isBtcTxHashAlreadyProcessed(Sha256Hash.of(("hash_" + i).getBytes())));
@@ -1781,7 +1759,7 @@ public class BridgeSupportTest {
 
     @Test
     public void getBtcTxHashProcessedHeight() throws IOException, BlockStoreException {
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, null, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), getBridgeStorageProviderMockWithProcessedHashes(), null, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, null, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), getBridgeStorageProviderMockWithProcessedHashes(), null, null);
 
         for (int i = 0; i < 10; i++) {
             Assert.assertEquals((long) i, bridgeSupport.getBtcTxHashProcessedHeight(Sha256Hash.of(("hash_" + i).getBytes())).longValue());
@@ -2861,7 +2839,7 @@ public class BridgeSupportTest {
         when(authorizer.isAuthorized(tx))
                 .thenReturn(true);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, repositoryMock, null, constants, provider, null, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, repositoryMock, null, constants, provider, null, null);
         bridgeSupport.voteFeePerKbChange(tx, null);
         verify(provider, never()).setFeePerKb(any());
     }
@@ -2884,7 +2862,7 @@ public class BridgeSupportTest {
         when(authorizer.isAuthorized(tx))
                 .thenReturn(false);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, repositoryMock, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, null, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, repositoryMock, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), provider, null, null);
         assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(-10));
         verify(provider, never()).setFeePerKb(any());
     }
@@ -2911,7 +2889,7 @@ public class BridgeSupportTest {
         when(authorizer.getRequiredAuthorizedKeys())
                 .thenReturn(2);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, repositoryMock, null, constants, provider, null, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, repositoryMock, null, constants, provider, null, null);
         assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
         verify(provider, never()).setFeePerKb(any());
     }
@@ -2938,7 +2916,7 @@ public class BridgeSupportTest {
         when(authorizer.getRequiredAuthorizedKeys())
                 .thenReturn(1);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, repositoryMock, null, constants, provider, null, null);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, repositoryMock, null, constants, provider, null, null);
         assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
         verify(provider).setFeePerKb(Coin.CENT);
     }
@@ -3043,7 +3021,7 @@ public class BridgeSupportTest {
             return null;
         }).when(providerMock).setPendingFederation(any());
 
-        BridgeSupport result = new BridgeSupport(ConfigHelper.CONFIG, null, eventLogger, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), providerMock, null, null);
+        BridgeSupport result = new BridgeSupport(config, null, eventLogger, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), providerMock, null, null);
 
         Whitebox.setInternalState(result, "bridgeConstants", constantsMock);
         Whitebox.setInternalState(result, "rskExecutionBlock", executionBlock);
@@ -3059,7 +3037,7 @@ public class BridgeSupportTest {
         BridgeStorageProvider providerMock = mock(BridgeStorageProvider.class);
         when(providerMock.getLockWhitelist()).thenReturn(mockedWhitelist);
 
-        BridgeSupport result = new BridgeSupport(ConfigHelper.CONFIG, null, null, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants(), providerMock, null, null);
+        BridgeSupport result = new BridgeSupport(config, null, null, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), providerMock, null, null);
 
         Whitebox.setInternalState(result, "bridgeConstants", constantsMock);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -24,7 +24,7 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.peg.bitcoin.SimpleBtcTransaction;
 import co.rsk.test.World;
@@ -34,7 +34,6 @@ import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.vm.PrecompiledContracts;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -56,10 +55,7 @@ import static org.mockito.Mockito.*;
  */
 public class BridgeTest {
 
-
-    private static NetworkParameters networkParameters = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
-
-    private static BlockchainNetConfig blockchainNetConfigOriginal;
+    private static NetworkParameters networkParameters;
     private static BridgeConstants bridgeConstants;
 
     private static final BigInteger AMOUNT = new BigInteger("1000000000000000000");
@@ -67,18 +63,13 @@ public class BridgeTest {
     private static final BigInteger GAS_PRICE = new BigInteger("100");
     private static final BigInteger GAS_LIMIT = new BigInteger("1000");
     private static final String DATA = "80af2871";
+    private static RskSystemProperties config = new RskSystemProperties();
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-        bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        config.setBlockchainConfig(new RegTestConfig());
+        bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         networkParameters = bridgeConstants.getBtcParams();
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test
@@ -87,10 +78,10 @@ public class BridgeTest {
         BtcTransaction tx2 = createTransaction();
         BtcTransaction tx3 = createTransaction();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         provider0.getReleaseTransactionSet().add(tx1, 1L);
         provider0.getReleaseTransactionSet().add(tx2, 2L);
@@ -102,9 +93,9 @@ public class BridgeTest {
 
         track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         World world = new World();
         bridge.init(rskTx, world.getBlockChain().getBestBlock(), track, world.getBlockChain().getBlockStore(), world.getBlockChain().getReceiptStore(), new LinkedList<>());
 
@@ -112,7 +103,7 @@ public class BridgeTest {
 
         track.commit();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(3, provider.getReleaseTransactionSet().getEntries().size());
         Assert.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
@@ -124,10 +115,10 @@ public class BridgeTest {
         BtcTransaction tx2 = createTransaction();
         BtcTransaction tx3 = createTransaction();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         provider0.getReleaseTransactionSet().add(tx1, 1L);
         provider0.getReleaseTransactionSet().add(tx2, 2L);
@@ -142,19 +133,19 @@ public class BridgeTest {
         World world = new World();
         List<Block> blocks = BlockGenerator.getInstance().getSimpleBlockChain(world.getBlockChain().getBestBlock(), 10);
 
-        Transaction rskTx = Transaction.create(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         world.getBlockChain().getBlockStore().saveBlock(blocks.get(1), BigInteger.ONE, true);
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(rskTx, blocks.get(9), track, world.getBlockChain().getBlockStore(), world.getBlockChain().getReceiptStore(), new LinkedList<>());
 
         bridge.execute(Bridge.UPDATE_COLLECTIONS.encode());
 
         track.commit();
 
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants());
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
 
         Assert.assertEquals(2, provider.getReleaseTransactionSet().getEntries().size());
         Assert.assertEquals(1, provider.getRskTxsWaitingForSignatures().size());
@@ -162,10 +153,10 @@ public class BridgeTest {
 
     @Test
     public void sendNoBlockHeader() throws IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         bridge.execute(Bridge.RECEIVE_HEADERS.encode());
@@ -175,10 +166,10 @@ public class BridgeTest {
 
     @Test
     public void sendOrphanBlockHeader() throws IOException {
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         co.rsk.bitcoinj.core.BtcBlock block = new co.rsk.bitcoinj.core.BtcBlock(networkParameters, 1, PegTestUtils.createHash(), PegTestUtils.createHash(), 1, Utils.encodeCompactBits(networkParameters.getMaxTarget()), 1, new ArrayList<>());
@@ -197,24 +188,24 @@ public class BridgeTest {
 
     @Test
     public void executeWithFunctionSignatureLengthTooShort() throws Exception{
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         Assert.assertNull(bridge.execute(new byte[3]));
     }
 
 
     @Test
     public void executeWithInexistentFunction() throws Exception{
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         Assert.assertNull(bridge.execute(new byte[4]));
     }
 
 
     @Test
     public void receiveHeadersWithNonParseableHeader() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         Object[] objectArray = new Object[1];
@@ -228,10 +219,10 @@ public class BridgeTest {
 
     @Test
     public void registerBtcTransactionWithNonParseableTx() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
 
@@ -242,10 +233,10 @@ public class BridgeTest {
 
     @Test
     public void registerBtcTransactionWithNonParseableMerkleeProof1() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         NetworkParameters btcParams = RegTestParams.get();
@@ -260,10 +251,10 @@ public class BridgeTest {
 
     @Test
     public void registerBtcTransactionWithNonParseableMerkleeProof2() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         NetworkParameters btcParams = RegTestParams.get();
@@ -280,10 +271,10 @@ public class BridgeTest {
     public void getFederationAddress() throws Exception {
         // Case with genesis federation
         Federation federation = bridgeConstants.getGenesisFederation();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         byte[] data = Bridge.GET_FEDERATION_ADDRESS.encode();
@@ -293,11 +284,11 @@ public class BridgeTest {
 
     @Test
     public void getMinimumLockTxValue() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         byte[] data = Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode();
@@ -307,9 +298,9 @@ public class BridgeTest {
 
     @Test
     public void addSignatureWithNonParseablePublicKey() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new byte[3];
@@ -322,9 +313,9 @@ public class BridgeTest {
 
     @Test
     public void addSignatureWithEmptySignatureArray() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new BtcECKey().getPubKey();
@@ -337,10 +328,10 @@ public class BridgeTest {
 
     @Test
     public void addSignatureWithNonParseableSignature() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, BlockGenerator.getInstance().getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new BtcECKey().getPubKey();
@@ -353,10 +344,10 @@ public class BridgeTest {
 
     @Test
     public void addSignatureWithNonParseableRskTx() throws Exception{
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, BlockGenerator.getInstance().getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new BtcECKey().getPubKey();
@@ -369,7 +360,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInUpdateCollection() {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
 
         try {
             bridge.updateCollections(null);
@@ -382,7 +373,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInReleaseBtc() {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
 
         try {
             bridge.releaseBtc(null);
@@ -395,7 +386,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInGetStateForBtcReleaseClient() {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
 
         try {
             bridge. getStateForBtcReleaseClient(null);
@@ -408,7 +399,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInGetStateForDebugging() {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
 
         try {
             bridge.getStateForDebugging(null);
@@ -421,7 +412,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInGetBtcBlockchainBestChainHeight() {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
 
         try {
             bridge.getBtcBlockchainBestChainHeight(null);
@@ -434,7 +425,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInGetBtcBlockchainBlockLocator() {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
 
         try {
             bridge.getBtcBlockchainBlockLocator(null);
@@ -451,13 +442,13 @@ public class BridgeTest {
 
     @Test
     public void getGasForDataFreeTx() {
-        BlockchainNetConfig blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new UnitTestBlockchainNetConfig());
+        BlockchainNetConfig blockchainNetConfigOriginal = config.getBlockchainConfig();
+        config.setBlockchainConfig(new UnitTestBlockchainNetConfig());
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
 
         org.ethereum.core.Transaction rskTx = CallTransaction.createCallTransaction(
-                ConfigHelper.CONFIG, 0,
+                config, 0,
                 1,
                 1,
                 PrecompiledContracts.BRIDGE_ADDR,
@@ -465,11 +456,11 @@ public class BridgeTest {
                 Bridge.UPDATE_COLLECTIONS);
         rskTx.sign(((BridgeRegTestConstants)bridgeConstants).getFederatorPrivateKeys().get(0).getPrivKeyBytes());
 
-        Block rskExecutionBlock = BlockGenerator.getInstance().createChildBlock(Genesis.getInstance(ConfigHelper.CONFIG));
+        Block rskExecutionBlock = BlockGenerator.getInstance().createChildBlock(Genesis.getInstance(config));
         bridge.init(rskTx, rskExecutionBlock, null, null, null, null);
         Assert.assertEquals(0, bridge.getGasForData(rskTx.getData()));
 
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
+        config.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test
@@ -532,14 +523,14 @@ public class BridgeTest {
     }
 
     private void getGasForDataPaidTx(int expected, CallTransaction.Function function, Object... funcArgs) {
-        BlockchainNetConfig blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new UnitTestBlockchainNetConfig());
+        BlockchainNetConfig blockchainNetConfigOriginal = config.getBlockchainConfig();
+        config.setBlockchainConfig(new UnitTestBlockchainNetConfig());
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         org.ethereum.core.Transaction rskTx;
         if (function==null) {
             rskTx = CallTransaction.createRawTransaction(
-                    ConfigHelper.CONFIG, 0,
+                    config, 0,
                     1,
                     1,
                     PrecompiledContracts.BRIDGE_ADDR,
@@ -547,7 +538,7 @@ public class BridgeTest {
                     new byte[]{1,2,3});
         } else {
             rskTx = CallTransaction.createCallTransaction(
-                    ConfigHelper.CONFIG, 0,
+                    config, 0,
                     1,
                     1,
                     PrecompiledContracts.BRIDGE_ADDR,
@@ -558,19 +549,19 @@ public class BridgeTest {
 
         rskTx.sign(((BridgeRegTestConstants)bridgeConstants).getFederatorPrivateKeys().get(0).getPrivKeyBytes());
 
-        Block rskExecutionBlock = BlockGenerator.getInstance().createChildBlock(Genesis.getInstance(ConfigHelper.CONFIG));
+        Block rskExecutionBlock = BlockGenerator.getInstance().createChildBlock(Genesis.getInstance(config));
         for (int i = 0; i < 20; i++) {
             rskExecutionBlock = BlockGenerator.getInstance().createChildBlock(rskExecutionBlock);
         }
         bridge.init(rskTx, rskExecutionBlock, null, null, null, null);
         Assert.assertEquals(expected, bridge.getGasForData(rskTx.getData()));
 
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
+        config.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test
     public void isBtcTxHashAlreadyProcessed_normalFlow() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -592,7 +583,7 @@ public class BridgeTest {
 
     @Test
     public void isBtcTxHashAlreadyProcessed_exception() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -609,7 +600,7 @@ public class BridgeTest {
 
     @Test
     public void getBtcTxHashProcessedHeight_normalFlow() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -630,7 +621,7 @@ public class BridgeTest {
 
     @Test
     public void getBtcTxHashProcessedHeight_exception() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -647,7 +638,7 @@ public class BridgeTest {
 
     @Test
     public void getFederationSize() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -658,7 +649,7 @@ public class BridgeTest {
 
     @Test
     public void getFederationThreshold() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -669,7 +660,7 @@ public class BridgeTest {
 
     @Test
     public void getFederationCreationTime() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -680,7 +671,7 @@ public class BridgeTest {
 
     @Test
     public void getFederationCreationBlockNumber() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getFederationCreationBlockNumber()).thenReturn(42L);
@@ -690,7 +681,7 @@ public class BridgeTest {
 
     @Test
     public void getFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -704,7 +695,7 @@ public class BridgeTest {
 
     @Test
     public void getRetiringFederationSize() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -715,7 +706,7 @@ public class BridgeTest {
 
     @Test
     public void getRetiringFederationThreshold() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -726,7 +717,7 @@ public class BridgeTest {
 
     @Test
     public void getRetiringFederationCreationTime() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -737,7 +728,7 @@ public class BridgeTest {
 
     @Test
     public void getRetiringFederationCreationBlockNumber() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getRetiringFederationCreationBlockNumber()).thenReturn(42L);
@@ -747,7 +738,7 @@ public class BridgeTest {
 
     @Test
     public void getRetiringFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -761,7 +752,7 @@ public class BridgeTest {
 
     @Test
     public void getPendingFederationSize() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -772,7 +763,7 @@ public class BridgeTest {
 
     @Test
     public void getPendingFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -787,7 +778,7 @@ public class BridgeTest {
     @Test
     public void createFederation() throws IOException {
         Transaction txMock = mock(Transaction.class);
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -799,7 +790,7 @@ public class BridgeTest {
     @Test
     public void addFederatorPublicKey_ok() throws IOException {
         Transaction txMock = mock(Transaction.class);
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -811,7 +802,7 @@ public class BridgeTest {
 
     @Test
     public void addFederatorPublicKey_wrongParameterType() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -823,7 +814,7 @@ public class BridgeTest {
     @Test
     public void commitFederation_ok() throws IOException {
         Transaction txMock = mock(Transaction.class);
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -835,7 +826,7 @@ public class BridgeTest {
 
     @Test
     public void commitFederation_wrongParameterType() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -847,7 +838,7 @@ public class BridgeTest {
     @Test
     public void rollbackFederation() throws IOException {
         Transaction txMock = mock(Transaction.class);
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -858,7 +849,7 @@ public class BridgeTest {
 
     @Test
     public void getLockWhitelistSize() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -869,7 +860,7 @@ public class BridgeTest {
 
     @Test
     public void getLockWhitelistAddress() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -883,7 +874,7 @@ public class BridgeTest {
     @Test
     public void addLockWhitelistAddress() throws IOException {
         Transaction mockedTransaction = mock(Transaction.class);
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(mockedTransaction, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -895,7 +886,7 @@ public class BridgeTest {
     @Test
     public void removeLockWhitelistAddress() throws IOException {
         Transaction mockedTransaction = mock(Transaction.class);
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(mockedTransaction, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -906,7 +897,7 @@ public class BridgeTest {
 
     @Test
     public void getFeePerKb() {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getFeePerKb())
@@ -918,7 +909,7 @@ public class BridgeTest {
     @Test
     public void voteFeePerKb_ok() throws IOException {
         Transaction txMock = mock(Transaction.class);
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(txMock, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -930,7 +921,7 @@ public class BridgeTest {
 
     @Test
     public void voteFeePerKb_wrongParameterType() throws IOException {
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         bridge.init(null, null, null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -18,8 +18,6 @@
 
 package co.rsk.peg;
 
-import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.params.RegTestParams;
@@ -27,16 +25,18 @@ import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.wallet.CoinSelector;
 import co.rsk.bitcoinj.wallet.Wallet;
-import co.rsk.config.ConfigHelper;
+import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
-import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Genesis;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +67,12 @@ public class BridgeUtilsTest {
     private static final BigInteger GAS_PRICE = new BigInteger("100");
     private static final BigInteger GAS_LIMIT = new BigInteger("1000");
     private static final String DATA = "80af2871";
+    private RskSystemProperties config;
+
+    @Before
+    public void setupConfig(){
+        config = new RskSystemProperties();
+    }
 
     @Test
     public void testIsLock() throws Exception {
@@ -274,7 +280,7 @@ public class BridgeUtilsTest {
 
     @Test
     public void getAddressFromEthTransaction() {
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         byte[] privKey = generatePrivKey();
         tx.sign(privKey);
 
@@ -286,7 +292,7 @@ public class BridgeUtilsTest {
 
     @Test(expected = Exception.class)
     public void getAddressFromEthNotSignTransaction() {
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(ConfigHelper.CONFIG, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         BridgeUtils.recoverBtcAddressFromEthTransaction(tx, RegTestParams.get());
     }
 
@@ -324,27 +330,31 @@ public class BridgeUtilsTest {
 
     @Test
     public void isFreeBridgeTxTrue() {
-        isFreeBridgeTx(true, PrecompiledContracts.BRIDGE_ADDR, new UnitTestBlockchainNetConfig(), BridgeRegTestConstants.getInstance().getFederatorPrivateKeys().get(0).getPrivKeyBytes());
+        config.setBlockchainConfig(new UnitTestBlockchainNetConfig());
+        isFreeBridgeTx(true, PrecompiledContracts.BRIDGE_ADDR, BridgeRegTestConstants.getInstance().getFederatorPrivateKeys().get(0).getPrivKeyBytes());
     }
 
     @Test
     public void isFreeBridgeTxOtherContract() {
-        isFreeBridgeTx(false, PrecompiledContracts.IDENTITY_ADDR, new UnitTestBlockchainNetConfig(), BridgeRegTestConstants.getInstance().getFederatorPrivateKeys().get(0).getPrivKeyBytes());
+        config.setBlockchainConfig(new UnitTestBlockchainNetConfig());
+        isFreeBridgeTx(false, PrecompiledContracts.IDENTITY_ADDR, BridgeRegTestConstants.getInstance().getFederatorPrivateKeys().get(0).getPrivKeyBytes());
     }
 
     @Test
     public void isFreeBridgeTxFreeTxDisabled() {
-        isFreeBridgeTx(false, PrecompiledContracts.BRIDGE_ADDR, new RegTestConfig() {
+        config.setBlockchainConfig(new RegTestConfig() {
             @Override
             public boolean areBridgeTxsFree() {
                 return false;
             }
-        }, BridgeRegTestConstants.getInstance().getFederatorPrivateKeys().get(0).getPrivKeyBytes());
+        });
+        isFreeBridgeTx(false, PrecompiledContracts.BRIDGE_ADDR, BridgeRegTestConstants.getInstance().getFederatorPrivateKeys().get(0).getPrivKeyBytes());
     }
 
     @Test
     public void isFreeBridgeTxNonFederatorKey() {
-        isFreeBridgeTx(false, PrecompiledContracts.BRIDGE_ADDR, new UnitTestBlockchainNetConfig(), new BtcECKey().getPrivKeyBytes());
+        config.setBlockchainConfig(new UnitTestBlockchainNetConfig());
+        isFreeBridgeTx(false, PrecompiledContracts.BRIDGE_ADDR, new BtcECKey().getPrivKeyBytes());
     }
 
     @Test
@@ -396,14 +406,11 @@ public class BridgeUtilsTest {
     }
 
 
-    private void isFreeBridgeTx(boolean expected, RskAddress destinationAddress, BlockchainNetConfig config, byte[] privKeyBytes) {
-        BlockchainNetConfig blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(config);
-
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+    private void isFreeBridgeTx(boolean expected, RskAddress destinationAddress, byte[] privKeyBytes) {
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
 
         org.ethereum.core.Transaction rskTx = CallTransaction.createCallTransaction(
-                ConfigHelper.CONFIG, 0,
+                config, 0,
                 1,
                 1,
                 destinationAddress,
@@ -411,10 +418,8 @@ public class BridgeUtilsTest {
                 Bridge.UPDATE_COLLECTIONS);
         rskTx.sign(privKeyBytes);
 
-        Block rskExecutionBlock = BlockGenerator.getInstance().createChildBlock(Genesis.getInstance(ConfigHelper.CONFIG));
+        Block rskExecutionBlock = BlockGenerator.getInstance().createChildBlock(Genesis.getInstance(config));
         bridge.init(rskTx, rskExecutionBlock, null, null, null, null);
-        Assert.assertEquals(expected, BridgeUtils.isFreeBridgeTx(ConfigHelper.CONFIG, rskTx, rskExecutionBlock.getNumber()));
-
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
+        Assert.assertEquals(expected, BridgeUtils.isFreeBridgeTx(config, rskTx, rskExecutionBlock.getNumber()));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -18,19 +18,16 @@
 
 package co.rsk.peg;
 
-import co.rsk.config.BridgeConstants;
-import co.rsk.config.ConfigHelper;
-import co.rsk.crypto.Sha3Hash;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.wallet.RedeemData;
+import co.rsk.crypto.Sha3Hash;
 
 /**
  * Created by oscar on 05/08/2016.
  */
 public class PegTestUtils {
-    private static BridgeConstants bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
 
     public static void main(String[] args) {
         for (int i = 0; i < 257; i++) {

--- a/rskj-core/src/test/java/co/rsk/peg/RepositoryBlockStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RepositoryBlockStoreTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.BtcBlock;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.StoredBlock;
 import co.rsk.bitcoinj.params.RegTestParams;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.db.RepositoryImplForTesting;
 import org.apache.commons.lang3.tuple.Triple;
 import org.ethereum.core.Repository;
@@ -82,7 +82,8 @@ public class RepositoryBlockStoreTest {
         InputStream fileInputStream = ClassLoader.getSystemResourceAsStream("peg/RepositoryBlockStore_data.ser");
         ObjectInputStream objectInputStream = new ObjectInputStream(fileInputStream);
         Repository repository = new RepositoryImplForTesting();
-        RepositoryBlockStore store = new RepositoryBlockStore(ConfigHelper.CONFIG, repository, PrecompiledContracts.BRIDGE_ADDR);
+        RskSystemProperties config = new RskSystemProperties();
+        RepositoryBlockStore store = new RepositoryBlockStore(config, repository, PrecompiledContracts.BRIDGE_ADDR);
         for (int i = 0; i < 614; i++) {
             Triple<byte[], BigInteger , Integer> tripleStoredBlock = (Triple<byte[], BigInteger , Integer>) objectInputStream.readObject();
             BtcBlock header = RegTestParams.get().getDefaultSerializer().makeBlock(tripleStoredBlock.getLeft());
@@ -94,7 +95,7 @@ public class RepositoryBlockStoreTest {
         }
 
         // Create a new instance of the store
-        RepositoryBlockStore store2 = new RepositoryBlockStore(ConfigHelper.CONFIG, repository, PrecompiledContracts.BRIDGE_ADDR);
+        RepositoryBlockStore store2 = new RepositoryBlockStore(config, repository, PrecompiledContracts.BRIDGE_ADDR);
 
 
         // Check a specific block that used to fail when we had a bug

--- a/rskj-core/src/test/java/co/rsk/peg/SamplePrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/SamplePrecompiledContractTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.peg;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import org.apache.commons.lang3.StringUtils;
 import org.ethereum.core.CallTransaction;
@@ -38,11 +38,14 @@ import static org.junit.Assert.assertNull;
  * Created by adrian.eidelman on 3/15/2016.
  */
 public class SamplePrecompiledContractTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void samplePrecompiledContractMethod1Ok()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
 
 
         String funcJson = "{\n" +
@@ -61,7 +64,7 @@ public class SamplePrecompiledContractTest {
         byte[] bytes = new byte[]{(byte) 0xab, (byte) 0xcd, (byte) 0xef};
         byte[] data = function.encode(111, bytes, 222);
 
-        contract.init(null, null, new RepositoryImpl(ConfigHelper.CONFIG), null, null, new ArrayList<LogInfo>());
+        contract.init(null, null, new RepositoryImpl(config), null, null, new ArrayList<LogInfo>());
         byte[] result = contract.execute(data);
 
         Object[] results = function.decodeResult(result);
@@ -72,7 +75,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractMethod1WrongData()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
 
 
         String funcJson = "{\n" +
@@ -90,7 +93,7 @@ public class SamplePrecompiledContractTest {
 
         byte[] data = new byte[]{(byte) 0xab, (byte) 0xcd, (byte) 0xef};
 
-        contract.init(null, null, new RepositoryImpl(ConfigHelper.CONFIG), null, null, new ArrayList<LogInfo>());
+        contract.init(null, null, new RepositoryImpl(config), null, null, new ArrayList<LogInfo>());
         byte[] result = contract.execute(data);
 
         assertNull(result);
@@ -100,7 +103,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractMethodDoesNotExist()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
 
 
         String funcJson = "{\n" +
@@ -119,7 +122,7 @@ public class SamplePrecompiledContractTest {
         byte[] bytes = new byte[]{(byte) 0xab, (byte) 0xcd, (byte) 0xef};
         byte[] data = function.encode(111, bytes, 222);
 
-        contract.init(null, null, new RepositoryImpl(ConfigHelper.CONFIG), null, null, new ArrayList<LogInfo>());
+        contract.init(null, null, new RepositoryImpl(config), null, null, new ArrayList<LogInfo>());
         byte[] result = contract.execute(data);
 
         assertNull(result);
@@ -129,7 +132,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractMethod1LargeData()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
 
 
         String funcJson = "{\n" +
@@ -146,7 +149,7 @@ public class SamplePrecompiledContractTest {
 
         byte[] data = function.encode(111, StringUtils.leftPad("foobar", 1000000, '*'));
 
-        contract.init(null, null, new RepositoryImpl(ConfigHelper.CONFIG), null, null, new ArrayList<LogInfo>());
+        contract.init(null, null, new RepositoryImpl(config), null, null, new ArrayList<LogInfo>());
         byte[] result = contract.execute(data);
 
         Object[] results = function.decodeResult(result);
@@ -157,7 +160,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractAddBalanceOk()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
 
 
         String funcJson = "{\n" +
@@ -173,7 +176,7 @@ public class SamplePrecompiledContractTest {
 
         byte[] data = function.encode();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         contract.init(null, null, repository, null, null, new ArrayList<LogInfo>());
         contract.execute(data);
 
@@ -184,7 +187,7 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractGetBalanceInitialBalance()
     {
-        int balance = this.GetBalance(new RepositoryImpl(ConfigHelper.CONFIG));
+        int balance = this.GetBalance(new RepositoryImpl(config));
         assertEquals(0, balance);
     }
 
@@ -192,7 +195,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractIncrementResultOk()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
 
 
         String funcJson = "{\n" +
@@ -208,7 +211,7 @@ public class SamplePrecompiledContractTest {
 
         byte[] data = function.encode();
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
         contract.init(null, null, track, null, null, new ArrayList<LogInfo>());
         contract.execute(data);
@@ -221,14 +224,14 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractGetResultInitialValue()
     {
-        int result = this.GetResult(new RepositoryImpl(ConfigHelper.CONFIG));
+        int result = this.GetResult(new RepositoryImpl(config));
         assertEquals(0, result);
     }
 
     private int GetBalance(Repository repository)
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
 
 
         String funcJson = "{\n" +
@@ -255,7 +258,7 @@ public class SamplePrecompiledContractTest {
     private int GetResult(Repository repository)
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
 
 
         String funcJson = "{\n" +

--- a/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
@@ -18,11 +18,11 @@
 
 package co.rsk.peg;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.crypto.Sha3Hash;
 import org.apache.commons.lang3.tuple.Pair;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.BtcTransaction;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class StateForFederatorTest {
     private static final String SHA3_3 = "3333333333333333333333333333333333333333333333333333333333333333";
     private static final String SHA3_4 = "4444444444444444444444444444444444444444444444444444444444444444";
 
-    private static final NetworkParameters NETWORK_PARAMETERS = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
+    private static final NetworkParameters NETWORK_PARAMETERS = new RskSystemProperties().getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
 
     @Test
     public void serialize() {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
@@ -20,14 +20,13 @@ package co.rsk.peg.performance;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.config.BridgeConstants;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.db.RepositoryTrackWithBenchmarking;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.vm.VMPerformanceTest;
-import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Repository;
@@ -51,9 +50,9 @@ import java.util.List;
 import java.util.Random;
 
 public abstract class BridgePerformanceTestCase {
-    protected static NetworkParameters networkParameters = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
-    protected static BlockchainNetConfig blockchainNetConfigOriginal;
+    protected static NetworkParameters networkParameters;
     protected static BridgeConstants bridgeConstants;
+    private static RskSystemProperties config;
 
     private boolean oldCpuTimeEnabled;
     private ThreadMXBean thread;
@@ -99,15 +98,10 @@ public abstract class BridgePerformanceTestCase {
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-        bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new RegTestConfig());
+        bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         networkParameters = bridgeConstants.getBtcParams();
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @AfterClass
@@ -253,7 +247,7 @@ public abstract class BridgePerformanceTestCase {
 
         ExecutionTracker executionInfo = new ExecutionTracker(thread);
 
-        RepositoryImpl repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        RepositoryImpl repository = new RepositoryImpl(config);
         Repository track = repository.startTracking();
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants);
 
@@ -270,9 +264,9 @@ public abstract class BridgePerformanceTestCase {
 
         List<LogInfo> logs = new ArrayList<>();
 
-        RepositoryTrackWithBenchmarking benchmarkerTrack = new RepositoryTrackWithBenchmarking(ConfigHelper.CONFIG, repository);
+        RepositoryTrackWithBenchmarking benchmarkerTrack = new RepositoryTrackWithBenchmarking(config, repository);
 
-        Bridge bridge = new Bridge(ConfigHelper.CONFIG, PrecompiledContracts.BRIDGE_ADDR);
+        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         Blockchain blockchain = BlockChainBuilder.ofSizeWithNoPendingStateCleaner(heightProvider.getHeight(executionIndex));
         bridge.init(
                 tx,

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BtcBlockchainTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BtcBlockchainTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.BtcBlockChain;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.RepositoryBlockStore;
@@ -56,7 +56,7 @@ public class BtcBlockchainTest extends BridgePerformanceTestCase {
         final int maxBtcBlocks = 2000;
 
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, repository, PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new RskSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/LockWhitelistTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/LockWhitelistTest.java
@@ -21,7 +21,7 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.LockWhitelist;
@@ -122,7 +122,7 @@ public class LockWhitelistTest extends BridgePerformanceTestCase {
         final int maxBtcBlocks = 1000;
 
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, repository, PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new RskSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
@@ -23,7 +23,7 @@ import co.rsk.bitcoinj.core.BtcBlockChain;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.RepositoryBlockStore;
@@ -46,7 +46,7 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
         final int maxBtcBlocks = 2000;
 
         BridgeStorageProviderInitializer storageInitializer = (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, repository, PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new RskSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.RepositoryBlockStore;
@@ -97,7 +97,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
 
     private BridgeStorageProviderInitializer generateInitializerForLock(int minBtcBlocks, int maxBtcBlocks, int numberOfLockConfirmations, boolean markAsAlreadyProcessed) {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(ConfigHelper.CONFIG, repository, PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new RskSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascContractExecuteTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascContractExecuteTest.java
@@ -18,39 +18,34 @@
 
 package co.rsk.remasc;
 
-import co.rsk.config.ConfigHelper;
 import co.rsk.config.RemascConfig;
 import co.rsk.config.RemascConfigFactory;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.Program;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 public class RemascContractExecuteTest {
 
     private static BlockchainNetConfig blockchainNetConfigOriginal;
     private static RemascConfig remascConfig;
+    private static RskSystemProperties config;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new RegTestConfig());
         remascConfig = new RemascConfigFactory(RemascContract.REMASC_CONFIG).createRemascConfig("regtest");
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test(expected = Program.OutOfGasException.class)
     public void executeWithFunctionSignatureLengthTooShort() throws Exception{
-        RemascContract remasc = new RemascContract(ConfigHelper.CONFIG, remascConfig, PrecompiledContracts.REMASC_ADDR);
+        RemascContract remasc = new RemascContract(config, remascConfig, PrecompiledContracts.REMASC_ADDR);
 
         remasc.execute(new byte[3]);
         fail("Expected OutOfGasException");
@@ -58,7 +53,7 @@ public class RemascContractExecuteTest {
 
     @Test(expected = Program.OutOfGasException.class)
     public void executeWithInexistentFunction() throws Exception{
-        RemascContract remasc = new RemascContract(ConfigHelper.CONFIG, remascConfig, PrecompiledContracts.REMASC_ADDR);
+        RemascContract remasc = new RemascContract(config, remascConfig, PrecompiledContracts.REMASC_ADDR);
 
         remasc.execute(new byte[4]);
         fail("Expected OutOfGasException");
@@ -66,7 +61,7 @@ public class RemascContractExecuteTest {
 
     @Test(expected = Program.OutOfGasException.class)
     public void executeWithDataLengthTooLong() throws Exception{
-        RemascContract remasc = new RemascContract(ConfigHelper.CONFIG, remascConfig, PrecompiledContracts.REMASC_ADDR);
+        RemascContract remasc = new RemascContract(config, remascConfig, PrecompiledContracts.REMASC_ADDR);
 
         remasc.execute(new byte[6]);
         fail("Expected OutOfGasException");

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
@@ -2,7 +2,7 @@ package co.rsk.remasc;
 
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.peg.BridgeSupport;
 import co.rsk.test.builders.BlockChainBuilder;
 import org.ethereum.core.Blockchain;
@@ -38,7 +38,7 @@ public class RemascFederationProviderTest {
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
         Blockchain blockchain = builder.build();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(ConfigHelper.CONFIG, blockchain.getRepository(),
+        BridgeSupport bridgeSupport = new BridgeSupport(new RskSystemProperties(), blockchain.getRepository(),
                 null,
                 PrecompiledContracts.BRIDGE_ADDR,
                 null);

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -19,7 +19,10 @@
 package co.rsk.remasc;
 
 import co.rsk.bitcoinj.store.BlockStoreException;
-import co.rsk.config.*;
+import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.config.RemascConfig;
+import co.rsk.config.RemascConfigFactory;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.crypto.Sha3Hash;
@@ -35,7 +38,6 @@ import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.SHA3Helper;
 import org.ethereum.vm.PrecompiledContracts;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
@@ -44,12 +46,14 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class RemascProcessMinerFeesTest {
 
     private static BlockchainNetConfig blockchainNetConfigOriginal;
     private static RemascConfig remascConfig;
+    private static RskSystemProperties config;
 
     private BigInteger cowInitialBalance = new BigInteger("1000000000000000000");
     private long initialGasLimit = 10000000L;
@@ -72,8 +76,8 @@ public class RemascProcessMinerFeesTest {
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new RegTestConfig());
         remascConfig = new RemascConfigFactory(RemascContract.REMASC_CONFIG).createRemascConfig("regtest");
 
         accountsAddressesUpToD = new LinkedList<>();
@@ -81,11 +85,6 @@ public class RemascProcessMinerFeesTest {
         accountsAddressesUpToD.add(coinbaseB.getBytes());
         accountsAddressesUpToD.add(coinbaseC.getBytes());
         accountsAddressesUpToD.add(coinbaseD.getBytes());
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
     }
 
     @Test
@@ -111,7 +110,7 @@ public class RemascProcessMinerFeesTest {
         blocks.add(blockWithOneTx);
         blocks.addAll(createSimpleBlocks(blockWithOneTx, 9));
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
 
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock());
@@ -154,7 +153,7 @@ public class RemascProcessMinerFeesTest {
         blocks.add(blockWithOneTx);
         blocks.addAll(createSimpleBlocks(blockWithOneTx, 9));
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
 
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock());
@@ -212,7 +211,7 @@ public class RemascProcessMinerFeesTest {
         blocks.add(blockThatIncludesUncle);
         blocks.addAll(createSimpleBlocks(blockThatIncludesUncle, 8));
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
 
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock());
@@ -314,7 +313,7 @@ public class RemascProcessMinerFeesTest {
         blocks.add(blockThatIncludesUnclesE);
         blocks.addAll(createSimpleBlocks(blockThatIncludesUnclesE, 7));
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(), blockchain,
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(), blockchain,
                 blockchain.getBlockStore(), null);
 
         for (Block b : blocks) {
@@ -430,7 +429,7 @@ public class RemascProcessMinerFeesTest {
         blocks.add(blockThatIncludesUncleC);
         blocks.addAll(createSimpleBlocks(blockThatIncludesUncleC, 7));
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
 
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock());
@@ -505,7 +504,7 @@ public class RemascProcessMinerFeesTest {
         blocks.add(blockWithOneTxD);
         blocks.addAll(createSimpleBlocks(blockWithOneTxD, 7));
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(),
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(),
                 blockchain, blockchain.getBlockStore(), null);
 
         for (Block b : blocks) {
@@ -589,7 +588,7 @@ public class RemascProcessMinerFeesTest {
         blocks.add(blockWithOneTx);
         blocks.addAll(createSimpleBlocks(blockWithOneTx, 9));
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
 
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock());
@@ -616,7 +615,7 @@ public class RemascProcessMinerFeesTest {
                 PrecompiledContracts.REMASC_ADDR.getBytes() ,
                 BigInteger.valueOf(txValue*2).toByteArray(),
                 null,
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         tx.sign(cowKey.getPrivKeyBytes());
         Block newblock = RemascTestRunner.createBlock(this.genesisBlock, blocks.get(blocks.size()-1),
                 PegTestUtils.createHash3(), TestUtils.randomAddress(), null, null, tx);
@@ -653,7 +652,7 @@ public class RemascProcessMinerFeesTest {
         blocks.add(blockWithOneTx);
         blocks.addAll(createSimpleBlocks(blockWithOneTx, 9));
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
+        BlockExecutor blockExecutor = new BlockExecutor(config, blockchain.getRepository(), blockchain, blockchain.getBlockStore(), null);
 
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock());
@@ -692,7 +691,7 @@ public class RemascProcessMinerFeesTest {
                 null ,
                 BigInteger.valueOf(0).toByteArray(),
                 Hex.decode("6060604052346000575b6077806100176000396000f30060606040525b3460005760495b6000600890508073ffffffffffffffffffffffffffffffffffffffff166040518090506000604051808303816000866161da5a03f1915050505b50565b0000a165627a7a7230582036692fbb1395da1688af0189be5b0ac18df3d93a2402f4fc8f927b31c1baa2460029"),
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         txCreateContract.sign(cowKey.getPrivKeyBytes());
         long txCallRemascGasLimit = 21828;
         Transaction txCallRemasc = new Transaction(
@@ -702,7 +701,7 @@ public class RemascProcessMinerFeesTest {
                 Hex.decode("da7ce79725418f4f6e13bf5f520c89cec5f6a974") ,
                 BigInteger.valueOf(0).toByteArray(),
                 null,
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                config.getBlockchainConfig().getCommonConstants().getChainId());
         txCallRemasc.sign(cowKey.getPrivKeyBytes());
 
         Block newblock = RemascTestRunner.createBlock(this.genesisBlock, blocks.get(blocks.size()-1),
@@ -918,7 +917,7 @@ public class RemascProcessMinerFeesTest {
 
     private void validateFederatorsBalanceIsCorrect(Repository repository, long federationReward) throws IOException, BlockStoreException {
         BridgeSupport bridgeSupport = new BridgeSupport(
-                ConfigHelper.CONFIG, repository,
+                config, repository,
                 null,
             PrecompiledContracts.BRIDGE_ADDR,
             null);

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -19,7 +19,7 @@
 package co.rsk.remasc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.db.RepositoryImplForTesting;
@@ -39,10 +39,13 @@ import java.util.SortedMap;
  * Created by usuario on 13/04/2017.
  */
 public class RemascStorageProviderTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void getDefautRewardBalance() {
         RskAddress accountAddress = randomAddress();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         RemascStorageProvider provider = new RemascStorageProvider(repository, accountAddress);
 
@@ -52,7 +55,7 @@ public class RemascStorageProviderTest {
     @Test
     public void setAndGetRewardBalance() {
         RskAddress accountAddress = randomAddress();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         RemascStorageProvider provider = new RemascStorageProvider(repository, accountAddress);
 
@@ -80,7 +83,7 @@ public class RemascStorageProviderTest {
     @Test
     public void getDefautBurnedBalance() {
         RskAddress accountAddress = randomAddress();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         RemascStorageProvider provider = new RemascStorageProvider(repository, accountAddress);
 
@@ -90,7 +93,7 @@ public class RemascStorageProviderTest {
     @Test
     public void setAndGetBurnedBalance() {
         RskAddress accountAddress = randomAddress();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         RemascStorageProvider provider = new RemascStorageProvider(repository, accountAddress);
 
@@ -118,7 +121,7 @@ public class RemascStorageProviderTest {
     @Test
     public void getDefaultBrokenSelectionRule() {
         RskAddress accountAddress = randomAddress();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         RemascStorageProvider provider = new RemascStorageProvider(repository, accountAddress);
 
@@ -128,7 +131,7 @@ public class RemascStorageProviderTest {
     @Test
     public void setAndGetBrokenSelectionRule() {
         RskAddress accountAddress = randomAddress();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         RemascStorageProvider provider = new RemascStorageProvider(repository, accountAddress);
 
@@ -156,7 +159,7 @@ public class RemascStorageProviderTest {
     @Test
     public void getDefaultSiblings() {
         RskAddress accountAddress = randomAddress();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         RemascStorageProvider provider = new RemascStorageProvider(repository, accountAddress);
 
@@ -169,7 +172,7 @@ public class RemascStorageProviderTest {
     @Test
     public void setAndGetSiblings() {
         RskAddress accountAddress = randomAddress();
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG);
+        Repository repository = new RepositoryImpl(config);
 
         RemascStorageProvider provider = new RemascStorageProvider(repository, accountAddress);
 

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -18,7 +18,7 @@
 
 package co.rsk.remasc;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
@@ -104,7 +104,7 @@ class RemascTestRunner {
         List<Block> mainChainBlocks = new ArrayList<>();
         this.blockchain.tryToConnect(this.genesis);
 
-        BlockExecutor blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, blockchain.getRepository(),
+        BlockExecutor blockExecutor = new BlockExecutor(new RskSystemProperties(), blockchain.getRepository(),
                 blockchain, blockchain.getBlockStore(), null);
 
         for(int i = 0; i <= this.initialHeight; i++) {
@@ -189,7 +189,7 @@ class RemascTestRunner {
                 new ECKey().getAddress() ,
                 BigInteger.valueOf(txValue).toByteArray(),
                 null,
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                new RskSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
 
         tx.sign(txSigningKey.getPrivKeyBytes());
         //createBlook 1

--- a/rskj-core/src/test/java/co/rsk/rpc/CorsConfigurationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/CorsConfigurationTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -47,7 +47,7 @@ public class CorsConfigurationTest {
 
     @Test
     public void hasHeaderFromTestConfig() {
-        CorsConfiguration config = new CorsConfiguration(ConfigHelper.CONFIG.corsDomains());
+        CorsConfiguration config = new CorsConfiguration(new RskSystemProperties().corsDomains());
 
         Assert.assertNotNull(config.getHeader());
         Assert.assertEquals(EXPECTED_CORS_CONFIG, config.getHeader());

--- a/rskj-core/src/test/java/co/rsk/rpc/ModuleDescriptionTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/ModuleDescriptionTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -181,7 +181,8 @@ public class ModuleDescriptionTest {
 
     @Test
     public void getModulesFromTestNewRskSystemProperties() {
-        List<ModuleDescription> modules = ConfigHelper.CONFIG.getRpcModules();
+        RskSystemProperties config = new RskSystemProperties();
+        List<ModuleDescription> modules = config.getRpcModules();
 
         Assert.assertNotNull(modules);
         Assert.assertFalse(modules.isEmpty());

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
 import org.ethereum.core.Repository;
@@ -41,7 +41,7 @@ public class Web3ImplRpcTest {
         WorldManager worldManager = Web3Mocks.getMockWorldManager();
         PersonalModule pm = new PersonalModuleWalletDisabled();
         Repository repository = Web3Mocks.getMockRepository();
-        Web3Impl web3 = new Web3RskImpl(eth, worldManager, ConfigHelper.CONFIG, null, null, pm, null, null, repository, null, null, null, null);
+        Web3Impl web3 = new Web3RskImpl(eth, worldManager, new RskSystemProperties(), null, null, pm, null, null, repository, null, null, null, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.NetworkStateExporter;
 import co.rsk.core.Rsk;
 import co.rsk.core.Wallet;
@@ -39,9 +39,9 @@ import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.Web3Mocks;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,9 +69,10 @@ public class Web3RskImplTest {
         Mockito.when(blockchain.getBestBlock()).thenReturn(block);
 
         Wallet wallet = WalletFactory.createWallet();
-        PersonalModule pm = new PersonalModuleWalletEnabled(ConfigHelper.CONFIG, rsk, wallet, null);
-        EthModule em = new EthModule(ConfigHelper.CONFIG, rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(ConfigHelper.CONFIG, rsk, wallet, null));
-        Web3RskImpl web3 = new Web3RskImpl(rsk, worldManager, ConfigHelper.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, networkStateExporter, blockStore, null);
+        RskSystemProperties config = new RskSystemProperties();
+        PersonalModule pm = new PersonalModuleWalletEnabled(config, rsk, wallet, null);
+        EthModule em = new EthModule(config, rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, rsk, wallet, null));
+        Web3RskImpl web3 = new Web3RskImpl(rsk, worldManager, config, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, networkStateExporter, blockStore, null);
         web3.ext_dumpState();
     }
 

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -18,7 +18,7 @@
 
 package co.rsk.test;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockChainImplTest;
 import co.rsk.core.bc.BlockExecutor;
@@ -72,7 +72,7 @@ public class World {
 
     public BlockExecutor getBlockExecutor() {
         if (this.blockExecutor == null)
-            this.blockExecutor = new BlockExecutor(ConfigHelper.CONFIG, this.getRepository(), this.getBlockChain(), this.getBlockChain().getBlockStore(), null);
+            this.blockExecutor = new BlockExecutor(new RskSystemProperties(), this.getRepository(), this.getBlockChain(), this.getBlockChain().getBlockStore(), null);
 
         return this.blockExecutor;
     }

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
@@ -19,7 +19,7 @@
 package co.rsk.test.builders;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.test.World;
@@ -93,7 +93,7 @@ public class BlockBuilder {
         Block block = BlockGenerator.getInstance().createChildBlock(parent, txs, uncles, difficulty, this.minGasPrice, gasLimit);
 
         if (blockChain != null) {
-            BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, blockChain.getRepository(), blockChain, blockChain.getBlockStore(), blockChain.getListener());
+            BlockExecutor executor = new BlockExecutor(new RskSystemProperties(), blockChain.getRepository(), blockChain, blockChain.getBlockStore(), blockChain.getListener());
             executor.executeAndFill(block, parent);
         }
 

--- a/rskj-core/src/test/java/co/rsk/test/builders/TransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/TransactionBuilder.java
@@ -18,7 +18,7 @@
 
 package co.rsk.test.builders;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.Account;
 import org.ethereum.core.ImmutableTransaction;
 import org.ethereum.core.Transaction;
@@ -92,7 +92,7 @@ public class TransactionBuilder {
 
     public Transaction build() {
         Transaction tx = Transaction.create(
-                ConfigHelper.CONFIG, receiver != null ? Hex.toHexString(receiver.getAddress().getBytes()) : (receiverAddress != null ? Hex.toHexString(receiverAddress) : null),
+                new RskSystemProperties(), receiver != null ? Hex.toHexString(receiver.getAddress().getBytes()) : (receiverAddress != null ? Hex.toHexString(receiverAddress) : null),
                 value, nonce, gasPrice, gasLimit, data);
         tx.sign(sender.getEcKey().getPrivKeyBytes());
 

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -18,7 +18,7 @@
 
 package co.rsk.test.dsl;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
@@ -32,7 +32,6 @@ import org.ethereum.core.ImportResult;
 import org.ethereum.core.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -223,7 +222,7 @@ public class WorldDslProcessor {
                 difficulty = difficultyTokenizer.hasMoreTokens()?parseDifficulty(difficultyTokenizer.nextToken(),k):k;
             }
             Block block = new BlockBuilder().difficulty(difficulty).parent(parent).build();
-            BlockExecutor executor = new BlockExecutor(ConfigHelper.CONFIG, world.getRepository(),
+            BlockExecutor executor = new BlockExecutor(new RskSystemProperties(), world.getRepository(),
                     world.getBlockChain(), world.getBlockChain().getBlockStore(), null);
             executor.executeAndFill(block, parent);
             world.saveBlock(name, block);

--- a/rskj-core/src/test/java/co/rsk/validators/BlockDifficultyValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockDifficultyValidationRuleTest.java
@@ -18,16 +18,12 @@
 
 package co.rsk.validators;
 
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.config.BridgeConstants;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.RskAddress;
-import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,21 +36,12 @@ import java.math.BigInteger;
  */
 public class BlockDifficultyValidationRuleTest {
 
-    private static BlockchainNetConfig blockchainNetConfigOriginal;
-    private static BridgeConstants bridgeConstants;
-    private static NetworkParameters btcParams;
+    private static RskSystemProperties config;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        blockchainNetConfigOriginal = ConfigHelper.CONFIG.getBlockchainConfig();
-        ConfigHelper.CONFIG.setBlockchainConfig(new RegTestConfig());
-        bridgeConstants = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getBridgeConstants();
-        btcParams = bridgeConstants.getBtcParams();
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        ConfigHelper.CONFIG.setBlockchainConfig(blockchainNetConfigOriginal);
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new RegTestConfig());
     }
 
     private BlockHeader getEmptyHeader(BigInteger difficulty,long blockTimestamp,int uCount) {
@@ -67,7 +54,7 @@ public class BlockDifficultyValidationRuleTest {
 
     @Test
     public void testDifficulty() {
-        DifficultyCalculator difficultyCalculator = new DifficultyCalculator(ConfigHelper.CONFIG);
+        DifficultyCalculator difficultyCalculator = new DifficultyCalculator(config);
         BlockDifficultyRule validationRule = new BlockDifficultyRule(difficultyCalculator);
 
         Block block = Mockito.mock(Block.class);

--- a/rskj-core/src/test/java/co/rsk/validators/BlockUnclesValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockUnclesValidationRuleTest.java
@@ -1,7 +1,7 @@
 package co.rsk.validators;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockChainImplTest;
 import org.ethereum.core.Block;
@@ -18,6 +18,9 @@ import java.util.List;
  * Created by ajlopez on 18/08/2017.
  */
 public class BlockUnclesValidationRuleTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void rejectBlockWithSiblingUncle() {
         Block genesis = BlockGenerator.getInstance().getGenesisBlock();
@@ -35,7 +38,7 @@ public class BlockUnclesValidationRuleTest {
         store.saveBlock(genesis, BigInteger.valueOf(1), true);
         store.saveBlock(block1, BigInteger.valueOf(2), true);
 
-        BlockUnclesValidationRule rule = new BlockUnclesValidationRule(ConfigHelper.CONFIG, store, 10, 10, new BlockCompositeRule(), new BlockParentCompositeRule());
+        BlockUnclesValidationRule rule = new BlockUnclesValidationRule(config, store, 10, 10, new BlockCompositeRule(), new BlockParentCompositeRule());
 
         Assert.assertFalse(rule.isValid(block));
     }
@@ -58,7 +61,7 @@ public class BlockUnclesValidationRuleTest {
         store.saveBlock(genesis, BigInteger.valueOf(1), true);
         store.saveBlock(block1, BigInteger.valueOf(2), true);
 
-        BlockUnclesValidationRule rule = new BlockUnclesValidationRule(ConfigHelper.CONFIG, store, 10, 10, new BlockCompositeRule(), new BlockParentCompositeRule());
+        BlockUnclesValidationRule rule = new BlockUnclesValidationRule(config, store, 10, 10, new BlockCompositeRule(), new BlockParentCompositeRule());
 
         Assert.assertFalse(rule.isValid(block));
     }

--- a/rskj-core/src/test/java/co/rsk/validators/GasLimitRuleTests.java
+++ b/rskj-core/src/test/java/co/rsk/validators/GasLimitRuleTests.java
@@ -18,13 +18,12 @@
 
 package co.rsk.validators;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.vm.DataWord;
 import org.junit.Test;
-
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -34,23 +33,24 @@ import static org.junit.Assert.assertTrue;
  * @since 02.23.2016
  */
 public class GasLimitRuleTests {
+    private final RskSystemProperties config = new RskSystemProperties();
     private GasLimitRule rule = new GasLimitRule(3000000);
 
     @Test // pass rule
     public void gasLimitGreaterThanMinimumGasLimit() {
-        Block block = getBlock(ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getMinGasLimit() + 1);
+        Block block = getBlock(config.getBlockchainConfig().getCommonConstants().getMinGasLimit() + 1);
         assertTrue(rule.isValid(block));
     }
 
     @Test // pass rule
     public void gasLimitEqualMinimumGasLimit() {
-        Block block = getBlock(ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getMinGasLimit());
+        Block block = getBlock(config.getBlockchainConfig().getCommonConstants().getMinGasLimit());
         assertTrue(rule.isValid(block));
     }
 
     @Test // no pass rule
     public void gasLimitLessThanMinimumGasLimit() {
-        Block block = getBlock(ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getMinGasLimit() - 1);
+        Block block = getBlock(config.getBlockchainConfig().getCommonConstants().getMinGasLimit() - 1);
         assertFalse(rule.isValid(block));
     }
 

--- a/rskj-core/src/test/java/co/rsk/validators/RemascValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/RemascValidationRuleTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.validators;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
@@ -35,6 +35,8 @@ import java.util.List;
  */
 public class RemascValidationRuleTest {
 
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void noTxInTheBlock() {
         Block b = Mockito.mock(Block.class);
@@ -48,7 +50,7 @@ public class RemascValidationRuleTest {
         Block b = Mockito.mock(Block.class);
 
         List<Transaction> tx = new ArrayList<>();
-        tx.add(Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
+        tx.add(Transaction.create(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
 
         Mockito.when(b.getTransactionsList()).thenReturn(tx);
 
@@ -63,7 +65,7 @@ public class RemascValidationRuleTest {
 
         List<Transaction> tx = new ArrayList<>();
         tx.add(new RemascTransaction(1L));
-        tx.add(Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
+        tx.add(Transaction.create(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
 
         Mockito.when(b.getTransactionsList()).thenReturn(tx);
 
@@ -77,7 +79,7 @@ public class RemascValidationRuleTest {
         Block b = Mockito.mock(Block.class);
 
         List<Transaction> tx = new ArrayList<>();
-        tx.add(Transaction.create(ConfigHelper.CONFIG, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
+        tx.add(Transaction.create(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
         tx.add(new RemascTransaction(1L));
 
         Mockito.when(b.getTransactionsList()).thenReturn(tx);

--- a/rskj-core/src/test/java/co/rsk/vm/BlockchainVMTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/BlockchainVMTest.java
@@ -19,7 +19,7 @@
 package co.rsk.vm;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.test.World;
 import org.ethereum.core.*;
@@ -77,7 +77,7 @@ public class BlockchainVMTest {
                 dstAddress ,
                 transferAmount.toByteArray(),
                 null,
-                ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId());
+                new RskSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
 
         t.sign(binfo.faucetKey.getPrivKeyBytes());
         txs.add(t);

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -18,7 +18,7 @@
 
 package co.rsk.vm;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.mine.GasLimitCalculator;
 import co.rsk.panic.PanicProcessor;
@@ -41,6 +41,7 @@ import java.util.List;
 public class MinerHelper {
     private static final Logger logger = LoggerFactory.getLogger("minerhelper");
     private static final PanicProcessor panicProcessor = new PanicProcessor();
+    private final RskSystemProperties config = new RskSystemProperties();
     @Autowired
     private BlockStore blockStore;
 
@@ -66,7 +67,7 @@ public class MinerHelper {
         this.repository = repository;
         this.blockchain = blockchain;
        // this.blockStore =blockStore;
-        gasLimitCalculator = new GasLimitCalculator(ConfigHelper.CONFIG);
+        gasLimitCalculator = new GasLimitCalculator(config);
     }
 
     public void processBlock( Block block, Block parent) {
@@ -99,7 +100,7 @@ public class MinerHelper {
 
         for (Transaction tx : block.getTransactionsList()) {
 
-            TransactionExecutor executor = new TransactionExecutor(ConfigHelper.CONFIG, tx, txindex++, block.getCoinbase(),
+            TransactionExecutor executor = new TransactionExecutor(config, tx, txindex++, block.getCoinbase(),
                     track, blockStore, blockchain.getReceiptStore(),
                     programInvokeFactory, block, new EthereumListenerAdapter(), totalGasUsed);
 
@@ -144,8 +145,8 @@ public class MinerHelper {
 
         newBlock.getHeader().setLogsBloom(logBloom.getData());
 
-        BigInteger minGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getMinGasLimit());
-        BigInteger targetGasLimit = BigInteger.valueOf(ConfigHelper.CONFIG.getTargetGasLimit());
+        BigInteger minGasLimit = BigInteger.valueOf(config.getBlockchainConfig().getCommonConstants().getMinGasLimit());
+        BigInteger targetGasLimit = BigInteger.valueOf(config.getTargetGasLimit());
         BigInteger parentGasLimit = new BigInteger(1, parent.getGasLimit());
         BigInteger gasLimit = gasLimitCalculator.calculateBlockGasLimit(parentGasLimit, BigInteger.valueOf(totalGasUsed), minGasLimit, targetGasLimit, false);
 

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.vm;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.peg.Bridge;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
@@ -28,10 +28,12 @@ import org.junit.Test;
 
 public class PrecompiledContractTest {
 
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void getBridgeContract() {
         DataWord bridgeAddress = new DataWord(PrecompiledContracts.BRIDGE_ADDR.getBytes());
-        PrecompiledContract bridge = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, bridgeAddress);
+        PrecompiledContract bridge = PrecompiledContracts.getContractForAddress(config, bridgeAddress);
 
         Assert.assertNotNull(bridge);
         Assert.assertEquals(Bridge.class, bridge.getClass());
@@ -40,8 +42,8 @@ public class PrecompiledContractTest {
     @Test
     public void getBridgeContractTwice() {
         DataWord bridgeAddress = new DataWord(PrecompiledContracts.BRIDGE_ADDR.getBytes());
-        PrecompiledContract bridge1 = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, bridgeAddress);
-        PrecompiledContract bridge2 = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, bridgeAddress);
+        PrecompiledContract bridge1 = PrecompiledContracts.getContractForAddress(config, bridgeAddress);
+        PrecompiledContract bridge2 = PrecompiledContracts.getContractForAddress(config, bridgeAddress);
 
         Assert.assertNotNull(bridge1);
         Assert.assertNotNull(bridge2);

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.vm;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.VM;
 import org.ethereum.vm.program.Program;
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertEquals;
  * Created by ajlopez on 25/01/2017.
  */
 public class VMExecutionTest {
+    private final RskSystemProperties config = new RskSystemProperties();
     private ProgramInvokeMockImpl invoke;
     private BytecodeCompiler compiler;
 
@@ -244,7 +245,7 @@ public class VMExecutionTest {
     @Test
     public void dupnArgumentIsNotJumpdest() {
         byte[] code = compiler.compile("JUMPDEST DUPN 0x5b 0x5b");
-        Program program = new Program(ConfigHelper.CONFIG, code, invoke);
+        Program program = new Program(config, code, invoke);
 
         BitSet jumpdestSet = program.getJumpdestSet();
 
@@ -259,7 +260,7 @@ public class VMExecutionTest {
     @Test
     public void swapnArgumentIsNotJumpdest() {
         byte[] code = compiler.compile("JUMPDEST SWAPN 0x5b 0x5b");
-        Program program = new Program(ConfigHelper.CONFIG, code, invoke);
+        Program program = new Program(config, code, invoke);
 
         BitSet jumpdestSet = program.getJumpdestSet();
 
@@ -356,9 +357,9 @@ public class VMExecutionTest {
     }
 
     private Program executeCode(byte[] code, int nsteps) {
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
 
-        Program program = new Program(ConfigHelper.CONFIG, code, invoke);
+        Program program = new Program(config, code, invoke);
 
         for (int k = 0; k < nsteps; k++)
             vm.step(program);

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -18,14 +18,18 @@
 
 package co.rsk.vm;
 
-import co.rsk.config.ConfigHelper;
-import org.ethereum.TestUtils;
+import co.rsk.config.RskSystemProperties;
+import org.ethereum.vm.DataWord;
+import org.ethereum.vm.OpCode;
+import org.ethereum.vm.VM;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.invoke.ProgramInvokeMockImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
-import org.ethereum.vm.VM;
-import org.ethereum.vm.OpCode;
-import org.ethereum.vm.DataWord;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.management.GarbageCollectorMXBean;
@@ -36,17 +40,17 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-// Remove junit imports for standalone use
-import org.junit.*;
-
 import static org.ethereum.TestUtils.padLeft;
 import static org.ethereum.TestUtils.padRight;
 import static org.junit.Assert.assertEquals;
+
+// Remove junit imports for standalone use
 
 /**
  * Created by Sergio on 03/07/2016.
  */
 public class VMPerformanceTest {
+    private final RskSystemProperties config = new RskSystemProperties();
     private ProgramInvokeMockImpl invoke;
     private Program program;
     ThreadMXBean thread;
@@ -162,7 +166,7 @@ public class VMPerformanceTest {
 
         Boolean old = thread.isThreadCpuTimeEnabled();
         thread.setThreadCpuTimeEnabled(true);
-        vm = new VM(ConfigHelper.CONFIG);
+        vm = new VM(config);
         if (useProfiler)
             waitForProfiler();
 
@@ -291,7 +295,7 @@ public class VMPerformanceTest {
             baos.write(code, 0, code.length);
         byte[] newCode = baos.toByteArray();
 
-        program = new Program(ConfigHelper.CONFIG, newCode, invoke);
+        program = new Program(config, newCode, invoke);
         int sa = program.getStartAddr();
 
         long myLoops = maxLoops / cloneCount;
@@ -471,7 +475,7 @@ public class VMPerformanceTest {
 } // contract
         */
 
-        vm = new VM(ConfigHelper.CONFIG);
+        vm = new VM(config);
         // Strip the first 16 bytes which are added by Solidity to store the contract.
         byte[] codePlusPrefix = Hex.decode(
                 //---------------------------------------------------------------------------------------------------------------------nn
@@ -498,7 +502,7 @@ public class VMPerformanceTest {
         ------------------------------------------------------------------------------------------------------------------------------------------------------*/
         byte[] code = Arrays.copyOfRange(codePlusPrefix,16,codePlusPrefix.length);
 
-        program =new Program(ConfigHelper.CONFIG, code, invoke);
+        program =new Program(config, code, invoke);
 
         //String s_expected_1 = "000000000000000000000000000000000000000000000000000000033FFC1244"; // 55
         //String s_expected_1 = "00000000000000000000000000000000000000000000000000000002EE333961";// 50
@@ -557,7 +561,7 @@ public class VMPerformanceTest {
          }
          } // contract
          ********************************************************************************************/
-        vm = new VM(ConfigHelper.CONFIG);
+        vm = new VM(config);
         /////////////////////////////////////////////////////////////////////////////////////////////////
         // To increase precesion of the measurement, the maximum k value was increased
         // until the contract took more than 30 seconds
@@ -613,7 +617,7 @@ public class VMPerformanceTest {
     -----------------------------------------------------------------------------*/
 
     public void testRunTime(byte[] code, String s_expected) {
-        program = new Program(ConfigHelper.CONFIG, code, invoke);
+        program = new Program(config, code, invoke);
         System.out.println("-----------------------------------------------------------------------------");
         System.out.println("Starting test....");
         System.out.println("Configuration: Program.useDataWordPool =  " + Program.getUseDataWordPool().toString());

--- a/rskj-core/src/test/java/org/ethereum/cli/ClIInterfaceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/cli/ClIInterfaceTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.cli;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.rpc.CorsConfigurationTest;
 import org.ethereum.config.SystemProperties;
 import org.junit.Assert;
@@ -31,6 +31,9 @@ import java.util.Map;
  * Created by martin.medina on 03/02/2017.
  */
 public class ClIInterfaceTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void callPrintHelp() {
         // TODO add test output
@@ -41,7 +44,7 @@ public class ClIInterfaceTest {
     public void callTestWithCorrectInputParams() {
 
         String[] inputParams = { "-listen", "3332", "-db", "java", "-reset", "on", "-rpc", "4444" };
-        Map<String, String> result = CLIInterface.call(ConfigHelper.CONFIG, inputParams);
+        Map<String, String> result = CLIInterface.call(config, inputParams);
 
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_DB_DIR), "java");
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_LISTEN_PORT), "3332");
@@ -53,10 +56,10 @@ public class ClIInterfaceTest {
     @Test
     public void changeAndRestoreRpcCorsConfig() {
         String[] inputParams = { "-rpccors", "*.ethereum.io" };
-        Map<String, String> result = CLIInterface.call(ConfigHelper.CONFIG, inputParams);
+        Map<String, String> result = CLIInterface.call(config, inputParams);
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_RPC_CORS), "*.ethereum.io");
         String[] restoreParams = { "-rpccors", CorsConfigurationTest.EXPECTED_CORS_CONFIG };
-        result = CLIInterface.call(ConfigHelper.CONFIG, restoreParams);
+        result = CLIInterface.call(config, restoreParams);
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_RPC_CORS), CorsConfigurationTest.EXPECTED_CORS_CONFIG  );
     }
 
@@ -64,7 +67,7 @@ public class ClIInterfaceTest {
     public void callTestWrongPortFormat() {
 
         String[] inputParams = { "-rpc", "-4444" };
-        Map<String, String> result = CLIInterface.call(ConfigHelper.CONFIG, inputParams);
+        Map<String, String> result = CLIInterface.call(config, inputParams);
 
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_RPC_ENABLED), "true");
     }
@@ -73,7 +76,7 @@ public class ClIInterfaceTest {
     public void callTestResetOff() {
 
         String[] inputParams = { "-reset", "off" };
-        Map<String, String> result = CLIInterface.call(ConfigHelper.CONFIG, inputParams);
+        Map<String, String> result = CLIInterface.call(config, inputParams);
 
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_DB_RESET), "false");
     }
@@ -82,7 +85,7 @@ public class ClIInterfaceTest {
     public void callTestResetFalse() {
 
         String[] inputParams = { "-reset", "false" };
-        Map<String, String> result = CLIInterface.call(ConfigHelper.CONFIG, inputParams);
+        Map<String, String> result = CLIInterface.call(config, inputParams);
 
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_DB_RESET), "false");
     }
@@ -91,7 +94,7 @@ public class ClIInterfaceTest {
     public void callTestTestResetNo() {
 
         String[] inputParams = { "-reset", "no" };
-        Map<String, String> result = CLIInterface.call(ConfigHelper.CONFIG, inputParams);
+        Map<String, String> result = CLIInterface.call(config, inputParams);
 
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_DB_RESET), "false");
     }
@@ -100,7 +103,7 @@ public class ClIInterfaceTest {
     public void callTestTestResetYes() {
 
         String[] inputParams = { "-reset", "yes" };
-        Map<String, String> result = CLIInterface.call(ConfigHelper.CONFIG, inputParams);
+        Map<String, String> result = CLIInterface.call(config, inputParams);
 
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_DB_RESET), "true");
     }
@@ -109,7 +112,7 @@ public class ClIInterfaceTest {
     public void callTestTestResetTrue(){
 
         String[] inputParams = { "-reset", "true" };
-        Map<String, String> result = CLIInterface.call(ConfigHelper.CONFIG, inputParams);
+        Map<String, String> result = CLIInterface.call(config, inputParams);
 
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_DB_RESET), "true");
     }

--- a/rskj-core/src/test/java/org/ethereum/config/ConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/ConfigTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.config;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import com.typesafe.config.*;
 import org.junit.Assert;
 import org.junit.Test;
@@ -76,7 +76,8 @@ public class ConfigTest {
 
     @Test
     public void ethereumjConfTest() {
-        System.out.println("'" + ConfigHelper.CONFIG.databaseDir() + "'");
-        System.out.println(ConfigHelper.CONFIG.peerActive());
+        RskSystemProperties config = new RskSystemProperties();
+        System.out.println("'" + config.databaseDir() + "'");
+        System.out.println(config.peerActive());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.config;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,9 +29,10 @@ import org.junit.Test;
 public class SystemPropertiesTest {
     @Test
     public void punchBindIpTest() {
-        ConfigHelper.CONFIG.overrideParams("peer.bind.ip", "");
+        RskSystemProperties config = new RskSystemProperties();
+        config.overrideParams("peer.bind.ip", "");
         long st = System.currentTimeMillis();
-        String ip = ConfigHelper.CONFIG.getPeerDiscoveryBindAddress();
+        String ip = config.getPeerDiscoveryBindAddress();
         long t = System.currentTimeMillis() - st;
         System.out.println(ip + " in " + t + " msec");
         Assert.assertTrue(t < 10 * 1000);
@@ -40,9 +41,10 @@ public class SystemPropertiesTest {
 
     @Test
     public void externalIpTest() {
-        ConfigHelper.CONFIG.overrideParams("peer.discovery.external.ip", "");
+        RskSystemProperties config = new RskSystemProperties();
+        config.overrideParams("peer.discovery.external.ip", "");
         long st = System.currentTimeMillis();
-        String ip = ConfigHelper.CONFIG.getExternalIp();
+        String ip = config.getExternalIp();
         long t = System.currentTimeMillis() - st;
         System.out.println(ip + " in " + t + " msec");
         Assert.assertTrue(t < 10 * 1000);

--- a/rskj-core/src/test/java/org/ethereum/core/ABITest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ABITest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.core;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.crypto.SHA3Helper;
 import org.junit.Assert;
@@ -34,12 +34,13 @@ import org.spongycastle.util.encoders.Hex;
 public class ABITest {
 
     private static final Logger logger = LoggerFactory.getLogger("test");
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void testTransactionCreate() {
         // demo only
         CallTransaction.Function function = CallTransaction.Function.fromJsonInterface(funcJson1);
-        Transaction ctx = CallTransaction.createCallTransaction(ConfigHelper.CONFIG, 1, 1_000_000_000,
+        Transaction ctx = CallTransaction.createCallTransaction(config, 1, 1_000_000_000,
                 1_000_000_000, new RskAddress("86e0497e32a8e1d79fe38ab87dc80140df5470d9"), 0, function, "1234567890abcdef1234567890abcdef12345678");
         ctx.sign(SHA3Helper.sha3("974f963ee4571e86e5f9bc3b493e453db9c15e5bd19829a4ef9a790de0da0015".getBytes()));
     }
@@ -90,7 +91,7 @@ public class ABITest {
         logger.info("\n{}", funcJson2);
 
         CallTransaction.Function function = CallTransaction.Function.fromJsonInterface(funcJson2);
-        Transaction ctx = CallTransaction.createCallTransaction(ConfigHelper.CONFIG, 1, 1_000_000_000, 1_000_000_000,
+        Transaction ctx = CallTransaction.createCallTransaction(config, 1, 1_000_000_000, 1_000_000_000,
                 new RskAddress("86e0497e32a8e1d79fe38ab87dc80140df5470d9"), 0, function);
         ctx.sign(SHA3Helper.sha3("974f963ee4571e86e5f9bc3b493e453db9c15e5bd19829a4ef9a790de0da0015".getBytes()));
 

--- a/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -19,15 +19,14 @@
 
 package org.ethereum.core;
 
-import co.rsk.config.ConfigHelper;
 import co.rsk.core.RskAddress;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.PendingStateImpl;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.trie.TrieStoreImpl;
 import co.rsk.validators.DummyBlockValidator;
 import org.ethereum.config.blockchain.GenesisConfig;
-import org.ethereum.config.net.MainNetConfig;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.db.ByteArrayWrapper;
@@ -36,8 +35,6 @@ import org.ethereum.db.ReceiptStore;
 import org.ethereum.db.ReceiptStoreImpl;
 import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.manager.AdminInfo;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 
 import java.math.BigInteger;
 import java.util.HashMap;
@@ -47,26 +44,18 @@ import java.util.HashMap;
  */
 public class ImportLightTest {
 
-    @BeforeClass
-    public static void setup() {
-        ConfigHelper.CONFIG.setBlockchainConfig(new GenesisConfig(new GenesisConfig.GenesisConstants() {
+    public static BlockChainImpl createBlockchain(Genesis genesis) {
+        RskSystemProperties config = new RskSystemProperties();
+        config.setBlockchainConfig(new GenesisConfig(new GenesisConfig.GenesisConstants() {
             @Override
             public BigInteger getMinimumDifficulty() {
                 return BigInteger.ONE;
             }
         }));
-    }
-
-    @AfterClass
-    public static void cleanup() {
-        ConfigHelper.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-    }
-
-    public static BlockChainImpl createBlockchain(Genesis genesis) {
-        IndexedBlockStore blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore blockStore = new IndexedBlockStore(config);
         blockStore.init(new HashMap<>(), new HashMapDB(), null);
 
-        Repository repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
 
         EthereumListenerAdapter listener = new EthereumListenerAdapter();
 
@@ -75,7 +64,7 @@ public class ImportLightTest {
         ReceiptStore receiptStore = new ReceiptStoreImpl(ds);
 
         BlockChainImpl blockchain = new BlockChainImpl(
-                ConfigHelper.CONFIG, repository,
+                config, repository,
                 blockStore,
                 receiptStore,
                 null,
@@ -86,7 +75,7 @@ public class ImportLightTest {
 
         blockchain.setNoValidation(true);
 
-        PendingStateImpl pendingState = new PendingStateImpl(ConfigHelper.CONFIG, blockchain, repository, null, null, listener, 10, 100);
+        PendingStateImpl pendingState = new PendingStateImpl(config, blockchain, repository, null, null, listener, 10, 100);
 
         blockchain.setPendingState(pendingState);
 

--- a/rskj-core/src/test/java/org/ethereum/core/StateTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/StateTest.java
@@ -20,18 +20,15 @@
 package org.ethereum.core;
 
 
-import co.rsk.config.ConfigHelper;
-import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.ByteArrayWrapper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieImpl;
-
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.db.ByteArrayWrapper;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
@@ -131,7 +128,7 @@ public class StateTest {
 
     private Trie generateGenesisState() {
         Trie trie = new TrieImpl();
-        Genesis genesis = (Genesis)Genesis.getInstance(ConfigHelper.CONFIG);
+        Genesis genesis = (Genesis)Genesis.getInstance(new RskSystemProperties());
 
         for (ByteArrayWrapper key : genesis.getPremine().keySet())
             trie = trie.put(key.getData(), genesis.getPremine().get(key).getAccountState().getEncoded());

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.core;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.config.net.MainNetConfig;
@@ -52,6 +52,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class TransactionTest {
+
+    private RskSystemProperties config = new RskSystemProperties();
 
     @Test /* sign transaction  https://tools.ietf.org/html/rfc6979 */
     public void test1() throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeyException, IOException {
@@ -429,14 +431,14 @@ public class TransactionTest {
                 {
                     Repository track = repository.startTracking();
 
-                    Transaction txConst = CallTransaction.createCallTransaction(ConfigHelper.CONFIG, 0, 0, 100000000000000L,
+                    Transaction txConst = CallTransaction.createCallTransaction(config, 0, 0, 100000000000000L,
                             new RskAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), 0, CallTransaction.Function.fromSignature("get"));
                     txConst.sign(new byte[32]);
 
                     Block bestBlock = block;
 
                     TransactionExecutor executor = new TransactionExecutor
-                            (ConfigHelper.CONFIG, txConst, 0, bestBlock.getCoinbase(), track, new BlockStoreDummy(), null,
+                            (config, txConst, 0, bestBlock.getCoinbase(), track, new BlockStoreDummy(), null,
                                     invokeFactory, bestBlock)
                             .setLocalCall(true);
 
@@ -539,11 +541,11 @@ public class TransactionTest {
         System.out.println(json.replaceAll("'", "\""));
 
         try {
-            ConfigHelper.CONFIG.setBlockchainConfig(new GenesisConfig());
+            config.setBlockchainConfig(new GenesisConfig());
             List<String> res = new StateTestRunner(stateTestSuite.getTestCases().get("test1")).runImpl();
             if (!res.isEmpty()) throw new RuntimeException("Test failed: " + res);
         } finally {
-            ConfigHelper.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
+            config.setBlockchainConfig(new MainNetConfig());
         }
     }
 
@@ -572,8 +574,8 @@ public class TransactionTest {
 
          */
 
-        BigInteger nonce = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getInitialNonce();
-        Blockchain blockchain = ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(ConfigHelper.CONFIG, nonce,
+        BigInteger nonce = config.getBlockchainConfig().getCommonConstants().getInitialNonce();
+        Blockchain blockchain = ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(config, nonce,
                 getClass().getResourceAsStream("/genesis/genesis-light.json"), false));
 
         ECKey sender = ECKey.fromPrivate(Hex.decode("3ec771c31cac8c0dba77a69e503765701d3c2bb62435888d4ffa38fed60c445c"));
@@ -642,8 +644,8 @@ public class TransactionTest {
 
          */
 
-        BigInteger nonce = ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getInitialNonce();
-        Blockchain blockchain = ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(ConfigHelper.CONFIG, nonce,
+        BigInteger nonce = config.getBlockchainConfig().getCommonConstants().getInitialNonce();
+        Blockchain blockchain = ImportLightTest.createBlockchain(GenesisLoader.loadGenesis(config, nonce,
                 getClass().getResourceAsStream("/genesis/genesis-light.json"), false));
 
         ECKey sender = ECKey.fromPrivate(Hex.decode("3ec771c31cac8c0dba77a69e503765701d3c2bb62435888d4ffa38fed60c445c"));
@@ -692,7 +694,7 @@ public class TransactionTest {
 
     private TransactionExecutor executeTransaction(Blockchain blockchain, Transaction tx) {
         Repository track = blockchain.getRepository().startTracking();
-        TransactionExecutor executor = new TransactionExecutor(ConfigHelper.CONFIG, tx, 0, RskAddress.nullAddress(), blockchain.getRepository(),
+        TransactionExecutor executor = new TransactionExecutor(config, tx, 0, RskAddress.nullAddress(), blockchain.getRepository(),
                 blockchain.getBlockStore(), blockchain.getReceiptStore(), new ProgramInvokeFactoryImpl(), blockchain.getBestBlock());
 
         executor.init();

--- a/rskj-core/src/test/java/org/ethereum/core/genesis/BlockchainLoaderTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/genesis/BlockchainLoaderTest.java
@@ -19,7 +19,6 @@
 
 package org.ethereum.core.genesis;
 
-import co.rsk.config.ConfigHelper;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImplTest;
@@ -53,7 +52,7 @@ public class BlockchainLoaderTest {
         BlockchainNetConfig blockchainNetConfig = Mockito.mock(BlockchainNetConfig.class);
         Mockito.when(blockchainNetConfig.getCommonConstants()).thenReturn(constants);
 
-        Mockito.when(systemProperties.databaseDir()).thenReturn(ConfigHelper.CONFIG.databaseDir());
+        Mockito.when(systemProperties.databaseDir()).thenReturn(new RskSystemProperties().databaseDir());
         Mockito.when(systemProperties.getBlockchainConfig()).thenReturn(blockchainNetConfig);
         Mockito.when(systemProperties.genesisInfo()).thenReturn(jsonFile);
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
@@ -19,7 +19,8 @@
 
 package org.ethereum.datasource;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -33,9 +34,16 @@ import static org.junit.Assert.assertNotNull;
 @Ignore
 public class LevelDbDataSourceTest {
 
+    private RskSystemProperties config;
+
+    @Before
+    public void setup(){
+        config = new RskSystemProperties();
+    }
+
     @Test
     public void testBatchUpdating() {
-        LevelDbDataSource dataSource = new LevelDbDataSource(ConfigHelper.CONFIG, "test");
+        LevelDbDataSource dataSource = new LevelDbDataSource(config, "test");
         dataSource.init();
 
         final int batchSize = 100;
@@ -50,7 +58,7 @@ public class LevelDbDataSourceTest {
 
     @Test
     public void testPutting() {
-        LevelDbDataSource dataSource = new LevelDbDataSource(ConfigHelper.CONFIG, "test");
+        LevelDbDataSource dataSource = new LevelDbDataSource(config, "test");
         dataSource.init();
 
         byte[] key = randomBytes(32);

--- a/rskj-core/src/test/java/org/ethereum/datasource/mapdb/MapDBFactoryImpl.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/mapdb/MapDBFactoryImpl.java
@@ -19,8 +19,7 @@
 
 package org.ethereum.datasource.mapdb;
 
-import co.rsk.config.ConfigHelper;
-import org.ethereum.config.SystemProperties;
+import co.rsk.config.RskSystemProperties;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
 
@@ -29,8 +28,6 @@ import java.io.File;
 import static java.lang.System.getProperty;
 
 public class MapDBFactoryImpl implements MapDBFactory {
-
-    private static final SystemProperties config = ConfigHelper.CONFIG;
 
     @Override
     public DB createDB(String name) {
@@ -43,7 +40,7 @@ public class MapDBFactoryImpl implements MapDBFactory {
     }
 
     private DB createDB(String name, boolean transactional) {
-        File dbFile = new File(getProperty("user.dir") + "/" + config.databaseDir() + "/" + name);
+        File dbFile = new File(getProperty("user.dir") + "/" + new RskSystemProperties().databaseDir() + "/" + name);
         if (!dbFile.getParentFile().exists()) {
             dbFile.getParentFile().mkdirs();
         }

--- a/rskj-core/src/test/java/org/ethereum/datasource/mapdb/Serializers.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/mapdb/Serializers.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.datasource.mapdb;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockHeaderWrapper;
@@ -95,7 +95,7 @@ public class Serializers {
         @Override
         public BlockWrapper deserialize(DataInput in, int available) throws IOException {
             byte[] bytes = BYTE_ARRAY.deserialize(in, available);
-            return bytes.length > 0 ? new BlockWrapper(ConfigHelper.CONFIG, bytes) : null;
+            return bytes.length > 0 ? new BlockWrapper(new RskSystemProperties(), bytes) : null;
         }
     };
 

--- a/rskj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.db;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.db.ContractDetailsImpl;
 import org.ethereum.datasource.HashMapDB;
@@ -27,22 +27,25 @@ import org.ethereum.vm.DataWord;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
-import static org.ethereum.TestUtils.*;
-import static org.junit.Assert.*;
+import static org.ethereum.TestUtils.randomAddress;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class DetailsDataStoreTest {
+
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Test
     public void test1(){
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore(ConfigHelper.CONFIG, db);
+        DetailsDataStore dds = new DetailsDataStore(config, db);
 
         RskAddress c_key = new RskAddress("0000000000000000000000000000000000001a2b");
         byte[] code = Hex.decode("60606060");
         byte[] key =  Hex.decode("11");
         byte[] value =  Hex.decode("aa");
 
-        ContractDetails contractDetails = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetails contractDetails = new ContractDetailsImpl(config);
         contractDetails.setAddress(randomAddress().getBytes());
         contractDetails.setCode(code);
         contractDetails.put(new DataWord(key), new DataWord(value));
@@ -67,14 +70,14 @@ public class DetailsDataStoreTest {
     public void test2(){
 
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore(ConfigHelper.CONFIG, db);
+        DetailsDataStore dds = new DetailsDataStore(config, db);
 
         RskAddress c_key = new RskAddress("0000000000000000000000000000000000001a2b");
         byte[] code = Hex.decode("60606060");
         byte[] key =  Hex.decode("11");
         byte[] value =  Hex.decode("aa");
 
-        ContractDetails contractDetails = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetails contractDetails = new ContractDetailsImpl(config);
         contractDetails.setCode(code);
         contractDetails.setAddress(randomAddress().getBytes());
         contractDetails.put(new DataWord(key), new DataWord(value));
@@ -103,14 +106,14 @@ public class DetailsDataStoreTest {
     public void test3(){
 
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore(ConfigHelper.CONFIG, db);
+        DetailsDataStore dds = new DetailsDataStore(config, db);
 
         RskAddress c_key = new RskAddress("0000000000000000000000000000000000001a2b");
         byte[] code = Hex.decode("60606060");
         byte[] key =  Hex.decode("11");
         byte[] value =  Hex.decode("aa");
 
-        ContractDetails contractDetails = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetails contractDetails = new ContractDetailsImpl(config);
         contractDetails.setCode(code);
         contractDetails.put(new DataWord(key), new DataWord(value));
 
@@ -141,7 +144,7 @@ public class DetailsDataStoreTest {
     public void test4() {
 
         DatabaseImpl db = new DatabaseImpl(new HashMapDB());
-        DetailsDataStore dds = new DetailsDataStore(ConfigHelper.CONFIG, db);
+        DetailsDataStore dds = new DetailsDataStore(config, db);
 
         RskAddress c_key = new RskAddress("0000000000000000000000000000000000001a2b");
 

--- a/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
@@ -93,7 +93,6 @@ public class IndexedBlockStoreTest {
     @Test // save some load, and check it exist
     @Ignore
     public void test1(){
-        config = new RskSystemProperties();
         IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
 
@@ -201,7 +200,6 @@ public class IndexedBlockStoreTest {
     @Test // save some load, and check it exist
     @Ignore
     public void test2(){
-        config = new RskSystemProperties();
         IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
 
@@ -311,7 +309,6 @@ public class IndexedBlockStoreTest {
     @Test
     @Ignore
     public void test3(){
-        config = new RskSystemProperties();
         IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
 
@@ -422,7 +419,6 @@ public class IndexedBlockStoreTest {
     @Test // leveldb + mapdb, save some load, flush to disk, and check it exist
     @Ignore
     public void test4() throws IOException {
-        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
         config.setDataBaseDir(testDir);
@@ -571,7 +567,6 @@ public class IndexedBlockStoreTest {
     @Test // leveldb + mapdb, save part to disk part to cache, and check it exist
     @Ignore
     public void test5() throws IOException {
-        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
         config.setDataBaseDir(testDir);
@@ -734,7 +729,6 @@ public class IndexedBlockStoreTest {
 
     @Test // leveldb + mapdb, multi branch, total difficulty test
     public void test6() throws IOException {
-        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
         config.setDataBaseDir(testDir);
@@ -839,7 +833,6 @@ public class IndexedBlockStoreTest {
 
     @Test // leveldb + mapdb, multi branch, total re-branch test
     public void test7() throws IOException {
-        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
         config.setDataBaseDir(testDir);
@@ -894,7 +887,6 @@ public class IndexedBlockStoreTest {
 
     @Test // leveldb + mapdb, multi branch, total re-branch test
     public void test8() throws IOException {
-        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
         config.setDataBaseDir(testDir);
@@ -971,7 +963,6 @@ public class IndexedBlockStoreTest {
 
     @Test // test index merging during the flush
     public void test9() {
-        config = new RskSystemProperties();
         IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
 

--- a/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.db;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.Block;
 import org.ethereum.core.Genesis;
 import org.ethereum.datasource.HashMapDB;
@@ -56,6 +56,7 @@ public class IndexedBlockStoreTest {
     private static final Logger logger = LoggerFactory.getLogger("test");
     private List<Block> blocks = new ArrayList<>();
     private BigInteger cumDifficulty = ZERO;
+    private RskSystemProperties config;
 
     @Before
     public void setup() throws URISyntaxException, IOException {
@@ -65,8 +66,8 @@ public class IndexedBlockStoreTest {
 
         File file = new File(scenario1.toURI());
         List<String> strData = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
-
-        Block genesis = Genesis.getInstance(ConfigHelper.CONFIG);
+        config = new RskSystemProperties();
+        Block genesis = Genesis.getInstance(config);
         blocks.add(genesis);
         cumDifficulty = cumDifficulty.add(genesis.getCumulativeDifficulty());
 
@@ -92,8 +93,8 @@ public class IndexedBlockStoreTest {
     @Test // save some load, and check it exist
     @Ignore
     public void test1(){
-
-        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        config = new RskSystemProperties();
+        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
 
         BigInteger cummDiff = BigInteger.ZERO;
@@ -200,7 +201,8 @@ public class IndexedBlockStoreTest {
     @Test // save some load, and check it exist
     @Ignore
     public void test2(){
-        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        config = new RskSystemProperties();
+        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
 
         BigInteger cummDiff = BigInteger.ZERO;
@@ -309,7 +311,8 @@ public class IndexedBlockStoreTest {
     @Test
     @Ignore
     public void test3(){
-        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        config = new RskSystemProperties();
+        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
 
         BigInteger cummDiff = BigInteger.ZERO;
@@ -419,17 +422,18 @@ public class IndexedBlockStoreTest {
     @Test // leveldb + mapdb, save some load, flush to disk, and check it exist
     @Ignore
     public void test4() throws IOException {
+        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
-        ConfigHelper.CONFIG.setDataBaseDir(testDir);
+        config.setDataBaseDir(testDir);
 
         DB indexDB = createMapDB(testDir);
         Map<Long, List<IndexedBlockStore.BlockInfo>> indexMap = createIndexMap(indexDB);
 
-        KeyValueDataSource blocksDB = new LevelDbDataSource(ConfigHelper.CONFIG, "blocks");
+        KeyValueDataSource blocksDB = new LevelDbDataSource(config, "blocks");
         blocksDB.init();
 
-        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(indexMap, blocksDB, indexDB);
 
         BigInteger cummDiff = BigInteger.ZERO;
@@ -542,10 +546,10 @@ public class IndexedBlockStoreTest {
         indexDB = createMapDB(testDir);
         indexMap = createIndexMap(indexDB);
 
-        blocksDB = new LevelDbDataSource(ConfigHelper.CONFIG, "blocks");
+        blocksDB = new LevelDbDataSource(config, "blocks");
         blocksDB.init();
 
-        indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(indexMap, blocksDB, indexDB);
 
         //  testing: getListHashesStartWith(long, long)
@@ -567,18 +571,19 @@ public class IndexedBlockStoreTest {
     @Test // leveldb + mapdb, save part to disk part to cache, and check it exist
     @Ignore
     public void test5() throws IOException {
+        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
-        ConfigHelper.CONFIG.setDataBaseDir(testDir);
+        config.setDataBaseDir(testDir);
 
         DB indexDB = createMapDB(testDir);
         Map<Long, List<IndexedBlockStore.BlockInfo>> indexMap = createIndexMap(indexDB);
 
-        KeyValueDataSource blocksDB = new LevelDbDataSource(ConfigHelper.CONFIG, "blocks");
+        KeyValueDataSource blocksDB = new LevelDbDataSource(config, "blocks");
         blocksDB.init();
 
         try {
-            IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+            IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
             indexedBlockStore.init(indexMap, blocksDB, indexDB);
 
             BigInteger cummDiff = BigInteger.ZERO;
@@ -703,10 +708,10 @@ public class IndexedBlockStoreTest {
             indexDB = createMapDB(testDir);
             indexMap = createIndexMap(indexDB);
 
-            blocksDB = new LevelDbDataSource(ConfigHelper.CONFIG, "blocks");
+            blocksDB = new LevelDbDataSource(config, "blocks");
             blocksDB.init();
 
-            indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+            indexedBlockStore = new IndexedBlockStore(config);
             indexedBlockStore.init(indexMap, blocksDB, indexDB);
 
             //  testing: getListHashesStartWith(long, long)
@@ -729,21 +734,22 @@ public class IndexedBlockStoreTest {
 
     @Test // leveldb + mapdb, multi branch, total difficulty test
     public void test6() throws IOException {
+        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
-        ConfigHelper.CONFIG.setDataBaseDir(testDir);
+        config.setDataBaseDir(testDir);
 
         DB indexDB = createMapDB(testDir);
         Map<Long, List<IndexedBlockStore.BlockInfo>> indexMap = createIndexMap(indexDB);
 
-        KeyValueDataSource blocksDB = new LevelDbDataSource(ConfigHelper.CONFIG, "blocks");
+        KeyValueDataSource blocksDB = new LevelDbDataSource(config, "blocks");
         blocksDB.init();
 
         try {
-            IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+            IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
             indexedBlockStore.init(indexMap, blocksDB, indexDB);
 
-            Block genesis = Genesis.getInstance(ConfigHelper.CONFIG);
+            Block genesis = Genesis.getInstance(config);
             List<Block> bestLine = getRandomChain(genesis.getHash(), 1, 100);
 
             indexedBlockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
@@ -772,7 +778,7 @@ public class IndexedBlockStoreTest {
 
             // calc all TDs
             Map<ByteArrayWrapper, BigInteger> tDiffs = new HashMap<>();
-            td = Genesis.getInstance(ConfigHelper.CONFIG).getCumulativeDifficulty();
+            td = Genesis.getInstance(config).getCumulativeDifficulty();
             for (Block block : bestLine){
                 td = td.add(block.getCumulativeDifficulty());
                 tDiffs.put(wrap(block.getHash()), td);
@@ -833,22 +839,22 @@ public class IndexedBlockStoreTest {
 
     @Test // leveldb + mapdb, multi branch, total re-branch test
     public void test7() throws IOException {
-
+        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
-        ConfigHelper.CONFIG.setDataBaseDir(testDir);
+        config.setDataBaseDir(testDir);
 
         DB indexDB = createMapDB(testDir);
         Map<Long, List<IndexedBlockStore.BlockInfo>> indexMap = createIndexMap(indexDB);
 
-        KeyValueDataSource blocksDB = new LevelDbDataSource(ConfigHelper.CONFIG, "blocks");
+        KeyValueDataSource blocksDB = new LevelDbDataSource(config, "blocks");
         blocksDB.init();
 
         try {
-            IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+            IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
             indexedBlockStore.init(indexMap, blocksDB, indexDB);
 
-            Block genesis = Genesis.getInstance(ConfigHelper.CONFIG);
+            Block genesis = Genesis.getInstance(config);
             List<Block> bestLine = getRandomChain(genesis.getHash(), 1, 100);
 
             indexedBlockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
@@ -888,22 +894,22 @@ public class IndexedBlockStoreTest {
 
     @Test // leveldb + mapdb, multi branch, total re-branch test
     public void test8() throws IOException {
-
+        config = new RskSystemProperties();
         BigInteger bi = new BigInteger(32, new Random());
         String testDir = "test_db_" + bi;
-        ConfigHelper.CONFIG.setDataBaseDir(testDir);
+        config.setDataBaseDir(testDir);
 
         DB indexDB = createMapDB(testDir);
         Map<Long, List<IndexedBlockStore.BlockInfo>> indexMap = createIndexMap(indexDB);
 
-        KeyValueDataSource blocksDB = new LevelDbDataSource(ConfigHelper.CONFIG, "blocks");
+        KeyValueDataSource blocksDB = new LevelDbDataSource(config, "blocks");
         blocksDB.init();
 
         try {
-            IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+            IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
             indexedBlockStore.init(indexMap, blocksDB, indexDB);
 
-            Block genesis = Genesis.getInstance(ConfigHelper.CONFIG);
+            Block genesis = Genesis.getInstance(config);
             List<Block> bestLine = getRandomChain(genesis.getHash(), 1, 100);
 
             indexedBlockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
@@ -965,7 +971,8 @@ public class IndexedBlockStoreTest {
 
     @Test // test index merging during the flush
     public void test9() {
-        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        config = new RskSystemProperties();
+        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
 
         // blocks with the same block number

--- a/rskj-core/src/test/java/org/ethereum/db/TrackDatabaseTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/TrackDatabaseTest.java
@@ -19,22 +19,20 @@
 
 package org.ethereum.db;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.LevelDbDataSource;
-
 import org.iq80.leveldb.Options;
-
 import org.junit.AfterClass;
 import org.junit.Test;
-
 import org.spongycastle.util.encoders.Hex;
 
 import java.io.File;
 import java.io.IOException;
 
 import static org.iq80.leveldb.impl.Iq80DBFactory.factory;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Roman Mandeleil
@@ -45,7 +43,7 @@ public class TrackDatabaseTest {
     @Test
     public void test1() {
 
-        KeyValueDataSource keyValueDataSource = new LevelDbDataSource(ConfigHelper.CONFIG, "temp");
+        KeyValueDataSource keyValueDataSource = new LevelDbDataSource(new RskSystemProperties(), "temp");
         keyValueDataSource.init();
 
         DatabaseImpl db1 = new DatabaseImpl(keyValueDataSource);

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
@@ -19,13 +19,12 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.config.net.MainNetConfig;
 import org.ethereum.core.BlockHeader;
 import org.json.simple.parser.ParseException;
-import org.junit.After;
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -45,20 +44,15 @@ import static org.junit.Assert.assertEquals;
 @Ignore
 public class GitHubBasicTest {
 
+    private static RskSystemProperties config = new RskSystemProperties();
     private static final Logger logger = LoggerFactory.getLogger("TCK-Test");
-    private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(ConfigHelper.CONFIG);
+    private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
 
     public String shacommit = "99afe8f5aad7bca5d0f1b1685390a4dea32d73c3";
 
-    @After
-    public void recover() {
-        ConfigHelper.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
-    }
-
     @Test
     public void runDifficultyTest() throws IOException, ParseException {
-
-        ConfigHelper.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
+        config.setBlockchainConfig(new MainNetConfig());
 
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficulty.json", shacommit);
 
@@ -78,7 +72,7 @@ public class GitHubBasicTest {
     @Test
     public void runDifficultyFrontierTest() throws IOException, ParseException {
 
-        ConfigHelper.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
+        config.setBlockchainConfig(new MainNetConfig());
 
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficultyFrontier.json", shacommit);
 
@@ -98,7 +92,7 @@ public class GitHubBasicTest {
     @Test
     public void runDifficultyHomesteadTest() throws IOException, ParseException {
 
-        ConfigHelper.CONFIG.setBlockchainConfig(new GenesisConfig());
+        config.setBlockchainConfig(new GenesisConfig());
 
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficultyHomestead.json", shacommit);
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBlockTest.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBlockTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.config.net.MainNetConfig;
 import org.json.simple.parser.ParseException;
@@ -41,8 +41,9 @@ public class GitHubBlockTest {
     @Ignore // test for conveniently running a single test
     @Test
     public void runSingleTest() throws ParseException, IOException {
-        ConfigHelper.CONFIG.setGenesisInfo("frontier.json");
-        ConfigHelper.CONFIG.setBlockchainConfig(new GenesisConfig());
+        RskSystemProperties config = new RskSystemProperties();
+        config.setGenesisInfo("frontier.json");
+        config.setBlockchainConfig(new GenesisConfig());
 
         String json = JSONReader.loadJSONFromCommit("BlockchainTests/Homestead/bcTotalDifficultyTest.json", shacommit);
         GitHubJSONTestSuite.runGitHubJsonSingleBlockTest(json, "sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4");
@@ -55,11 +56,12 @@ public class GitHubBlockTest {
 
     private void runHomestead(String name) throws IOException, ParseException {
         String json = JSONReader.loadJSONFromCommit("BlockchainTests/Homestead/" + name + ".json", shacommit);
-        ConfigHelper.CONFIG.setBlockchainConfig(new GenesisConfig());
+        RskSystemProperties config = new RskSystemProperties();
+        config.setBlockchainConfig(new GenesisConfig());
         try {
             GitHubJSONTestSuite.runGitHubJsonBlockTest(json, Collections.EMPTY_SET);
         } finally {
-            ConfigHelper.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
+            config.setBlockchainConfig(new MainNetConfig());
         }
     }
 
@@ -98,7 +100,8 @@ public class GitHubBlockTest {
     @Ignore
     @Test
     public void runBCValidBlockTest() throws ParseException, IOException {
-        ConfigHelper.CONFIG.setGenesisInfo("frontier.json");
+        RskSystemProperties config = new RskSystemProperties();
+        config.setGenesisInfo("frontier.json");
         run("bcValidBlockTest", true, true);
     }
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
@@ -19,10 +19,9 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.config.net.AbstractNetConfig;
-import org.ethereum.config.net.MainNetConfig;
 import org.json.simple.parser.ParseException;
 import org.junit.*;
 import org.junit.runners.MethodSorters;
@@ -44,20 +43,17 @@ public class GitHubStateTest {
 
 
     private long oldForkValue;
+    private static RskSystemProperties config;
 
-    @Before
+    @BeforeClass
     public void setup() {
         // TODO remove this after Homestead launch and shacommit update with actual block number
         // for this JSON test commit the Homestead block was defined as 900000
-        ConfigHelper.CONFIG.setBlockchainConfig(new AbstractNetConfig() {{
+        config = new RskSystemProperties();
+        config.setBlockchainConfig(new AbstractNetConfig() {{
             add(0, new GenesisConfig());
 
         }});
-    }
-
-    @After
-    public void clean() {
-        ConfigHelper.CONFIG.setBlockchainConfig(MainNetConfig.INSTANCE);
     }
 
     @Ignore

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/JSONReader.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/JSONReader.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.apache.commons.codec.binary.Base64;
 import org.h2.util.IOUtils;
 import org.json.simple.JSONArray;
@@ -38,11 +38,12 @@ import java.util.List;
 
 public class JSONReader {
 
+    private static final RskSystemProperties config = new RskSystemProperties();
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
 
     public static String loadJSON(String filename) {
         String json = "";
-        if (!ConfigHelper.CONFIG.vmTestLoadLocal())
+        if (!config.vmTestLoadLocal())
             json = getFromUrl("https://raw.githubusercontent.com/ethereum/tests/develop/" + filename);
         return json.isEmpty() ? getFromLocal(filename) : json;
     }
@@ -68,7 +69,7 @@ public class JSONReader {
 
     public static String loadJSONFromCommit(String filename, String shacommit) {
         String json = "";
-        if (!ConfigHelper.CONFIG.vmTestLoadLocal())
+        if (!config.vmTestLoadLocal())
             json = getFromUrl("https://raw.githubusercontent.com/ethereum/tests/" + shacommit + "/" + filename);
         if (!json.isEmpty()) json = json.replaceAll("//", "data");
         return json.isEmpty() ? getFromLocal(filename) : json;

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/AccountBuilder.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/AccountBuilder.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite.builder;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.db.ContractDetailsImpl;
 import org.ethereum.core.AccountState;
 import org.ethereum.jsontestsuite.model.AccountTck;
@@ -37,7 +37,7 @@ public class AccountBuilder {
 
     public static StateWrap build(AccountTck account) {
 
-        ContractDetailsImpl details = new ContractDetailsImpl(ConfigHelper.CONFIG);
+        ContractDetailsImpl details = new ContractDetailsImpl(new RskSystemProperties());
         details.setCode(parseData(account.getCode()));
         details.setStorage(convertStorage(account.getStorage()));
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/RepositoryBuilder.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/RepositoryBuilder.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite.builder;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.trie.TrieStoreImpl;
@@ -56,7 +56,7 @@ public class RepositoryBuilder {
             detailsBatch.put(addr, detailsCache);
         }
 
-        RepositoryImpl repositoryDummy = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(new HashMapDB()));
+        RepositoryImpl repositoryDummy = new RepositoryImpl(new RskSystemProperties(), new TrieStoreImpl(new HashMapDB()));
         Repository track = repositoryDummy.startTracking();
         track.updateBatch(stateBatch, detailsBatch);
         track.commit();

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -19,10 +19,13 @@
 
 package org.ethereum.jsontestsuite.runners;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
-import org.ethereum.core.*;
+import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionExecutor;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.BlockStoreDummy;
@@ -48,6 +51,7 @@ import java.util.List;
 public class StateTestRunner {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
+    private final RskSystemProperties config = new RskSystemProperties();
 
     public static List<String> run(StateTestCase stateTestCase2) {
         return new StateTestRunner(stateTestCase2).runImpl();
@@ -69,7 +73,7 @@ public class StateTestRunner {
         Repository track = repository.startTracking();
 
         TransactionExecutor executor =
-                new TransactionExecutor(ConfigHelper.CONFIG, transaction, 0, new RskAddress(env.getCurrentCoinbase()), track, new BlockStoreDummy(), null,
+                new TransactionExecutor(config, transaction, 0, new RskAddress(env.getCurrentCoinbase()), track, new BlockStoreDummy(), null,
                         invokeFactory, blockchain.getBestBlock());
 
         try{
@@ -94,11 +98,11 @@ public class StateTestRunner {
 
         transaction = TransactionBuilder.build(stateTestCase.getTransaction());
         logger.info("transaction: {}", transaction.toString());
-        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+        IndexedBlockStore indexedBlockStore = new IndexedBlockStore(config);
         indexedBlockStore.init(new HashMap<>(), new HashMapDB(), null);
         BlockStore blockStore = indexedBlockStore;
 
-        blockchain = new BlockChainImpl(ConfigHelper.CONFIG, repository, blockStore, null, null, null, null, null);
+        blockchain = new BlockChainImpl(config, repository, blockStore, null, null, null, null, null);
 
         env = EnvBuilder.build(stateTestCase.getEnv());
         invokeFactory = new TestProgramInvokeFactory(env);

--- a/rskj-core/src/test/java/org/ethereum/net/NewBlockMessageTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/NewBlockMessageTest.java
@@ -19,14 +19,11 @@
 
 package org.ethereum.net;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.net.eth.message.NewBlockMessage;
-
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.spongycastle.util.encoders.Hex;
 
 public class NewBlockMessageTest {
@@ -41,7 +38,7 @@ public class NewBlockMessageTest {
 
         byte[] payload = Hex.decode("f90144f9013Bf90136a0d8faffbc4c4213d35db9007de41cece45d95db7fd6c0f129e158baa888c48eefa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d4934794baedba0480e1b882b606cd302d8c4f5701cabac7a0c7d4565fb7b3d98e54a0dec8b76f8c001a784a5689954ce0aedcc1bbe8d13095a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b8400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000083063477825fc88609184e72a0008301e8488084543ffee680a00de0b9d4a0f0c23546d31f1f70db00d25cf6a7af79365b4e058e4a6a3b69527bc0c0850177ddbebe");
 
-        NewBlockMessage newBlockMessage = new NewBlockMessage(ConfigHelper.CONFIG, payload);
+        NewBlockMessage newBlockMessage = new NewBlockMessage(new RskSystemProperties(), payload);
         logger.trace("{}", newBlockMessage);
     }
 

--- a/rskj-core/src/test/java/org/ethereum/net/TransactionsMessageTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/TransactionsMessageTest.java
@@ -19,26 +19,26 @@
 
 package org.ethereum.net;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.net.eth.message.EthMessageCodes;
 import org.ethereum.net.eth.message.TransactionsMessage;
 import org.ethereum.util.ByteUtil;
-
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Iterator;
 
-import java.util.*;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TransactionsMessageTest {
+    private final RskSystemProperties config = new RskSystemProperties();
 
     /* TRANSACTIONS */
 
@@ -53,7 +53,7 @@ public class TransactionsMessageTest {
 
         byte[] payload = Hex.decode(txsPacketRaw);
 
-        TransactionsMessage transactionsMessage = new TransactionsMessage(ConfigHelper.CONFIG, payload);
+        TransactionsMessage transactionsMessage = new TransactionsMessage(config, payload);
         System.out.println(transactionsMessage);
 
         assertEquals(EthMessageCodes.TRANSACTIONS, transactionsMessage.getCommand());
@@ -100,7 +100,7 @@ public class TransactionsMessageTest {
 
         byte[] payload = Hex.decode(txsPacketRaw);
 
-        TransactionsMessage transactionsMessage = new TransactionsMessage(ConfigHelper.CONFIG, payload);
+        TransactionsMessage transactionsMessage = new TransactionsMessage(config, payload);
         System.out.println(transactionsMessage);
 
         assertEquals(EthMessageCodes.TRANSACTIONS, transactionsMessage.getCommand());
@@ -194,7 +194,7 @@ public class TransactionsMessageTest {
         tx.sign(privKey);
         tx.getEncoded();
 
-        TransactionsMessage transactionsMessage = new TransactionsMessage(ConfigHelper.CONFIG, Collections.singletonList(tx));
+        TransactionsMessage transactionsMessage = new TransactionsMessage(config, Collections.singletonList(tx));
 
         assertEquals(expected, Hex.toHexString(transactionsMessage.getEncoded()));
     }
@@ -202,7 +202,7 @@ public class TransactionsMessageTest {
     @Test
     public void test_4() {
         String msg = "f872f87083011a6d850ba43b740083015f9094ec210ec3715d5918b37cfa4d344a45d177ed849f881b461c1416b9d000801ba023a3035235ca0a6f80f08a1d4bd760445d5b0f8a25c32678fe18a451a88d6377a0765dde224118bdb40a67f315583d542d93d17d8637302b1da26e1013518d3ae8";
-        TransactionsMessage tmsg = new TransactionsMessage(ConfigHelper.CONFIG, Hex.decode(msg));
+        TransactionsMessage tmsg = new TransactionsMessage(config, Hex.decode(msg));
         assertEquals(1, tmsg.getTransactions().size());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -18,7 +18,7 @@
 
 package org.ethereum.rpc;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.core.bc.PendingStateImpl;
@@ -77,6 +77,7 @@ public class Web3ImplLogsTest {
     private final static String GET_VALUED_EVENT_SIGNATURE = "1ee041944547858a75ebef916083b6d4f5ae04bea9cd809334469dd07dbf441b";
     private final static String INCREMENT_METHOD_SIGNATURE = "371303c0";
     private final static String GET_VALUE_METHOD_SIGNATURE = "20965255";
+    private final RskSystemProperties config = new RskSystemProperties();
 
     //20965255 getValue()
     //371303c0 inc()
@@ -112,7 +113,7 @@ public class Web3ImplLogsTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
 
         SimpleEthereum eth = new SimpleEthereum();
@@ -319,7 +320,7 @@ public class Web3ImplLogsTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
 
         SimpleEthereum eth = new SimpleEthereum();
@@ -360,7 +361,7 @@ public class Web3ImplLogsTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
 
         SimpleEthereum eth = new SimpleEthereum();
@@ -415,7 +416,7 @@ public class Web3ImplLogsTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
 
         SimpleEthereum eth = new SimpleEthereum();
@@ -476,9 +477,9 @@ public class Web3ImplLogsTest {
     }
 
     private Web3Impl createWeb3(Ethereum eth, WorldManager worldManager, Wallet wallet) {
-        PersonalModule personalModule = new PersonalModuleWalletEnabled(ConfigHelper.CONFIG, eth, wallet, null);
-        EthModule ethModule = new EthModule(ConfigHelper.CONFIG, eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(ConfigHelper.CONFIG, eth, wallet, null));
-        return new Web3RskImpl(eth, worldManager, ConfigHelper.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null, null);
+        PersonalModule personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, null);
+        EthModule ethModule = new EthModule(config, eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, eth, wallet, null));
+        return new Web3RskImpl(eth, worldManager, config, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null, null);
     }
 
     private Web3Impl getWeb3() {
@@ -543,7 +544,7 @@ public class Web3ImplLogsTest {
 
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
 
         Web3Impl web3 = createWeb3(worldManager);
@@ -568,7 +569,7 @@ public class Web3ImplLogsTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
 
         Web3Impl web3 = createWeb3(worldManager);
@@ -600,7 +601,7 @@ public class Web3ImplLogsTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
 
         Web3Impl web3 = createWeb3(worldManager);
@@ -641,7 +642,7 @@ public class Web3ImplLogsTest {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
         worldManager.setBlockStore(world.getBlockChain().getBlockStore());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
 
         Web3Impl web3 = createWeb3(worldManager);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -18,7 +18,7 @@
 
 package org.ethereum.rpc;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.net.NodeID;
@@ -355,9 +355,10 @@ public class Web3ImplScoringTest {
         rsk.worldManager = worldManager;
 
         Wallet wallet = WalletFactory.createWallet();
-        PersonalModule pm = new PersonalModuleWalletEnabled(ConfigHelper.CONFIG, rsk, wallet, null);
-        EthModule em = new EthModule(ConfigHelper.CONFIG, rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(ConfigHelper.CONFIG, rsk, wallet, null));
-        return new Web3RskImpl(rsk, worldManager, ConfigHelper.CONFIG, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager, null, null, null);
+        RskSystemProperties config = new RskSystemProperties();
+        PersonalModule pm = new PersonalModuleWalletEnabled(config, rsk, wallet, null);
+        EthModule em = new EthModule(config, rsk, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, rsk, wallet, null));
+        return new Web3RskImpl(rsk, worldManager, config, Web3Mocks.getMockMinerClient(), Web3Mocks.getMockMinerServer(), pm, em, Web3Mocks.getMockChannelManager(), rsk.getRepository(), peerScoringManager, null, null, null);
     }
 
     private static NodeID generateNodeID() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -19,8 +19,8 @@
 package org.ethereum.rpc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
 import co.rsk.config.ConfigUtils;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.bc.BlockChainStatus;
 import co.rsk.mine.*;
@@ -42,6 +42,9 @@ import java.util.List;
  * Created by ajlopez on 15/04/2017.
  */
 public class Web3ImplSnapshotTest {
+
+    private static final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void takeFirstSnapshot() {
         World world = new World();
@@ -165,7 +168,7 @@ public class Web3ImplSnapshotTest {
     }
 
     private static Web3Impl createWeb3(World world, SimpleEthereum ethereum, MinerServer minerServer) {
-        MinerClientImpl minerClient = new MinerClientImpl(null, minerServer, ConfigHelper.CONFIG);
+        MinerClientImpl minerClient = new MinerClientImpl(null, minerServer, config);
         PersonalModule pm = new PersonalModuleWalletDisabled();
 
         SimpleWorldManager worldManager = new SimpleWorldManager();
@@ -183,9 +186,9 @@ public class Web3ImplSnapshotTest {
 
     static MinerServer getMinerServerForTest(World world, SimpleEthereum ethereum) {
         BlockValidationRule rule = new MinerManagerTest.BlockValidationRuleDummy();
-        return new MinerServerImpl(ConfigHelper.CONFIG, ethereum, world.getBlockChain(), world.getBlockChain().getBlockStore(),
-                world.getBlockChain().getPendingState(), world.getBlockChain().getRepository(), ConfigUtils.getDefaultMiningConfig(), rule, world.getBlockProcessor(), new DifficultyCalculator(ConfigHelper.CONFIG), new GasLimitCalculator(ConfigHelper.CONFIG),
-                new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false));
+        return new MinerServerImpl(config, ethereum, world.getBlockChain(), world.getBlockChain().getBlockStore(),
+                world.getBlockChain().getPendingState(), world.getBlockChain().getRepository(), ConfigUtils.getDefaultMiningConfig(), rule, world.getBlockProcessor(), new DifficultyCalculator(config), new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
     }
 
     private static void addBlocks(Blockchain blockchain, int size) {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -18,7 +18,6 @@
 
 package org.ethereum.rpc;
 
-import co.rsk.config.ConfigHelper;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.Wallet;
@@ -72,6 +71,7 @@ import java.util.stream.Collectors;
  */
 public class Web3ImplTest {
 
+    private final RskSystemProperties config = new RskSystemProperties();
     Wallet wallet;
 
     @Test
@@ -89,7 +89,7 @@ public class Web3ImplTest {
 
         String netVersion = web3.net_version();
 
-        Assert.assertTrue("RSK net version different than expected", netVersion.compareTo(Byte.toString(ConfigHelper.CONFIG.getBlockchainConfig().getCommonConstants().getChainId())) == 0);
+        Assert.assertTrue("RSK net version different than expected", netVersion.compareTo(Byte.toString(config.getBlockchainConfig().getCommonConstants().getChainId())) == 0);
     }
 
     @Test
@@ -223,7 +223,7 @@ public class Web3ImplTest {
         World world = new World();
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
         Account acc1 = new AccountBuilder(world).name("acc1").balance(BigInteger.valueOf(10000000)).build();
         Account acc2 = new AccountBuilder(world).name("acc2").build();
@@ -414,7 +414,7 @@ public class Web3ImplTest {
         World world = new World();
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
         Web3Impl web3 = createWeb3(worldManager);
 
@@ -1122,7 +1122,7 @@ public class Web3ImplTest {
         }
 
         // ***** Verifies tx hash
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
+        Transaction tx = Transaction.create(config, toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
         Account account = wallet.getAccount(new RskAddress(addr1), "passphrase1");
         tx.sign(account.getEcKey().getPrivKeyBytes());
 
@@ -1224,7 +1224,7 @@ public class Web3ImplTest {
         }
 
         // ***** Verifies tx hash
-        Transaction tx = Transaction.create(ConfigHelper.CONFIG, toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
+        Transaction tx = Transaction.create(config, toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
         tx.sign(wallet.getAccount(new RskAddress(addr1)).getEcKey().getPrivKeyBytes());
 
         String expectedHash = TypeConverter.toJsonHex(tx.getHash());
@@ -1243,7 +1243,7 @@ public class Web3ImplTest {
     private Web3Impl createWeb3Mocked(World world, Block block1) {
         SimpleWorldManager worldManager = new SimpleWorldManager();
         worldManager.setBlockchain(world.getBlockChain());
-        PendingState pendingState = new PendingStateImpl(ConfigHelper.CONFIG, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
+        PendingState pendingState = new PendingStateImpl(config, world.getBlockChain(), world.getRepository(), world.getBlockChain().getBlockStore(), null, null, 10, 100);
         worldManager.setPendingState(pendingState);
         Ethereum ethMock = Mockito.mock(Ethereum.class);
         ProgramResult res = new ProgramResult();
@@ -1255,20 +1255,20 @@ public class Web3ImplTest {
     private Web3Impl createWeb3(SimpleEthereum eth, PeerServer peerServer) {
         wallet = WalletFactory.createWallet();
         WorldManager worldManager = Web3Mocks.getMockWorldManager();
-        PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(ConfigHelper.CONFIG, eth, wallet, null);
-        EthModule ethModule = new EthModule(ConfigHelper.CONFIG, eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(ConfigHelper.CONFIG, eth, wallet, null));
+        PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, null);
+        EthModule ethModule = new EthModule(config, eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, eth, wallet, null));
         MinerClient minerClient = new SimpleMinerClient();
         ChannelManager channelManager = new SimpleChannelManager();
-        return new Web3RskImpl(eth, worldManager, ConfigHelper.CONFIG, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule, channelManager, Web3Mocks.getMockRepository(), null, null, null, peerServer);
+        return new Web3RskImpl(eth, worldManager, config, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule, channelManager, Web3Mocks.getMockRepository(), null, null, null, peerServer);
     }
 
     private Web3Impl createWeb3(Ethereum eth, WorldManager worldManager) {
         wallet = WalletFactory.createWallet();
-        PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(ConfigHelper.CONFIG, eth, wallet, worldManager.getPendingState());
-        EthModule ethModule = new EthModule(ConfigHelper.CONFIG, eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(ConfigHelper.CONFIG, eth, wallet, worldManager.getPendingState()));
+        PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, worldManager.getPendingState());
+        EthModule ethModule = new EthModule(config, eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, eth, wallet, worldManager.getPendingState()));
         MinerClient minerClient = new SimpleMinerClient();
         ChannelManager channelManager = new SimpleChannelManager();
-        return new Web3RskImpl(eth, worldManager, ConfigHelper.CONFIG, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule, channelManager, Web3Mocks.getMockRepository(), null, null, null, null);
+        return new Web3RskImpl(eth, worldManager, config, minerClient, Web3Mocks.getMockMinerServer(), personalModule, ethModule, channelManager, Web3Mocks.getMockRepository(), null, null, null, null);
     }
 
     @Test
@@ -1281,7 +1281,7 @@ public class Web3ImplTest {
 
         Mockito.when(systemProperties.customSolcPath()).thenReturn(solc);
         Ethereum eth = Mockito.mock(Ethereum.class);
-        EthModule ethModule = new EthModule(ConfigHelper.CONFIG, eth, new EthModuleSolidityEnabled(new SolidityCompiler(systemProperties)), null);
+        EthModule ethModule = new EthModule(config, eth, new EthModuleSolidityEnabled(new SolidityCompiler(systemProperties)), null);
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
         Web3Impl web3 = new Web3RskImpl(eth, null, systemProperties, null, null, personalModule, ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null, null);
         String contract = "pragma solidity ^0.4.1; contract rsk { function multiply(uint a) returns(uint d) {   return a * 7;   } }";
@@ -1310,8 +1310,8 @@ public class Web3ImplTest {
         Wallet wallet = WalletFactory.createWallet();
         Ethereum eth = Web3Mocks.getMockEthereum();
         WorldManager worldManager = Web3Mocks.getMockWorldManager();
-        EthModule ethModule = new EthModule(ConfigHelper.CONFIG, eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(ConfigHelper.CONFIG, eth, wallet, null));
-        Web3Impl web3 = new Web3RskImpl(eth, worldManager, ConfigHelper.CONFIG, null, null, new PersonalModuleWalletDisabled(), ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null, null);
+        EthModule ethModule = new EthModule(config, eth, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, eth, wallet, null));
+        Web3Impl web3 = new Web3RskImpl(eth, worldManager, config, null, null, new PersonalModuleWalletDisabled(), ethModule, Web3Mocks.getMockChannelManager(), Web3Mocks.getMockRepository(), null, null, null, null);
 
         String contract = "pragma solidity ^0.4.1; contract rsk { function multiply(uint a) returns(uint d) {   return a * 7;   } }";
 

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -1,6 +1,6 @@
 package org.ethereum.util;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.test.builders.AccountBuilder;
@@ -104,7 +104,7 @@ public class ContractRunner {
 
     private TransactionExecutor executeTransaction(Transaction transaction) {
         Repository track = repository.startTracking();
-        TransactionExecutor executor = new TransactionExecutor(ConfigHelper.CONFIG, transaction, 0, RskAddress.nullAddress(),
+        TransactionExecutor executor = new TransactionExecutor(new RskSystemProperties(), transaction, 0, RskAddress.nullAddress(),
                 repository, blockStore, receiptStore,
                 new ProgramInvokeFactoryImpl(), blockchain.getBestBlock());
         executor.init();

--- a/rskj-core/src/test/java/org/ethereum/util/RskTestFactory.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RskTestFactory.java
@@ -1,7 +1,7 @@
 package org.ethereum.util;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.PendingStateImpl;
@@ -29,6 +29,7 @@ import java.util.HashMap;
  * tests yet.
  */
 public class RskTestFactory {
+    private final RskSystemProperties config = new RskSystemProperties();
     private BlockChainImpl blockchain;
     private IndexedBlockStore blockStore;
     private PendingState pendingState;
@@ -82,7 +83,7 @@ public class RskTestFactory {
 
     private TransactionExecutor executeTransaction(Transaction transaction) {
         Repository track = getRepository().startTracking();
-        TransactionExecutor executor = new TransactionExecutor(ConfigHelper.CONFIG, transaction, 0, RskAddress.nullAddress(),
+        TransactionExecutor executor = new TransactionExecutor(config, transaction, 0, RskAddress.nullAddress(),
                 getRepository(), getBlockStore(), getReceiptStore(),
                 getProgramInvokeFactory(), getBlockchain().getBestBlock());
         executor.init();
@@ -104,7 +105,7 @@ public class RskTestFactory {
     public BlockChainImpl getBlockchain() {
         if (blockchain == null) {
             blockchain = new BlockChainImpl(
-                    ConfigHelper.CONFIG, getRepository(),
+                    config, getRepository(),
                     getBlockStore(),
                     getReceiptStore(),
                     null, //circular dependency
@@ -126,7 +127,7 @@ public class RskTestFactory {
 
     public BlockStore getBlockStore() {
         if (blockStore == null) {
-            blockStore = new IndexedBlockStore(ConfigHelper.CONFIG);
+            blockStore = new IndexedBlockStore(config);
             HashMapDB blockStore = new HashMapDB();
             this.blockStore.init(new HashMap<>(), blockStore, null);
         }
@@ -142,7 +143,7 @@ public class RskTestFactory {
                     null,
                     getProgramInvokeFactory(),
                     getRepository(),
-                    ConfigHelper.CONFIG
+                    config
             );
         }
 
@@ -152,7 +153,7 @@ public class RskTestFactory {
     public Repository getRepository() {
         if (repository == null) {
             HashMapDB stateStore = new HashMapDB();
-            repository = new RepositoryImpl(ConfigHelper.CONFIG, new TrieStoreImpl(stateStore));
+            repository = new RepositoryImpl(config, new TrieStoreImpl(stateStore));
         }
 
         return repository;

--- a/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
@@ -18,7 +18,7 @@
 
 package org.ethereum.validator;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.BlockHeader;
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
  * @since 02.23.2016
  */
 public class DifficultyRuleTest {
-    private final DifficultyRule rule = new DifficultyRule(new DifficultyCalculator(ConfigHelper.CONFIG));
+    private final DifficultyRule rule = new DifficultyRule(new DifficultyCalculator(new RskSystemProperties()));
 
     @Ignore
     @Test // pass rule

--- a/rskj-core/src/test/java/org/ethereum/validator/ProofOfWorkRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/ProofOfWorkRuleTest.java
@@ -21,8 +21,8 @@ package org.ethereum.validator;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.blockchain.utils.BlockMiner;
-import co.rsk.config.ConfigHelper;
 import co.rsk.config.RskMiningConstants;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.crypto.Sha3Hash;
 import co.rsk.mine.MinerUtils;
 import co.rsk.util.DifficultyUtils;
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ProofOfWorkRuleTest {
 
-    private ProofOfWorkRule rule = new ProofOfWorkRule(ConfigHelper.CONFIG).setFallbackMiningEnabled(false);
+    private ProofOfWorkRule rule = new ProofOfWorkRule(new RskSystemProperties()).setFallbackMiningEnabled(false);
 
     @Test
     public void test_1() {

--- a/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.util.BIUtil;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts.PrecompiledContract;
@@ -37,11 +37,13 @@ import static org.junit.Assert.*;
 public class PrecompiledContractTest {
 
 
+    private final RskSystemProperties config = new RskSystemProperties();
+
     @Test
     public void identityTest1() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000004");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
         byte[] data = Hex.decode("112233445566");
         byte[] expected = Hex.decode("112233445566");
 
@@ -55,7 +57,7 @@ public class PrecompiledContractTest {
     public void sha256Test1() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
         byte[] data = null;
         String expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
@@ -68,7 +70,7 @@ public class PrecompiledContractTest {
     public void sha256Test2() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
         byte[] data = ByteUtil.EMPTY_BYTE_ARRAY;
         String expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
@@ -81,7 +83,7 @@ public class PrecompiledContractTest {
     public void sha256Test3() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
         byte[] data = Hex.decode("112233");
         String expected = "49ee2bf93aac3b1fb4117e59095e07abe555c3383b38d608da37680a406096e8";
 
@@ -95,7 +97,7 @@ public class PrecompiledContractTest {
     public void Ripempd160Test1() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000003");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
         byte[] data = Hex.decode("0000000000000000000000000000000000000000000000000000000000000001");
         String expected = "000000000000000000000000ae387fcfeb723c3f5964509af111cf5a67f30661";
 
@@ -109,7 +111,7 @@ public class PrecompiledContractTest {
 
         byte[] data = Hex.decode("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549");
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000001");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
         String expected = "000000000000000000000000ae387fcfeb723c3f5964509af111cf5a67f30661";
 
         byte[] result = contract.execute(data);
@@ -122,7 +124,7 @@ public class PrecompiledContractTest {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000005");
 
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(ConfigHelper.CONFIG, addr);
+        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
         assertNotNull(contract);
 
         byte[] data1 = Hex.decode(

--- a/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
@@ -19,28 +19,25 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.util.ByteUtil;
-
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.invoke.ProgramInvokeMockImpl;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class ProgramMemoryTest {
 
     ProgramInvokeMockImpl pi = new ProgramInvokeMockImpl();
     Program program;
-    ByteBuffer memory;
 
     @Before
     public void createProgram() {
-        program = new Program(ConfigHelper.CONFIG, ByteUtil.EMPTY_BYTE_ARRAY, pi);
+        program = new Program(new RskSystemProperties(), ByteUtil.EMPTY_BYTE_ARRAY, pi);
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
@@ -19,19 +19,17 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.AccountState;
-import org.ethereum.crypto.HashUtil;
 import org.ethereum.core.Repository;
-
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.invoke.ProgramInvokeMockImpl;
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
@@ -48,6 +46,7 @@ import static org.junit.Assert.assertEquals;
 public class VMComplexTest {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Ignore //TODO #POC9
     @Test // contract call recursive
@@ -98,8 +97,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeB, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -182,8 +181,8 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeB, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -270,8 +269,8 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeB, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -348,8 +347,8 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeA, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeA, pi);
 
         try {
             while (!program.isStopped())
@@ -420,8 +419,8 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeB, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -484,8 +483,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeB, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -543,8 +542,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeB, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -602,8 +601,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeB, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -661,8 +660,8 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(ConfigHelper.CONFIG);
-        Program program = new Program(ConfigHelper.CONFIG, codeB, pi);
+        VM vm = new VM(config);
+        Program program = new Program(config, codeB, pi);
 
         try {
             while (!program.isStopped())

--- a/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.Program.OutOfGasException;
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertTrue;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class VMCustomTest {
 
+    private final RskSystemProperties config = new RskSystemProperties();
     private ProgramInvokeMockImpl invoke;
     private Program program;
 
@@ -65,8 +66,8 @@ public class VMCustomTest {
     @Test // CALLDATASIZE OP
     public void testCALLDATASIZE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("36"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("36"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000040";
 
         vm.step(program);
@@ -79,9 +80,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("600035"), invoke);
+                new Program(config, Hex.decode("600035"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000A1";
 
         vm.step(program);
@@ -94,9 +95,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("600235"), invoke);
+                new Program(config, Hex.decode("600235"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000A10000";
 
         vm.step(program);
@@ -110,9 +111,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("602035"), invoke);
+                new Program(config, Hex.decode("602035"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000B1";
 
         vm.step(program);
@@ -126,9 +127,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("602335"), invoke);
+                new Program(config, Hex.decode("602335"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000B1000000";
 
         vm.step(program);
@@ -141,9 +142,9 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_5() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("603F35"), invoke);
+                new Program(config, Hex.decode("603F35"), invoke);
         String s_expected_1 = "B100000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -156,9 +157,9 @@ public class VMCustomTest {
     @Test(expected = RuntimeException.class) // CALLDATALOAD OP mal
     public void testCALLDATALOAD_6() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("35"), invoke);
+                new Program(config, Hex.decode("35"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -169,9 +170,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("60206000600037"), invoke);
+                new Program(config, Hex.decode("60206000600037"), invoke);
         String m_expected = "00000000000000000000000000000000000000000000000000000000000000A1";
 
         vm.step(program);
@@ -185,9 +186,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("60406000600037"), invoke);
+                new Program(config, Hex.decode("60406000600037"), invoke);
         String m_expected = "00000000000000000000000000000000000000000000000000000000000000A1" +
                 "00000000000000000000000000000000000000000000000000000000000000B1";
 
@@ -203,9 +204,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("60406004600037"), invoke);
+                new Program(config, Hex.decode("60406004600037"), invoke);
         String m_expected = "000000000000000000000000000000000000000000000000000000A100000000" +
                 "000000000000000000000000000000000000000000000000000000B100000000";
 
@@ -221,9 +222,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("60406000600437"), invoke);
+                new Program(config, Hex.decode("60406000600437"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "000000A100000000000000000000000000000000000000000000000000000000" +
                 "000000B100000000000000000000000000000000000000000000000000000000";
@@ -239,9 +240,9 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_5() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("60406000600437"), invoke);
+                new Program(config, Hex.decode("60406000600437"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "000000A100000000000000000000000000000000000000000000000000000000" +
                 "000000B100000000000000000000000000000000000000000000000000000000";
@@ -258,9 +259,9 @@ public class VMCustomTest {
     @Test(expected = StackTooSmallException.class) // CALLDATACOPY OP mal
     public void testCALLDATACOPY_6() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("6040600037"), invoke);
+                new Program(config, Hex.decode("6040600037"), invoke);
 
         try {
             vm.step(program);
@@ -274,9 +275,9 @@ public class VMCustomTest {
     @Test(expected = OutOfGasException.class) // CALLDATACOPY OP mal
     public void testCALLDATACOPY_7() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("6020600073CC0929EB16730E7C14FEFC63006AC2D794C5795637"), invoke);
+                new Program(config, Hex.decode("6020600073CC0929EB16730E7C14FEFC63006AC2D794C5795637"), invoke);
 
         try {
             vm.step(program);
@@ -291,8 +292,8 @@ public class VMCustomTest {
     @Test // ADDRESS OP
     public void testADDRESS_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("30"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("30"), invoke);
         String s_expected_1 = "00000000000000000000000077045E71A7A2C50903D88E564CD72FAB11E82051";
 
         vm.step(program);
@@ -305,9 +306,9 @@ public class VMCustomTest {
     @Test // BALANCE OP
     public void testBALANCE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("3031"), invoke);
+                new Program(config, Hex.decode("3031"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000003E8";
 
         vm.step(program);
@@ -320,9 +321,9 @@ public class VMCustomTest {
     @Test // ORIGIN OP
     public void testORIGIN_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("32"), invoke);
+                new Program(config, Hex.decode("32"), invoke);
         String s_expected_1 = "00000000000000000000000013978AEE95F38490E9769C39B2773ED763D9CD5F";
 
         vm.step(program);
@@ -334,9 +335,9 @@ public class VMCustomTest {
     @Test // CALLER OP
     public void testCALLER_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("33"), invoke);
+                new Program(config, Hex.decode("33"), invoke);
         String s_expected_1 = "000000000000000000000000885F93EED577F2FC341EBB9A5C9B2CE4465D96C4";
 
         vm.step(program);
@@ -348,9 +349,9 @@ public class VMCustomTest {
     @Test // CALLVALUE OP
     public void testCALLVALUE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("34"), invoke);
+                new Program(config, Hex.decode("34"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000DE0B6B3A7640000";
 
         vm.step(program);
@@ -362,9 +363,9 @@ public class VMCustomTest {
     @Test // SHA3 OP
     public void testSHA3_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("60016000536001600020"), invoke);
+                new Program(config, Hex.decode("60016000536001600020"), invoke);
         String s_expected_1 = "5FE7F977E71DBA2EA1A68E21057BEEBB9BE2AC30C6410AA38D4F3FBE41DCFFD2";
 
         vm.step(program);
@@ -381,9 +382,9 @@ public class VMCustomTest {
     @Test // SHA3 OP
     public void testSHA3_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("6102016000526002601E20"), invoke);
+                new Program(config, Hex.decode("6102016000526002601E20"), invoke);
         String s_expected_1 = "114A3FE82A0219FCC31ABD15617966A125F12B0FD3409105FC83B487A9D82DE4";
 
         vm.step(program);
@@ -400,9 +401,9 @@ public class VMCustomTest {
     @Test(expected = StackTooSmallException.class) // SHA3 OP mal
     public void testSHA3_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("610201600052600220"), invoke);
+                new Program(config, Hex.decode("610201600052600220"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -417,9 +418,9 @@ public class VMCustomTest {
     @Test // BLOCKHASH OP
     public void testBLOCKHASH_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("600140"), invoke);
+                new Program(config, Hex.decode("600140"), invoke);
         String s_expected_1 = "C89EFDAA54C0F20C7ADF612882DF0950F5A951637E0307CDCB4C672F298B8BC6";
 
         vm.step(program);
@@ -432,9 +433,9 @@ public class VMCustomTest {
     @Test // COINBASE OP
     public void testCOINBASE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("41"), invoke);
+                new Program(config, Hex.decode("41"), invoke);
         String s_expected_1 = "000000000000000000000000E559DE5527492BCB42EC68D07DF0742A98EC3F1E";
 
         vm.step(program);
@@ -446,9 +447,9 @@ public class VMCustomTest {
     @Test // TIMESTAMP OP
     public void testTIMESTAMP_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("42"), invoke);
+                new Program(config, Hex.decode("42"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000005387FE24";
 
         vm.step(program);
@@ -460,9 +461,9 @@ public class VMCustomTest {
     @Test // NUMBER OP
     public void testNUMBER_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("43"), invoke);
+                new Program(config, Hex.decode("43"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000021";
 
         vm.step(program);
@@ -474,9 +475,9 @@ public class VMCustomTest {
     @Test // DIFFICULTY OP
     public void testDIFFICULTY_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("44"), invoke);
+                new Program(config, Hex.decode("44"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000003ED290";
 
         vm.step(program);
@@ -488,9 +489,9 @@ public class VMCustomTest {
     @Test // GASPRICE OP
     public void testGASPRICE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("3A"), invoke);
+                new Program(config, Hex.decode("3A"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000009184E72A000";
 
         vm.step(program);
@@ -503,9 +504,9 @@ public class VMCustomTest {
     @Test // GAS OP
     public void testGAS_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("5A"), invoke);
+                new Program(config, Hex.decode("5A"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000F423F";
 
         vm.step(program);
@@ -517,9 +518,9 @@ public class VMCustomTest {
     @Test // GASLIMIT OP
     public void testGASLIMIT_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("45"), invoke);
+                new Program(config, Hex.decode("45"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000F4240";
 
         vm.step(program);
@@ -531,8 +532,8 @@ public class VMCustomTest {
     @Test(expected = Program.IllegalOperationException.class) // INVALID OP
     public void testINVALID_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60012F6002"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60012F6002"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         try {

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -20,7 +20,7 @@
 package org.ethereum.vm;
 
 import co.rsk.asm.EVMAssembler;
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.Repository;
 import org.ethereum.util.ByteUtil;
@@ -48,6 +48,7 @@ public class VMTest {
 
     private ProgramInvokeMockImpl invoke;
     private Program program;
+    private final RskSystemProperties config = new RskSystemProperties();
 
     @Before
     public void setup() {
@@ -62,8 +63,8 @@ public class VMTest {
     @Test  // PUSH1 OP
     public void testPUSH1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60A0"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60A0"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000A0";
 
         program.fullTrace();
@@ -75,8 +76,8 @@ public class VMTest {
     @Test  // PUSH2 OP
     public void testPUSH2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61A0B0"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61A0B0"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000A0B0";
 
         program.fullTrace();
@@ -88,8 +89,8 @@ public class VMTest {
     @Test  // PUSH3 OP
     public void testPUSH3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("62A0B0C0"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("62A0B0C0"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000A0B0C0";
 
         program.fullTrace();
@@ -101,8 +102,8 @@ public class VMTest {
     @Test  // PUSH4 OP
     public void testPUSH4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("63A0B0C0D0"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("63A0B0C0D0"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000A0B0C0D0";
 
         program.fullTrace();
@@ -114,8 +115,8 @@ public class VMTest {
     @Test  // PUSH5 OP
     public void testPUSH5() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("64A0B0C0D0E0"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("64A0B0C0D0E0"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000A0B0C0D0E0";
 
         program.fullTrace();
@@ -127,8 +128,8 @@ public class VMTest {
     @Test  // PUSH6 OP
     public void testPUSH6() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("65A0B0C0D0E0F0"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("65A0B0C0D0E0F0"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000A0B0C0D0E0F0";
 
         program.fullTrace();
@@ -140,8 +141,8 @@ public class VMTest {
     @Test  // PUSH7 OP
     public void testPUSH7() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("66A0B0C0D0E0F0A1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("66A0B0C0D0E0F0A1"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000A0B0C0D0E0F0A1";
 
         program.fullTrace();
@@ -153,8 +154,8 @@ public class VMTest {
     @Test  // PUSH8 OP
     public void testPUSH8() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("67A0B0C0D0E0F0A1B1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("67A0B0C0D0E0F0A1B1"), invoke);
         String expected = "000000000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1";
 
         program.fullTrace();
@@ -166,8 +167,8 @@ public class VMTest {
     @Test  // PUSH9 OP
     public void testPUSH9() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("68A0B0C0D0E0F0A1B1C1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("68A0B0C0D0E0F0A1B1C1"), invoke);
         String expected = "0000000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1";
 
         program.fullTrace();
@@ -180,8 +181,8 @@ public class VMTest {
     @Test  // PUSH10 OP
     public void testPUSH10() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("69A0B0C0D0E0F0A1B1C1D1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("69A0B0C0D0E0F0A1B1C1D1"), invoke);
         String expected = "00000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1";
 
         program.fullTrace();
@@ -193,8 +194,8 @@ public class VMTest {
     @Test  // PUSH11 OP
     public void testPUSH11() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6AA0B0C0D0E0F0A1B1C1D1E1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6AA0B0C0D0E0F0A1B1C1D1E1"), invoke);
         String expected = "000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1";
 
         program.fullTrace();
@@ -206,8 +207,8 @@ public class VMTest {
     @Test  // PUSH12 OP
     public void testPUSH12() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6BA0B0C0D0E0F0A1B1C1D1E1F1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6BA0B0C0D0E0F0A1B1C1D1E1F1"), invoke);
         String expected = "0000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1";
 
         program.fullTrace();
@@ -219,8 +220,8 @@ public class VMTest {
     @Test  // PUSH13 OP
     public void testPUSH13() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6CA0B0C0D0E0F0A1B1C1D1E1F1A2"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6CA0B0C0D0E0F0A1B1C1D1E1F1A2"), invoke);
         String expected = "00000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2";
 
         program.fullTrace();
@@ -232,8 +233,8 @@ public class VMTest {
     @Test  // PUSH14 OP
     public void testPUSH14() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6DA0B0C0D0E0F0A1B1C1D1E1F1A2B2"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6DA0B0C0D0E0F0A1B1C1D1E1F1A2B2"), invoke);
         String expected = "000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2";
 
         program.fullTrace();
@@ -245,8 +246,8 @@ public class VMTest {
     @Test  // PUSH15 OP
     public void testPUSH15() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2"), invoke);
         String expected = "0000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2";
 
         program.fullTrace();
@@ -258,8 +259,8 @@ public class VMTest {
     @Test  // PUSH16 OP
     public void testPUSH16() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2"), invoke);
         String expected = "00000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2";
 
         program.fullTrace();
@@ -271,8 +272,8 @@ public class VMTest {
     @Test  // PUSH17 OP
     public void testPUSH17() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("70A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("70A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2"), invoke);
         String expected = "000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2";
 
         program.fullTrace();
@@ -284,8 +285,8 @@ public class VMTest {
     @Test  // PUSH18 OP
     public void testPUSH18() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("71A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("71A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2"), invoke);
         String expected = "0000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2";
 
         program.fullTrace();
@@ -297,8 +298,8 @@ public class VMTest {
     @Test  // PUSH19 OP
     public void testPUSH19() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("72A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("72A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3"), invoke);
         String expected = "00000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3";
 
         program.fullTrace();
@@ -310,8 +311,8 @@ public class VMTest {
     @Test  // PUSH20 OP
     public void testPUSH20() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("73A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("73A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3"), invoke);
         String expected = "000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3";
 
         program.fullTrace();
@@ -323,8 +324,8 @@ public class VMTest {
     @Test  // PUSH21 OP
     public void testPUSH21() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("74A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("74A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3"), invoke);
         String expected = "0000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3";
 
         program.fullTrace();
@@ -336,8 +337,8 @@ public class VMTest {
     @Test  // PUSH22 OP
     public void testPUSH22() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("75A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("75A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3"), invoke);
         String expected = "00000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3";
 
         program.fullTrace();
@@ -349,8 +350,8 @@ public class VMTest {
     @Test  // PUSH23 OP
     public void testPUSH23() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("76A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("76A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3"), invoke);
         String expected = "000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3";
 
         program.fullTrace();
@@ -362,8 +363,8 @@ public class VMTest {
     @Test  // PUSH24 OP
     public void testPUSH24() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("77A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("77A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3"), invoke);
         String expected = "0000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3";
 
         program.fullTrace();
@@ -375,8 +376,8 @@ public class VMTest {
     @Test  // PUSH25 OP
     public void testPUSH25() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("78A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("78A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4"), invoke);
         String expected = "00000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4";
 
         program.fullTrace();
@@ -388,8 +389,8 @@ public class VMTest {
     @Test  // PUSH26 OP
     public void testPUSH26() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("79A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("79A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4"), invoke);
         String expected = "000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4";
 
         program.fullTrace();
@@ -401,8 +402,8 @@ public class VMTest {
     @Test  // PUSH27 OP
     public void testPUSH27() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7AA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7AA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4"), invoke);
         String expected = "0000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4";
 
         program.fullTrace();
@@ -414,8 +415,8 @@ public class VMTest {
     @Test  // PUSH28 OP
     public void testPUSH28() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7BA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7BA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4"), invoke);
         String expected = "00000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4";
 
         program.fullTrace();
@@ -427,8 +428,8 @@ public class VMTest {
     @Test  // PUSH29 OP
     public void testPUSH29() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7CA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7CA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4"), invoke);
         String expected = "000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4";
 
         program.fullTrace();
@@ -440,8 +441,8 @@ public class VMTest {
     @Test  // PUSH30 OP
     public void testPUSH30() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7DA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7DA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4"), invoke);
         String expected = "0000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4";
 
         program.fullTrace();
@@ -453,8 +454,8 @@ public class VMTest {
     @Test  // PUSH31 OP
     public void testPUSH31() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1"), invoke);
         String expected = "00A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1";
 
         program.fullTrace();
@@ -466,8 +467,8 @@ public class VMTest {
     @Test  // PUSH32 OP
     public void testPUSH32() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1"), invoke);
         String expected = "A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1";
 
         program.fullTrace();
@@ -479,8 +480,8 @@ public class VMTest {
     @Test // PUSHN OP not enough data
     public void testPUSHN_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61AA"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61AA"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000AA00";
 
         program.fullTrace();
@@ -493,8 +494,8 @@ public class VMTest {
     @Test // PUSHN OP not enough data
     public void testPUSHN_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7fAABB"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7fAABB"), invoke);
         String expected = "AABB000000000000000000000000000000000000000000000000000000000000";
 
         program.fullTrace();
@@ -508,8 +509,8 @@ public class VMTest {
     @Test  // AND OP
     public void testAND_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600A600A16"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600A600A16"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000000A";
 
         vm.step(program);
@@ -522,8 +523,8 @@ public class VMTest {
     @Test  // AND OP
     public void testAND_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60C0600A16"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60C0600A16"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -536,8 +537,8 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // AND OP mal data
     public void testAND_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60C016"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60C016"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -550,8 +551,8 @@ public class VMTest {
     @Test  // OR OP
     public void testOR_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60F0600F17"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60F0600F17"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -564,8 +565,8 @@ public class VMTest {
     @Test  // OR OP
     public void testOR_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60C3603C17"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60C3603C17"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -578,8 +579,8 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // OR OP mal data
     public void testOR_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60C017"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60C017"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -592,8 +593,8 @@ public class VMTest {
     @Test  // XOR OP
     public void testXOR_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60FF60FF18"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60FF60FF18"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -606,8 +607,8 @@ public class VMTest {
     @Test  // XOR OP
     public void testXOR_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600F60F018"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600F60F018"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -621,8 +622,8 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // XOR OP mal data
     public void testXOR_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60C018"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60C018"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -635,8 +636,8 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("65AABBCCDDEEFF601E1A"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("65AABBCCDDEEFF601E1A"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000EE";
 
         vm.step(program);
@@ -649,8 +650,8 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("65AABBCCDDEEFF60201A"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("65AABBCCDDEEFF60201A"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -663,8 +664,8 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("65AABBCCDDEE3A601F1A"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("65AABBCCDDEE3A601F1A"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000003A";
 
         vm.step(program);
@@ -678,8 +679,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // BYTE OP mal data
     public void testBYTE_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("65AABBCCDDEE3A1A"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("65AABBCCDDEE3A1A"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -692,8 +693,8 @@ public class VMTest {
     @Test  // ISZERO OP
     public void testISZERO_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600015"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600015"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -705,8 +706,8 @@ public class VMTest {
     @Test  // ISZERO OP
     public void testISZERO_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602A15"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602A15"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -718,8 +719,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // ISZERO OP mal data
     public void testISZERO_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("15"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("15"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -732,8 +733,8 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602A602A14"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602A602A14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -746,8 +747,8 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("622A3B4C622A3B4C14"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("622A3B4C622A3B4C14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -760,8 +761,8 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("622A3B5C622A3B4C14"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("622A3B5C622A3B4C14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -774,8 +775,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // EQ OP mal data
     public void testEQ_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("622A3B4C14"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("622A3B4C14"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -788,8 +789,8 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6001600211"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6001600211"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -802,8 +803,8 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6001610F0011"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6001610F0011"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -816,8 +817,8 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6301020304610F0011"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6301020304610F0011"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -830,8 +831,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // GT OP mal data
     public void testGT_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("622A3B4C11"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("622A3B4C11"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -844,8 +845,8 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6001600213"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6001600213"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -858,8 +859,8 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "13"), invoke);
 
@@ -875,8 +876,8 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
                 "13"), invoke);
 
@@ -892,8 +893,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SGT OP mal
     public void testSGT_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "13"), invoke);
         try {
             vm.step(program);
@@ -907,8 +908,8 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6001600210"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6001600210"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -921,8 +922,8 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6001610F0010"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6001610F0010"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -935,8 +936,8 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6301020304610F0010"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6301020304610F0010"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -949,8 +950,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // LT OP mal data
     public void testLT_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("622A3B4C10"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("622A3B4C10"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -963,8 +964,8 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6001600212"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6001600212"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -977,8 +978,8 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "12"), invoke);
 
@@ -994,8 +995,8 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
                 "12"), invoke);
 
@@ -1011,8 +1012,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SLT OP mal
     public void testSLT_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "12"), invoke);
         try {
             vm.step(program);
@@ -1026,8 +1027,8 @@ public class VMTest {
     @Test  // NOT OP
     public void testNOT_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600119"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600119"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE";
 
         vm.step(program);
@@ -1039,8 +1040,8 @@ public class VMTest {
     @Test  // NOT OP
     public void testNOT_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61A00319"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61A00319"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5FFC";
 
         vm.step(program);
@@ -1053,8 +1054,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // BNOT OP
     public void testBNOT_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("1a"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("1a"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1066,8 +1067,8 @@ public class VMTest {
     @Test  // NOT OP test from real failure
     public void testNOT_5() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600019"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600019"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
         vm.step(program);
@@ -1080,8 +1081,8 @@ public class VMTest {
     @Test // POP OP
     public void testPOP_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61000060016200000250"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61000060016200000250"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -1095,8 +1096,8 @@ public class VMTest {
     @Test // POP OP
     public void testPOP_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6100006001620000025050"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6100006001620000025050"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1111,8 +1112,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // POP OP mal data
     public void testPOP_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61000060016200000250505050"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61000060016200000250505050"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1140,13 +1141,13 @@ public class VMTest {
      */
     private void testDUPN_1(int n) {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         byte operation = (byte) (OpCode.DUP1.val() + n - 1);
         String programCode = "";
         for (int i = 0; i < n; i++) {
             programCode += "60" + (12 + i);
         }
-        program = new Program(ConfigHelper.CONFIG, ByteUtil.appendByte(Hex.decode(programCode.getBytes()), operation), invoke);
+        program = new Program(config, ByteUtil.appendByte(Hex.decode(programCode.getBytes()), operation), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000012";
         int expectedLen = n + 1;
 
@@ -1165,8 +1166,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // DUPN OP mal data
     public void testDUPN_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("80"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("80"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -1188,7 +1189,7 @@ public class VMTest {
      */
     private void testSWAPN_1(int n) {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         byte operation = (byte) (OpCode.SWAP1.val() + n - 1);
 
         String programCode = "";
@@ -1200,7 +1201,7 @@ public class VMTest {
 
         programCode += Hex.toHexString(new byte[]{   (byte)(OpCode.SWAP1.val() + n - 1)   });
 
-        program = new Program(ConfigHelper.CONFIG, ByteUtil.appendByte(Hex.decode(programCode), operation), invoke);
+        program = new Program(config, ByteUtil.appendByte(Hex.decode(programCode), operation), invoke);
 
         for (int i = 0; i < n + 2; ++i) {
             vm.step(program);
@@ -1213,8 +1214,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SWAPN OP mal data
     public void testSWAPN_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("90"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("90"), invoke);
 
         try {
             vm.step(program);
@@ -1226,8 +1227,8 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("611234600052"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("611234600052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000001234";
 
         vm.step(program);
@@ -1241,8 +1242,8 @@ public class VMTest {
     @Test // LOG0 OP
     public void tesLog0() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123460005260206000A0"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123460005260206000A0"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1263,8 +1264,8 @@ public class VMTest {
     @Test // LOG1 OP
     public void tesLog1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123460005261999960206000A1"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123460005261999960206000A1"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1286,8 +1287,8 @@ public class VMTest {
     @Test // LOG2 OP
     public void tesLog2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123460005261999961666660206000A2"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123460005261999961666660206000A2"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1310,8 +1311,8 @@ public class VMTest {
     @Test // LOG3 OP
     public void tesLog3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123460005261999961666661333360206000A3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123460005261999961666661333360206000A3"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1336,8 +1337,8 @@ public class VMTest {
     @Test // LOG4 OP
     public void tesLog4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123460005261999961666661333361555560206000A4"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123460005261999961666661333361555560206000A4"), invoke);
 
         vm.step(program);
         vm.step(program);
@@ -1363,8 +1364,8 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("611234600052615566602052"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("611234600052615566602052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000001234" +
                 "0000000000000000000000000000000000000000000000000000000000005566";
 
@@ -1381,8 +1382,8 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("611234600052615566602052618888600052"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("611234600052615566602052618888600052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000008888" +
                 "0000000000000000000000000000000000000000000000000000000000005566";
 
@@ -1402,8 +1403,8 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123460A052"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123460A052"), invoke);
         String expected = "" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
@@ -1422,8 +1423,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MSTORE OP
     public void testMSTORE_5() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123452"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123452"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1435,8 +1436,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600051"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1450,8 +1451,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602251"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602251"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1468,8 +1469,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602051"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1484,8 +1485,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("611234602052602051"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("611234602052602051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000001234";
@@ -1503,8 +1504,8 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_5() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("611234602052601F51"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("611234602052601F51"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000012";
@@ -1523,8 +1524,8 @@ public class VMTest {
     @Test
     public void testVersioning_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode(
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode(
                 "FC010100" // this is the header
                 + "611234602052601F51"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
@@ -1546,7 +1547,7 @@ public class VMTest {
     @Test
     public void testVersioning_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         //
         byte[] header = Hex.decode("FC810180"); // test negative exeVersion also, 0x80 byte to skip
 
@@ -1566,7 +1567,7 @@ public class VMTest {
 
         byte code[] = outputStream.toByteArray( );
 
-        program = new Program(ConfigHelper.CONFIG, code, invoke);
+        program = new Program(config, code, invoke);
         // no negative values allowed. Currently values over 127 are limited
         // in the future exeversion and scriptversion can be made of size int.
         Assert.assertEquals(program.getExeVersion(), 127);
@@ -1587,8 +1588,8 @@ public class VMTest {
     @Test(expected = Program.IllegalOperationException.class)
     public void testInvalidOpcodes_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("A5"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("A5"), invoke);
 
         vm.step(program);
 
@@ -1597,8 +1598,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MLOAD OP mal data
     public void testMLOAD_6() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("51"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("51"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -1609,8 +1610,8 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6011600053"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6011600053"), invoke);
         String m_expected = "1100000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1624,8 +1625,8 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6022600153"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6022600153"), invoke);
         String m_expected = "0022000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1638,8 +1639,8 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6022602153"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6022602153"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0022000000000000000000000000000000000000000000000000000000000000";
 
@@ -1653,8 +1654,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MSTORE8 OP mal
     public void testMSTORE8_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602253"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602253"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1666,9 +1667,9 @@ public class VMTest {
     @Test // SSTORE OP
     public void testSSTORE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
 
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602260AA55"), invoke);
+        program = new Program(config, Hex.decode("602260AA55"), invoke);
         String s_expected_key = "00000000000000000000000000000000000000000000000000000000000000AA";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000022";
 
@@ -1685,9 +1686,9 @@ public class VMTest {
     @Test // SSTORE OP
     public void testSSTORE_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
 
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602260AA55602260BB55"), invoke);
+        program = new Program(config, Hex.decode("602260AA55602260BB55"), invoke);
         String s_expected_key = "00000000000000000000000000000000000000000000000000000000000000BB";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000022";
 
@@ -1708,8 +1709,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SSTORE OP
     public void testSSTORE_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602255"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602255"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1721,8 +1722,8 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60AA54"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60AA54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1734,8 +1735,8 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602260AA5560AA54"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602260AA5560AA54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000022";
 
         vm.step(program);
@@ -1750,8 +1751,8 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602260AA55603360CC5560CC54"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602260AA55603360CC5560CC54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000033";
 
         vm.step(program);
@@ -1769,8 +1770,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SLOAD OP
     public void testSLOAD_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("56"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("56"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -1781,8 +1782,8 @@ public class VMTest {
     @Test // PC OP
     public void testPC_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("58"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("58"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1794,8 +1795,8 @@ public class VMTest {
     @Test // PC OP
     public void testPC_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602260AA5260AA5458"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602260AA5260AA5458"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000008";
 
         vm.step(program);
@@ -1811,8 +1812,8 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMP_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60AA60BB600E5660CC60DD60EE5B60FF"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60AA60BB600E5660CC60DD60EE5B60FF"), invoke);
         String s_expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -1827,8 +1828,8 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMP_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600C600C905660CC60DD60EE60FF"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600C600C905660CC60DD60EE60FF"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1843,8 +1844,8 @@ public class VMTest {
     @Test // JUMPI OP
     public void testJUMPI_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60016005575B60CC"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60016005575B60CC"), invoke);
         String s_expected = "00000000000000000000000000000000000000000000000000000000000000CC";
 
         vm.step(program);
@@ -1860,8 +1861,8 @@ public class VMTest {
     @Test // JUMPI OP
     public void testJUMPI_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("630000000060445760CC60DD"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("630000000060445760CC60DD"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000DD";
         String s_expected_2 = "00000000000000000000000000000000000000000000000000000000000000CC";
 
@@ -1881,8 +1882,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // JUMPI OP mal
     public void testJUMPI_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600157"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600157"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1894,8 +1895,8 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMPI OP mal
     public void testJUMPI_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60016022909057"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60016022909057"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -1910,8 +1911,8 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMPDEST_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602360085660015b600255"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602360085660015b600255"), invoke);
 
         String s_expected_key = "0000000000000000000000000000000000000000000000000000000000000002";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000023";
@@ -1932,8 +1933,8 @@ public class VMTest {
     @Test // JUMPDEST OP for JUMPI
     public void testJUMPDEST_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6023600160095760015b600255"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6023600160095760015b600255"), invoke);
 
         String s_expected_key = "0000000000000000000000000000000000000000000000000000000000000002";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000023";
@@ -1956,8 +1957,8 @@ public class VMTest {
     @Test // ADD OP mal
     public void testADD_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6002600201"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6002600201"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -1971,8 +1972,8 @@ public class VMTest {
     @Test // ADD OP
     public void testADD_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("611002600201"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("611002600201"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000001004";
 
         vm.step(program);
@@ -1986,8 +1987,8 @@ public class VMTest {
     @Test // ADD OP
     public void testADD_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6110026512345678900901"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6110026512345678900901"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000012345678A00B";
 
         vm.step(program);
@@ -2001,8 +2002,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // ADD OP mal
     public void testADD_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123401"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123401"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2013,8 +2014,8 @@ public class VMTest {
 
     @Test // ADDMOD OP mal
     public void testADDMOD_1() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60026002600308"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60026002600308"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2029,8 +2030,8 @@ public class VMTest {
 
     @Test // ADDMOD OP
     public void testADDMOD_2() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6110006002611002086000"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6110006002611002086000"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -2045,8 +2046,8 @@ public class VMTest {
 
     @Test // ADDMOD OP
     public void testADDMOD_3() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61100265123456789009600208"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61100265123456789009600208"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000000000093B";
 
         vm.step(program);
@@ -2061,8 +2062,8 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // ADDMOD OP mal
     public void testADDMOD_4() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123408"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123408"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2074,8 +2075,8 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6003600202"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6003600202"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000006";
 
         vm.step(program);
@@ -2089,8 +2090,8 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("62222222600302"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("62222222600302"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000666666";
 
         vm.step(program);
@@ -2104,8 +2105,8 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("622222226233333302"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("622222226233333302"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000006D3A05F92C6";
 
         vm.step(program);
@@ -2119,8 +2120,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MUL OP mal
     public void testMUL_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600102"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600102"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2131,8 +2132,8 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_1() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60036002600409"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60036002600409"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2146,8 +2147,8 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_2() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("622222226003600409"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("622222226003600409"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000000000000C";
 
         vm.step(program);
@@ -2161,8 +2162,8 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_3() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("62222222623333336244444409"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("62222222623333336244444409"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2176,8 +2177,8 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // MULMOD OP mal
     public void testMULMOD_4() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600109"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600109"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2189,8 +2190,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6002600404"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6002600404"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2204,8 +2205,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6033609904"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6033609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000003";
 
         vm.step(program);
@@ -2220,8 +2221,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6022609904"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6022609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -2235,8 +2236,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6015609904"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6015609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000007";
 
         vm.step(program);
@@ -2251,8 +2252,8 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_5() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6004600704"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6004600704"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2266,8 +2267,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // DIV OP
     public void testDIV_6() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600704"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600704"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2279,8 +2280,8 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6103E87FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC1805" +
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6103E87FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC1805" +
                 ""), invoke);
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
@@ -2295,8 +2296,8 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60FF60FF05"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60FF60FF05"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2310,8 +2311,8 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600060FF05"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600060FF05"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2325,8 +2326,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SDIV OP mal
     public void testSDIV_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60FF05"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60FF05"), invoke);
 
         try {
             vm.step(program);
@@ -2339,8 +2340,8 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6004600603"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6004600603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2354,8 +2355,8 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61444461666603"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61444461666603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000002222";
 
         vm.step(program);
@@ -2369,8 +2370,8 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("614444639999666603"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("614444639999666603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000099992222";
 
         vm.step(program);
@@ -2384,8 +2385,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SUB OP mal
     public void testSUB_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("639999666603"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("639999666603"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2397,8 +2398,8 @@ public class VMTest {
     @Test // MSIZE OP
     public void testMSIZE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("59"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("59"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2410,8 +2411,8 @@ public class VMTest {
     @Test // MSIZE OP
     public void testMSIZE_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("602060305259"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("602060305259"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000060";
 
         vm.step(program);
@@ -2427,8 +2428,8 @@ public class VMTest {
     @Test // STOP OP
     public void testSTOP_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("60206030601060306011602300"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("60206030601060306011602300"), invoke);
         int expectedSteps = 7;
 
         int i = 0;
@@ -2443,8 +2444,8 @@ public class VMTest {
     @Test
     public void testEXP_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600360020a"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600360020a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000008";
 
         vm.step(program);
@@ -2461,8 +2462,8 @@ public class VMTest {
     @Test
     public void testEXP_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6000621234560a"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6000621234560a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2479,8 +2480,8 @@ public class VMTest {
     @Test
     public void testEXP_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61112260010a"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61112260010a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2498,8 +2499,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // EXP OP mal
     public void testEXP_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("621234560a"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("621234560a"), invoke);
         try {
             vm.step(program);
             vm.step(program);
@@ -2511,8 +2512,8 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61123460005260206000F3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61123460005260206000F3"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000001234";
 
         vm.step(program);
@@ -2530,8 +2531,8 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6112346000526020601FF3"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6112346000526020601FF3"), invoke);
         String s_expected_1 = "3400000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2548,9 +2549,9 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_3() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206000F3"),
                         invoke);
         String s_expected_1 = "A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1";
@@ -2570,9 +2571,9 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206010F3"),
                         invoke);
         String s_expected_1 = "E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B100000000000000000000000000000000";
@@ -2592,9 +2593,9 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("60036007600039123456"), invoke);
+                new Program(config, Hex.decode("60036007600039123456"), invoke);
         String m_expected_1 = "1234560000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2611,9 +2612,9 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054"),
                         invoke);
         String m_expected_1 =
@@ -2637,9 +2638,9 @@ public class VMTest {
         // 94 - data copied
         // 95 - new bytes allocated
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
                         invoke);
 
@@ -2655,9 +2656,9 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
                         invoke);
 
@@ -2673,9 +2674,9 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_5() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("611234600054615566602054607060006020396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
                         invoke);
 
@@ -2697,9 +2698,9 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // CODECOPY OP mal
     public void testCODECOPY_6() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("605E6007396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
                         invoke);
         try {
@@ -2714,9 +2715,9 @@ public class VMTest {
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("60036007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C123456"), invoke);
+                new Program(config, Hex.decode("60036007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C123456"), invoke);
         String m_expected_1 = "6000600000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2731,9 +2732,9 @@ public class VMTest {
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_2() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("603E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054"),
                         invoke);
         String m_expected_1 =
@@ -2750,9 +2751,9 @@ public class VMTest {
 
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_3() {
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("605E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
                         invoke);
 
@@ -2770,9 +2771,9 @@ public class VMTest {
 
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_4() {
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("611234600054615566602054603E6000602073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
                         invoke);
 
@@ -2794,9 +2795,9 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // EXTCODECOPY OP mal
     public void testEXTCODECOPY_5() {
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode("605E600773471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C"),
+                new Program(config, Hex.decode("605E600773471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C"),
                         invoke);
         try {
             vm.step(program);
@@ -2812,9 +2813,9 @@ public class VMTest {
     @Test // CODESIZE OP
     public void testCODESIZE_1() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("385E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
                         invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000062";
@@ -2828,9 +2829,9 @@ public class VMTest {
     @Ignore // todo: test is not testing EXTCODESIZE
     @Test // EXTCODESIZE OP
     public void testEXTCODESIZE_1() {
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         program =
-                new Program(ConfigHelper.CONFIG, Hex.decode
+                new Program(config, Hex.decode
                         ("73471FD3AD3E9EEADEEC4608B92D16CE6B500704CC395E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
                         invoke); // Push address on the stack and perform EXTCODECOPY
         String s_expected_1 = "000000000000000000000000471FD3AD3E9EEADEEC4608B92D16CE6B500704CC";
@@ -2843,8 +2844,8 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_1() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6003600406"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6003600406"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2857,8 +2858,8 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_2() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("61012C6101F406"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("61012C6101F406"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000C8";
 
         vm.step(program);
@@ -2871,8 +2872,8 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_3() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6004600206"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6004600206"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2886,8 +2887,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MOD OP mal
     public void testMOD_4() {
 
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("600406"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("600406"), invoke);
 
         try {
             vm.step(program);
@@ -2900,8 +2901,8 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_1() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("6003600407"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("6003600407"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2914,8 +2915,8 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_2() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE2" + //  -30
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE2" + //  -30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "07"), invoke);
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEC";
@@ -2930,8 +2931,8 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_3() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "07"), invoke);
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEC";
@@ -2946,8 +2947,8 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // SMOD OP mal
     public void testSMOD_4() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "07"), invoke);
         try {
             vm.step(program);
@@ -2992,8 +2993,8 @@ public class VMTest {
     // header must be 4 bytes or more to be valid
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion0() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode("FC"), invoke);
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode("FC"), invoke);
         try {
             vm.step(program);
         } finally {
@@ -3005,8 +3006,8 @@ public class VMTest {
     // Should produce invalidop exception
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion1() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode(
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode(
                 "FC000000" + //header
                 "FC" // invalid opcode
         ), invoke);
@@ -3022,8 +3023,8 @@ public class VMTest {
 
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion2() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode(
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode(
                 "FC010100" + //header
                         "FC" // invalid code
         ), invoke);
@@ -3039,8 +3040,8 @@ public class VMTest {
     // This is a long header with additional data that is skipped
     @Test
     public void testScriptVersion3() {
-        VM vm = new VM(ConfigHelper.CONFIG);
-        program = new Program(ConfigHelper.CONFIG, Hex.decode(
+        VM vm = new VM(config);
+        program = new Program(config, Hex.decode(
                 "FC01010A" + //header with 10 additional bytes
                         "0102030405060708090A" + // additional header bytes
                         "00" // STOP code
@@ -3059,11 +3060,11 @@ public class VMTest {
     public void testCodereplace_0() {
 
         // CODEREPLACE is invalid if scriptVersion is zero
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         String asm ="256 0x00FF CODEREPLACE";
         EVMAssembler assembler = new EVMAssembler();
         byte[] code = assembler.assemble(asm);
-        program = new Program(ConfigHelper.CONFIG, code, invoke);
+        program = new Program(config, code, invoke);
         vm.step(program);  // push
         vm.step(program);  // push
         vm.step(program);  // CODEREPLACE
@@ -3072,7 +3073,7 @@ public class VMTest {
     public void testCodereplace_1() {
 
         // CODEREPLACE is invalid if scriptVersion is zero
-        VM vm = new VM(ConfigHelper.CONFIG);
+        VM vm = new VM(config);
         String asm ="0xFC 0x00 0x01 0x00 "+ // opHEADER, exevesion scriptversion extheaderlenth
                 "0x00 "+ // address
                 "0x01 "+ // value
@@ -3084,7 +3085,7 @@ public class VMTest {
 
         EVMAssembler assembler = new EVMAssembler();
         byte[] code = assembler.assemble(asm);
-        program = new Program(ConfigHelper.CONFIG, code, invoke);
+        program = new Program(config, code, invoke);
 
         vm.step(program);  // push
         vm.step(program);  // push

--- a/rskj-core/src/test/java/org/ethereum/vm/VMUtilsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMUtilsTest.java
@@ -1,6 +1,6 @@
 package org.ethereum.vm;
 
-import co.rsk.config.ConfigHelper;
+import co.rsk.config.RskSystemProperties;
 import org.ethereum.vm.trace.ProgramTrace;
 import org.ethereum.vm.trace.Serializers;
 import org.junit.Assert;
@@ -18,13 +18,14 @@ import static org.hamcrest.core.Is.is;
 
 public class VMUtilsTest {
 
+    private final RskSystemProperties config = new RskSystemProperties();
     @Rule
     public TemporaryFolder tempRule = new TemporaryFolder();
 
     @Test
     public void savePlainProgramTraceFile() throws Exception {
         Path traceFilePath = tempRule.newFolder().toPath();
-        ProgramTrace mockTrace = new ProgramTrace(ConfigHelper.CONFIG);
+        ProgramTrace mockTrace = new ProgramTrace(config);
         String mockTxHash = "1234";
 
         VMUtils.saveProgramTraceFile(
@@ -41,7 +42,7 @@ public class VMUtilsTest {
     @Test
     public void saveZippedProgramTraceFile() throws Exception {
         Path traceFilePath = tempRule.newFolder().toPath();
-        ProgramTrace mockTrace = new ProgramTrace(ConfigHelper.CONFIG);
+        ProgramTrace mockTrace = new ProgramTrace(config);
         String mockTxHash = "1234";
 
         VMUtils.saveProgramTraceFile(


### PR DESCRIPTION
ConfigHelper has a static instance of configuration that is used for many tests. So as first step this PR intends to remove it's usage from all the tests that were using it's setter methods. 