### PR TITLE
Sync timeouts

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -108,12 +108,14 @@ public class RskFactory {
                                           Blockchain blockchain,
                                           BlockSyncService blockSyncService,
                                           PeerScoringManager peerScoringManager,
+                                          ChannelManager channelManager,
                                           SyncConfiguration syncConfiguration,
                                           DifficultyCalculator difficultyCalculator,
                                           ProofOfWorkRule proofOfWorkRule) {
 
         // TODO(lsebrie): add new BlockCompositeRule(new ProofOfWorkRule(), blockTimeStampValidationRule, new ValidGasUsedRule());
-        return new SyncProcessor(config, blockchain, blockSyncService, peerScoringManager, syncConfiguration, proofOfWorkRule, difficultyCalculator);
+        return new SyncProcessor(config, blockchain, blockSyncService, peerScoringManager, channelManager,
+                syncConfiguration, proofOfWorkRule, difficultyCalculator);
     }
 
     @Bean

--- a/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
@@ -67,7 +67,7 @@ public class BlockSyncService {
         this.unknownBlockHashes = new HashMap<>();
     }
 
-    public BlockProcessResult processBlock(MessageChannel sender, @Nonnull Block block, boolean ignoreMissingHashes) {
+    public BlockProcessResult processBlock(@Nonnull Block block, MessageChannel sender, boolean ignoreMissingHashes) {
         Instant start = Instant.now();
         long bestBlockNumber = this.getBestBlockNumber();
         long blockNumber = block.getNumber();

--- a/rskj-core/src/main/java/co/rsk/net/CheckingBestHeaderSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/CheckingBestHeaderSyncState.java
@@ -17,7 +17,7 @@ public class CheckingBestHeaderSyncState extends BaseSyncState implements SyncSt
 
     @Override
     public void onEnter(){
-        syncEventsHandler.sendBlockHeadersRequest(miniChunk);
+        trySendRequest();
     }
 
     @Override
@@ -32,5 +32,13 @@ public class CheckingBestHeaderSyncState extends BaseSyncState implements SyncSt
         }
 
         syncEventsHandler.startFindingConnectionPoint();
+    }
+
+    private void trySendRequest() {
+        boolean sent = syncEventsHandler.sendBlockHeadersRequest(miniChunk);
+        if (!sent) {
+            syncEventsHandler.onSyncIssue("Channel failed to sent on {} to {}",
+                    this.getClass(), syncInformation.getSelectedPeerId());
+        }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -185,6 +185,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processBlockHeadersRequest(@Nonnull final MessageChannel sender, long requestId, @Nonnull final byte[] hash, int count) {
+        logger.trace("Processing headers request {} {} from {}", requestId, Hex.toHexString(hash).substring(0, 10), sender.getPeerNodeID());
         Block block = blockSyncService.getBlockFromStoreOrBlockchain(hash);
 
         if (block == null) {
@@ -192,7 +193,6 @@ public class NodeBlockProcessor implements BlockProcessor {
         }
 
         List<BlockHeader> headers = new ArrayList<>();
-
         headers.add(block.getHeader());
 
         for (int k = 1; k < count; k++) {
@@ -219,7 +219,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processBodyRequest(@Nonnull final MessageChannel sender, long requestId, @Nonnull final byte[] hash) {
-        logger.trace("Processing body request {} {} from {}", requestId, Hex.toHexString(hash).substring(0, 10), sender.getPeerNodeID().toString());
+        logger.trace("Processing body request {} {} from {}", requestId, Hex.toHexString(hash).substring(0, 10), sender.getPeerNodeID());
         final Block block = blockSyncService.getBlockFromStoreOrBlockchain(hash);
 
         if (block == null) {
@@ -239,7 +239,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processBlockHashRequest(@Nonnull final MessageChannel sender, long requestId, long height) {
-        logger.trace("Processing block hash request {} {} from {}", requestId, height, sender.getPeerNodeID().toString());
+        logger.trace("Processing block hash request {} {} from {}", requestId, height, sender.getPeerNodeID());
         if (height == 0){
             return;
         }
@@ -262,7 +262,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processSkeletonRequest(@Nonnull final MessageChannel sender, long requestId, long startNumber) {
-        logger.trace("Processing block hash request {} {} {} from {}", requestId, startNumber, sender.getPeerNodeID());
+        logger.trace("Processing skeleton request {} {} from {}", requestId, startNumber, sender.getPeerNodeID());
         int skeletonStep = syncConfiguration.getChunkSize();
         Block blockStart = this.getBlockFromBlockchainStore(startNumber);
 
@@ -372,7 +372,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public BlockProcessResult processBlock(@Nullable final MessageChannel sender, @Nonnull final Block block) {
-        return blockSyncService.processBlock(sender, block, false);
+        return blockSyncService.processBlock(block, sender, false);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/net/NodeMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeMessageHandler.java
@@ -228,8 +228,11 @@ public class NodeMessageHandler implements MessageHandler, Runnable {
     private void updateTimedEvents() {
         Long now = System.currentTimeMillis();
         Duration timeTick = Duration.ofMillis(now - lastTickSent);
-        this.syncProcessor.onTimePassed(timeTick);
+        // TODO(lsebrie): handle timeouts properly
         lastTickSent = now;
+        if (queue.isEmpty()){
+            this.syncProcessor.onTimePassed(timeTick);
+        }
 
         //Refresh status to peers every 10 seconds or so
         Duration timeStatus = Duration.ofMillis(now - lastStatusSent);
@@ -373,9 +376,7 @@ public class NodeMessageHandler implements MessageHandler, Runnable {
     }
 
     private void processBlockHashRequestMessage(@Nonnull final MessageChannel sender, @Nonnull final BlockHashRequestMessage message) {
-        final long requestId = message.getId();
-        final long height = message.getHeight();
-        this.blockProcessor.processBlockHashRequest(sender, requestId, height);
+        this.blockProcessor.processBlockHashRequest(sender, message.getId(), message.getHeight());
     }
 
     private void processBlockHashResponseMessage(@Nonnull final MessageChannel sender, @Nonnull final BlockHashResponseMessage message) {

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -399,10 +399,6 @@ public class SyncProcessor implements SyncEventsHandler {
             peerScoringManager.recordEvent(peerId, null, eventType);
         }
 
-        public void logData(String message, Object... arguments) {
-            logger.trace(message, arguments);
-        }
-
         @Override
         public int getScore(NodeID peerId) {
             return peerScoringManager.getPeerScoring(peerId).getScore();

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -14,6 +14,7 @@ import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockIdentifier;
 import org.ethereum.core.Blockchain;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.net.server.ChannelManager;
 import org.ethereum.validator.DependentBlockHeaderRule;
 import org.ethereum.validator.DifficultyRule;
 import org.slf4j.Logger;
@@ -22,27 +23,29 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.time.Duration;
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.time.Instant;
+import java.util.*;
 
 /**
  * Created by ajlopez on 29/08/2017.
  * This class' methods are executed one at a time because NodeMessageHandler is synchronized.
  */
 public class SyncProcessor implements SyncEventsHandler {
+    public static final int MAX_SIZE_FAILURE_RECORDS = 10;
+    public static final int TIME_LIMIT_FAILURE_RECORD = 600;
     private static final Logger logger = LoggerFactory.getLogger("syncprocessor");
 
     private final RskSystemProperties config;
     private final Blockchain blockchain;
     private final BlockSyncService blockSyncService;
     private final PeerScoringManager peerScoringManager;
+    private final ChannelManager channelManager;
     private final SyncConfiguration syncConfiguration;
     private final PeersInformation peerStatuses;
 
     private final PendingMessages pendingMessages;
     private final SyncInformationImpl syncInformation;
+    private final Map<NodeID, Instant> failedPeers;
     private SyncState syncState;
     private NodeID selectedPeerId;
 
@@ -50,6 +53,7 @@ public class SyncProcessor implements SyncEventsHandler {
                          Blockchain blockchain,
                          BlockSyncService blockSyncService,
                          PeerScoringManager peerScoringManager,
+                         ChannelManager channelManager,
                          SyncConfiguration syncConfiguration,
                          BlockHeaderValidationRule blockHeaderValidationRule,
                          DifficultyCalculator difficultyCalculator) {
@@ -57,46 +61,54 @@ public class SyncProcessor implements SyncEventsHandler {
         this.blockchain = blockchain;
         this.blockSyncService = blockSyncService;
         this.peerScoringManager = peerScoringManager;
+        this.channelManager = channelManager;
         this.syncConfiguration = syncConfiguration;
         this.syncInformation = new SyncInformationImpl(blockHeaderValidationRule, difficultyCalculator);
-        this.peerStatuses = new PeersInformation(syncConfiguration, syncInformation);
+        this.peerStatuses = new PeersInformation(syncInformation, channelManager, syncConfiguration);
         this.pendingMessages = new PendingMessages();
+        this.failedPeers = new LinkedHashMap<NodeID, Instant>(MAX_SIZE_FAILURE_RECORDS, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<NodeID, Instant> eldest) {
+                return size() > MAX_SIZE_FAILURE_RECORDS;
+            }
+        };
         setSyncState(new DecidingSyncState(this.syncConfiguration, this, syncInformation, peerStatuses));
     }
 
     public void processStatus(MessageChannel sender, Status status) {
         logger.trace("Receiving syncState from node {} block {} {}", sender.getPeerNodeID(), status.getBestBlockNumber(), HashUtil.shortHash(status.getBestBlockHash()), status.getBestBlockHash());
-        this.peerStatuses.registerPeer(sender).setStatus(status);
-        this.syncState.newPeerStatus();
+        peerStatuses.registerPeer(sender.getPeerNodeID()).setStatus(status);
+        syncState.newPeerStatus();
     }
 
     public void processSkeletonResponse(MessageChannel peer, SkeletonResponseMessage message) {
         logger.trace("Process skeleton response from node {}", peer.getPeerNodeID());
-        peerStatuses.getOrRegisterPeer(peer);
+        peerStatuses.getOrRegisterPeer(peer.getPeerNodeID());
 
         if (!pendingMessages.isPending(message)){
             peerScoringManager.recordEvent(peer.getPeerNodeID(), null, EventType.UNEXPECTED_MESSAGE);
             return;
         }
 
-        this.syncState.newSkeleton(message.getBlockIdentifiers(), peer);
+        syncState.newSkeleton(message.getBlockIdentifiers(), peer);
     }
 
     public void processBlockHashResponse(MessageChannel peer, BlockHashResponseMessage message) {
-        logger.trace("Process block hash response from node {} hash {}", peer.getPeerNodeID(), HashUtil.shortHash(message.getHash()));
-        peerStatuses.getOrRegisterPeer(peer);
+        NodeID nodeID = peer.getPeerNodeID();
+        logger.trace("Process block hash response from node {} hash {}", nodeID, HashUtil.shortHash(message.getHash()));
+        peerStatuses.getOrRegisterPeer(nodeID);
 
         if (!pendingMessages.isPending(message)){
-            peerScoringManager.recordEvent(peer.getPeerNodeID(), null, EventType.UNEXPECTED_MESSAGE);
+            peerScoringManager.recordEvent(nodeID, null, EventType.UNEXPECTED_MESSAGE);
             return;
         }
 
-        this.syncState.newConnectionPointData(message.getHash());
+        syncState.newConnectionPointData(message.getHash());
     }
 
     public void processBlockHeadersResponse(MessageChannel peer, BlockHeadersResponseMessage message) {
         logger.trace("Process block headers response from node {}", peer.getPeerNodeID());
-        peerStatuses.getOrRegisterPeer(peer);
+        peerStatuses.getOrRegisterPeer(peer.getPeerNodeID());
 
         if (!pendingMessages.isPending(message)){
             peerScoringManager.recordEvent(peer.getPeerNodeID(), null, EventType.UNEXPECTED_MESSAGE);
@@ -108,7 +120,7 @@ public class SyncProcessor implements SyncEventsHandler {
 
     public void processBodyResponse(MessageChannel peer, BodyResponseMessage message) {
         logger.trace("Process body response from node {}", peer.getPeerNodeID());
-        peerStatuses.getOrRegisterPeer(peer);
+        peerStatuses.getOrRegisterPeer(peer.getPeerNodeID());
 
         if (!pendingMessages.isPending(message)){
             peerScoringManager.recordEvent(peer.getPeerNodeID(), null, EventType.UNEXPECTED_MESSAGE);
@@ -118,41 +130,61 @@ public class SyncProcessor implements SyncEventsHandler {
         this.syncState.newBody(message, peer);
     }
 
-    public void processNewBlockHash(MessageChannel sender, NewBlockHashMessage message) {
-        logger.trace("Process new block hash from node {} hash {}", sender.getPeerNodeID(), HashUtil.shortHash(message.getBlockHash()));
+    public void processNewBlockHash(MessageChannel peer, NewBlockHashMessage message) {
+        NodeID nodeID = peer.getPeerNodeID();
+        logger.trace("Process new block hash from node {} hash {}", nodeID, HashUtil.shortHash(message.getBlockHash()));
         byte[] hash = message.getBlockHash();
 
         if (syncState instanceof DecidingSyncState && blockSyncService.getBlockFromStoreOrBlockchain(hash) == null) {
-            sendMessage(sender, new BlockRequestMessage(pendingMessages.getNextRequestId(), hash));
-            peerStatuses.getOrRegisterPeer(sender);
+            peerStatuses.getOrRegisterPeer(nodeID);
+            sendMessage(nodeID, new BlockRequestMessage(pendingMessages.getNextRequestId(), hash));
         }
-    }
-
-    @Override
-    public void sendSkeletonRequest(MessageChannel peer, long height) {
-        logger.trace("Send skeleton request to node {} height {}", peer, height);
-        MessageWithId message = new SkeletonRequestMessage(pendingMessages.getNextRequestId(), height);
-        sendMessage(peer, message);
-    }
-
-    @Override
-    public void sendBlockHashRequest(long height) {
-        logger.trace("Send hash request to node {} height {}", selectedPeerId, height);
-        BlockHashRequestMessage message = new BlockHashRequestMessage(pendingMessages.getNextRequestId(), height);
-        MessageChannel channel = peerStatuses.getPeer(selectedPeerId).getMessageChannel();
-        sendMessage(channel, message);
     }
 
     public void processBlockResponse(MessageChannel peer, BlockResponseMessage message) {
-        logger.trace("Process block response from node {} block {} {}", peer.getPeerNodeID(), message.getBlock().getNumber(), message.getBlock().getShortHash());
-        peerStatuses.getOrRegisterPeer(peer);
+        NodeID nodeID = peer.getPeerNodeID();
+        logger.trace("Process block response from node {} block {} {}", nodeID, message.getBlock().getNumber(), message.getBlock().getShortHash());
+        peerStatuses.getOrRegisterPeer(nodeID);
 
         if (!pendingMessages.isPending(message)){
-            peerScoringManager.recordEvent(peer.getPeerNodeID(), null, EventType.UNEXPECTED_MESSAGE);
+            peerScoringManager.recordEvent(nodeID, null, EventType.UNEXPECTED_MESSAGE);
             return;
         }
 
-        blockSyncService.processBlock(peer, message.getBlock(), false);
+        blockSyncService.processBlock(message.getBlock(), peer, false);
+    }
+
+    @Override
+    public boolean sendSkeletonRequest(NodeID nodeID, long height) {
+        logger.trace("Send skeleton request to node {} height {}", nodeID, height);
+        MessageWithId message = new SkeletonRequestMessage(pendingMessages.getNextRequestId(), height);
+        return sendMessage(nodeID, message);
+    }
+
+    @Override
+    public boolean sendBlockHashRequest(long height) {
+        logger.trace("Send hash request to node {} height {}", selectedPeerId, height);
+        BlockHashRequestMessage message = new BlockHashRequestMessage(pendingMessages.getNextRequestId(), height);
+        return sendMessage(selectedPeerId, message);
+    }
+
+    @Override
+    public boolean sendBlockHeadersRequest(ChunkDescriptor chunk) {
+        logger.trace("Send headers request to node {}", selectedPeerId);
+
+        BlockHeadersRequestMessage message = new BlockHeadersRequestMessage(pendingMessages.getNextRequestId(), chunk.getHash(), chunk.getCount());
+        return sendMessage(selectedPeerId, message);
+    }
+
+    @Override
+    public Long sendBodyRequest(@Nonnull BlockHeader header, NodeID peerId) {
+        logger.trace("Send body request block {} hash {} to peer {}", header.getNumber(), HashUtil.shortHash(header.getHash().getBytes()), peerId);
+
+        BodyRequestMessage message = new BodyRequestMessage(pendingMessages.getNextRequestId(), header.getHash().getBytes());
+        if (!sendMessage(peerId, message)){
+            return null;
+        }
+        return message.getId();
     }
 
     public Set<NodeID> getKnownPeersNodeIDs() {
@@ -165,28 +197,9 @@ public class SyncProcessor implements SyncEventsHandler {
     }
 
     @Override
-    public void sendBlockHeadersRequest(ChunkDescriptor chunk) {
-        logger.trace("Send headers request to node {}", selectedPeerId);
-
-        MessageChannel channel = peerStatuses.getPeer(selectedPeerId).getMessageChannel();
-        BlockHeadersRequestMessage message = new BlockHeadersRequestMessage(pendingMessages.getNextRequestId(), chunk.getHash(), chunk.getCount());
-        sendMessage(channel, message);
-    }
-
-    @Override
-    public long sendBodyRequest(@Nonnull BlockHeader header, NodeID peerId) {
-        logger.trace("Send body request block {} hash {} to peer {}", header.getNumber(), HashUtil.shortHash(header.getHash().getBytes()), peerId);
-
-        MessageChannel channel = peerStatuses.getPeer(peerId).getMessageChannel();
-        BodyRequestMessage message = new BodyRequestMessage(pendingMessages.getNextRequestId(), header.getHash().getBytes());
-        sendMessage(channel, message);
-        return message.getId();
-    }
-
-    @Override
-    public void startSyncing(MessageChannel peer) {
-        selectedPeerId = peer.getPeerNodeID();
-        logger.trace("Start syncing with node {}", peer.getPeerNodeID());
+    public void startSyncing(NodeID nodeID) {
+        selectedPeerId = nodeID;
+        logger.trace("Start syncing with node {}", nodeID);
         byte[] bestBlockHash = syncInformation.getPeerStatus(selectedPeerId).getStatus().getBestBlockHash();
         setSyncState(new CheckingBestHeaderSyncState(this.syncConfiguration, this, syncInformation, bestBlockHash));
     }
@@ -201,7 +214,7 @@ public class SyncProcessor implements SyncEventsHandler {
             blockSyncService.setLastKnownBlockNumber(peerBestBlockNumber);
         }
 
-        setSyncState(new DownloadingBodiesSyncState(config, this.syncConfiguration, this, syncInformation, pendingHeaders, skeletons));
+        setSyncState(new DownloadingBodiesSyncState(this.syncConfiguration, this, syncInformation, pendingHeaders, skeletons));
     }
 
     @Override
@@ -215,17 +228,32 @@ public class SyncProcessor implements SyncEventsHandler {
     }
 
     @Override
+    public void startFindingConnectionPoint() {
+        logger.trace("Find connection point with node {}", selectedPeerId);
+        long bestBlockNumber = syncInformation.getPeerStatus(selectedPeerId).getStatus().getBestBlockNumber();
+        setSyncState(new FindingConnectionPointSyncState(this.syncConfiguration, this, syncInformation, bestBlockNumber));
+    }
+
+    @Override
     public void stopSyncing() {
         selectedPeerId = null;
         this.pendingMessages.clear();
         // always that a syncing process ends unexpectedly the best block number is reset
         blockSyncService.setLastKnownBlockNumber(blockchain.getBestBlock().getNumber());
+        clearOldFailureEntries();
         setSyncState(new DecidingSyncState(this.syncConfiguration, this, syncInformation, peerStatuses));
     }
 
     @Override
     public void onErrorSyncing(String message, EventType eventType, Object... arguments) {
-        peerScoringManager.recordEvent(this.selectedPeerId, null, eventType);
+        failedPeers.put(selectedPeerId, Instant.now());
+        peerScoringManager.recordEvent(selectedPeerId, null, eventType);
+        logger.trace(message, arguments);
+        stopSyncing();
+    }
+
+    @Override
+    public void onSyncIssue(String message, Object... arguments) {
         logger.trace(message, arguments);
         stopSyncing();
     }
@@ -236,21 +264,26 @@ public class SyncProcessor implements SyncEventsHandler {
         stopSyncing();
     }
 
-    @Override
-    public void startFindingConnectionPoint() {
-        logger.trace("Find connection point with node {}", selectedPeerId);
-        long bestBlockNumber = syncInformation.getPeerStatus(selectedPeerId).getStatus().getBestBlockNumber();
-        setSyncState(new FindingConnectionPointSyncState(this.syncConfiguration, this, syncInformation, bestBlockNumber));
+    private boolean sendMessage(NodeID nodeID, MessageWithId message) {
+        boolean sent = sendMessageTo(nodeID, message);
+        if (sent){
+            pendingMessages.register(message);
+        }
+        return sent;
     }
 
-    private void sendMessage(MessageChannel channel, MessageWithId message) {
-        pendingMessages.register(message);
-        channel.sendMessage(message);
+    private boolean sendMessageTo(NodeID nodeID, MessageWithId message) {
+        return channelManager.sendMessageTo(nodeID, message);
     }
 
     private void setSyncState(SyncState syncState) {
         this.syncState = syncState;
         this.syncState.onEnter();
+    }
+
+    private void clearOldFailureEntries() {
+        Instant limit = Instant.now().minusSeconds(TIME_LIMIT_FAILURE_RECORD);
+        failedPeers.values().removeIf(limit::isAfter);
     }
 
     @VisibleForTesting
@@ -276,8 +309,8 @@ public class SyncProcessor implements SyncEventsHandler {
 
     @VisibleForTesting
     public void setSelectedPeer(MessageChannel peer, Status status, long height) {
-        peerStatuses.getOrRegisterPeer(peer).setStatus(status);
         selectedPeerId = peer.getPeerNodeID();
+        peerStatuses.getOrRegisterPeer(selectedPeerId).setStatus(status);
         FindingConnectionPointSyncState newState = new FindingConnectionPointSyncState(this.syncConfiguration, this, syncInformation, height);
         newState.setConnectionPoint(height);
         this.syncState = newState;
@@ -297,8 +330,8 @@ public class SyncProcessor implements SyncEventsHandler {
     public Map<Long, MessageType> getExpectedResponses() {
         return this.pendingMessages.getExpectedMessages();
     }
-
     private class SyncInformationImpl implements SyncInformation {
+
         private final DependentBlockHeaderRule blockParentValidationRule;
         private final BlockHeaderValidationRule blockHeaderValidationRule;
 
@@ -322,9 +355,9 @@ public class SyncProcessor implements SyncEventsHandler {
         }
 
         @Override
-        public BlockProcessResult processBlock(Block block) {
+        public BlockProcessResult processBlock(Block block, MessageChannel channel) {
             // this is a controled place where we ask for blocks, we never should look for missing hashes
-            return blockSyncService.processBlock(getSelectedPeerChannel(), block, true);
+            return blockSyncService.processBlock(block, channel, true);
         }
 
         @Override
@@ -366,14 +399,24 @@ public class SyncProcessor implements SyncEventsHandler {
             peerScoringManager.recordEvent(peerId, null, eventType);
         }
 
+        public void logData(String message, Object... arguments) {
+            logger.trace(message, arguments);
+        }
+
         @Override
         public int getScore(NodeID peerId) {
             return peerScoringManager.getPeerScoring(peerId).getScore();
         }
 
-        public MessageChannel getSelectedPeerChannel() {
-            return peerStatuses.getPeer(selectedPeerId).getMessageChannel();
+        @Override
+        public Instant getFailInstant(NodeID peerId) {
+            Instant instant = failedPeers.get(peerId);
+            if (instant != null){
+                return instant;
+            }
+            return Instant.EPOCH;
         }
+
 
         private SyncPeerStatus getPeerStatus(NodeID nodeID) {
             return peerStatuses.getPeer(nodeID);

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
@@ -1,6 +1,5 @@
 package co.rsk.net.sync;
 
-import co.rsk.config.RskSystemProperties;
 import co.rsk.net.MessageChannel;
 import co.rsk.net.NodeID;
 import co.rsk.net.messages.BodyResponseMessage;
@@ -51,17 +50,17 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
 
     // peers that can be used to download blocks
     private final List<NodeID> suitablePeers;
-    private final RskSystemProperties config;
+    // maximum time waiting for a peer to answer
+    private final Duration limit;
 
-    public DownloadingBodiesSyncState(RskSystemProperties config,
-                                      SyncConfiguration syncConfiguration,
+    public DownloadingBodiesSyncState(SyncConfiguration syncConfiguration,
                                       SyncEventsHandler syncEventsHandler,
                                       SyncInformation syncInformation,
                                       List<Deque<BlockHeader>> pendingHeaders,
                                       Map<NodeID, List<BlockIdentifier>> skeletons) {
 
         super(syncInformation, syncEventsHandler, syncConfiguration);
-        this.config = config;
+        this.limit = syncConfiguration.getTimeoutWaitingRequest();
         this.blockUnclesHashValidationRule = new BlockUnclesHashValidationRule();
         this.blockTransactionsValidationRule = new BlockRootValidationRule();
         this.pendingBodyResponses = new HashMap<>();
@@ -95,7 +94,7 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
         }
 
         // handle block
-        if (syncInformation.processBlock(block).isInvalidBlock()){
+        if (syncInformation.processBlock(block, peer).isInvalidBlock()){
             handleInvalidBlock(peerId, header);
             return;
         }
@@ -116,7 +115,7 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
 
     private void tryRequestNextBody(NodeID peerId) {
         updateHeadersAndChunks(peerId, chunksBeingDownloaded.get(peerId))
-                .ifPresent(blockHeader -> requestBody(peerId, blockHeader));
+                .ifPresent(blockHeader -> tryRequestBody(peerId, blockHeader));
     }
 
     private void handleInvalidBlock(NodeID peerId, BlockHeader header) {
@@ -231,7 +230,7 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
     }
 
     private void startDownloading(List<NodeID> peers) {
-        peers.forEach(p -> tryFindBlockHeader(p).ifPresent(header -> requestBody(p, header)));
+        peers.forEach(p -> tryFindBlockHeader(p).ifPresent(header -> tryRequestBody(p, header)));
     }
 
     @Override
@@ -243,8 +242,7 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
 
         updatedNodes.forEach(k -> timeElapsedByPeer.put(k, timeElapsedByPeer.get(k).plus(duration)));
 
-        // we get the nodes that got beyond timeout limit and ban them
-        Duration limit = syncConfiguration.getTimeoutWaitingRequest();
+        // we get the nodes that got beyond timeout limit and remove them
         updatedNodes.stream()
             .filter(k -> timeElapsedByPeer.get(k).compareTo(limit) >= 0)
             .forEach(this::handleTimeoutMessage);
@@ -262,7 +260,7 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
     }
 
     private void handleTimeoutMessage(NodeID peerId) {
-        syncInformation.reportEvent("Timeout waiting requests from node {}",
+        syncInformation.reportEvent("Timeout waiting body from node {}",
                 EventType.TIMEOUT_MESSAGE, peerId, peerId);
         Long messageId = messagesByPeers.remove(peerId);
         BlockHeader header = pendingBodyResponses.remove(messageId).header;
@@ -327,11 +325,18 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
         nodes.forEach(nodeID -> segmentByNode.put(nodeID, segmentNumber));
     }
 
-    private void requestBody(NodeID peerId, BlockHeader header){
-        long messageId = syncEventsHandler.sendBodyRequest(header, peerId);
-        pendingBodyResponses.put(messageId, new PendingBodyResponse(peerId, header));
-        timeElapsedByPeer.put(peerId, Duration.ZERO);
-        messagesByPeers.put(peerId, messageId);
+    private void tryRequestBody(NodeID peerId, BlockHeader header){
+        Long messageId = syncEventsHandler.sendBodyRequest(header, peerId);
+        if (messageId != null){
+            pendingBodyResponses.put(messageId, new PendingBodyResponse(peerId, header));
+            timeElapsedByPeer.put(peerId, Duration.ZERO);
+            messagesByPeers.put(peerId, messageId);
+        } else {
+            // since a message could fail to be delivered we have to discard peer if can't be reached
+            clearPeerInfo(peerId);
+            syncEventsHandler.onSyncIssue("Channel failed to sent on {} to {}",
+                    this.getClass(), peerId);
+        }
     }
 
     private boolean isExpectedBody(long requestId, NodeID peerId) {

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingHeadersSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingHeadersSyncState.java
@@ -62,16 +62,24 @@ public class DownloadingHeadersSyncState extends BaseSyncState {
         }
 
         resetTimeElapsed();
-        syncEventsHandler.sendBlockHeadersRequest(chunksDownloadHelper.getNextChunk());
+        trySendRequest();
     }
 
     @Override
     public void onEnter() {
-        syncEventsHandler.sendBlockHeadersRequest(chunksDownloadHelper.getNextChunk());
+        trySendRequest();
     }
 
     @VisibleForTesting
     public List<BlockIdentifier> getSkeleton() {
         return chunksDownloadHelper.getSkeleton();
+    }
+
+    private void trySendRequest() {
+        boolean sent = syncEventsHandler.sendBlockHeadersRequest(chunksDownloadHelper.getNextChunk());
+        if (!sent) {
+            syncEventsHandler.onSyncIssue("Channel failed to sent on {} to {}",
+                    this.getClass(), syncInformation.getSelectedPeerId());
+        }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
@@ -1,6 +1,5 @@
 package co.rsk.net.sync;
 
-import co.rsk.net.MessageChannel;
 import co.rsk.net.NodeID;
 import co.rsk.scoring.EventType;
 import org.ethereum.core.BlockHeader;
@@ -12,13 +11,13 @@ import java.util.List;
 import java.util.Map;
 
 public interface SyncEventsHandler {
-    void sendSkeletonRequest(MessageChannel peer, long height);
+    boolean sendSkeletonRequest(NodeID nodeID, long height);
 
-    void sendBlockHashRequest(long height);
+    boolean sendBlockHashRequest(long height);
 
-    void sendBlockHeadersRequest(ChunkDescriptor chunk);
+    boolean sendBlockHeadersRequest(ChunkDescriptor chunk);
 
-    long sendBodyRequest(@Nonnull BlockHeader header, NodeID peerId);
+    Long sendBodyRequest(@Nonnull BlockHeader header, NodeID peerId);
 
     void startDownloadingBodies(List<Deque<BlockHeader>> pendingHeaders, Map<NodeID, List<BlockIdentifier>> skeletons);
 
@@ -26,9 +25,11 @@ public interface SyncEventsHandler {
 
     void startDownloadingSkeleton(long connectionPoint);
 
-    void startSyncing(MessageChannel peer);
+    void startSyncing(NodeID nodeID);
 
     void stopSyncing();
+
+    void onSyncIssue(String message, Object... arguments);
 
     void onErrorSyncing(String message, EventType eventType, Object... arguments);
 

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncInformation.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncInformation.java
@@ -1,19 +1,21 @@
 package co.rsk.net.sync;
 
 import co.rsk.net.BlockProcessResult;
+import co.rsk.net.MessageChannel;
 import co.rsk.net.NodeID;
 import co.rsk.scoring.EventType;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 
 import javax.annotation.Nonnull;
+import java.time.Instant;
 
 public interface SyncInformation {
     boolean isKnownBlock(byte[] hash);
 
     boolean hasLowerDifficulty(NodeID nodeID);
 
-    BlockProcessResult processBlock(Block block);
+    BlockProcessResult processBlock(Block block, MessageChannel channel);
 
     boolean blockHeaderIsValid(@Nonnull BlockHeader header);
 
@@ -25,5 +27,9 @@ public interface SyncInformation {
 
     void reportEvent(String message, EventType eventType, NodeID peerId, Object... arguments);
 
+    void logData(String message, Object... arguments);
+
     int getScore(NodeID key);
+
+    Instant getFailInstant(NodeID peerId);
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncInformation.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncInformation.java
@@ -27,8 +27,6 @@ public interface SyncInformation {
 
     void reportEvent(String message, EventType eventType, NodeID peerId, Object... arguments);
 
-    void logData(String message, Object... arguments);
-
     int getScore(NodeID key);
 
     Instant getFailInstant(NodeID peerId);

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncPeerStatus.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncPeerStatus.java
@@ -1,7 +1,6 @@
 package co.rsk.net.sync;
 
 import co.rsk.core.BlockDifficulty;
-import co.rsk.net.MessageChannel;
 import co.rsk.net.Status;
 
 import java.time.Clock;
@@ -14,13 +13,11 @@ import java.time.Instant;
 public class SyncPeerStatus {
     // Peer status
     private Status status;
-    private MessageChannel messageChannel;
 
     private final Clock clock = Clock.systemUTC();
     private Instant lastActivity;
 
-    public SyncPeerStatus(MessageChannel messageChannel) {
-        this.messageChannel = messageChannel;
+    public SyncPeerStatus() {
         this.updateActivity();
     }
 
@@ -54,10 +51,6 @@ public class SyncPeerStatus {
 
     public Status getStatus() {
         return this.status;
-    }
-
-    public MessageChannel getMessageChannel() {
-        return messageChannel;
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/scoring/PeerScoring.java
+++ b/rskj-core/src/main/java/co/rsk/scoring/PeerScoring.java
@@ -45,7 +45,8 @@ public class PeerScoring {
                 case INVALID_TRANSACTION:
                 case INVALID_MESSAGE:
                 case INVALID_HEADER:
-                case TIMEOUT_MESSAGE:
+                    // TODO(lsebrie): review how to handle timeouts properly
+                    //case TIMEOUT_MESSAGE:
                     if (score > 0) {
                         score = 0;
                     }
@@ -191,6 +192,7 @@ public class PeerScoring {
         }
         this.goodReputation = true;
         this.timeLostGoodReputation = 0;
+        this.score = 0;
     }
 
     @VisibleForTesting

--- a/rskj-core/src/main/java/co/rsk/scoring/ScoringCalculator.java
+++ b/rskj-core/src/main/java/co/rsk/scoring/ScoringCalculator.java
@@ -16,7 +16,7 @@ public class ScoringCalculator {
      * @return  <tt>true</tt> if the peer has good reputation
      */
     public boolean hasGoodReputation(PeerScoring scoring) {
-        return scoring.getEventCounter(EventType.INVALID_BLOCK) < 1 &&
+        return  scoring.getEventCounter(EventType.INVALID_BLOCK) < 1 &&
                 scoring.getEventCounter(EventType.INVALID_MESSAGE) < 1 &&
                 scoring.getEventCounter(EventType.INVALID_HEADER) < 1;
         //TODO: implement empty messages as responses so timeout can be handled as it should

--- a/rskj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/ChannelManager.java
@@ -21,6 +21,7 @@ package org.ethereum.net.server;
 
 import co.rsk.net.NodeID;
 import co.rsk.net.Status;
+import co.rsk.net.messages.MessageWithId;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockIdentifier;
 import org.ethereum.core.Transaction;
@@ -53,7 +54,7 @@ public interface ChannelManager {
      * @param receivedFrom the peer which sent original message or null if
      *                     the transactions were originated by this peer
      */
-    void sendTransaction(List<Transaction> tx, Channel receivedFrom);
+    void broadcastTransactionMessage(List<Transaction> tx, Channel receivedFrom);
 
 
     /**
@@ -101,4 +102,6 @@ public interface ChannelManager {
     void onSyncDone(boolean done) ;
 
     Collection<Channel> getActivePeers();
+
+    boolean sendMessageTo(NodeID nodeID, MessageWithId message);
 }

--- a/rskj-core/src/main/java/org/ethereum/net/submit/TransactionTask.java
+++ b/rskj-core/src/main/java/org/ethereum/net/submit/TransactionTask.java
@@ -60,7 +60,7 @@ public class TransactionTask implements Callable<List<Transaction>> {
 
         try {
             logger.trace("submit tx: {}", tx.toString());
-            channelManager.sendTransaction(tx, receivedFrom);
+            channelManager.broadcastTransactionMessage(tx, receivedFrom);
             return tx;
 
         } catch (Throwable th) {

--- a/rskj-core/src/test/java/co/rsk/net/BlockSyncServiceTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/BlockSyncServiceTest.java
@@ -41,7 +41,7 @@ public class BlockSyncServiceTest {
 
             List<Block> extendedChain = new BlockGenerator().getBlockChain(blockchain.getBestBlock(), i);
             for (Block block : extendedChain) {
-                blockSyncService.processBlock(null, block, false);
+                blockSyncService.processBlock(block, null, false);
                 Assert.assertEquals(block.getNumber(), blockchain.getBestBlock().getNumber());
                 Assert.assertEquals(block.getHash(), blockchain.getBestBlock().getHash());
             }
@@ -62,7 +62,7 @@ public class BlockSyncServiceTest {
             Collections.reverse(extendedChain);
             for (int j = 0; j < extendedChain.size() - 1; j++) {
                 Block block = extendedChain.get(j);
-                blockSyncService.processBlock(null, block, false);
+                blockSyncService.processBlock(block, null, false);
                 // we don't have all the parents, so we wait to update the best chain
                 Assert.assertEquals(initialBestBlock.getNumber(), blockchain.getBestBlock().getNumber());
                 Assert.assertEquals(initialBestBlock.getHash(), blockchain.getBestBlock().getHash());
@@ -71,7 +71,7 @@ public class BlockSyncServiceTest {
             // the chain is complete, we have a new best block
             Block closingBlock = extendedChain.get(extendedChain.size() - 1);
             Block newBestBlock = extendedChain.get(0);
-            blockSyncService.processBlock(null, closingBlock, false);
+            blockSyncService.processBlock(closingBlock, null, false);
             Assert.assertEquals(newBestBlock.getNumber(), blockchain.getBestBlock().getNumber());
             Assert.assertEquals(newBestBlock.getHash(), blockchain.getBestBlock().getHash());
         }
@@ -93,7 +93,7 @@ public class BlockSyncServiceTest {
         // we have just surpassed the best branch
         for (int i = 0; i < extendedChain.size(); i++) {
             Block newBestBlock = extendedChain.get(i);
-            blockSyncService.processBlock(null, newBestBlock, false);
+            blockSyncService.processBlock(newBestBlock, null, false);
             Assert.assertEquals(newBestBlock.getNumber(), blockchain.getBestBlock().getNumber());
             Assert.assertEquals(newBestBlock.getHash(), blockchain.getBestBlock().getHash());
         }

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -39,11 +39,11 @@ import co.rsk.test.World;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.validators.DummyBlockValidationRule;
 import co.rsk.validators.ProofOfWorkRule;
-import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
 import org.ethereum.util.RskMockFactory;
@@ -52,6 +52,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
@@ -67,7 +68,6 @@ import static org.mockito.Mockito.*;
  * Created by ajlopez on 5/10/2016.
  */
 public class NodeMessageHandlerTest {
-    private static BlockchainNetConfig blockchainNetConfigOriginal;
     private static RskSystemProperties config;
 
     @BeforeClass
@@ -299,29 +299,29 @@ public class NodeMessageHandlerTest {
         Assert.assertArrayEquals(block.getHash().getBytes(), gbMessage.getBlockHash());
     }
 
-    @Test
+    @Test()
     public void processStatusMessageUsingSyncProcessor() throws UnknownHostException {
         final SimpleMessageChannel sender = new SimpleMessageChannel();
+
         final ChannelManager channelManager = mock(ChannelManager.class);
-//        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(sender));
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final Message[] msg = new Message[1];
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            msg[0] = invocation.getArgumentAt(1, Message.class);
+            return true;
+        });
         final NodeMessageHandler handler = NodeMessageHandlerUtil.createHandlerWithSyncProcessor(SyncConfiguration.IMMEDIATE_FOR_TESTING, channelManager);
 
         BlockGenerator blockGenerator = new BlockGenerator();
         final Block block = blockGenerator.createChildBlock(blockGenerator.getGenesisBlock());
         final Status status = new Status(block.getNumber(), block.getHash().getBytes(), block.getParentHash().getBytes(), new BlockDifficulty(BigInteger.TEN));
         final Message message = new StatusMessage(status);
-
         handler.processMessage(sender, message);
 
-        Assert.assertNotNull(sender.getGetBlockMessages());
-        Assert.assertTrue(sender.getGetBlockMessages().isEmpty());
-        Assert.assertNotNull(sender.getMessages());
-        Assert.assertEquals(1, sender.getMessages().size());
-
-        Message request = sender.getMessages().get(0);
-
-        Assert.assertNotNull(request);
-        Assert.assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, request.getMessageType());
+        Assert.assertNotNull(msg[0]);
+        Assert.assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, msg[0].getMessageType());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -302,7 +302,9 @@ public class NodeMessageHandlerTest {
     @Test
     public void processStatusMessageUsingSyncProcessor() throws UnknownHostException {
         final SimpleMessageChannel sender = new SimpleMessageChannel();
-        final NodeMessageHandler handler = NodeMessageHandlerUtil.createHandlerWithSyncProcessor();
+        final ChannelManager channelManager = mock(ChannelManager.class);
+//        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(sender));
+        final NodeMessageHandler handler = NodeMessageHandlerUtil.createHandlerWithSyncProcessor(SyncConfiguration.IMMEDIATE_FOR_TESTING, channelManager);
 
         BlockGenerator blockGenerator = new BlockGenerator();
         final Block block = blockGenerator.createChildBlock(blockGenerator.getGenesisBlock());
@@ -333,7 +335,7 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         final SimpleMessageChannel sender = new SimpleMessageChannel();
-        final SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), null);
+        final SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), RskMockFactory.getChannelManager(), syncConfiguration, new DummyBlockValidationRule(), null);
         final NodeMessageHandler handler = new NodeMessageHandler(config, bp, syncProcessor, null, null, null, null,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
 
@@ -933,7 +935,7 @@ public class NodeMessageHandlerTest {
 
         handler.processMessage(null, message);
 
-        verify(channelManager, never()).broadcastTransaction(any(), any());
+        verify(channelManager, never()).broadcastTransactionMessage(any(), any());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
@@ -9,7 +9,10 @@ import co.rsk.validators.BlockValidationRule;
 import co.rsk.validators.DummyBlockValidationRule;
 import co.rsk.validators.ProofOfWorkRule;
 import org.ethereum.core.Blockchain;
+import org.ethereum.net.server.ChannelManager;
+import org.ethereum.net.server.ChannelManagerImpl;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
+import org.ethereum.sync.SyncPool;
 import org.ethereum.util.RskMockFactory;
 import org.mockito.Mockito;
 
@@ -28,7 +31,7 @@ public class NodeMessageHandlerUtil {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
-        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), RskMockFactory.getChannelManager(), syncConfiguration, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
         return new NodeMessageHandler(config, processor, syncProcessor, new SimpleChannelManager(), null, null, RskMockFactory.getPeerScoringManager(), validationRule);
@@ -39,12 +42,23 @@ public class NodeMessageHandlerUtil {
     }
 
     public static NodeMessageHandler createHandlerWithSyncProcessor(SyncConfiguration syncConfiguration) {
-        final World world = new World();
-        final Blockchain blockchain = world.getBlockChain();
-        return createHandlerWithSyncProcessor(blockchain, syncConfiguration);
+        return createHandlerWithSyncProcessor(syncConfiguration, new ChannelManagerImpl(config, mock(SyncPool.class)));
     }
 
-    public static NodeMessageHandler createHandlerWithSyncProcessor(Blockchain blockchain, SyncConfiguration syncConfiguration) {
+    public static NodeMessageHandler createHandlerWithSyncProcessor(ChannelManager channelManager) {
+        return createHandlerWithSyncProcessor(SyncConfiguration.IMMEDIATE_FOR_TESTING, channelManager);
+    }
+
+    public static NodeMessageHandler createHandlerWithSyncProcessor(SyncConfiguration syncConfiguration, ChannelManager channelManager) {
+        final World world = new World();
+        final Blockchain blockchain = world.getBlockChain();
+        return createHandlerWithSyncProcessor(blockchain, syncConfiguration, channelManager);
+    }
+
+    public static NodeMessageHandler createHandlerWithSyncProcessor(
+            Blockchain blockchain,
+            SyncConfiguration syncConfiguration,
+            ChannelManager channelManager) {
         final BlockStore store = new BlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -53,7 +67,7 @@ public class NodeMessageHandlerUtil {
         ProofOfWorkRule blockValidationRule = new ProofOfWorkRule(config);
         PeerScoringManager peerScoringManager = mock(PeerScoringManager.class);
         Mockito.when(peerScoringManager.hasGoodReputation(isA(NodeID.class))).thenReturn(true);
-        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, peerScoringManager, syncConfiguration, blockValidationRule, DIFFICULTY_CALCULATOR);
-        return new NodeMessageHandler(config, processor, syncProcessor, null, null, null, null, blockValidationRule);
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, peerScoringManager, channelManager, syncConfiguration, blockValidationRule, DIFFICULTY_CALCULATOR);
+        return new NodeMessageHandler(config, processor, syncProcessor, channelManager, null, null, null, blockValidationRule);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -50,10 +50,11 @@ public class OneAsyncNodeTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), RskMockFactory.getChannelManager(), syncConfiguration, new DummyBlockValidationRule(), new DifficultyCalculator(config));
-        NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, new SimpleChannelManager(), null, null, RskMockFactory.getPeerScoringManager(), new DummyBlockValidationRule());
+        SimpleChannelManager channelManager = new SimpleChannelManager();
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager, syncConfiguration, new DummyBlockValidationRule(), new DifficultyCalculator(config));
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, channelManager, null, null, RskMockFactory.getPeerScoringManager(), new DummyBlockValidationRule());
 
-        return new SimpleAsyncNode(handler);
+        return new SimpleAsyncNode(handler, syncProcessor, channelManager);
     }
 
     private static Block getGenesis() {

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -50,7 +50,7 @@ public class OneAsyncNodeTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), syncConfiguration, new DummyBlockValidationRule(), new DifficultyCalculator(config));
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), RskMockFactory.getChannelManager(), syncConfiguration, new DummyBlockValidationRule(), new DifficultyCalculator(config));
         NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, new SimpleChannelManager(), null, null, RskMockFactory.getPeerScoringManager(), new DummyBlockValidationRule());
 
         return new SimpleAsyncNode(handler);

--- a/rskj-core/src/test/java/co/rsk/net/SyncPeerStatusTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncPeerStatusTest.java
@@ -13,14 +13,14 @@ import java.util.concurrent.TimeUnit;
 public class SyncPeerStatusTest {
     @Test
     public void justCreatedIsNotExpired() {
-        SyncPeerStatus status = new SyncPeerStatus(null);
+        SyncPeerStatus status = new SyncPeerStatus();
 
         Assert.assertFalse(status.isExpired(Duration.ofMillis(1000)));
     }
 
     @Test
     public void isExpiredAfterTimeout() throws InterruptedException {
-        SyncPeerStatus status = new SyncPeerStatus(null);
+        SyncPeerStatus status = new SyncPeerStatus();
 
         TimeUnit.MILLISECONDS.sleep(1000);
 
@@ -29,7 +29,7 @@ public class SyncPeerStatusTest {
 
     @Test
     public void isNotExpiredAfterShortTimeout() throws InterruptedException {
-        SyncPeerStatus status = new SyncPeerStatus(null);
+        SyncPeerStatus status = new SyncPeerStatus();
 
         TimeUnit.MILLISECONDS.sleep(100);
 

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -19,16 +19,23 @@ import co.rsk.validators.ProofOfWorkRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
 import org.ethereum.util.RskMockFactory;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
 import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.time.Duration;
 import java.util.*;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by ajlopez on 29/08/2017.
@@ -65,9 +72,19 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
-                SyncConfiguration.IMMEDIATE_FOR_TESTING, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[]{0x01});
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final List<Message> messages = new ArrayList<>();
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            messages.add(invocation.getArgumentAt(1, Message.class));
+            return true;
+        });
+
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
+                SyncConfiguration.IMMEDIATE_FOR_TESTING, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.processStatus(sender, status);
 
         Assert.assertEquals(1, processor.getPeersCount());
@@ -77,10 +94,10 @@ public class SyncProcessorTest {
         Assert.assertFalse(ids.isEmpty());
         Assert.assertTrue(ids.contains(sender.getPeerNodeID()));
 
-        Assert.assertFalse(sender.getMessages().isEmpty());
-        Assert.assertEquals(1, sender.getMessages().size());
+        Assert.assertFalse(messages.isEmpty());
+        Assert.assertEquals(1, messages.size());
 
-        Message message = sender.getMessages().get(0);
+        Message message = messages.get(0);
 
         Assert.assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, message.getMessageType());
 
@@ -102,9 +119,19 @@ public class SyncProcessorTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
 
-        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
-                syncConfiguration, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[]{0x01});
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final List<Message> messages = new ArrayList<>();
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            messages.add(invocation.getArgumentAt(1, Message.class));
+            return true;
+        });
+
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
+                syncConfiguration, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
         processor.processStatus(sender, status);
 
         Assert.assertEquals(1, processor.getPeersCount());
@@ -113,16 +140,16 @@ public class SyncProcessorTest {
         Set<NodeID> ids = processor.getKnownPeersNodeIDs();
         Assert.assertFalse(ids.isEmpty());
         Assert.assertTrue(ids.contains(sender.getPeerNodeID()));
-        Assert.assertTrue(sender.getMessages().isEmpty());
+        Assert.assertTrue(messages.isEmpty());
 
         processor.onTimePassed(syncConfiguration.getTimeoutWaitingPeers().dividedBy(2));
-        Assert.assertTrue(sender.getMessages().isEmpty());
+        Assert.assertTrue(messages.isEmpty());
 
         processor.onTimePassed(syncConfiguration.getTimeoutWaitingPeers().dividedBy(2));
-        Assert.assertFalse(sender.getMessages().isEmpty());
-        Assert.assertEquals(1, sender.getMessages().size());
+        Assert.assertFalse(messages.isEmpty());
+        Assert.assertEquals(1, messages.size());
 
-        Message message = sender.getMessages().get(0);
+        Message message = messages.get(0);
 
         Assert.assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, message.getMessageType());
 
@@ -175,19 +202,31 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
                 SyncConfiguration.DEFAULT, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
-        List<SimpleMessageChannel> senders = new ArrayList<SimpleMessageChannel>();
+        List<SimpleMessageChannel> senders = new ArrayList<>();
+        List<Channel> channels = new ArrayList<>();
+        Map<NodeID, List<Message>> messagesByNode = new HashMap<>();
 
         int lessPeers = SyncConfiguration.DEFAULT.getExpectedPeers() - 1;
         for (int i = 0; i < lessPeers; i++) {
-            senders.add(new SimpleMessageChannel());
+            SimpleMessageChannel sender = new SimpleMessageChannel();
+            senders.add(sender);
+            Channel channel = mock(Channel.class);
+            messagesByNode.put(sender.getPeerNodeID(), new ArrayList<>());
+            when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+            when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+            when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+                messagesByNode.get(sender.getPeerNodeID()).add(invocation.getArgumentAt(1, Message.class));
+                return true;
+            });
         }
 
-        senders.forEach(s -> Assert.assertTrue(s.getMessages().isEmpty()));
+        messagesByNode.values().forEach(m -> Assert.assertTrue(m.isEmpty()));
         senders.forEach(s -> processor.processStatus(s, status));
-        senders.forEach(s -> Assert.assertTrue(s.getMessages().isEmpty()));
+        messagesByNode.values().forEach(m -> Assert.assertTrue(m.isEmpty()));
 
         Assert.assertEquals(lessPeers, processor.getNoAdvancedPeers());
 
@@ -197,6 +236,8 @@ public class SyncProcessorTest {
                 .forEach(peerId -> Assert.assertTrue(ids.contains(peerId)));
 
         SimpleMessageChannel lastSender = new SimpleMessageChannel();
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(lastSender.getPeerNodeID());
         Assert.assertFalse(ids.contains(lastSender.getPeerNodeID()));
 
         processor.processStatus(lastSender, status);
@@ -204,15 +245,13 @@ public class SyncProcessorTest {
         // now test with all senders
         senders.add(lastSender);
         Assert.assertTrue(ids.contains(lastSender.getPeerNodeID()));
-        Assert.assertFalse(senders.stream().allMatch(s -> s.getMessages().isEmpty()));
-        Assert.assertEquals(1, senders.stream()
-                .map(SimpleMessageChannel::getMessages)
+        Assert.assertFalse(messagesByNode.values().stream().allMatch(m -> m.isEmpty()));
+        Assert.assertEquals(1, messagesByNode.values().stream()
                 .mapToInt(List::size)
                 .sum());
 
-        Message message = senders.stream().filter(s -> !s.getMessages().isEmpty())
+        Message message = messagesByNode.values().stream().filter(m -> !m.isEmpty())
                 .findFirst()
-                .map(SimpleMessageChannel::getMessages)
                 .get().get(0);
 
         Assert.assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, message.getMessageType());
@@ -253,19 +292,23 @@ public class SyncProcessorTest {
     public void sendSkeletonRequest() {
         Blockchain blockchain = BlockChainBuilder.ofSize(100);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final Message[] msg = new Message[1];
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            msg[0] = invocation.getArgumentAt(1, Message.class);
+            return true;
+        });
 
-
-        SyncProcessor processor = new SyncProcessor(config, blockchain, null, RskMockFactory.getPeerScoringManager(), getChannelManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, null, RskMockFactory.getPeerScoringManager(), channelManager,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
         processor.sendSkeletonRequest(sender.getPeerNodeID(), 0);
 
-        Assert.assertFalse(sender.getMessages().isEmpty());
-        Assert.assertEquals(1, sender.getMessages().size());
-
-        Message message = sender.getMessages().get(0);
-
+        Message message = msg[0];
         Assert.assertNotNull(message);
 
         Assert.assertEquals(MessageType.SKELETON_REQUEST_MESSAGE, message.getMessageType());
@@ -281,10 +324,19 @@ public class SyncProcessorTest {
     @Test
     public void sendBlockHashRequest() {
         Blockchain blockchain = BlockChainBuilder.ofSize(0);
+
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final Message[] msg = new Message[1];
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            msg[0] = invocation.getArgumentAt(1, Message.class);
+            return true;
+        });
 
-
-        SyncProcessor processor = new SyncProcessor(config, blockchain, null, RskMockFactory.getPeerScoringManager(), getChannelManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, null, RskMockFactory.getPeerScoringManager(), channelManager,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         processor.setSelectedPeer(sender, StatusUtils.getFakeStatus(), 0);
@@ -292,10 +344,7 @@ public class SyncProcessorTest {
 
         processor.sendBlockHashRequest(100);
 
-        Assert.assertFalse(sender.getMessages().isEmpty());
-        Assert.assertEquals(1, sender.getMessages().size());
-
-        Message message = sender.getMessages().get(0);
+        Message message = msg[0];
 
         Assert.assertNotNull(message);
         Assert.assertEquals(MessageType.BLOCK_HASH_REQUEST_MESSAGE, message.getMessageType());
@@ -551,9 +600,6 @@ public class SyncProcessorTest {
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();
-//        for (int i = 1; i <= blockchain.getBestBlock().getNumber(); i++){
-//            headerStack.add(blockchain.getBlockByNumber(i).getHeader());
-//        }
         headerStack.add(block.getHeader());
         List<Deque<BlockHeader>> headers = new ArrayList<>();
         headers.add(headerStack);
@@ -676,22 +722,32 @@ public class SyncProcessorTest {
         Blockchain advancedBlockchain = BlockChainBuilder.ofSize(100);
 
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final List<Message> messages = new ArrayList<>();
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            messages.add(invocation.getArgumentAt(1, Message.class));
+            return true;
+        });
 
         BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
+                SyncConfiguration.IMMEDIATE_FOR_TESTING, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
 
         processor.processStatus(sender, StatusUtils.fromBlockchain(advancedBlockchain));
-        BlockHeadersRequestMessage requestMessage = (BlockHeadersRequestMessage)sender.getMessages().get(0);
+        BlockHeadersRequestMessage requestMessage = (BlockHeadersRequestMessage)messages.get(0);
         processor.processBlockHeadersResponse(sender, new BlockHeadersResponseMessage(requestMessage.getId(), Collections.singletonList(advancedBlockchain.getBestBlock().getHeader())));
 
         long[] expectedHeights = new long[] { 50, 25, 12, 6, 3, 1 };
 
         for (int k = 0; k < expectedHeights.length; k++) {
-            Assert.assertEquals( k + 2, sender.getMessages().size());
-            Message message = sender.getMessages().get(k + 1);
+            Assert.assertEquals( k + 2, messages.size());
+            Message message = messages.get(k + 1);
             Assert.assertEquals(MessageType.BLOCK_HASH_REQUEST_MESSAGE, message.getMessageType());
             BlockHashRequestMessage request = (BlockHashRequestMessage)message;
             long requestId = request.getId();
@@ -702,9 +758,9 @@ public class SyncProcessorTest {
             processor.processBlockHashResponse(sender, new BlockHashResponseMessage(requestId, block.getHash().getBytes()));
         }
 
-        Assert.assertEquals(expectedHeights.length + 2, sender.getMessages().size());
+        Assert.assertEquals(expectedHeights.length + 2, messages.size());
 
-        Message message = sender.getMessages().get(sender.getMessages().size() - 1);
+        Message message = messages.get(messages.size() - 1);
 
         Assert.assertEquals(MessageType.SKELETON_REQUEST_MESSAGE, message.getMessageType());
 
@@ -720,22 +776,32 @@ public class SyncProcessorTest {
         Blockchain advancedBlockchain = BlockChainBuilder.copyAndExtend(blockchain, 70);
 
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final List<Message> messages = new ArrayList<>();
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            messages.add(invocation.getArgumentAt(1, Message.class));
+            return true;
+        });
 
         BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
+                SyncConfiguration.IMMEDIATE_FOR_TESTING, new DummyBlockValidationRule(), DIFFICULTY_CALCULATOR);
 
         Status status = StatusUtils.fromBlockchain(advancedBlockchain);
         processor.processStatus(sender, status);
-        BlockHeadersRequestMessage requestMessage = (BlockHeadersRequestMessage)sender.getMessages().get(0);
+        BlockHeadersRequestMessage requestMessage = (BlockHeadersRequestMessage)messages.get(0);
         processor.processBlockHeadersResponse(sender, new BlockHeadersResponseMessage(requestMessage.getId(), Collections.singletonList(advancedBlockchain.getBestBlock().getHeader())));
 
         long[] binarySearchHeights = new long[] { 50, 25, 37, 31, 28, 29, 30 };
         for (int k = 0; k < binarySearchHeights.length; k++) {
-            Assert.assertEquals(k + 2, sender.getMessages().size());
-            Message message = sender.getMessages().get(k + 1);
+            Assert.assertEquals(k + 2, messages.size());
+            Message message = messages.get(k + 1);
             Assert.assertEquals(MessageType.BLOCK_HASH_REQUEST_MESSAGE, message.getMessageType());
             BlockHashRequestMessage request = (BlockHashRequestMessage)message;
             long requestId = request.getId();
@@ -746,9 +812,9 @@ public class SyncProcessorTest {
             processor.processBlockHashResponse(sender, new BlockHashResponseMessage(requestId, block.getHash().getBytes()));
         }
 
-        Assert.assertEquals(binarySearchHeights.length + 2, sender.getMessages().size());
+        Assert.assertEquals(binarySearchHeights.length + 2, messages.size());
 
-        Message message = sender.getMessages().get(sender.getMessages().size() - 1);
+        Message message = messages.get(messages.size() - 1);
 
         Assert.assertEquals(MessageType.SKELETON_REQUEST_MESSAGE, message.getMessageType());
 
@@ -766,9 +832,17 @@ public class SyncProcessorTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final Message[] msg = new Message[1];
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            msg[0] = invocation.getArgumentAt(1, Message.class);
+            return true;
+        });
 
-
-        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         int connectionPoint = 0;
@@ -782,10 +856,7 @@ public class SyncProcessorTest {
         processor.registerExpectedMessage(response);
         processor.processSkeletonResponse(sender, response);
 
-        Assert.assertFalse(sender.getMessages().isEmpty());
-        Assert.assertEquals(1, sender.getMessages().size());
-
-        Message message = sender.getMessages().get(0);
+        Message message = msg[0];
 
         Assert.assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, message.getMessageType());
 
@@ -833,7 +904,16 @@ public class SyncProcessorTest {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
-        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
+        final ChannelManager channelManager = mock(ChannelManager.class);
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
+        when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
+        final Message[] msg = new Message[1];
+        when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
+            msg[0] = invocation.getArgumentAt(1, Message.class);
+            return true;
+        });
+        SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
 
         int connectionPoint = 25;
@@ -847,10 +927,7 @@ public class SyncProcessorTest {
         processor.registerExpectedMessage(response);
         processor.processSkeletonResponse(sender, response);
 
-        Assert.assertFalse(sender.getMessages().isEmpty());
-        Assert.assertEquals(1, sender.getMessages().size());
-
-        Message message = sender.getMessages().get(0);
+        Message message = msg[0];
 
         Assert.assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, message.getMessageType());
 

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -23,20 +23,17 @@ import co.rsk.core.DifficultyCalculator;
 import co.rsk.net.*;
 import co.rsk.net.messages.Message;
 import co.rsk.net.sync.SyncConfiguration;
-import co.rsk.scoring.PeerScoring;
 import co.rsk.scoring.PeerScoringManager;
 import co.rsk.test.World;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.validators.DummyBlockValidationRule;
 import org.ethereum.core.Blockchain;
+import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
+import org.ethereum.util.RskMockFactory;
 import org.junit.Assert;
-import org.mockito.Mockito;
 
 import java.util.concurrent.*;
-
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by ajlopez on 5/15/2016.
@@ -116,10 +113,9 @@ public class SimpleAsyncNode extends SimpleNode {
         BlockSyncService blockSyncService = new BlockSyncService(store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         DummyBlockValidationRule blockValidationRule = new DummyBlockValidationRule();
-        PeerScoringManager peerScoringManager = Mockito.mock(PeerScoringManager.class);
-        when(peerScoringManager.hasGoodReputation(isA(NodeID.class))).thenReturn(true);
-        when(peerScoringManager.getPeerScoring(isA(NodeID.class))).thenReturn(new PeerScoring());
-        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, peerScoringManager, syncConfiguration, blockValidationRule, new DifficultyCalculator(config));
+        PeerScoringManager peerScoringManager = RskMockFactory.getPeerScoringManager();
+        ChannelManager channelManager = RskMockFactory.getChannelManager();
+        SyncProcessor syncProcessor = new SyncProcessor(config, blockchain, blockSyncService, peerScoringManager, channelManager, syncConfiguration, blockValidationRule, new DifficultyCalculator(config));
         NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, new SimpleChannelManager(), null, null, peerScoringManager, blockValidationRule);
         return new SimpleAsyncNode(handler, syncProcessor);
     }

--- a/rskj-core/src/test/java/co/rsk/net/sync/DecidingSyncStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/DecidingSyncStateTest.java
@@ -3,11 +3,19 @@ package co.rsk.net.sync;
 import co.rsk.net.NodeID;
 import co.rsk.net.utils.StatusUtils;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.net.server.Channel;
+import org.ethereum.net.server.ChannelManager;
 import org.ethereum.util.RskMockFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DecidingSyncStateTest {
 
@@ -16,12 +24,19 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation();
-        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
+        ChannelManager channelManager = RskMockFactory.getChannelManager();
+        PeersInformation knownPeers = new PeersInformation(syncInformation, channelManager, syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
+        Collection<Channel> peers = new ArrayList<>();
 
         for (int i = 0; i < 5; i++) {
             Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
-            knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId())).setStatus(StatusUtils.getFakeStatus());
+            NodeID nodeID = new NodeID(HashUtil.randomPeerId());
+            Channel channel = mock(Channel.class);
+            when(channel.getNodeId()).thenReturn(nodeID);
+            peers.add(channel);
+            when(channelManager.getActivePeers()).thenReturn(peers);
+            knownPeers.registerPeer(nodeID).setStatus(StatusUtils.getFakeStatus());
             syncState.newPeerStatus();
         }
 
@@ -33,10 +48,15 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation();
-        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
+        ChannelManager channelManager = RskMockFactory.getChannelManager();
+        PeersInformation knownPeers = new PeersInformation(syncInformation, channelManager, syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
+        Collection<Channel> peers = new ArrayList<>();
 
         NodeID peerToRepeat = new NodeID(HashUtil.randomPeerId());
+        Channel channel = mock(Channel.class);
+        when(channel.getNodeId()).thenReturn(peerToRepeat);
+        peers.add(channel);
         for (int i = 0; i < 10; i++) {
             Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
             knownPeers.registerPeer(peerToRepeat).setStatus(StatusUtils.getFakeStatus());
@@ -45,7 +65,12 @@ public class DecidingSyncStateTest {
 
         for (int i = 0; i < 4; i++) {
             Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
-            knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId())).setStatus(StatusUtils.getFakeStatus());
+            NodeID nodeID = new NodeID(HashUtil.randomPeerId());
+            knownPeers.registerPeer(nodeID).setStatus(StatusUtils.getFakeStatus());
+            channel = mock(Channel.class);
+            when(channel.getNodeId()).thenReturn(nodeID);
+            peers.add(channel);
+            when(channelManager.getActivePeers()).thenReturn(peers);
             syncState.newPeerStatus();
         }
 
@@ -69,11 +94,18 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation();
-        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
+        ChannelManager channelManager = RskMockFactory.getChannelManager();
+        PeersInformation knownPeers = new PeersInformation(syncInformation, channelManager, syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
         Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
 
-        knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId()));
+        Channel channel = mock(Channel.class);
+        NodeID nodeID = new NodeID(HashUtil.randomPeerId());
+        when(channel.getNodeId()).thenReturn(nodeID);
+        Collection<Channel> peers = Collections.singletonList(channel);
+        when(channelManager.getActivePeers()).thenReturn(peers);
+
+        knownPeers.registerPeer(nodeID);
         syncState.newPeerStatus();
         syncState.tick(Duration.ofMinutes(2));
         Assert.assertTrue(syncEventsHandler.startSyncingWasCalled());

--- a/rskj-core/src/test/java/co/rsk/net/sync/DecidingSyncStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/DecidingSyncStateTest.java
@@ -1,7 +1,9 @@
 package co.rsk.net.sync;
 
-import co.rsk.net.simples.SimpleMessageChannel;
+import co.rsk.net.NodeID;
 import co.rsk.net.utils.StatusUtils;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.RskMockFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -14,12 +16,12 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation();
-        PeersInformation knownPeers = new PeersInformation(syncConfiguration, syncInformation);
+        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
 
         for (int i = 0; i < 5; i++) {
             Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
-            knownPeers.registerPeer(new SimpleMessageChannel()).setStatus(StatusUtils.getFakeStatus());
+            knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId())).setStatus(StatusUtils.getFakeStatus());
             syncState.newPeerStatus();
         }
 
@@ -31,10 +33,10 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation();
-        PeersInformation knownPeers = new PeersInformation(syncConfiguration, syncInformation);
+        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
 
-        SimpleMessageChannel peerToRepeat = new SimpleMessageChannel();
+        NodeID peerToRepeat = new NodeID(HashUtil.randomPeerId());
         for (int i = 0; i < 10; i++) {
             Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
             knownPeers.registerPeer(peerToRepeat).setStatus(StatusUtils.getFakeStatus());
@@ -43,7 +45,7 @@ public class DecidingSyncStateTest {
 
         for (int i = 0; i < 4; i++) {
             Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
-            knownPeers.registerPeer(new SimpleMessageChannel()).setStatus(StatusUtils.getFakeStatus());
+            knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId())).setStatus(StatusUtils.getFakeStatus());
             syncState.newPeerStatus();
         }
 
@@ -55,7 +57,7 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation();
-        PeersInformation knownPeers = new PeersInformation(syncConfiguration, syncInformation);
+        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
 
         syncState.tick(Duration.ofMinutes(2));
@@ -67,11 +69,11 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation();
-        PeersInformation knownPeers = new PeersInformation(syncConfiguration, syncInformation);
+        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
         Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
 
-        knownPeers.registerPeer(new SimpleMessageChannel());
+        knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId()));
         syncState.newPeerStatus();
         syncState.tick(Duration.ofMinutes(2));
         Assert.assertTrue(syncEventsHandler.startSyncingWasCalled());
@@ -82,11 +84,11 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation();
-        PeersInformation knownPeers = new PeersInformation(syncConfiguration, syncInformation);
+        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
         Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
 
-        knownPeers.registerPeer(new SimpleMessageChannel());
+        knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId()));
         syncState.newPeerStatus();
         syncState.tick(syncConfiguration.getTimeoutWaitingPeers().minusSeconds(1L));
         Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
@@ -97,11 +99,11 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation().withWorsePeers();
-        PeersInformation knownPeers = new PeersInformation(syncConfiguration, syncInformation);
+        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
         Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
 
-        knownPeers.registerPeer(new SimpleMessageChannel());
+        knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId()));
         syncState.newPeerStatus();
         syncState.tick(Duration.ofMinutes(2));
         Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
@@ -112,15 +114,13 @@ public class DecidingSyncStateTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
         SimpleSyncEventsHandler syncEventsHandler = new SimpleSyncEventsHandler();
         SimpleSyncInformation syncInformation = new SimpleSyncInformation().withBadReputation();
-        PeersInformation knownPeers = new PeersInformation(syncConfiguration, syncInformation);
+        PeersInformation knownPeers = new PeersInformation(syncInformation, RskMockFactory.getChannelManager(), syncConfiguration);
         SyncState syncState = new DecidingSyncState(syncConfiguration, syncEventsHandler, syncInformation, knownPeers);
         Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
 
-        knownPeers.registerPeer(new SimpleMessageChannel());
+        knownPeers.registerPeer(new NodeID(HashUtil.randomPeerId()));
         syncState.newPeerStatus();
         syncState.tick(Duration.ofMinutes(2));
         Assert.assertFalse(syncEventsHandler.startSyncingWasCalled());
     }
-
-
 }

--- a/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
@@ -1,7 +1,6 @@
 package co.rsk.net.sync;
 
 
-import co.rsk.net.MessageChannel;
 import co.rsk.net.NodeID;
 import co.rsk.scoring.EventType;
 import org.ethereum.core.BlockHeader;
@@ -17,10 +16,10 @@ public class SimpleSyncEventsHandler implements SyncEventsHandler {
     private boolean stopSyncingWasCalled_;
 
     @Override
-    public void sendBlockHashRequest(long height) { }
+    public boolean sendBlockHashRequest(long height) { return true;}
 
     @Override
-    public void sendBlockHeadersRequest(ChunkDescriptor chunk) { }
+    public boolean sendBlockHeadersRequest(ChunkDescriptor chunk) { return true;}
 
     @Override
     public void onErrorSyncing(String message, EventType eventType, Object... arguments) {
@@ -38,16 +37,16 @@ public class SimpleSyncEventsHandler implements SyncEventsHandler {
     }
 
     @Override
-    public long sendBodyRequest(@Nonnull BlockHeader header, NodeID peerId) { return 0; }
+    public Long sendBodyRequest(@Nonnull BlockHeader header, NodeID peerId) { return 0L; }
 
     @Override
-    public void sendSkeletonRequest(MessageChannel peer, long height) { }
+    public boolean sendSkeletonRequest(NodeID nodeID, long height) { return true;}
 
     @Override
     public void startDownloadingHeaders(Map<NodeID, List<BlockIdentifier>> skeletons, long connectionPoint) { }
 
     @Override
-    public void startSyncing(MessageChannel peer) {
+    public void startSyncing(NodeID nodeID) {
         this.startSyncingWasCalled_ = true;
     }
 
@@ -59,6 +58,11 @@ public class SimpleSyncEventsHandler implements SyncEventsHandler {
 
     @Override
     public void stopSyncing() { this.stopSyncingWasCalled_ = true; }
+
+    @Override
+    public void onSyncIssue(String message, Object... arguments) {
+
+    }
 
     public boolean startSyncingWasCalled() {
         return startSyncingWasCalled_;

--- a/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncInformation.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncInformation.java
@@ -37,11 +37,6 @@ public class SimpleSyncInformation implements SyncInformation {
     }
 
     @Override
-    public void logData(String message, Object... arguments) {
-
-    }
-
-    @Override
     public int getScore(NodeID key) {
         return 1;
     }

--- a/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncInformation.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncInformation.java
@@ -2,6 +2,7 @@ package co.rsk.net.sync;
 
 
 import co.rsk.net.BlockProcessResult;
+import co.rsk.net.MessageChannel;
 import co.rsk.net.NodeID;
 import co.rsk.scoring.EventType;
 import org.ethereum.core.Block;
@@ -9,6 +10,7 @@ import org.ethereum.core.BlockHeader;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
+import java.time.Instant;
 
 public class SimpleSyncInformation implements SyncInformation {
     private boolean hasLowerDifficulty = true;
@@ -35,8 +37,18 @@ public class SimpleSyncInformation implements SyncInformation {
     }
 
     @Override
+    public void logData(String message, Object... arguments) {
+
+    }
+
+    @Override
     public int getScore(NodeID key) {
         return 1;
+    }
+
+    @Override
+    public Instant getFailInstant(NodeID peerId) {
+        return Instant.EPOCH;
     }
 
     @Override
@@ -45,7 +57,7 @@ public class SimpleSyncInformation implements SyncInformation {
     }
 
     @Override
-    public BlockProcessResult processBlock(Block block) {
+    public BlockProcessResult processBlock(Block block, MessageChannel channel) {
         return new BlockProcessResult(false, null, block.getShortHash(), Duration.ZERO);
     }
 

--- a/rskj-core/src/test/java/co/rsk/scoring/PeerScoringManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/scoring/PeerScoringManagerTest.java
@@ -234,8 +234,8 @@ public class PeerScoringManagerTest {
         Assert.assertEquals(1, manager.getPeerScoring(address).getEventCounter(EventType.INVALID_BLOCK));
         Assert.assertEquals(0, manager.getPeerScoring(address).getEventCounter(EventType.INVALID_TRANSACTION));
         Assert.assertEquals(2, manager.getPeerScoring(address).getPunishmentCounter());
-        Assert.assertEquals(-2, manager.getPeerScoring(address).getScore());
-        Assert.assertEquals(22, manager.getPeerScoring(address).getPunishmentTime());
+        Assert.assertEquals(-1, manager.getPeerScoring(address).getScore());
+        Assert.assertEquals(11, manager.getPeerScoring(address).getPunishmentTime());
         Assert.assertFalse(manager.hasGoodReputation(address));
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleChannelManager.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleChannelManager.java
@@ -20,6 +20,7 @@ package org.ethereum.rpc.Simples;
 
 import co.rsk.net.NodeID;
 import co.rsk.net.Status;
+import co.rsk.net.messages.MessageWithId;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockIdentifier;
 import org.ethereum.core.Transaction;
@@ -52,7 +53,7 @@ public class SimpleChannelManager implements ChannelManager {
     }
 
     @Override
-    public void sendTransaction(List<Transaction> tx, Channel receivedFrom) {
+    public void broadcastTransactionMessage(List<Transaction> tx, Channel receivedFrom) {
 
     }
 
@@ -107,6 +108,11 @@ public class SimpleChannelManager implements ChannelManager {
         channels.add(new Channel(null, null, null, null, null, null, null, null));
         channels.add(new Channel(null, null, null, null, null, null, null, null));
         return channels;
+    }
+
+    @Override
+    public boolean sendMessageTo(NodeID nodeID, MessageWithId message) {
+        return true;
     }
 
     public List<Transaction> getTransactions() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -119,7 +119,7 @@ public class Web3ImplTest {
         String peerCount  = web3.net_peerCount();
 
         Assert.assertEquals("Different number of peers than expected",
-                "0x2", peerCount);
+                "0x0", peerCount);
     }
 
 

--- a/rskj-core/src/test/java/org/ethereum/util/RskMockFactory.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RskMockFactory.java
@@ -3,6 +3,7 @@ package org.ethereum.util;
 import co.rsk.net.NodeID;
 import co.rsk.scoring.PeerScoring;
 import co.rsk.scoring.PeerScoringManager;
+import org.ethereum.net.server.ChannelManager;
 
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
@@ -15,5 +16,9 @@ public class RskMockFactory {
         when(peerScoringManager.hasGoodReputation(isA(NodeID.class))).thenReturn(true);
         when(peerScoringManager.getPeerScoring(isA(NodeID.class))).thenReturn(new PeerScoring());
         return peerScoringManager;
+    }
+
+    public static ChannelManager getChannelManager() {
+        return mock(ChannelManager.class);
     }
 }


### PR DESCRIPTION
Rework of sync timeout handling. Now SyncProcessor only tries to send messages to other peers through ChannelManager. 
Also timeouts are **only**  considered when message queue is empty to handle large chunks of blocks connected.