### PR TITLE
Tool for migrating configurations between versions

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/CliArgsParser.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliArgsParser.java
@@ -1,0 +1,67 @@
+package co.rsk.cli;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class CliArgsParser<O extends Enum<O> & OptionalizableArgument, F extends Enum<F>> {
+
+    private final List<String> arguments;
+    private final Map<O, String> options;
+    private final Set<F> flags;
+
+    public CliArgsParser(String[] args, ArgByNameProvider<O> optionsProvider, ArgByNameProvider<F> flagsProvider) {
+        arguments = new LinkedList<>();
+        options = new HashMap<>();
+        flags = new HashSet<>();
+
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i].charAt(0)) {
+                case '-':
+                    if (args[i].length() < 2) {
+                        throw new IllegalArgumentException("You must provide an option name, e.g. -d");
+                    }
+                    if (args[i].charAt(1) == '-') {
+                        if (args[i].length() < 3) {
+                            throw new IllegalArgumentException("You must provide a flag name, e.g. --quiet");
+                        }
+                        flags.add(flagsProvider.byName(args[i].substring(2, args[i].length())));
+                    } else {
+                        if (args.length - 1 == i) {
+                            throw new IllegalArgumentException("A value must be provided after the option -" + args[i]);
+                        }
+                        options.put(optionsProvider.byName(args[i].substring(1, args[i].length())), args[i+1]);
+                        i++;
+                    }
+                    break;
+                default:
+                    arguments.add(args[i]);
+                    break;
+            }
+        }
+
+        Set<O> missingOptions = optionsProvider.values().stream().filter(arg -> !arg.isOptional()).collect(Collectors.toSet());
+        missingOptions.removeAll(options.keySet());
+        if (!missingOptions.isEmpty()) {
+            throw new IllegalArgumentException(String.format("Missing configuration options: %s", missingOptions));
+        }
+
+    }
+
+    public List<String> getArguments() {
+        return Collections.unmodifiableList(arguments);
+    }
+
+    public Map<O, String> getOptions() {
+        return Collections.unmodifiableMap(options);
+    }
+
+    public Set<F> getFlags() {
+        return Collections.unmodifiableSet(flags);
+    }
+
+    public interface ArgByNameProvider<E extends Enum<E>> {
+        E byName(String name);
+
+        Collection<E> values();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/cli/OptionalizableArgument.java
+++ b/rskj-core/src/main/java/co/rsk/cli/OptionalizableArgument.java
@@ -1,0 +1,5 @@
+package co.rsk.cli;
+
+public interface OptionalizableArgument {
+    boolean isOptional();
+}

--- a/rskj-core/src/main/java/co/rsk/cli/config/MigrationTool.java
+++ b/rskj-core/src/main/java/co/rsk/cli/config/MigrationTool.java
@@ -1,0 +1,57 @@
+package co.rsk.cli.config;
+
+import co.rsk.cli.CliArgsParser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collection;
+
+public class MigrationTool {
+
+    public static void main(String[] commandLineArgs) throws IOException {
+        CliArgsParser<Migrator.MigratorOptions, Migrator.MigratorFlags> cliArgs = new CliArgsParser<>(
+                commandLineArgs,
+                new CliArgsParser.ArgByNameProvider<Migrator.MigratorOptions>() {
+                    @Override
+                    public Migrator.MigratorOptions byName(String name) {
+                        return Migrator.MigratorOptions.getByOptionName(name);
+                    }
+
+                    @Override
+                    public Collection<Migrator.MigratorOptions> values() {
+                        return Arrays.asList(Migrator.MigratorOptions.values());
+                    }
+                },
+                new CliArgsParser.ArgByNameProvider<Migrator.MigratorFlags>() {
+                    @Override
+                    public Migrator.MigratorFlags byName(String name) {
+                        return Migrator.MigratorFlags.getByFlagName(name);
+                    }
+
+                    @Override
+                    public Collection<Migrator.MigratorFlags> values() {
+                        return Arrays.asList(Migrator.MigratorFlags.values());
+                    }
+                }
+        );
+
+        MigratorConfiguration configuration = new MigratorConfiguration(
+                cliArgs.getOptions().get(Migrator.MigratorOptions.INPUT_FILE),
+                cliArgs.getOptions().get(Migrator.MigratorOptions.MIGRATION_FILE),
+                cliArgs.getOptions().get(Migrator.MigratorOptions.OUTPUT_FILE),
+                cliArgs.getFlags().contains(Migrator.MigratorFlags.REPLACE_IN_PLACE)
+        );
+
+        Migrator migrator = new Migrator(configuration);
+        String migratedConfigOutput = migrator.migrateConfiguration();
+        Path destination = configuration.getDestinationConfiguration();
+        Files.write(destination, migratedConfigOutput.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+
+        System.out.println("Configuration successfully migrated.");
+        System.out.printf("Source: %s\nDestination: %s\n", configuration.getSourceConfiguration(), destination);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/cli/config/Migrator.java
+++ b/rskj-core/src/main/java/co/rsk/cli/config/Migrator.java
@@ -1,0 +1,84 @@
+package co.rsk.cli.config;
+
+import co.rsk.cli.OptionalizableArgument;
+import com.typesafe.config.*;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class Migrator {
+
+    private final MigratorConfiguration configuration;
+
+    public Migrator(MigratorConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    public String migrateConfiguration() throws IOException {
+        return  migrateConfiguration(
+            Files.newBufferedReader(configuration.getSourceConfiguration(), StandardCharsets.UTF_8),
+            configuration.getMigrationConfiguration()
+        );
+    }
+
+    public static String migrateConfiguration(Reader sourceReader, Properties migrationConfiguration) {
+        Config migratedConfig = ConfigFactory.parseReader(sourceReader);
+        Enumeration migrationPaths = migrationConfiguration.propertyNames();
+        while (migrationPaths.hasMoreElements()) {
+            String originalPath = (String) migrationPaths.nextElement();
+            if (migratedConfig.hasPath(originalPath)) {
+                ConfigValue configurationValueToMigrate = migratedConfig.getValue(originalPath);
+                migratedConfig = migratedConfig.withValue(migrationConfiguration.getProperty(originalPath), configurationValueToMigrate).withoutPath(originalPath);
+            }
+        }
+
+        return migratedConfig.root().render(ConfigRenderOptions.defaults().setOriginComments(false).setJson(false));
+    }
+
+    public enum MigratorOptions implements OptionalizableArgument {
+        INPUT_FILE("i", false),
+        OUTPUT_FILE("o", true),
+        MIGRATION_FILE("m", false),
+        ;
+
+        private final String optionName;
+        private final boolean optional;
+
+        MigratorOptions(String name, boolean optional) {
+            this.optionName = name;
+            this.optional = optional;
+        }
+
+        @Override
+        public boolean isOptional() {
+            return optional;
+        }
+
+        public static MigratorOptions getByOptionName(String optionName) {
+            Optional<MigratorOptions> cliOption = Stream.of(values()).filter(option -> option.optionName.equals(optionName)).findFirst();
+            return cliOption.orElseThrow(() -> new NoSuchElementException(String.format("-%s is not a valid option", optionName)));
+        }
+
+    }
+
+    public enum MigratorFlags {
+        REPLACE_IN_PLACE("replace"),
+        ;
+
+        private final String flagName;
+
+        MigratorFlags(String flagName) {
+            this.flagName = flagName;
+        }
+
+        public static MigratorFlags getByFlagName(String flagName) {
+            Optional<MigratorFlags> cliFlag = Stream.of(values()).filter(flag -> flag.flagName.equals(flagName)).findFirst();
+            return cliFlag.orElseThrow(() -> new NoSuchElementException(String.format("--%s is not a valid flag", flagName)));
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/cli/config/MigratorConfiguration.java
+++ b/rskj-core/src/main/java/co/rsk/cli/config/MigratorConfiguration.java
@@ -1,0 +1,56 @@
+package co.rsk.cli.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+class MigratorConfiguration {
+
+    private static final String MIGRATION_FILE_FORMAT = "%s.new";
+    private final Path sourceConfiguration;
+    private final Properties migrationConfiguration;
+    private final Path destinationConfiguration;
+
+    public MigratorConfiguration(String sourceConfiguration, String migrationConfiguration, String destinationConfiguration, boolean replaceSource) {
+        this.sourceConfiguration = Paths.get(sourceConfiguration);
+        if (!Files.isRegularFile(this.sourceConfiguration)) {
+            throw new IllegalArgumentException(String.format("%s is not a valid input file", sourceConfiguration));
+        }
+        Path migrationConfigurationPath = Paths.get(migrationConfiguration);
+        if (!Files.isRegularFile(migrationConfigurationPath)) {
+            throw new IllegalArgumentException(String.format("%s is not a valid migration file", migrationConfigurationPath));
+        }
+        this.migrationConfiguration = new Properties();
+        try {
+            this.migrationConfiguration.load(Files.newInputStream(migrationConfigurationPath));
+        } catch (IOException e) {
+            throw new IllegalArgumentException(String.format("Unable to read migration config at %s", migrationConfigurationPath));
+        }
+
+        if (replaceSource) {
+            this.destinationConfiguration = this.sourceConfiguration;
+        } else if (destinationConfiguration != null) {
+            Path destinationConfigurationPath = Paths.get(destinationConfiguration);
+            if (!Files.isWritable(destinationConfigurationPath.getParent()) || Files.isDirectory(destinationConfigurationPath)) {
+                throw new IllegalArgumentException(String.format("%s is not a valid output file", destinationConfigurationPath));
+            }
+            this.destinationConfiguration = destinationConfigurationPath;
+        } else {
+            this.destinationConfiguration = this.sourceConfiguration.getParent().resolve(String.format(MIGRATION_FILE_FORMAT, this.sourceConfiguration.getFileName().toString()));
+        }
+    }
+
+    public Path getSourceConfiguration() {
+        return sourceConfiguration;
+    }
+
+    public Properties getMigrationConfiguration() {
+        return migrationConfiguration;
+    }
+
+    public Path getDestinationConfiguration() {
+        return destinationConfiguration;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/cli/config/MigratorTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/config/MigratorTest.java
@@ -1,0 +1,41 @@
+package co.rsk.cli.config;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class MigratorTest {
+
+    @Test
+    public void migrateConfiguration() {
+        Reader initialConfiguration = new StringReader("inline.config.name=\"value\"\n" +
+                "nested {\n" +
+                "  nested = {\n" +
+                "    #test comment\n" +
+                "    config = 13\n" +
+                "  }\n" +
+                "}\n" +
+                "another.config=\"don't change\"");
+        Properties migrationProperties = new Properties();
+        migrationProperties.put("inline.config.name", "inline.config.new.name");
+        migrationProperties.put("nested.nested.config", "nested.nested.new.config");
+        migrationProperties.put("unknown.config", "none");
+
+        String migratedConfiguration = Migrator.migrateConfiguration(initialConfiguration, migrationProperties);
+        Config config = ConfigFactory.parseString(migratedConfiguration);
+        assertThat(config.hasPath("inline.config.name"), is(false));
+        assertThat(config.getString("inline.config.new.name"), is("value"));
+        assertThat(config.hasPath("nested.nested.config"), is(false));
+        assertThat(config.getInt("nested.nested.new.config"), is(13));
+        assertThat(config.hasPath("unknown.config"), is(false));
+        assertThat(config.getString("another.config"), is("don't change"));
+    }
+}


### PR DESCRIPTION
This is a simple CLI program for migrating configurations. This must be invoked with:
```
java -cp [jar] co.rsk.cli.config.MigrationTool -i original.config -m migration.properties [-o output.config] [--replace]
```
`migration.properties` is a [properties](https://docs.oracle.com/cd/E23095_01/Platform.93/ATGProgGuide/html/s0204propertiesfileformat01.html) file which describes the mapping between the old and the new configuration. For example:
```properties
bind.address = bind_address

rpc.cors = rpc.providers.web.cors
rpc.enabled = rpc.providers.web.http.enabled
rpc.port = rpc.providers.web.http.port
rpc.bind_address = rpc.providers.web.http.bind_address
rpc.linger.time = rpc.providers.web.http.linger_time
```
By default you don't need to specify an output file, it'll create a new file in the same location as the _input file_ appending a *.new* suffix. This behavior can be overridden by a `-o` option or with `--replace` which will overwrite the original file (use this one with caution)