### PR TITLE
Feature/add submit bitcoin solution new  methods

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
@@ -22,6 +22,7 @@ import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 import java.util.Optional;
 
 
@@ -32,6 +33,11 @@ public interface MinerServer {
     void stop();
 
     boolean isRunning();
+
+    SubmitBlockResult submitBitcoinSolution(String blockHashForMergedMining,
+                                            co.rsk.bitcoinj.core.BtcBlock blockWithOnlyHeader,
+                                            co.rsk.bitcoinj.core.BtcTransaction coinbase,
+                                            List<String> txHashes);
 
     SubmitBlockResult submitBitcoinBlock(String blockHashForMergedMining, co.rsk.bitcoinj.core.BtcBlock bitcoinMergedMiningBlock);
 

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
@@ -37,7 +37,8 @@ public interface MinerServer {
     SubmitBlockResult submitBitcoinSolution(String blockHashForMergedMining,
                                             co.rsk.bitcoinj.core.BtcBlock blockWithOnlyHeader,
                                             co.rsk.bitcoinj.core.BtcTransaction coinbase,
-                                            List<String> txHashes);
+                                            List<String> merkleHashes,
+                                            int blockTxnCount);
 
     SubmitBlockResult submitBitcoinBlock(String blockHashForMergedMining, co.rsk.bitcoinj.core.BtcBlock bitcoinMergedMiningBlock);
 

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
@@ -18,6 +18,8 @@
 
 package co.rsk.mine;
 
+import co.rsk.bitcoinj.core.BtcBlock;
+import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
 
@@ -35,12 +37,12 @@ public interface MinerServer {
     boolean isRunning();
 
     SubmitBlockResult submitBitcoinSolution(String blockHashForMergedMining,
-                                            co.rsk.bitcoinj.core.BtcBlock blockWithOnlyHeader,
-                                            co.rsk.bitcoinj.core.BtcTransaction coinbase,
+                                            BtcBlock blockWithOnlyHeader,
+                                            BtcTransaction coinbase,
                                             List<String> merkleHashes,
                                             int blockTxnCount);
 
-    SubmitBlockResult submitBitcoinBlock(String blockHashForMergedMining, co.rsk.bitcoinj.core.BtcBlock bitcoinMergedMiningBlock);
+    SubmitBlockResult submitBitcoinBlock(String blockHashForMergedMining, BtcBlock bitcoinMergedMiningBlock);
 
     boolean generateFallbackBlock();
 

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
@@ -36,11 +36,20 @@ public interface MinerServer {
 
     boolean isRunning();
 
-    SubmitBlockResult submitBitcoinSolution(String blockHashForMergedMining,
-                                            BtcBlock blockWithOnlyHeader,
-                                            BtcTransaction coinbase,
-                                            List<String> merkleHashes,
-                                            int blockTxnCount);
+    SubmitBlockResult submitBitcoinBlockPartialMerkle(
+            String blockHashForMergedMining,
+            BtcBlock blockWithOnlyHeader,
+            BtcTransaction coinbase,
+            List<String> merkleHashes,
+            int blockTxnCount
+    );
+
+    SubmitBlockResult submitBitcoinBlockTransactions(
+            String blockHashForMergedMining,
+            BtcBlock blockWithOnlyHeader,
+            BtcTransaction coinbase,
+            List<String> txHashes
+    );
 
     SubmitBlockResult submitBitcoinBlock(String blockHashForMergedMining, BtcBlock bitcoinMergedMiningBlock);
 

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -61,6 +61,7 @@ import java.util.stream.Collectors;
 /**
  * The MinerServer provides support to components that perform the actual mining.
  * It builds blocks to mine and publishes blocks once a valid nonce was found by the miner.
+ *
  * @author Oscar Guindzberg
  */
 
@@ -148,7 +149,7 @@ public class MinerServerImpl implements MinerServer {
         secsBetweenFallbackMinedBlocks =
                 config.getAverageFallbackMiningTime();
         // default
-        if (secsBetweenFallbackMinedBlocks==0) {
+        if (secsBetweenFallbackMinedBlocks == 0) {
             secsBetweenFallbackMinedBlocks = (config.getBlockchainConfig().getCommonConstants().getDurationLimit());
         }
         autoSwitchBetweenNormalAndFallbackMining = !config.getBlockchainConfig().getCommonConstants().getFallbackMiningDifficulty().equals(BlockDifficulty.ZERO);
@@ -160,8 +161,7 @@ public class MinerServerImpl implements MinerServer {
     }
 
     private LinkedHashMap<Keccak256, Block> createNewBlocksWaitingList() {
-        return new LinkedHashMap<Keccak256, Block>(CACHE_SIZE)
-        {
+        return new LinkedHashMap<Keccak256, Block>(CACHE_SIZE) {
             @Override
             protected boolean removeEldestEntry(Map.Entry<Keccak256, Block> eldest) {
                 return size() > CACHE_SIZE;
@@ -186,15 +186,14 @@ public class MinerServerImpl implements MinerServer {
                     fallbackMiningTimer = new Timer("Private mining timer");
                 }
                 if (!fallbackMiningScheduled) {
-                    fallbackMiningTimer.schedule(new FallbackMiningTask(), 1000,1000 );
+                    fallbackMiningTimer.schedule(new FallbackMiningTask(), 1000, 1000);
                     fallbackMiningScheduled = true;
                 }
                 // Because the Refresh occurs only once every minute,
                 // we need to create at least one first block to mine
                 Block bestBlock = blockchain.getBestBlock();
                 buildBlockToMine(bestBlock, false);
-            }
-            else {
+            } else {
                 if (fallbackMiningTimer != null) {
                     fallbackMiningTimer.cancel();
                     fallbackMiningTimer = null;
@@ -319,7 +318,7 @@ public class MinerServerImpl implements MinerServer {
         }
 
         if (!isEvenBlockNumber && privKey1 == null) {
-           return false;
+            return false;
         }
 
         if (isEvenBlockNumber && privKey0 == null) {
@@ -340,7 +339,7 @@ public class MinerServerImpl implements MinerServer {
         BlockHeader newHeader = newBlock.getHeader();
 
         newHeader.setTimestamp(this.getCurrentTimeInSeconds());
-        Block parentBlock =blockchain.getBlockByHash(newHeader.getParentHash().getBytes());
+        Block parentBlock = blockchain.getBlockByHash(newHeader.getParentHash().getBytes());
         newHeader.setDifficulty(
                 difficultyCalculator.calcDifficulty(newHeader, parentBlock.getHeader()));
 
@@ -381,10 +380,11 @@ public class MinerServerImpl implements MinerServer {
     }
 
     @Override
-    public SubmitBlockResult submitBitcoinSolution(String blockHashForMergedMining,
-                                                    BtcBlock blockWithHeaderOnly,
-                                                    BtcTransaction coinbase,
-                                                    List<String> txHashes) {
+    public SubmitBlockResult submitBitcoinSolution(
+            String blockHashForMergedMining,
+            BtcBlock blockWithHeaderOnly,
+            BtcTransaction coinbase,
+            List<String> txHashes) {
         logger.debug("Received solution with hash {} for merged mining", blockHashForMergedMining);
 
         PartialMerkleTree bitcoinMergedMiningMerkleBranch = getBitcoinMergedMerkleBranch(blockWithHeaderOnly.getParams(), txHashes);
@@ -407,7 +407,12 @@ public class MinerServerImpl implements MinerServer {
         return processSolution(blockHashForMergedMining, bitcoinMergedMiningBlock, coinbase, bitcoinMergedMiningMerkleBranch, lastTag);
     }
 
-    private SubmitBlockResult processSolution(String blockHashForMergedMining, BtcBlock blockWithHeaderOnly, BtcTransaction coinbase, PartialMerkleTree bitcoinMergedMiningMerkleBranch, boolean lastTag) {
+    private SubmitBlockResult processSolution(
+            String blockHashForMergedMining,
+            BtcBlock blockWithHeaderOnly,
+            BtcTransaction coinbase,
+            PartialMerkleTree bitcoinMergedMiningMerkleBranch,
+            boolean lastTag) {
         Block newBlock;
         Keccak256 key = new Keccak256(TypeConverter.removeZeroX(blockHashForMergedMining));
 
@@ -469,12 +474,12 @@ public class MinerServerImpl implements MinerServer {
         return compressCoinbase(bitcoinMergedMiningCoinbaseTransactionSerialized, true);
     }
 
-    public static byte[] compressCoinbase(byte[] bitcoinMergedMiningCoinbaseTransactionSerialized, boolean lastOcurrence) {
+    public static byte[] compressCoinbase(byte[] bitcoinMergedMiningCoinbaseTransactionSerialized, boolean lastOccurrence) {
         List<Byte> coinBaseTransactionSerializedAsList = java.util.Arrays.asList(ArrayUtils.toObject(bitcoinMergedMiningCoinbaseTransactionSerialized));
         List<Byte> tagAsList = java.util.Arrays.asList(ArrayUtils.toObject(RskMiningConstants.RSK_TAG));
 
         int rskTagPosition;
-        if (lastOcurrence) {
+        if (lastOccurrence) {
             rskTagPosition = Collections.lastIndexOfSubList(coinBaseTransactionSerializedAsList, tagAsList);
         } else {
             rskTagPosition = Collections.indexOfSubList(coinBaseTransactionSerializedAsList, tagAsList);
@@ -500,7 +505,7 @@ public class MinerServerImpl implements MinerServer {
      * getBitcoinMergedMerkleBranch returns the Partial Merkle Branch needed to validate that the coinbase tx
      * is part of the Merkle Tree.
      *
-     * @param networkParams bitcoin network params.
+     * @param networkParams  bitcoin network params.
      * @param txStringHashes hashes for the txs of the bitcoin block used for merged mining.
      * @return A Partial Merkle Branch in which you can validate the coinbase tx.
      */
@@ -557,7 +562,7 @@ public class MinerServerImpl implements MinerServer {
         if (work == null) {
             return null;
         }
-        
+
         if (work.getNotify()) {
             /**
              * Set currentWork.notify to false for the next time this function is called.
@@ -567,11 +572,11 @@ public class MinerServerImpl implements MinerServer {
              * currentWork, regardless of what it is.
              */
             synchronized (lock) {
-                if (currentWork != work ||  currentWork == null) {
+                if (currentWork != work || currentWork == null) {
                     return currentWork;
                 }
                 currentWork = new MinerWork(currentWork.getBlockHashForMergedMining(), currentWork.getTarget(),
-                                            currentWork.getFeesPaidToMiner(),false, currentWork.getParentBlockHash());
+                        currentWork.getFeesPaidToMiner(), false, currentWork.getParentBlockHash());
             }
         }
         return work;
@@ -601,7 +606,7 @@ public class MinerServerImpl implements MinerServer {
     /**
      * buildBlockToMine creates a block to mine based on the given block as parent.
      *
-     * @param newBlockParent              the new block parent.
+     * @param newBlockParent         the new block parent.
      * @param createCompetitiveBlock used for testing.
      */
     @Override
@@ -736,16 +741,16 @@ public class MinerServerImpl implements MinerServer {
                 long curtimestampSeconds = getCurrentTimeInSeconds();
 
 
-                if (curtimestampSeconds > bestBlock.getTimestamp() + secsBetweenFallbackMinedBlocks)
-                    {
-                        generateFallbackBlock();
-            }
+                if (curtimestampSeconds > bestBlock.getTimestamp() + secsBetweenFallbackMinedBlocks) {
+                    generateFallbackBlock();
+                }
             } catch (Throwable th) {
                 logger.error("Unexpected error: {}", th);
                 panicProcessor.panic("mserror", th.getMessage());
             }
         }
     }
+
     /**
      * RefreshBlocks rebuilds the block to mine.
      */

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -539,7 +539,7 @@ public class MinerServerImpl implements MinerServer {
 
         // bits indicates which nodes are going to be used for building the partial merkle tree
         // for more information please refer to {@link co.rsk.bitcoinj.core.PartialMerkleTree#buildFromLeaves } method
-        byte[] bits = new byte[(int) Math.ceil(bitList.size() / 8.0)];
+        byte[] bits = new byte[(bitList.size() + 7) / 8];
         for (int i = 0; i < bitList.size(); i++) {
             if (bitList.get(i)) {
                 Utils.setBitLE(bits, i);
@@ -588,7 +588,7 @@ public class MinerServerImpl implements MinerServer {
            We need txs.size() / 8 bytes to represent this vector.
            The coinbase tx is the first one of the txs so we set the first bit to 1.
          */
-        byte[] bitvector = new byte[(int) Math.ceil(txHashes.size() / 8.0)];
+        byte[] bitvector = new byte[(txHashes.size() + 7) / 8];
         Utils.setBitLE(bitvector, 0);
         return PartialMerkleTree.buildFromLeaves(params, bitvector, txHashes);
     }

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -505,7 +505,7 @@ public class MinerServerImpl implements MinerServer {
      * @return A Partial Merkle Branch in which you can validate the coinbase tx.
      */
     public static PartialMerkleTree getBitcoinMergedMerkleBranch(NetworkParameters networkParams, List<String> txStringHashes) {
-        List<co.rsk.bitcoinj.core.Sha256Hash> txHashes = txStringHashes.stream().map(Sha256Hash::wrap).collect(Collectors.toList());
+        List<Sha256Hash> txHashes = txStringHashes.stream().map(Sha256Hash::wrap).collect(Collectors.toList());
 
         return buildMerkleBranch(txHashes, networkParams);
     }
@@ -519,7 +519,7 @@ public class MinerServerImpl implements MinerServer {
      */
     public static PartialMerkleTree getBitcoinMergedMerkleBranch(BtcBlock bitcoinMergedMiningBlock) {
         List<BtcTransaction> txs = bitcoinMergedMiningBlock.getTransactions();
-        List<co.rsk.bitcoinj.core.Sha256Hash> txHashes = new ArrayList<>(txs.size());
+        List<Sha256Hash> txHashes = new ArrayList<>(txs.size());
         for (BtcTransaction tx : txs) {
             txHashes.add(tx.getHash());
         }

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.crypto.digests.SHA256Digest;
 import org.spongycastle.util.Arrays;
+import org.spongycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -397,7 +397,7 @@ public class MinerServerImpl implements MinerServer {
         co.rsk.bitcoinj.core.PartialMerkleTree bitcoinMergedMiningMerkleBranch = getBitcoinMergedMerkleBranch(blockWithOnlyHeader.getParams(), txHashes);
 
         Block newBlock;
-        Sha3Hash key = new Sha3Hash(TypeConverter.removeZeroX(blockHashForMergedMining));
+        Keccak256 key = new Keccak256(TypeConverter.removeZeroX(blockHashForMergedMining));
 
         synchronized (lock) {
             Block workingBlock = blocksWaitingforPoW.get(key);

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -515,7 +515,7 @@ public class MinerServerImpl implements MinerServer {
             NetworkParameters networkParams,
             List<String> merkleStringHashes,
             int blockTxnCount) {
-        List<Sha256Hash> merkleHashes = merkleStringHashes.stream().map(Sha256Hash::wrap).collect(Collectors.toList());
+        List<Sha256Hash> merkleHashes = merkleStringHashes.stream().map(mk -> Sha256Hash.wrapReversed(Hex.decode(mk))).collect(Collectors.toList());
         int merkleTreeHeight = (int) Math.ceil(Math.log(blockTxnCount) / Math.log(2));
 
         // bitlist will always have ones at the beginning because merkle branch is built for coinbase tx

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -383,18 +383,11 @@ public class MinerServerImpl implements MinerServer {
 
     @Override
     public SubmitBlockResult submitBitcoinSolution(String blockHashForMergedMining,
-                                                   co.rsk.bitcoinj.core.BtcBlock blockWithOnlyHeader,
-                                                   co.rsk.bitcoinj.core.BtcTransaction coinbase,
-                                                   List<String> txHashes) {
-        return submitBitcoinSolution(blockHashForMergedMining, blockWithOnlyHeader, coinbase, txHashes, true);
-    }
-
-    public SubmitBlockResult submitBitcoinSolution(String blockHashForMergedMining,
-                                                    co.rsk.bitcoinj.core.BtcBlock blockWithOnlyHeader,
+                                                    co.rsk.bitcoinj.core.BtcBlock blockWithHeaderOnly,
                                                     co.rsk.bitcoinj.core.BtcTransaction coinbase,
-                                                    List<String> txHashes, boolean lastTag) {
+                                                    List<String> txHashes) {
         logger.debug("Received block with hash {} for merged mining", blockHashForMergedMining);
-        co.rsk.bitcoinj.core.PartialMerkleTree bitcoinMergedMiningMerkleBranch = getBitcoinMergedMerkleBranch(blockWithOnlyHeader.getParams(), txHashes);
+        co.rsk.bitcoinj.core.PartialMerkleTree bitcoinMergedMiningMerkleBranch = getBitcoinMergedMerkleBranch(blockWithHeaderOnly.getParams(), txHashes);
 
         Block newBlock;
         Keccak256 key = new Keccak256(TypeConverter.removeZeroX(blockHashForMergedMining));
@@ -424,8 +417,8 @@ public class MinerServerImpl implements MinerServer {
 
         logger.info("Received block {} {}", newBlock.getNumber(), Hex.toHexString(newBlock.getHash()));
 
-        newBlock.setBitcoinMergedMiningHeader(blockWithOnlyHeader.cloneAsHeader().bitcoinSerialize());
-        newBlock.setBitcoinMergedMiningCoinbaseTransaction(compressCoinbase(coinbase.bitcoinSerialize(), lastTag));
+        newBlock.setBitcoinMergedMiningHeader(blockWithHeaderOnly.cloneAsHeader().bitcoinSerialize());
+        newBlock.setBitcoinMergedMiningCoinbaseTransaction(compressCoinbase(coinbase.bitcoinSerialize(), true));
         newBlock.setBitcoinMergedMiningMerkleProof(bitcoinMergedMiningMerkleBranch.bitcoinSerialize());
         newBlock.seal();
 

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -26,7 +26,6 @@ import co.rsk.core.bc.PendingStateImpl;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.remasc.RemascTransaction;
-import com.google.common.collect.Lists;
 import org.ethereum.core.PendingState;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -39,10 +38,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Created by oscar on 26/09/2016.
@@ -127,9 +123,11 @@ public class MinerUtils {
         return coinbaseTransaction;
     }
 
-    public static co.rsk.bitcoinj.core.BtcBlock getBitcoinMergedMiningBlock(co.rsk.bitcoinj.core.NetworkParameters params,
-                                                                      co.rsk.bitcoinj.core.BtcTransaction coinbaseTransaction) {
-        List<BtcTransaction> transactions = Lists.newArrayList(coinbaseTransaction);
+    public static co.rsk.bitcoinj.core.BtcBlock getBitcoinMergedMiningBlock(co.rsk.bitcoinj.core.NetworkParameters params, BtcTransaction transaction) {
+        return getBitcoinMergedMiningBlock(params, Collections.singletonList(transaction));
+    }
+
+    public static co.rsk.bitcoinj.core.BtcBlock getBitcoinMergedMiningBlock(co.rsk.bitcoinj.core.NetworkParameters params, List<BtcTransaction> transactions) {
         co.rsk.bitcoinj.core.Sha256Hash prevBlockHash = co.rsk.bitcoinj.core.Sha256Hash.ZERO_HASH;
         long time = System.currentTimeMillis() / 1000;
         long difficultyTarget = co.rsk.bitcoinj.core.Utils.encodeCompactBits(params.getMaxTarget());

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -92,17 +92,13 @@ public class Web3RskImpl extends Web3Impl {
     }
 
     public MinerWork mnr_getWork() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("mnr_getWork()");
-        }
+        logger.debug("mnr_getWork()");
 
         return minerServer.getWork();
     }
 
     public SubmittedBlockInfo mnr_submitBitcoinBlock(String bitcoinBlockHex) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("mnr_submitBitcoinBlock(): {}", bitcoinBlockHex.length());
-        }
+        logger.debug("mnr_submitBitcoinBlock(): {}", bitcoinBlockHex.length());
 
         NetworkParameters params = RegTestParams.get();
         new Context(params);
@@ -124,9 +120,7 @@ public class Web3RskImpl extends Web3Impl {
             String merkleHashesHex,
             String blockTxnCountHex
     ) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("mnr_submitBitcoinSolution(): {}, {}, {}, {}, {}", blockHashHex, blockHeaderHex, coinbaseHex, merkleHashesHex, blockTxnCountHex);
-        }
+        logger.debug("mnr_submitBitcoinSolution(): {}, {}, {}, {}, {}", blockHashHex, blockHeaderHex, coinbaseHex, merkleHashesHex, blockTxnCountHex);
 
         NetworkParameters params = RegTestParams.get();
         new Context(params);

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -139,7 +139,7 @@ public class Web3RskImpl extends Web3Impl {
         return parseResultAndReturn(result);
     }
 
-    public void ext_dumpState()  {
+    public void ext_dumpState() {
         Block bestBlcock = blockStore.getBestBlock();
         logger.info("Dumping state for block hash {}, block number {}", bestBlcock.getHash(), bestBlcock.getNumber());
         networkStateExporter.exportStatus(System.getProperty("user.dir") + "/" + "rskdump.json");
@@ -147,12 +147,13 @@ public class Web3RskImpl extends Web3Impl {
 
     /**
      * Export the blockchain tree as a tgf file to user.dir/rskblockchain.tgf
+     *
      * @param numberOfBlocks Number of block heights to include. Eg if best block is block 2300 and numberOfBlocks is 10, the graph will include blocks in heights 2290 to 2300.
-     * @param includeUncles Whether to show uncle links (recommended value is false)
+     * @param includeUncles  Whether to show uncle links (recommended value is false)
      */
-    public void ext_dumpBlockchain(long numberOfBlocks, boolean includeUncles)  {
+    public void ext_dumpBlockchain(long numberOfBlocks, boolean includeUncles) {
         Block bestBlock = blockStore.getBestBlock();
-        logger.info("Dumping blockchain starting on block number {}, to best block number {}", bestBlock.getNumber()-numberOfBlocks, bestBlock.getNumber());
+        logger.info("Dumping blockchain starting on block number {}, to best block number {}", bestBlock.getNumber() - numberOfBlocks, bestBlock.getNumber());
         PrintWriter writer = null;
         try {
             File graphFile = new File(System.getProperty("user.dir") + "/" + "rskblockchain.tgf");
@@ -167,7 +168,7 @@ public class Web3RskImpl extends Web3Impl {
                 result.addAll(blockStore.getChainBlocksByNumber(i));
             }
             for (Block block : result) {
-                writer.println(toSmallHash(block.getHash().getBytes()) + " " + block.getNumber()+"-"+toSmallHash(block.getHash().getBytes()));
+                writer.println(toSmallHash(block.getHash().getBytes()) + " " + block.getNumber() + "-" + toSmallHash(block.getHash().getBytes()));
             }
             writer.println("#");
             for (Block block : result) {
@@ -181,16 +182,17 @@ public class Web3RskImpl extends Web3Impl {
         } catch (IOException e) {
             logger.error("Could nos save node graph to file", e);
         } finally {
-            if (writer!=null) {
+            if (writer != null) {
                 try {
                     writer.close();
-                } catch (Exception e) {}
+                } catch (Exception e) {
+                }
             }
         }
     }
 
     private String toSmallHash(byte[] input) {
-        return Hex.toHexString(input).substring(56,64);
+        return Hex.toHexString(input).substring(56, 64);
     }
 
     private BtcBlock getBtcBlock(String blockHeaderHex, NetworkParameters params) {
@@ -205,8 +207,8 @@ public class Web3RskImpl extends Web3Impl {
         List<Byte> rskTagAsByteList = Arrays.asList(ArrayUtils.toObject(RskMiningConstants.RSK_TAG));
 
         int rskTagPosition = Collections.lastIndexOfSubList(coinbaseAsByteList, rskTagAsByteList);
-        byte[] blockHashForMergedMiningArray = new byte[Keccak256Helper.Size.S256.getValue()/8];
-        System.arraycopy(coinbaseAsByteArray, rskTagPosition+ RskMiningConstants.RSK_TAG.length, blockHashForMergedMiningArray, 0, blockHashForMergedMiningArray.length);
+        byte[] blockHashForMergedMiningArray = new byte[Keccak256Helper.Size.S256.getValue() / 8];
+        System.arraycopy(coinbaseAsByteArray, rskTagPosition + RskMiningConstants.RSK_TAG.length, blockHashForMergedMiningArray, 0, blockHashForMergedMiningArray.length);
         return TypeConverter.toJsonHex(blockHashForMergedMiningArray);
     }
 
@@ -216,7 +218,7 @@ public class Web3RskImpl extends Web3Impl {
     }
 
     private SubmittedBlockInfo parseResultAndReturn(SubmitBlockResult result) {
-        if("OK".equals(result.getStatus())) {
+        if ("OK".equals(result.getStatus())) {
             return result.getBlockInfo();
         } else {
             throw new JsonRpcSubmitBlockException(result.getMessage());

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -207,11 +207,8 @@ public class Web3RskImpl extends Web3Impl {
     }
 
     private List<String> parseTransactionHashes(String txnHashesHex) {
-        List<String> txnHashes = new ArrayList<>();
-        for (int start = 0; start < txnHashesHex.length(); start += 64) {
-            txnHashes.add(txnHashesHex.substring(start, Math.min(txnHashesHex.length(), start + 64)));
-        }
-        return txnHashes;
+        String[] split = txnHashesHex.split("\\s+");
+        return Arrays.asList(split);
     }
 
     private SubmittedBlockInfo parseResultAndReturn(SubmitBlockResult result) {

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -113,14 +113,14 @@ public class Web3RskImpl extends Web3Impl {
         return parseResultAndReturn(result);
     }
 
-    public SubmittedBlockInfo mnr_submitBitcoinSolution(
+    public SubmittedBlockInfo mnr_submitBitcoinBlockPartialMerkle(
             String blockHashHex,
             String blockHeaderHex,
             String coinbaseHex,
             String merkleHashesHex,
             String blockTxnCountHex
     ) {
-        logger.debug("mnr_submitBitcoinSolution(): {}, {}, {}, {}, {}", blockHashHex, blockHeaderHex, coinbaseHex, merkleHashesHex, blockTxnCountHex);
+        logger.debug("mnr_submitBitcoinBlockPartialMerkle(): {}, {}, {}, {}, {}", blockHashHex, blockHeaderHex, coinbaseHex, merkleHashesHex, blockTxnCountHex);
 
         NetworkParameters params = RegTestParams.get();
         new Context(params);
@@ -130,11 +130,34 @@ public class Web3RskImpl extends Web3Impl {
 
         String blockHashForMergedMining = extractBlockHashForMergedMining(coinbase);
 
-        List<String> merkleHashes = parseMerkleHashes(merkleHashesHex);
+        List<String> merkleHashes = parseHashes(merkleHashesHex);
 
         int txnCount = Integer.parseInt(blockTxnCountHex, 16);
 
-        SubmitBlockResult result = minerServer.submitBitcoinSolution(blockHashForMergedMining, bitcoinBlockWithHeaderOnly, coinbase, merkleHashes, txnCount);
+        SubmitBlockResult result = minerServer.submitBitcoinBlockPartialMerkle(blockHashForMergedMining, bitcoinBlockWithHeaderOnly, coinbase, merkleHashes, txnCount);
+
+        return parseResultAndReturn(result);
+    }
+
+    public SubmittedBlockInfo mnr_submitBitcoinBlockTransactions(
+            String blockHashHex,
+            String blockHeaderHex,
+            String coinbaseHex,
+            String txnHashesHex
+    ) {
+        logger.debug("mnr_submitBitcoinBlockTransactions(): {}, {}, {}, {}", blockHashHex, blockHeaderHex, coinbaseHex, txnHashesHex);
+
+        NetworkParameters params = RegTestParams.get();
+        new Context(params);
+
+        BtcBlock bitcoinBlockWithHeaderOnly = getBtcBlock(blockHeaderHex, params);
+        BtcTransaction coinbase = new BtcTransaction(params, Hex.decode(coinbaseHex));
+
+        String blockHashForMergedMining = extractBlockHashForMergedMining(coinbase);
+
+        List<String> txnHashes = parseHashes(txnHashesHex);
+
+        SubmitBlockResult result = minerServer.submitBitcoinBlockTransactions(blockHashForMergedMining, bitcoinBlockWithHeaderOnly, coinbase, txnHashes);
 
         return parseResultAndReturn(result);
     }
@@ -212,7 +235,7 @@ public class Web3RskImpl extends Web3Impl {
         return TypeConverter.toJsonHex(blockHashForMergedMiningArray);
     }
 
-    private List<String> parseMerkleHashes(String txnHashesHex) {
+    private List<String> parseHashes(String txnHashesHex) {
         String[] split = txnHashesHex.split("\\s+");
         return Arrays.asList(split);
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -49,6 +49,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -141,7 +142,12 @@ public class Web3RskImpl extends Web3Impl {
         System.arraycopy(coinbaseAsByteArray, rskTagPosition+ RskMiningConstants.RSK_TAG.length, blockHashForMergedMiningArray, 0, blockHashForMergedMiningArray.length);
         String blockHashForMergedMining = TypeConverter.toJsonHex(blockHashForMergedMiningArray);
 
-        SubmitBlockResult result = minerServer.submitBitcoinBlock(blockHashForMergedMining, bitcoinBlock);
+        List<String> txnHashes = new ArrayList<>();
+        for (int start = 0; start < txnHashesHex.length(); start += 64) {
+            txnHashes.add(txnHashesHex.substring(start, Math.min(txnHashesHex.length(), start + 64)));
+        }
+
+        SubmitBlockResult result = minerServer.submitBitcoinSolution(blockHashForMergedMining, bitcoinBlock, coinbase, txnHashes);
 
         if("OK".equals(result.getStatus())) {
             return result.getBlockInfo();

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -257,7 +257,7 @@ public class MinerServerTest {
 
             //noinspection ConstantConditions
             BtcTransaction coinbase = bitcoinMergedMiningBlock.getTransactions().get(0);
-            SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, Collections.singletonList(coinbase.getHashAsString()));
+            SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, Collections.singletonList(coinbase.getHashAsString()), 1);
 
             Assert.assertEquals("OK", result.getStatus());
             Assert.assertNotNull(result.getBlockInfo());
@@ -297,8 +297,8 @@ public class MinerServerTest {
 
             //noinspection ConstantConditions
             BtcTransaction coinbase = bitcoinMergedMiningBlock.getTransactions().get(0);
-            List<String> txs = Arrays.asList(coinbase.getHashAsString(), otherTxHash.toString());
-            SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, txs);
+            List<String> merkleHashes = Arrays.asList(coinbase.getHashAsString(), otherTxHash.toString());
+            SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, merkleHashes, 2);
 
             Assert.assertEquals("OK", result.getStatus());
             Assert.assertNotNull(result.getBlockInfo());

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -242,11 +242,26 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null, null,
-                blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
-                unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(config),
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(
+                config,
+                ethereumImpl,
+                blockchain,
+                null,
+                DIFFICULTY_CALCULATOR,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
+                new BlockToMineBuilder(
+                        ConfigUtils.getDefaultMiningConfig(),
+                        blockchain.getRepository(),
+                        blockchain.getBlockStore(),
+                        blockchain.getPendingState(),
+                        DIFFICULTY_CALCULATOR,
+                        new GasLimitCalculator(config),
+                        unclesValidationRule,
+                        config,
+                        null
+                ),
+                ConfigUtils.getDefaultMiningConfig()
+        );
         try {
             minerServer.start();
             MinerWork work = minerServer.getWork();
@@ -278,11 +293,26 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null, null,
-                blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
-                unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(config),
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(
+                config,
+                ethereumImpl,
+                blockchain,
+                null,
+                DIFFICULTY_CALCULATOR,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
+                new BlockToMineBuilder(
+                        ConfigUtils.getDefaultMiningConfig(),
+                        blockchain.getRepository(),
+                        blockchain.getBlockStore(),
+                        blockchain.getPendingState(),
+                        DIFFICULTY_CALCULATOR,
+                        new GasLimitCalculator(config),
+                        unclesValidationRule,
+                        config,
+                        null
+                ),
+                ConfigUtils.getDefaultMiningConfig()
+        );
         try {
             minerServer.start();
             MinerWork work = minerServer.getWork();
@@ -321,11 +351,26 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null, null,
-                blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
-                unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(config),
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(
+                config,
+                ethereumImpl,
+                blockchain,
+                null,
+                DIFFICULTY_CALCULATOR,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
+                new BlockToMineBuilder(
+                        ConfigUtils.getDefaultMiningConfig(),
+                        blockchain.getRepository(),
+                        blockchain.getBlockStore(),
+                        blockchain.getPendingState(),
+                        DIFFICULTY_CALCULATOR,
+                        new GasLimitCalculator(config),
+                        unclesValidationRule,
+                        config,
+                        null
+                ),
+                ConfigUtils.getDefaultMiningConfig()
+        );
         try {
             minerServer.start();
             MinerWork work = minerServer.getWork();
@@ -356,11 +401,26 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null, null,
-                blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
-                unclesValidationRule, null, DIFFICULTY_CALCULATOR,
-                new GasLimitCalculator(config),
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        MinerServer minerServer = new MinerServerImpl(
+                config,
+                ethereumImpl,
+                blockchain,
+                null,
+                DIFFICULTY_CALCULATOR,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
+                new BlockToMineBuilder(
+                        ConfigUtils.getDefaultMiningConfig(),
+                        blockchain.getRepository(),
+                        blockchain.getBlockStore(),
+                        blockchain.getPendingState(),
+                        DIFFICULTY_CALCULATOR,
+                        new GasLimitCalculator(config),
+                        unclesValidationRule,
+                        config,
+                        null
+                ),
+                ConfigUtils.getDefaultMiningConfig()
+        );
         try {
             minerServer.start();
             MinerWork work = minerServer.getWork();

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -257,7 +257,8 @@ public class MinerServerTest {
 
             //noinspection ConstantConditions
             BtcTransaction coinbase = bitcoinMergedMiningBlock.getTransactions().get(0);
-            SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, Collections.singletonList(coinbase.getHashAsString()), 1);
+            List<String> coinbaseReversedHash = Collections.singletonList(Sha256Hash.wrap(coinbase.getHash().getReversedBytes()).toString());
+            SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, coinbaseReversedHash, 1);
 
             Assert.assertEquals("OK", result.getStatus());
             Assert.assertNotNull(result.getBlockInfo());
@@ -297,7 +298,9 @@ public class MinerServerTest {
 
             //noinspection ConstantConditions
             BtcTransaction coinbase = bitcoinMergedMiningBlock.getTransactions().get(0);
-            List<String> merkleHashes = Arrays.asList(coinbase.getHashAsString(), otherTxHash.toString());
+            String coinbaseReversedHash = Sha256Hash.wrap(coinbase.getHash().getReversedBytes()).toString();
+            String otherTxHashReversed = Sha256Hash.wrap(otherTxHash.getReversedBytes()).toString();
+            List<String> merkleHashes = Arrays.asList(coinbaseReversedHash, otherTxHashReversed);
             SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, merkleHashes, 2);
 
             Assert.assertEquals("OK", result.getStatus());

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -19,10 +19,7 @@
 package co.rsk.mine;
 
 import co.rsk.TestHelpers.Tx;
-import co.rsk.bitcoinj.core.BtcBlock;
-import co.rsk.bitcoinj.core.BtcTransaction;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.VerificationException;
+import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.config.ConfigUtils;
 import co.rsk.config.RskSystemProperties;
@@ -49,6 +46,7 @@ import org.mockito.Mockito;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
@@ -220,7 +218,7 @@ public class MinerServerTest {
             minerServer.start();
             MinerWork work = minerServer.getWork();
 
-            BtcBlock bitcoinMergedMiningBlock = getMergedMiningBlock(work);
+            BtcBlock bitcoinMergedMiningBlock = getMergedMiningBlockWithOnlyCoinbase(work);
 
             findNonce(work, bitcoinMergedMiningBlock);
 
@@ -238,7 +236,7 @@ public class MinerServerTest {
     }
 
     @Test
-    public void submitBitcoinSolution() {
+    public void submitBitcoinSolutionWhenBlockIsEmpty() {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
         Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
 
@@ -253,13 +251,54 @@ public class MinerServerTest {
             minerServer.start();
             MinerWork work = minerServer.getWork();
 
-            BtcBlock bitcoinMergedMiningBlock = getMergedMiningBlock(work);
+            BtcBlock bitcoinMergedMiningBlock = getMergedMiningBlockWithOnlyCoinbase(work);
 
             findNonce(work, bitcoinMergedMiningBlock);
 
             //noinspection ConstantConditions
             BtcTransaction coinbase = bitcoinMergedMiningBlock.getTransactions().get(0);
             SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, Collections.singletonList(coinbase.getHashAsString()));
+
+            Assert.assertEquals("OK", result.getStatus());
+            Assert.assertNotNull(result.getBlockInfo());
+            Assert.assertEquals("0x1", result.getBlockInfo().getBlockIncludedHeight());
+            Assert.assertEquals("0x494d504f525445445f42455354", result.getBlockInfo().getBlockImportedResult());
+
+            Mockito.verify(ethereumImpl, Mockito.times(1)).addNewMinedBlock(Mockito.any());
+        } finally {
+            minerServer.stop();
+        }
+    }
+
+    @Test
+    public void submitBitcoinSolutionWhenBlockHasTransactions() {
+        EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
+        Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
+
+        BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
+        Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null,
+                blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
+                unclesValidationRule, null, DIFFICULTY_CALCULATOR,
+                new GasLimitCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        try {
+            minerServer.start();
+            MinerWork work = minerServer.getWork();
+
+            BtcTransaction otherTx = Mockito.mock(BtcTransaction.class);
+            Sha256Hash otherTxHash = Sha256Hash.wrap("aaaabbbbccccddddaaaabbbbccccddddaaaabbbbccccddddaaaabbbbccccdddd");
+            Mockito.when(otherTx.getHash()).thenReturn(otherTxHash);
+            Mockito.when(otherTx.getHashAsString()).thenReturn(otherTxHash.toString());
+
+            BtcBlock bitcoinMergedMiningBlock = getMergedMiningBlock(work, Collections.singletonList(otherTx));
+
+            findNonce(work, bitcoinMergedMiningBlock);
+
+            //noinspection ConstantConditions
+            BtcTransaction coinbase = bitcoinMergedMiningBlock.getTransactions().get(0);
+            List<String> txs = Arrays.asList(coinbase.getHashAsString(), otherTxHash.toString());
+            SubmitBlockResult result = minerServer.submitBitcoinSolution(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock, coinbase, txs);
 
             Assert.assertEquals("OK", result.getStatus());
             Assert.assertNotNull(result.getBlockInfo());
@@ -484,16 +523,25 @@ public class MinerServerTest {
         Assert.assertTrue(result <= current + 11);
     }
 
-    private BtcBlock getMergedMiningBlock(MinerWork work) {
-        NetworkParameters bitcoinNetworkParameters = RegTestParams.get();
-        BtcTransaction bitcoinMergedMiningCoinbaseTransaction = MinerUtils.getBitcoinMergedMiningCoinbaseTransaction(bitcoinNetworkParameters, work);
-        return MinerUtils.getBitcoinMergedMiningBlock(bitcoinNetworkParameters, bitcoinMergedMiningCoinbaseTransaction);
+    private BtcBlock getMergedMiningBlockWithOnlyCoinbase(MinerWork work) {
+        return getMergedMiningBlock(work, Collections.emptyList());
     }
 
-    private BtcBlock getMergedMiningBlockWithTwoTags(MinerWork work,MinerWork work2) {
+    private BtcBlock getMergedMiningBlock(MinerWork work, List<BtcTransaction> txs) {
+        NetworkParameters bitcoinNetworkParameters = RegTestParams.get();
+        BtcTransaction bitcoinMergedMiningCoinbaseTransaction = MinerUtils.getBitcoinMergedMiningCoinbaseTransaction(bitcoinNetworkParameters, work);
+
+        List<BtcTransaction> blockTxs = new ArrayList<>();
+        blockTxs.add(bitcoinMergedMiningCoinbaseTransaction);
+        blockTxs.addAll(txs);
+
+        return MinerUtils.getBitcoinMergedMiningBlock(bitcoinNetworkParameters, blockTxs);
+    }
+
+    private BtcBlock getMergedMiningBlockWithTwoTags(MinerWork work, MinerWork work2) {
         NetworkParameters bitcoinNetworkParameters = RegTestParams.get();
         BtcTransaction bitcoinMergedMiningCoinbaseTransaction =
-                MinerUtils.getBitcoinMergedMiningCoinbaseTransactionWithTwoTags(bitcoinNetworkParameters, work,work2);
+                MinerUtils.getBitcoinMergedMiningCoinbaseTransactionWithTwoTags(bitcoinNetworkParameters, work, work2);
         return MinerUtils.getBitcoinMergedMiningBlock(bitcoinNetworkParameters, bitcoinMergedMiningCoinbaseTransaction);
     }
 

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -47,6 +47,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -77,9 +78,7 @@ public class MinerServerTest {
 
         Transaction tx1 = Tx.create(config, 0, 21000, 100, 0, 0, 0);
         byte[] s1 = new byte[32];
-        byte[] s2 = new byte[32];
         s1[0] = 0;
-        s2[0] = 1;
         Mockito.when(tx1.getHash()).thenReturn(new Keccak256(s1));
         Mockito.when(tx1.getEncoded()).thenReturn(new byte[32]);
 
@@ -88,7 +87,7 @@ public class MinerServerTest {
         Mockito.when(repository.getBalance(tx1.getSender())).thenReturn(Coin.valueOf(4200000L));
         Mockito.when(repository.getBalance(RemascTransaction.REMASC_ADDRESS)).thenReturn(Coin.valueOf(4200000L));
 
-        List<Transaction> txs = new ArrayList<>(Arrays.asList(tx1));
+        List<Transaction> txs = new ArrayList<>(Collections.singletonList(tx1));
 
         PendingState localPendingState = Mockito.mock(PendingState.class);
         Mockito.when(localPendingState.getPendingTransactions()).thenReturn(txs);

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -242,7 +242,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null,
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null, null,
                 blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
                 unclesValidationRule, null, DIFFICULTY_CALCULATOR,
                 new GasLimitCalculator(config),
@@ -277,7 +277,7 @@ public class MinerServerTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null,
+        MinerServer minerServer = new MinerServerImpl(config, ethereumImpl, blockchain, null, null,
                 blockchain.getPendingState(), blockchain.getRepository(), ConfigUtils.getDefaultMiningConfig(),
                 unclesValidationRule, null, DIFFICULTY_CALCULATOR,
                 new GasLimitCalculator(config),


### PR DESCRIPTION
New methods to support submission of merged mining solution:
- submitBitcoinBlockTransactions
- submitBitcoinBlockPartialMerkle

Both receive less information than old submitBitcoinBlock method which is still available for backward compatibility reasons.