### PR TITLE
Timestamp rule with 0 value period

### DIFF
--- a/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
@@ -40,18 +40,28 @@ public class BlockTimeStampValidationRule implements BlockParentDependantValidat
 
     @Override
     public boolean isValid(Block block) {
+        if (this.validPeriodLength == 0) {
+            return true;
+        }
+
         final long currentTime = System.currentTimeMillis() / 1000;
         final long blockTime = block.getTimestamp();
 
         boolean result = blockTime - currentTime <= this.validPeriodLength;
+
         if(!result) {
             logger.warn("Error validating block. Invalid timestamp {}.", blockTime);
         }
+
         return result;
     }
 
     @Override
     public boolean isValid(Block block, Block parent) {
+        if (this.validPeriodLength == 0) {
+            return true;
+        }
+
         boolean result = this.isValid(block);
 
         final long blockTime = block.getTimestamp();

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/RegTestConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/RegTestConfig.java
@@ -53,7 +53,7 @@ public class RegTestConfig extends GenesisConfig {
 
         @Override
         public int getNewBlockMaxSecondsInTheFuture() {
-            return 540;
+            return 0;
         }
 
         @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -1227,10 +1227,10 @@ public class Web3Impl implements Web3 {
     @Override
     public String evm_increaseTime(String seconds) {
         try {
-            long nseconds = stringHexToBigInteger(seconds).longValue();
+            long nseconds = stringNumberAsBigInt(seconds).longValue();
             String result = toJsonHex(minerServer.increaseTime(nseconds));
             if (logger.isDebugEnabled()) {
-                logger.debug("evm_increaseTime({}): {}", seconds, result);
+                logger.debug("evm_increaseTime({}): {}", nseconds, result);
             }
             return result;
         } catch (NumberFormatException | StringIndexOutOfBoundsException e) {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -814,13 +814,12 @@ public class BlockValidatorTest {
         Assert.assertTrue(validator.isValid(block));
     }
 
-
     @Test
     public void blockInTheFuture() {
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
 
-        int validPeriod = config.getBlockchainConfig().getCommonConstants().getNewBlockMaxSecondsInTheFuture();
+        int validPeriod = 6000;
 
         Block block = Mockito.mock(Block.class);
         Mockito.when(block.getTimestamp())
@@ -836,6 +835,32 @@ public class BlockValidatorTest {
 
         Mockito.when(block.getTimestamp())
                 .thenReturn((System.currentTimeMillis() / 1000) + validPeriod);
+
+        Assert.assertTrue(validator.isValid(block));
+    }
+
+
+    @Test
+    public void blockInTheFutureIsAcceptedWhenValidPeriodIsZero() {
+        BlockGenerator blockGenerator = new BlockGenerator();
+        Block genesis = blockGenerator.getGenesisBlock();
+
+        int validPeriod = 0;
+
+        Block block = Mockito.mock(Block.class);
+        Mockito.when(block.getTimestamp())
+                .thenReturn((System.currentTimeMillis() / 1000) + 2000);
+
+        Mockito.when(block.getParentHash()).thenReturn(genesis.getHash());
+
+        BlockValidatorImpl validator = new BlockValidatorBuilder()
+                .addBlockTimeStampValidationRule(validPeriod)
+                .build();
+
+        Assert.assertTrue(validator.isValid(block));
+
+        Mockito.when(block.getTimestamp())
+                .thenReturn((System.currentTimeMillis() / 1000) + 2000);
 
         Assert.assertTrue(validator.isValid(block));
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -140,13 +140,26 @@ public class Web3ImplSnapshotTest {
     }
 
     @Test
-    public void increaseTime() {
+    public void increaseTimeUsingHexadecimalValue() {
         World world = new World();
         SimpleEthereum ethereum = new SimpleEthereum();
         MinerServer minerServer = getMinerServerForTest(world, ethereum);
         Web3Impl web3 = createWeb3(world, ethereum, minerServer);
 
         String result = web3.evm_increaseTime("0x10");
+
+        Assert.assertEquals("0x10", result);
+        Assert.assertEquals(16, minerServer.increaseTime(0));
+    }
+
+    @Test
+    public void increaseTimeUsingDecimalValue() {
+        World world = new World();
+        SimpleEthereum ethereum = new SimpleEthereum();
+        MinerServer minerServer = getMinerServerForTest(world, ethereum);
+        Web3Impl web3 = createWeb3(world, ethereum, minerServer);
+
+        String result = web3.evm_increaseTime("16");
 
         Assert.assertEquals("0x10", result);
         Assert.assertEquals(16, minerServer.increaseTime(0));
@@ -161,6 +174,20 @@ public class Web3ImplSnapshotTest {
 
         web3.evm_increaseTime("0x10");
         String result = web3.evm_increaseTime("0x10");
+
+        Assert.assertEquals("0x20", result);
+        Assert.assertEquals(32, minerServer.increaseTime(0));
+    }
+
+    @Test
+    public void increaseTimeTwiceUsingDecimalValues() {
+        World world = new World();
+        SimpleEthereum ethereum = new SimpleEthereum();
+        MinerServer minerServer = getMinerServerForTest(world, ethereum);
+        Web3Impl web3 = createWeb3(world, ethereum, minerServer);
+
+        web3.evm_increaseTime("16");
+        String result = web3.evm_increaseTime("16");
 
         Assert.assertEquals("0x20", result);
         Assert.assertEquals(32, minerServer.increaseTime(0));


### PR DESCRIPTION
In regtest: timestamp block rule receives 0 value as period. With this value, a future block is accepted. 

With this change, truffle tests can send future blocks (tested with truffle OpenZeppelin tests)