### PR TITLE
Dns rebinding fix

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -159,7 +159,7 @@ public class RskFactory {
 
     @Bean
     public JsonRpcWeb3FilterHandler getJsonRpcWeb3FilterHandler(RskSystemProperties rskSystemProperties) {
-        return new JsonRpcWeb3FilterHandler(rskSystemProperties.corsDomains());
+        return new JsonRpcWeb3FilterHandler(rskSystemProperties.corsDomains(), rskSystemProperties.rpcAddress(), rskSystemProperties.rpcHost());
     }
 
     @Bean

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3FilterHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3FilterHandler.java
@@ -13,6 +13,9 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by ajlopez on 18/10/2017.
@@ -20,28 +23,48 @@ import java.net.SocketException;
 
 @ChannelHandler.Sharable
 public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
-    private static final Logger LOGGER = LoggerFactory.getLogger("jsonrpc");
-    private final InetAddress rpcHost;
+    private static final Logger logger = LoggerFactory.getLogger("jsonrpc");
+    private final List<String> rpcHost;
+    private final InetAddress rpcAddress;
 
     private OriginValidator originValidator;
 
-    public JsonRpcWeb3FilterHandler(String corsDomains, InetAddress rpcHost) {
+    public JsonRpcWeb3FilterHandler(String corsDomains, InetAddress rpcAddress, List<String> rpcHost) {
         this.originValidator = new OriginValidator(corsDomains);
         this.rpcHost = rpcHost;
+        this.rpcAddress = rpcAddress;
     }
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
-        HttpMethod httpMethod = request.getMethod();
         HttpResponse response;
-
+        HttpMethod httpMethod = request.getMethod();
         HttpHeaders headers = request.headers();
+        String hostHeader = headers.get(HttpHeaders.Names.HOST).split(":")[0];
+        List<String> hosts = new ArrayList<>();
 
-        String host = headers.get(HttpHeaders.Names.HOST);
-        if (!isLocalIpAddress(InetAddress.getByName(host)) &&
-                !host.equals(rpcHost.getHostName())) {
-            LOGGER.error("Invalid host");
-            response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN);
+        if (isAcceptedAddress(rpcAddress)) {
+            hosts.add(rpcAddress.getHostName());
+            hosts.add(rpcAddress.getHostAddress());
+        } else {
+            for (String host : rpcHost) {
+                try {
+                    InetAddress hostAddress = InetAddress.getByName(host);
+                    if (!hostAddress.isAnyLocalAddress()) {
+                        hosts.add(hostAddress.getHostAddress());
+                        hosts.add(hostAddress.getHostName());
+                    } else {
+                        logger.warn("Wildcard address is not allowed on rpc host property {}", hostAddress);
+                    }
+                } catch (UnknownHostException e) {
+                    logger.info("Invalid Host defined on rpc.host", e);
+                }
+            }
+        }
+
+        if (!hosts.contains(hostHeader)) {
+            logger.error("Invalid hostHeader");
+            response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST);
             ctx.write(response).addListener(ChannelFutureListener.CLOSE);
             return;
         }
@@ -52,15 +75,15 @@ public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHt
             String origin = headers.get(HttpHeaders.Names.ORIGIN);
             String referer = headers.get(HttpHeaders.Names.REFERER);
 
+                logger.error("Unsupported content type");
             if (!"application/json".equals(mimeType) && !"application/json-rpc".equals(mimeType)) {
-                LOGGER.error("Unsupported content type");
                 response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE);
             } else if (origin != null && !this.originValidator.isValidOrigin(origin)) {
-                LOGGER.error("Invalid origin");
-                response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN);
+                logger.error("Invalid origin");
+                response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST);
             } else if (referer != null && !this.originValidator.isValidReferer(referer)) {
-                LOGGER.error("Invalid referer");
-                response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN);
+                logger.error("Invalid referer");
+                response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST);
             }
             else {
                 ctx.fireChannelRead(request);
@@ -73,14 +96,14 @@ public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHt
         ctx.write(response).addListener(ChannelFutureListener.CLOSE);
     }
 
