### PR TITLE
RFS-95 - Federation key enhancement (RFS-109 - Part A)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import com.google.common.collect.Lists;
 import org.ethereum.crypto.ECKey;
 import org.spongycastle.util.encoders.Hex;
@@ -45,6 +46,12 @@ public class BridgeDevNetConstants extends BridgeConstants {
         List<BtcECKey> genesisFederationPublicKeys = Lists.newArrayList(
                 federator0PublicKey, federator1PublicKey, federator2PublicKey
         );
+
+        // IMPORTANT: Both BTC and RSK keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        List<FederationMember> federationMembers = genesisFederationPublicKeys.stream().map(pk -> new FederationMember(
+                pk, ECKey.fromPublicOnly(pk.getPubKey())
+        )).collect(Collectors.toList());
         
         // Currently set to:
         // Monday, November 13, 2017 9:00:00 PM GMT-03:00
@@ -53,7 +60,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
         // Expected federation address is:
         // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
         genesisFederation = new Federation(
-                genesisFederationPublicKeys,
+                federationMembers,
                 genesisFederationAddressCreatedAt,
                 1L,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -5,6 +5,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import com.google.common.collect.Lists;
 import org.ethereum.crypto.ECKey;
 import org.spongycastle.util.encoders.Hex;
@@ -44,12 +45,18 @@ public class BridgeMainNetConstants extends BridgeConstants {
                 federator12PublicKey, federator13PublicKey, federator14PublicKey
         );
 
+        // IMPORTANT: Both BTC and RSK keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        List<FederationMember> federationMembers = genesisFederationPublicKeys.stream().map(pk -> new FederationMember(
+                pk, ECKey.fromPublicOnly(pk.getPubKey())
+        )).collect(Collectors.toList());
+
         // Currently set to:
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400l);
         
         genesisFederation = new Federation(
-                genesisFederationPublicKeys,
+                federationMembers,
                 genesisFederationAddressCreatedAt,
                 1L,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import com.google.common.collect.Lists;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -50,10 +51,16 @@ public class BridgeRegTestConstants extends BridgeConstants {
         federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey);
         List<BtcECKey> federatorPublicKeys = federatorPrivateKeys.stream().map(key -> BtcECKey.fromPublicOnly(key.getPubKey())).collect(Collectors.toList());
 
+        // IMPORTANT: Both BTC and RSK keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        List<FederationMember> federationMembers = federatorPublicKeys.stream().map(pk -> new FederationMember(
+                pk, ECKey.fromPublicOnly(pk.getPubKey())
+        )).collect(Collectors.toList());
+
         Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
         genesisFederation = new Federation(
-                federatorPublicKeys,
+                federationMembers,
                 genesisFederationCreatedAt,
                 1L,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import com.google.common.collect.Lists;
 import org.ethereum.crypto.ECKey;
 import org.spongycastle.util.encoders.Hex;
@@ -52,12 +53,18 @@ public class BridgeTestNetConstants extends BridgeConstants {
                 federator6PublicKey
         );
 
+        // IMPORTANT: Both BTC and RSK keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        List<FederationMember> federationMembers = genesisFederationPublicKeys.stream().map(pk -> new FederationMember(
+                pk, ECKey.fromPublicOnly(pk.getPubKey())
+        )).collect(Collectors.toList());
+
         // Currently set to:
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400l);
 
         genesisFederation = new Federation(
-                genesisFederationPublicKeys,
+                federationMembers,
                 genesisFederationAddressCreatedAt,
                 1L,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeBtcWallet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeBtcWallet.java
@@ -52,6 +52,6 @@ public class BridgeBtcWallet extends Wallet {
         if (!destinationFederation.isPresent()) {
             return null;
         }
-        return RedeemData.of(destinationFederation.get().getPublicKeys(), destinationFederation.get().getRedeemScript());
+        return RedeemData.of(destinationFederation.get().getBtcPublicKeys(), destinationFederation.get().getRedeemScript());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Sha3Hash;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.spongycastle.util.BigIntegers;
@@ -203,7 +204,7 @@ public class BridgeSerializationUtils {
     // list of public keys -> [pubkey1, pubkey2, ..., pubkeyn], sorted
     // using the lexicographical order of the public keys (see BtcECKey.PUBKEY_COMPARATOR).
     public static byte[] serializeFederation(Federation federation) {
-        List<byte[]> publicKeys = federation.getPublicKeys().stream()
+        List<byte[]> publicKeys = federation.getBtcPublicKeys().stream()
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .map(key -> RLP.encodeElement(key.getPubKey()))
                 .collect(Collectors.toList());
@@ -225,27 +226,40 @@ public class BridgeSerializationUtils {
         byte[] creationTimeBytes = rlpList.get(FEDERATION_CREATION_TIME_INDEX).getRLPData();
         Instant creationTime = Instant.ofEpochMilli(BigIntegers.fromUnsignedByteArray(creationTimeBytes).longValue());
 
-        List<BtcECKey> pubKeys = ((RLPList) rlpList.get(FEDERATION_PUB_KEYS_INDEX)).stream()
-                .map(pubKeyBytes -> BtcECKey.fromPublicOnly(pubKeyBytes.getRLPData()))
+        // IMPORTANT: Both BTC and RSK public keys are the same.
+        // This is for compatibility with the pre <INSERT FORK NAME HERE> fork network.
+        List<FederationMember> federationMembers = ((RLPList) rlpList.get(FEDERATION_PUB_KEYS_INDEX)).stream()
+                .map(pubKeyBytes -> new FederationMember(
+                        BtcECKey.fromPublicOnly(pubKeyBytes.getRLPData()),
+                        ECKey.fromPublicOnly(pubKeyBytes.getRLPData())
+                )).collect(Collectors.toList());
+
+        List<ECKey> rskPubKeys = ((RLPList) rlpList.get(FEDERATION_PUB_KEYS_INDEX)).stream()
+                .map(pubKeyBytes -> ECKey.fromPublicOnly(pubKeyBytes.getRLPData()))
                 .collect(Collectors.toList());
 
         byte[] creationBlockNumberBytes = rlpList.get(FEDERATION_CREATION_BLOCK_NUMBER_INDEX).getRLPData();
         long creationBlockNumber = BigIntegers.fromUnsignedByteArray(creationBlockNumberBytes).longValue();
 
-        return new Federation(pubKeys, creationTime, creationBlockNumber, btcContext.getParams());
+        return new Federation(federationMembers, creationTime, creationBlockNumber, btcContext.getParams());
     }
 
     // A pending federation is serialized as the
     // public keys conforming it.
     // See BridgeSerializationUtils::serializePublicKeys
     public static byte[] serializePendingFederation(PendingFederation pendingFederation) {
-        return serializeBtcPublicKeys(pendingFederation.getPublicKeys());
+        return serializeBtcPublicKeys(pendingFederation.getBtcPublicKeys());
     }
 
     // For the serialization format, see BridgeSerializationUtils::serializePendingFederation
     // and serializePublicKeys::deserializePublicKeys
     public static PendingFederation deserializePendingFederation(byte[] data) {
-        return new PendingFederation(deserializeBtcPublicKeys(data));
+        // BTC and RSK keys are the same
+        List<FederationMember> members = deserializeBtcPublicKeys(data).stream().map(pk ->
+            new FederationMember(pk, ECKey.fromPublicOnly(pk.getPubKey()))
+        ).collect(Collectors.toList());
+
+        return new PendingFederation(members);
     }
 
     // An ABI call election is serialized as a list of the votes, like so:

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -824,10 +824,10 @@ public class BridgeSupport {
                     logger.debug("Tx input {} for tx {} signed.", i, new Sha3Hash(rskTxHash));
                 } catch (IllegalStateException e) {
                     Federation retiringFederation = getRetiringFederation();
-                    if (getActiveFederation().hasPublicKey(federatorPublicKey)) {
+                    if (getActiveFederation().hasBtcPublicKey(federatorPublicKey)) {
                         logger.debug("A member of the active federation is trying to sign a tx of the retiring one");
                         return;
-                    } else if (retiringFederation != null && retiringFederation.hasPublicKey(federatorPublicKey)) {
+                    } else if (retiringFederation != null && retiringFederation.hasBtcPublicKey(federatorPublicKey)) {
                         logger.debug("A member of the retiring federation is trying to sign a tx of the active one");
                         return;
                     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.Program;
 import org.slf4j.Logger;
@@ -746,7 +747,7 @@ public class BridgeSupport {
     public void addSignature(long executionBlockNumber, BtcECKey federatorPublicKey, List<byte[]> signatures, byte[] rskTxHash) throws Exception {
         Context.propagate(btcContext);
         Federation retiringFederation = getRetiringFederation();
-        if (!getActiveFederation().getPublicKeys().contains(federatorPublicKey) && (retiringFederation == null || !retiringFederation.getPublicKeys().contains(federatorPublicKey))) {
+        if (!getActiveFederation().getBtcPublicKeys().contains(federatorPublicKey) && (retiringFederation == null || !retiringFederation.getBtcPublicKeys().contains(federatorPublicKey))) {
             logger.warn("Supplied federator public key {} does not belong to any of the federators.", federatorPublicKey);
             return;
         }
@@ -1177,7 +1178,7 @@ public class BridgeSupport {
      * @return the federation size
      */
     public Integer getFederationSize() {
-        return getActiveFederation().getPublicKeys().size();
+        return getActiveFederation().getBtcPublicKeys().size();
     }
 
     /**
@@ -1194,7 +1195,7 @@ public class BridgeSupport {
      * @return the federator's public key
      */
     public byte[] getFederatorPublicKey(int index) {
-        List<BtcECKey> publicKeys = getActiveFederation().getPublicKeys();
+        List<BtcECKey> publicKeys = getActiveFederation().getBtcPublicKeys();
 
         if (index < 0 || index >= publicKeys.size()) {
             throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and {}", publicKeys.size() - 1));
@@ -1243,7 +1244,7 @@ public class BridgeSupport {
             return -1;
         }
 
-        return retiringFederation.getPublicKeys().size();
+        return retiringFederation.getBtcPublicKeys().size();
     }
 
     /**
@@ -1270,7 +1271,7 @@ public class BridgeSupport {
             return null;
         }
 
-        List<BtcECKey> publicKeys = retiringFederation.getPublicKeys();
+        List<BtcECKey> publicKeys = retiringFederation.getBtcPublicKeys();
 
         if (index < 0 || index >= publicKeys.size()) {
             throw new IndexOutOfBoundsException(String.format("Retiring federator index must be between 0 and {}", publicKeys.size() - 1));
@@ -1363,7 +1364,9 @@ public class BridgeSupport {
     }
 
     /**
-     * Adds the given key to the current pending federation
+     * Adds the given key to the current pending federation.
+     * IMPORTANT: the given key is used both for BTC and RSK.
+     *
      * @param dryRun whether to just do a dry run
      * @param key the public key to add
      * @return 1 upon success, -1 if there was no pending federation, -2 if the key was already in the pending federation
@@ -1375,7 +1378,7 @@ public class BridgeSupport {
             return -1;
         }
 
-        if (currentPendingFederation.getPublicKeys().contains(key)) {
+        if (currentPendingFederation.getBtcPublicKeys().contains(key)) {
             return -2;
         }
 
@@ -1383,7 +1386,10 @@ public class BridgeSupport {
             return 1;
         }
 
-        currentPendingFederation = currentPendingFederation.addPublicKey(key);
+        // Build the new federation member using the same key for both BTC and RSK
+        FederationMember member = new FederationMember(key, ECKey.fromPublicOnly(key.getPubKey()));
+
+        currentPendingFederation = currentPendingFederation.addMember(member);
 
         provider.setPendingFederation(currentPendingFederation);
 
@@ -1585,7 +1591,7 @@ public class BridgeSupport {
             return -1;
         }
 
-        return currentPendingFederation.getPublicKeys().size();
+        return currentPendingFederation.getBtcPublicKeys().size();
     }
 
     /**
@@ -1600,7 +1606,7 @@ public class BridgeSupport {
             return null;
         }
 
-        List<BtcECKey> publicKeys = currentPendingFederation.getPublicKeys();
+        List<BtcECKey> publicKeys = currentPendingFederation.getBtcPublicKeys();
 
         if (index < 0 || index >= publicKeys.size()) {
             throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and {}", publicKeys.size() - 1));

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -23,7 +23,6 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -123,7 +122,7 @@ public final class Federation {
         return members.size();
     }
 
-    public Integer getPublicKeyIndex(BtcECKey key) {
+    public Integer getBtcPublicKeyIndex(BtcECKey key) {
         for (int i = 0; i < members.size(); i++) {
             // note that this comparison doesn't take into account
             // key compression
@@ -135,8 +134,8 @@ public final class Federation {
         return null;
     }
 
-    public boolean hasPublicKey(BtcECKey key) {
-        return getPublicKeyIndex(key) != null;
+    public boolean hasBtcPublicKey(BtcECKey key) {
+        return getBtcPublicKeyIndex(key) != null;
     }
 
     public boolean hasMemberWithRskAddress(byte[] address) {

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -25,7 +25,9 @@ import org.spongycastle.util.encoders.Hex;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Immutable representation of an RSK Federation member.
@@ -38,6 +40,14 @@ import java.util.Objects;
 public final class FederationMember {
     private final BtcECKey btcPublicKey;
     private final ECKey rskPublicKey;
+
+    // To be removed when different keys per federation member feature is implemented. This is just a helper
+    // method to make it easier w.r.t. compatibility with the current approach
+    public static List<FederationMember> getFederationMembersFromKeys(List<BtcECKey> pks) {
+        return pks.stream().map(pk ->
+                new FederationMember(pk, ECKey.fromPublicOnly(pk.getPubKey()))
+        ).collect(Collectors.toList());
+    }
 
     /**
      * Compares federation members based on their underlying keys.

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import com.google.common.primitives.UnsignedBytes;
+import org.ethereum.crypto.ECKey;
+import org.spongycastle.util.encoders.Hex;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Immutable representation of an RSK Federation member.
+ *
+ * It's composed of two public keys: one for the RSK and one for the
+ * BTC network.
+ *
+ * @author Ariel Mendelzon
+ */
+public final class FederationMember {
+    private final BtcECKey btcPublicKey;
+    private final ECKey rskPublicKey;
+
+    /**
+     * Compares federation members based on their underlying keys.
+     *
+     * The total ordering is defined such that, for any two members M1, M2,
+     * 1) M1 < M2 iif BTC_PUB_KEY(M1) <lex BTC_PUB_KEY(M2) OR
+     *              (BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND
+     *               RSK_PUB_KEY(M1) <lex RSK_PUB_KEY(M2))
+     * 2) M1 == M2 iff BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND RSK_PUB_KEY(M1) ==lex RSK_PUB_KEY(M2)
+     * 3) M1 > M2 otherwise
+     *
+     * where <lex and ==lex is given by negative and zero values (resp.) of the
+     * UnsignedBytes.lexicographicalComparator() comparator.
+     */
+    public static final Comparator<FederationMember> BTC_RSK_PUBKEYS_COMPARATOR = new Comparator<FederationMember>() {
+        private Comparator<byte[]> comparator = UnsignedBytes.lexicographicalComparator();
+
+        @Override
+        public int compare(FederationMember m1, FederationMember m2) {
+            int btcKeysComparison = comparator.compare(m1.getBtcPublicKey().getPubKey(), m2.getBtcPublicKey().getPubKey());
+            if (btcKeysComparison == 0) {
+                return comparator.compare(m1.getRskPublicKey().getPubKey(), m2.getRskPublicKey().getPubKey());
+            }
+            return btcKeysComparison;
+        }
+    };
+
+    public FederationMember(BtcECKey btcPublicKey, ECKey rskPublicKey) {
+        // Copy public keys to ensure effective immutability
+        this.btcPublicKey = BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
+        this.rskPublicKey = ECKey.fromPublicOnly(rskPublicKey.getPubKey());
+    }
+
+    BtcECKey getBtcPublicKey() {
+        // Return a copy
+        return BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
+    }
+
+    ECKey getRskPublicKey() {
+        // Return a copy
+        return ECKey.fromPublicOnly(rskPublicKey.getPubKey());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("<BTC-%s, RSK-%s> federation member", Hex.toHexString(btcPublicKey.getPubKey()), Hex.toHexString(rskPublicKey.getPubKey()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || this.getClass() != other.getClass()) {
+            return false;
+        }
+
+        FederationMember otherFederationMember = (FederationMember) other;
+
+        return Arrays.equals(btcPublicKey.getPubKey(), otherFederationMember.btcPublicKey.getPubKey()) &&
+                Arrays.equals(rskPublicKey.getPubKey(), otherFederationMember.rskPublicKey.getPubKey());
+    }
+
+    @Override
+    public int hashCode() {
+        // Can use java.util.Objects.hash since all of Instant, int and List<BtcECKey> have
+        // well-defined hashCode()s
+        return Objects.hash(
+                btcPublicKey,
+                rskPublicKey
+        );
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -114,8 +114,8 @@ public final class FederationMember {
 
     @Override
     public int hashCode() {
-        // Can use java.util.Objects.hash since all of Instant, int and List<BtcECKey> have
-        // well-defined hashCode()s
+        // Can use java.util.Objects.hash since both BtcECKey and ECKey have
+        // well-defined hashCode(s).
         return Objects.hash(
                 btcPublicKey,
                 rskPublicKey

--- a/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
@@ -21,12 +21,13 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Sha3Hash;
-import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**

--- a/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Sha3Hash;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.ByteArrayWrapper;
 
@@ -37,34 +38,40 @@ import java.util.stream.Collectors;
  * @author Ariel Mendelzon
  */
 public final class PendingFederation {
-    private static final int MIN_FEDERATORS_REQUIRED = 2;
+    private static final int MIN_MEMBERS_REQUIRED = 2;
 
-    private List<BtcECKey> publicKeys;
+    private List<FederationMember> members;
 
-    public PendingFederation(List<BtcECKey> publicKeys) {
-        // Sorting public keys ensures same order of federators for same public keys
-        // Immutability provides protection unless unwanted modification, thus making the Pending Federation instance
+    public PendingFederation(List<FederationMember> members) {
+        // Sorting members ensures same order for members
+        // Immutability provides protection against unwanted modification, thus making the Pending Federation instance
         // effectively immutable
-        this.publicKeys = Collections.unmodifiableList(publicKeys.stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList()));
+        this.members = Collections.unmodifiableList(members.stream().sorted(FederationMember.BTC_RSK_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
     }
 
-    public List<BtcECKey> getPublicKeys() {
-        return publicKeys;
+    public List<FederationMember> getMembers() {
+        // Safe to return instance since both the list and instances are immutable
+        return members;
+    }
+
+    public List<BtcECKey> getBtcPublicKeys() {
+        // Copy keys since we don't control immutability of BtcECKey(s)
+        return members.stream().map(m -> m.getBtcPublicKey()).collect(Collectors.toList());
     }
 
     public boolean isComplete() {
-        return this.publicKeys.size() >= MIN_FEDERATORS_REQUIRED;
+        return this.members.size() >= MIN_MEMBERS_REQUIRED;
     }
 
     /**
-     * Creates a new PendingFederation with the additional specified public key
-     * @param key the new public key
-     * @return a new PendingFederation with the added public key
+     * Creates a new PendingFederation with the additional specified member
+     * @param member the new federation member
+     * @return a new PendingFederation with the added member
      */
-    public PendingFederation addPublicKey(BtcECKey key) {
-        List<BtcECKey> newKeys = new ArrayList<>(publicKeys);
-        newKeys.add(key);
-        return new PendingFederation(newKeys);
+    public PendingFederation addMember(FederationMember member) {
+        List<FederationMember> newMembers = new ArrayList<>(members);
+        newMembers.add(member);
+        return new PendingFederation(newMembers);
     }
 
     /**
@@ -79,7 +86,7 @@ public final class PendingFederation {
         }
 
         return new Federation(
-                publicKeys,
+                members,
                 creationTime,
                 blockNumber,
                 btcParams
@@ -88,7 +95,7 @@ public final class PendingFederation {
 
     @Override
     public String toString() {
-        return String.format("%d signatures pending federation (%s)", publicKeys.size(), isComplete() ? "complete" : "incomplete");
+        return String.format("%d signatures pending federation (%s)", members.size(), isComplete() ? "complete" : "incomplete");
     }
 
     @Override
@@ -101,18 +108,7 @@ public final class PendingFederation {
             return false;
         }
 
-        PendingFederation otherFederation = (PendingFederation) other;
-        ByteArrayWrapper[] thisPublicKeys = this.getPublicKeys().stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(k -> new ByteArrayWrapper(k.getPubKey()))
-                .toArray(ByteArrayWrapper[]::new);
-        ByteArrayWrapper[] otherPublicKeys = otherFederation.getPublicKeys().stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(k -> new ByteArrayWrapper(k.getPubKey()))
-                .toArray(ByteArrayWrapper[]::new);
-
-        return this.getPublicKeys().size() == otherFederation.getPublicKeys().size() &&
-                Arrays.equals(thisPublicKeys, otherPublicKeys);
+        return this.members.equals(((PendingFederation) other).members);
     }
 
     public Sha3Hash getHash() {
@@ -124,6 +120,6 @@ public final class PendingFederation {
     public int hashCode() {
         // Can use java.util.Objects.hash since List<BtcECKey> has a
         // well-defined hashCode()
-        return Objects.hash(getPublicKeys());
+        return Objects.hash(getBtcPublicKeys());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -80,10 +80,10 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     public void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation) {
         List<DataWord> topics = Collections.singletonList(Bridge.COMMIT_FEDERATION_TOPIC);
 
-        byte[] oldFedFlatPubKeys = flatKeysAsRlpCollection(oldFederation.getPublicKeys());
+        byte[] oldFedFlatPubKeys = flatKeysAsRlpCollection(oldFederation.getBtcPublicKeys());
         byte[] oldFedData = RLP.encodeList(RLP.encodeElement(oldFederation.getAddress().getHash160()), RLP.encodeList(oldFedFlatPubKeys));
 
-        byte[] newFedFlatPubKeys = flatKeysAsRlpCollection(newFederation.getPublicKeys());
+        byte[] newFedFlatPubKeys = flatKeysAsRlpCollection(newFederation.getBtcPublicKeys());
         byte[] newFedData = RLP.encodeList(RLP.encodeElement(newFederation.getAddress().getHash160()), RLP.encodeList(newFedFlatPubKeys));
 
         long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge();

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
@@ -178,7 +178,7 @@ public class TxValidatorTest {
         Mockito.when(transaction.getGasLimitAsInteger()).thenReturn(BigInteger.ZERO);
         // Federation is the genesis federation ATM
         Federation federation = config.getBlockchainConfig().getCommonConstants().getBridgeConstants().getGenesisFederation();
-        byte[] federator0PubKey = federation.getPublicKeys().get(0).getPubKey();
+        byte[] federator0PubKey = federation.getBtcPublicKeys().get(0).getPubKey();
         Mockito.when(transaction.getKey()).thenReturn(ECKey.fromPublicOnly(federator0PubKey));
         return transaction;
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.core.RskAddress;
 import com.google.common.primitives.UnsignedBytes;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.junit.Assert;
@@ -130,14 +131,14 @@ public class BridgeSerializationUtilsTest {
         };
 
         Federation federation = new Federation(
-            Arrays.asList(new BtcECKey[]{
+            FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                     BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[2]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[3]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[4]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[5]),
-            }),
+            })),
             Instant.ofEpochMilli(0xabcdef), //
             42L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -234,14 +235,14 @@ public class BridgeSerializationUtilsTest {
         };
 
         PendingFederation pendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[2]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[3]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[4]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[5]),
-                })
+                }))
         );
 
         byte[] result = BridgeSerializationUtils.serializePendingFederation(pendingFederation);
@@ -592,14 +593,14 @@ public class BridgeSerializationUtilsTest {
         };
 
         Federation federation = new Federation(
-                Arrays.asList(
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(
                         BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[2]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[3]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[4]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[5])
-                ),
+                )),
                 Instant.ofEpochMilli(0xabcdef),
                 42L,
                 networkParms

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -147,7 +147,7 @@ public class BridgeSerializationUtilsTest {
         StringBuilder expectedBuilder = new StringBuilder();
         expectedBuilder.append("ff00abcdef"); // Creation time
         expectedBuilder.append("ff2a"); // Creation block number
-        federation.getPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
+        federation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
             expectedBuilder.append("dd");
             expectedBuilder.append(Hex.toHexString(key.getPubKey()));
         });
@@ -183,10 +183,10 @@ public class BridgeSerializationUtilsTest {
 
         Assert.assertEquals(5000, deserializedFederation.getCreationTime().toEpochMilli());
         Assert.assertEquals(4, deserializedFederation.getNumberOfSignaturesRequired());
-        Assert.assertEquals(6, deserializedFederation.getPublicKeys().size());
+        Assert.assertEquals(6, deserializedFederation.getBtcPublicKeys().size());
         Assert.assertThat(deserializedFederation.getCreationBlockNumber(), is(42L));
         for (int i = 0; i < 6; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedFederation.getPublicKeys().get(i).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedFederation.getBtcPublicKeys().get(i).getPubKey()));
         }
         Assert.assertEquals(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), deserializedFederation.getBtcParams());
     }
@@ -246,7 +246,7 @@ public class BridgeSerializationUtilsTest {
 
         byte[] result = BridgeSerializationUtils.serializePendingFederation(pendingFederation);
         StringBuilder expectedBuilder = new StringBuilder();
-        pendingFederation.getPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
+        pendingFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
             expectedBuilder.append("dd");
             expectedBuilder.append(Hex.toHexString(key.getPubKey()));
         });
@@ -274,9 +274,9 @@ public class BridgeSerializationUtilsTest {
 
         PendingFederation deserializedPendingFederation = BridgeSerializationUtils.deserializePendingFederation(sample);
 
-        Assert.assertEquals(6, deserializedPendingFederation.getPublicKeys().size());
+        Assert.assertEquals(6, deserializedPendingFederation.getBtcPublicKeys().size());
         for (int i = 0; i < 6; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedPendingFederation.getPublicKeys().get(i).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedPendingFederation.getBtcPublicKeys().get(i).getPubKey()));
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -27,6 +27,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.crypto.Sha3Hash;
 import co.rsk.db.RepositoryImpl;
 import org.ethereum.core.Repository;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
@@ -45,6 +46,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -248,7 +250,7 @@ public class BridgeStorageProviderTest {
     public void getNewFederation() throws IOException {
         List<Integer> calls = new ArrayList<>();
         Context contextMock = mock(Context.class);
-        Federation newFederation = new Federation(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))})), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants());
@@ -310,7 +312,7 @@ public class BridgeStorageProviderTest {
 
     @Test
     public void saveNewFederation() throws IOException {
-        Federation newFederation = new Federation(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))})), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         List<Integer> storageBytesCalls = new ArrayList<>();
         List<Integer> serializeCalls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
@@ -683,5 +685,4 @@ public class BridgeStorageProviderTest {
         when(mock.getBytes()).thenReturn(Hex.decode(addr));
         return mock;
     }
-
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -67,6 +67,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.spongycastle.crypto.kems.ECIESKeyEncapsulation;
 import org.spongycastle.crypto.params.ECPrivateKeyParameters;
 import org.spongycastle.crypto.signers.ECDSASigner;
 import org.spongycastle.util.encoders.Hex;
@@ -481,8 +482,10 @@ public class BridgeSupportTest {
     public void minimumProcessFundsMigrationValue() throws IOException, BlockStoreException {
         BridgeConstants bridgeConstants = BridgeRegTestConstants.getInstance();
         Federation oldFederation = bridgeConstants.getGenesisFederation();
+        BtcECKey key = new BtcECKey(new SecureRandom());
+        FederationMember member = new FederationMember(key, ECKey.fromPublicOnly(key.getPubKey()));
         Federation newFederation = new Federation(
-                Collections.singletonList(new BtcECKey(new SecureRandom())),
+                Collections.singletonList(member),
                 Instant.EPOCH,
                 5L,
                 bridgeConstants.getBtcParams()
@@ -1412,13 +1415,15 @@ public class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation activeFederation = new Federation(activeFederationKeys, Instant.ofEpochMilli(2000L), 2L, parameters);
+
+        Federation activeFederation = new Federation(FederationMember.getFederationMembersFromKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
 
         List<BtcECKey> retiringFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fb01")),
             BtcECKey.fromPrivate(Hex.decode("fb02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation retiringFederation = new Federation(retiringFederationKeys, Instant.ofEpochMilli(1000L), 1L, parameters);
+
+        Federation retiringFederation = new Federation(FederationMember.getFederationMembersFromKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
 
         Repository repository = new RepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1501,7 +1506,8 @@ public class BridgeSupportTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")),
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = new Federation(federation1Keys, Instant.ofEpochMilli(1000L), 0L, parameters);
+
+        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -1509,7 +1515,8 @@ public class BridgeSupportTest {
                 BtcECKey.fromPrivate(Hex.decode("fb03")),
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), 0L, parameters);
+
+        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Repository repository = new RepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1624,7 +1631,8 @@ public class BridgeSupportTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")),
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = new Federation(federation1Keys, Instant.ofEpochMilli(1000L), 0L, parameters);
+
+        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -1632,7 +1640,8 @@ public class BridgeSupportTest {
                 BtcECKey.fromPrivate(Hex.decode("fb03")),
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), 0L, parameters);
+
+        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Repository repository = new RepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1779,13 +1788,13 @@ public class BridgeSupportTest {
     @Test
     public void getFederationMethods_genesis() throws IOException {
         Federation activeFederation = new Federation(
-                getTestFederationPublicKeys(3),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = new Federation(
-                getTestFederationPublicKeys(6),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1804,13 +1813,13 @@ public class BridgeSupportTest {
     @Test
     public void getFederationMethods_active() throws IOException {
         Federation activeFederation = new Federation(
-                getTestFederationPublicKeys(3),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = new Federation(
-                getTestFederationPublicKeys(6),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1837,13 +1846,13 @@ public class BridgeSupportTest {
     @Test
     public void getFederationMethods_newActivated() throws IOException {
         Federation newFederation = new Federation(
-                getTestFederationPublicKeys(3),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
                 Instant.ofEpochMilli(1000),
                 15L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation oldFederation = new Federation(
-                getTestFederationPublicKeys(6),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1874,13 +1883,13 @@ public class BridgeSupportTest {
     @Test
     public void getFederationMethods_newNotActivated() throws IOException {
         Federation newFederation = new Federation(
-                getTestFederationPublicKeys(3),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
                 Instant.ofEpochMilli(1000),
                 15L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation oldFederation = new Federation(
-                getTestFederationPublicKeys(6),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1920,14 +1929,14 @@ public class BridgeSupportTest {
     @Test
     public void getRetiringFederationMethods_presentNewInactive() throws IOException {
         Federation mockedNewFederation = new Federation(
-                getTestFederationPublicKeys(2),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                getTestFederationPublicKeys(4),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1954,14 +1963,14 @@ public class BridgeSupportTest {
     @Test
     public void getRetiringFederationMethods_presentNewActive() throws IOException {
         Federation mockedNewFederation = new Federation(
-                getTestFederationPublicKeys(2),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                getTestFederationPublicKeys(4),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2001,7 +2010,7 @@ public class BridgeSupportTest {
     @Test
     public void getPendingFederationMethods_present() throws IOException {
         PendingFederation mockedPendingFederation = new PendingFederation(
-                getTestFederationPublicKeys(5)
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(5))
         );
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, mockedPendingFederation, null, null);
 
@@ -2151,14 +2160,14 @@ public class BridgeSupportTest {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
 
         Federation mockedNewFederation = new Federation(
-                getTestFederationPublicKeys(2),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                getTestFederationPublicKeys(4),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2192,14 +2201,14 @@ public class BridgeSupportTest {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
 
         Federation mockedNewFederation = new Federation(
-                getTestFederationPublicKeys(2),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                getTestFederationPublicKeys(4),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2267,9 +2276,9 @@ public class BridgeSupportTest {
                 Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")
         }, true);
 
-        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }));
+        })));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
                 null,
@@ -2327,9 +2336,9 @@ public class BridgeSupportTest {
                 Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")
         }, false);
 
-        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
             BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }));
+        })));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
                 null,
@@ -2376,10 +2385,10 @@ public class BridgeSupportTest {
     public void rollbackFederation_ok() throws IOException {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("rollback", new byte[][]{}, true);
 
-        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }));
+        })));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
                 null,
@@ -2429,11 +2438,12 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_ok() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(
+        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
-                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))));
+                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49")))
+        ));
 
         VotingMocksProvider mocksProvider = new VotingMocksProvider("commit", new byte[][]{
                 pendingFederation.getHash().getBytes()
@@ -2443,17 +2453,17 @@ public class BridgeSupportTest {
         when(executionBlock.getTimestamp()).thenReturn(15005L);
         when(executionBlock.getNumber()).thenReturn(15L);
 
-        Federation expectedFederation = new Federation(Arrays.asList(
+        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
-                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))),
+                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49")))),
                 Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
-        Federation newFederation = new Federation(Arrays.asList(
+        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
                 BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
-                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))),
+                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338")))),
                 Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         BridgeEventLogger eventLoggerMock = mock(BridgeEventLogger.class);
@@ -2540,9 +2550,9 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_incompleteFederation() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }));
+        })));
 
         VotingMocksProvider mocksProvider = new VotingMocksProvider("commit", new byte[][]{
                 new Sha3Hash(HashUtil.sha3(Hex.decode("aabbcc"))).getBytes()
@@ -2568,10 +2578,10 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_hashMismatch() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12"))
-        }));
+        })));
 
         VotingMocksProvider mocksProvider = new VotingMocksProvider("commit", new byte[][]{
                 new Sha3Hash(HashUtil.sha3(Hex.decode("aabbcc"))).getBytes()
@@ -2597,10 +2607,10 @@ public class BridgeSupportTest {
 
     @Test
     public void getActiveFederationWallet() throws IOException {
-        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        })), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
                 expectedFederation,
@@ -2630,16 +2640,16 @@ public class BridgeSupportTest {
     @Test
     public void getRetiringFederationWallet_nonEmpty() throws IOException {
         Federation mockedNewFederation = new Federation(
-                getTestFederationPublicKeys(2),
+                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
-        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        })), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         Block mockedBlock = mock(Block.class);
         when(mockedBlock.getNumber()).thenReturn(25L);
@@ -3102,7 +3112,7 @@ public class BridgeSupportTest {
         result.sort(BtcECKey.PUBKEY_COMPARATOR);
         return result;
     }
-    
+
     private BtcTransaction createTransaction() {
         BtcTransaction btcTx = new BtcTransaction(btcParams);
         btcTx.addInput(new TransactionInput(btcParams, btcTx, new byte[0]));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -34,6 +34,7 @@ import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Genesis;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Before;
@@ -123,7 +124,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")),
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = new Federation(federation1Keys, Instant.ofEpochMilli(1000L), 0L, parameters);
+        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -131,7 +132,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fb03")),
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), 0L, parameters);
+        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Address address1 = federation1.getAddress();
         Address address2 = federation2.getAddress();
@@ -241,14 +242,14 @@ public class BridgeUtilsTest {
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation activeFederation = new Federation(activeFederationKeys, Instant.ofEpochMilli(2000L), 2L, parameters);
+        Federation activeFederation = new Federation(FederationMember.getFederationMembersFromKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
 
         List<BtcECKey> retiringFederationKeys = Stream.of(
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
                 BtcECKey.fromPrivate(Hex.decode("fb02")),
                 BtcECKey.fromPrivate(Hex.decode("fb03"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation retiringFederation = new Federation(retiringFederationKeys, Instant.ofEpochMilli(1000L), 1L, parameters);
+        Federation retiringFederation = new Federation(FederationMember.getFederationMembersFromKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
 
         Address activeFederationAddress = activeFederation.getAddress();
 
@@ -360,10 +361,10 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationNoSpendWallet() {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
+        })), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(regTestParameters);
 
@@ -375,10 +376,10 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationSpendWallet() throws UTXOProviderException {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
+        })), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(regTestParameters);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -318,7 +318,7 @@ public class BridgeUtilsTest {
 
     private Script signWithOneKey(Federation federation, List<BtcECKey> privateKeys, Script inputScript, Sha256Hash sighash, int federatorIndex, BridgeRegTestConstants bridgeConstants) {
         BtcECKey federatorPrivKey = privateKeys.get(federatorIndex);
-        BtcECKey federatorPublicKey = federation.getPublicKeys().get(federatorIndex);
+        BtcECKey federatorPublicKey = federation.getBtcPublicKeys().get(federatorIndex);
 
         BtcECKey.ECDSASignature sig = federatorPrivKey.sign(sighash);
         TransactionSignature txSig = new TransactionSignature(sig, BtcTransaction.SigHash.ALL, false);

--- a/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+import org.ethereum.crypto.ECKey;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.Matchers.any;
+
+public class FederationMemberTest {
+    private BtcECKey btcKey;
+    private ECKey rskKey;
+    private FederationMember member;
+
+    @Before
+    public void createFederationMember() {
+        btcKey = new BtcECKey();
+        rskKey = new ECKey();
+        member = new FederationMember(btcKey, rskKey);
+    }
+
+    @Test
+    public void immutable() {
+        Assert.assertNotSame(btcKey, member.getBtcPublicKey());
+        Assert.assertTrue(Arrays.equals(btcKey.getPubKey(), member.getBtcPublicKey().getPubKey()));
+        Assert.assertNotSame(rskKey, member.getRskPublicKey());
+        Assert.assertTrue(Arrays.equals(rskKey.getPubKey(), member.getRskPublicKey().getPubKey()));
+    }
+
+    @Test
+    public void testEquals_basic() {
+        Assert.assertTrue(member.equals(member));
+
+        Assert.assertFalse(member.equals(null));
+        Assert.assertFalse(member.equals(new Object()));
+        Assert.assertFalse(member.equals("something else"));
+    }
+
+    @Test
+    public void testEquals_sameKeys() {
+        FederationMember otherMember = new FederationMember(btcKey, rskKey);
+
+        Assert.assertTrue(member.equals(otherMember));
+    }
+
+    @Test
+    public void testEquals_differentBtcKey() {
+        FederationMember otherMember = new FederationMember(new BtcECKey(), rskKey);
+
+        Assert.assertFalse(member.equals(otherMember));
+    }
+
+    @Test
+    public void testEquals_differentRskKey() {
+        FederationMember otherMember = new FederationMember(btcKey, new ECKey());
+
+        Assert.assertFalse(member.equals(otherMember));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -81,7 +81,7 @@ public class FederationTest {
     public void publicKeysImmutable() {
         boolean exception = false;
         try {
-            federation.getPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
+            federation.getBtcPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
         } catch (Exception e) {
             exception = true;
         }
@@ -89,7 +89,7 @@ public class FederationTest {
 
         exception = false;
         try {
-            federation.getPublicKeys().remove(0);
+            federation.getBtcPublicKeys().remove(0);
         } catch (Exception e) {
             exception = true;
         }
@@ -287,7 +287,7 @@ public class FederationTest {
 
     @Test
     public void getPublicKeyIndex() {
-        for (int i = 0; i < federation.getPublicKeys().size(); i++) {
+        for (int i = 0; i < federation.getBtcPublicKeys().size(); i++) {
             Assert.assertEquals(i, federation.getPublicKeyIndex(sortedPublicKeys.get(i)).intValue());
         }
         Assert.assertNull(federation.getPublicKeyIndex(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
@@ -295,7 +295,7 @@ public class FederationTest {
 
     @Test
     public void hasPublicKey() {
-        for (int i = 0; i < federation.getPublicKeys().size(); i++) {
+        for (int i = 0; i < federation.getBtcPublicKeys().size(); i++) {
             Assert.assertTrue(federation.hasPublicKey(sortedPublicKeys.get(i)));
         }
         Assert.assertFalse(federation.hasPublicKey(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
@@ -303,7 +303,7 @@ public class FederationTest {
 
     @Test
     public void hasMemberWithRskAddress() {
-        for (int i = 0; i < federation.getPublicKeys().size(); i++) {
+        for (int i = 0; i < federation.getBtcPublicKeys().size(); i++) {
             Assert.assertTrue(federation.hasMemberWithRskAddress(rskAddresses.get(i)));
         }
 

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -52,14 +52,14 @@ public class FederationTest {
     @Before
     public void createFederation() {
         federation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -78,10 +78,10 @@ public class FederationTest {
     }
 
     @Test
-    public void publicKeysImmutable() {
+    public void membersImmutable() {
         boolean exception = false;
         try {
-            federation.getBtcPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
+            federation.getMembers().add(new FederationMember(new BtcECKey(), new ECKey()));
         } catch (Exception e) {
             exception = true;
         }
@@ -89,7 +89,7 @@ public class FederationTest {
 
         exception = false;
         try {
-            federation.getBtcPublicKeys().remove(0);
+            federation.getMembers().remove(0);
         } catch (Exception e) {
             exception = true;
         }
@@ -179,7 +179,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentNumberOfPublicKeys() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -187,7 +187,7 @@ public class FederationTest {
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -198,14 +198,14 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationTime() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -216,14 +216,14 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationBlockNumber() {
         Federation otherFederation = new Federation(
-                Arrays.asList(
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(
                     BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(600))
-                ),
+                )),
                 ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
                 1L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -234,14 +234,14 @@ public class FederationTest {
     @Test
     public void testEquals_differentNetworkParameters() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_TESTNET)
@@ -252,14 +252,14 @@ public class FederationTest {
     @Test
     public void testEquals_differentPublicKeys() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(610)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -270,14 +270,14 @@ public class FederationTest {
     @Test
     public void testEquals_same() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -286,19 +286,19 @@ public class FederationTest {
     }
 
     @Test
-    public void getPublicKeyIndex() {
+    public void getBtcPublicKeyIndex() {
         for (int i = 0; i < federation.getBtcPublicKeys().size(); i++) {
-            Assert.assertEquals(i, federation.getPublicKeyIndex(sortedPublicKeys.get(i)).intValue());
+            Assert.assertEquals(i, federation.getBtcPublicKeyIndex(sortedPublicKeys.get(i)).intValue());
         }
-        Assert.assertNull(federation.getPublicKeyIndex(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
+        Assert.assertNull(federation.getBtcPublicKeyIndex(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
     }
 
     @Test
-    public void hasPublicKey() {
+    public void hasBtcPublicKey() {
         for (int i = 0; i < federation.getBtcPublicKeys().size(); i++) {
-            Assert.assertTrue(federation.hasPublicKey(sortedPublicKeys.get(i)));
+            Assert.assertTrue(federation.hasBtcPublicKey(sortedPublicKeys.get(i)));
         }
-        Assert.assertFalse(federation.hasPublicKey(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
+        Assert.assertFalse(federation.hasBtcPublicKey(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -36,6 +36,7 @@ import java.math.BigInteger;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -168,7 +169,7 @@ public class FederationTest {
     }
 
     @Test
-    public void testEquals_a() {
+    public void testEquals_basic() {
         Assert.assertTrue(federation.equals(federation));
 
         Assert.assertFalse(federation.equals(null));
@@ -177,7 +178,7 @@ public class FederationTest {
     }
 
     @Test
-    public void testEquals_differentNumberOfPublicKeys() {
+    public void testEquals_differentNumberOfMembers() {
         Federation otherFederation = new Federation(
                 FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
@@ -250,21 +251,35 @@ public class FederationTest {
     }
 
     @Test
-    public void testEquals_differentPublicKeys() {
+    public void testEquals_differentMembers() {
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
+        }));
+
+        members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(600))));
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(610)),
-                })),
+                members,
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
+
+        members.remove(members.size()-1);
+        members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(610))));
+        Federation yetOtherFederation = new Federation(
+                members,
+                ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
+                0L,
+                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
+
+        Assert.assertFalse(otherFederation.equals(yetOtherFederation));
         Assert.assertFalse(federation.equals(otherFederation));
+        Assert.assertFalse(federation.equals(yetOtherFederation));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -57,13 +57,13 @@ public class PegTestUtils {
     public static Script createBaseInputScriptThatSpendsFromTheFederation(Federation federation) {
         Script scriptPubKey = federation.getP2SHScript();
         Script redeemScript = createBaseRedeemScriptThatSpendsFromTheFederation(federation);
-        RedeemData redeemData = RedeemData.of(federation.getPublicKeys(), redeemScript);
+        RedeemData redeemData = RedeemData.of(federation.getBtcPublicKeys(), redeemScript);
         Script inputScript = scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript);
         return inputScript;
     }
 
     public static Script createBaseRedeemScriptThatSpendsFromTheFederation(Federation federation) {
-        Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getPublicKeys());
+        Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getBtcPublicKeys());
         return redeemScript;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -101,7 +101,7 @@ public class PendingFederationTest {
     }
 
     @Test
-    public void testEquals_a() {
+    public void testEquals_basic() {
         Assert.assertTrue(pendingFederation.equals(pendingFederation));
 
         Assert.assertFalse(pendingFederation.equals(null));
@@ -110,7 +110,7 @@ public class PendingFederationTest {
     }
 
     @Test
-    public void testEquals_differentNumberOfPublicKeys() {
+    public void testEquals_differentNumberOfMembers() {
         PendingFederation otherPendingFederation = new PendingFederation(
                 FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
@@ -126,18 +126,25 @@ public class PendingFederationTest {
     }
 
     @Test
-    public void testEquals_differentPublicKeys() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(610)),
-                }))
-        );
+    public void testEquals_differentMembers() {
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
+        }));
+
+        members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(600))));
+        PendingFederation otherPendingFederation = new PendingFederation(members);
+
+        members.remove(members.size()-1);
+        members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(610))));
+        PendingFederation yetOtherPendingFederation = new PendingFederation(members);
+
+        Assert.assertFalse(otherPendingFederation.equals(yetOtherPendingFederation));
         Assert.assertFalse(pendingFederation.equals(otherPendingFederation));
+        Assert.assertFalse(pendingFederation.equals(yetOtherPendingFederation));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -20,8 +20,6 @@ package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.script.Script;
-import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.crypto.Sha3Hash;
 import org.ethereum.crypto.HashUtil;
 import org.junit.Assert;
@@ -31,12 +29,9 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -74,7 +69,7 @@ public class PendingFederationTest {
     public void publicKeysImmutable() {
         boolean exception = false;
         try {
-            pendingFederation.getPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
+            pendingFederation.getBtcPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
         } catch (Exception e) {
             exception = true;
         }
@@ -82,7 +77,7 @@ public class PendingFederationTest {
 
         exception = false;
         try {
-            pendingFederation.getPublicKeys().remove(0);
+            pendingFederation.getBtcPublicKeys().remove(0);
         } catch (Exception e) {
             exception = true;
         }

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Sha3Hash;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,14 +47,14 @@ public class PendingFederationTest {
     @Before
     public void createPendingFederation() {
         pendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })
+                }))
         );
         sortedPublicKeys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
@@ -66,10 +67,10 @@ public class PendingFederationTest {
     }
 
     @Test
-    public void publicKeysImmutable() {
+    public void membersImmutable() {
         boolean exception = false;
         try {
-            pendingFederation.getBtcPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
+            pendingFederation.getMembers().add(new FederationMember(new BtcECKey(), new ECKey()));
         } catch (Exception e) {
             exception = true;
         }
@@ -77,7 +78,7 @@ public class PendingFederationTest {
 
         exception = false;
         try {
-            pendingFederation.getBtcPublicKeys().remove(0);
+            pendingFederation.getMembers().remove(0);
         } catch (Exception e) {
             exception = true;
         }
@@ -92,9 +93,9 @@ public class PendingFederationTest {
     @Test
     public void isComplete_not() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                })
+                }))
         );
         Assert.assertFalse(otherPendingFederation.isComplete());
     }
@@ -111,7 +112,7 @@ public class PendingFederationTest {
     @Test
     public void testEquals_differentNumberOfPublicKeys() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -119,7 +120,7 @@ public class PendingFederationTest {
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                })
+                }))
         );
         Assert.assertFalse(pendingFederation.equals(otherPendingFederation));
     }
@@ -127,14 +128,14 @@ public class PendingFederationTest {
     @Test
     public void testEquals_differentPublicKeys() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(610)),
-                })
+                }))
         );
         Assert.assertFalse(pendingFederation.equals(otherPendingFederation));
     }
@@ -142,14 +143,14 @@ public class PendingFederationTest {
     @Test
     public void testEquals_same() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })
+                }))
         );
         Assert.assertTrue(pendingFederation.equals(otherPendingFederation));
     }
@@ -158,9 +159,9 @@ public class PendingFederationTest {
     public void testToString() {
         Assert.assertEquals("6 signatures pending federation (complete)", pendingFederation.toString());
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                })
+                }))
         );
         Assert.assertEquals("1 signatures pending federation (incomplete)", otherPendingFederation.toString());
     }
@@ -168,24 +169,24 @@ public class PendingFederationTest {
     @Test
     public void buildFederation_ok_a() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })
+                }))
         );
 
-        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-        }), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        })), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         Assert.assertEquals(
                 expectedFederation,
@@ -200,7 +201,7 @@ public class PendingFederationTest {
     @Test
     public void buildFederation_ok_b() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -210,10 +211,10 @@ public class PendingFederationTest {
                         BtcECKey.fromPrivate(BigInteger.valueOf(700)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(800)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(900)),
-                })
+                }))
         );
 
-        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -223,7 +224,7 @@ public class PendingFederationTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(700)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(800)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(900)),
-        }), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        })), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         Assert.assertEquals(
                 expectedFederation,
@@ -238,9 +239,9 @@ public class PendingFederationTest {
     @Test
     public void buildFederation_incomplete() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                })
+                }))
         );
 
         try {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -22,8 +22,10 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
+import org.ethereum.crypto.ECKey;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -32,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 @Ignore
 public class ActiveFederationTest extends BridgePerformanceTestCase {
@@ -104,8 +107,13 @@ public class ActiveFederationTest extends BridgePerformanceTestCase {
                 for (int i = 0; i < numFederators; i++) {
                     federatorKeys.add(new BtcECKey());
                 }
+
+                List<FederationMember> members = federatorKeys.stream().map(pk ->
+                        new FederationMember(pk, ECKey.fromPublicOnly(pk.getPubKey()))
+                ).collect(Collectors.toList());
+
                 federation = new Federation(
-                        federatorKeys,
+                        members,
                         Instant.ofEpochMilli(new Random().nextLong()),
                         Helper.randomInRange(1, 10),
                         networkParameters

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -65,7 +65,7 @@ public class ActiveFederationTest extends BridgePerformanceTestCase {
     @Test
     public void getFederatorPublicKey() throws IOException {
         ExecutionStats stats = new ExecutionStats("getFederatorPublicKey");
-        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, federation.getPublicKeys().size()-1)});
+        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, federation.getBtcPublicKeys().size()-1)});
         executeTestCaseSection(abiEncoder, "getFederatorPublicKey", true,50, stats);
         executeTestCaseSection(abiEncoder, "getFederatorPublicKey", false,500, stats);
         BridgePerformanceTest.addStats(stats);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
@@ -196,7 +196,9 @@ public class FederationChangeTest extends BridgePerformanceTestCase {
                 for (int i = 0; i < numKeys; i++) {
                     pendingFederationKeys.add(new BtcECKey());
                 }
-                pendingFederation = new PendingFederation(pendingFederationKeys);
+                pendingFederation = new PendingFederation(pendingFederationKeys.stream().map(pk ->
+                        new FederationMember(pk, ECKey.fromPublicOnly(pk.getPubKey())
+                )).collect(Collectors.toList()));
                 provider.setPendingFederation(pendingFederation);
             }
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
@@ -21,15 +21,18 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
+import co.rsk.peg.FederationMember;
 import co.rsk.peg.PendingFederation;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
+import org.ethereum.crypto.ECKey;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Ignore
 public class PendingFederationTest extends BridgePerformanceTestCase {
@@ -89,7 +92,9 @@ public class PendingFederationTest extends BridgePerformanceTestCase {
                 for (int i = 0; i < numFederators; i++) {
                     federatorKeys.add(new BtcECKey());
                 }
-                pendingFederation = new PendingFederation(federatorKeys);
+                pendingFederation = new PendingFederation(federatorKeys.stream().map(pk ->
+                        new FederationMember(pk, ECKey.fromPublicOnly(pk.getPubKey())
+                )).collect(Collectors.toList()));
                 provider.setPendingFederation(pendingFederation);
             } else {
                 pendingFederation = null;

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
@@ -21,7 +21,6 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
-import co.rsk.peg.Federation;
 import co.rsk.peg.PendingFederation;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
@@ -29,10 +28,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 @Ignore
 public class PendingFederationTest extends BridgePerformanceTestCase {
@@ -52,7 +49,7 @@ public class PendingFederationTest extends BridgePerformanceTestCase {
     public void getPendingFederatorPublicKey() throws IOException {
         ExecutionStats stats = new ExecutionStats("getPendingFederatorPublicKey");
         ABIEncoder abiEncoder;
-        abiEncoder = (int executionIndex) -> Bridge.GET_PENDING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, pendingFederation.getPublicKeys().size()-1)});
+        abiEncoder = (int executionIndex) -> Bridge.GET_PENDING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, pendingFederation.getBtcPublicKeys().size()-1)});
         executeTestCaseSection(abiEncoder, "getPendingFederatorPublicKey", true,200, stats);
         abiEncoder = (int executionIndex) -> Bridge.GET_PENDING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, 10)});
         executeTestCaseSection(abiEncoder, "getPendingFederatorPublicKey", false,200, stats);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -22,8 +22,10 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
+import org.ethereum.crypto.ECKey;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -32,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 @Ignore
 public class RetiringFederationTest extends BridgePerformanceTestCase {
@@ -107,7 +110,9 @@ public class RetiringFederationTest extends BridgePerformanceTestCase {
                     federatorKeys.add(new BtcECKey());
                 }
                 retiringFederation = new Federation(
-                        federatorKeys,
+                        federatorKeys.stream().map(pk ->
+                                new FederationMember(pk, ECKey.fromPublicOnly(pk.getPubKey())
+                        )).collect(Collectors.toList()),
                         Instant.ofEpochMilli(new Random().nextLong()),
                         Helper.randomInRange(1, 10),
                         networkParameters

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -66,7 +66,7 @@ public class RetiringFederationTest extends BridgePerformanceTestCase {
     public void getRetiringFederatorPublicKey() throws IOException {
         ExecutionStats stats = new ExecutionStats("getRetiringFederatorPublicKey");
         ABIEncoder abiEncoder;
-        abiEncoder = (int executionIndex) -> Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, retiringFederation.getPublicKeys().size()-1)});
+        abiEncoder = (int executionIndex) -> Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, retiringFederation.getBtcPublicKeys().size()-1)});
         executeTestCaseSection(abiEncoder, "getRetiringFederatorPublicKey", true,50, stats);
         abiEncoder = (int executionIndex) -> Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, 10)});
         executeTestCaseSection(abiEncoder, "getRetiringFederatorPublicKey", false,500, stats);

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -106,7 +106,7 @@ public class BridgeEventLoggerImplTest {
         RLPList oldFedPubKeys = (RLPList) oldFedData.get(1);
         Assert.assertEquals(4, oldFedPubKeys.size());
         for(int i = 0; i < 4; i++) {
-            Assert.assertEquals(oldFederation.getPublicKeys().get(i), BtcECKey.fromPublicOnly(oldFedPubKeys.get(i).getRLPData()));
+            Assert.assertEquals(oldFederation.getBtcPublicKeys().get(i), BtcECKey.fromPublicOnly(oldFedPubKeys.get(i).getRLPData()));
         }
 
         // Assert new federation data
@@ -117,7 +117,7 @@ public class BridgeEventLoggerImplTest {
         RLPList newFedPubKeys = (RLPList) newFedData.get(1);
         Assert.assertEquals(3, newFedPubKeys.size());
         for(int i = 0; i < 3; i++) {
-            Assert.assertEquals(newFederation.getPublicKeys().get(i), BtcECKey.fromPublicOnly(newFedPubKeys.get(i).getRLPData()));
+            Assert.assertEquals(newFederation.getBtcPublicKeys().get(i), BtcECKey.fromPublicOnly(newFedPubKeys.get(i).getRLPData()));
         }
 
         // Assert new federation activation block number

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -24,7 +24,9 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.core.Block;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
@@ -39,6 +41,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -64,17 +67,31 @@ public class BridgeEventLoggerImplTest {
         when(executionBlock.getTimestamp()).thenReturn(15005L);
         when(executionBlock.getNumber()).thenReturn(15L);
 
-        Federation oldFederation = new Federation(Arrays.asList(
+        List<BtcECKey> oldFederationKeys = Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
-                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))),
+                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))
+        );
+
+        List<FederationMember> oldFederationMembers = oldFederationKeys.stream().map(pk ->
+                new FederationMember(pk, ECKey.fromPublicOnly(pk.getPubKey()))
+        ).collect(Collectors.toList());
+
+        Federation oldFederation = new Federation(oldFederationMembers,
                 Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
-        Federation newFederation = new Federation(Arrays.asList(
+        List<BtcECKey> newFederationKeys = Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
                 BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
-                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))),
+                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
+        );
+
+        List<FederationMember> newFederationMembers = newFederationKeys.stream().map(pk ->
+                new FederationMember(pk, ECKey.fromPublicOnly(pk.getPubKey()))
+        ).collect(Collectors.toList());
+
+        Federation newFederation = new Federation(newFederationMembers,
                 Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         // Do method call


### PR DESCRIPTION
Refactor:

`Federation` and `PendingFederation` are now composed of a list of `FederationMember` instead of `BtcECKey`. Each `FederationMember` is composed of a pair of keys (one for BTC and one for RSK). Usages across the system have been updated as to use same keys for BTC and RSK.