### PR TITLE
Fixed assemble of labels

### DIFF
--- a/rskj-core/src/test/java/co/rsk/util/AssemblerTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/AssemblerTest.java
@@ -1,0 +1,37 @@
+package co.rsk.util;
+
+import co.rsk.asm.EVMAssembler;
+import org.junit.Assert;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+/**
+ * Created by SerAdmin on 3/20/2018.
+ */
+public class AssemblerTest {
+    @Test
+    public void assemblerTest1() throws IOException, InterruptedException {
+
+
+        String asm ="0x01 label1: JUMPDEST @label1 JUMPI";
+
+        EVMAssembler assembler = new EVMAssembler();
+        byte[] code = assembler.assemble(asm);
+        byte[] compilerCode = {
+                96, // PUSH1
+                1,  // 0x01
+                91, // JUMPDEST
+                99, // PUSH4
+                0,
+                0,
+                0,
+                2,  // Offset label
+                87}; // JUMPI
+
+        Assert.assertArrayEquals(code,compilerCode);
+
+    }
+}


### PR DESCRIPTION
The toy assembler was used only for tests. It had (broken) support for labels. The feature was unused. Now there is need to use it, therefore the feature was fixed. A test was added and code has been cleaned up a bit.
