### PR TITLE
Fix TransactionResultDTO Remasc sender serialization

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -19,6 +19,8 @@
 package org.ethereum.rpc.dto;
 
 import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 import org.ethereum.rpc.TypeConverter;
@@ -56,8 +58,8 @@ public class TransactionResultDTO {
         blockHash = b != null ? b.getHashJsonString() : null;
         blockNumber = b != null ? TypeConverter.toJsonHex(b.getNumber()) : null;
         transactionIndex = index != null ? TypeConverter.toJsonHex(index) : null;
-        from= TypeConverter.toJsonHex(tx.getSender().getBytes());
-        to = TypeConverter.toJsonHex(tx.getReceiveAddress().getBytes());
+        from = addressToJsonHex(tx.getSender());
+        to = addressToJsonHex(tx.getReceiveAddress());
         gas = TypeConverter.toJsonHex(tx.getGasLimit()); // Todo: unclear if it's the gas limit or gas consumed what is asked
 
         gasPrice = TypeConverter.toJsonHex(tx.getGasPrice().getBytes());
@@ -69,6 +71,16 @@ public class TransactionResultDTO {
         }
 
         input = TypeConverter.toJsonHex(tx.getData());
+    }
+
+    private String addressToJsonHex(RskAddress address) {
+        // Web3.js requires the address to be valid (20 bytes),
+        // so we have to serialize the Remasc sender as a valid address.
+        if (address.equals(RemascTransaction.REMASC_ADDRESS)) {
+            return TypeConverter.toJsonHex(RskAddress.nullAddress().getBytes());
+        }
+
+        return TypeConverter.toJsonHex(address.getBytes());
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.rpc.dto;
+
+import co.rsk.core.Coin;
+import co.rsk.crypto.Keccak256;
+import co.rsk.remasc.RemascTransaction;
+import org.ethereum.TestUtils;
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransactionResultDTOTest {
+    @Test
+    public void remascAddressSerialization() {
+        Block b = mock(Block.class);
+        Integer index = 42;
+        Transaction tx = mock(Transaction.class);
+
+        when(tx.getHash()).thenReturn(new Keccak256(TestUtils.randomBytes(32)));
+        when(tx.getSender()).thenReturn(RemascTransaction.REMASC_ADDRESS);
+        when(tx.getReceiveAddress()).thenReturn(TestUtils.randomAddress());
+        when(tx.getGasPrice()).thenReturn(Coin.valueOf(42));
+        when(tx.getValue()).thenReturn(Coin.ZERO);
+        when(tx.getData()).thenReturn(TestUtils.randomBytes(2));
+
+        TransactionResultDTO dto = new TransactionResultDTO(b, index, tx);
+        assertThat(dto.from, is("0x0000000000000000000000000000000000000000"));
+    }
+}


### PR DESCRIPTION
@sirhill reported this issue in [Gitter](https://gitter.im/rsksmart/rskj?at=5a9d5f3df3f6d24c683c7dcf). It can be reproduced running the following code on `web3.js:1.0-beta30`:

```js
var Web3 = require('web3');
var web3 = new Web3('http://localhost:4444');
web3.eth.getTransaction('0x1b32ef862ace0ab9759775427dbb348dcb28b29152e8866eef56014d38b8d524')
    .then(console.log);
```

This is caused because `web3.js` is performing a strict validation on the sender address (`from` field): https://github.com/ethereum/web3.js/blob/a4d592e8d6d89e531ace066018bfc004ef501f0c/packages/web3-utils/src/index.js#L247

This fixes the `Remasc` sender address serialization to be a valid address.