### PR TITLE
Fix JsonRpcNettyServer pipeline order to fix issue with Expect header

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/JsonRpcNettyServer.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/JsonRpcNettyServer.java
@@ -59,8 +59,8 @@ public class JsonRpcNettyServer {
                 protected void initChannel(SocketChannel ch) throws Exception {
                     ChannelPipeline p = ch.pipeline();
                     p.addLast(new HttpRequestDecoder());
-                    p.addLast(new HttpObjectAggregator(1024 * 1024 * 5));
                     p.addLast(new HttpResponseEncoder());
+                    p.addLast(new HttpObjectAggregator(1024 * 1024 * 5));
                     p.addLast(new HttpContentCompressor());
                     if (corsConfiguration.hasHeader()) {
                         p.addLast(new CorsHandler(


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/19834.

Example of a failing `cURL` request:

```bash
$ curl -X POST \
    -H "Content-Type: application/json" \
    -d '{"id":1,"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826","gas":"0x47e76c","gasPrice":"0x4a817c800","data":"0x6060604052341561000f57600080fd5b6040805190810160405280601281526020017f48656c6c6f20736d61727420776f726c642100000000000000000000000000008152506000908051906020019061005a929190610060565b50610105565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f106100a157805160ff19168380011785556100cf565b828001600101855582156100cf579182015b828111156100ce5782518255916020019190600101906100b3565b5b5090506100dc91906100e0565b5090565b61010291905b808211156100fe5760008160009055506001016100e6565b5090565b90565b610303806101146000396000f30060606040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063a413686214610051578063fe50cc72146100c6575b600080fd5b341561005c57600080fd5b6100ac600480803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050610154565b604051808215151515815260200191505060405180910390f35b34156100d157600080fd5b6100d9610176565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156101195780820151818401526020810190506100fe565b50505050905090810190601f1680156101465780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6000816000908051906020019061016c92919061021e565b5060019050919050565b61017e61029e565b60008054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156102145780601f106101e957610100808354040283529160200191610214565b820191906000526020600020905b8154815290600101906020018083116101f757829003601f168201915b5050505050905090565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061025f57805160ff191683800117855561028d565b8280016001018555821561028d579182015b8281111561028c578251825591602001919060010190610271565b5b50905061029a91906102b2565b5090565b602060405190810160405280600081525090565b6102d491905b808211156102d05760008160009055506001016102b8565b5090565b905600a165627a7a72305820d53d336cf2312fefa6d99cdc442b8afbb1b66381d20644b156b273232a1e87180029"}]}' \
    http://localhost:4444
```