### PR TITLE
All net interfaces now bind to a unique address

### DIFF
--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -196,7 +196,7 @@ public class Start {
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Service, rskSystemProperties.getRpcModules());
         JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler(rskSystemProperties.corsDomains());
         new JsonRpcNettyServer(
-            rskSystemProperties.getBindAddress(),
+            rskSystemProperties.rpcAddress(),
             rskSystemProperties.rpcPort(),
             rskSystemProperties.soLingerTime(),
             true,

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -38,8 +38,6 @@ import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -68,7 +66,7 @@ public class RskSystemProperties extends SystemProperties {
 
     @Nullable
     public RskAddress coinbaseAddress() {
-        if (!minerServerEnabled()) {
+        if (!isMinerServerEnabled()) {
             return RskAddress.nullAddress();
         }
 
@@ -88,7 +86,7 @@ public class RskSystemProperties extends SystemProperties {
 
     @Nullable
     public Account localCoinbaseAccount() {
-        if (!minerServerEnabled()) {
+        if (!isMinerServerEnabled()) {
             return null;
         }
 
@@ -110,12 +108,12 @@ public class RskSystemProperties extends SystemProperties {
         return new Account(ECKey.fromPrivate(HashUtil.sha3(coinbaseSecret.getBytes(StandardCharsets.UTF_8))));
     }
 
-    public boolean minerClientEnabled() {
+    public boolean isMinerClientEnabled() {
         return configFromFiles.hasPath("miner.client.enabled") ?
                 configFromFiles.getBoolean("miner.client.enabled") : false;
     }
 
-    public boolean minerServerEnabled() {
+    public boolean isMinerServerEnabled() {
         return configFromFiles.hasPath("miner.server.enabled") ?
                 configFromFiles.getBoolean("miner.server.enabled") : false;
     }
@@ -157,31 +155,6 @@ public class RskSystemProperties extends SystemProperties {
 
     public boolean waitForSync() {
         return configFromFiles.hasPath("sync.waitForSync") && configFromFiles.getBoolean("sync.waitForSync");
-    }
-
-    // TODO review added method
-    public boolean isRpcEnabled() {
-        return configFromFiles.hasPath("rpc.enabled") ?
-                configFromFiles.getBoolean("rpc.enabled") : false;
-    }
-
-    // TODO review added method
-    public int rpcPort() {
-        return configFromFiles.hasPath("rpc.port") ?
-                configFromFiles.getInt("rpc.port") : 4444;
-    }
-
-    public InetAddress rpcHost() {
-        if (!configFromFiles.hasPath("rpc.host")) {
-            return InetAddress.getLoopbackAddress();
-        }
-        String host = configFromFiles.getString("rpc.host");
-        try {
-            return InetAddress.getByName(host);
-        } catch (UnknownHostException e) {
-            logger.warn("Unable to bind to {}. Using loopback instead", e);
-            return InetAddress.getLoopbackAddress();
-        }
     }
 
     public boolean isWalletEnabled() {

--- a/rskj-core/src/main/java/org/ethereum/cli/CLIInterface.java
+++ b/rskj-core/src/main/java/org/ethereum/cli/CLIInterface.java
@@ -66,7 +66,7 @@ public class CLIInterface {
                 if (i + 1 < args.length && "-listen".equals(args[i])) {
                     String port = args[i + 1];
                     logger.info("Listen port set to [{}]", port);
-                    cliOptions.put(SystemProperties.PROPERTY_LISTEN_PORT, port);
+                    cliOptions.put(SystemProperties.PROPERTY_PEER_PORT, port);
                 }
 
                 // override the connect host:port directory

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -109,7 +109,7 @@ public class DefaultConfig {
     @Bean
     public HashRateCalculator hashRateCalculator(RskSystemProperties rskSystemProperties, BlockStore blockStore, MiningConfig miningConfig) {
         RskCustomCache<ByteArrayWrapper, BlockHeaderElement> cache = new RskCustomCache<>(60000L);
-        if (!rskSystemProperties.minerServerEnabled()) {
+        if (!rskSystemProperties.isMinerServerEnabled()) {
             return new HashRateCalculatorNonMining(blockStore, cache);
         }
 
@@ -225,6 +225,6 @@ public class DefaultConfig {
 
     @Bean
     public UDPServer udpServer(PeerExplorer peerExplorer, RskSystemProperties rskConfig) {
-        return new UDPServer(rskConfig.getPeerDiscoveryBindAddress(), rskConfig.listenPort(), peerExplorer);
+        return new UDPServer(rskConfig.getBindAddress().getHostAddress(), rskConfig.listenPort(), peerExplorer);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -208,7 +208,7 @@ public class DefaultConfig {
     @Bean
     public PeerExplorer peerExplorer(RskSystemProperties rskConfig) {
         ECKey key = rskConfig.getMyKey();
-        Node localNode = new Node(key.getNodeId(), rskConfig.getPublicIp(), rskConfig.peerPort());
+        Node localNode = new Node(key.getNodeId(), rskConfig.getPublicIp(), rskConfig.getPeerPort());
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, localNode);
         long msgTimeOut = rskConfig.peerDiscoveryMessageTimeOut();
         long refreshPeriod = rskConfig.peerDiscoveryRefreshPeriod();
@@ -225,6 +225,6 @@ public class DefaultConfig {
 
     @Bean
     public UDPServer udpServer(PeerExplorer peerExplorer, RskSystemProperties rskConfig) {
-        return new UDPServer(rskConfig.getBindAddress().getHostAddress(), rskConfig.peerPort(), peerExplorer);
+        return new UDPServer(rskConfig.getBindAddress().getHostAddress(), rskConfig.getPeerPort(), peerExplorer);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -208,7 +208,7 @@ public class DefaultConfig {
     @Bean
     public PeerExplorer peerExplorer(RskSystemProperties rskConfig) {
         ECKey key = rskConfig.getMyKey();
-        Node localNode = new Node(key.getNodeId(), rskConfig.getExternalIp(), rskConfig.listenPort());
+        Node localNode = new Node(key.getNodeId(), rskConfig.getPublicIp(), rskConfig.peerPort());
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, localNode);
         long msgTimeOut = rskConfig.peerDiscoveryMessageTimeOut();
         long refreshPeriod = rskConfig.peerDiscoveryRefreshPeriod();
@@ -225,6 +225,6 @@ public class DefaultConfig {
 
     @Bean
     public UDPServer udpServer(PeerExplorer peerExplorer, RskSystemProperties rskConfig) {
-        return new UDPServer(rskConfig.getBindAddress().getHostAddress(), rskConfig.listenPort(), peerExplorer);
+        return new UDPServer(rskConfig.getBindAddress().getHostAddress(), rskConfig.peerPort(), peerExplorer);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -558,7 +558,7 @@ public abstract class SystemProperties {
     }
 
     @ValidateMe
-    public int peerPort() {
+    public int getPeerPort() {
         return configFromFiles.getInt(PROPERTY_PEER_PORT);
     }
 

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -92,7 +92,7 @@ public class EthereumImpl implements Ethereum {
 
     @Override
     public void init() {
-        if (config.listenPort() > 0) {
+        if (config.peerPort() > 0) {
             peerServiceExecutor = Executors.newSingleThreadExecutor(runnable -> {
                 Thread thread = new Thread(runnable, "Peer Server");
                 thread.setUncaughtExceptionHandler((exceptionThread, exception) ->
@@ -100,11 +100,11 @@ public class EthereumImpl implements Ethereum {
                 );
                 return thread;
             });
-            peerServiceExecutor.execute(() -> peerServer.start(config.getBindAddress(), config.listenPort()));
+            peerServiceExecutor.execute(() -> peerServer.start(config.getBindAddress(), config.peerPort()));
         }
         compositeEthereumListener.addListener(gasPriceTracker);
 
-        gLogger.info("RskJ node started: enode://{}@{}:{}" , Hex.toHexString(config.nodeId()), config.getExternalIp(), config.listenPort());
+        gLogger.info("RskJ node started: enode://{}@{}:{}" , Hex.toHexString(config.nodeId()), config.getPublicIp(), config.peerPort());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -52,7 +52,6 @@ import java.util.concurrent.Future;
 
 public class EthereumImpl implements Ethereum {
 
-    private static final Logger logger = LoggerFactory.getLogger("facade");
     private static final Logger gLogger = LoggerFactory.getLogger("general");
 
     private final ChannelManager channelManager;
@@ -96,12 +95,12 @@ public class EthereumImpl implements Ethereum {
         if (config.listenPort() > 0) {
             peerServiceExecutor = Executors.newSingleThreadExecutor(runnable -> {
                 Thread thread = new Thread(runnable, "Peer Server");
-                thread.setUncaughtExceptionHandler((exceptionThread, exception) -> {
-                    gLogger.error("Unable to start peer server", exception);
-                });
+                thread.setUncaughtExceptionHandler((exceptionThread, exception) ->
+                    gLogger.error("Unable to start peer server", exception)
+                );
                 return thread;
             });
-            peerServiceExecutor.execute(() -> peerServer.start(config.listenPort()));
+            peerServiceExecutor.execute(() -> peerServer.start(config.getBindAddress(), config.listenPort()));
         }
         compositeEthereumListener.addListener(gasPriceTracker);
 

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -92,7 +92,7 @@ public class EthereumImpl implements Ethereum {
 
     @Override
     public void init() {
-        if (config.peerPort() > 0) {
+        if (config.getPeerPort() > 0) {
             peerServiceExecutor = Executors.newSingleThreadExecutor(runnable -> {
                 Thread thread = new Thread(runnable, "Peer Server");
                 thread.setUncaughtExceptionHandler((exceptionThread, exception) ->
@@ -100,11 +100,11 @@ public class EthereumImpl implements Ethereum {
                 );
                 return thread;
             });
-            peerServiceExecutor.execute(() -> peerServer.start(config.getBindAddress(), config.peerPort()));
+            peerServiceExecutor.execute(() -> peerServer.start(config.getBindAddress(), config.getPeerPort()));
         }
         compositeEthereumListener.addListener(gasPriceTracker);
 
-        gLogger.info("RskJ node started: enode://{}@{}:{}" , Hex.toHexString(config.nodeId()), config.getPublicIp(), config.peerPort());
+        gLogger.info("RskJ node started: enode://{}@{}:{}" , Hex.toHexString(config.nodeId()), config.getPublicIp(), config.getPeerPort());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/net/NodeManager.java
+++ b/rskj-core/src/main/java/org/ethereum/net/NodeManager.java
@@ -73,7 +73,7 @@ public class NodeManager {
     void init() {
         discoveryEnabled = config.isPeerDiscoveryEnabled();
 
-        homeNode = new Node(config.nodeId(), config.getPublicIp(), config.peerPort());
+        homeNode = new Node(config.nodeId(), config.getPublicIp(), config.getPeerPort());
 
         for (Node node : config.peerActive()) {
             NodeHandler handler = new NodeHandler(node, this);

--- a/rskj-core/src/main/java/org/ethereum/net/NodeManager.java
+++ b/rskj-core/src/main/java/org/ethereum/net/NodeManager.java
@@ -50,7 +50,7 @@ public class NodeManager {
 
 
     // to avoid checking for null
-    private static NodeStatistics DUMMY_STAT = new NodeStatistics(new Node(new byte[0], "dummy.node", 0));
+    private static final NodeStatistics DUMMY_STAT = new NodeStatistics(new Node(new byte[0], "dummy.node", 0));
 
     private final PeerExplorer peerExplorer;
     private final SystemProperties config;
@@ -71,7 +71,7 @@ public class NodeManager {
 
     @PostConstruct
     void init() {
-        discoveryEnabled = config.peerDiscovery();
+        discoveryEnabled = config.isPeerDiscoveryEnabled();
 
         homeNode = new Node(config.nodeId(), config.getExternalIp(), config.listenPort());
 

--- a/rskj-core/src/main/java/org/ethereum/net/NodeManager.java
+++ b/rskj-core/src/main/java/org/ethereum/net/NodeManager.java
@@ -73,7 +73,7 @@ public class NodeManager {
     void init() {
         discoveryEnabled = config.isPeerDiscoveryEnabled();
 
-        homeNode = new Node(config.nodeId(), config.getExternalIp(), config.listenPort());
+        homeNode = new Node(config.nodeId(), config.getPublicIp(), config.peerPort());
 
         for (Node node : config.peerActive()) {
             NodeHandler handler = new NodeHandler(node, this);

--- a/rskj-core/src/main/java/org/ethereum/net/message/StaticMessages.java
+++ b/rskj-core/src/main/java/org/ethereum/net/message/StaticMessages.java
@@ -55,7 +55,7 @@ public class StaticMessages {
     }
 
     public HelloMessage createHelloMessage(String peerId) {
-        return createHelloMessage(peerId, config.peerPort());
+        return createHelloMessage(peerId, config.getPeerPort());
     }
     public HelloMessage createHelloMessage(String peerId, int listenPort) {
 

--- a/rskj-core/src/main/java/org/ethereum/net/message/StaticMessages.java
+++ b/rskj-core/src/main/java/org/ethereum/net/message/StaticMessages.java
@@ -55,7 +55,7 @@ public class StaticMessages {
     }
 
     public HelloMessage createHelloMessage(String peerId) {
-        return createHelloMessage(peerId, config.listenPort());
+        return createHelloMessage(peerId, config.peerPort());
     }
     public HelloMessage createHelloMessage(String peerId, int listenPort) {
 

--- a/rskj-core/src/main/java/org/ethereum/net/p2p/HelloMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/p2p/HelloMessage.java
@@ -194,7 +194,7 @@ public class HelloMessage extends P2pMessage {
         return "[" + this.getCommand().name() + " p2pVersion="
                 + this.p2pVersion + " clientId=" + this.clientId
                 + " capabilities=[" + Joiner.on(" ").join(this.capabilities)
-                + "]" + " peerPort=" + this.listenPort + " peerId="
+                + "]" + " getPeerPort=" + this.listenPort + " peerId="
                 + this.peerId + "]";
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/Node.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/Node.java
@@ -22,18 +22,13 @@ package org.ethereum.net.rlpx;
 import co.rsk.net.NodeID;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
-import org.ethereum.util.RLPList;
 import org.ethereum.util.Utils;
 import org.spongycastle.util.encoders.Hex;
 
 import java.io.Serializable;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -62,8 +57,8 @@ public class Node implements Serializable {
 
     public Node(byte[] id, String host, int port) {
         this.id = id;
-        this.host = host;
         this.port = port;
+        this.host = host;
     }
 
     public Node(byte[] rlp) {
@@ -84,9 +79,9 @@ public class Node implements Serializable {
         String host = new String(hostB, Charset.forName("UTF-8"));
         int port = byteArrayToInt(portB);
 
-        this.host = host;
         this.port = port;
         this.id = idB;
+        this.host = host;
     }
 
 

--- a/rskj-core/src/main/java/org/ethereum/net/server/PeerServer.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/PeerServer.java
@@ -19,6 +19,8 @@
 
 package org.ethereum.net.server;
 
+import java.net.InetAddress;
+
 /**
  * This class establishes a listener for incoming connections.
  * See <a href="http://netty.io">http://netty.io</a>.
@@ -29,7 +31,7 @@ package org.ethereum.net.server;
 
 public interface PeerServer {
 
-    void start(int port);
+    void start(InetAddress host, int port);
 
     boolean isListening();
 }

--- a/rskj-core/src/main/java/org/ethereum/net/server/PeerServerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/PeerServerImpl.java
@@ -34,6 +34,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
+import java.net.InetAddress;
+
 /**
  * This class establishes a listener for incoming connections.
  * See <a href="http://netty.io">http://netty.io</a>.
@@ -55,7 +57,7 @@ public class PeerServerImpl implements PeerServer {
         this.ethereumChannelInitializerFactory = ethereumChannelInitializerFactory;
     }
 
-    public void start(int port) {
+    public void start(InetAddress host, int port) {
         // TODO review listening use
         listening = true;
 

--- a/rskj-core/src/main/resources/config/rsk-sample.conf
+++ b/rskj-core/src/main/resources/config/rsk-sample.conf
@@ -31,10 +31,6 @@ peer {
             "bootstrap15.rsk.co:5050",
             "bootstrap16.rsk.co:5050"
         ]
-
-        # Interface to bind UDP
-        # Make sure you are using the correct bind ip. Wildcard value: 0.0.0.0
-        # bind.ip = 0.0.0.0
     }
 
     # Boot node list
@@ -91,6 +87,10 @@ peer {
     # the incoming connection from the peer matching 'peer.trusted' entry is always accepted
     maxActivePeers = 30
 }
+
+# Interface to bind servers
+# Make sure you are using the correct bind ip. Wildcard value: 0.0.0.0
+bind.ip = 0.0.0.0
 
 # the folder resources/genesis contains several versions of genesis configuration according to the network the peer will run on
 genesis = rsk-mainnet.json

--- a/rskj-core/src/main/resources/config/rsk-sample.conf
+++ b/rskj-core/src/main/resources/config/rsk-sample.conf
@@ -56,9 +56,9 @@ peer {
         # }
     ]
 
-    # Peer for server to listen for incoming connections
+    # Port for server to listen for incoming connections
     # 5050 for mainnet
-    listen.port = 5050
+    port = 5050
 
     # connection timeout for trying to connect to a peer [seconds]
     connection.timeout = 2
@@ -92,10 +92,10 @@ peer {
 # Make sure you are using the correct bind ip. Wildcard value: 0.0.0.0
 bind.address = 0.0.0.0
 
-# external IP/hostname which is reported as our host during discovery
+# public IP/hostname which is reported as our host during discovery
 # if not set, the service http://checkip.amazonaws.com is used
 # the last resort is to get the bind.ip address
-# external.ip = google.com
+# public.ip = google.com
 
 # the folder resources/genesis contains several versions of genesis configuration according to the network the peer will run on
 genesis = rsk-mainnet.json

--- a/rskj-core/src/main/resources/config/rsk-sample.conf
+++ b/rskj-core/src/main/resources/config/rsk-sample.conf
@@ -88,9 +88,9 @@ peer {
     maxActivePeers = 30
 }
 
-# Interface to bind servers
+# Interface to bind peer discovery and wire protocol
 # Make sure you are using the correct bind ip. Wildcard value: 0.0.0.0
-bind.ip = 0.0.0.0
+bind.address = 0.0.0.0
 
 # external IP/hostname which is reported as our host during discovery
 # if not set, the service http://checkip.amazonaws.com is used
@@ -189,6 +189,9 @@ sync {
 
 rpc {
     enabled = true
+    # Interface to bind rpc
+    # Make sure you are using the correct bind. Default value: localhost
+    address = localhost
     port = 4444
 
     # A value greater than zero sets the socket value in milliseconds. Node attempts to gently close all TCP/IP connections with proper half close semantics,

--- a/rskj-core/src/main/resources/config/rsk-sample.conf
+++ b/rskj-core/src/main/resources/config/rsk-sample.conf
@@ -92,6 +92,11 @@ peer {
 # Make sure you are using the correct bind ip. Wildcard value: 0.0.0.0
 bind.ip = 0.0.0.0
 
+# external IP/hostname which is reported as our host during discovery
+# if not set, the service http://checkip.amazonaws.com is used
+# the last resort is to get the bind.ip address
+# external.ip = google.com
+
 # the folder resources/genesis contains several versions of genesis configuration according to the network the peer will run on
 genesis = rsk-mainnet.json
 

--- a/rskj-core/src/main/resources/config/rsk-sample.conf
+++ b/rskj-core/src/main/resources/config/rsk-sample.conf
@@ -93,8 +93,8 @@ peer {
 bind.address = 0.0.0.0
 
 # public IP/hostname which is reported as our host during discovery
-# if not set, the service http://checkip.amazonaws.com is used
-# the last resort is to get the bind.ip address
+# if not set, the service http://checkip.amazonaws.com is used.
+# bind.address is the last resort for public ip when it cannot be obtained by other ways
 # public.ip = google.com
 
 # the folder resources/genesis contains several versions of genesis configuration according to the network the peer will run on

--- a/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
@@ -32,8 +32,8 @@ public class RskSystemPropertiesTest {
 
     @Test
     public void defaultValues() {
-        Assert.assertEquals(false, config.minerClientEnabled());
-        Assert.assertEquals(false, config.minerServerEnabled());
+        Assert.assertEquals(false, config.isMinerClientEnabled());
+        Assert.assertEquals(false, config.isMinerServerEnabled());
         Assert.assertEquals(0, config.minerMinGasPrice());
         Assert.assertEquals(0, config.minerGasUnitInDollars(), 0.001);
         Assert.assertEquals(0, config.minerMinFeesNotifyInDollars(), 0.001);

--- a/rskj-core/src/test/java/co/rsk/net/discovery/UDPServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/UDPServerTest.java
@@ -45,7 +45,7 @@ public class UDPServerTest {
     private static final String KEY_3 = "bd3d20e480dfb1c9c07ba0bc8cf9052f89923d38b5128c5dbfc18d4eea38263f";
     private static final String NODE_ID_3 = "e229918d45c131e130c91c4ea51c97ab4f66cfbd0437b35c92392b5c2b3d44b28ea15b84a262459437c955f6cc7f10ad1290132d3fc866bfaf4115eac0e8e860";
 
-    private static final String HOST = "localhost";
+    private String HOST = "localhost";
     private static final int PORT_1 = 40305;
     private static final int PORT_2 = 40306;
     private static final int PORT_3 = 40307;
@@ -55,7 +55,6 @@ public class UDPServerTest {
 
     @Test
     public void run3NodesFullTest() throws InterruptedException {
-
         ECKey key1 = ECKey.fromPrivate(Hex.decode(KEY_1)).decompress();
         ECKey key2 = ECKey.fromPrivate(Hex.decode(KEY_2)).decompress();
         ECKey key3 = ECKey.fromPrivate(Hex.decode(KEY_3)).decompress();

--- a/rskj-core/src/test/java/org/ethereum/cli/ClIInterfaceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/cli/ClIInterfaceTest.java
@@ -47,7 +47,7 @@ public class ClIInterfaceTest {
         Map<String, String> result = CLIInterface.call(config, inputParams);
 
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_DB_DIR), "java");
-        Assert.assertEquals(result.get(SystemProperties.PROPERTY_LISTEN_PORT), "3332");
+        Assert.assertEquals(result.get(SystemProperties.PROPERTY_PEER_PORT), "3332");
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_DB_RESET), "true");
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_RPC_PORT), "4444");
         Assert.assertEquals(result.get(SystemProperties.PROPERTY_RPC_ENABLED), "true");

--- a/rskj-core/src/test/java/org/ethereum/config/ConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/ConfigTest.java
@@ -37,7 +37,7 @@ public class ConfigTest {
         Config config = ConfigFactory.parseResources("test-rskj.conf");
         System.out.println(config.root().render(ConfigRenderOptions.defaults().setComments(false)));
 
-        System.out.println("peer.listen.port: " + config.getInt("peer.listen.port"));
+        System.out.println("peer.port: " + config.getInt("peer.port"));
         System.out.println("peer.discovery.ip.list: " + config.getAnyRefList("peer.discovery.ip.list"));
         System.out.println("peer.discovery.ip.list: " + config.getAnyRefList("peer.active"));
 

--- a/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
@@ -23,6 +23,8 @@ import co.rsk.config.RskSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.net.InetAddress;
+
 /**
  * Created by Anton Nashatyrev on 26.08.2015.
  */
@@ -32,11 +34,11 @@ public class SystemPropertiesTest {
         RskSystemProperties config = new RskSystemProperties();
         config.overrideParams("peer.bind.ip", "");
         long st = System.currentTimeMillis();
-        String ip = config.getPeerDiscoveryBindAddress();
+        InetAddress ip = config.getBindAddress();
         long t = System.currentTimeMillis() - st;
         System.out.println(ip + " in " + t + " msec");
         Assert.assertTrue(t < 10 * 1000);
-        Assert.assertFalse(ip.isEmpty());
+        Assert.assertFalse(ip.toString().isEmpty());
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
@@ -32,7 +32,7 @@ public class SystemPropertiesTest {
     @Test
     public void punchBindIpTest() {
         RskSystemProperties config = new RskSystemProperties();
-        config.overrideParams("peer.bind.ip", "");
+        config.overrideParams("bind.address", "");
         long st = System.currentTimeMillis();
         InetAddress ip = config.getBindAddress();
         long t = System.currentTimeMillis() - st;
@@ -44,9 +44,9 @@ public class SystemPropertiesTest {
     @Test
     public void externalIpTest() {
         RskSystemProperties config = new RskSystemProperties();
-        config.overrideParams("peer.discovery.external.ip", "");
+        config.overrideParams("public.ip", "");
         long st = System.currentTimeMillis();
-        String ip = config.getExternalIp();
+        String ip = config.getPublicIp();
         long t = System.currentTimeMillis() - st;
         System.out.println(ip + " in " + t + " msec");
         Assert.assertTrue(t < 10 * 1000);

--- a/rskj-core/src/test/java/org/ethereum/net/NodeManagerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/NodeManagerTest.java
@@ -54,7 +54,7 @@ public class NodeManagerTest {
 
         Mockito.when(config.nodeId()).thenReturn(Hex.decode(NODE_ID_1));
         Mockito.when(config.getPublicIp()).thenReturn("127.0.0.1");
-        Mockito.when(config.peerPort()).thenReturn(8080);
+        Mockito.when(config.getPeerPort()).thenReturn(8080);
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/net/NodeManagerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/NodeManagerTest.java
@@ -67,7 +67,7 @@ public class NodeManagerTest {
 
         Mockito.when(config.peerActive()).thenReturn(activePeers);
         Mockito.when(peerExplorer.getNodes()).thenReturn(bootNodes);
-        Mockito.when(config.peerDiscovery()).thenReturn(false);
+        Mockito.when(config.isPeerDiscoveryEnabled()).thenReturn(false);
 
         nodeManager.init();
 
@@ -92,7 +92,7 @@ public class NodeManagerTest {
 
         Mockito.when(config.peerActive()).thenReturn(activePeers);
         Mockito.when(peerExplorer.getNodes()).thenReturn(bootNodes);
-        Mockito.when(config.peerDiscovery()).thenReturn(true);
+        Mockito.when(config.isPeerDiscoveryEnabled()).thenReturn(true);
 
         nodeManager.init();
 
@@ -114,7 +114,7 @@ public class NodeManagerTest {
 
         Mockito.when(config.peerActive()).thenReturn(activePeers);
         Mockito.when(peerExplorer.getNodes()).thenReturn(bootNodes);
-        Mockito.when(config.peerDiscovery()).thenReturn(true);
+        Mockito.when(config.isPeerDiscoveryEnabled()).thenReturn(true);
 
         nodeManager.init();
 

--- a/rskj-core/src/test/java/org/ethereum/net/NodeManagerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/NodeManagerTest.java
@@ -53,8 +53,8 @@ public class NodeManagerTest {
         nodeManager = new NodeManager(peerExplorer, config);
 
         Mockito.when(config.nodeId()).thenReturn(Hex.decode(NODE_ID_1));
-        Mockito.when(config.getExternalIp()).thenReturn("127.0.0.1");
-        Mockito.when(config.listenPort()).thenReturn(8080);
+        Mockito.when(config.getPublicIp()).thenReturn("127.0.0.1");
+        Mockito.when(config.peerPort()).thenReturn(8080);
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimplePeerServer.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimplePeerServer.java
@@ -20,6 +20,8 @@ package org.ethereum.rpc.Simples;
 
 import org.ethereum.net.server.PeerServer;
 
+import java.net.InetAddress;
+
 /**
  * Created by Ruben on 15/06/2016.
  */
@@ -27,7 +29,7 @@ public class SimplePeerServer implements PeerServer {
 
     public boolean isListening = false;
 
-    public void start(int port) {
+    public void start(InetAddress host, int port) {
 
     }
 

--- a/rskj-core/src/test/resources/test-rskj.conf
+++ b/rskj-core/src/test/resources/test-rskj.conf
@@ -49,7 +49,7 @@ peer.capabilities = [eth, shh]
 
 # Peer for server to listen for incoming
 # connections
-peer.listen.port = 10101
+peer.port = 10101
 
 # connection timeout for trying to
 # connect to a peer [seconds]


### PR DESCRIPTION
The goal is that all services integrated on the node now are binded to a unique interface defined at config on bind.ip property. The properties peer.bind.ip and rpc.host now dissapear. Peer discovery, rpc server and wire protocol now all use the same binding. 