### PR TITLE
Feature/avoid null get work return

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/MinerClientImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClientImpl.java
@@ -141,15 +141,6 @@ public class MinerClientImpl implements MinerClient {
 
         newBestBlockArrivedFromAnotherNode = false;
         work = minerServer.getWork();
-        if (work == null) {
-            logger.warn("No work to do");
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException ex) {
-                logger.error("Interrupted mining sleep", ex);
-            }
-            return false;
-        }
 
         co.rsk.bitcoinj.core.NetworkParameters bitcoinNetworkParameters = co.rsk.bitcoinj.params.RegTestParams.get();
         co.rsk.bitcoinj.core.BtcTransaction bitcoinMergedMiningCoinbaseTransaction = MinerUtils.getBitcoinMergedMiningCoinbaseTransaction(bitcoinNetworkParameters, work);

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -45,20 +45,6 @@ public class MinerManagerTest {
     private static final RskSystemProperties config = new RskSystemProperties();
 
     @Test
-    public void mineBlockWhenStopped() {
-        World world = new World();
-        Blockchain blockchain = world.getBlockChain();
-
-        Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
-
-        MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
-
-        minerClient.stop();
-        Assert.assertFalse(minerClient.mineBlock());
-    }
-
-    @Test
     public void refreshWorkRunOnce() {
         World world = new World();
         Blockchain blockchain = world.getBlockChain();
@@ -135,8 +121,6 @@ public class MinerManagerTest {
         Assert.assertEquals(1, bestBlock.getNumber());
 
         // reuse the same work
-        Assert.assertNull(minerServer.getWork());
-        minerServer.setWork(minerWork);
         Assert.assertNotNull(minerServer.getWork());
 
         Assert.assertTrue(minerClient.mineBlock());
@@ -213,23 +197,6 @@ public class MinerManagerTest {
         minerClient.doWork();
 
         Assert.assertEquals(1, blockchain.getBestBlock().getNumber());
-    }
-
-    @Test
-    public void doWorkWithoutGetWork() {
-        World world = new World();
-        Blockchain blockchain = world.getBlockChain();
-
-        Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
-
-        MinerServerImpl minerServer = getMinerServer(blockchain);
-        MinerClientImpl minerClient = getMinerClient(minerServer);
-
-        Assert.assertNull(minerServer.getWork());
-
-        minerClient.doWork();
-
-        Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
     }
 
     @Test


### PR DESCRIPTION
When miner asks for new work right after submitting a new solution (while block is still been processed by MinerServer) do not return null. Return "old" work instead. 
Miner can mine "old" work (and generate a new uncle solution) while MinerServer builds a new one. The time in which the miner will be working on an "old" work will depend on two factors.
- Next getWork request. Depends on poll period configuration from mining pool 
- new block processing time + new work generation time.