### PR TITLE
Block wrapped hash

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
@@ -18,12 +18,12 @@
 
 package co.rsk.core.bc;
 
+import co.rsk.crypto.Keccak256;
 import co.rsk.net.BlockStore;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Blockchain;
 import org.ethereum.db.BlockInformation;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -36,34 +36,27 @@ public class BlockUtils {
     private BlockUtils() { }
 
     public static boolean blockInSomeBlockChain(Block block, Blockchain blockChain) {
-        return blockInSomeBlockChain(block.getHash().getBytes(), block.getNumber(), blockChain);
+        return blockInSomeBlockChain(block.getHash(), block.getNumber(), blockChain);
     }
 
-    public static boolean blockInSomeBlockChain(byte[] blockHash, long blockNumber, Blockchain blockChain) {
-        final ByteArrayWrapper key = new ByteArrayWrapper(blockHash);
-        final List<BlockInformation> blocks = blockChain.getBlocksInformationByNumber(blockNumber);
-
-        return blocks.stream().anyMatch(bi -> key.equalsToByteArray(bi.getHash()));
+    private static boolean blockInSomeBlockChain(Keccak256 blockHash, long blockNumber, Blockchain blockChain) {
+        final List<BlockInformation> blockInformations = blockChain.getBlocksInformationByNumber(blockNumber);
+        return blockInformations.stream().anyMatch(bi -> Arrays.equals(blockHash.getBytes(), bi.getHash()));
     }
 
-    public static Set<ByteArrayWrapper> unknownDirectAncestorsHashes(Block block, Blockchain blockChain, BlockStore store) {
-        Set<ByteArrayWrapper> hashes = new HashSet<>();
-
-        hashes.add(block.getWrappedParentHash());
-
+    public static Set<Keccak256> unknownDirectAncestorsHashes(Block block, Blockchain blockChain, BlockStore store) {
+        Set<Keccak256> hashes = Collections.singleton(block.getParentHash());
         return unknownAncestorsHashes(hashes, blockChain, store, false);
     }
 
-    public static Set<ByteArrayWrapper> unknownAncestorsHashes(byte[] blockHash, Blockchain blockChain, BlockStore store) {
-        Set<ByteArrayWrapper> hashes = new HashSet<>();
-        hashes.add(new ByteArrayWrapper(blockHash));
-
+    public static Set<Keccak256> unknownAncestorsHashes(Keccak256 blockHash, Blockchain blockChain, BlockStore store) {
+        Set<Keccak256> hashes = Collections.singleton(blockHash);
         return unknownAncestorsHashes(hashes, blockChain, store, true);
     }
 
-    public static Set<ByteArrayWrapper> unknownAncestorsHashes(Set<ByteArrayWrapper> hashesToProcess, Blockchain blockChain, BlockStore store, boolean withUncles) {
-        Set<ByteArrayWrapper> unknown = new HashSet<>();
-        Set<ByteArrayWrapper> hashes = hashesToProcess;
+    public static Set<Keccak256> unknownAncestorsHashes(Set<Keccak256> hashesToProcess, Blockchain blockChain, BlockStore store, boolean withUncles) {
+        Set<Keccak256> unknown = new HashSet<>();
+        Set<Keccak256> hashes = hashesToProcess;
 
         while (!hashes.isEmpty()) {
             hashes = getNextHashes(hashes, unknown, blockChain, store, withUncles);
@@ -72,16 +65,16 @@ public class BlockUtils {
         return unknown;
     }
 
-    private static Set<ByteArrayWrapper> getNextHashes(Set<ByteArrayWrapper> previousHashes, Set<ByteArrayWrapper> unknown, Blockchain blockChain, BlockStore store, boolean withUncles) {
-        Set<ByteArrayWrapper> nextHashes = new HashSet<>();
-        for (ByteArrayWrapper hash : previousHashes) {
+    private static Set<Keccak256> getNextHashes(Set<Keccak256> previousHashes, Set<Keccak256> unknown, Blockchain blockChain, BlockStore store, boolean withUncles) {
+        Set<Keccak256> nextHashes = new HashSet<>();
+        for (Keccak256 hash : previousHashes) {
             if (unknown.contains(hash)) {
                 continue;
             }
 
-            Block block = blockChain.getBlockByHash(hash.getData());
+            Block block = blockChain.getBlockByHash(hash.getBytes());
             if (block == null) {
-                block = store.getBlockByHash(hash.getData());
+                block = store.getBlockByHash(hash.getBytes());
             }
 
             if (block == null) {
@@ -90,11 +83,11 @@ public class BlockUtils {
             }
 
             if (!block.isGenesis() && !blockInSomeBlockChain(block, blockChain)) {
-                nextHashes.add(block.getWrappedParentHash());
+                nextHashes.add(block.getParentHash());
 
                 if (withUncles) {
                     for (BlockHeader uncleHeader : block.getUncleList()) {
-                        nextHashes.add(new ByteArrayWrapper(uncleHeader.getHash().getBytes()));
+                        nextHashes.add(uncleHeader.getHash());
                     }
                 }
             }
@@ -103,10 +96,8 @@ public class BlockUtils {
     }
 
     public static void addBlockToList(List<Block> blocks, Block block) {
-        byte[] hash = block.getHash().getBytes();
-
         for (Block b : blocks) {
-            if (b.getHash().equals(hash)) {
+            if (b.getHash().equals(block.getHash())) {
                 return;
             }
         }

--- a/rskj-core/src/main/java/co/rsk/metrics/HashRateCalculator.java
+++ b/rskj-core/src/main/java/co/rsk/metrics/HashRateCalculator.java
@@ -22,7 +22,6 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.util.RskCustomCache;
 import org.ethereum.core.Block;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.math.BigInteger;
 import java.time.Clock;
@@ -33,9 +32,9 @@ import java.util.function.Predicate;
 public abstract class HashRateCalculator {
 
     private final BlockStore blockStore;
-    private final RskCustomCache<ByteArrayWrapper, BlockHeaderElement> headerCache;
+    private final RskCustomCache<Keccak256, BlockHeaderElement> headerCache;
 
-    public HashRateCalculator(BlockStore blockStore, RskCustomCache<ByteArrayWrapper, BlockHeaderElement> headerCache) {
+    public HashRateCalculator(BlockStore blockStore, RskCustomCache<Keccak256, BlockHeaderElement> headerCache) {
         this.blockStore = blockStore;
         this.headerCache = headerCache;
     }
@@ -91,13 +90,12 @@ public abstract class HashRateCalculator {
     private BlockHeaderElement getHeaderElement(Keccak256 hash) {
         BlockHeaderElement element = null;
         if (hash != null) {
-            ByteArrayWrapper key = new ByteArrayWrapper(hash.getBytes());
-            element = this.headerCache.get(key);
+            element = this.headerCache.get(hash);
             if (element == null) {
                 Block block = this.blockStore.getBlockByHash(hash.getBytes());
                 if (block != null) {
                     element = new BlockHeaderElement(block.getHeader(), this.blockStore.getBlockByHash(hash.getBytes()).getCumulativeDifficulty());
-                    this.headerCache.put(key, element);
+                    this.headerCache.put(hash, element);
                 }
             }
         }

--- a/rskj-core/src/main/java/co/rsk/metrics/HashRateCalculatorMining.java
+++ b/rskj-core/src/main/java/co/rsk/metrics/HashRateCalculatorMining.java
@@ -19,9 +19,9 @@
 package co.rsk.metrics;
 
 import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
 import co.rsk.util.RskCustomCache;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.math.BigInteger;
 import java.time.Duration;
@@ -30,7 +30,7 @@ public class HashRateCalculatorMining extends HashRateCalculator {
 
     private final RskAddress coinbaseAddress;
 
-    public HashRateCalculatorMining(BlockStore blockStore, RskCustomCache<ByteArrayWrapper, BlockHeaderElement> headerCache, RskAddress coinbaseAddress) {
+    public HashRateCalculatorMining(BlockStore blockStore, RskCustomCache<Keccak256, BlockHeaderElement> headerCache, RskAddress coinbaseAddress) {
         super(blockStore, headerCache);
         this.coinbaseAddress = coinbaseAddress;
     }

--- a/rskj-core/src/main/java/co/rsk/metrics/HashRateCalculatorNonMining.java
+++ b/rskj-core/src/main/java/co/rsk/metrics/HashRateCalculatorNonMining.java
@@ -18,16 +18,16 @@
 
 package co.rsk.metrics;
 
+import co.rsk.crypto.Keccak256;
 import co.rsk.util.RskCustomCache;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.math.BigInteger;
 import java.time.Duration;
 
 public class HashRateCalculatorNonMining extends HashRateCalculator {
 
-    public HashRateCalculatorNonMining(BlockStore blockStore, RskCustomCache<ByteArrayWrapper, BlockHeaderElement> headerCache) {
+    public HashRateCalculatorNonMining(BlockStore blockStore, RskCustomCache<Keccak256, BlockHeaderElement> headerCache) {
         super(blockStore, headerCache);
     }
 

--- a/rskj-core/src/main/java/co/rsk/net/BlockCache.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockCache.java
@@ -19,8 +19,8 @@
 
 package co.rsk.net;
 
+import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -29,36 +29,32 @@ import java.util.Map;
  * Created by ajlopez on 17/06/2017.
  */
 public class BlockCache {
-    private final LinkedHashMap<ByteArrayWrapper, Block> linkedHashMap;
+    private final LinkedHashMap<Keccak256, Block> linkedHashMap;
 
     public BlockCache(int cacheSize) {
-        this.linkedHashMap = new LinkedHashMap<ByteArrayWrapper, Block>(cacheSize, 0.75f, true) {
+        this.linkedHashMap = new LinkedHashMap<Keccak256, Block>(cacheSize, 0.75f, true) {
             @Override
-            protected boolean removeEldestEntry(Map.Entry<ByteArrayWrapper, Block> eldest) {
+            protected boolean removeEldestEntry(Map.Entry<Keccak256, Block> eldest) {
                 return size() > cacheSize;
             }
         };
     }
 
     public void removeBlock(Block block) {
-        ByteArrayWrapper key = block.getWrappedHash();
-
-        linkedHashMap.remove(key);
+        linkedHashMap.remove(block.getHash());
     }
 
     public void addBlock(Block block) {
-        ByteArrayWrapper key = block.getWrappedHash();
-
-        linkedHashMap.put(key, block);
+        linkedHashMap.put(block.getHash(), block);
     }
 
     public Block getBlockByHash(byte[] hash) {
-        ByteArrayWrapper key = new ByteArrayWrapper(hash);
+        Keccak256 key = new Keccak256(hash);
 
         return linkedHashMap.get(key);
     }
 
-    public Block put(ByteArrayWrapper key, Block block) {
+    public Block put(Keccak256 key, Block block) {
         return linkedHashMap.put(key, block);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/BlockNodeInformation.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockNodeInformation.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net;
 
-import org.ethereum.db.ByteArrayWrapper;
+import co.rsk.crypto.Keccak256;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
@@ -35,8 +35,8 @@ import java.util.*;
  */
 @Component
 public class BlockNodeInformation {
-    private final Map<NodeID, Set<ByteArrayWrapper>> blocksByNode;
-    private final LinkedHashMap<ByteArrayWrapper, Set<NodeID>> nodesByBlock;
+    private final Map<NodeID, Set<Keccak256>> blocksByNode;
+    private final LinkedHashMap<Keccak256, Set<NodeID>> nodesByBlock;
     private final int maxBlocks;
     private final int maxPeers;
 
@@ -45,16 +45,16 @@ public class BlockNodeInformation {
         this.maxPeers = maxPeers;
 
         // Nodes are evicted in Least-recently-accessed order.
-        blocksByNode = new LinkedHashMap<NodeID, Set<ByteArrayWrapper>>(BlockNodeInformation.this.maxPeers, 0.75f, true) {
+        blocksByNode = new LinkedHashMap<NodeID, Set<Keccak256>>(BlockNodeInformation.this.maxPeers, 0.75f, true) {
             @Override
-            protected boolean removeEldestEntry(Map.Entry<NodeID, Set<ByteArrayWrapper>> eldest) {
+            protected boolean removeEldestEntry(Map.Entry<NodeID, Set<Keccak256>> eldest) {
                 return size() > BlockNodeInformation.this.maxPeers;
             }
         };
         // Blocks are evicted in Least-recently-accessed order.
-        nodesByBlock = new LinkedHashMap<ByteArrayWrapper, Set<NodeID>>(BlockNodeInformation.this.maxBlocks, 0.75f, true) {
+        nodesByBlock = new LinkedHashMap<Keccak256, Set<NodeID>>(BlockNodeInformation.this.maxBlocks, 0.75f, true) {
             @Override
-            protected boolean removeEldestEntry(Map.Entry<ByteArrayWrapper, Set<NodeID>> eldest) {
+            protected boolean removeEldestEntry(Map.Entry<Keccak256, Set<NodeID>> eldest) {
                 return size() > BlockNodeInformation.this.maxBlocks;
             }
         };
@@ -70,14 +70,14 @@ public class BlockNodeInformation {
      * @param blockHash the block hash.
      * @param nodeID    the node to add the block to.
      */
-    public void addBlockToNode(@Nonnull final ByteArrayWrapper blockHash, @Nonnull final NodeID nodeID) {
-        Set<ByteArrayWrapper> nodeBlocks = blocksByNode.get(nodeID);
+    public void addBlockToNode(@Nonnull final Keccak256 blockHash, @Nonnull final NodeID nodeID) {
+        Set<Keccak256> nodeBlocks = blocksByNode.get(nodeID);
         if (nodeBlocks == null) {
             // Create a new empty LRUCache for the blocks that a node know.
             // NodeBlocks are evicted in reverse insertion order.
             nodeBlocks = Collections.newSetFromMap(
-                    new LinkedHashMap<ByteArrayWrapper, Boolean>() {
-                        protected boolean removeEldestEntry(Map.Entry<ByteArrayWrapper, Boolean> eldest) {
+                    new LinkedHashMap<Keccak256, Boolean>() {
+                        protected boolean removeEldestEntry(Map.Entry<Keccak256, Boolean> eldest) {
                             return size() > maxBlocks;
                         }
                     }
@@ -104,8 +104,8 @@ public class BlockNodeInformation {
      * @return all the blocks known by the given nodeID.
      */
     @Nonnull
-    public Set<ByteArrayWrapper> getBlocksByNode(@Nonnull final NodeID nodeID) {
-        Set<ByteArrayWrapper> result = blocksByNode.get(nodeID);
+    public Set<Keccak256> getBlocksByNode(@Nonnull final NodeID nodeID) {
+        Set<Keccak256> result = blocksByNode.get(nodeID);
         if (result == null) {
             result = new HashSet<>();
         }
@@ -119,7 +119,7 @@ public class BlockNodeInformation {
      * @return A set containing all the nodes that have that block.
      */
     @Nonnull
-    public Set<NodeID> getNodesByBlock(@Nonnull final ByteArrayWrapper blockHash) {
+    public Set<NodeID> getNodesByBlock(@Nonnull final Keccak256 blockHash) {
         Set<NodeID> result = nodesByBlock.get(blockHash);
         if (result == null) {
             result = new HashSet<>();
@@ -128,14 +128,14 @@ public class BlockNodeInformation {
     }
 
     /**
-     * getNodesByBlock is a convenient function to avoid creating a ByteArrayWrapper.
+     * getNodesByBlock is a convenient function to avoid creating a Keccak256.
      *
      * @param blockHash the block hash.
      * @return all the nodeIDs that contain the given block.
      */
     @Nonnull
     public Set<NodeID> getNodesByBlock(@Nonnull final byte[] blockHash) {
-        return getNodesByBlock(new ByteArrayWrapper(blockHash));
+        return getNodesByBlock(new Keccak256(blockHash));
     }
 
     /**
@@ -145,7 +145,7 @@ public class BlockNodeInformation {
      * @return all the hashes of the blocks that the given node knows.
      */
     @Nonnull
-    public Set<ByteArrayWrapper> getBlocksByNode(@Nonnull final byte[] nodeID) {
+    public Set<Keccak256> getBlocksByNode(@Nonnull final byte[] nodeID) {
         return getBlocksByNode(new NodeID(nodeID));
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/BlockProcessResult.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockProcessResult.java
@@ -18,9 +18,9 @@
 
 package co.rsk.net;
 
+import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
 import org.ethereum.core.ImportResult;
-import org.ethereum.db.ByteArrayWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,9 +37,9 @@ public class BlockProcessResult {
 
     private boolean additionalValidationsOk = false;
 
-    private Map<ByteArrayWrapper, ImportResult> result;
+    private Map<Keccak256, ImportResult> result;
 
-    public BlockProcessResult(boolean additionalValidations, Map<ByteArrayWrapper, ImportResult> result, String blockHash, Duration processingTime) {
+    public BlockProcessResult(boolean additionalValidations, Map<Keccak256, ImportResult> result, String blockHash, Duration processingTime) {
         this.additionalValidationsOk = additionalValidations;
         this.result = result;
         if (processingTime.compareTo(LOG_TIME_LIMIT) >= 0) {
@@ -48,7 +48,7 @@ public class BlockProcessResult {
     }
 
     public boolean wasBlockAdded(Block block) {
-        return additionalValidationsOk && !result.isEmpty() && importOk(result.get(block.getWrappedHash()));
+        return additionalValidationsOk && !result.isEmpty() && importOk(result.get(block.getHash()));
     }
 
     public static boolean importOk(ImportResult blockResult) {
@@ -67,7 +67,7 @@ public class BlockProcessResult {
             StringBuilder sb = new StringBuilder("[MESSAGE PROCESS] Block[")
                     .append(blockHash).append("] After[").append(processingTime.toNanos()).append("] nano, process result. Connections attempts: ").append(result.size()).append(" | ");
 
-            for(Map.Entry<ByteArrayWrapper, ImportResult> entry : this.result.entrySet()) {
+            for(Map.Entry<Keccak256, ImportResult> entry : this.result.entrySet()) {
                 sb.append(entry.getKey().toString()).append(" - ").append(entry.getValue()).append(" | ");
             }
             logger.debug(sb.toString());

--- a/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
@@ -19,12 +19,12 @@
 package co.rsk.net;
 
 import co.rsk.core.bc.BlockUtils;
+import co.rsk.crypto.Keccak256;
 import co.rsk.net.messages.GetBlockMessage;
 import co.rsk.net.sync.SyncConfiguration;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.ImportResult;
-import org.ethereum.db.ByteArrayWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,7 @@ public class BlockSyncService {
     public static final int CHUNK_PART_LIMIT = 8;
     public static final int PROCESSED_BLOCKS_TO_CHECK_STORE = 200;
     public static final int RELEASED_RANGE = 1000;
-    private Map<ByteArrayWrapper, Integer> unknownBlockHashes;
+    private Map<Keccak256, Integer> unknownBlockHashes;
     private long processedBlocksCounter;
     private long lastKnownBlockNumber = 0;
 
@@ -71,7 +71,7 @@ public class BlockSyncService {
         Instant start = Instant.now();
         long bestBlockNumber = this.getBestBlockNumber();
         long blockNumber = block.getNumber();
-        final ByteArrayWrapper blockHash = block.getWrappedHash();
+        final Keccak256 blockHash = block.getHash();
         int syncMaxDistance = syncConfiguration.getChunkSize() * syncConfiguration.getMaxSkeletonChunks();
 
         tryReleaseStore(bestBlockNumber);
@@ -97,7 +97,7 @@ public class BlockSyncService {
         }
         trySaveStore(block);
 
-        Set<ByteArrayWrapper> unknownHashes = BlockUtils.unknownDirectAncestorsHashes(block, blockchain, store);
+        Set<Keccak256> unknownHashes = BlockUtils.unknownDirectAncestorsHashes(block, blockchain, store);
         // We can't add the block if there are missing ancestors or uncles. Request the missing blocks to the sender.
         if (!unknownHashes.isEmpty()) {
             if (!ignoreMissingHashes){
@@ -110,7 +110,7 @@ public class BlockSyncService {
 
         logger.trace("Trying to add to blockchain");
 
-        Map<ByteArrayWrapper, ImportResult> connectResult = connectBlocksAndDescendants(sender,
+        Map<Keccak256, ImportResult> connectResult = connectBlocksAndDescendants(sender,
                 BlockUtils.sortBlocksByNumber(this.getParentsNotInBlockchain(block)), ignoreMissingHashes);
 
         return new BlockProcessResult(true, connectResult, block.getShortHash(),
@@ -152,8 +152,8 @@ public class BlockSyncService {
         }
     }
 
-    private Map<ByteArrayWrapper, ImportResult> connectBlocksAndDescendants(MessageChannel sender, List<Block> blocks, boolean ignoreMissingHashes) {
-        Map<ByteArrayWrapper, ImportResult> connectionsResult = new HashMap<>();
+    private Map<Keccak256, ImportResult> connectBlocksAndDescendants(MessageChannel sender, List<Block> blocks, boolean ignoreMissingHashes) {
+        Map<Keccak256, ImportResult> connectionsResult = new HashMap<>();
         List<Block> remainingBlocks = blocks;
         while (!remainingBlocks.isEmpty()) {
             Set<Block> connected = getConnectedBlocks(remainingBlocks, sender, connectionsResult, ignoreMissingHashes);
@@ -163,13 +163,13 @@ public class BlockSyncService {
         return connectionsResult;
     }
 
-    private Set<Block> getConnectedBlocks(List<Block> remainingBlocks, MessageChannel sender, Map<ByteArrayWrapper, ImportResult> connectionsResult, boolean ignoreMissingHashes) {
+    private Set<Block> getConnectedBlocks(List<Block> remainingBlocks, MessageChannel sender, Map<Keccak256, ImportResult> connectionsResult, boolean ignoreMissingHashes) {
         Set<Block> connected = new HashSet<>();
 
         for (Block block : remainingBlocks) {
             logger.trace("Trying to add block {} {}", block.getNumber(), block.getShortHash());
 
-            Set<ByteArrayWrapper> missingHashes = BlockUtils.unknownDirectAncestorsHashes(block, blockchain, store);
+            Set<Keccak256> missingHashes = BlockUtils.unknownDirectAncestorsHashes(block, blockchain, store);
 
             if (!missingHashes.isEmpty()) {
                 if (!ignoreMissingHashes){
@@ -179,7 +179,7 @@ public class BlockSyncService {
                 continue;
             }
 
-            connectionsResult.put(block.getWrappedHash(), blockchain.tryToConnect(block));
+            connectionsResult.put(block.getHash(), blockchain.tryToConnect(block));
 
             if (BlockUtils.blockInSomeBlockChain(block, blockchain)) {
                 this.store.removeBlock(block);
@@ -189,15 +189,15 @@ public class BlockSyncService {
         return connected;
     }
 
-    private void requestMissingHashes(MessageChannel sender, Set<ByteArrayWrapper> hashes) {
+    private void requestMissingHashes(MessageChannel sender, Set<Keccak256> hashes) {
         logger.trace("Missing blocks to process {}", hashes.size());
 
-        for (ByteArrayWrapper hash : hashes) {
+        for (Keccak256 hash : hashes) {
             this.requestMissingHash(sender, hash);
         }
     }
 
-    private void requestMissingHash(MessageChannel sender, ByteArrayWrapper hash) {
+    private void requestMissingHash(MessageChannel sender, Keccak256 hash) {
         if (sender == null) {
             return;
         }
@@ -206,7 +206,7 @@ public class BlockSyncService {
 
         logger.trace("Missing block {}", hash.toString().substring(0, 10));
 
-        sender.sendMessage(new GetBlockMessage(hash.getData()));
+        sender.sendMessage(new GetBlockMessage(hash.getBytes()));
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/util/RskCustomCache.java
+++ b/rskj-core/src/main/java/co/rsk/util/RskCustomCache.java
@@ -18,8 +18,6 @@
 
 package co.rsk.util;
 
-import org.ethereum.db.ByteArrayWrapper;
-
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.*;
@@ -61,7 +59,7 @@ public class RskCustomCache<K, T> {
         this.cache.put(key, new CacheElement<T>(data, this.timeToLive));
     }
 
-    public T get(ByteArrayWrapper key) {
+    public T get(K key) {
         T ret = null;
         CacheElement<T> element = this.cache.get(key);
         if(element != null) {

--- a/rskj-core/src/main/java/co/rsk/validators/BlockUnclesValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockUnclesValidationRule.java
@@ -20,12 +20,12 @@ package co.rsk.validators;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.FamilyUtils;
+import co.rsk.crypto.Keccak256;
 import co.rsk.panic.PanicProcessor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.ByteArrayWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,17 +106,16 @@ public class BlockUnclesValidationRule implements BlockValidationRule {
      * @param used        used uncles
      * @return true if the uncles in the list are valid, false if not
      */
-    public boolean validateUncleList(long blockNumber, List<BlockHeader> uncles, Set<ByteArrayWrapper> ancestors, Set<ByteArrayWrapper> used) {
+    public boolean validateUncleList(long blockNumber, List<BlockHeader> uncles, Set<Keccak256> ancestors, Set<Keccak256> used) {
         if (uncles.size() > uncleListLimit) {
             logger.error("Uncle list to big: block.getUncleList().size() > UNCLE_LIST_LIMIT");
             panicProcessor.panic(INVALIDUNCLE, "Uncle list to big: block.getUncleList().size() > UNCLE_LIST_LIMIT");
             return false;
         }
 
-        Set<ByteArrayWrapper> hashes = new HashSet<>();
+        Set<Keccak256> hashes = new HashSet<>();
 
         for (BlockHeader uncle : uncles) {
-            byte[] uhash = uncle.getHash().getBytes();
 
             Block blockForUncleHeader = new Block(uncle);
 
@@ -125,7 +124,7 @@ public class BlockUnclesValidationRule implements BlockValidationRule {
                 return false;
             }
 
-            ByteArrayWrapper uncleHash = new ByteArrayWrapper(uhash);
+            Keccak256 uncleHash = uncle.getHash();
 
             /* Just checking that the uncle is not added twice */
             if (hashes.contains(uncleHash)) {
@@ -162,7 +161,7 @@ public class BlockUnclesValidationRule implements BlockValidationRule {
         return true;
     }
 
-    private boolean validateUnclesAncestors(Set<ByteArrayWrapper> ancestors, ByteArrayWrapper uncleHash) {
+    private boolean validateUnclesAncestors(Set<Keccak256> ancestors, Keccak256 uncleHash) {
         if (ancestors != null && ancestors.contains(uncleHash)) {
             String uHashStr = uncleHash.toString();
             logger.error("Uncle is direct ancestor: {}", uHashStr);
@@ -172,7 +171,7 @@ public class BlockUnclesValidationRule implements BlockValidationRule {
         return true;
     }
 
-    private boolean validateIfUncleWasNeverUsed(Set<ByteArrayWrapper> used, ByteArrayWrapper uncleHash) {
+    private boolean validateIfUncleWasNeverUsed(Set<Keccak256> used, Keccak256 uncleHash) {
         String uhashString = uncleHash.toString();
         if (used != null && used.contains(uncleHash)) {
             logger.error("Uncle is not unique: {}", uhashString);
@@ -182,11 +181,11 @@ public class BlockUnclesValidationRule implements BlockValidationRule {
         return true;
     }
 
-    private boolean validateUncleParent(Set<ByteArrayWrapper> ancestors, Block uncle) {
+    private boolean validateUncleParent(Set<Keccak256> ancestors, Block uncle) {
         String uhashString = uncle.getHash().toString();
         Block parent = blockStore.getBlockByHash(uncle.getParentHash().getBytes());
 
-        if (ancestors != null && (parent == null || !ancestors.contains(parent.getWrappedHash()))) {
+        if (ancestors != null && (parent == null || !ancestors.contains(parent.getHash()))) {
             logger.error("Uncle has no common parent: {}", uhashString);
             panicProcessor.panic(INVALIDUNCLE, String.format("Uncle has no common parent: %s", uhashString));
             return false;

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -24,6 +24,7 @@ import co.rsk.config.MiningConfig;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.NetworkStateExporter;
+import co.rsk.crypto.Keccak256;
 import co.rsk.metrics.BlockHeaderElement;
 import co.rsk.metrics.HashRateCalculator;
 import co.rsk.metrics.HashRateCalculatorMining;
@@ -106,7 +107,7 @@ public class DefaultConfig {
 
     @Bean
     public HashRateCalculator hashRateCalculator(RskSystemProperties rskSystemProperties, BlockStore blockStore, MiningConfig miningConfig) {
-        RskCustomCache<ByteArrayWrapper, BlockHeaderElement> cache = new RskCustomCache<>(60000L);
+        RskCustomCache<Keccak256, BlockHeaderElement> cache = new RskCustomCache<>(60000L);
         if (!rskSystemProperties.isMinerServerEnabled()) {
             return new HashRateCalculatorNonMining(blockStore, cache);
         }

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -28,7 +28,6 @@ import co.rsk.remasc.RemascTransaction;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieImpl;
 import org.ethereum.crypto.Keccak256Helper;
-import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
@@ -260,24 +259,11 @@ public class Block {
         return this.header.getHash();
     }
 
-    public ByteArrayWrapper getWrappedHash() {
-        Keccak256 hash = getHash();
-        byte[] rawHash = null;
-        if (hash != null) {
-            rawHash = hash.getBytes();
-        }
-        return new ByteArrayWrapper(rawHash);
-    }
-
     public Keccak256 getParentHash() {
         if (!parsed) {
             parseRLP();
         }
         return this.header.getParentHash();
-    }
-
-    public ByteArrayWrapper getWrappedParentHash() {
-        return new ByteArrayWrapper(getParentHash().getBytes());
     }
 
     public byte[] getUnclesHash() {

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -215,7 +215,7 @@ public class IndexedBlockStore extends AbstractBlockstore {
         }
 
         block = new Block(blockRlp);
-        this.blockCache.put(new ByteArrayWrapper(hash), block);
+        this.blockCache.put(new Keccak256(hash), block);
         return block;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/db/ReceiptStoreImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/db/ReceiptStoreImpl.java
@@ -169,7 +169,7 @@ public class ReceiptStoreImpl implements ReceiptStore {
                 continue;
             }
 
-            if (new ByteArrayWrapper(bhash).equals(mblock.getWrappedHash())) {
+            if (Arrays.equals(bhash, mblock.getHash().getBytes())) {
                 return ti;
             }
         }

--- a/rskj-core/src/main/java/org/ethereum/db/ReceiptStoreImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/db/ReceiptStoreImpl.java
@@ -19,6 +19,7 @@
 
 package org.ethereum.db;
 
+import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.datasource.KeyValueDataSource;
@@ -80,14 +81,14 @@ public class ReceiptStoreImpl implements ReceiptStore {
         }
 
         Block block = null;
-        Map<ByteArrayWrapper, Block> tiblocks = new HashMap();
+        Map<Keccak256, Block> tiblocks = new HashMap();
 
         if (store != null) {
             block = store.getBlockByHash(blockHash);
 
             for (TransactionInfo ti : txsInfo) {
                 byte[] bhash = ti.getBlockHash();
-                ByteArrayWrapper key = new ByteArrayWrapper(bhash);
+                Keccak256 key = new Keccak256(bhash);
                 tiblocks.put(key, store.getBlockByHash(bhash));
             }
         }
@@ -97,7 +98,7 @@ public class ReceiptStoreImpl implements ReceiptStore {
 
             for (TransactionInfo ti : txsInfo) {
                 byte[] hash = ti.getBlockHash();
-                ByteArrayWrapper key = new ByteArrayWrapper(hash);
+                Keccak256 key = new Keccak256(hash);
                 Block tiblock = tiblocks.get(key);
 
                 if (tiblock != null && block != null) {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockUtilsTest.java
@@ -20,6 +20,7 @@ package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.BlockDifficulty;
+import co.rsk.crypto.Keccak256;
 import co.rsk.net.BlockStore;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.BlockChainBuilder;
@@ -27,7 +28,6 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Genesis;
 import org.ethereum.core.ImportResult;
-import org.ethereum.db.ByteArrayWrapper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -85,34 +85,34 @@ public class BlockUtilsTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
         Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, blockChain.tryToConnect(block1b));
 
-        Set<ByteArrayWrapper> hashes = BlockUtils.unknownAncestorsHashes(genesis.getHash().getBytes(), blockChain, store);
+        Set<Keccak256> hashes = BlockUtils.unknownAncestorsHashes(genesis.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertTrue(hashes.isEmpty());
 
-        hashes = BlockUtils.unknownAncestorsHashes(block1.getHash().getBytes(), blockChain, store);
+        hashes = BlockUtils.unknownAncestorsHashes(block1.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertTrue(hashes.isEmpty());
 
-        hashes = BlockUtils.unknownAncestorsHashes(block1b.getHash().getBytes(), blockChain, store);
+        hashes = BlockUtils.unknownAncestorsHashes(block1b.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertTrue(hashes.isEmpty());
 
-        hashes = BlockUtils.unknownAncestorsHashes(block2.getHash().getBytes(), blockChain, store);
+        hashes = BlockUtils.unknownAncestorsHashes(block2.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertFalse(hashes.isEmpty());
         Assert.assertEquals(1, hashes.size());
-        Assert.assertTrue(hashes.contains(block2.getWrappedHash()));
+        Assert.assertTrue(hashes.contains(block2.getHash()));
 
-        hashes = BlockUtils.unknownAncestorsHashes(block3.getHash().getBytes(), blockChain, store);
+        hashes = BlockUtils.unknownAncestorsHashes(block3.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertFalse(hashes.isEmpty());
         Assert.assertEquals(1, hashes.size());
-        Assert.assertTrue(hashes.contains(block2.getWrappedHash()));
+        Assert.assertTrue(hashes.contains(block2.getHash()));
     }
 
     @Test
@@ -143,36 +143,36 @@ public class BlockUtilsTest {
         blockChain.tryToConnect(block1);
         blockChain.tryToConnect(block1b);
 
-        Set<ByteArrayWrapper> hashes = BlockUtils.unknownAncestorsHashes(genesis.getHash().getBytes(), blockChain, store);
+        Set<Keccak256> hashes = BlockUtils.unknownAncestorsHashes(genesis.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertTrue(hashes.isEmpty());
 
-        hashes = BlockUtils.unknownAncestorsHashes(block1.getHash().getBytes(), blockChain, store);
+        hashes = BlockUtils.unknownAncestorsHashes(block1.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertTrue(hashes.isEmpty());
 
-        hashes = BlockUtils.unknownAncestorsHashes(block1b.getHash().getBytes(), blockChain, store);
+        hashes = BlockUtils.unknownAncestorsHashes(block1b.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
 
         Assert.assertTrue(hashes.isEmpty());
 
-        hashes = BlockUtils.unknownAncestorsHashes(block2.getHash().getBytes(), blockChain, store);
+        hashes = BlockUtils.unknownAncestorsHashes(block2.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertFalse(hashes.isEmpty());
         Assert.assertEquals(1, hashes.size());
-        Assert.assertTrue(hashes.contains(block2.getWrappedHash()));
+        Assert.assertTrue(hashes.contains(block2.getHash()));
 
-        hashes = BlockUtils.unknownAncestorsHashes(block3.getHash().getBytes(), blockChain, store);
+        hashes = BlockUtils.unknownAncestorsHashes(block3.getHash(), blockChain, store);
 
         Assert.assertNotNull(hashes);
         Assert.assertFalse(hashes.isEmpty());
         Assert.assertEquals(3, hashes.size());
-        Assert.assertTrue(hashes.contains(block2.getWrappedHash()));
-        Assert.assertTrue(hashes.contains(uncle1.getWrappedHash()));
-        Assert.assertTrue(hashes.contains(uncle2.getWrappedHash()));
+        Assert.assertTrue(hashes.contains(block2.getHash()));
+        Assert.assertTrue(hashes.contains(uncle1.getHash()));
+        Assert.assertTrue(hashes.contains(uncle2.getHash()));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -33,7 +33,7 @@ import org.ethereum.core.*;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockInformation;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.ByteArrayWrapper;
+import co.rsk.crypto.Keccak256;
 import org.ethereum.db.IndexedBlockStore;
 import org.junit.Assert;
 import org.junit.Test;
@@ -224,10 +224,10 @@ public class BlockValidatorTest {
         store.saveBlock(genesis, TEST_DIFFICULTY, true);
         Block block = new BlockGenerator().createChildBlock(genesis);
 
-        Set<ByteArrayWrapper> ancestors = FamilyUtils.getAncestors(store, block, 6);
+        Set<Keccak256> ancestors = FamilyUtils.getAncestors(store, block, 6);
         Assert.assertFalse(ancestors.isEmpty());
-        Assert.assertTrue(ancestors.contains(genesis.getWrappedHash()));
-        Assert.assertFalse(ancestors.contains(block.getWrappedHash()));
+        Assert.assertTrue(ancestors.contains(genesis.getHash()));
+        Assert.assertFalse(ancestors.contains(block.getHash()));
     }
 
     @Test
@@ -248,15 +248,15 @@ public class BlockValidatorTest {
         Block block5 = blockGenerator.createChildBlock(block4);
         store.saveBlock(block5, TEST_DIFFICULTY, true);
 
-        Set<ByteArrayWrapper> ancestors = FamilyUtils.getAncestors(store, block5, 3);
+        Set<Keccak256> ancestors = FamilyUtils.getAncestors(store, block5, 3);
         Assert.assertFalse(ancestors.isEmpty());
         Assert.assertEquals(3, ancestors.size());
-        Assert.assertFalse(ancestors.contains(genesis.getWrappedHash()));
-        Assert.assertFalse(ancestors.contains(block1.getWrappedHash()));
-        Assert.assertTrue(ancestors.contains(block2.getWrappedHash()));
-        Assert.assertTrue(ancestors.contains(block3.getWrappedHash()));
-        Assert.assertTrue(ancestors.contains(block4.getWrappedHash()));
-        Assert.assertFalse(ancestors.contains(block5.getWrappedHash()));
+        Assert.assertFalse(ancestors.contains(genesis.getHash()));
+        Assert.assertFalse(ancestors.contains(block1.getHash()));
+        Assert.assertTrue(ancestors.contains(block2.getHash()));
+        Assert.assertTrue(ancestors.contains(block3.getHash()));
+        Assert.assertTrue(ancestors.contains(block4.getHash()));
+        Assert.assertFalse(ancestors.contains(block5.getHash()));
     }
 
     @Test
@@ -291,17 +291,17 @@ public class BlockValidatorTest {
         store.saveBlock(uncle2b, TEST_DIFFICULTY, false);
         store.saveBlock(block2, TEST_DIFFICULTY, true);
 
-        Set<ByteArrayWrapper> used = FamilyUtils.getUsedUncles(store, block3, 6);
+        Set<Keccak256> used = FamilyUtils.getUsedUncles(store, block3, 6);
 
         Assert.assertFalse(used.isEmpty());
-        Assert.assertFalse(used.contains(block3.getWrappedHash()));
-        Assert.assertFalse(used.contains(block2.getWrappedHash()));
-        Assert.assertTrue(used.contains(uncle2a.getWrappedHash()));
-        Assert.assertTrue(used.contains(uncle2b.getWrappedHash()));
-        Assert.assertFalse(used.contains(block1.getWrappedHash()));
-        Assert.assertTrue(used.contains(uncle1a.getWrappedHash()));
-        Assert.assertTrue(used.contains(uncle1b.getWrappedHash()));
-        Assert.assertFalse(used.contains(genesis.getWrappedHash()));
+        Assert.assertFalse(used.contains(block3.getHash()));
+        Assert.assertFalse(used.contains(block2.getHash()));
+        Assert.assertTrue(used.contains(uncle2a.getHash()));
+        Assert.assertTrue(used.contains(uncle2b.getHash()));
+        Assert.assertFalse(used.contains(block1.getHash()));
+        Assert.assertTrue(used.contains(uncle1a.getHash()));
+        Assert.assertTrue(used.contains(uncle1b.getHash()));
+        Assert.assertFalse(used.contains(genesis.getHash()));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/core/bc/FamilyUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/FamilyUtilsTest.java
@@ -25,13 +25,14 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.db.IndexedBlockStore;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by ajlopez on 12/08/2016.
@@ -51,13 +52,13 @@ public class FamilyUtilsTest {
         store.saveBlock(genesis, TEST_DIFFICULTY, true);
         store.saveBlock(block1, TEST_DIFFICULTY, true);
 
-        Set<ByteArrayWrapper> family = FamilyUtils.getFamily(store, block1, 6);
+        Set<Keccak256> family = FamilyUtils.getFamily(store, block1, 6);
 
         Assert.assertNotNull(family);
         Assert.assertFalse(family.isEmpty());
         Assert.assertEquals(1, family.size());
 
-        Assert.assertTrue(family.contains(genesis.getWrappedHash()));
+        Assert.assertTrue(family.contains(genesis.getHash()));
     }
 
     @Test
@@ -68,7 +69,7 @@ public class FamilyUtilsTest {
 
         store.saveBlock(genesis, TEST_DIFFICULTY, true);
 
-        Set<ByteArrayWrapper> family = FamilyUtils.getFamily(store, genesis, 6);
+        Set<Keccak256> family = FamilyUtils.getFamily(store, genesis, 6);
 
         Assert.assertNotNull(family);
         Assert.assertTrue(family.isEmpty());
@@ -89,16 +90,16 @@ public class FamilyUtilsTest {
         store.saveBlock(block2, TEST_DIFFICULTY, true);
         store.saveBlock(block3, TEST_DIFFICULTY, true);
 
-        Set<ByteArrayWrapper> family = FamilyUtils.getFamily(store, block3, 2);
+        Set<Keccak256> family = FamilyUtils.getFamily(store, block3, 2);
 
         Assert.assertNotNull(family);
         Assert.assertFalse(family.isEmpty());
         Assert.assertEquals(2, family.size());
 
-        Assert.assertFalse(family.contains(genesis.getWrappedHash()));
-        Assert.assertFalse(family.contains(block3.getWrappedHash()));
-        Assert.assertTrue(family.contains(block1.getWrappedHash()));
-        Assert.assertTrue(family.contains(block2.getWrappedHash()));
+        Assert.assertFalse(family.contains(genesis.getHash()));
+        Assert.assertFalse(family.contains(block3.getHash()));
+        Assert.assertTrue(family.contains(block1.getHash()));
+        Assert.assertTrue(family.contains(block2.getHash()));
     }
 
     @Test
@@ -128,22 +129,22 @@ public class FamilyUtilsTest {
         store.saveBlock(uncle31, TEST_DIFFICULTY, false);
         store.saveBlock(uncle32, TEST_DIFFICULTY, false);
 
-        Set<ByteArrayWrapper> family = FamilyUtils.getFamily(store, block3, 2);
+        Set<Keccak256> family = FamilyUtils.getFamily(store, block3, 2);
 
         Assert.assertNotNull(family);
         Assert.assertFalse(family.isEmpty());
         Assert.assertEquals(4, family.size());
 
-        Assert.assertFalse(family.contains(genesis.getWrappedHash()));
-        Assert.assertTrue(family.contains(block1.getWrappedHash()));
-        Assert.assertFalse(family.contains(uncle11.getWrappedHash()));
-        Assert.assertFalse(family.contains(uncle12.getWrappedHash()));
-        Assert.assertTrue(family.contains(block2.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle21.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle22.getWrappedHash()));
-        Assert.assertFalse(family.contains(block3.getWrappedHash()));
-        Assert.assertFalse(family.contains(uncle31.getWrappedHash()));
-        Assert.assertFalse(family.contains(uncle32.getWrappedHash()));
+        Assert.assertFalse(family.contains(genesis.getHash()));
+        Assert.assertTrue(family.contains(block1.getHash()));
+        Assert.assertFalse(family.contains(uncle11.getHash()));
+        Assert.assertFalse(family.contains(uncle12.getHash()));
+        Assert.assertTrue(family.contains(block2.getHash()));
+        Assert.assertTrue(family.contains(uncle21.getHash()));
+        Assert.assertTrue(family.contains(uncle22.getHash()));
+        Assert.assertFalse(family.contains(block3.getHash()));
+        Assert.assertFalse(family.contains(uncle31.getHash()));
+        Assert.assertFalse(family.contains(uncle32.getHash()));
 
         family = FamilyUtils.getFamily(store, block3, 3);
 
@@ -151,16 +152,16 @@ public class FamilyUtilsTest {
         Assert.assertFalse(family.isEmpty());
         Assert.assertEquals(7, family.size());
 
-        Assert.assertTrue(family.contains(genesis.getWrappedHash()));
-        Assert.assertTrue(family.contains(block1.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle11.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle12.getWrappedHash()));
-        Assert.assertTrue(family.contains(block2.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle21.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle22.getWrappedHash()));
-        Assert.assertFalse(family.contains(block3.getWrappedHash()));
-        Assert.assertFalse(family.contains(uncle31.getWrappedHash()));
-        Assert.assertFalse(family.contains(uncle32.getWrappedHash()));
+        Assert.assertTrue(family.contains(genesis.getHash()));
+        Assert.assertTrue(family.contains(block1.getHash()));
+        Assert.assertTrue(family.contains(uncle11.getHash()));
+        Assert.assertTrue(family.contains(uncle12.getHash()));
+        Assert.assertTrue(family.contains(block2.getHash()));
+        Assert.assertTrue(family.contains(uncle21.getHash()));
+        Assert.assertTrue(family.contains(uncle22.getHash()));
+        Assert.assertFalse(family.contains(block3.getHash()));
+        Assert.assertFalse(family.contains(uncle31.getHash()));
+        Assert.assertFalse(family.contains(uncle32.getHash()));
     }
 
     @Test
@@ -233,22 +234,22 @@ public class FamilyUtilsTest {
         store.saveBlock(uncle31, TEST_DIFFICULTY, false);
         store.saveBlock(uncle32, TEST_DIFFICULTY, false);
 
-        Set<ByteArrayWrapper> family = FamilyUtils.getUncles(store, block3, 3);
+        Set<Keccak256> family = FamilyUtils.getUncles(store, block3, 3);
 
         Assert.assertNotNull(family);
         Assert.assertFalse(family.isEmpty());
         Assert.assertEquals(4, family.size());
 
-        Assert.assertFalse(family.contains(genesis.getWrappedHash()));
-        Assert.assertFalse(family.contains(block1.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle11.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle12.getWrappedHash()));
-        Assert.assertFalse(family.contains(block2.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle21.getWrappedHash()));
-        Assert.assertTrue(family.contains(uncle22.getWrappedHash()));
-        Assert.assertFalse(family.contains(block3.getWrappedHash()));
-        Assert.assertFalse(family.contains(uncle31.getWrappedHash()));
-        Assert.assertFalse(family.contains(uncle32.getWrappedHash()));
+        Assert.assertFalse(family.contains(genesis.getHash()));
+        Assert.assertFalse(family.contains(block1.getHash()));
+        Assert.assertTrue(family.contains(uncle11.getHash()));
+        Assert.assertTrue(family.contains(uncle12.getHash()));
+        Assert.assertFalse(family.contains(block2.getHash()));
+        Assert.assertTrue(family.contains(uncle21.getHash()));
+        Assert.assertTrue(family.contains(uncle22.getHash()));
+        Assert.assertFalse(family.contains(block3.getHash()));
+        Assert.assertFalse(family.contains(uncle31.getHash()));
+        Assert.assertFalse(family.contains(uncle32.getHash()));
     }
 
     private static BlockStore createBlockStore() {

--- a/rskj-core/src/test/java/co/rsk/net/BlockCacheTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/BlockCacheTest.java
@@ -22,7 +22,6 @@ package co.rsk.net;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.ByteArrayWrapper;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -48,7 +47,7 @@ public class BlockCacheTest {
     public void putAndGetValue() {
         BlockCache store = getSubject();
         Block block = Mockito.mock(Block.class);
-        store.put(new ByteArrayWrapper(HASH_1), block);
+        store.put(new Keccak256(HASH_1), block);
 
         assertThat(store.getBlockByHash(HASH_1), is(block));
     }
@@ -56,11 +55,11 @@ public class BlockCacheTest {
     @Test
     public void putMoreThanSizeAndCheckCleanup() {
         BlockCache store = getSubject();
-        store.put(new ByteArrayWrapper(HASH_1), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_2), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_3), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_4), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_5), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_1), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_2), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_3), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_4), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_5), Mockito.mock(Block.class));
 
         assertThat(store.getBlockByHash(HASH_1), nullValue());
         assertThat(store.getBlockByHash(HASH_2), notNullValue());
@@ -72,12 +71,12 @@ public class BlockCacheTest {
     @Test
     public void repeatingValueAtEndPreventsCleanup() {
         BlockCache store = getSubject();
-        store.put(new ByteArrayWrapper(HASH_1), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_2), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_3), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_4), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_1), Mockito.mock(Block.class));
-        store.put(new ByteArrayWrapper(HASH_5), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_1), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_2), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_3), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_4), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_1), Mockito.mock(Block.class));
+        store.put(new Keccak256(HASH_5), Mockito.mock(Block.class));
 
         assertThat(store.getBlockByHash(HASH_1), notNullValue());
         assertThat(store.getBlockByHash(HASH_2), nullValue());
@@ -90,7 +89,7 @@ public class BlockCacheTest {
     public void addAndRetrieveBlock() {
         BlockCache store = getSubject();
         Block block = Mockito.mock(Block.class);
-        when(block.getWrappedHash()).thenReturn(new ByteArrayWrapper(HASH_1));
+        when(block.getHash()).thenReturn(new Keccak256(HASH_1));
         store.addBlock(block);
 
         assertThat(store.getBlockByHash(HASH_1), is(block));

--- a/rskj-core/src/test/java/co/rsk/net/BlockNodeInformationTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/BlockNodeInformationTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net;
 
-import org.ethereum.db.ByteArrayWrapper;
+import co.rsk.crypto.Keccak256;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,8 +28,8 @@ import java.util.Set;
 public class BlockNodeInformationTest {
 
     // createBlockHash is a convenience function to create a ByteArrayWrapper wrapping an int.
-    private ByteArrayWrapper createBlockHash(int i) {
-        return new ByteArrayWrapper(ByteBuffer.allocate(4).putInt(i).array());
+    private Keccak256 createBlockHash(int i) {
+        return new Keccak256(ByteBuffer.allocate(32).putInt(i).array());
     }
 
     // createNodeID is a convenience function to create a NodeID based on an int.
@@ -40,7 +40,7 @@ public class BlockNodeInformationTest {
     @Test
     public void nodeEvictionPolicy() {
         final BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        final ByteArrayWrapper block = createBlockHash(10);
+        final Keccak256 block = createBlockHash(10);
 
         // Add a few nodes, not exceeding the node limit.
         // These nodes should contain the block when we call getBlocksByNode
@@ -76,7 +76,7 @@ public class BlockNodeInformationTest {
 
         // Add a few blocks, without exceeding the block limit. NodeID1 should contain them all.
         for (int i = 0; i < 500; i++) {
-            final ByteArrayWrapper hash1 = createBlockHash(i);
+            final Keccak256 hash1 = createBlockHash(i);
             nodeInformation.addBlockToNode(hash1, nodeID1);
         }
 
@@ -89,7 +89,7 @@ public class BlockNodeInformationTest {
         // Add more blocks, exceeding MAX_NODES. All previous blocks should be evicted.
         // Except from block 10, which is being constantly accessed.
         for (int i = 500; i < 2000; i++) {
-            final ByteArrayWrapper hash1 = createBlockHash(i);
+            final Keccak256 hash1 = createBlockHash(i);
             nodeInformation.addBlockToNode(hash1, nodeID1);
 
             nodeInformation.getNodesByBlock(createBlockHash(10));
@@ -113,22 +113,22 @@ public class BlockNodeInformationTest {
         final BlockNodeInformation nodeInformation = new BlockNodeInformation();
 
         Assert.assertTrue(nodeInformation.getBlocksByNode(new NodeID(new byte[]{})).size() == 0);
-        Assert.assertTrue(nodeInformation.getNodesByBlock(new ByteArrayWrapper(new byte[]{})).size() == 0);
-        Assert.assertTrue(nodeInformation.getBlocksByNode(new byte[]{}).size() == 0);
-        Assert.assertTrue(nodeInformation.getNodesByBlock(new byte[]{}).size() == 0);
+        Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(0)).size() == 0);
+        Assert.assertTrue(nodeInformation.getBlocksByNode(createBlockHash(0).getBytes()).size() == 0);
+        Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(0)).size() == 0);
     }
 
     @Test
     public void getIsNotEmptyIfPresent() {
         final BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        final ByteArrayWrapper hash1 = new ByteArrayWrapper(new byte[]{1});
+        final Keccak256 hash1 = createBlockHash(1);
         final NodeID nodeID1 = new NodeID(new byte[]{2});
 
-        final ByteArrayWrapper badHash = new ByteArrayWrapper(new byte[]{3});
+        final Keccak256 badHash = createBlockHash(3);
         final NodeID badNode = new NodeID(new byte[]{4});
 
         nodeInformation.addBlockToNode(hash1, nodeID1);
-        Set<ByteArrayWrapper> blocks = nodeInformation.getBlocksByNode(nodeID1);
+        Set<Keccak256> blocks = nodeInformation.getBlocksByNode(nodeID1);
         Assert.assertTrue(blocks.size() == 1);
         Assert.assertTrue(blocks.contains(hash1));
         Assert.assertFalse(blocks.contains(badHash));
@@ -148,18 +148,18 @@ public class BlockNodeInformationTest {
     @Test
     public void twoNodesTwoBlocks() {
         final BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        final ByteArrayWrapper hash1 = new ByteArrayWrapper(new byte[]{1});
+        final Keccak256 hash1 = createBlockHash(1);
         final NodeID nodeID1 = new NodeID(new byte[]{2});
 
-        final ByteArrayWrapper hash2 = new ByteArrayWrapper(new byte[]{3});
+        final Keccak256 hash2 = createBlockHash(3);
         final NodeID nodeID2 = new NodeID(new byte[]{4});
 
         nodeInformation.addBlockToNode(hash1, nodeID1);
         nodeInformation.addBlockToNode(hash2, nodeID1);
         nodeInformation.addBlockToNode(hash2, nodeID2);
 
-        Set<ByteArrayWrapper> blocks1 = nodeInformation.getBlocksByNode(nodeID1);
-        Set<ByteArrayWrapper> blocks2 = nodeInformation.getBlocksByNode(nodeID2);
+        Set<Keccak256> blocks1 = nodeInformation.getBlocksByNode(nodeID1);
+        Set<Keccak256> blocks2 = nodeInformation.getBlocksByNode(nodeID2);
         Set<NodeID> nodes1 = nodeInformation.getNodesByBlock(hash1);
         Set<NodeID> nodes2 = nodeInformation.getNodesByBlock(hash2);
 

--- a/rskj-core/src/test/java/co/rsk/net/BlockStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/BlockStoreTest.java
@@ -21,6 +21,7 @@ package co.rsk.net;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.RskAddress;
 import com.google.common.collect.Lists;
+import org.ethereum.TestUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Bloom;
@@ -38,8 +39,7 @@ public class BlockStoreTest {
     @Test
     public void getUnknownBlockAsNull() {
         BlockStore store = new BlockStore();
-
-        Assert.assertNull(store.getBlockByHash(new byte[] { 0x01, 0x20 }));
+        Assert.assertNull(store.getBlockByHash(TestUtils.randomBytes(32)));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class BlockStoreTest {
 
         Assert.assertNull(store.getBlockByHash(block.getHash().getBytes()));
         Assert.assertTrue(store.getBlocksByNumber(block.getNumber()).isEmpty());
-        Assert.assertTrue(store.getBlocksByParentHash(block.getParentHash().getBytes()).isEmpty());
+        Assert.assertTrue(store.getBlocksByParentHash(block.getParentHash()).isEmpty());
         Assert.assertEquals(0, store.size());
     }
 
@@ -100,8 +100,8 @@ public class BlockStoreTest {
 
         Assert.assertNull(store.getBlockByHash(grandson.getHash().getBytes()));
         Assert.assertTrue(store.getBlocksByNumber(grandson.getNumber()).isEmpty());
-        Assert.assertTrue(store.getBlocksByParentHash(son1.getHash().getBytes()).isEmpty());
-        Assert.assertTrue(store.getBlocksByParentHash(son2.getHash().getBytes()).isEmpty());
+        Assert.assertTrue(store.getBlocksByParentHash(son1.getHash()).isEmpty());
+        Assert.assertTrue(store.getBlocksByParentHash(son2.getHash()).isEmpty());
         Assert.assertEquals(2, store.size());
     }
 
@@ -133,7 +133,7 @@ public class BlockStoreTest {
 
         Assert.assertEquals(eve.getHash(), childrenByNumber.get(0).getHash());
 
-        List<Block> childrenByParent = store.getBlocksByParentHash(adam.getHash().getBytes());
+        List<Block> childrenByParent = store.getBlocksByParentHash(adam.getHash());
 
         Assert.assertNotNull(childrenByParent);
         Assert.assertEquals(1, childrenByParent.size());
@@ -198,7 +198,7 @@ public class BlockStoreTest {
         store.saveBlock(block1);
         store.saveBlock(block2);
 
-        List<Block> blocks = store.getBlocksByParentHash(genesis.getHash().getBytes());
+        List<Block> blocks = store.getBlocksByParentHash(genesis.getHash());
 
         Assert.assertTrue(blocks.contains(block1));
         Assert.assertTrue(blocks.contains(block2));
@@ -236,7 +236,7 @@ public class BlockStoreTest {
         );
 
         store.saveHeader(blockHeader);
-        Assert.assertTrue(store.hasHeader(blockHeader.getHash().getBytes()));
+        Assert.assertTrue(store.hasHeader(blockHeader.getHash()));
     }
 
     @Test
@@ -261,7 +261,7 @@ public class BlockStoreTest {
 
         store.saveHeader(blockHeader);
         store.removeHeader(blockHeader);
-        Assert.assertFalse(store.hasHeader(blockHeader.getHash().getBytes()));
+        Assert.assertFalse(store.hasHeader(blockHeader.getHash()));
     }
 }
 

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
@@ -20,6 +20,7 @@ package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.BlockDifficulty;
+import co.rsk.crypto.Keccak256;
 import co.rsk.net.messages.*;
 import co.rsk.net.simples.SimpleMessageChannel;
 import co.rsk.net.sync.SyncConfiguration;
@@ -28,7 +29,6 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockIdentifier;
 import org.ethereum.core.Blockchain;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.ByteArrayWrapper;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -468,7 +468,7 @@ public class NodeBlockProcessorTest {
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
         final Block block = blockchain.getBestBlock();
-        final ByteArrayWrapper blockHash = block.getWrappedHash();
+        final Keccak256 blockHash = block.getHash();
 
 //        final Status status = new Status(block.getNumber(), block.getHash());
 
@@ -492,7 +492,7 @@ public class NodeBlockProcessorTest {
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
         final Block block = blockchain.getBlockByNumber(1);
-        final ByteArrayWrapper blockHash = block.getWrappedHash();
+        final Keccak256 blockHash = block.getHash();
 
         store.saveBlock(block);
 //        final Status status = new Status(block.getNumber(), block.getHash());
@@ -586,7 +586,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processGetBlockMessageUsingBlockInStore() throws UnknownHostException {
         final Block block = new BlockGenerator().getBlock(3);
-        final ByteArrayWrapper blockHash = block.getWrappedHash();
+        final Keccak256 blockHash = block.getHash();
 
         final BlockStore store = new BlockStore();
         store.saveBlock(block);
@@ -643,7 +643,7 @@ public class NodeBlockProcessorTest {
     public void processGetBlockMessageUsingBlockInBlockchain() throws UnknownHostException {
         final Blockchain blockchain = BlockChainBuilder.ofSize(10);
         final Block block = blockchain.getBlockByNumber(5);
-        final ByteArrayWrapper blockHash = block.getWrappedHash();
+        final Keccak256 blockHash = block.getHash();
         final BlockStore store = new BlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -674,7 +674,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processBlockRequestMessageUsingBlockInStore() throws UnknownHostException {
         final Block block = new BlockGenerator().getBlock(3);
-        final ByteArrayWrapper blockHash = block.getWrappedHash();
+        final Keccak256 blockHash = block.getHash();
 
         final BlockStore store = new BlockStore();
         store.saveBlock(block);
@@ -737,7 +737,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processBlockHashRequestMessageUsingEmptyStore() throws UnknownHostException {
         final Block block = new BlockGenerator().getBlock(3);
-        final ByteArrayWrapper blockHash = block.getWrappedHash();
+        final Keccak256 blockHash = block.getHash();
         final BlockStore store = new BlockStore();
         final Blockchain blockchain = BlockChainBuilder.ofSize(0);
 
@@ -761,7 +761,7 @@ public class NodeBlockProcessorTest {
     public void processBlockHashRequestMessageUsingBlockInBlockchain() throws UnknownHostException {
         final Blockchain blockchain = BlockChainBuilder.ofSize(10);
         final Block block = blockchain.getBlockByNumber(5);
-        final ByteArrayWrapper blockHash = block.getWrappedHash();
+        final Keccak256 blockHash = block.getHash();
         final BlockStore store = new BlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorUnclesTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorUnclesTest.java
@@ -136,7 +136,7 @@ public class NodeBlockProcessorUnclesTest {
         Assert.assertEquals(0, processor.getBlockchain().getBestBlock().getNumber());
         Assert.assertArrayEquals(genesis.getHash().getBytes(), processor.getBlockchain().getBestBlockHash());
         Assert.assertEquals(1, sender.getGetBlockMessages().size());
-        Assert.assertTrue(sender.getGetBlockMessagesHashes().contains(block1.getWrappedHash()));
+        Assert.assertTrue(sender.getGetBlockMessagesHashes().contains(block1.getHash()));
     }
 
     private static NodeBlockProcessor createNodeBlockProcessor(BlockChainImpl blockChain) {

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -21,6 +21,7 @@ package co.rsk.net;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.BlockDifficulty;
+import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.net.handler.TxHandler;
 import co.rsk.net.handler.TxHandlerImpl;
@@ -42,7 +43,6 @@ import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
@@ -584,22 +584,22 @@ public class NodeMessageHandlerTest {
 
             Assert.assertTrue(sender.getMessages().stream().allMatch(m -> m.getMessageType() == MessageType.GET_BLOCK_MESSAGE));
 
-            List<ByteArrayWrapper> msgs = sender.getMessages().stream()
+            List<Keccak256> msgs = sender.getMessages().stream()
                     .map(m -> (GetBlockMessage) m)
                     .map(m -> m.getBlockHash())
-                    .map(h -> new ByteArrayWrapper(h))
+                    .map(h -> new Keccak256(h))
                     .collect(Collectors.toList());
 
-            Set<ByteArrayWrapper> expected = testCase.expected.stream()
+            Set<Keccak256> expected = testCase.expected.stream()
                     .map(b -> b.getHash().getBytes())
-                    .map(h -> new ByteArrayWrapper(h))
+                    .map(h -> new Keccak256(h))
                     .collect(Collectors.toSet());
 
-            for (ByteArrayWrapper h : msgs) {
+            for (Keccak256 h : msgs) {
                 Assert.assertTrue(expected.contains(h));
             }
 
-            for (ByteArrayWrapper h : expected) {
+            for (Keccak256 h : expected) {
                 Assert.assertTrue(
                         msgs.stream()
                                 .filter(h1 -> h.equals(h1))

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleBlockProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleBlockProcessor.java
@@ -18,13 +18,16 @@
 
 package co.rsk.net.simples;
 
-import co.rsk.net.*;
+import co.rsk.crypto.Keccak256;
+import co.rsk.net.BlockNodeInformation;
+import co.rsk.net.BlockProcessResult;
+import co.rsk.net.BlockProcessor;
+import co.rsk.net.MessageChannel;
 import co.rsk.net.messages.NewBlockHashesMessage;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.ImportResult;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -44,9 +47,9 @@ public class SimpleBlockProcessor implements BlockProcessor {
 
     @Override
     public BlockProcessResult processBlock(MessageChannel sender, Block block) {
-        Map<ByteArrayWrapper, ImportResult> connectionsResult = new HashMap<>();
+        Map<Keccak256, ImportResult> connectionsResult = new HashMap<>();
         this.blocks.add(block);
-        connectionsResult.put(block.getWrappedHash(), ImportResult.IMPORTED_BEST);
+        connectionsResult.put(block.getHash(), ImportResult.IMPORTED_BEST);
         return new BlockProcessResult(false, connectionsResult, block.getShortHash(), Duration.ZERO);
     }
 

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleMessageChannel.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleMessageChannel.java
@@ -18,12 +18,12 @@
 
 package co.rsk.net.simples;
 
+import co.rsk.crypto.Keccak256;
 import co.rsk.net.MessageChannel;
 import co.rsk.net.NodeID;
 import co.rsk.net.messages.GetBlockMessage;
 import co.rsk.net.messages.Message;
 import co.rsk.net.messages.MessageType;
-import org.ethereum.db.ByteArrayWrapper;
 import org.junit.Assert;
 
 import java.net.InetAddress;
@@ -74,10 +74,10 @@ public class SimpleMessageChannel implements MessageChannel {
                 .collect(Collectors.toList());
     }
 
-    public List<ByteArrayWrapper> getGetBlockMessagesHashes() {
+    public List<Keccak256> getGetBlockMessagesHashes() {
         return this.messages.stream()
                 .filter(message -> message.getMessageType() == MessageType.GET_BLOCK_MESSAGE)
-                .map(message -> new ByteArrayWrapper(((GetBlockMessage) message).getBlockHash()))
+                .map(message -> new Keccak256(((GetBlockMessage) message).getBlockHash()))
                 .collect(Collectors.toList());
     }
 

--- a/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
@@ -21,6 +21,7 @@ package org.ethereum.db;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.BlockDifficulty;
+import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
 import org.ethereum.core.Genesis;
 import org.ethereum.datasource.HashMapDB;
@@ -47,7 +48,6 @@ import java.util.*;
 
 import static co.rsk.core.BlockDifficulty.ZERO;
 import static org.ethereum.TestUtils.*;
-import static org.ethereum.util.ByteUtil.wrap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -764,55 +764,55 @@ public class IndexedBlockStoreTest {
             }
 
             // calc all TDs
-            Map<ByteArrayWrapper, BlockDifficulty> tDiffs = new HashMap<>();
+            Map<Keccak256, BlockDifficulty> tDiffs = new HashMap<>();
             td = Genesis.getInstance(config).getCumulativeDifficulty();
             for (Block block : bestLine){
                 td = td.add(block.getCumulativeDifficulty());
-                tDiffs.put(wrap(block.getHash().getBytes()), td);
+                tDiffs.put(block.getHash(), td);
             }
 
-            Map<ByteArrayWrapper, BlockDifficulty> tForkDiffs = new HashMap<>();
+            Map<Keccak256, BlockDifficulty> tForkDiffs = new HashMap<>();
             Block block = forkLine.get(0);
-            td = tDiffs.get(wrap(block.getParentHash().getBytes()));
+            td = tDiffs.get(block.getParentHash());
             for (Block currBlock : forkLine){
                 td = td.add(currBlock.getCumulativeDifficulty());
-                tForkDiffs.put(wrap(currBlock.getHash().getBytes()), td);
+                tForkDiffs.put(currBlock.getHash(), td);
             }
 
             // Assert tds on bestLine
-            for ( ByteArrayWrapper hash :  tDiffs.keySet()) {
+            for ( Keccak256 hash :  tDiffs.keySet()) {
                 BlockDifficulty currTD = tDiffs.get(hash);
-                BlockDifficulty checkTd =  indexedBlockStore.getTotalDifficultyForHash(hash.getData());
+                BlockDifficulty checkTd =  indexedBlockStore.getTotalDifficultyForHash(hash.getBytes());
                 assertEquals(checkTd, currTD);
             }
 
             // Assert tds on forkLine
-            for ( ByteArrayWrapper hash :  tForkDiffs.keySet()) {
+            for ( Keccak256 hash :  tForkDiffs.keySet()) {
                 BlockDifficulty currTD = tForkDiffs.get(hash);
-                BlockDifficulty checkTd =  indexedBlockStore.getTotalDifficultyForHash(hash.getData());
+                BlockDifficulty checkTd =  indexedBlockStore.getTotalDifficultyForHash(hash.getBytes());
                 assertEquals(checkTd, currTD);
             }
 
             indexedBlockStore.flush();
 
             // Assert tds on bestLine
-            for ( ByteArrayWrapper hash :  tDiffs.keySet()) {
+            for ( Keccak256 hash :  tDiffs.keySet()) {
                 BlockDifficulty currTD = tDiffs.get(hash);
-                BlockDifficulty checkTd =  indexedBlockStore.getTotalDifficultyForHash(hash.getData());
+                BlockDifficulty checkTd =  indexedBlockStore.getTotalDifficultyForHash(hash.getBytes());
                 assertEquals(checkTd, currTD);
             }
 
             // check total difficulty
             Block bestBlock = bestLine.get(bestLine.size() - 1);
             BlockDifficulty totalDifficulty  = indexedBlockStore.getTotalDifficultyForHash(bestBlock.getHash().getBytes());
-            BlockDifficulty totalDifficulty_ = tDiffs.get(wrap(bestBlock.getHash().getBytes()));
+            BlockDifficulty totalDifficulty_ = tDiffs.get(bestBlock.getHash());
 
             assertEquals(totalDifficulty_, totalDifficulty);
 
             // Assert tds on forkLine
-            for ( ByteArrayWrapper hash :  tForkDiffs.keySet()) {
+            for ( Keccak256 hash :  tForkDiffs.keySet()) {
                 BlockDifficulty currTD = tForkDiffs.get(hash);
-                BlockDifficulty checkTd =  indexedBlockStore.getTotalDifficultyForHash(hash.getData());
+                BlockDifficulty checkTd =  indexedBlockStore.getTotalDifficultyForHash(hash.getBytes());
                 assertEquals(checkTd, currTD);
             }
 

--- a/rskj-core/src/test/java/org/ethereum/db/ReceiptStoreImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/ReceiptStoreImplTest.java
@@ -169,8 +169,8 @@ public class ReceiptStoreImplTest {
         ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
         TransactionReceipt receipt = createReceipt();
 
-        byte[] blockHash0 = Hex.decode("0102030405060708");
-        byte[] blockHash = Hex.decode("010203040506070809");
+        byte[] blockHash0 = Hex.decode("0102030405060708000000000000000000000000000000000000000000000000");
+        byte[] blockHash = Hex.decode("0102030405060708090000000000000000000000000000000000000000000000");
 
         store.add(blockHash, 1, receipt);
 
@@ -184,12 +184,12 @@ public class ReceiptStoreImplTest {
         ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
 
         TransactionReceipt receipt0 = createReceipt();
-        byte[] blockHash0 = Hex.decode("010203040506070809");
+        byte[] blockHash0 = Hex.decode("0102030405060708090000000000000000000000000000000000000000000000");
 
         store.add(blockHash0, 3, receipt0);
 
         TransactionReceipt receipt = createReceipt();
-        byte[] blockHash = Hex.decode("0102030405060708");
+        byte[] blockHash = Hex.decode("0102030405060708000000000000000000000000000000000000000000000000");
 
         store.add(blockHash, 42, receipt);
 
@@ -206,12 +206,12 @@ public class ReceiptStoreImplTest {
         ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
 
         TransactionReceipt receipt0 = createReceipt();
-        byte[] blockHash0 = Hex.decode("010203040506070809");
+        byte[] blockHash0 = Hex.decode("0102030405060708090000000000000000000000000000000000000000000000");
 
         store.add(blockHash0, 3, receipt0);
 
         TransactionReceipt receipt = createReceipt();
-        byte[] blockHash = Hex.decode("0102030405060708");
+        byte[] blockHash = Hex.decode("0102030405060708000000000000000000000000000000000000000000000000");
 
         store.add(blockHash, 42, receipt);
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -794,7 +794,7 @@ public class Web3ImplTest {
 
         Web3Impl web3 = createWeb3(world);
 
-        Web3.BlockResult blockResult = web3.eth_getBlockByHash("0x1234", false);
+        Web3.BlockResult blockResult = web3.eth_getBlockByHash("0x1234000000000000000000000000000000000000000000000000000000000000", false);
 
         Assert.assertNull(blockResult);
     }


### PR DESCRIPTION
The goal is to remove the lasts uses of ByteArrayWrapper that are wrapping block hashes. The remaining ones should be wrapping bytes for other uses.