### PR TITLE
Add support for new configuration keys with default value

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/config/Migrator.java
+++ b/rskj-core/src/main/java/co/rsk/cli/config/Migrator.java
@@ -13,6 +13,8 @@ import java.util.stream.Stream;
 
 public class Migrator {
 
+    private static final String MINIMAL_CONFIG_FORMAT = "{%s: %s}";
+
     private final MigratorConfiguration configuration;
 
     public Migrator(MigratorConfiguration configuration) {
@@ -34,6 +36,13 @@ public class Migrator {
             if (migratedConfig.hasPath(originalPath)) {
                 ConfigValue configurationValueToMigrate = migratedConfig.getValue(originalPath);
                 migratedConfig = migratedConfig.withValue(migrationConfiguration.getProperty(originalPath), configurationValueToMigrate).withoutPath(originalPath);
+            } else {
+                try {
+                    Config newConfiguration = ConfigFactory.parseString(String.format(MINIMAL_CONFIG_FORMAT, originalPath, migrationConfiguration.getProperty(originalPath)));
+                    migratedConfig = migratedConfig.withFallback(newConfiguration);
+                } catch (ConfigException e) {
+                    throw new IllegalArgumentException(String.format("Unable to parse value for the %s property", originalPath), e);
+                }
             }
         }
 


### PR DESCRIPTION
A new semantic has been added to the migration file. Now you can put an non existing key in the origin and it will be added to the destination with the value as its default value. For example
```properties
rpc.host = ["localhost"]
```