### PR TITLE
Introduce a VmConfig class

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -392,7 +392,7 @@ public class RskSystemProperties extends SystemProperties {
 
     public VmConfig getVmConfig() {
         if (vmConfig == null) {
-            vmConfig = new VmConfig(vmTrace(), dumpBlock(), dumpStyle());
+            vmConfig = new VmConfig(vmTrace(), vmTraceInitStorageLimit(), dumpBlock(), dumpStyle());
         }
 
         return vmConfig;

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -63,6 +63,7 @@ public class RskSystemProperties extends SystemProperties {
     private MessageRecorder messageRecorder;
 
     private List<ModuleDescription> moduleDescriptions;
+    private VmConfig vmConfig;
 
     @Nullable
     public RskAddress coinbaseAddress() {
@@ -387,5 +388,13 @@ public class RskSystemProperties extends SystemProperties {
     // its fixed, cannot be set by config file
     public int getChunkSize() {
         return CHUNK_SIZE;
+    }
+
+    public VmConfig getVmConfig() {
+        if (vmConfig == null) {
+            vmConfig = new VmConfig(vmTrace(), dumpBlock(), dumpStyle());
+        }
+
+        return vmConfig;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/VmConfig.java
+++ b/rskj-core/src/main/java/co/rsk/config/VmConfig.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.config;
+
+/**
+ * Wraps configuration for the VM, which is usually derived from configuration files.
+ */
+public class VmConfig {
+
+    private final boolean vmTrace;
+    private final int dumpBlock;
+    private final String dumpStyle;
+
+    public VmConfig(
+            boolean vmTrace,
+            int dumpBlock,
+            String dumpStyle) {
+        this.vmTrace = vmTrace;
+        this.dumpBlock = dumpBlock;
+        this.dumpStyle = dumpStyle;
+    }
+
+    public int dumpBlock() {
+        return dumpBlock;
+    }
+
+    public String dumpStyle() {
+        return dumpStyle;
+    }
+
+    public boolean vmTrace() {
+        return vmTrace;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/config/VmConfig.java
+++ b/rskj-core/src/main/java/co/rsk/config/VmConfig.java
@@ -24,14 +24,17 @@ package co.rsk.config;
 public class VmConfig {
 
     private final boolean vmTrace;
+    private final int vmTraceInitStorageLimit;
     private final int dumpBlock;
     private final String dumpStyle;
 
     public VmConfig(
             boolean vmTrace,
+            int vmTraceInitStorageLimit,
             int dumpBlock,
             String dumpStyle) {
         this.vmTrace = vmTrace;
+        this.vmTraceInitStorageLimit = vmTraceInitStorageLimit;
         this.dumpBlock = dumpBlock;
         this.dumpStyle = dumpStyle;
     }
@@ -46,5 +49,9 @@ public class VmConfig {
 
     public boolean vmTrace() {
         return vmTrace;
+    }
+
+    public int vmTraceInitStorageLimit() {
+        return vmTraceInitStorageLimit;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -68,6 +68,7 @@ public class TransactionExecutor {
     private final Repository cacheTrack;
     private final BlockStore blockStore;
     private final ReceiptStore receiptStore;
+    private final PrecompiledContracts precompiledContracts;
     private String executionError = "";
     private final long gasUsedInTheBlock;
     private Coin paidFees;
@@ -113,6 +114,7 @@ public class TransactionExecutor {
         this.executionBlock = executionBlock;
         this.listener = listener;
         this.gasUsedInTheBlock = gasUsedInTheBlock;
+        this.precompiledContracts = new PrecompiledContracts(config);
     }
 
 
@@ -245,7 +247,7 @@ public class TransactionExecutor {
         // java.lang.RuntimeException: Data word can't exceed 32 bytes:
         // if targetAddress size is greater than 32 bytes.
         // But init() will detect this earlier
-        precompiledContract = PrecompiledContracts.getContractForAddress(config, new DataWord(targetAddress.getBytes()));
+        precompiledContract = precompiledContracts.getContractForAddress(new DataWord(targetAddress.getBytes()));
 
         if (precompiledContract != null) {
             precompiledContract.init(tx, executionBlock, track, blockStore, receiptStore, result.getLogInfoList());

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -288,7 +288,7 @@ public class TransactionExecutor {
                         programInvokeFactory.createProgramInvoke(tx, txindex, executionBlock, cacheTrack, blockStore);
 
                 this.vm = new VM(vmConfig, precompiledContracts);
-                this.program = new Program(config, code, programInvoke, tx);
+                this.program = new Program(vmConfig, precompiledContracts, code, programInvoke, tx);
             }
         }
 
@@ -307,7 +307,7 @@ public class TransactionExecutor {
             ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(tx, txindex, executionBlock, cacheTrack, blockStore);
 
             this.vm = new VM(vmConfig, precompiledContracts);
-            this.program = new Program(config, tx.getData(), programInvoke, tx);
+            this.program = new Program(vmConfig, precompiledContracts, tx.getData(), programInvoke, tx);
 
             // reset storage if the contract with the same address already exists
             // TCK test case only - normally this is near-impossible situation in the real network

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -20,6 +20,7 @@
 package org.ethereum.core;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.panic.PanicProcessor;
@@ -68,6 +69,7 @@ public class TransactionExecutor {
     private final Repository cacheTrack;
     private final BlockStore blockStore;
     private final ReceiptStore receiptStore;
+    private final VmConfig vmConfig;
     private final PrecompiledContracts precompiledContracts;
     private String executionError = "";
     private final long gasUsedInTheBlock;
@@ -114,6 +116,7 @@ public class TransactionExecutor {
         this.executionBlock = executionBlock;
         this.listener = listener;
         this.gasUsedInTheBlock = gasUsedInTheBlock;
+        this.vmConfig = config.getVmConfig();
         this.precompiledContracts = new PrecompiledContracts(config);
     }
 
@@ -284,7 +287,7 @@ public class TransactionExecutor {
                 ProgramInvoke programInvoke =
                         programInvokeFactory.createProgramInvoke(tx, txindex, executionBlock, cacheTrack, blockStore);
 
-                this.vm = new VM(config);
+                this.vm = new VM(vmConfig, precompiledContracts);
                 this.program = new Program(config, code, programInvoke, tx);
             }
         }
@@ -303,7 +306,7 @@ public class TransactionExecutor {
         } else {
             ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(tx, txindex, executionBlock, cacheTrack, blockStore);
 
-            this.vm = new VM(config);
+            this.vm = new VM(vmConfig, precompiledContracts);
             this.program = new Program(config, tx.getData(), programInvoke, tx);
 
             // reset storage if the contract with the same address already exists

--- a/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
@@ -70,7 +70,13 @@ public class PrecompiledContracts {
     private static SamplePrecompiledContract sample = new SamplePrecompiledContract(SAMPLE_ADDR);
     private static BigIntegerModexp bigIntegerModexp = new BigIntegerModexp();
 
-    public static PrecompiledContract getContractForAddress(RskSystemProperties config, DataWord address) {
+    private final RskSystemProperties config;
+
+    public PrecompiledContracts(RskSystemProperties config) {
+        this.config = config;
+    }
+
+    public PrecompiledContract getContractForAddress(DataWord address) {
 
         if (address == null) {
             return identity;

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -20,6 +20,7 @@
 package org.ethereum.vm;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.ContractDetails;
@@ -35,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.ethereum.crypto.HashUtil.keccak256;
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
 
 
@@ -89,6 +89,7 @@ public class VM {
     private static VMHook vmHook;
 
     private final RskSystemProperties config;
+    private final VmConfig vmConfig;
 
     // Execution variables
     Program program;
@@ -106,6 +107,7 @@ public class VM {
 
     public VM(RskSystemProperties config) {
         this.config = config;
+        this.vmConfig = config.getVmConfig();
         isLogEnabled = logger.isInfoEnabled();
     }
 
@@ -1872,7 +1874,7 @@ public class VM {
                     break;
                 }
 
-                if (this.config.vmTrace()) {
+                if (vmConfig.vmTrace()) {
                     program.saveOpTrace();
                 }
 
@@ -1895,14 +1897,14 @@ public class VM {
 
                 gasCost = op.getTier().asInt();
 
-                if (this.config.dumpBlock() >= 0) {
+                if (vmConfig.dumpBlock() >= 0) {
                     gasBefore = program.getRemainingGas();
                     stepBefore = program.getPC();
                     memWords = 0; // parameters for logging
                 }
 
                 // Log debugging line for VM
-                if (this.config.dumpBlock() >= 0 && program.getNumber().intValue() == this.config.dumpBlock()) {
+                if (vmConfig.dumpBlock() >= 0 && program.getNumber().intValue() == vmConfig.dumpBlock()) {
                     this.dumpLine(op, gasBefore, gasCost , memWords, program);
                 }
 
@@ -1981,7 +1983,7 @@ public class VM {
                     gasBefore, gasCost, memWords)
      */
     private void dumpLine(OpCode op, long gasBefore, long gasCost, long memWords, Program program) {
-        if ("standard+".equals(config.dumpStyle())) {
+        if ("standard+".equals(vmConfig.dumpStyle())) {
             switch (op) {
                 case STOP:
                 case RETURN:
@@ -2005,7 +2007,7 @@ public class VM {
             String gasString = Long.toHexString(program.getRemainingGas());
 
             dumpLogger.trace("{} {} {} {}", addressString, pcString, opString, gasString);
-        } else if ("pretty".equals(config.dumpStyle())) {
+        } else if ("pretty".equals(vmConfig.dumpStyle())) {
             dumpLogger.trace("-------------------------------------------------------------------------");
             dumpLogger.trace("    STACK");
             program.getStack().forEach(item -> dumpLogger.trace("{}", item));

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -19,7 +19,6 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.RskSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
 import org.ethereum.crypto.HashUtil;
@@ -105,9 +104,9 @@ public class VM {
     int stepBefore; // only for debugging
     boolean isLogEnabled;
 
-    public VM(RskSystemProperties config) {
-        this.vmConfig = config.getVmConfig();
-        this.precompiledContracts = new PrecompiledContracts(config);
+    public VM(VmConfig vmConfig, PrecompiledContracts precompiledContracts) {
+        this.vmConfig = vmConfig;
+        this.precompiledContracts = precompiledContracts;
         isLogEnabled = logger.isInfoEnabled();
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -88,8 +88,8 @@ public class VM {
 
     private static VMHook vmHook;
 
-    private final RskSystemProperties config;
     private final VmConfig vmConfig;
+    private final PrecompiledContracts precompiledContracts;
 
     // Execution variables
     Program program;
@@ -106,8 +106,8 @@ public class VM {
     boolean isLogEnabled;
 
     public VM(RskSystemProperties config) {
-        this.config = config;
         this.vmConfig = config.getVmConfig();
+        this.precompiledContracts = new PrecompiledContracts(config);
         isLogEnabled = logger.isInfoEnabled();
     }
 
@@ -1470,7 +1470,7 @@ public class VM {
     }
 
     private void callToAddress(DataWord codeAddress, MessageCall msg) {
-        PrecompiledContracts.PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, codeAddress);
+        PrecompiledContracts.PrecompiledContract contract = precompiledContracts.getContractForAddress(codeAddress);
 
         if (contract != null) {
             program.callToPrecompiledAddress(msg, contract);

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -19,7 +19,6 @@
 
 package org.ethereum.vm.program;
 
-import co.rsk.config.RskSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
@@ -87,7 +86,7 @@ public class Program {
     //Max size for stack checks
     private static final int MAX_STACKSIZE = 1024;
 
-    private Transaction transaction;
+    private final Transaction transaction;
 
     private final ProgramInvoke invoke;
     private final ProgramInvokeFactory programInvokeFactory = new ProgramInvokeFactoryImpl();
@@ -180,16 +179,20 @@ public class Program {
 
     private static Boolean useDataWordPool = true;
 
-    private final RskSystemProperties config;
-    private final VmConfig vmConfig;
+    private final VmConfig config;
     private final PrecompiledContracts precompiledContracts;
     boolean isLogEnabled;
     boolean isGasLogEnabled;
 
-    public Program(RskSystemProperties config, byte[] ops, ProgramInvoke programInvoke) {
+    public Program(
+            VmConfig config,
+            PrecompiledContracts precompiledContracts,
+            byte[] ops,
+            ProgramInvoke programInvoke,
+            Transaction transaction) {
         this.config = config;
-        this.vmConfig = config.getVmConfig();
-        this.precompiledContracts = new PrecompiledContracts(config);
+        this.precompiledContracts = precompiledContracts;
+        this.transaction = transaction;
         isLogEnabled = logger.isInfoEnabled();
         isGasLogEnabled = gasLogger.isInfoEnabled();
 
@@ -209,7 +212,7 @@ public class Program {
         this.stack = setupProgramListener(new Stack());
         this.stack.ensureCapacity(1024); // faster?
         this.storage = setupProgramListener(new Storage(programInvoke));
-        this.trace = new ProgramTrace(vmConfig, programInvoke);
+        this.trace = new ProgramTrace(config, programInvoke);
 
         if (useDataWordPool) {
             this.dataWordPool = new java.util.Stack<>();
@@ -219,12 +222,7 @@ public class Program {
         }
 
         precompile();
-        traceListener = new ProgramTraceListener(vmConfig);
-    }
-
-    public Program(RskSystemProperties config, byte[] ops, ProgramInvoke programInvoke, Transaction transaction) {
-        this(config, ops, programInvoke);
-        this.transaction = transaction;
+        traceListener = new ProgramTraceListener(config);
     }
 
     public static void setUseDataWordPool(Boolean value) {
@@ -655,8 +653,8 @@ public class Program {
         ProgramResult programResult = ProgramResult.empty();
         returnDataBuffer = null; // reset return buffer right before the call
         if (isNotEmpty(programCode)) {
-            VM vm = new VM(vmConfig, precompiledContracts);
-            Program program = new Program(config, programCode, programInvoke, internalTx);
+            VM vm = new VM(config, precompiledContracts);
+            Program program = new Program(config, precompiledContracts, programCode, programInvoke, internalTx);
             vm.play(program);
             programResult = program.getResult();
         }
@@ -881,8 +879,8 @@ public class Program {
                 msg.getType() == MsgType.DELEGATECALL ? getCallValue() : msg.getEndowment(),
                 limitToMaxLong(msg.getGas()), contextBalance, data, track, this.invoke.getBlockStore(), byTestingSuite());
 
-        VM vm = new VM(vmConfig, precompiledContracts);
-        Program program = new Program(config, programCode, programInvoke, internalTx);
+        VM vm = new VM(config, precompiledContracts);
+        Program program = new Program(config, precompiledContracts, programCode, programInvoke, internalTx);
         vm.play(program);
         childResult  = program.getResult();
 

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm.trace;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.Repository;
 import org.ethereum.db.ContractDetails;
@@ -52,11 +52,7 @@ public class ProgramTrace {
     private int storageSize;
     private String contractAddress;
 
-    public ProgramTrace(RskSystemProperties config) {
-        this(config, null);
-    }
-
-    public ProgramTrace(RskSystemProperties config, ProgramInvoke programInvoke) {
+    public ProgramTrace(VmConfig config, ProgramInvoke programInvoke) {
         if (config.vmTrace() && programInvoke != null) {
             contractAddress = Hex.toHexString(programInvoke.getOwnerAddress().getLast20Bytes());
 

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTraceListener.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTraceListener.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm.trace;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.program.listener.ProgramListenerAdaptor;
 
@@ -28,7 +28,7 @@ public class ProgramTraceListener extends ProgramListenerAdaptor {
     private final boolean enabled;
     private OpActions actions = new OpActions();
 
-    public ProgramTraceListener(RskSystemProperties config) {
+    public ProgramTraceListener(VmConfig config) {
         enabled = config.vmTrace();
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/SamplePrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/SamplePrecompiledContractTest.java
@@ -40,12 +40,13 @@ import static org.junit.Assert.assertNull;
 public class SamplePrecompiledContractTest {
 
     private final RskSystemProperties config = new RskSystemProperties();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 
     @Test
     public void samplePrecompiledContractMethod1Ok()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(addr);
 
 
         String funcJson = "{\n" +
@@ -75,7 +76,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractMethod1WrongData()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(addr);
 
 
         String funcJson = "{\n" +
@@ -103,7 +104,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractMethodDoesNotExist()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(addr);
 
 
         String funcJson = "{\n" +
@@ -132,7 +133,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractMethod1LargeData()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(addr);
 
 
         String funcJson = "{\n" +
@@ -160,7 +161,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractAddBalanceOk()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(addr);
 
 
         String funcJson = "{\n" +
@@ -195,7 +196,7 @@ public class SamplePrecompiledContractTest {
     public void samplePrecompiledContractIncrementResultOk()
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(addr);
 
 
         String funcJson = "{\n" +
@@ -231,7 +232,7 @@ public class SamplePrecompiledContractTest {
     private int GetBalance(Repository repository)
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(addr);
 
 
         String funcJson = "{\n" +
@@ -258,7 +259,7 @@ public class SamplePrecompiledContractTest {
     private int GetResult(Repository repository)
     {
         DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
-        SamplePrecompiledContract contract = (SamplePrecompiledContract)PrecompiledContracts.getContractForAddress(config, addr);
+        SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(addr);
 
 
         String funcJson = "{\n" +

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
@@ -29,11 +29,12 @@ import org.junit.Test;
 public class PrecompiledContractTest {
 
     private final RskSystemProperties config = new RskSystemProperties();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 
     @Test
     public void getBridgeContract() {
         DataWord bridgeAddress = new DataWord(PrecompiledContracts.BRIDGE_ADDR.getBytes());
-        PrecompiledContract bridge = PrecompiledContracts.getContractForAddress(config, bridgeAddress);
+        PrecompiledContract bridge = precompiledContracts.getContractForAddress(bridgeAddress);
 
         Assert.assertNotNull(bridge);
         Assert.assertEquals(Bridge.class, bridge.getClass());
@@ -42,8 +43,8 @@ public class PrecompiledContractTest {
     @Test
     public void getBridgeContractTwice() {
         DataWord bridgeAddress = new DataWord(PrecompiledContracts.BRIDGE_ADDR.getBytes());
-        PrecompiledContract bridge1 = PrecompiledContracts.getContractForAddress(config, bridgeAddress);
-        PrecompiledContract bridge2 = PrecompiledContracts.getContractForAddress(config, bridgeAddress);
+        PrecompiledContract bridge1 = precompiledContracts.getContractForAddress(bridgeAddress);
+        PrecompiledContract bridge2 = precompiledContracts.getContractForAddress(bridgeAddress);
 
         Assert.assertNotNull(bridge1);
         Assert.assertNotNull(bridge2);

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -20,6 +20,7 @@ package co.rsk.vm;
 
 import co.rsk.config.RskSystemProperties;
 import org.ethereum.vm.DataWord;
+import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.VM;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.Stack;
@@ -357,7 +358,7 @@ public class VMExecutionTest {
     }
 
     private Program executeCode(byte[] code, int nsteps) {
-        VM vm = new VM(config);
+        VM vm = new VM(config.getVmConfig(), new PrecompiledContracts(config));
 
         Program program = new Program(config, code, invoke);
 

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -19,6 +19,7 @@
 package co.rsk.vm;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.VM;
@@ -41,6 +42,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class VMExecutionTest {
     private final RskSystemProperties config = new RskSystemProperties();
+    private final VmConfig vmConfig = config.getVmConfig();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
     private ProgramInvokeMockImpl invoke;
     private BytecodeCompiler compiler;
 
@@ -246,7 +249,7 @@ public class VMExecutionTest {
     @Test
     public void dupnArgumentIsNotJumpdest() {
         byte[] code = compiler.compile("JUMPDEST DUPN 0x5b 0x5b");
-        Program program = new Program(config, code, invoke);
+        Program program = new Program(vmConfig, precompiledContracts, code, invoke, null);
 
         BitSet jumpdestSet = program.getJumpdestSet();
 
@@ -261,7 +264,7 @@ public class VMExecutionTest {
     @Test
     public void swapnArgumentIsNotJumpdest() {
         byte[] code = compiler.compile("JUMPDEST SWAPN 0x5b 0x5b");
-        Program program = new Program(config, code, invoke);
+        Program program = new Program(vmConfig, precompiledContracts, code, invoke, null);
 
         BitSet jumpdestSet = program.getJumpdestSet();
 
@@ -358,9 +361,9 @@ public class VMExecutionTest {
     }
 
     private Program executeCode(byte[] code, int nsteps) {
-        VM vm = new VM(config.getVmConfig(), new PrecompiledContracts(config));
+        VM vm = new VM(vmConfig, precompiledContracts);
 
-        Program program = new Program(config, code, invoke);
+        Program program = new Program(vmConfig, precompiledContracts, code, invoke, null);
 
         for (int k = 0; k < nsteps; k++)
             vm.step(program);

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -19,6 +19,7 @@
 package co.rsk.vm;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.OpCode;
 import org.ethereum.vm.PrecompiledContracts;
@@ -52,6 +53,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class VMPerformanceTest {
     private final RskSystemProperties config = new RskSystemProperties();
+    private final VmConfig vmConfig = config.getVmConfig();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
     private ProgramInvokeMockImpl invoke;
     private Program program;
     ThreadMXBean thread;
@@ -296,7 +299,7 @@ public class VMPerformanceTest {
             baos.write(code, 0, code.length);
         byte[] newCode = baos.toByteArray();
 
-        program = new Program(config, newCode, invoke);
+        program = new Program(vmConfig, precompiledContracts, newCode, invoke, null);
         int sa = program.getStartAddr();
 
         long myLoops = maxLoops / cloneCount;
@@ -503,7 +506,7 @@ public class VMPerformanceTest {
         ------------------------------------------------------------------------------------------------------------------------------------------------------*/
         byte[] code = Arrays.copyOfRange(codePlusPrefix,16,codePlusPrefix.length);
 
-        program =new Program(config, code, invoke);
+        program =new Program(vmConfig, precompiledContracts, code, invoke, null);
 
         //String s_expected_1 = "000000000000000000000000000000000000000000000000000000033FFC1244"; // 55
         //String s_expected_1 = "00000000000000000000000000000000000000000000000000000002EE333961";// 50
@@ -618,7 +621,7 @@ public class VMPerformanceTest {
     -----------------------------------------------------------------------------*/
 
     public void testRunTime(byte[] code, String s_expected) {
-        program = new Program(config, code, invoke);
+        program = new Program(vmConfig, precompiledContracts, code, invoke, null);
         System.out.println("-----------------------------------------------------------------------------");
         System.out.println("Starting test....");
         System.out.println("Configuration: Program.useDataWordPool =  " + Program.getUseDataWordPool().toString());

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -21,6 +21,7 @@ package co.rsk.vm;
 import co.rsk.config.RskSystemProperties;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.OpCode;
+import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.VM;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.invoke.ProgramInvokeMockImpl;
@@ -166,7 +167,7 @@ public class VMPerformanceTest {
 
         Boolean old = thread.isThreadCpuTimeEnabled();
         thread.setThreadCpuTimeEnabled(true);
-        vm = new VM(config);
+        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config));
         if (useProfiler)
             waitForProfiler();
 
@@ -475,7 +476,7 @@ public class VMPerformanceTest {
 } // contract
         */
 
-        vm = new VM(config);
+        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config));
         // Strip the first 16 bytes which are added by Solidity to store the contract.
         byte[] codePlusPrefix = Hex.decode(
                 //---------------------------------------------------------------------------------------------------------------------nn
@@ -561,7 +562,7 @@ public class VMPerformanceTest {
          }
          } // contract
          ********************************************************************************************/
-        vm = new VM(config);
+        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config));
         /////////////////////////////////////////////////////////////////////////////////////////////////
         // To increase precesion of the measurement, the maximum k value was increased
         // until the contract took more than 30 seconds

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -20,6 +20,7 @@
 package org.ethereum.jsontestsuite;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
@@ -70,6 +71,8 @@ import static org.ethereum.vm.VMUtils.saveProgramTraceFile;
 public class TestRunner {
 
     private final RskSystemProperties config = new RskSystemProperties();
+    private final VmConfig vmConfig = config.getVmConfig();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
     private Logger logger = LoggerFactory.getLogger("TCK-Test");
     private ProgramTrace trace = null;
     private boolean setNewStateRoot;
@@ -229,8 +232,8 @@ public class TestRunner {
 
             /* 3. Create Program - exec.code */
             /* 4. run VM */
-            VM vm = new VM(config.getVmConfig(), new PrecompiledContracts(config));
-            Program program = new Program(config, exec.getCode(), programInvoke);
+            VM vm = new VM(vmConfig, precompiledContracts);
+            Program program = new Program(vmConfig, precompiledContracts, exec.getCode(), programInvoke, null);
             boolean vmDidThrowAnEception = false;
             Exception e = null;
             ThreadMXBean thread;

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -42,6 +42,7 @@ import org.ethereum.listener.EthereumListener;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.VM;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
@@ -228,7 +229,7 @@ public class TestRunner {
 
             /* 3. Create Program - exec.code */
             /* 4. run VM */
-            VM vm = new VM(config);
+            VM vm = new VM(config.getVmConfig(), new PrecompiledContracts(config));
             Program program = new Program(config, exec.getCode(), programInvoke);
             boolean vmDidThrowAnEception = false;
             Exception e = null;

--- a/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
@@ -38,12 +38,13 @@ public class PrecompiledContractTest {
 
 
     private final RskSystemProperties config = new RskSystemProperties();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 
     @Test
     public void identityTest1() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000004");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
+        PrecompiledContract contract = precompiledContracts.getContractForAddress(addr);
         byte[] data = Hex.decode("112233445566");
         byte[] expected = Hex.decode("112233445566");
 
@@ -57,7 +58,7 @@ public class PrecompiledContractTest {
     public void sha256Test1() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
+        PrecompiledContract contract = precompiledContracts.getContractForAddress(addr);
         byte[] data = null;
         String expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
@@ -70,7 +71,7 @@ public class PrecompiledContractTest {
     public void sha256Test2() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
+        PrecompiledContract contract = precompiledContracts.getContractForAddress(addr);
         byte[] data = ByteUtil.EMPTY_BYTE_ARRAY;
         String expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
@@ -83,7 +84,7 @@ public class PrecompiledContractTest {
     public void sha256Test3() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
+        PrecompiledContract contract = precompiledContracts.getContractForAddress(addr);
         byte[] data = Hex.decode("112233");
         String expected = "49ee2bf93aac3b1fb4117e59095e07abe555c3383b38d608da37680a406096e8";
 
@@ -97,7 +98,7 @@ public class PrecompiledContractTest {
     public void Ripempd160Test1() {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000003");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
+        PrecompiledContract contract = precompiledContracts.getContractForAddress(addr);
         byte[] data = Hex.decode("0000000000000000000000000000000000000000000000000000000000000001");
         String expected = "000000000000000000000000ae387fcfeb723c3f5964509af111cf5a67f30661";
 
@@ -111,7 +112,7 @@ public class PrecompiledContractTest {
 
         byte[] data = Hex.decode("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549");
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000001");
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
+        PrecompiledContract contract = precompiledContracts.getContractForAddress(addr);
         String expected = "000000000000000000000000ae387fcfeb723c3f5964509af111cf5a67f30661";
 
         byte[] result = contract.execute(data);
@@ -124,7 +125,7 @@ public class PrecompiledContractTest {
 
         DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000005");
 
-        PrecompiledContract contract = PrecompiledContracts.getContractForAddress(config, addr);
+        PrecompiledContract contract = precompiledContracts.getContractForAddress(addr);
         assertNotNull(contract);
 
         byte[] data1 = Hex.decode(

--- a/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
@@ -37,7 +37,8 @@ public class ProgramMemoryTest {
 
     @Before
     public void createProgram() {
-        program = new Program(new RskSystemProperties(), ByteUtil.EMPTY_BYTE_ARRAY, pi);
+        RskSystemProperties config = new RskSystemProperties();
+        program = new Program(config.getVmConfig(), new PrecompiledContracts(config), ByteUtil.EMPTY_BYTE_ARRAY, pi, null);
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
@@ -99,7 +99,7 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeB, pi);
 
         try {
@@ -184,7 +184,7 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeB, pi);
 
         try {
@@ -273,7 +273,7 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeB, pi);
 
         try {
@@ -351,7 +351,7 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeA, pi);
 
         try {
@@ -425,7 +425,7 @@ public class VMComplexTest {
         // ****************** //
         //  Play the program  //
         // ****************** //
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeB, pi);
 
         try {
@@ -490,7 +490,7 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeB, pi);
 
         try {
@@ -550,7 +550,7 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeB, pi);
 
         try {
@@ -610,7 +610,7 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeB, pi);
 
         try {
@@ -670,7 +670,7 @@ public class VMComplexTest {
         repository.addStorageRow(contractAddrB, key1, value1);
 
         // Play the program
-        VM vm = new VM(config);
+        VM vm = getSubject();
         Program program = new Program(config, codeB, pi);
 
         try {
@@ -692,5 +692,9 @@ public class VMComplexTest {
 
         repository.close();
         assertEquals(expectedGas, program.getResult().getGasUsed());
+    }
+
+    private VM getSubject() {
+        return new VM(config.getVmConfig(), new PrecompiledContracts(config));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
@@ -20,12 +20,14 @@
 package org.ethereum.vm;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Repository;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.vm.program.Program;
+import org.ethereum.vm.program.invoke.ProgramInvoke;
 import org.ethereum.vm.program.invoke.ProgramInvokeMockImpl;
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;
@@ -48,6 +50,8 @@ public class VMComplexTest {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
     private final RskSystemProperties config = new RskSystemProperties();
+    private final VmConfig vmConfig = config.getVmConfig();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 
     @Ignore //TODO #POC9
     @Test // contract call recursive
@@ -100,7 +104,7 @@ public class VMComplexTest {
 
         // Play the program
         VM vm = getSubject();
-        Program program = new Program(config, codeB, pi);
+        Program program = getProgram(codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -185,7 +189,7 @@ public class VMComplexTest {
         //  Play the program  //
         // ****************** //
         VM vm = getSubject();
-        Program program = new Program(config, codeB, pi);
+        Program program = getProgram(codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -274,7 +278,7 @@ public class VMComplexTest {
         //  Play the program  //
         // ****************** //
         VM vm = getSubject();
-        Program program = new Program(config, codeB, pi);
+        Program program = getProgram(codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -352,7 +356,7 @@ public class VMComplexTest {
         //  Play the program  //
         // ****************** //
         VM vm = getSubject();
-        Program program = new Program(config, codeA, pi);
+        Program program = getProgram(codeA, pi);
 
         try {
             while (!program.isStopped())
@@ -426,7 +430,7 @@ public class VMComplexTest {
         //  Play the program  //
         // ****************** //
         VM vm = getSubject();
-        Program program = new Program(config, codeB, pi);
+        Program program = getProgram(codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -491,7 +495,7 @@ public class VMComplexTest {
 
         // Play the program
         VM vm = getSubject();
-        Program program = new Program(config, codeB, pi);
+        Program program = getProgram(codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -551,7 +555,7 @@ public class VMComplexTest {
 
         // Play the program
         VM vm = getSubject();
-        Program program = new Program(config, codeB, pi);
+        Program program = getProgram(codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -611,7 +615,7 @@ public class VMComplexTest {
 
         // Play the program
         VM vm = getSubject();
-        Program program = new Program(config, codeB, pi);
+        Program program = getProgram(codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -671,7 +675,7 @@ public class VMComplexTest {
 
         // Play the program
         VM vm = getSubject();
-        Program program = new Program(config, codeB, pi);
+        Program program = getProgram(codeB, pi);
 
         try {
             while (!program.isStopped())
@@ -695,6 +699,10 @@ public class VMComplexTest {
     }
 
     private VM getSubject() {
-        return new VM(config.getVmConfig(), new PrecompiledContracts(config));
+        return new VM(vmConfig, precompiledContracts);
+    }
+
+    private Program getProgram(byte[] code, ProgramInvoke pi) {
+        return new Program(vmConfig, precompiledContracts, code, pi, null);
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
@@ -65,7 +65,7 @@ public class VMCustomTest {
     @Test // CALLDATASIZE OP
     public void testCALLDATASIZE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("36"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000040";
 
@@ -79,7 +79,7 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("600035"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000A1";
@@ -94,7 +94,7 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("600235"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000A10000";
@@ -110,7 +110,7 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("602035"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000B1";
@@ -126,7 +126,7 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("602335"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000B1000000";
@@ -141,7 +141,7 @@ public class VMCustomTest {
     @Test // CALLDATALOAD OP
     public void testCALLDATALOAD_5() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("603F35"), invoke);
         String s_expected_1 = "B100000000000000000000000000000000000000000000000000000000000000";
@@ -156,7 +156,7 @@ public class VMCustomTest {
     @Test(expected = RuntimeException.class) // CALLDATALOAD OP mal
     public void testCALLDATALOAD_6() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("35"), invoke);
         try {
@@ -169,7 +169,7 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("60206000600037"), invoke);
         String m_expected = "00000000000000000000000000000000000000000000000000000000000000A1";
@@ -185,7 +185,7 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("60406000600037"), invoke);
         String m_expected = "00000000000000000000000000000000000000000000000000000000000000A1" +
@@ -203,7 +203,7 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("60406004600037"), invoke);
         String m_expected = "000000000000000000000000000000000000000000000000000000A100000000" +
@@ -221,7 +221,7 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("60406000600437"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
@@ -239,7 +239,7 @@ public class VMCustomTest {
     @Test // CALLDATACOPY OP
     public void testCALLDATACOPY_5() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("60406000600437"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
@@ -258,7 +258,7 @@ public class VMCustomTest {
     @Test(expected = StackTooSmallException.class) // CALLDATACOPY OP mal
     public void testCALLDATACOPY_6() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("6040600037"), invoke);
 
@@ -274,7 +274,7 @@ public class VMCustomTest {
     @Test(expected = OutOfGasException.class) // CALLDATACOPY OP mal
     public void testCALLDATACOPY_7() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("6020600073CC0929EB16730E7C14FEFC63006AC2D794C5795637"), invoke);
 
@@ -291,7 +291,7 @@ public class VMCustomTest {
     @Test // ADDRESS OP
     public void testADDRESS_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("30"), invoke);
         String s_expected_1 = "00000000000000000000000077045E71A7A2C50903D88E564CD72FAB11E82051";
 
@@ -305,7 +305,7 @@ public class VMCustomTest {
     @Test // BALANCE OP
     public void testBALANCE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("3031"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000003E8";
@@ -320,7 +320,7 @@ public class VMCustomTest {
     @Test // ORIGIN OP
     public void testORIGIN_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("32"), invoke);
         String s_expected_1 = "00000000000000000000000013978AEE95F38490E9769C39B2773ED763D9CD5F";
@@ -334,7 +334,7 @@ public class VMCustomTest {
     @Test // CALLER OP
     public void testCALLER_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("33"), invoke);
         String s_expected_1 = "000000000000000000000000885F93EED577F2FC341EBB9A5C9B2CE4465D96C4";
@@ -348,7 +348,7 @@ public class VMCustomTest {
     @Test // CALLVALUE OP
     public void testCALLVALUE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("34"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000DE0B6B3A7640000";
@@ -362,7 +362,7 @@ public class VMCustomTest {
     @Test // SHA3 OP
     public void testSHA3_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("60016000536001600020"), invoke);
         String s_expected_1 = "5FE7F977E71DBA2EA1A68E21057BEEBB9BE2AC30C6410AA38D4F3FBE41DCFFD2";
@@ -381,7 +381,7 @@ public class VMCustomTest {
     @Test // SHA3 OP
     public void testSHA3_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("6102016000526002601E20"), invoke);
         String s_expected_1 = "114A3FE82A0219FCC31ABD15617966A125F12B0FD3409105FC83B487A9D82DE4";
@@ -400,7 +400,7 @@ public class VMCustomTest {
     @Test(expected = StackTooSmallException.class) // SHA3 OP mal
     public void testSHA3_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("610201600052600220"), invoke);
         try {
@@ -417,7 +417,7 @@ public class VMCustomTest {
     @Test // BLOCKHASH OP
     public void testBLOCKHASH_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("600140"), invoke);
         String s_expected_1 = "C89EFDAA54C0F20C7ADF612882DF0950F5A951637E0307CDCB4C672F298B8BC6";
@@ -432,7 +432,7 @@ public class VMCustomTest {
     @Test // COINBASE OP
     public void testCOINBASE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("41"), invoke);
         String s_expected_1 = "000000000000000000000000E559DE5527492BCB42EC68D07DF0742A98EC3F1E";
@@ -446,7 +446,7 @@ public class VMCustomTest {
     @Test // TIMESTAMP OP
     public void testTIMESTAMP_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("42"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000005387FE24";
@@ -460,7 +460,7 @@ public class VMCustomTest {
     @Test // NUMBER OP
     public void testNUMBER_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("43"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000021";
@@ -474,7 +474,7 @@ public class VMCustomTest {
     @Test // DIFFICULTY OP
     public void testDIFFICULTY_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("44"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000003ED290";
@@ -488,7 +488,7 @@ public class VMCustomTest {
     @Test // GASPRICE OP
     public void testGASPRICE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("3A"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000009184E72A000";
@@ -503,7 +503,7 @@ public class VMCustomTest {
     @Test // GAS OP
     public void testGAS_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("5A"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000F423F";
@@ -517,7 +517,7 @@ public class VMCustomTest {
     @Test // GASLIMIT OP
     public void testGASLIMIT_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("45"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000F4240";
@@ -531,7 +531,7 @@ public class VMCustomTest {
     @Test(expected = Program.IllegalOperationException.class) // INVALID OP
     public void testINVALID_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60012F6002"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -543,6 +543,10 @@ public class VMCustomTest {
             DataWord item1 = program.stackPop();
             assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
         }
+    }
+
+    private VM getSubject() {
+        return new VM(config.getVmConfig(), new PrecompiledContracts(config));
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
@@ -20,6 +20,7 @@
 package org.ethereum.vm;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import org.ethereum.vm.program.Program;
@@ -41,6 +42,8 @@ import static org.junit.Assert.assertTrue;
 public class VMCustomTest {
 
     private final RskSystemProperties config = new RskSystemProperties();
+    private final VmConfig vmConfig = config.getVmConfig();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
     private ProgramInvokeMockImpl invoke;
     private Program program;
 
@@ -66,7 +69,7 @@ public class VMCustomTest {
     public void testCALLDATASIZE_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("36"), invoke);
+        program = getProgram("36");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000040";
 
         vm.step(program);
@@ -80,8 +83,7 @@ public class VMCustomTest {
     public void testCALLDATALOAD_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("600035"), invoke);
+        program = getProgram("600035");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000A1";
 
         vm.step(program);
@@ -95,8 +97,7 @@ public class VMCustomTest {
     public void testCALLDATALOAD_2() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("600235"), invoke);
+        program = getProgram("600235");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000A10000";
 
         vm.step(program);
@@ -111,8 +112,7 @@ public class VMCustomTest {
     public void testCALLDATALOAD_3() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("602035"), invoke);
+        program = getProgram("602035");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000B1";
 
         vm.step(program);
@@ -127,8 +127,7 @@ public class VMCustomTest {
     public void testCALLDATALOAD_4() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("602335"), invoke);
+        program = getProgram("602335");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000B1000000";
 
         vm.step(program);
@@ -142,8 +141,7 @@ public class VMCustomTest {
     public void testCALLDATALOAD_5() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("603F35"), invoke);
+        program = getProgram("603F35");
         String s_expected_1 = "B100000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -157,8 +155,7 @@ public class VMCustomTest {
     public void testCALLDATALOAD_6() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("35"), invoke);
+        program = getProgram("35");
         try {
             vm.step(program);
         } finally {
@@ -170,8 +167,7 @@ public class VMCustomTest {
     public void testCALLDATACOPY_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("60206000600037"), invoke);
+        program = getProgram("60206000600037");
         String m_expected = "00000000000000000000000000000000000000000000000000000000000000A1";
 
         vm.step(program);
@@ -186,8 +182,7 @@ public class VMCustomTest {
     public void testCALLDATACOPY_2() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("60406000600037"), invoke);
+        program = getProgram("60406000600037");
         String m_expected = "00000000000000000000000000000000000000000000000000000000000000A1" +
                 "00000000000000000000000000000000000000000000000000000000000000B1";
 
@@ -204,8 +199,7 @@ public class VMCustomTest {
     public void testCALLDATACOPY_3() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("60406004600037"), invoke);
+        program = getProgram("60406004600037");
         String m_expected = "000000000000000000000000000000000000000000000000000000A100000000" +
                 "000000000000000000000000000000000000000000000000000000B100000000";
 
@@ -222,8 +216,7 @@ public class VMCustomTest {
     public void testCALLDATACOPY_4() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("60406000600437"), invoke);
+        program = getProgram("60406000600437");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "000000A100000000000000000000000000000000000000000000000000000000" +
                 "000000B100000000000000000000000000000000000000000000000000000000";
@@ -240,8 +233,7 @@ public class VMCustomTest {
     public void testCALLDATACOPY_5() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("60406000600437"), invoke);
+        program = getProgram("60406000600437");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "000000A100000000000000000000000000000000000000000000000000000000" +
                 "000000B100000000000000000000000000000000000000000000000000000000";
@@ -259,8 +251,7 @@ public class VMCustomTest {
     public void testCALLDATACOPY_6() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("6040600037"), invoke);
+        program = getProgram("6040600037");
 
         try {
             vm.step(program);
@@ -275,8 +266,7 @@ public class VMCustomTest {
     public void testCALLDATACOPY_7() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("6020600073CC0929EB16730E7C14FEFC63006AC2D794C5795637"), invoke);
+        program = getProgram("6020600073CC0929EB16730E7C14FEFC63006AC2D794C5795637");
 
         try {
             vm.step(program);
@@ -292,7 +282,7 @@ public class VMCustomTest {
     public void testADDRESS_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("30"), invoke);
+        program = getProgram("30");
         String s_expected_1 = "00000000000000000000000077045E71A7A2C50903D88E564CD72FAB11E82051";
 
         vm.step(program);
@@ -306,8 +296,7 @@ public class VMCustomTest {
     public void testBALANCE_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("3031"), invoke);
+        program = getProgram("3031");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000003E8";
 
         vm.step(program);
@@ -321,8 +310,7 @@ public class VMCustomTest {
     public void testORIGIN_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("32"), invoke);
+        program = getProgram("32");
         String s_expected_1 = "00000000000000000000000013978AEE95F38490E9769C39B2773ED763D9CD5F";
 
         vm.step(program);
@@ -335,8 +323,7 @@ public class VMCustomTest {
     public void testCALLER_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("33"), invoke);
+        program = getProgram("33");
         String s_expected_1 = "000000000000000000000000885F93EED577F2FC341EBB9A5C9B2CE4465D96C4";
 
         vm.step(program);
@@ -349,8 +336,7 @@ public class VMCustomTest {
     public void testCALLVALUE_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("34"), invoke);
+        program = getProgram("34");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000DE0B6B3A7640000";
 
         vm.step(program);
@@ -363,8 +349,7 @@ public class VMCustomTest {
     public void testSHA3_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("60016000536001600020"), invoke);
+        program = getProgram("60016000536001600020");
         String s_expected_1 = "5FE7F977E71DBA2EA1A68E21057BEEBB9BE2AC30C6410AA38D4F3FBE41DCFFD2";
 
         vm.step(program);
@@ -382,8 +367,7 @@ public class VMCustomTest {
     public void testSHA3_2() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("6102016000526002601E20"), invoke);
+        program = getProgram("6102016000526002601E20");
         String s_expected_1 = "114A3FE82A0219FCC31ABD15617966A125F12B0FD3409105FC83B487A9D82DE4";
 
         vm.step(program);
@@ -401,8 +385,7 @@ public class VMCustomTest {
     public void testSHA3_3() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("610201600052600220"), invoke);
+        program = getProgram("610201600052600220");
         try {
             vm.step(program);
             vm.step(program);
@@ -418,8 +401,7 @@ public class VMCustomTest {
     public void testBLOCKHASH_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("600140"), invoke);
+        program = getProgram("600140");
         String s_expected_1 = "C89EFDAA54C0F20C7ADF612882DF0950F5A951637E0307CDCB4C672F298B8BC6";
 
         vm.step(program);
@@ -433,8 +415,7 @@ public class VMCustomTest {
     public void testCOINBASE_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("41"), invoke);
+        program = getProgram("41");
         String s_expected_1 = "000000000000000000000000E559DE5527492BCB42EC68D07DF0742A98EC3F1E";
 
         vm.step(program);
@@ -447,8 +428,7 @@ public class VMCustomTest {
     public void testTIMESTAMP_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("42"), invoke);
+        program = getProgram("42");
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000005387FE24";
 
         vm.step(program);
@@ -461,8 +441,7 @@ public class VMCustomTest {
     public void testNUMBER_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("43"), invoke);
+        program = getProgram("43");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000021";
 
         vm.step(program);
@@ -475,8 +454,7 @@ public class VMCustomTest {
     public void testDIFFICULTY_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("44"), invoke);
+        program = getProgram("44");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000003ED290";
 
         vm.step(program);
@@ -489,8 +467,7 @@ public class VMCustomTest {
     public void testGASPRICE_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("3A"), invoke);
+        program = getProgram("3A");
         String s_expected_1 = "000000000000000000000000000000000000000000000000000009184E72A000";
 
         vm.step(program);
@@ -504,8 +481,7 @@ public class VMCustomTest {
     public void testGAS_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("5A"), invoke);
+        program = getProgram("5A");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000F423F";
 
         vm.step(program);
@@ -518,8 +494,7 @@ public class VMCustomTest {
     public void testGASLIMIT_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("45"), invoke);
+        program = getProgram("45");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000F4240";
 
         vm.step(program);
@@ -532,7 +507,7 @@ public class VMCustomTest {
     public void testINVALID_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60012F6002"), invoke);
+        program = getProgram("60012F6002");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         try {
@@ -546,7 +521,11 @@ public class VMCustomTest {
     }
 
     private VM getSubject() {
-        return new VM(config.getVmConfig(), new PrecompiledContracts(config));
+        return new VM(vmConfig, precompiledContracts);
+    }
+
+    private Program getProgram(String ops) {
+        return new Program(vmConfig, precompiledContracts, Hex.decode(ops), invoke, null);
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -63,7 +63,7 @@ public class VMTest {
     @Test  // PUSH1 OP
     public void testPUSH1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60A0"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000A0";
 
@@ -76,7 +76,7 @@ public class VMTest {
     @Test  // PUSH2 OP
     public void testPUSH2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61A0B0"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000A0B0";
 
@@ -89,7 +89,7 @@ public class VMTest {
     @Test  // PUSH3 OP
     public void testPUSH3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("62A0B0C0"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000A0B0C0";
 
@@ -102,7 +102,7 @@ public class VMTest {
     @Test  // PUSH4 OP
     public void testPUSH4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("63A0B0C0D0"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000A0B0C0D0";
 
@@ -115,7 +115,7 @@ public class VMTest {
     @Test  // PUSH5 OP
     public void testPUSH5() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("64A0B0C0D0E0"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000A0B0C0D0E0";
 
@@ -128,7 +128,7 @@ public class VMTest {
     @Test  // PUSH6 OP
     public void testPUSH6() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("65A0B0C0D0E0F0"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000A0B0C0D0E0F0";
 
@@ -141,7 +141,7 @@ public class VMTest {
     @Test  // PUSH7 OP
     public void testPUSH7() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("66A0B0C0D0E0F0A1"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000A0B0C0D0E0F0A1";
 
@@ -154,7 +154,7 @@ public class VMTest {
     @Test  // PUSH8 OP
     public void testPUSH8() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("67A0B0C0D0E0F0A1B1"), invoke);
         String expected = "000000000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1";
 
@@ -167,7 +167,7 @@ public class VMTest {
     @Test  // PUSH9 OP
     public void testPUSH9() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("68A0B0C0D0E0F0A1B1C1"), invoke);
         String expected = "0000000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1";
 
@@ -181,7 +181,7 @@ public class VMTest {
     @Test  // PUSH10 OP
     public void testPUSH10() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("69A0B0C0D0E0F0A1B1C1D1"), invoke);
         String expected = "00000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1";
 
@@ -194,7 +194,7 @@ public class VMTest {
     @Test  // PUSH11 OP
     public void testPUSH11() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6AA0B0C0D0E0F0A1B1C1D1E1"), invoke);
         String expected = "000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1";
 
@@ -207,7 +207,7 @@ public class VMTest {
     @Test  // PUSH12 OP
     public void testPUSH12() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6BA0B0C0D0E0F0A1B1C1D1E1F1"), invoke);
         String expected = "0000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1";
 
@@ -220,7 +220,7 @@ public class VMTest {
     @Test  // PUSH13 OP
     public void testPUSH13() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6CA0B0C0D0E0F0A1B1C1D1E1F1A2"), invoke);
         String expected = "00000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2";
 
@@ -233,7 +233,7 @@ public class VMTest {
     @Test  // PUSH14 OP
     public void testPUSH14() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6DA0B0C0D0E0F0A1B1C1D1E1F1A2B2"), invoke);
         String expected = "000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2";
 
@@ -246,7 +246,7 @@ public class VMTest {
     @Test  // PUSH15 OP
     public void testPUSH15() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2"), invoke);
         String expected = "0000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2";
 
@@ -259,7 +259,7 @@ public class VMTest {
     @Test  // PUSH16 OP
     public void testPUSH16() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2"), invoke);
         String expected = "00000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2";
 
@@ -272,7 +272,7 @@ public class VMTest {
     @Test  // PUSH17 OP
     public void testPUSH17() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("70A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2"), invoke);
         String expected = "000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2";
 
@@ -285,7 +285,7 @@ public class VMTest {
     @Test  // PUSH18 OP
     public void testPUSH18() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("71A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2"), invoke);
         String expected = "0000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2";
 
@@ -298,7 +298,7 @@ public class VMTest {
     @Test  // PUSH19 OP
     public void testPUSH19() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("72A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3"), invoke);
         String expected = "00000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3";
 
@@ -311,7 +311,7 @@ public class VMTest {
     @Test  // PUSH20 OP
     public void testPUSH20() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("73A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3"), invoke);
         String expected = "000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3";
 
@@ -324,7 +324,7 @@ public class VMTest {
     @Test  // PUSH21 OP
     public void testPUSH21() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("74A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3"), invoke);
         String expected = "0000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3";
 
@@ -337,7 +337,7 @@ public class VMTest {
     @Test  // PUSH22 OP
     public void testPUSH22() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("75A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3"), invoke);
         String expected = "00000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3";
 
@@ -350,7 +350,7 @@ public class VMTest {
     @Test  // PUSH23 OP
     public void testPUSH23() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("76A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3"), invoke);
         String expected = "000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3";
 
@@ -363,7 +363,7 @@ public class VMTest {
     @Test  // PUSH24 OP
     public void testPUSH24() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("77A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3"), invoke);
         String expected = "0000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3";
 
@@ -376,7 +376,7 @@ public class VMTest {
     @Test  // PUSH25 OP
     public void testPUSH25() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("78A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4"), invoke);
         String expected = "00000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4";
 
@@ -389,7 +389,7 @@ public class VMTest {
     @Test  // PUSH26 OP
     public void testPUSH26() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("79A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4"), invoke);
         String expected = "000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4";
 
@@ -402,7 +402,7 @@ public class VMTest {
     @Test  // PUSH27 OP
     public void testPUSH27() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7AA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4"), invoke);
         String expected = "0000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4";
 
@@ -415,7 +415,7 @@ public class VMTest {
     @Test  // PUSH28 OP
     public void testPUSH28() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7BA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4"), invoke);
         String expected = "00000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4";
 
@@ -428,7 +428,7 @@ public class VMTest {
     @Test  // PUSH29 OP
     public void testPUSH29() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7CA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4"), invoke);
         String expected = "000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4";
 
@@ -441,7 +441,7 @@ public class VMTest {
     @Test  // PUSH30 OP
     public void testPUSH30() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7DA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4"), invoke);
         String expected = "0000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4";
 
@@ -454,7 +454,7 @@ public class VMTest {
     @Test  // PUSH31 OP
     public void testPUSH31() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1"), invoke);
         String expected = "00A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1";
 
@@ -467,7 +467,7 @@ public class VMTest {
     @Test  // PUSH32 OP
     public void testPUSH32() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1"), invoke);
         String expected = "A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1";
 
@@ -480,7 +480,7 @@ public class VMTest {
     @Test // PUSHN OP not enough data
     public void testPUSHN_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61AA"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000AA00";
 
@@ -494,7 +494,7 @@ public class VMTest {
     @Test // PUSHN OP not enough data
     public void testPUSHN_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7fAABB"), invoke);
         String expected = "AABB000000000000000000000000000000000000000000000000000000000000";
 
@@ -509,7 +509,7 @@ public class VMTest {
     @Test  // AND OP
     public void testAND_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600A600A16"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000000A";
 
@@ -523,7 +523,7 @@ public class VMTest {
     @Test  // AND OP
     public void testAND_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60C0600A16"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -537,7 +537,7 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // AND OP mal data
     public void testAND_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60C016"), invoke);
         try {
             vm.step(program);
@@ -551,7 +551,7 @@ public class VMTest {
     @Test  // OR OP
     public void testOR_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60F0600F17"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
@@ -565,7 +565,7 @@ public class VMTest {
     @Test  // OR OP
     public void testOR_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60C3603C17"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
@@ -579,7 +579,7 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // OR OP mal data
     public void testOR_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60C017"), invoke);
         try {
             vm.step(program);
@@ -593,7 +593,7 @@ public class VMTest {
     @Test  // XOR OP
     public void testXOR_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60FF60FF18"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -607,7 +607,7 @@ public class VMTest {
     @Test  // XOR OP
     public void testXOR_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600F60F018"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
@@ -622,7 +622,7 @@ public class VMTest {
     @Test(expected = RuntimeException.class)  // XOR OP mal data
     public void testXOR_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60C018"), invoke);
         try {
             vm.step(program);
@@ -636,7 +636,7 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("65AABBCCDDEEFF601E1A"), invoke);
         String expected = "00000000000000000000000000000000000000000000000000000000000000EE";
 
@@ -650,7 +650,7 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("65AABBCCDDEEFF60201A"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -664,7 +664,7 @@ public class VMTest {
     @Test  // BYTE OP
     public void testBYTE_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("65AABBCCDDEE3A601F1A"), invoke);
         String expected = "000000000000000000000000000000000000000000000000000000000000003A";
 
@@ -679,7 +679,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // BYTE OP mal data
     public void testBYTE_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("65AABBCCDDEE3A1A"), invoke);
         try {
             vm.step(program);
@@ -693,7 +693,7 @@ public class VMTest {
     @Test  // ISZERO OP
     public void testISZERO_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600015"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -706,7 +706,7 @@ public class VMTest {
     @Test  // ISZERO OP
     public void testISZERO_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602A15"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -719,7 +719,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // ISZERO OP mal data
     public void testISZERO_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("15"), invoke);
         try {
             vm.step(program);
@@ -733,7 +733,7 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602A602A14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -747,7 +747,7 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("622A3B4C622A3B4C14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -761,7 +761,7 @@ public class VMTest {
     @Test  // EQ OP
     public void testEQ_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("622A3B5C622A3B4C14"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -775,7 +775,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // EQ OP mal data
     public void testEQ_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("622A3B4C14"), invoke);
         try {
             vm.step(program);
@@ -789,7 +789,7 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6001600211"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -803,7 +803,7 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6001610F0011"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -817,7 +817,7 @@ public class VMTest {
     @Test  // GT OP
     public void testGT_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6301020304610F0011"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -831,7 +831,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // GT OP mal data
     public void testGT_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("622A3B4C11"), invoke);
         try {
             vm.step(program);
@@ -845,7 +845,7 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6001600213"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -859,7 +859,7 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "13"), invoke);
@@ -876,7 +876,7 @@ public class VMTest {
     @Test  // SGT OP
     public void testSGT_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
                 "13"), invoke);
@@ -893,7 +893,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SGT OP mal
     public void testSGT_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "13"), invoke);
         try {
@@ -908,7 +908,7 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6001600210"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -922,7 +922,7 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6001610F0010"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -936,7 +936,7 @@ public class VMTest {
     @Test  // LT OP
     public void testLT_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6301020304610F0010"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -950,7 +950,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // LT OP mal data
     public void testLT_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("622A3B4C10"), invoke);
         try {
             vm.step(program);
@@ -964,7 +964,7 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6001600212"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -978,7 +978,7 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "12"), invoke);
@@ -995,7 +995,7 @@ public class VMTest {
     @Test  // SLT OP
     public void testSLT_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
                 "12"), invoke);
@@ -1012,7 +1012,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SLT OP mal
     public void testSLT_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "12"), invoke);
         try {
@@ -1027,7 +1027,7 @@ public class VMTest {
     @Test  // NOT OP
     public void testNOT_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600119"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE";
 
@@ -1040,7 +1040,7 @@ public class VMTest {
     @Test  // NOT OP
     public void testNOT_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61A00319"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5FFC";
 
@@ -1054,7 +1054,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // BNOT OP
     public void testBNOT_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("1a"), invoke);
         try {
             vm.step(program);
@@ -1067,7 +1067,7 @@ public class VMTest {
     @Test  // NOT OP test from real failure
     public void testNOT_5() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600019"), invoke);
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
@@ -1081,7 +1081,7 @@ public class VMTest {
     @Test // POP OP
     public void testPOP_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61000060016200000250"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -1096,7 +1096,7 @@ public class VMTest {
     @Test // POP OP
     public void testPOP_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6100006001620000025050"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1112,7 +1112,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // POP OP mal data
     public void testPOP_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61000060016200000250505050"), invoke);
         try {
             vm.step(program);
@@ -1141,7 +1141,7 @@ public class VMTest {
      */
     private void testDUPN_1(int n) {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         byte operation = (byte) (OpCode.DUP1.val() + n - 1);
         String programCode = "";
         for (int i = 0; i < n; i++) {
@@ -1166,7 +1166,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // DUPN OP mal data
     public void testDUPN_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("80"), invoke);
         try {
             vm.step(program);
@@ -1189,7 +1189,7 @@ public class VMTest {
      */
     private void testSWAPN_1(int n) {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         byte operation = (byte) (OpCode.SWAP1.val() + n - 1);
 
         String programCode = "";
@@ -1214,7 +1214,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class)  // SWAPN OP mal data
     public void testSWAPN_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("90"), invoke);
 
         try {
@@ -1227,7 +1227,7 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("611234600052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000001234";
 
@@ -1242,7 +1242,7 @@ public class VMTest {
     @Test // LOG0 OP
     public void tesLog0() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123460005260206000A0"), invoke);
 
         vm.step(program);
@@ -1264,7 +1264,7 @@ public class VMTest {
     @Test // LOG1 OP
     public void tesLog1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123460005261999960206000A1"), invoke);
 
         vm.step(program);
@@ -1287,7 +1287,7 @@ public class VMTest {
     @Test // LOG2 OP
     public void tesLog2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123460005261999961666660206000A2"), invoke);
 
         vm.step(program);
@@ -1311,7 +1311,7 @@ public class VMTest {
     @Test // LOG3 OP
     public void tesLog3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123460005261999961666661333360206000A3"), invoke);
 
         vm.step(program);
@@ -1337,7 +1337,7 @@ public class VMTest {
     @Test // LOG4 OP
     public void tesLog4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123460005261999961666661333361555560206000A4"), invoke);
 
         vm.step(program);
@@ -1364,7 +1364,7 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("611234600052615566602052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000001234" +
                 "0000000000000000000000000000000000000000000000000000000000005566";
@@ -1382,7 +1382,7 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("611234600052615566602052618888600052"), invoke);
         String expected = "0000000000000000000000000000000000000000000000000000000000008888" +
                 "0000000000000000000000000000000000000000000000000000000000005566";
@@ -1403,7 +1403,7 @@ public class VMTest {
     @Test // MSTORE OP
     public void testMSTORE_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123460A052"), invoke);
         String expected = "" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
@@ -1423,7 +1423,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MSTORE OP
     public void testMSTORE_5() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123452"), invoke);
         try {
             vm.step(program);
@@ -1436,7 +1436,7 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1451,7 +1451,7 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602251"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
@@ -1469,7 +1469,7 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1485,7 +1485,7 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("611234602052602051"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
@@ -1504,7 +1504,7 @@ public class VMTest {
     @Test // MLOAD OP
     public void testMLOAD_5() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("611234602052601F51"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
@@ -1524,7 +1524,7 @@ public class VMTest {
     @Test
     public void testVersioning_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode(
                 "FC010100" // this is the header
                 + "611234602052601F51"), invoke);
@@ -1547,7 +1547,7 @@ public class VMTest {
     @Test
     public void testVersioning_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         //
         byte[] header = Hex.decode("FC810180"); // test negative exeVersion also, 0x80 byte to skip
 
@@ -1588,7 +1588,7 @@ public class VMTest {
     @Test(expected = Program.IllegalOperationException.class)
     public void testInvalidOpcodes_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("A5"), invoke);
 
         vm.step(program);
@@ -1598,7 +1598,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MLOAD OP mal data
     public void testMLOAD_6() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("51"), invoke);
         try {
             vm.step(program);
@@ -1610,7 +1610,7 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6011600053"), invoke);
         String m_expected = "1100000000000000000000000000000000000000000000000000000000000000";
 
@@ -1625,7 +1625,7 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6022600153"), invoke);
         String m_expected = "0022000000000000000000000000000000000000000000000000000000000000";
 
@@ -1639,7 +1639,7 @@ public class VMTest {
     @Test // MSTORE8 OP
     public void testMSTORE8_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6022602153"), invoke);
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0022000000000000000000000000000000000000000000000000000000000000";
@@ -1654,7 +1654,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MSTORE8 OP mal
     public void testMSTORE8_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602253"), invoke);
         try {
             vm.step(program);
@@ -1667,7 +1667,7 @@ public class VMTest {
     @Test // SSTORE OP
     public void testSSTORE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
 
         program = new Program(config, Hex.decode("602260AA55"), invoke);
         String s_expected_key = "00000000000000000000000000000000000000000000000000000000000000AA";
@@ -1686,7 +1686,7 @@ public class VMTest {
     @Test // SSTORE OP
     public void testSSTORE_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
 
         program = new Program(config, Hex.decode("602260AA55602260BB55"), invoke);
         String s_expected_key = "00000000000000000000000000000000000000000000000000000000000000BB";
@@ -1709,7 +1709,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SSTORE OP
     public void testSSTORE_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602255"), invoke);
         try {
             vm.step(program);
@@ -1722,7 +1722,7 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60AA54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1735,7 +1735,7 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602260AA5560AA54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000022";
 
@@ -1751,7 +1751,7 @@ public class VMTest {
     @Test // SLOAD OP
     public void testSLOAD_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602260AA55603360CC5560CC54"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000033";
 
@@ -1770,7 +1770,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SLOAD OP
     public void testSLOAD_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("56"), invoke);
         try {
             vm.step(program);
@@ -1782,7 +1782,7 @@ public class VMTest {
     @Test // PC OP
     public void testPC_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("58"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1795,7 +1795,7 @@ public class VMTest {
     @Test // PC OP
     public void testPC_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602260AA5260AA5458"), invoke);
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000008";
 
@@ -1812,7 +1812,7 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMP_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60AA60BB600E5660CC60DD60EE5B60FF"), invoke);
         String s_expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
@@ -1828,7 +1828,7 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMP_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600C600C905660CC60DD60EE60FF"), invoke);
         try {
             vm.step(program);
@@ -1844,7 +1844,7 @@ public class VMTest {
     @Test // JUMPI OP
     public void testJUMPI_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60016005575B60CC"), invoke);
         String s_expected = "00000000000000000000000000000000000000000000000000000000000000CC";
 
@@ -1861,7 +1861,7 @@ public class VMTest {
     @Test // JUMPI OP
     public void testJUMPI_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("630000000060445760CC60DD"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000DD";
         String s_expected_2 = "00000000000000000000000000000000000000000000000000000000000000CC";
@@ -1882,7 +1882,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // JUMPI OP mal
     public void testJUMPI_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600157"), invoke);
         try {
             vm.step(program);
@@ -1895,7 +1895,7 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMPI OP mal
     public void testJUMPI_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60016022909057"), invoke);
         try {
             vm.step(program);
@@ -1911,7 +1911,7 @@ public class VMTest {
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
     public void testJUMPDEST_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602360085660015b600255"), invoke);
 
         String s_expected_key = "0000000000000000000000000000000000000000000000000000000000000002";
@@ -1933,7 +1933,7 @@ public class VMTest {
     @Test // JUMPDEST OP for JUMPI
     public void testJUMPDEST_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6023600160095760015b600255"), invoke);
 
         String s_expected_key = "0000000000000000000000000000000000000000000000000000000000000002";
@@ -1957,7 +1957,7 @@ public class VMTest {
     @Test // ADD OP mal
     public void testADD_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6002600201"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
@@ -1972,7 +1972,7 @@ public class VMTest {
     @Test // ADD OP
     public void testADD_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("611002600201"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000001004";
 
@@ -1987,7 +1987,7 @@ public class VMTest {
     @Test // ADD OP
     public void testADD_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6110026512345678900901"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000012345678A00B";
 
@@ -2002,7 +2002,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // ADD OP mal
     public void testADD_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123401"), invoke);
         try {
             vm.step(program);
@@ -2014,7 +2014,7 @@ public class VMTest {
 
     @Test // ADDMOD OP mal
     public void testADDMOD_1() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60026002600308"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -2030,7 +2030,7 @@ public class VMTest {
 
     @Test // ADDMOD OP
     public void testADDMOD_2() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6110006002611002086000"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
@@ -2046,7 +2046,7 @@ public class VMTest {
 
     @Test // ADDMOD OP
     public void testADDMOD_3() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61100265123456789009600208"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000000000093B";
 
@@ -2062,7 +2062,7 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // ADDMOD OP mal
     public void testADDMOD_4() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123408"), invoke);
         try {
             vm.step(program);
@@ -2075,7 +2075,7 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6003600202"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000006";
 
@@ -2090,7 +2090,7 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("62222222600302"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000666666";
 
@@ -2105,7 +2105,7 @@ public class VMTest {
     @Test // MUL OP
     public void testMUL_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("622222226233333302"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000006D3A05F92C6";
 
@@ -2120,7 +2120,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MUL OP mal
     public void testMUL_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600102"), invoke);
         try {
             vm.step(program);
@@ -2132,7 +2132,7 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_1() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60036002600409"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
@@ -2147,7 +2147,7 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_2() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("622222226003600409"), invoke);
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000000000000C";
 
@@ -2162,7 +2162,7 @@ public class VMTest {
 
     @Test // MULMOD OP
     public void testMULMOD_3() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("62222222623333336244444409"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -2177,7 +2177,7 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // MULMOD OP mal
     public void testMULMOD_4() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600109"), invoke);
         try {
             vm.step(program);
@@ -2190,7 +2190,7 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6002600404"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
@@ -2205,7 +2205,7 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6033609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000003";
 
@@ -2221,7 +2221,7 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6022609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
@@ -2236,7 +2236,7 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6015609904"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000007";
 
@@ -2252,7 +2252,7 @@ public class VMTest {
     @Test // DIV OP
     public void testDIV_5() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6004600704"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -2267,7 +2267,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // DIV OP
     public void testDIV_6() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600704"), invoke);
         try {
             vm.step(program);
@@ -2280,7 +2280,7 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6103E87FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC1805" +
                 ""), invoke);
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
@@ -2296,7 +2296,7 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60FF60FF05"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -2311,7 +2311,7 @@ public class VMTest {
     @Test // SDIV OP
     public void testSDIV_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600060FF05"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -2326,7 +2326,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SDIV OP mal
     public void testSDIV_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60FF05"), invoke);
 
         try {
@@ -2340,7 +2340,7 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6004600603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
@@ -2355,7 +2355,7 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61444461666603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000002222";
 
@@ -2370,7 +2370,7 @@ public class VMTest {
     @Test // SUB OP
     public void testSUB_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("614444639999666603"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000099992222";
 
@@ -2385,7 +2385,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SUB OP mal
     public void testSUB_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("639999666603"), invoke);
         try {
             vm.step(program);
@@ -2398,7 +2398,7 @@ public class VMTest {
     @Test // MSIZE OP
     public void testMSIZE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("59"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -2411,7 +2411,7 @@ public class VMTest {
     @Test // MSIZE OP
     public void testMSIZE_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("602060305259"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000060";
 
@@ -2428,7 +2428,7 @@ public class VMTest {
     @Test // STOP OP
     public void testSTOP_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("60206030601060306011602300"), invoke);
         int expectedSteps = 7;
 
@@ -2444,7 +2444,7 @@ public class VMTest {
     @Test
     public void testEXP_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600360020a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000008";
 
@@ -2462,7 +2462,7 @@ public class VMTest {
     @Test
     public void testEXP_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6000621234560a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -2480,7 +2480,7 @@ public class VMTest {
     @Test
     public void testEXP_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61112260010a"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -2499,7 +2499,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // EXP OP mal
     public void testEXP_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("621234560a"), invoke);
         try {
             vm.step(program);
@@ -2512,7 +2512,7 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61123460005260206000F3"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000001234";
 
@@ -2531,7 +2531,7 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6112346000526020601FF3"), invoke);
         String s_expected_1 = "3400000000000000000000000000000000000000000000000000000000000000";
 
@@ -2549,7 +2549,7 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_3() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206000F3"),
@@ -2571,7 +2571,7 @@ public class VMTest {
     @Test // RETURN OP
     public void testRETURN_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206010F3"),
@@ -2593,7 +2593,7 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("60036007600039123456"), invoke);
         String m_expected_1 = "1234560000000000000000000000000000000000000000000000000000000000";
@@ -2612,7 +2612,7 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054"),
@@ -2638,7 +2638,7 @@ public class VMTest {
         // 94 - data copied
         // 95 - new bytes allocated
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
@@ -2656,7 +2656,7 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
@@ -2674,7 +2674,7 @@ public class VMTest {
     @Test // CODECOPY OP
     public void testCODECOPY_5() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("611234600054615566602054607060006020396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
@@ -2698,7 +2698,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // CODECOPY OP mal
     public void testCODECOPY_6() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("605E6007396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
@@ -2715,7 +2715,7 @@ public class VMTest {
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("60036007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C123456"), invoke);
         String m_expected_1 = "6000600000000000000000000000000000000000000000000000000000000000";
@@ -2732,7 +2732,7 @@ public class VMTest {
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_2() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("603E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054"),
@@ -2751,7 +2751,7 @@ public class VMTest {
 
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_3() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("605E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
@@ -2771,7 +2771,7 @@ public class VMTest {
 
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_4() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("611234600054615566602054603E6000602073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
@@ -2795,7 +2795,7 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // EXTCODECOPY OP mal
     public void testEXTCODECOPY_5() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode("605E600773471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C"),
                         invoke);
@@ -2813,7 +2813,7 @@ public class VMTest {
     @Test // CODESIZE OP
     public void testCODESIZE_1() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("385E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
@@ -2829,7 +2829,7 @@ public class VMTest {
     @Ignore // todo: test is not testing EXTCODESIZE
     @Test // EXTCODESIZE OP
     public void testEXTCODESIZE_1() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program =
                 new Program(config, Hex.decode
                         ("73471FD3AD3E9EEADEEC4608B92D16CE6B500704CC395E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
@@ -2844,7 +2844,7 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_1() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6003600406"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -2858,7 +2858,7 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_2() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("61012C6101F406"), invoke);
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000C8";
 
@@ -2872,7 +2872,7 @@ public class VMTest {
 
     @Test // MOD OP
     public void testMOD_3() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6004600206"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
@@ -2887,7 +2887,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MOD OP mal
     public void testMOD_4() {
 
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("600406"), invoke);
 
         try {
@@ -2901,7 +2901,7 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_1() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("6003600407"), invoke);
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -2915,7 +2915,7 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_2() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE2" + //  -30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "07"), invoke);
@@ -2931,7 +2931,7 @@ public class VMTest {
 
     @Test // SMOD OP
     public void testSMOD_3() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
                 "07"), invoke);
@@ -2947,7 +2947,7 @@ public class VMTest {
 
     @Test(expected = StackTooSmallException.class) // SMOD OP mal
     public void testSMOD_4() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
                 "07"), invoke);
         try {
@@ -2993,7 +2993,7 @@ public class VMTest {
     // header must be 4 bytes or more to be valid
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion0() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode("FC"), invoke);
         try {
             vm.step(program);
@@ -3006,7 +3006,7 @@ public class VMTest {
     // Should produce invalidop exception
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion1() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode(
                 "FC000000" + //header
                 "FC" // invalid opcode
@@ -3023,7 +3023,7 @@ public class VMTest {
 
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion2() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode(
                 "FC010100" + //header
                         "FC" // invalid code
@@ -3040,7 +3040,7 @@ public class VMTest {
     // This is a long header with additional data that is skipped
     @Test
     public void testScriptVersion3() {
-        VM vm = new VM(config);
+        VM vm = getSubject();
         program = new Program(config, Hex.decode(
                 "FC01010A" + //header with 10 additional bytes
                         "0102030405060708090A" + // additional header bytes
@@ -3060,7 +3060,7 @@ public class VMTest {
     public void testCodereplace_0() {
 
         // CODEREPLACE is invalid if scriptVersion is zero
-        VM vm = new VM(config);
+        VM vm = getSubject();
         String asm ="256 0x00FF CODEREPLACE";
         EVMAssembler assembler = new EVMAssembler();
         byte[] code = assembler.assemble(asm);
@@ -3073,7 +3073,7 @@ public class VMTest {
     public void testCodereplace_1() {
 
         // CODEREPLACE is invalid if scriptVersion is zero
-        VM vm = new VM(config);
+        VM vm = getSubject();
         String asm ="0xFC 0x00 0x01 0x00 "+ // opHEADER, exevesion scriptversion extheaderlenth
                 "0x00 "+ // address
                 "0x01 "+ // value
@@ -3093,6 +3093,10 @@ public class VMTest {
         vm.step(program);  // push
         vm.step(program);  // push
         vm.step(program);  // CODEREPLACE
+    }
+
+    private VM getSubject() {
+        return new VM(config.getVmConfig(), new PrecompiledContracts(config));
     }
 }
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -21,6 +21,7 @@ package org.ethereum.vm;
 
 import co.rsk.asm.EVMAssembler;
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.Repository;
 import org.ethereum.util.ByteUtil;
@@ -49,6 +50,8 @@ public class VMTest {
     private ProgramInvokeMockImpl invoke;
     private Program program;
     private final RskSystemProperties config = new RskSystemProperties();
+    private final VmConfig vmConfig = config.getVmConfig();
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 
     @Before
     public void setup() {
@@ -64,7 +67,7 @@ public class VMTest {
     public void testPUSH1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60A0"), invoke);
+        program = getProgram("60A0");
         String expected = "00000000000000000000000000000000000000000000000000000000000000A0";
 
         program.fullTrace();
@@ -77,7 +80,7 @@ public class VMTest {
     public void testPUSH2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61A0B0"), invoke);
+        program = getProgram("61A0B0");
         String expected = "000000000000000000000000000000000000000000000000000000000000A0B0";
 
         program.fullTrace();
@@ -90,7 +93,7 @@ public class VMTest {
     public void testPUSH3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("62A0B0C0"), invoke);
+        program = getProgram("62A0B0C0");
         String expected = "0000000000000000000000000000000000000000000000000000000000A0B0C0";
 
         program.fullTrace();
@@ -103,7 +106,7 @@ public class VMTest {
     public void testPUSH4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("63A0B0C0D0"), invoke);
+        program = getProgram("63A0B0C0D0");
         String expected = "00000000000000000000000000000000000000000000000000000000A0B0C0D0";
 
         program.fullTrace();
@@ -116,7 +119,7 @@ public class VMTest {
     public void testPUSH5() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("64A0B0C0D0E0"), invoke);
+        program = getProgram("64A0B0C0D0E0");
         String expected = "000000000000000000000000000000000000000000000000000000A0B0C0D0E0";
 
         program.fullTrace();
@@ -129,7 +132,7 @@ public class VMTest {
     public void testPUSH6() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("65A0B0C0D0E0F0"), invoke);
+        program = getProgram("65A0B0C0D0E0F0");
         String expected = "0000000000000000000000000000000000000000000000000000A0B0C0D0E0F0";
 
         program.fullTrace();
@@ -142,7 +145,7 @@ public class VMTest {
     public void testPUSH7() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("66A0B0C0D0E0F0A1"), invoke);
+        program = getProgram("66A0B0C0D0E0F0A1");
         String expected = "00000000000000000000000000000000000000000000000000A0B0C0D0E0F0A1";
 
         program.fullTrace();
@@ -155,7 +158,7 @@ public class VMTest {
     public void testPUSH8() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("67A0B0C0D0E0F0A1B1"), invoke);
+        program = getProgram("67A0B0C0D0E0F0A1B1");
         String expected = "000000000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1";
 
         program.fullTrace();
@@ -168,7 +171,7 @@ public class VMTest {
     public void testPUSH9() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("68A0B0C0D0E0F0A1B1C1"), invoke);
+        program = getProgram("68A0B0C0D0E0F0A1B1C1");
         String expected = "0000000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1";
 
         program.fullTrace();
@@ -182,7 +185,7 @@ public class VMTest {
     public void testPUSH10() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("69A0B0C0D0E0F0A1B1C1D1"), invoke);
+        program = getProgram("69A0B0C0D0E0F0A1B1C1D1");
         String expected = "00000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1";
 
         program.fullTrace();
@@ -195,7 +198,7 @@ public class VMTest {
     public void testPUSH11() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6AA0B0C0D0E0F0A1B1C1D1E1"), invoke);
+        program = getProgram("6AA0B0C0D0E0F0A1B1C1D1E1");
         String expected = "000000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1";
 
         program.fullTrace();
@@ -208,7 +211,7 @@ public class VMTest {
     public void testPUSH12() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6BA0B0C0D0E0F0A1B1C1D1E1F1"), invoke);
+        program = getProgram("6BA0B0C0D0E0F0A1B1C1D1E1F1");
         String expected = "0000000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1";
 
         program.fullTrace();
@@ -221,7 +224,7 @@ public class VMTest {
     public void testPUSH13() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6CA0B0C0D0E0F0A1B1C1D1E1F1A2"), invoke);
+        program = getProgram("6CA0B0C0D0E0F0A1B1C1D1E1F1A2");
         String expected = "00000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2";
 
         program.fullTrace();
@@ -234,7 +237,7 @@ public class VMTest {
     public void testPUSH14() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6DA0B0C0D0E0F0A1B1C1D1E1F1A2B2"), invoke);
+        program = getProgram("6DA0B0C0D0E0F0A1B1C1D1E1F1A2B2");
         String expected = "000000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2";
 
         program.fullTrace();
@@ -247,7 +250,7 @@ public class VMTest {
     public void testPUSH15() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2"), invoke);
+        program = getProgram("6EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2");
         String expected = "0000000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2";
 
         program.fullTrace();
@@ -260,7 +263,7 @@ public class VMTest {
     public void testPUSH16() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2"), invoke);
+        program = getProgram("6FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2");
         String expected = "00000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2";
 
         program.fullTrace();
@@ -273,7 +276,7 @@ public class VMTest {
     public void testPUSH17() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("70A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2"), invoke);
+        program = getProgram("70A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2");
         String expected = "000000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2";
 
         program.fullTrace();
@@ -286,7 +289,7 @@ public class VMTest {
     public void testPUSH18() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("71A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2"), invoke);
+        program = getProgram("71A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2");
         String expected = "0000000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2";
 
         program.fullTrace();
@@ -299,7 +302,7 @@ public class VMTest {
     public void testPUSH19() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("72A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3"), invoke);
+        program = getProgram("72A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3");
         String expected = "00000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3";
 
         program.fullTrace();
@@ -312,7 +315,7 @@ public class VMTest {
     public void testPUSH20() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("73A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3"), invoke);
+        program = getProgram("73A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3");
         String expected = "000000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3";
 
         program.fullTrace();
@@ -325,7 +328,7 @@ public class VMTest {
     public void testPUSH21() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("74A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3"), invoke);
+        program = getProgram("74A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3");
         String expected = "0000000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3";
 
         program.fullTrace();
@@ -338,7 +341,7 @@ public class VMTest {
     public void testPUSH22() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("75A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3"), invoke);
+        program = getProgram("75A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3");
         String expected = "00000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3";
 
         program.fullTrace();
@@ -351,7 +354,7 @@ public class VMTest {
     public void testPUSH23() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("76A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3"), invoke);
+        program = getProgram("76A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3");
         String expected = "000000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3";
 
         program.fullTrace();
@@ -364,7 +367,7 @@ public class VMTest {
     public void testPUSH24() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("77A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3"), invoke);
+        program = getProgram("77A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3");
         String expected = "0000000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3";
 
         program.fullTrace();
@@ -377,7 +380,7 @@ public class VMTest {
     public void testPUSH25() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("78A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4"), invoke);
+        program = getProgram("78A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4");
         String expected = "00000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4";
 
         program.fullTrace();
@@ -390,7 +393,7 @@ public class VMTest {
     public void testPUSH26() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("79A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4"), invoke);
+        program = getProgram("79A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4");
         String expected = "000000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4";
 
         program.fullTrace();
@@ -403,7 +406,7 @@ public class VMTest {
     public void testPUSH27() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7AA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4"), invoke);
+        program = getProgram("7AA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4");
         String expected = "0000000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4";
 
         program.fullTrace();
@@ -416,7 +419,7 @@ public class VMTest {
     public void testPUSH28() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7BA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4"), invoke);
+        program = getProgram("7BA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4");
         String expected = "00000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4";
 
         program.fullTrace();
@@ -429,7 +432,7 @@ public class VMTest {
     public void testPUSH29() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7CA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4"), invoke);
+        program = getProgram("7CA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4");
         String expected = "000000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4";
 
         program.fullTrace();
@@ -442,7 +445,7 @@ public class VMTest {
     public void testPUSH30() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7DA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4"), invoke);
+        program = getProgram("7DA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4");
         String expected = "0000A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4";
 
         program.fullTrace();
@@ -455,7 +458,7 @@ public class VMTest {
     public void testPUSH31() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1"), invoke);
+        program = getProgram("7EA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1");
         String expected = "00A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1";
 
         program.fullTrace();
@@ -468,7 +471,7 @@ public class VMTest {
     public void testPUSH32() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1"), invoke);
+        program = getProgram("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1");
         String expected = "A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1";
 
         program.fullTrace();
@@ -481,7 +484,7 @@ public class VMTest {
     public void testPUSHN_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61AA"), invoke);
+        program = getProgram("61AA");
         String expected = "000000000000000000000000000000000000000000000000000000000000AA00";
 
         program.fullTrace();
@@ -495,7 +498,7 @@ public class VMTest {
     public void testPUSHN_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7fAABB"), invoke);
+        program = getProgram("7fAABB");
         String expected = "AABB000000000000000000000000000000000000000000000000000000000000";
 
         program.fullTrace();
@@ -510,7 +513,7 @@ public class VMTest {
     public void testAND_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600A600A16"), invoke);
+        program = getProgram("600A600A16");
         String expected = "000000000000000000000000000000000000000000000000000000000000000A";
 
         vm.step(program);
@@ -524,7 +527,7 @@ public class VMTest {
     public void testAND_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60C0600A16"), invoke);
+        program = getProgram("60C0600A16");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -538,7 +541,7 @@ public class VMTest {
     public void testAND_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60C016"), invoke);
+        program = getProgram("60C016");
         try {
             vm.step(program);
             vm.step(program);
@@ -552,7 +555,7 @@ public class VMTest {
     public void testOR_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60F0600F17"), invoke);
+        program = getProgram("60F0600F17");
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -566,7 +569,7 @@ public class VMTest {
     public void testOR_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60C3603C17"), invoke);
+        program = getProgram("60C3603C17");
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -580,7 +583,7 @@ public class VMTest {
     public void testOR_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60C017"), invoke);
+        program = getProgram("60C017");
         try {
             vm.step(program);
             vm.step(program);
@@ -594,7 +597,7 @@ public class VMTest {
     public void testXOR_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60FF60FF18"), invoke);
+        program = getProgram("60FF60FF18");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -608,7 +611,7 @@ public class VMTest {
     public void testXOR_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600F60F018"), invoke);
+        program = getProgram("600F60F018");
         String expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -623,7 +626,7 @@ public class VMTest {
     public void testXOR_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60C018"), invoke);
+        program = getProgram("60C018");
         try {
             vm.step(program);
             vm.step(program);
@@ -637,7 +640,7 @@ public class VMTest {
     public void testBYTE_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("65AABBCCDDEEFF601E1A"), invoke);
+        program = getProgram("65AABBCCDDEEFF601E1A");
         String expected = "00000000000000000000000000000000000000000000000000000000000000EE";
 
         vm.step(program);
@@ -651,7 +654,7 @@ public class VMTest {
     public void testBYTE_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("65AABBCCDDEEFF60201A"), invoke);
+        program = getProgram("65AABBCCDDEEFF60201A");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -665,7 +668,7 @@ public class VMTest {
     public void testBYTE_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("65AABBCCDDEE3A601F1A"), invoke);
+        program = getProgram("65AABBCCDDEE3A601F1A");
         String expected = "000000000000000000000000000000000000000000000000000000000000003A";
 
         vm.step(program);
@@ -680,7 +683,7 @@ public class VMTest {
     public void testBYTE_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("65AABBCCDDEE3A1A"), invoke);
+        program = getProgram("65AABBCCDDEE3A1A");
         try {
             vm.step(program);
             vm.step(program);
@@ -694,7 +697,7 @@ public class VMTest {
     public void testISZERO_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600015"), invoke);
+        program = getProgram("600015");
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -707,7 +710,7 @@ public class VMTest {
     public void testISZERO_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602A15"), invoke);
+        program = getProgram("602A15");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -720,7 +723,7 @@ public class VMTest {
     public void testISZERO_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("15"), invoke);
+        program = getProgram("15");
         try {
             vm.step(program);
             vm.step(program);
@@ -734,7 +737,7 @@ public class VMTest {
     public void testEQ_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602A602A14"), invoke);
+        program = getProgram("602A602A14");
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -748,7 +751,7 @@ public class VMTest {
     public void testEQ_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("622A3B4C622A3B4C14"), invoke);
+        program = getProgram("622A3B4C622A3B4C14");
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -762,7 +765,7 @@ public class VMTest {
     public void testEQ_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("622A3B5C622A3B4C14"), invoke);
+        program = getProgram("622A3B5C622A3B4C14");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -776,7 +779,7 @@ public class VMTest {
     public void testEQ_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("622A3B4C14"), invoke);
+        program = getProgram("622A3B4C14");
         try {
             vm.step(program);
             vm.step(program);
@@ -790,7 +793,7 @@ public class VMTest {
     public void testGT_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6001600211"), invoke);
+        program = getProgram("6001600211");
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -804,7 +807,7 @@ public class VMTest {
     public void testGT_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6001610F0011"), invoke);
+        program = getProgram("6001610F0011");
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -818,7 +821,7 @@ public class VMTest {
     public void testGT_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6301020304610F0011"), invoke);
+        program = getProgram("6301020304610F0011");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -832,7 +835,7 @@ public class VMTest {
     public void testGT_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("622A3B4C11"), invoke);
+        program = getProgram("622A3B4C11");
         try {
             vm.step(program);
             vm.step(program);
@@ -846,7 +849,7 @@ public class VMTest {
     public void testSGT_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6001600213"), invoke);
+        program = getProgram("6001600213");
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -860,9 +863,9 @@ public class VMTest {
     public void testSGT_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
-                "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
-                "13"), invoke);
+        program = getProgram("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+                        "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+                        "13");
 
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -877,9 +880,9 @@ public class VMTest {
     public void testSGT_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
-                "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
-                "13"), invoke);
+        program = getProgram("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+                        "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
+                        "13");
 
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -894,8 +897,8 @@ public class VMTest {
     public void testSGT_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
-                "13"), invoke);
+        program = getProgram("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+                        "13");
         try {
             vm.step(program);
             vm.step(program);
@@ -909,7 +912,7 @@ public class VMTest {
     public void testLT_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6001600210"), invoke);
+        program = getProgram("6001600210");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -923,7 +926,7 @@ public class VMTest {
     public void testLT_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6001610F0010"), invoke);
+        program = getProgram("6001610F0010");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -937,7 +940,7 @@ public class VMTest {
     public void testLT_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6301020304610F0010"), invoke);
+        program = getProgram("6301020304610F0010");
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -951,7 +954,7 @@ public class VMTest {
     public void testLT_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("622A3B4C10"), invoke);
+        program = getProgram("622A3B4C10");
         try {
             vm.step(program);
             vm.step(program);
@@ -965,7 +968,7 @@ public class VMTest {
     public void testSLT_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6001600212"), invoke);
+        program = getProgram("6001600212");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -979,9 +982,9 @@ public class VMTest {
     public void testSLT_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
-                "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
-                "12"), invoke);
+        program = getProgram("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+                        "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+                        "12");
 
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -996,9 +999,9 @@ public class VMTest {
     public void testSLT_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
-                "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
-                "12"), invoke);
+        program = getProgram("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+                        "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF57" + // -169
+                        "12");
 
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1013,8 +1016,8 @@ public class VMTest {
     public void testSLT_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
-                "12"), invoke);
+        program = getProgram("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+                        "12");
         try {
             vm.step(program);
             vm.step(program);
@@ -1028,7 +1031,7 @@ public class VMTest {
     public void testNOT_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600119"), invoke);
+        program = getProgram("600119");
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE";
 
         vm.step(program);
@@ -1041,7 +1044,7 @@ public class VMTest {
     public void testNOT_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61A00319"), invoke);
+        program = getProgram("61A00319");
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5FFC";
 
         vm.step(program);
@@ -1055,7 +1058,7 @@ public class VMTest {
     public void testBNOT_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("1a"), invoke);
+        program = getProgram("1a");
         try {
             vm.step(program);
             vm.step(program);
@@ -1068,7 +1071,7 @@ public class VMTest {
     public void testNOT_5() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600019"), invoke);
+        program = getProgram("600019");
         String expected = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
         vm.step(program);
@@ -1082,7 +1085,7 @@ public class VMTest {
     public void testPOP_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61000060016200000250"), invoke);
+        program = getProgram("61000060016200000250");
         String expected = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -1097,7 +1100,7 @@ public class VMTest {
     public void testPOP_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6100006001620000025050"), invoke);
+        program = getProgram("6100006001620000025050");
         String expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1113,7 +1116,7 @@ public class VMTest {
     public void testPOP_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61000060016200000250505050"), invoke);
+        program = getProgram("61000060016200000250505050");
         try {
             vm.step(program);
             vm.step(program);
@@ -1147,7 +1150,7 @@ public class VMTest {
         for (int i = 0; i < n; i++) {
             programCode += "60" + (12 + i);
         }
-        program = new Program(config, ByteUtil.appendByte(Hex.decode(programCode.getBytes()), operation), invoke);
+        program = getProgram(ByteUtil.appendByte(Hex.decode(programCode.getBytes()), operation));
         String expected = "0000000000000000000000000000000000000000000000000000000000000012";
         int expectedLen = n + 1;
 
@@ -1167,7 +1170,7 @@ public class VMTest {
     public void testDUPN_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("80"), invoke);
+        program = getProgram("80");
         try {
             vm.step(program);
         } finally {
@@ -1201,7 +1204,7 @@ public class VMTest {
 
         programCode += Hex.toHexString(new byte[]{   (byte)(OpCode.SWAP1.val() + n - 1)   });
 
-        program = new Program(config, ByteUtil.appendByte(Hex.decode(programCode), operation), invoke);
+        program = getProgram(ByteUtil.appendByte(Hex.decode(programCode), operation));
 
         for (int i = 0; i < n + 2; ++i) {
             vm.step(program);
@@ -1215,7 +1218,7 @@ public class VMTest {
     public void testSWAPN_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("90"), invoke);
+        program = getProgram("90");
 
         try {
             vm.step(program);
@@ -1228,7 +1231,7 @@ public class VMTest {
     public void testMSTORE_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("611234600052"), invoke);
+        program = getProgram("611234600052");
         String expected = "0000000000000000000000000000000000000000000000000000000000001234";
 
         vm.step(program);
@@ -1243,7 +1246,7 @@ public class VMTest {
     public void tesLog0() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123460005260206000A0"), invoke);
+        program = getProgram("61123460005260206000A0");
 
         vm.step(program);
         vm.step(program);
@@ -1265,7 +1268,7 @@ public class VMTest {
     public void tesLog1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123460005261999960206000A1"), invoke);
+        program = getProgram("61123460005261999960206000A1");
 
         vm.step(program);
         vm.step(program);
@@ -1288,7 +1291,7 @@ public class VMTest {
     public void tesLog2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123460005261999961666660206000A2"), invoke);
+        program = getProgram("61123460005261999961666660206000A2");
 
         vm.step(program);
         vm.step(program);
@@ -1312,7 +1315,7 @@ public class VMTest {
     public void tesLog3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123460005261999961666661333360206000A3"), invoke);
+        program = getProgram("61123460005261999961666661333360206000A3");
 
         vm.step(program);
         vm.step(program);
@@ -1338,7 +1341,7 @@ public class VMTest {
     public void tesLog4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123460005261999961666661333361555560206000A4"), invoke);
+        program = getProgram("61123460005261999961666661333361555560206000A4");
 
         vm.step(program);
         vm.step(program);
@@ -1365,7 +1368,7 @@ public class VMTest {
     public void testMSTORE_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("611234600052615566602052"), invoke);
+        program = getProgram("611234600052615566602052");
         String expected = "0000000000000000000000000000000000000000000000000000000000001234" +
                 "0000000000000000000000000000000000000000000000000000000000005566";
 
@@ -1383,7 +1386,7 @@ public class VMTest {
     public void testMSTORE_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("611234600052615566602052618888600052"), invoke);
+        program = getProgram("611234600052615566602052618888600052");
         String expected = "0000000000000000000000000000000000000000000000000000000000008888" +
                 "0000000000000000000000000000000000000000000000000000000000005566";
 
@@ -1404,7 +1407,7 @@ public class VMTest {
     public void testMSTORE_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123460A052"), invoke);
+        program = getProgram("61123460A052");
         String expected = "" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
@@ -1424,7 +1427,7 @@ public class VMTest {
     public void testMSTORE_5() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123452"), invoke);
+        program = getProgram("61123452");
         try {
             vm.step(program);
             vm.step(program);
@@ -1437,7 +1440,7 @@ public class VMTest {
     public void testMLOAD_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600051"), invoke);
+        program = getProgram("600051");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1452,7 +1455,7 @@ public class VMTest {
     public void testMLOAD_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602251"), invoke);
+        program = getProgram("602251");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1470,7 +1473,7 @@ public class VMTest {
     public void testMLOAD_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602051"), invoke);
+        program = getProgram("602051");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000000000";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1486,7 +1489,7 @@ public class VMTest {
     public void testMLOAD_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("611234602052602051"), invoke);
+        program = getProgram("611234602052602051");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000001234";
@@ -1505,7 +1508,7 @@ public class VMTest {
     public void testMLOAD_5() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("611234602052601F51"), invoke);
+        program = getProgram("611234602052601F51");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000012";
@@ -1525,9 +1528,8 @@ public class VMTest {
     public void testVersioning_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode(
-                "FC010100" // this is the header
-                + "611234602052601F51"), invoke);
+        program = getProgram("FC010100" // this is the header
+        + "611234602052601F51");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0000000000000000000000000000000000000000000000000000000000001234";
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000012";
@@ -1567,7 +1569,7 @@ public class VMTest {
 
         byte code[] = outputStream.toByteArray( );
 
-        program = new Program(config, code, invoke);
+        program = getProgram(code);
         // no negative values allowed. Currently values over 127 are limited
         // in the future exeversion and scriptversion can be made of size int.
         Assert.assertEquals(program.getExeVersion(), 127);
@@ -1589,7 +1591,7 @@ public class VMTest {
     public void testInvalidOpcodes_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("A5"), invoke);
+        program = getProgram("A5");
 
         vm.step(program);
 
@@ -1599,7 +1601,7 @@ public class VMTest {
     public void testMLOAD_6() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("51"), invoke);
+        program = getProgram("51");
         try {
             vm.step(program);
         } finally {
@@ -1611,7 +1613,7 @@ public class VMTest {
     public void testMSTORE8_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6011600053"), invoke);
+        program = getProgram("6011600053");
         String m_expected = "1100000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1626,7 +1628,7 @@ public class VMTest {
     public void testMSTORE8_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6022600153"), invoke);
+        program = getProgram("6022600153");
         String m_expected = "0022000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1640,7 +1642,7 @@ public class VMTest {
     public void testMSTORE8_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6022602153"), invoke);
+        program = getProgram("6022602153");
         String m_expected = "0000000000000000000000000000000000000000000000000000000000000000" +
                 "0022000000000000000000000000000000000000000000000000000000000000";
 
@@ -1655,7 +1657,7 @@ public class VMTest {
     public void testMSTORE8_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602253"), invoke);
+        program = getProgram("602253");
         try {
             vm.step(program);
             vm.step(program);
@@ -1669,7 +1671,7 @@ public class VMTest {
 
         VM vm = getSubject();
 
-        program = new Program(config, Hex.decode("602260AA55"), invoke);
+        program = getProgram("602260AA55");
         String s_expected_key = "00000000000000000000000000000000000000000000000000000000000000AA";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000022";
 
@@ -1688,7 +1690,7 @@ public class VMTest {
 
         VM vm = getSubject();
 
-        program = new Program(config, Hex.decode("602260AA55602260BB55"), invoke);
+        program = getProgram("602260AA55602260BB55");
         String s_expected_key = "00000000000000000000000000000000000000000000000000000000000000BB";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000022";
 
@@ -1710,7 +1712,7 @@ public class VMTest {
     public void testSSTORE_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602255"), invoke);
+        program = getProgram("602255");
         try {
             vm.step(program);
             vm.step(program);
@@ -1723,7 +1725,7 @@ public class VMTest {
     public void testSLOAD_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60AA54"), invoke);
+        program = getProgram("60AA54");
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1736,7 +1738,7 @@ public class VMTest {
     public void testSLOAD_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602260AA5560AA54"), invoke);
+        program = getProgram("602260AA5560AA54");
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000022";
 
         vm.step(program);
@@ -1752,7 +1754,7 @@ public class VMTest {
     public void testSLOAD_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602260AA55603360CC5560CC54"), invoke);
+        program = getProgram("602260AA55603360CC5560CC54");
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000033";
 
         vm.step(program);
@@ -1771,7 +1773,7 @@ public class VMTest {
     public void testSLOAD_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("56"), invoke);
+        program = getProgram("56");
         try {
             vm.step(program);
         } finally {
@@ -1783,7 +1785,7 @@ public class VMTest {
     public void testPC_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("58"), invoke);
+        program = getProgram("58");
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -1796,7 +1798,7 @@ public class VMTest {
     public void testPC_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602260AA5260AA5458"), invoke);
+        program = getProgram("602260AA5260AA5458");
         String s_expected = "0000000000000000000000000000000000000000000000000000000000000008";
 
         vm.step(program);
@@ -1813,7 +1815,7 @@ public class VMTest {
     public void testJUMP_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60AA60BB600E5660CC60DD60EE5B60FF"), invoke);
+        program = getProgram("60AA60BB600E5660CC60DD60EE5B60FF");
         String s_expected = "00000000000000000000000000000000000000000000000000000000000000FF";
 
         vm.step(program);
@@ -1829,7 +1831,7 @@ public class VMTest {
     public void testJUMP_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600C600C905660CC60DD60EE60FF"), invoke);
+        program = getProgram("600C600C905660CC60DD60EE60FF");
         try {
             vm.step(program);
             vm.step(program);
@@ -1845,7 +1847,7 @@ public class VMTest {
     public void testJUMPI_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60016005575B60CC"), invoke);
+        program = getProgram("60016005575B60CC");
         String s_expected = "00000000000000000000000000000000000000000000000000000000000000CC";
 
         vm.step(program);
@@ -1862,7 +1864,7 @@ public class VMTest {
     public void testJUMPI_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("630000000060445760CC60DD"), invoke);
+        program = getProgram("630000000060445760CC60DD");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000DD";
         String s_expected_2 = "00000000000000000000000000000000000000000000000000000000000000CC";
 
@@ -1883,7 +1885,7 @@ public class VMTest {
     public void testJUMPI_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600157"), invoke);
+        program = getProgram("600157");
         try {
             vm.step(program);
             vm.step(program);
@@ -1896,7 +1898,7 @@ public class VMTest {
     public void testJUMPI_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60016022909057"), invoke);
+        program = getProgram("60016022909057");
         try {
             vm.step(program);
             vm.step(program);
@@ -1912,7 +1914,7 @@ public class VMTest {
     public void testJUMPDEST_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602360085660015b600255"), invoke);
+        program = getProgram("602360085660015b600255");
 
         String s_expected_key = "0000000000000000000000000000000000000000000000000000000000000002";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000023";
@@ -1934,7 +1936,7 @@ public class VMTest {
     public void testJUMPDEST_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6023600160095760015b600255"), invoke);
+        program = getProgram("6023600160095760015b600255");
 
         String s_expected_key = "0000000000000000000000000000000000000000000000000000000000000002";
         String s_expected_val = "0000000000000000000000000000000000000000000000000000000000000023";
@@ -1958,7 +1960,7 @@ public class VMTest {
     public void testADD_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6002600201"), invoke);
+        program = getProgram("6002600201");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -1973,7 +1975,7 @@ public class VMTest {
     public void testADD_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("611002600201"), invoke);
+        program = getProgram("611002600201");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000001004";
 
         vm.step(program);
@@ -1988,7 +1990,7 @@ public class VMTest {
     public void testADD_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6110026512345678900901"), invoke);
+        program = getProgram("6110026512345678900901");
         String s_expected_1 = "000000000000000000000000000000000000000000000000000012345678A00B";
 
         vm.step(program);
@@ -2003,7 +2005,7 @@ public class VMTest {
     public void testADD_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123401"), invoke);
+        program = getProgram("61123401");
         try {
             vm.step(program);
             vm.step(program);
@@ -2015,7 +2017,7 @@ public class VMTest {
     @Test // ADDMOD OP mal
     public void testADDMOD_1() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60026002600308"), invoke);
+        program = getProgram("60026002600308");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2031,7 +2033,7 @@ public class VMTest {
     @Test // ADDMOD OP
     public void testADDMOD_2() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6110006002611002086000"), invoke);
+        program = getProgram("6110006002611002086000");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -2047,7 +2049,7 @@ public class VMTest {
     @Test // ADDMOD OP
     public void testADDMOD_3() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61100265123456789009600208"), invoke);
+        program = getProgram("61100265123456789009600208");
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000000000093B";
 
         vm.step(program);
@@ -2063,7 +2065,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // ADDMOD OP mal
     public void testADDMOD_4() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123408"), invoke);
+        program = getProgram("61123408");
         try {
             vm.step(program);
             vm.step(program);
@@ -2076,7 +2078,7 @@ public class VMTest {
     public void testMUL_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6003600202"), invoke);
+        program = getProgram("6003600202");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000006";
 
         vm.step(program);
@@ -2091,7 +2093,7 @@ public class VMTest {
     public void testMUL_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("62222222600302"), invoke);
+        program = getProgram("62222222600302");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000666666";
 
         vm.step(program);
@@ -2106,7 +2108,7 @@ public class VMTest {
     public void testMUL_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("622222226233333302"), invoke);
+        program = getProgram("622222226233333302");
         String s_expected_1 = "000000000000000000000000000000000000000000000000000006D3A05F92C6";
 
         vm.step(program);
@@ -2121,7 +2123,7 @@ public class VMTest {
     public void testMUL_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600102"), invoke);
+        program = getProgram("600102");
         try {
             vm.step(program);
             vm.step(program);
@@ -2133,7 +2135,7 @@ public class VMTest {
     @Test // MULMOD OP
     public void testMULMOD_1() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60036002600409"), invoke);
+        program = getProgram("60036002600409");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2148,7 +2150,7 @@ public class VMTest {
     @Test // MULMOD OP
     public void testMULMOD_2() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("622222226003600409"), invoke);
+        program = getProgram("622222226003600409");
         String s_expected_1 = "000000000000000000000000000000000000000000000000000000000000000C";
 
         vm.step(program);
@@ -2163,7 +2165,7 @@ public class VMTest {
     @Test // MULMOD OP
     public void testMULMOD_3() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("62222222623333336244444409"), invoke);
+        program = getProgram("62222222623333336244444409");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2178,7 +2180,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // MULMOD OP mal
     public void testMULMOD_4() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600109"), invoke);
+        program = getProgram("600109");
         try {
             vm.step(program);
             vm.step(program);
@@ -2191,7 +2193,7 @@ public class VMTest {
     public void testDIV_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6002600404"), invoke);
+        program = getProgram("6002600404");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2206,7 +2208,7 @@ public class VMTest {
     public void testDIV_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6033609904"), invoke);
+        program = getProgram("6033609904");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000003";
 
         vm.step(program);
@@ -2222,7 +2224,7 @@ public class VMTest {
     public void testDIV_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6022609904"), invoke);
+        program = getProgram("6022609904");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000004";
 
         vm.step(program);
@@ -2237,7 +2239,7 @@ public class VMTest {
     public void testDIV_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6015609904"), invoke);
+        program = getProgram("6015609904");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000007";
 
         vm.step(program);
@@ -2253,7 +2255,7 @@ public class VMTest {
     public void testDIV_5() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6004600704"), invoke);
+        program = getProgram("6004600704");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2268,7 +2270,7 @@ public class VMTest {
     public void testDIV_6() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600704"), invoke);
+        program = getProgram("600704");
         try {
             vm.step(program);
             vm.step(program);
@@ -2281,8 +2283,8 @@ public class VMTest {
     public void testSDIV_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6103E87FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC1805" +
-                ""), invoke);
+        program = getProgram("6103E87FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC1805" +
+                        "");
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
         vm.step(program);
@@ -2297,7 +2299,7 @@ public class VMTest {
     public void testSDIV_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60FF60FF05"), invoke);
+        program = getProgram("60FF60FF05");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2312,7 +2314,7 @@ public class VMTest {
     public void testSDIV_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600060FF05"), invoke);
+        program = getProgram("600060FF05");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2327,7 +2329,7 @@ public class VMTest {
     public void testSDIV_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60FF05"), invoke);
+        program = getProgram("60FF05");
 
         try {
             vm.step(program);
@@ -2341,7 +2343,7 @@ public class VMTest {
     public void testSUB_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6004600603"), invoke);
+        program = getProgram("6004600603");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2356,7 +2358,7 @@ public class VMTest {
     public void testSUB_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61444461666603"), invoke);
+        program = getProgram("61444461666603");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000002222";
 
         vm.step(program);
@@ -2371,7 +2373,7 @@ public class VMTest {
     public void testSUB_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("614444639999666603"), invoke);
+        program = getProgram("614444639999666603");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000099992222";
 
         vm.step(program);
@@ -2386,7 +2388,7 @@ public class VMTest {
     public void testSUB_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("639999666603"), invoke);
+        program = getProgram("639999666603");
         try {
             vm.step(program);
             vm.step(program);
@@ -2399,7 +2401,7 @@ public class VMTest {
     public void testMSIZE_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("59"), invoke);
+        program = getProgram("59");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2412,7 +2414,7 @@ public class VMTest {
     public void testMSIZE_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("602060305259"), invoke);
+        program = getProgram("602060305259");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000060";
 
         vm.step(program);
@@ -2429,7 +2431,7 @@ public class VMTest {
     public void testSTOP_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("60206030601060306011602300"), invoke);
+        program = getProgram("60206030601060306011602300");
         int expectedSteps = 7;
 
         int i = 0;
@@ -2445,7 +2447,7 @@ public class VMTest {
     public void testEXP_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600360020a"), invoke);
+        program = getProgram("600360020a");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000008";
 
         vm.step(program);
@@ -2463,7 +2465,7 @@ public class VMTest {
     public void testEXP_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6000621234560a"), invoke);
+        program = getProgram("6000621234560a");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2481,7 +2483,7 @@ public class VMTest {
     public void testEXP_3() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61112260010a"), invoke);
+        program = getProgram("61112260010a");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2500,7 +2502,7 @@ public class VMTest {
     public void testEXP_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("621234560a"), invoke);
+        program = getProgram("621234560a");
         try {
             vm.step(program);
             vm.step(program);
@@ -2513,7 +2515,7 @@ public class VMTest {
     public void testRETURN_1() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61123460005260206000F3"), invoke);
+        program = getProgram("61123460005260206000F3");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000001234";
 
         vm.step(program);
@@ -2532,7 +2534,7 @@ public class VMTest {
     public void testRETURN_2() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6112346000526020601FF3"), invoke);
+        program = getProgram("6112346000526020601FF3");
         String s_expected_1 = "3400000000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2550,10 +2552,7 @@ public class VMTest {
     public void testRETURN_3() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206000F3"),
-                        invoke);
+        program = getProgram("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206000F3");
         String s_expected_1 = "A0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B1";
 
         vm.step(program);
@@ -2572,10 +2571,7 @@ public class VMTest {
     public void testRETURN_4() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206010F3"),
-                        invoke);
+        program = getProgram("7FA0B0C0D0E0F0A1B1C1D1E1F1A2B2C2D2E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B160005260206010F3");
         String s_expected_1 = "E2F2A3B3C3D3E3F3A4B4C4D4E4F4A1B100000000000000000000000000000000";
 
         vm.step(program);
@@ -2594,8 +2590,7 @@ public class VMTest {
     public void testCODECOPY_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("60036007600039123456"), invoke);
+        program = getProgram("60036007600039123456");
         String m_expected_1 = "1234560000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2613,10 +2608,7 @@ public class VMTest {
     public void testCODECOPY_2() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054"),
-                        invoke);
+        program = getProgram("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054");
         String m_expected_1 =
                 "6000605F556014600054601E60205463ABCDDCBA6040545B51602001600A5254516040016014525451606001601E5254516080016028525460A052546016604860003960166000F26000603F556103E756600054600053602002356020540000";
 
@@ -2639,10 +2631,7 @@ public class VMTest {
         // 95 - new bytes allocated
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
-                        invoke);
+        program = getProgram("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235");
 
         vm.step(program);
         vm.step(program);
@@ -2657,10 +2646,7 @@ public class VMTest {
     public void testCODECOPY_4() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
-                        invoke);
+        program = getProgram("605E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234");
 
         vm.step(program);
         vm.step(program);
@@ -2675,10 +2661,7 @@ public class VMTest {
     public void testCODECOPY_5() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("611234600054615566602054607060006020396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
-                        invoke);
+        program = getProgram("611234600054615566602054607060006020396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234");
 
         vm.step(program);
         vm.step(program);
@@ -2699,10 +2682,7 @@ public class VMTest {
     public void testCODECOPY_6() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("605E6007396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
-                        invoke);
+        program = getProgram("605E6007396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234");
         try {
             vm.step(program);
             vm.step(program);
@@ -2716,8 +2696,7 @@ public class VMTest {
     public void testEXTCODECOPY_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("60036007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C123456"), invoke);
+        program = getProgram("60036007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C123456");
         String m_expected_1 = "6000600000000000000000000000000000000000000000000000000000000000";
 
         vm.step(program);
@@ -2733,10 +2712,7 @@ public class VMTest {
     public void testEXTCODECOPY_2() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("603E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054"),
-                        invoke);
+        program = getProgram("603E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235602054");
         String m_expected_1 =
                 "6000605F556014600054601E60205463ABCDDCBA6040545B51602001600A5254516040016014525451606001601E5254516080016028525460A0525460160000";
 
@@ -2752,10 +2728,7 @@ public class VMTest {
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_3() {
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("605E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
-                        invoke);
+        program = getProgram("605E6007600073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235");
 
         String m_expected_1 =
                 "6000605F556014600054601E60205463ABCDDCBA6040545B51602001600A5254516040016014525451606001601E5254516080016028525460A052546016604860003960166000F26000603F556103E756600054600053602002350000000000";
@@ -2772,10 +2745,7 @@ public class VMTest {
     @Test // EXTCODECOPY OP
     public void testEXTCODECOPY_4() {
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("611234600054615566602054603E6000602073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234"),
-                        invoke);
+        program = getProgram("611234600054615566602054603E6000602073471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e756600054600053602002351234");
 
         vm.step(program);
         vm.step(program);
@@ -2796,9 +2766,7 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // EXTCODECOPY OP mal
     public void testEXTCODECOPY_5() {
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode("605E600773471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C"),
-                        invoke);
+        program = getProgram("605E600773471FD3AD3E9EEADEEC4608B92D16CE6B500704CC3C");
         try {
             vm.step(program);
             vm.step(program);
@@ -2814,10 +2782,7 @@ public class VMTest {
     public void testCODESIZE_1() {
 
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("385E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
-                        invoke);
+        program = getProgram("385E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000062";
 
         vm.step(program);
@@ -2830,10 +2795,7 @@ public class VMTest {
     @Test // EXTCODESIZE OP
     public void testEXTCODESIZE_1() {
         VM vm = getSubject();
-        program =
-                new Program(config, Hex.decode
-                        ("73471FD3AD3E9EEADEEC4608B92D16CE6B500704CC395E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"),
-                        invoke); // Push address on the stack and perform EXTCODECOPY
+        program = getProgram("73471FD3AD3E9EEADEEC4608B92D16CE6B500704CC395E60076000396000605f556014600054601e60205463abcddcba6040545b51602001600a5254516040016014525451606001601e5254516080016028525460a052546016604860003960166000f26000603f556103e75660005460005360200235"); // Push address on the stack and perform EXTCODECOPY
         String s_expected_1 = "000000000000000000000000471FD3AD3E9EEADEEC4608B92D16CE6B500704CC";
 
         vm.step(program);
@@ -2845,7 +2807,7 @@ public class VMTest {
     @Test // MOD OP
     public void testMOD_1() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6003600406"), invoke);
+        program = getProgram("6003600406");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2859,7 +2821,7 @@ public class VMTest {
     @Test // MOD OP
     public void testMOD_2() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("61012C6101F406"), invoke);
+        program = getProgram("61012C6101F406");
         String s_expected_1 = "00000000000000000000000000000000000000000000000000000000000000C8";
 
         vm.step(program);
@@ -2873,7 +2835,7 @@ public class VMTest {
     @Test // MOD OP
     public void testMOD_3() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6004600206"), invoke);
+        program = getProgram("6004600206");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000002";
 
         vm.step(program);
@@ -2888,7 +2850,7 @@ public class VMTest {
     public void testMOD_4() {
 
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("600406"), invoke);
+        program = getProgram("600406");
 
         try {
             vm.step(program);
@@ -2902,7 +2864,7 @@ public class VMTest {
     @Test // SMOD OP
     public void testSMOD_1() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("6003600407"), invoke);
+        program = getProgram("6003600407");
         String s_expected_1 = "0000000000000000000000000000000000000000000000000000000000000001";
 
         vm.step(program);
@@ -2916,9 +2878,9 @@ public class VMTest {
     @Test // SMOD OP
     public void testSMOD_2() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE2" + //  -30
-                "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
-                "07"), invoke);
+        program = getProgram("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE2" + //  -30
+                        "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+                        "07");
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEC";
 
         vm.step(program);
@@ -2932,9 +2894,9 @@ public class VMTest {
     @Test // SMOD OP
     public void testSMOD_3() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
-                "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
-                "07"), invoke);
+        program = getProgram("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+                        "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF56" + // -170
+                        "07");
         String s_expected_1 = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEC";
 
         vm.step(program);
@@ -2948,8 +2910,8 @@ public class VMTest {
     @Test(expected = StackTooSmallException.class) // SMOD OP mal
     public void testSMOD_4() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
-                "07"), invoke);
+        program = getProgram("7F000000000000000000000000000000000000000000000000000000000000001E" + //   30
+                        "07");
         try {
             vm.step(program);
             vm.step(program);
@@ -2994,7 +2956,7 @@ public class VMTest {
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion0() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode("FC"), invoke);
+        program = getProgram("FC");
         try {
             vm.step(program);
         } finally {
@@ -3007,10 +2969,8 @@ public class VMTest {
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion1() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode(
-                "FC000000" + //header
-                "FC" // invalid opcode
-        ), invoke);
+        program = getProgram("FC000000" + //header
+        "FC");
         try {
             // Only one step needs to be exeecuted because header is not.
             vm.step(program);
@@ -3024,10 +2984,8 @@ public class VMTest {
     @Test(expected = Program.IllegalOperationException.class)
     public void testScriptVersion2() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode(
-                "FC010100" + //header
-                        "FC" // invalid code
-        ), invoke);
+        program = getProgram("FC010100" + //header
+                "FC");
         try {
             // Only one step needs to be exaecuted because header is not.
             vm.step(program);
@@ -3041,11 +2999,9 @@ public class VMTest {
     @Test
     public void testScriptVersion3() {
         VM vm = getSubject();
-        program = new Program(config, Hex.decode(
-                "FC01010A" + //header with 10 additional bytes
-                        "0102030405060708090A" + // additional header bytes
-                        "00" // STOP code
-        ), invoke);
+        program = getProgram("FC01010A" + //header with 10 additional bytes
+                "0102030405060708090A" + // additional header bytes
+                "00");
         try {
             // Only one step needs to be exaecuted because header is not.
             vm.step(program);
@@ -3064,7 +3020,7 @@ public class VMTest {
         String asm ="256 0x00FF CODEREPLACE";
         EVMAssembler assembler = new EVMAssembler();
         byte[] code = assembler.assemble(asm);
-        program = new Program(config, code, invoke);
+        program = getProgram(code);
         vm.step(program);  // push
         vm.step(program);  // push
         vm.step(program);  // CODEREPLACE
@@ -3085,7 +3041,7 @@ public class VMTest {
 
         EVMAssembler assembler = new EVMAssembler();
         byte[] code = assembler.assemble(asm);
-        program = new Program(config, code, invoke);
+        program = getProgram(code);
 
         vm.step(program);  // push
         vm.step(program);  // push
@@ -3096,8 +3052,17 @@ public class VMTest {
     }
 
     private VM getSubject() {
-        return new VM(config.getVmConfig(), new PrecompiledContracts(config));
+        return new VM(vmConfig, precompiledContracts);
     }
+
+    private Program getProgram(String code) {
+        return getProgram(Hex.decode(code));
+    }
+
+    private Program getProgram(byte[] code) {
+        return new Program(vmConfig, precompiledContracts, code, invoke, null);
+    }
+
 }
 
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMUtilsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMUtilsTest.java
@@ -25,7 +25,7 @@ public class VMUtilsTest {
     @Test
     public void savePlainProgramTraceFile() throws Exception {
         Path traceFilePath = tempRule.newFolder().toPath();
-        ProgramTrace mockTrace = new ProgramTrace(config);
+        ProgramTrace mockTrace = new ProgramTrace(config.getVmConfig(), null);
         String mockTxHash = "1234";
 
         VMUtils.saveProgramTraceFile(
@@ -42,7 +42,7 @@ public class VMUtilsTest {
     @Test
     public void saveZippedProgramTraceFile() throws Exception {
         Path traceFilePath = tempRule.newFolder().toPath();
-        ProgramTrace mockTrace = new ProgramTrace(config);
+        ProgramTrace mockTrace = new ProgramTrace(config.getVmConfig(), null);
         String mockTxHash = "1234";
 
         VMUtils.saveProgramTraceFile(


### PR DESCRIPTION
This fixes the performance issue encountered in the `VM` by repeatedly accessing the `RskSystemProperties` object, **with a focus on improving code quality** via refactoring.

Basically, removes the `RskSystemProperties` object from `Program` and `VM`, helping with maintenance and testability.

* creates a `VmConfig` class
* makes `PrecompiledContracts` a non-static component
* replaces the injected `RskSystemProperties` with those two components in `Program` and `VM`