### PR TITLE
Web3 HTTP Server creation changes

### DIFF
--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -40,7 +40,7 @@ import org.ethereum.core.*;
 import org.ethereum.core.genesis.BlockChainLoader;
 import org.ethereum.net.eth.EthVersion;
 import org.ethereum.net.server.ChannelManager;
-import org.ethereum.rpc.JsonRpcNettyServer;
+import org.ethereum.rpc.Web3HttpServer;
 import org.ethereum.rpc.JsonRpcWeb3FilterHandler;
 import org.ethereum.rpc.JsonRpcWeb3ServerHandler;
 import org.ethereum.rpc.Web3;
@@ -195,7 +195,7 @@ public class Start {
         web3Service.start();
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Service, rskSystemProperties.getRpcModules());
         JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler(rskSystemProperties.corsDomains());
-        new JsonRpcNettyServer(
+        new Web3HttpServer(
             rskSystemProperties.rpcAddress(),
             rskSystemProperties.rpcPort(),
             rskSystemProperties.soLingerTime(),

--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -33,7 +33,6 @@ import co.rsk.net.MessageHandler;
 import co.rsk.net.Metrics;
 import co.rsk.net.discovery.UDPServer;
 import co.rsk.net.handler.TxHandler;
-import co.rsk.rpc.CorsConfiguration;
 import org.ethereum.cli.CLIInterface;
 import org.ethereum.config.DefaultConfig;
 import org.ethereum.core.*;
@@ -41,8 +40,6 @@ import org.ethereum.core.genesis.BlockChainLoader;
 import org.ethereum.net.eth.EthVersion;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Web3HttpServer;
-import org.ethereum.rpc.JsonRpcWeb3FilterHandler;
-import org.ethereum.rpc.JsonRpcWeb3ServerHandler;
 import org.ethereum.rpc.Web3;
 import org.ethereum.sync.SyncPool;
 import org.ethereum.util.BuildInfo;
@@ -65,7 +62,7 @@ public class Start {
     private final MinerServer minerServer;
     private final MinerClient minerClient;
     private final RskSystemProperties rskSystemProperties;
-    private final Web3Factory web3Factory;
+    private final Web3HttpServer web3HttpServer;
     private final BlockChainLoader loader;
     private final Repository repository;
     private final Blockchain blockchain;
@@ -74,7 +71,7 @@ public class Start {
     private final MessageHandler messageHandler;
     private final TxHandler txHandler;
 
-    private Web3 web3Service;
+    private final Web3 web3Service;
     private final BlockProcessor nodeBlockProcessor;
     private final PendingState pendingState;
     private final SyncPool.PeerClientFactory peerClientFactory;
@@ -92,7 +89,8 @@ public class Start {
                  MinerServer minerServer,
                  MinerClient minerClient,
                  RskSystemProperties rskSystemProperties,
-                 Web3Factory web3Factory,
+                 Web3 web3Service,
+                 Web3HttpServer web3HttpServer,
                  BlockChainLoader loader,
                  Repository repository,
                  Blockchain blockchain,
@@ -108,7 +106,8 @@ public class Start {
         this.minerServer = minerServer;
         this.minerClient = minerClient;
         this.rskSystemProperties = rskSystemProperties;
-        this.web3Factory = web3Factory;
+        this.web3HttpServer = web3HttpServer;
+        this.web3Service = web3Service;
         this.loader = loader;
         this.repository = repository;
         this.blockchain = blockchain;
@@ -191,19 +190,8 @@ public class Start {
     }
 
     private void startRPCServer() throws InterruptedException {
-        web3Service = web3Factory.newInstance();
         web3Service.start();
-        JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Service, rskSystemProperties.getRpcModules());
-        JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler(rskSystemProperties.corsDomains());
-        new Web3HttpServer(
-            rskSystemProperties.rpcAddress(),
-            rskSystemProperties.rpcPort(),
-            rskSystemProperties.soLingerTime(),
-            true,
-            new CorsConfiguration(rskSystemProperties.corsDomains()),
-            filterHandler,
-            serverHandler
-        ).start();
+        web3HttpServer.start();
     }
 
     private void enableSimulateTxs() {
@@ -268,9 +256,5 @@ public class Start {
                 cm.broadcastBlock(block, null);
             }
         }
-    }
-
-    public interface Web3Factory {
-        Web3 newInstance();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -18,7 +18,6 @@
 
 package co.rsk.core;
 
-import co.rsk.Start;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.PendingStateImpl;
@@ -30,6 +29,7 @@ import co.rsk.net.eth.RskWireProtocol;
 import co.rsk.net.handler.TxHandler;
 import co.rsk.net.handler.TxHandlerImpl;
 import co.rsk.net.sync.SyncConfiguration;
+import co.rsk.rpc.CorsConfiguration;
 import co.rsk.rpc.Web3RskImpl;
 import co.rsk.rpc.modules.eth.*;
 import co.rsk.rpc.modules.personal.PersonalModule;
@@ -61,6 +61,10 @@ import org.ethereum.net.p2p.P2pHandler;
 import org.ethereum.net.rlpx.HandshakeHandler;
 import org.ethereum.net.rlpx.MessageCodec;
 import org.ethereum.net.server.*;
+import org.ethereum.rpc.JsonRpcWeb3FilterHandler;
+import org.ethereum.rpc.JsonRpcWeb3ServerHandler;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.Web3HttpServer;
 import org.ethereum.solidity.compiler.SolidityCompiler;
 import org.ethereum.sync.SyncPool;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactory;
@@ -134,24 +138,49 @@ public class RskFactory {
     }
 
     @Bean
-    public Start.Web3Factory getWeb3Factory(Rsk rsk,
-                                            Blockchain blockchain,
-                                            PendingState pendingState,
-                                            RskSystemProperties config,
-                                            MinerClient minerClient,
-                                            MinerServer minerServer,
-                                            PersonalModule personalModule,
-                                            EthModule ethModule,
-                                            ChannelManager channelManager,
-                                            Repository repository,
-                                            PeerScoringManager peerScoringManager,
-                                            NetworkStateExporter networkStateExporter,
-                                            org.ethereum.db.BlockStore blockStore,
-                                            PeerServer peerServer,
-                                            BlockProcessor nodeBlockProcessor,
-                                            HashRateCalculator hashRateCalculator,
-                                            ConfigCapabilities configCapabilities) {
-        return () -> new Web3RskImpl(rsk, blockchain, pendingState, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, networkStateExporter, blockStore, peerServer, nodeBlockProcessor, hashRateCalculator, configCapabilities);
+    public Web3 getWeb3Factory(Rsk rsk,
+                               Blockchain blockchain,
+                               PendingState pendingState,
+                               RskSystemProperties config,
+                               MinerClient minerClient,
+                               MinerServer minerServer,
+                               PersonalModule personalModule,
+                               EthModule ethModule,
+                               ChannelManager channelManager,
+                               Repository repository,
+                               PeerScoringManager peerScoringManager,
+                               NetworkStateExporter networkStateExporter,
+                               org.ethereum.db.BlockStore blockStore,
+                               PeerServer peerServer,
+                               BlockProcessor nodeBlockProcessor,
+                               HashRateCalculator hashRateCalculator,
+                               ConfigCapabilities configCapabilities) {
+        return new Web3RskImpl(rsk, blockchain, pendingState, config, minerClient, minerServer, personalModule, ethModule, channelManager, repository, peerScoringManager, networkStateExporter, blockStore, peerServer, nodeBlockProcessor, hashRateCalculator, configCapabilities);
+    }
+
+    @Bean
+    public JsonRpcWeb3FilterHandler getJsonRpcWeb3FilterHandler(RskSystemProperties rskSystemProperties) {
+        return new JsonRpcWeb3FilterHandler(rskSystemProperties.corsDomains());
+    }
+
+    @Bean
+    public JsonRpcWeb3ServerHandler getJsonRpcWeb3ServerHandler(Web3 web3Service, RskSystemProperties rskSystemProperties) {
+        return new JsonRpcWeb3ServerHandler(web3Service, rskSystemProperties.getRpcModules());
+    }
+
+    @Bean
+    public Web3HttpServer getWeb3HttpServer(RskSystemProperties rskSystemProperties,
+                                            JsonRpcWeb3FilterHandler filterHandler,
+                                            JsonRpcWeb3ServerHandler serverHandler) {
+        return new Web3HttpServer(
+            rskSystemProperties.rpcAddress(),
+            rskSystemProperties.rpcPort(),
+            rskSystemProperties.soLingerTime(),
+            true,
+            new CorsConfiguration(rskSystemProperties.corsDomains()),
+            filterHandler,
+            serverHandler
+        );
     }
 
     @Bean

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3HttpServer.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3HttpServer.java
@@ -17,7 +17,7 @@ import io.netty.handler.logging.LoggingHandler;
 
 import java.net.InetAddress;
 
-public class JsonRpcNettyServer {
+public class Web3HttpServer {
 
     private final InetAddress host;
     private int port;
@@ -29,13 +29,13 @@ public class JsonRpcNettyServer {
     private final JsonRpcWeb3FilterHandler jsonRpcWeb3FilterHandler;
     private final JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler;
 
-    public JsonRpcNettyServer(InetAddress host,
-                              int port,
-                              int socketLinger,
-                              boolean reuseAddress,
-                              CorsConfiguration corsConfiguration,
-                              JsonRpcWeb3FilterHandler jsonRpcWeb3FilterHandler,
-                              JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler) {
+    public Web3HttpServer(InetAddress host,
+                          int port,
+                          int socketLinger,
+                          boolean reuseAddress,
+                          CorsConfiguration corsConfiguration,
+                          JsonRpcWeb3FilterHandler jsonRpcWeb3FilterHandler,
+                          JsonRpcWeb3ServerHandler jsonRpcWeb3ServerHandler) {
         this.host = host;
         this.port = port;
         this.socketLinger = socketLinger;

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3HttpServerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3HttpServerTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-public class JsonRpcNettyServerTest {
+public class Web3HttpServerTest {
 
     private static JsonNodeFactory JSON_NODE_FACTORY = JsonNodeFactory.instance;
     private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -65,7 +65,7 @@ public class JsonRpcNettyServerTest {
         List<ModuleDescription> filteredModules = Collections.singletonList(new ModuleDescription("web3", "1.0", true, Collections.emptyList(), Collections.emptyList()));
         JsonRpcWeb3FilterHandler filterHandler = new JsonRpcWeb3FilterHandler("*");
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Mock, filteredModules);
-        JsonRpcNettyServer server = new JsonRpcNettyServer(InetAddress.getLoopbackAddress(), randomPort, 0, Boolean.TRUE, mockCorsConfiguration, filterHandler, serverHandler);
+        Web3HttpServer server = new Web3HttpServer(InetAddress.getLoopbackAddress(), randomPort, 0, Boolean.TRUE, mockCorsConfiguration, filterHandler, serverHandler);
         server.start();
 
         HttpURLConnection conn = sendJsonRpcMessage(randomPort, contentType);


### PR DESCRIPTION
This is an intermediate PR for the websockets provider task. The idea is to reuse the `org.ethereum.rpc.JsonRpcWeb3ServerHandler` instance in the new provider