### PR TITLE
Fix Transaction::valueRaw storage

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -246,7 +246,7 @@ public class Transaction {
         this.gasPrice = RLP.parseCoin(this.gasPriceRaw);
         this.gasLimit = transaction.get(2).getRLPData();
         this.receiveAddress = RLP.parseRskAddress(transaction.get(3).getRLPData());
-        this.valueRaw = nullToZeroArray(transaction.get(4).getRLPData());
+        this.valueRaw = transaction.get(4).getRLPData();
         this.value = RLP.parseCoin(this.valueRaw);
         this.data = transaction.get(5).getRLPData();
         // only parse signature in case tx is signed


### PR DESCRIPTION
Previously we would convert `null`s to `[0]`, which ended up in a different serialization.