### PR TITLE
Add a smoke test for the basic object graph

### DIFF
--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -50,6 +50,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component
@@ -82,38 +83,39 @@ public class Start {
     }
 
     @Autowired
-    public Start(Rsk rsk,
-                 UDPServer udpServer,
-                 MinerServer minerServer,
-                 MinerClient minerClient,
-                 RskSystemProperties rskSystemProperties,
-                 Web3 web3Service,
-                 Web3HttpServer web3HttpServer,
-                 Repository repository,
-                 Blockchain blockchain,
-                 ChannelManager channelManager,
-                 SyncPool syncPool,
-                 MessageHandler messageHandler,
-                 TxHandler txHandler,
-                 BlockProcessor nodeBlockProcessor,
-                 PendingState pendingState,
-                 SyncPool.PeerClientFactory peerClientFactory) {
-        this.rsk = rsk;
-        this.udpServer = udpServer;
-        this.minerServer = minerServer;
-        this.minerClient = minerClient;
-        this.rskSystemProperties = rskSystemProperties;
-        this.web3HttpServer = web3HttpServer;
-        this.web3Service = web3Service;
-        this.repository = repository;
-        this.blockchain = blockchain;
-        this.channelManager = channelManager;
-        this.syncPool = syncPool;
-        this.messageHandler = messageHandler;
-        this.txHandler = txHandler;
-        this.nodeBlockProcessor = nodeBlockProcessor;
-        this.pendingState = pendingState;
-        this.peerClientFactory = peerClientFactory;
+    public Start(
+            Rsk rsk,
+            UDPServer udpServer,
+            MinerServer minerServer,
+            MinerClient minerClient,
+            RskSystemProperties rskSystemProperties,
+            Web3 web3Service,
+            Web3HttpServer web3HttpServer,
+            Repository repository,
+            Blockchain blockchain,
+            ChannelManager channelManager,
+            SyncPool syncPool,
+            MessageHandler messageHandler,
+            TxHandler txHandler,
+            BlockProcessor nodeBlockProcessor,
+            PendingState pendingState,
+            SyncPool.PeerClientFactory peerClientFactory) {
+        this.rsk = Objects.requireNonNull(rsk);
+        this.udpServer = Objects.requireNonNull(udpServer);
+        this.minerServer = Objects.requireNonNull(minerServer);
+        this.minerClient = Objects.requireNonNull(minerClient);
+        this.rskSystemProperties = Objects.requireNonNull(rskSystemProperties);
+        this.web3HttpServer = Objects.requireNonNull(web3HttpServer);
+        this.web3Service = Objects.requireNonNull(web3Service);
+        this.repository = Objects.requireNonNull(repository);
+        this.blockchain = Objects.requireNonNull(blockchain);
+        this.channelManager = Objects.requireNonNull(channelManager);
+        this.syncPool = Objects.requireNonNull(syncPool);
+        this.messageHandler = Objects.requireNonNull(messageHandler);
+        this.txHandler = Objects.requireNonNull(txHandler);
+        this.nodeBlockProcessor = Objects.requireNonNull(nodeBlockProcessor);
+        this.pendingState = Objects.requireNonNull(pendingState);
+        this.peerClientFactory = Objects.requireNonNull(peerClientFactory);
     }
 
     public void startNode(String[] args) throws Exception {

--- a/rskj-core/src/test/java/co/rsk/StartTest.java
+++ b/rskj-core/src/test/java/co/rsk/StartTest.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk;
+
+import org.ethereum.config.DefaultConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+public class StartTest {
+
+    @Test
+    public void objectGraphSmokeTest() {
+        // This line will fail when the context can't be created (e.g. circular dependencies)
+        ApplicationContext ctx = new AnnotationConfigApplicationContext(DefaultConfig.class);
+        Assert.assertThat(ctx.getBean(Start.class), not(nullValue()));
+    }
+}


### PR DESCRIPTION
This catches some issues that were previously only detected when spinning up a node.