### PR TITLE
[RFS-60] Refactored signing logic for both BTC and RSK transactions

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -394,7 +394,11 @@ public class Transaction {
     public void sign(byte[] privKeyBytes) throws MissingPrivateKeyException {
         byte[] rawHash = this.getRawHash().getBytes();
         ECKey key = ECKey.fromPrivate(privKeyBytes).decompress();
-        this.signature = key.sign(rawHash);
+        this.setSignature(key.sign(rawHash));
+    }
+
+    public void setSignature(ECDSASignature signature) {
+        this.signature = signature;
         this.rlpEncoded = null;
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -19,6 +19,7 @@
 package co.rsk.core;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.crypto.Keccak256;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -65,6 +66,54 @@ public class TransactionTest {
                 null);
 
         tx.sign(senderPrivKey);
+
+        System.out.println("v\t\t\t: " + Hex.toHexString(new byte[]{tx.getSignature().v}));
+        System.out.println("r\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().r)));
+        System.out.println("s\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().s)));
+
+        System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
+
+        // retrieve the signer/sender of the transaction
+        ECKey key = ECKey.signatureToKey(tx.getHash().getBytes(), tx.getSignature().toBase64());
+
+        System.out.println("Tx unsigned RLP\t\t: " + Hex.toHexString(tx.getEncodedRaw()));
+        System.out.println("Tx signed   RLP\t\t: " + Hex.toHexString(tx.getEncoded()));
+
+        System.out.println("Signature public key\t: " + Hex.toHexString(key.getPubKey()));
+        System.out.println("Sender is\t\t: " + Hex.toHexString(key.getAddress()));
+
+        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826",
+                Hex.toHexString(key.getAddress()));
+
+        System.out.println(tx.toString());
+    }
+
+    @Test  /* achieve public key of the sender when signature manually set */
+    public void test3() throws Exception {
+        if (config.getBlockchainConfig().getCommonConstants().getChainId() != 0)
+            return;
+
+        // cat --> 79b08ad8787060333663d19704909ee7b1903e58
+        // cow --> cd2a3d9f938e13cd947ec05abc7fe734df8dd826
+
+        BigInteger value = new BigInteger("1000000000000000000000");
+
+        byte[] privKey = HashUtil.keccak256("cat".getBytes());
+        ECKey ecKey = ECKey.fromPrivate(privKey);
+
+        byte[] senderPrivKey = HashUtil.keccak256("cow".getBytes());
+
+        byte[] gasPrice = Hex.decode("09184e72a000");
+        byte[] gas = Hex.decode("4255");
+
+        // Tn (nonce); Tp(pgas); Tg(gaslimi); Tt(value); Tv(value); Ti(sender);  Tw; Tr; Ts
+        Transaction tx = new Transaction(null, gasPrice, gas, ecKey.getAddress(),
+                value.toByteArray(),
+                null);
+
+        Keccak256 hash = tx.getRawHash();
+        ECKey.ECDSASignature signature = ECKey.fromPrivate(senderPrivKey).sign(hash.getBytes());
+        tx.setSignature(signature);
 
         System.out.println("v\t\t\t: " + Hex.toHexString(new byte[]{tx.getSignature().v}));
         System.out.println("r\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().r)));


### PR DESCRIPTION
This is the master backport of [#441](https://github.com/rsksmart/rskj/pull/441/) against `0.5.0`