-    private boolean isLocalIpAddress(final InetAddress address) {
+    private boolean isAcceptedAddress(final InetAddress address) {
         // Check if the address is a valid special local or loop back
-        if (address.isAnyLocalAddress() || address.isLoopbackAddress()) {
+        if (address.isLoopbackAddress() ) {
             return true;
         }
         // Check if the address is defined on any interface
         try {
-            return NetworkInterface.getByInetAddress(address) != null;
+            return !address.isAnyLocalAddress() && NetworkInterface.getByInetAddress(address) != null;
         } catch (SocketException se) {
             return false;
         }

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3FilterHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3FilterHandler.java
@@ -10,6 +10,9 @@ import org.ethereum.rpc.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 
 /**
  * Created by ajlopez on 18/10/2017.
@@ -18,11 +21,13 @@ import org.slf4j.LoggerFactory;
 @ChannelHandler.Sharable
 public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
     private static final Logger LOGGER = LoggerFactory.getLogger("jsonrpc");
+    private final InetAddress rpcHost;
 
     private OriginValidator originValidator;
 
-    public JsonRpcWeb3FilterHandler(String corsOrigins) {
-        this.originValidator = new OriginValidator(corsOrigins);
+    public JsonRpcWeb3FilterHandler(String corsDomains, InetAddress rpcHost) {
+        this.originValidator = new OriginValidator(corsDomains);
+        this.rpcHost = rpcHost;
     }
 
     @Override
@@ -30,8 +35,18 @@ public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHt
         HttpMethod httpMethod = request.getMethod();
         HttpResponse response;
 
+        HttpHeaders headers = request.headers();
+
+        String host = headers.get(HttpHeaders.Names.HOST);
+        if (!isLocalIpAddress(InetAddress.getByName(host)) &&
+                !host.equals(rpcHost.getHostName())) {
+            LOGGER.error("Invalid host");
+            response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN);
+            ctx.write(response).addListener(ChannelFutureListener.CLOSE);
+            return;
+        }
+
         if (HttpMethod.POST.equals(httpMethod)) {
-            HttpHeaders headers = request.headers();
 
             String mimeType = HttpUtils.getMimeType(headers.get(HttpHeaders.Names.CONTENT_TYPE));
             String origin = headers.get(HttpHeaders.Names.ORIGIN);
@@ -57,4 +72,18 @@ public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHt
 
         ctx.write(response).addListener(ChannelFutureListener.CLOSE);
     }
+
+    private boolean isLocalIpAddress(final InetAddress address) {
+        // Check if the address is a valid special local or loop back
+        if (address.isAnyLocalAddress() || address.isLoopbackAddress()) {
+            return true;
+        }
+        // Check if the address is defined on any interface
+        try {
+            return NetworkInterface.getByInetAddress(address) != null;
+        } catch (SocketException se) {
+            return false;
+        }
+    }
+
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpServer.java
@@ -19,7 +19,7 @@ import java.net.InetAddress;
 
 public class Web3HttpServer {
 
-    private final InetAddress host;
+    private final InetAddress bindAddress;
     private int port;
     private final EventLoopGroup bossGroup;
     private final EventLoopGroup workerGroup;
@@ -37,6 +37,7 @@ public class Web3HttpServer {
                           JsonRpcWeb3FilterHandler jsonRpcWeb3FilterHandler,
                           JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler) {
         this.host = host;
+        this.bindAddress = bindAddress;
         this.port = port;
         this.socketLinger = socketLinger;
         this.reuseAddress = reuseAddress;
@@ -75,7 +76,7 @@ public class Web3HttpServer {
                     p.addLast(jsonRpcWeb3ServerHandler);
                 }
             });
-        b.bind(host, port).sync();
+        b.bind(bindAddress, port).sync();
     }
 
     public void stop() {

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpServer.java
@@ -29,14 +29,13 @@ public class Web3HttpServer {
     private final JsonRpcWeb3FilterHandler jsonRpcWeb3FilterHandler;
     private final JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler;
 
-    public Web3HttpServer(InetAddress host,
+    public Web3HttpServer(InetAddress bindAddress,
                           int port,
                           int socketLinger,
                           boolean reuseAddress,
                           CorsConfiguration corsConfiguration,
                           JsonRpcWeb3FilterHandler jsonRpcWeb3FilterHandler,
                           JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler) {
-        this.host = host;
         this.bindAddress = bindAddress;
         this.port = port;
         this.socketLinger = socketLinger;

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -78,6 +78,7 @@ public abstract class SystemProperties {
     // TODO review rpc properties
     public static final String PROPERTY_RPC_ENABLED = "rpc.enabled";
     public static final String PROPERTY_RPC_PORT = "rpc.port";
+    public static final String PROPERTY_RPC_HOST = "rpc.host";
     public static final String PROPERTY_RPC_CORS = "rpc.cors";
     public static final String PROPERTY_RPC_ADDRESS = "rpc.address";
     public static final String PROPERTY_PUBLIC_IP = "public.ip";
@@ -751,6 +752,11 @@ public abstract class SystemProperties {
     public int rpcPort() {
         return configFromFiles.hasPath(PROPERTY_RPC_PORT) ?
                 configFromFiles.getInt(PROPERTY_RPC_PORT) : DEFAULT_RPC_PORT;
+    }
+
+    public List<String> rpcHost() {
+        return !configFromFiles.hasPath(PROPERTY_RPC_HOST) ? new ArrayList<>() :
+                configFromFiles.getStringList(PROPERTY_RPC_HOST);
     }
 
     public InetAddress rpcAddress() {

--- a/rskj-core/src/main/resources/config/rsk-sample.conf
+++ b/rskj-core/src/main/resources/config/rsk-sample.conf
@@ -193,6 +193,7 @@ rpc {
     # Make sure you are using the correct bind. Default value: localhost
     address = localhost
     port = 4444
+    # host = [example.com, www.example.com]
 
     # A value greater than zero sets the socket value in milliseconds. Node attempts to gently close all TCP/IP connections with proper half close semantics,
     # so a linger timeout should not be required and thus the default is -1.

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.ethereum.vm.program.Program;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.ethereum.rpc.Web3;
@@ -21,10 +20,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -82,21 +78,21 @@ public class Web3HttpServerTest {
 
     @Test
     public void smokeTestUsingValidHostAndHostName() throws Exception {
-        smokeTest(APPLICATION_JSON, "www.google.com", InetAddress.getByName("www.google.com"));
+        smokeTest(APPLICATION_JSON, "www.google.com", InetAddress.getByName("www.google.com"), new ArrayList<>());
     }
 
     @Test(expected = IOException.class)
     public void smokeTestUsingInvalidHostAndHostName() throws Exception {
         InetAddress google = InetAddress.getByName("www.google.com");
-        smokeTest(APPLICATION_JSON, google.getHostAddress(), google);
+        smokeTest(APPLICATION_JSON, google.getHostAddress(), google, new ArrayList<>());
     }
 
 
     private void smokeTest(String contentType, String host) throws Exception {
-        smokeTest(contentType, host, InetAddress.getLocalHost());
+        smokeTest(contentType, host, InetAddress.getLocalHost(), new ArrayList<>());
     }
 
-    private void smokeTest(String contentType, String host, InetAddress rpcHost) throws Exception {
+    private void smokeTest(String contentType, String host, InetAddress rpcAddress, List<String> rpcHost) throws Exception {
         Web3 web3Mock = Mockito.mock(Web3.class);
         String mockResult = "output";
         Mockito.when(web3Mock.web3_sha3(Mockito.anyString())).thenReturn(mockResult);
@@ -107,7 +103,7 @@ public class Web3HttpServerTest {
         int randomPort = 9999;//new ServerSocket(0).getLocalPort();
 
         List<ModuleDescription> filteredModules = Collections.singletonList(new ModuleDescription("web3", "1.0", true, Collections.emptyList(), Collections.emptyList()));
-        JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler("*", rpcHost);
+        JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler("*", rpcAddress, rpcHost);
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Mock, filteredModules);
         Web3HttpServer server = new Web3HttpServer(InetAddress.getLoopbackAddress(), randomPort, 0, Boolean.TRUE, mockCorsConfiguration, filterHandler, serverHandler);
         server.start();

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
@@ -78,7 +78,10 @@ public class Web3HttpServerTest {
 
     @Test
     public void smokeTestUsingValidHostAndHostName() throws Exception {
-        smokeTest(APPLICATION_JSON, "www.google.com", InetAddress.getByName("www.google.com"), new ArrayList<>());
+        String domain = "www.google.com";
+        List<String> rpcHost = new ArrayList<>();
+        rpcHost.add(domain);
+        smokeTest(APPLICATION_JSON, domain, InetAddress.getByName(domain), rpcHost);
     }
 
     @Test(expected = IOException.class)
@@ -89,7 +92,7 @@ public class Web3HttpServerTest {
 
 
     private void smokeTest(String contentType, String host) throws Exception {
-        smokeTest(contentType, host, InetAddress.getLocalHost(), new ArrayList<>());
+        smokeTest(contentType, host, InetAddress.getLoopbackAddress(), new ArrayList<>());
     }
 
     private void smokeTest(String contentType, String host, InetAddress rpcAddress, List<String> rpcHost) throws Exception {

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertThat;
 
 public class Web3HttpServerTest {
 
+    public static final String APPLICATION_JSON = "application/json";
     private static JsonNodeFactory JSON_NODE_FACTORY = JsonNodeFactory.instance;
     private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -46,7 +47,7 @@ public class Web3HttpServerTest {
 
     @Test
     public void smokeTestUsingJsonContentType() throws Exception {
-        smokeTest("application/json");
+        smokeTest(APPLICATION_JSON);
     }
 
     @Test
@@ -71,15 +72,31 @@ public class Web3HttpServerTest {
 
     @Test
     public void smokeTestUsingValidHost() throws Exception {
-        smokeTest("application/json", "localhost");
+        smokeTest(APPLICATION_JSON, "localhost");
     }
 
     @Test(expected = IOException.class)
     public void smokeTestUsingInvalidHost() throws Exception {
-        smokeTest("application/json", "evil.com");
+        smokeTest(APPLICATION_JSON, "evil.com");
     }
 
+    @Test
+    public void smokeTestUsingValidHostAndHostName() throws Exception {
+        smokeTest(APPLICATION_JSON, "www.google.com", InetAddress.getByName("www.google.com"));
+    }
+
+    @Test(expected = IOException.class)
+    public void smokeTestUsingInvalidHostAndHostName() throws Exception {
+        InetAddress google = InetAddress.getByName("www.google.com");
+        smokeTest(APPLICATION_JSON, google.getHostAddress(), google);
+    }
+
+
     private void smokeTest(String contentType, String host) throws Exception {
+        smokeTest(contentType, host, InetAddress.getLocalHost());
+    }
+
+    private void smokeTest(String contentType, String host, InetAddress rpcHost) throws Exception {
         Web3 web3Mock = Mockito.mock(Web3.class);
         String mockResult = "output";
         Mockito.when(web3Mock.web3_sha3(Mockito.anyString())).thenReturn(mockResult);
@@ -90,17 +107,23 @@ public class Web3HttpServerTest {
         int randomPort = 9999;//new ServerSocket(0).getLocalPort();
 
         List<ModuleDescription> filteredModules = Collections.singletonList(new ModuleDescription("web3", "1.0", true, Collections.emptyList(), Collections.emptyList()));
-        JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler("*");
+        JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler("*", rpcHost);
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Mock, filteredModules);
         Web3HttpServer server = new Web3HttpServer(InetAddress.getLoopbackAddress(), randomPort, 0, Boolean.TRUE, mockCorsConfiguration, filterHandler, serverHandler);
         server.start();
+        HttpURLConnection conn = null;
+        try {
+            conn = sendJsonRpcMessage(randomPort, contentType, host);
+            JsonNode jsonRpcResponse = OBJECT_MAPPER.readTree(conn.getInputStream());
 
-        HttpURLConnection conn = sendJsonRpcMessage(randomPort, contentType, host);
-        JsonNode jsonRpcResponse = OBJECT_MAPPER.readTree(conn.getInputStream());
-
-        assertThat(conn.getResponseCode(), is(HttpResponseStatus.OK.code()));
-        assertThat(jsonRpcResponse.at("/result").asText(), is(mockResult));
-        server.stop();
+            assertThat(conn.getResponseCode(), is(HttpResponseStatus.OK.code()));
+            assertThat(jsonRpcResponse.at("/result").asText(), is(mockResult));
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+            server.stop();
+        }
     }
 
     private void smokeTest(String contentType) throws Exception {

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
@@ -9,6 +9,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.ethereum.vm.program.Program;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.ethereum.rpc.Web3;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -30,6 +33,16 @@ public class Web3HttpServerTest {
 
     private static JsonNodeFactory JSON_NODE_FACTORY = JsonNodeFactory.instance;
     private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @BeforeClass
+    public static void init() {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "false");
+    }
 
     @Test
     public void smokeTestUsingJsonContentType() throws Exception {
@@ -56,7 +69,17 @@ public class Web3HttpServerTest {
         smokeTest("text/plain");
     }
 
-    public void smokeTest(String contentType) throws Exception {
+    @Test
+    public void smokeTestUsingValidHost() throws Exception {
+        smokeTest("application/json", "localhost");
+    }
+
+    @Test(expected = IOException.class)
+    public void smokeTestUsingInvalidHost() throws Exception {
+        smokeTest("application/json", "evil.com");
+    }
+
+    private void smokeTest(String contentType, String host) throws Exception {
         Web3 web3Mock = Mockito.mock(Web3.class);
         String mockResult = "output";
         Mockito.when(web3Mock.web3_sha3(Mockito.anyString())).thenReturn(mockResult);
@@ -72,7 +95,7 @@ public class Web3HttpServerTest {
         Web3HttpServer server = new Web3HttpServer(InetAddress.getLoopbackAddress(), randomPort, 0, Boolean.TRUE, mockCorsConfiguration, filterHandler, serverHandler);
         server.start();
 
-        HttpURLConnection conn = sendJsonRpcMessage(randomPort, contentType);
+        HttpURLConnection conn = sendJsonRpcMessage(randomPort, contentType, host);
         JsonNode jsonRpcResponse = OBJECT_MAPPER.readTree(conn.getInputStream());
 
         assertThat(conn.getResponseCode(), is(HttpResponseStatus.OK.code()));
@@ -80,7 +103,11 @@ public class Web3HttpServerTest {
         server.stop();
     }
 
-    private HttpURLConnection sendJsonRpcMessage(int port, String contentType) throws IOException {
+    private void smokeTest(String contentType) throws Exception {
+        smokeTest(contentType, "127.0.0.1");
+    }
+
+    private HttpURLConnection sendJsonRpcMessage(int port, String contentType, String host) throws IOException {
         Map<String, JsonNode> jsonRpcRequestProperties = new HashMap<>();
         jsonRpcRequestProperties.put("jsonrpc", JSON_NODE_FACTORY.textNode("2.0"));
         jsonRpcRequestProperties.put("id", JSON_NODE_FACTORY.numberNode(13));
@@ -95,6 +122,7 @@ public class Web3HttpServerTest {
         jsonRpcConnection.setRequestMethod("POST");
         jsonRpcConnection.setRequestProperty("Content-Type", contentType);
         jsonRpcConnection.setRequestProperty("Content-Length", String.valueOf(request.length));
+        jsonRpcConnection.setRequestProperty("Host", host);
         OutputStream os = jsonRpcConnection.getOutputStream();
         os.write(request);
         return jsonRpcConnection;


### PR DESCRIPTION
Header host is validated now. It checks that is accepted from rpc.address and if rpc.address is using a wildcard it uses a new param defined called rpc.host for the task.