### PR TITLE
[RFS-94] Remove bridge method get state for debugging

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -340,6 +340,10 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
                 return null;
             }
 
+            if (blockchainConfig.isRfs94() && GET_STATE_FOR_DEBUGGING.equals(bridgeParsedData.function)) {
+                throw new NoSuchMethodException(GET_STATE_FOR_DEBUGGING.name + " call is not supported after Bamboo");
+            }
+
             this.bridgeSupport = setup();
 
             // bridgeParsedData.function should be one of the CallTransaction.Function declared above.

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -44,4 +44,6 @@ public interface BlockchainConfig {
     boolean isRfs55();
 
     boolean isRfs90();
+
+    boolean isRfs94();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
@@ -139,4 +139,9 @@ public abstract class AbstractConfig implements BlockchainConfig, BlockchainNetC
     public boolean isRfs90() {
         return false;
     }
+
+    @Override
+    public boolean isRfs94() {
+        return false;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/DevNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/DevNetConfig.java
@@ -59,4 +59,9 @@ public class DevNetConfig extends TestNetAfterBridgeSyncConfig {
     public boolean isRfs90() {
         return true;
     }
+
+    @Override
+    public boolean isRfs94() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/RegTestConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/RegTestConfig.java
@@ -80,4 +80,9 @@ public class RegTestConfig extends GenesisConfig {
     public boolean isRfs90() {
         return true;
     }
+
+    @Override
+    public boolean isRfs94() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetFirstForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetFirstForkConfig.java
@@ -11,4 +11,9 @@ public class MainNetFirstForkConfig extends MainNetAfterBridgeSyncConfig {
     public boolean isRfs90() {
         return true;
     }
+
+    @Override
+    public boolean isRfs94() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetFirstForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetFirstForkConfig.java
@@ -11,4 +11,9 @@ public class TestNetFirstForkConfig extends TestNetAfterBridgeSyncConfig {
     public boolean isRfs90() {
         return true;
     }
+
+    @Override
+    public boolean isRfs94() {
+        return true;
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -333,7 +333,14 @@ public class RskForksBridgeTest {
     }
 
     private BridgeState callGetStateForDebuggingTx() throws IOException, ClassNotFoundException {
-        Transaction rskTx = CallTransaction.createRawTransaction(config, 0,
+        RskSystemProperties beforeBambooProperties = new RskSystemProperties();
+        beforeBambooProperties.setBlockchainConfig(new RegTestConfig() {
+            @Override
+            public boolean isRfs94() {
+                return false;
+            }
+        });
+        Transaction rskTx = CallTransaction.createRawTransaction(beforeBambooProperties, 0,
                 Long.MAX_VALUE,
                 Long.MAX_VALUE,
                 PrecompiledContracts.BRIDGE_ADDR,
@@ -341,7 +348,7 @@ public class RskForksBridgeTest {
                 Bridge.GET_STATE_FOR_DEBUGGING.encode(new Object[]{}));
         rskTx.sign(new byte[32]);
 
-        TransactionExecutor executor = new TransactionExecutor(config, rskTx, 0, blockChain.getBestBlock().getCoinbase(), repository,
+        TransactionExecutor executor = new TransactionExecutor(beforeBambooProperties, rskTx, 0, blockChain.getBestBlock().getCoinbase(), repository,
                         blockChain.getBlockStore(), blockChain.getReceiptStore(), new ProgramInvokeFactoryImpl(), blockChain.getBestBlock())
                 .setLocalCall(true);
 
@@ -354,7 +361,7 @@ public class RskForksBridgeTest {
 
         Object[] result = Bridge.GET_STATE_FOR_DEBUGGING.decodeResult(res.getHReturn());
 
-        return BridgeState.create(config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), (byte[])result[0]);
+        return BridgeState.create(beforeBambooProperties.getBlockchainConfig().getCommonConstants().getBridgeConstants(), (byte[])result[0]);
     }
 
 


### PR DESCRIPTION
This is the hard fork implementation of #394 