### PR TITLE
Configuration defaults for a better out of the box experience

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
+++ b/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.config;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class ConfigLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger("config");
+
+    private static final String YES = "yes";
+    private static final String NO = "no";
+
+    public static Config getConfigFromFiles() {
+        Config javaSystemProperties = ConfigFactory.load("no-such-resource-only-system-props");
+        Config referenceConfig = ConfigFactory.parseResources("rskj.conf");
+        logger.info(
+                "Config ( {} ): default properties from resource 'rskj.conf'",
+                referenceConfig.entrySet().isEmpty() ? NO : YES
+        );
+        File installerFile = new File("/etc/rsk/node.conf");
+        Config installerConfig = installerFile.exists() ? ConfigFactory.parseFile(installerFile) : ConfigFactory.empty();
+        logger.info(
+                "Config ( {} ): default properties from installer '/etc/rsk/node.conf'",
+                installerConfig.entrySet().isEmpty() ? NO : YES
+        );
+        Config testConfig = ConfigFactory.parseResources("test-rskj.conf");
+        logger.info(
+                "Config ( {} ): test properties from resource 'test-rskj.conf'",
+                testConfig.entrySet().isEmpty() ? NO : YES
+        );
+        String file = System.getProperty("rsk.conf.file");
+        Config cmdLineConfigFile = file != null ? ConfigFactory.parseFile(new File(file)) : ConfigFactory.empty();
+        logger.info(
+                "Config ( {} ): user properties from -Drsk.conf.file file '{}'",
+                cmdLineConfigFile.entrySet().isEmpty() ? NO : YES,
+                file
+        );
+        return javaSystemProperties
+                .withFallback(cmdLineConfigFile)
+                .withFallback(testConfig)
+                .withFallback(referenceConfig)
+                .withFallback(installerConfig);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
+++ b/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
@@ -31,7 +31,7 @@ public class ConfigLoader {
     private static final String YES = "yes";
     private static final String NO = "no";
 
-    public static Config getConfigFromFiles() {
+    public Config getConfigFromFiles() {
         File installerFile = new File("/etc/rsk/node.conf");
         Config installerConfig = installerFile.exists() ? ConfigFactory.parseFile(installerFile) : ConfigFactory.empty();
         logger.info(
@@ -57,7 +57,7 @@ public class ConfigLoader {
     /**
      * @return the network-specific configuration based on the user config, or mainnet if no configuration is specified.
      */
-    public static Config getNetworkBaseConfig(Config userConfig) {
+    private Config getNetworkBaseConfig(Config userConfig) {
         // these read reference.conf automatically, and overlay the network config on top
         if (userConfig.hasPath("blockchain.config.name")) {
             String network = userConfig.getString("blockchain.config.name");

--- a/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
+++ b/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
@@ -33,21 +33,11 @@ public class ConfigLoader {
 
     public static Config getConfigFromFiles() {
         Config javaSystemProperties = ConfigFactory.load("no-such-resource-only-system-props");
-        Config referenceConfig = ConfigFactory.parseResources("rskj.conf");
-        logger.info(
-                "Config ( {} ): default properties from resource 'rskj.conf'",
-                referenceConfig.entrySet().isEmpty() ? NO : YES
-        );
         File installerFile = new File("/etc/rsk/node.conf");
         Config installerConfig = installerFile.exists() ? ConfigFactory.parseFile(installerFile) : ConfigFactory.empty();
         logger.info(
                 "Config ( {} ): default properties from installer '/etc/rsk/node.conf'",
                 installerConfig.entrySet().isEmpty() ? NO : YES
-        );
-        Config testConfig = ConfigFactory.parseResources("test-rskj.conf");
-        logger.info(
-                "Config ( {} ): test properties from resource 'test-rskj.conf'",
-                testConfig.entrySet().isEmpty() ? NO : YES
         );
         String file = System.getProperty("rsk.conf.file");
         Config cmdLineConfigFile = file != null ? ConfigFactory.parseFile(new File(file)) : ConfigFactory.empty();
@@ -58,8 +48,6 @@ public class ConfigLoader {
         );
         return javaSystemProperties
                 .withFallback(cmdLineConfigFile)
-                .withFallback(testConfig)
-                .withFallback(referenceConfig)
                 .withFallback(installerConfig);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
+++ b/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
@@ -66,7 +66,7 @@ public class ConfigLoader {
             } else if ("regtest".equals(network)) {
                 return ConfigFactory.load("config/regtest");
             } else {
-                logger.info("Invalid network '{}', using mainnet by default", network);
+                logger.warn("Invalid network '{}', using mainnet by default", network);
             }
         } else {
             logger.info("Network not set, using mainnet by default");

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -65,6 +65,10 @@ public class RskSystemProperties extends SystemProperties {
     private List<ModuleDescription> moduleDescriptions;
     private VmConfig vmConfig;
 
+    public RskSystemProperties(ConfigLoader loader) {
+        super(loader);
+    }
+
     @Nullable
     public RskAddress coinbaseAddress() {
         if (!isMinerServerEnabled()) {

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -19,6 +19,7 @@
 
 package org.ethereum.config;
 
+import co.rsk.config.ConfigLoader;
 import co.rsk.config.GasLimitConfig;
 import co.rsk.config.MiningConfig;
 import co.rsk.config.RskSystemProperties;
@@ -134,7 +135,7 @@ public class DefaultConfig {
 
     @Bean
     public RskSystemProperties rskSystemProperties() {
-        return new RskSystemProperties();
+        return new RskSystemProperties(new ConfigLoader());
     }
 
     @Bean

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -95,7 +95,7 @@ public abstract class SystemProperties {
     @Retention(RetentionPolicy.RUNTIME)
     private @interface ValidateMe {}
 
-    protected static Config configFromFiles;
+    protected Config configFromFiles;
 
     // mutable options for tests
     private String databaseDir = null;
@@ -115,13 +115,12 @@ public abstract class SystemProperties {
     
     protected SystemProperties(ConfigLoader loader) {
         try {
-            // could be locked but the result should be the same if there is no race condition
-            if (configFromFiles == null){
-                configFromFiles = loader.getConfigFromFiles();
-                logger.debug("Config trace: " + configFromFiles.root().render(ConfigRenderOptions.defaults().
-                        setComments(false).setJson(false)));
-                validateConfig();
-            }
+            this.configFromFiles = loader.getConfigFromFiles();
+            logger.debug(
+                    "Config trace: {}",
+                    configFromFiles.root().render(ConfigRenderOptions.defaults().setComments(false).setJson(false))
+            );
+            validateConfig();
 
             Properties props = new Properties();
             InputStream is = getClass().getResourceAsStream("/version.properties");

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -113,11 +113,11 @@ public abstract class SystemProperties {
 
     private BlockchainNetConfig blockchainConfig;
     
-    protected SystemProperties() {
+    protected SystemProperties(ConfigLoader loader) {
         try {
             // could be locked but the result should be the same if there is no race condition
             if (configFromFiles == null){
-                configFromFiles = ConfigLoader.getConfigFromFiles();
+                configFromFiles = loader.getConfigFromFiles();
                 logger.debug("Config trace: " + configFromFiles.root().render(ConfigRenderOptions.defaults().
                         setComments(false).setJson(false)));
                 validateConfig();

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -116,7 +116,7 @@ public abstract class SystemProperties {
     protected SystemProperties(ConfigLoader loader) {
         try {
             this.configFromFiles = loader.getConfigFromFiles();
-            logger.debug(
+            logger.trace(
                     "Config trace: {}",
                     configFromFiles.root().render(ConfigRenderOptions.defaults().setComments(false).setJson(false))
             );

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -1,0 +1,58 @@
+blockchain.config.name = main
+
+peer {
+
+    discovery = {
+
+        # if peer discovery is off
+        # the peer window will show
+        # only what retrieved by active
+        # peer [true/false]
+        enabled = true
+
+        # List of the peers to start
+        # the search of the online peers
+        # values: [ip:port]
+        ip.list = [
+            "bootstrap01.rsk.co:5050",
+            "bootstrap02.rsk.co:5050",
+            "bootstrap03.rsk.co:5050",
+            "bootstrap04.rsk.co:5050",
+            "bootstrap05.rsk.co:5050",
+            "bootstrap06.rsk.co:5050",
+            "bootstrap07.rsk.co:5050",
+            "bootstrap08.rsk.co:5050",
+            "bootstrap09.rsk.co:5050",
+            "bootstrap10.rsk.co:5050",
+            "bootstrap11.rsk.co:5050",
+            "bootstrap12.rsk.co:5050",
+            "bootstrap13.rsk.co:5050",
+            "bootstrap14.rsk.co:5050",
+            "bootstrap15.rsk.co:5050",
+            "bootstrap16.rsk.co:5050"
+        ]
+    }
+
+    # Port for server to listen for incoming connections
+    port = 5050
+
+    # Network id
+    networkId = 775
+}
+
+# the folder resources/genesis contains several versions of genesis configuration according to the network the peer will run on
+genesis = rsk-mainnet.json
+
+database {
+    # place to save physical storage files
+    dir = ${user.home}/.rsk/mainnet/database
+}
+
+# hello phrase will be included in the hello message of the peer
+hello.phrase = MainNet
+
+# account loaded when the node start.
+wallet {
+    enabled = false
+    accounts = []
+}

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -1,0 +1,51 @@
+blockchain.config.name = regtest
+
+peer {
+
+    discovery = {
+
+        # if peer discovery is off
+        # the peer window will show
+        # only what retrieved by active
+        # peer [true/false]
+        enabled = false
+
+        # List of the peers to start
+        # the search of the online peers
+        # values: [ip:port]
+        ip.list = [ ]
+    }
+
+    # Port for server to listen for incoming connections
+    port = 50501
+
+    # Network id
+    networkId = 7771
+}
+
+miner {
+    server.enabled = true
+    client.enabled = true
+    minGasPrice = 0
+
+    # this is a secret passphrase that is used to derive the address where the miner gets the reward.
+    # please note this is stored in a local wallet and not recommended for production.
+    coinbase.secret = regtest_miner_secret_please_change
+}
+
+# the folder resources/genesis contains several versions of genesis configuration according to the network the peer will run on
+genesis = rsk-dev.json
+
+database {
+    # place to save physical storage files
+    dir = ${user.home}/.rsk/regtest/database
+}
+
+# hello phrase will be included in the hello message of the peer
+hello.phrase = RegTest
+
+# account loaded when the node start.
+wallet {
+    accounts = []
+    enabled = true
+}

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -1,0 +1,48 @@
+blockchain.config.name = testnet
+
+peer {
+
+    discovery = {
+
+        # if peer discovery is off
+        # the peer window will show
+        # only what retrieved by active
+        # peer [true/false]
+        enabled = true
+
+        # List of the peers to start
+        # the search of the online peers
+        # values: [ip:port]
+        ip.list = [
+            "bootstrap01.testnet.rsk.co:50505",
+            "bootstrap02.testnet.rsk.co:50505",
+            "bootstrap03.testnet.rsk.co:50505",
+            "bootstrap04.testnet.rsk.co:50505",
+            "bootstrap05.testnet.rsk.co:50505",
+            "bootstrap06.testnet.rsk.co:50505"
+        ]
+    }
+
+    # Port for server to listen for incoming connections
+    port = 50505
+
+    # Network id
+    networkId = 779
+}
+
+# the folder resources/genesis contains several versions of genesis configuration according to the network the peer will run on
+genesis = bamboo-testnet.json
+
+database {
+    # place to save physical storage files
+    dir = ${user.home}/.rsk/testnet/database
+}
+
+# hello phrase will be included in the hello message of the peer
+hello.phrase = TestNet
+
+# account loaded when the node start.
+wallet {
+    enabled = false
+    accounts = []
+}

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -1,0 +1,237 @@
+peer {
+    # Boot node list
+    # Use to connect to specific nodes
+    active = [ ]
+
+    # list of trusted peers the incoming connections is always accepted from. Even if the max amount of connections is reached
+    # This is used to create a filter of Trusted peers
+    trusted = [
+        # Sample entries:
+        # {nodeId = "e437a4836b77ad9d9ffe73ee782ef2614e6d8370fcf62191a6e488276e23717147073a7ce0b444d485fff5a0c34c4577251a7a990cf80d8542e21b95aa8c5e6c"},
+        # {ip = "11.22.33.44"},
+        # {ip = "11.22.33.*"},
+        # {
+        #   nodeId = "e437a4836b77ad9d9ffe73ee782ef2614e6d8370fcf62191a6e488276e23717147073a7ce0b444d485fff5a0c34c4577251a7a990cf80d8542e21b95aa8c5e6c"
+        #   ip = "11.22.33.44"
+        # }
+    ]
+
+    # connection timeout for trying to connect to a peer [seconds]
+    connection.timeout = 2
+
+    # the parameter specifies how much time we will wait for a message to come before closing the channel
+    channel.read.timeout = 30
+
+    # Private key of the peer
+    # nodeId = <NODE_ID>
+    # privateKey = <PRIVATE_KEY>
+
+    p2p {
+        # max frame size in bytes when framing is enabled
+        framing.maxSize = 32768
+
+        # forces peer to send Handshake message in format defined by EIP-8,
+        # see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md
+        eip8 = true
+    }
+
+    # max number of active peers our node will maintain
+    # extra peers trying to connect us will be dropeed with TOO_MANY_PEERS message
+    # the incoming connection from the peer matching 'peer.trusted' entry is always accepted
+    maxActivePeers = 30
+}
+
+database {
+    # every time the application starts the existing database will be destroyed and all the data will be downloaded from peers again
+    # having this set on true does NOT mean that the block chain will start from the last point
+    # [true/false]
+    reset = false
+}
+
+# Interface to bind peer discovery and wire protocol
+# Make sure you are using the correct bind ip. Wildcard value: 0.0.0.0
+bind.address = 0.0.0.0
+
+# public IP/hostname which is reported as our host during discovery
+# if not set, the service http://checkip.amazonaws.com is used.
+# bind.address is the last resort for public ip when it cannot be obtained by other ways
+# public.ip = google.com
+
+# the number of blocks should pass before pending transaction is removed
+transaction.outdated.threshold = 10
+
+# the number of seconds should pass before pending transaction is removed
+# (suggested value: 10 blocks * 10 seconds by block = 100 seconds)
+transaction.outdated.timeout = 650
+
+
+dump {
+    # for testing purposes all the state will be dumped in JSON form to [dump.dir] if [dump.full] = true
+    # possible values [true/false]
+    full = false
+
+    dir = dmp
+
+    # This defines the vmtrace dump to the console and the style
+    # -1 for no block trace
+    block = -1
+
+    # styles: [pretty/standard+] (default: standard+)
+    style = pretty
+
+    # clean the dump dir each start
+    clean.on.restart = true
+}
+
+# structured trace is the trace being collected in the form of objects and exposed to the user in json or any other convenient form
+vm.structured {
+    trace = false
+    dir = vmtrace
+    compressed = true
+    initStorageLimit = 10000
+}
+
+# invoke vm program on message received, if the vm is not invoked the balance transfer occurs anyway  [true/false]
+play.vm = true
+
+# Key value data source values: [leveldb]
+keyvalue.datasource = leveldb
+
+# the parameter specify when exactly to switch managing storage of the account on autonomous db
+details.inmemory.storage.limit = 1
+
+sync {
+    # block chain synchronization can be: [true/false]
+    enabled = true
+
+    # maximum blocks hashes to ask sending GET_BLOCK_HASHES msg we specify number of block we want to get, recomended value [1..1000]
+    # Default: unlimited
+    max.hashes.ask = 10000
+
+    # minimal peers count used in sync process sync may use more peers than this value but always trying to get at least this number from discovery
+    peer.count = 10
+
+    # The expected number of peers we would want to start finding a connection point.
+    expectedPeers = 5
+
+    # Timeout in minutes to start finding the connection point when we have at least one peer
+    timeoutWaitingPeers = 1
+
+    # Timeout in seconds to wait for syncing requests
+    timeoutWaitingRequest = 30
+
+    # Expiration time in minutes for peer status
+    expirationTimePeerStatus = 10
+
+    # Maximum amount of chunks included in a skeleton message
+    maxSkeletonChunks = 20
+
+    # Amount of blocks contained in a chunk,
+    # MUST BE 192 or a divisor of 192
+    chunkSize = 192
+}
+
+rpc {
+    enabled = true
+    # Interface to bind rpc
+    # Make sure you are using the correct bind. Default value: localhost
+    address = localhost
+    port = 4444
+    # host = ["localhost", "private.ip", "external.ip", "example.com", "www.example.com"]
+
+    # A value greater than zero sets the socket value in milliseconds. Node attempts to gently close all TCP/IP connections with proper half close semantics,
+    # so a linger timeout should not be required and thus the default is -1.
+    # linger.time = 0
+
+    cors = "*.rsk.co"
+
+    # Enabled RPC Modules. If the module is NOT in the list, and mark as "enabled", the rpc calls will be discard.
+    # It is possible to enable/disable a particular method in a module
+    # {
+    #  name: "evm",
+    #  version: "1.0",
+    #  enabled: "true",
+    #  methods: {
+    #      enabled: [ "evm_snapshot", "evm_revert" ],
+    #       disabled: [ "evm_reset", "evm_increaseTime" ]
+    #  }
+    # }
+    modules = [
+        {
+            name: "eth",
+            version: "1.0",
+            enabled: "true",
+        },
+        {
+            name: "net",
+            version: "1.0",
+            enabled: "true",
+        },
+        {
+            name: "rpc",
+            version: "1.0",
+            enabled: "true",
+        },
+        {
+            name: "web3",
+            version: "1.0",
+            enabled: "true",
+        },
+        {
+            name: "evm",
+            version: "1.0",
+            enabled: "true"
+        },
+        {
+            name: "sco",
+            version: "1.0",
+            enabled: "true",
+        },
+        {
+            name: "txpool",
+            version: "1.0",
+            enabled: "true",
+        },
+        {
+            name: "personal",
+            version: "1.0",
+            enabled: "true"
+        }
+    ]
+}
+
+wire {
+    protocol: "rsk"
+}
+
+# solc compiler path
+solc.path = /bin/false
+
+# not good reputation expiration time in seconds
+scoring {
+    # punishment by node id
+    nodes {
+        # number of nodes to keep scoring
+        number: 100
+
+        # initial punishment duration (in minutes, default = 10 minutes)
+        duration: 12
+
+        # punishment duration increment (in percentage, default = 10)
+        increment: 10
+
+        # maximum punishment duration (in minutes, default = 0 minutes, no maximum)
+        maximum: 0
+    }
+    # punishment by address
+    addresses {
+        # initial punishment duration (in minutes, default = 10 minutes)
+        duration: 12
+
+        # punishment duration increment (in percentage, default = 10)
+        increment: 10
+
+        # maximum punishment duration (in minutes, default = 1 week)
+        maximum: 6000
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
+++ b/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
@@ -18,7 +18,7 @@
 
 package co.rsk.blockchain.utils;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.DifficultyCalculator;
@@ -61,7 +61,7 @@ public class BlockGenerator {
 
     private static final Block[] blockCache = new Block[5];
 
-    private final DifficultyCalculator difficultyCalculator = new DifficultyCalculator(new RskSystemProperties());
+    private final DifficultyCalculator difficultyCalculator = new DifficultyCalculator(new TestSystemProperties());
     private int count = 0;
 
     public Genesis getGenesisBlock() {

--- a/rskj-core/src/test/java/co/rsk/blocks/FileBlockPlayerTest.java
+++ b/rskj-core/src/test/java/co/rsk/blocks/FileBlockPlayerTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.blocks;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,7 +33,7 @@ public class FileBlockPlayerTest {
         FileBlockRecorder recorder = new FileBlockRecorder("testblocks.txt");
         recorder.close();
 
-        FileBlockPlayer player = new FileBlockPlayer(new RskSystemProperties(), "testblocks.txt");
+        FileBlockPlayer player = new FileBlockPlayer(new TestSystemProperties(), "testblocks.txt");
 
         File file = new File("testblocks.txt");
         Assert.assertTrue(file.exists());

--- a/rskj-core/src/test/java/co/rsk/config/CommonConfigTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/CommonConfigTest.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class CommonConfigTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void createRepositoryUsingNewRepository() {

--- a/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public class RskSystemPropertiesTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void defaultValues() {

--- a/rskj-core/src/test/java/co/rsk/config/TestSystemProperties.java
+++ b/rskj-core/src/test/java/co/rsk/config/TestSystemProperties.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.config;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+public class TestSystemProperties extends RskSystemProperties {
+    private static final ConfigLoader TEST_LOADER = new ConfigLoader() {
+        /**
+         * Cache configurations that don't change so we don't read files multiple times.
+         */
+        private final Config TEST_CONFIG = ConfigFactory.parseResources("test-rskj.conf")
+                .withFallback(ConfigFactory.parseResources("rskj.conf"))
+                .withFallback(ConfigFactory.load("config/regtest"));
+
+        @Override
+        public Config getConfigFromFiles() {
+            return TEST_CONFIG;
+        }
+    };
+
+    public TestSystemProperties() {
+        super(TEST_LOADER);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.test.World;
 import co.rsk.test.builders.AccountBuilder;
 import org.ethereum.core.*;
@@ -34,7 +34,7 @@ import java.math.BigInteger;
  */
 public class CallContractTest {
 
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void callContractReturningOne() {

--- a/rskj-core/src/test/java/co/rsk/core/CodeReplaceTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CodeReplaceTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core;
 
 import co.rsk.asm.EVMAssembler;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -41,7 +41,7 @@ import java.util.Arrays;
  */
 public class CodeReplaceTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void replaceCodeTest1() throws IOException, InterruptedException {

--- a/rskj-core/src/test/java/co/rsk/core/NetworkStateExporterTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/NetworkStateExporterTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.trie.TrieStoreImpl;
 import com.fasterxml.jackson.databind.JavaType;
@@ -40,7 +40,6 @@ import org.spongycastle.util.encoders.Hex;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,11 +50,11 @@ public class NetworkStateExporterTest {
     private static final byte[] ZERO_BYTE_ARRAY = new byte[]{0};
 
     static String jsonFileName = "networkStateExporterTest.json";
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     @Before
     public void setup(){
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
     }
 
     @AfterClass

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 
 public class TransactionTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test  /* achieve public key of the sender */
     public void test2() throws Exception {

--- a/rskj-core/src/test/java/co/rsk/core/WalletFactory.java
+++ b/rskj-core/src/test/java/co/rsk/core/WalletFactory.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.LevelDbDataSource;
@@ -26,7 +26,7 @@ import org.ethereum.datasource.LevelDbDataSource;
 public class WalletFactory {
 
     public static Wallet createPersistentWallet(String storeName) {
-        KeyValueDataSource ds = new LevelDbDataSource(new RskSystemProperties(), storeName);
+        KeyValueDataSource ds = new LevelDbDataSource(new TestSystemProperties(), storeName);
         ds.init();
         return new Wallet(ds);
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
@@ -20,7 +20,7 @@ package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.blocks.DummyBlockRecorder;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryImpl;
@@ -58,7 +58,7 @@ import java.util.List;
 
 public class BlockChainImplTest {
 
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void addGenesisBlock() {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.test.builders.BlockChainBuilder;
@@ -55,7 +55,7 @@ import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
  */
 public class BlockExecutorTest {
     public static final byte[] EMPTY_TRIE_HASH = sha3(RLP.encodeElement(EMPTY_BYTE_ARRAY));
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void executeBlockWithoutTransaction() {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockForkTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockForkTest.java
@@ -19,7 +19,6 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import org.ethereum.core.Block;
 import org.ethereum.datasource.HashMapDB;

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
@@ -18,7 +18,7 @@
 
 package co.rsk.core.bc;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.validators.*;
 import org.ethereum.core.Repository;
@@ -30,7 +30,7 @@ import org.mockito.Mockito;
  */
 public class BlockValidatorBuilder {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private BlockTxsValidationRule blockTxsValidationRule;
 
     private BlockTxsFieldsValidationRule blockTxsFieldsValidationRule;

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.peg.simples.SimpleBlock;
 import co.rsk.remasc.RemascTransaction;
@@ -52,7 +52,7 @@ public class BlockValidatorTest {
 
     public static final BlockDifficulty TEST_DIFFICULTY = new BlockDifficulty(BigInteger.ONE);
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void validateGenesisBlock() {

--- a/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.test.builders.BlockBuilder;
@@ -44,7 +44,7 @@ import static org.ethereum.util.TransactionFactoryHelper.*;
  * Created by ajlopez on 08/08/2016.
  */
 public class TransactionPoolImplTest {
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void usingRepository() {

--- a/rskj-core/src/test/java/co/rsk/datasource/DataSourcePoolTest.java
+++ b/rskj-core/src/test/java/co/rsk/datasource/DataSourcePoolTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.datasource;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.datasource.DataSourcePool;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.junit.Assert;
@@ -30,11 +30,11 @@ import org.junit.Test;
  */
 public class DataSourcePoolTest {
 
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     @Before
     public void setup(){
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/db/ContractDetailsImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/ContractDetailsImplTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieImpl;
 import co.rsk.trie.TrieStore;
@@ -40,7 +40,7 @@ import static org.ethereum.util.ByteUtil.toHexString;
  * Created by ajlopez on 05/04/2017.
  */
 public class ContractDetailsImplTest {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final int IN_MEMORY_STORAGE_LIMIT = config.detailsInMemoryStorageLimit();
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplForTesting.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplForTesting.java
@@ -18,7 +18,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.AccountState;
 import org.ethereum.db.ContractDetails;
@@ -29,7 +29,7 @@ import org.ethereum.vm.DataWord;
  */
 public class RepositoryImplForTesting extends RepositoryImpl {
     public RepositoryImplForTesting() {
-        super(new RskSystemProperties());
+        super(new TestSystemProperties());
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
@@ -19,7 +19,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.trie.TrieStore;
@@ -53,7 +53,7 @@ public class RepositoryImplOriginalTest {
 
     public static final RskAddress COW = new RskAddress("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
     public static final RskAddress HORSE = new RskAddress("13978AEE95F38490E9769C39B2773ED763D9CD5F");
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void test1() {

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -42,7 +42,7 @@ import java.util.Set;
  */
 public class RepositoryImplTest {
     private static Keccak256 emptyHash = TrieImplHashTest.makeEmptyHash();
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void getNonceUnknownAccount() {

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.db;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
@@ -48,7 +48,7 @@ public class RepositoryTest {
 
     public static final RskAddress COW = new RskAddress("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
     public static final RskAddress HORSE = new RskAddress("13978AEE95F38490E9769C39B2773ED763D9CD5F");
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void test4() {

--- a/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
+++ b/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.jsontestsuite;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.DifficultyCalculator;
 import org.ethereum.config.net.MainNetConfig;
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 public class LocalBasicTest {
 
     private static final Logger logger = LoggerFactory.getLogger("TCK-Test");
-    private RskSystemProperties config = new RskSystemProperties();;
+    private TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void runDifficultyTest() throws IOException, ParseException {

--- a/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBlockTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.jsontestsuite;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.jsontestsuite.GitHubJSONTestSuite;
 import org.ethereum.jsontestsuite.JSONReader;
 import org.json.simple.parser.ParseException;
@@ -38,7 +38,7 @@ import java.util.Collections;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class LocalBlockTest {
     private ClassLoader loader = LocalBlockTest.class.getClassLoader();
-    private static RskSystemProperties config = new RskSystemProperties();
+    private static TestSystemProperties config = new TestSystemProperties();
 
     @BeforeClass
     public static void init() {

--- a/rskj-core/src/test/java/co/rsk/mine/GasLimitCalculatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/GasLimitCalculatorTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.mine;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.config.Constants;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.validator.ParentGasLimitRule;
@@ -34,7 +34,7 @@ import static org.ethereum.validator.ParentGasLimitRuleTest.getHeader;
  */
 public class GasLimitCalculatorTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private Constants constants = new Constants();
     private ParentGasLimitRule rule = new ParentGasLimitRule(1024);
 

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -2,7 +2,7 @@ package co.rsk.mine;
 
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.config.ConfigUtils;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.bc.BlockChainImpl;
@@ -42,11 +42,11 @@ public class MainNetMinerTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     @Before
     public void setup() {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new FallbackMainNetConfig());
         DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
         World world = new World();
@@ -124,7 +124,7 @@ public class MainNetMinerTest {
         byte[] privKey1 = privateMiningKey1.getPrivKeyBytes();
         saveToFile(privKey1, new File(folder.getRoot().getCanonicalPath(), "privkey1.bin"));
 
-        RskSystemProperties tempConfig = new RskSystemProperties() {
+        TestSystemProperties tempConfig = new TestSystemProperties() {
 
             BlockchainNetConfig blockchainNetConfig = config.getBlockchainConfig();
 

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -19,7 +19,7 @@
 package co.rsk.mine;
 
 import co.rsk.config.ConfigUtils;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.RskImpl;
 import co.rsk.core.SnapshotManager;
@@ -42,7 +42,7 @@ import java.util.concurrent.Callable;
  */
 public class MinerManagerTest {
 
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void refreshWorkRunOnce() {

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -22,7 +22,7 @@ import co.rsk.TestHelpers.Tx;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.config.ConfigUtils;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.bc.BlockChainImpl;
@@ -55,7 +55,7 @@ import static org.junit.Assert.*;
  * Created by adrian.eidelman on 3/16/2016.
  */
 public class MinerServerTest {
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
     private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
 
     private BlockChainImpl blockchain;

--- a/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
@@ -19,7 +19,7 @@
 package co.rsk.mine;
 
 import co.rsk.TestHelpers.Tx;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -36,7 +36,7 @@ import java.util.*;
 
 public class MinerUtilsTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void getAllTransactionsTest() {

--- a/rskj-core/src/test/java/co/rsk/mine/TxBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TxBuilderTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.mine;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.net.BlockProcessor;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -31,7 +31,7 @@ import java.math.BigInteger;
 
 public class TxBuilderTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void createBasicTransaction() {

--- a/rskj-core/src/test/java/co/rsk/net/BlockSyncServiceTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/BlockSyncServiceTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.net.sync.SyncConfiguration;
 import co.rsk.test.builders.BlockChainBuilder;
 import org.ethereum.core.Block;
@@ -37,7 +37,7 @@ public class BlockSyncServiceTest {
             Blockchain blockchain = BlockChainBuilder.ofSize(10 * i);
             BlockStore store = new BlockStore();
             BlockNodeInformation nodeInformation = new BlockNodeInformation();
-            RskSystemProperties config = new RskSystemProperties();
+            TestSystemProperties config = new TestSystemProperties();
             BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
             Assert.assertEquals(10 * i, blockchain.getBestBlock().getNumber());
 
@@ -56,7 +56,7 @@ public class BlockSyncServiceTest {
             Blockchain blockchain = BlockChainBuilder.ofSize(10 * i);
             BlockStore store = new BlockStore();
             BlockNodeInformation nodeInformation = new BlockNodeInformation();
-            RskSystemProperties config = new RskSystemProperties();
+            TestSystemProperties config = new TestSystemProperties();
             BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
             Assert.assertEquals(10 * i, blockchain.getBestBlock().getNumber());
 
@@ -85,7 +85,7 @@ public class BlockSyncServiceTest {
         Blockchain blockchain = BlockChainBuilder.ofSize(10);
         BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         Block initialBestBlock = blockchain.getBestBlock();

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
 import co.rsk.net.messages.*;
@@ -54,7 +54,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -75,7 +75,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -97,7 +97,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = BlockChainBuilder.ofSize(0);
         final long advancedBlockNumber = syncConfiguration.getChunkSize() * syncConfiguration.getMaxSkeletonChunks() + blockchain.getBestBlock().getNumber() + 1;
 
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -114,7 +114,7 @@ public class NodeBlockProcessorTest {
         final SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
 
         final Blockchain blockchain = BlockChainBuilder.ofSize(15);
-        final RskSystemProperties config = new RskSystemProperties();
+        final TestSystemProperties config = new TestSystemProperties();
         int uncleGenerationLimit = config.getBlockchainConfig().getCommonConstants().getUncleGenerationLimit();
         final long blockNumberThatCanBeIgnored = blockchain.getBestBlock().getNumber() - 1 - uncleGenerationLimit;
 
@@ -141,7 +141,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -163,7 +163,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -188,7 +188,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -216,7 +216,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -239,7 +239,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -254,7 +254,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -274,7 +274,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -294,7 +294,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -329,7 +329,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -351,7 +351,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -373,7 +373,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -404,7 +404,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -430,7 +430,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         final SimpleMessageChannel sender = new SimpleMessageChannel();
@@ -464,7 +464,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         final SimpleMessageChannel sender = new SimpleMessageChannel();
@@ -496,7 +496,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = BlockChainBuilder.ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         final SimpleMessageChannel sender = new SimpleMessageChannel();
@@ -519,7 +519,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = BlockChainBuilder.ofSize(2);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -544,7 +544,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = BlockChainBuilder.ofSize(2);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -574,7 +574,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = BlockChainBuilder.ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -602,7 +602,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -625,7 +625,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -656,7 +656,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = BlockChainBuilder.ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -688,7 +688,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -712,7 +712,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -747,7 +747,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = BlockChainBuilder.ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -779,7 +779,7 @@ public class NodeBlockProcessorTest {
         final BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -810,7 +810,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -834,7 +834,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -865,7 +865,7 @@ public class NodeBlockProcessorTest {
         final BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -884,7 +884,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -916,7 +916,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -937,7 +937,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -973,7 +973,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
@@ -1011,7 +1011,7 @@ public class NodeBlockProcessorTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorUnclesTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorUnclesTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.net.simples.SimpleMessageChannel;
 import co.rsk.net.sync.SyncConfiguration;
@@ -150,7 +150,7 @@ public class NodeBlockProcessorUnclesTest {
         BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockChain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockChain, nodeInformation, blockSyncService, syncConfiguration);
 

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryImpl;
@@ -61,18 +61,17 @@ import java.net.UnknownHostException;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 /**
  * Created by ajlopez on 5/10/2016.
  */
 public class NodeMessageHandlerTest {
-    private static RskSystemProperties config;
+    private static TestSystemProperties config;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
     }
 

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
@@ -1,6 +1,6 @@
 package co.rsk.net;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.net.sync.SyncConfiguration;
 import co.rsk.scoring.PeerScoringManager;
@@ -20,7 +20,7 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 
 public class NodeMessageHandlerUtil {
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
     private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
 
     public static NodeMessageHandler createHandler(BlockValidationRule validationRule) {

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.net.messages.BlockMessage;
 import co.rsk.net.simples.SimpleAsyncNode;
@@ -45,7 +45,7 @@ public class OneAsyncNodeTest {
         final BlockStore store = new BlockStore();
         final Blockchain blockchain = world.getBlockChain();
 
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -1,7 +1,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.DifficultyCalculator;
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
  */
 public class SyncProcessorTest {
 
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
     public static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
 
     @Test
@@ -50,7 +50,7 @@ public class SyncProcessorTest {
         final BlockStore store = new BlockStore();
         Blockchain blockchain = BlockChainBuilder.ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, getPeerScoringManager(), getChannelManager(),
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
@@ -71,7 +71,7 @@ public class SyncProcessorTest {
         Status status = new Status(100, hash, parentHash, blockchain.getTotalDifficulty().add(new BlockDifficulty(BigInteger.TEN)));
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[]{0x01});
@@ -118,7 +118,7 @@ public class SyncProcessorTest {
         Status status = new Status(100, hash, parentHash, blockchain.getTotalDifficulty().add(new BlockDifficulty(BigInteger.TEN)));
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
         SyncConfiguration syncConfiguration = SyncConfiguration.DEFAULT;
 
@@ -171,7 +171,7 @@ public class SyncProcessorTest {
         Status status = new Status(0, hash, parentHash, blockchain.getTotalDifficulty());
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
@@ -204,7 +204,7 @@ public class SyncProcessorTest {
         Status status = new Status(100, hash, parentHash, blockchain.getTotalDifficulty().add(new BlockDifficulty(BigInteger.TEN)));
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         final ChannelManager channelManager = mock(ChannelManager.class);
@@ -277,7 +277,7 @@ public class SyncProcessorTest {
         Status status = new Status(blockchain.getStatus().getBestBlockNumber(), hash, parentHash, blockchain.getStatus().getTotalDifficulty());
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
@@ -379,7 +379,7 @@ public class SyncProcessorTest {
         Blockchain blockchain = BlockChainBuilder.ofSize(0);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
                 syncConfiguration, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
@@ -401,7 +401,7 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
                 syncConfiguration, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
@@ -424,7 +424,7 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
                 syncConfiguration, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
@@ -450,7 +450,7 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
                 syncConfiguration, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
@@ -472,7 +472,7 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
                 syncConfiguration, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
@@ -500,7 +500,7 @@ public class SyncProcessorTest {
         Assert.assertArrayEquals(blockchain.getBestBlockHash(), block.getParentHash().getBytes());
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
@@ -545,7 +545,7 @@ public class SyncProcessorTest {
         Assert.assertArrayEquals(blockchain.getBestBlockHash(), block.getParentHash().getBytes());
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
@@ -601,7 +601,7 @@ public class SyncProcessorTest {
         Assert.assertArrayEquals(blockchain.getBestBlockHash(), block.getParentHash().getBytes());
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
@@ -671,7 +671,7 @@ public class SyncProcessorTest {
         Assert.assertArrayEquals(blockchain.getBestBlockHash(), block.getParentHash().getBytes());
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
@@ -716,7 +716,7 @@ public class SyncProcessorTest {
         Assert.assertArrayEquals(blockchain.getBestBlockHash(), block.getParentHash().getBytes());
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
@@ -750,7 +750,7 @@ public class SyncProcessorTest {
 
         BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
@@ -805,7 +805,7 @@ public class SyncProcessorTest {
 
         BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,
@@ -847,7 +847,7 @@ public class SyncProcessorTest {
         final BlockStore store = new BlockStore();
         Blockchain blockchain = BlockChainBuilder.ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
@@ -898,7 +898,7 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(config, blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), getChannelManager(),
                 syncConfiguration, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), DIFFICULTY_CALCULATOR);
@@ -921,7 +921,7 @@ public class SyncProcessorTest {
 
         final BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });

--- a/rskj-core/src/test/java/co/rsk/net/TwoAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TwoAsyncNodeTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.net.messages.BlockMessage;
 import co.rsk.net.simples.SimpleAsyncNode;
 import co.rsk.net.sync.SyncConfiguration;
@@ -38,7 +38,7 @@ import java.util.List;
  */
 public class TwoAsyncNodeTest {
 
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
 
     private static SimpleAsyncNode createNode(int size) {
         final World world = new World();

--- a/rskj-core/src/test/java/co/rsk/net/TwoNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TwoNodeTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.net.messages.BlockMessage;
 import co.rsk.net.simples.SimpleNode;
 import co.rsk.net.sync.SyncConfiguration;
@@ -49,10 +49,10 @@ public class TwoNodeTest {
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        NodeMessageHandler handler = new NodeMessageHandler(new RskSystemProperties(), processor, null, null, null, null, null, new DummyBlockValidationRule());
+        NodeMessageHandler handler = new NodeMessageHandler(new TestSystemProperties(), processor, null, null, null, null, null, new DummyBlockValidationRule());
 
         return new SimpleNode(handler);
     }

--- a/rskj-core/src/test/java/co/rsk/net/eth/RskMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/eth/RskMessageTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net.eth;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.net.Status;
 import co.rsk.net.messages.*;
 import org.ethereum.core.Block;
@@ -34,7 +34,7 @@ import org.junit.Test;
  */
 public class RskMessageTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void encodeDecodeGetBlockMessage() {

--- a/rskj-core/src/test/java/co/rsk/net/eth/WriterMessageRecorderTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/eth/WriterMessageRecorderTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net.eth;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.net.NodeID;
 import co.rsk.net.messages.GetBlockMessage;
 import co.rsk.test.builders.AccountBuilder;
@@ -45,7 +45,7 @@ import java.util.Random;
  */
 public class WriterMessageRecorderTest {
 
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void recordRskMessage() throws IOException {

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net.handler;
 
 import co.rsk.TestHelpers.Tx;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Transaction;
 import org.junit.Assert;
@@ -62,7 +62,7 @@ public class TxPendingValidatorTest {
     }
 
     private Transaction createTransaction(long value, long gaslimit, long gasprice, long nonce, long data, long sender) {
-        return Tx.create(new RskSystemProperties(), value, gaslimit, gasprice, nonce, data, sender);
+        return Tx.create(new TestSystemProperties(), value, gaslimit, gasprice, nonce, data, sender);
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxValidatorTest.java
@@ -19,9 +19,8 @@
 package co.rsk.net.handler;
 
 import co.rsk.TestHelpers.Tx;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
-import co.rsk.core.RskAddress;
 import co.rsk.peg.Federation;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.*;
@@ -40,13 +39,13 @@ import static org.mockito.Matchers.eq;
 public class TxValidatorTest {
 
 
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     Random hashes = new Random(0);
 
     @Before
     public void setup(){
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
     }
 
     @Test
@@ -169,7 +168,7 @@ public class TxValidatorTest {
     }
 
     public static Transaction createBridgeTx(
-            RskSystemProperties config,
+            TestSystemProperties config,
             long value,
             long gaslimit,
             long gasprice,

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxFilterAccumCostFilterTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxFilterAccumCostFilterTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net.handler.txvalidator;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.net.handler.TxsPerAccount;
 import org.ethereum.core.AccountState;
@@ -32,7 +32,7 @@ import java.util.LinkedList;
 
 public class TxFilterAccumCostFilterTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void twoTxsValidAccumGasPrice() {

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidatorTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net.handler.txvalidator;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
@@ -80,7 +80,7 @@ public class TxValidatorAccountBalanceValidatorTest {
                 new ECKey().getAddress(),
                 BigInteger.ZERO.toByteArray(),
                 Hex.decode("0001"),
-                new RskSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
+                new TestSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
 
         tx.sign(new ECKey().getPrivKeyBytes());
 

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.config.BridgeRegTestConstants;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.spongycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.core.AccountState;
@@ -29,16 +29,17 @@ import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
 public class TxValidatorIntrinsicGasLimitValidatorTest {
 
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     @Before
     public void setUp() {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
     }
 

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net.simples;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.net.*;
 import co.rsk.net.messages.Message;
@@ -38,7 +38,7 @@ import java.util.concurrent.*;
  * Created by ajlopez on 5/15/2016.
  */
 public class SimpleAsyncNode extends SimpleNode {
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
     private ExecutorService executor = Executors.newSingleThreadExecutor();
     private LinkedBlockingQueue<Future> futures = new LinkedBlockingQueue<>(5000);
     private SyncProcessor syncProcessor;

--- a/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net.utils;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
@@ -57,7 +57,7 @@ public class TransactionUtils {
     }
 
     public static Transaction createTransaction(byte[] privateKey, String toAddress, BigInteger value, BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit) {
-        Transaction tx = Transaction.create(new RskSystemProperties(), toAddress, value, nonce, gasPrice, gasLimit);
+        Transaction tx = Transaction.create(new TestSystemProperties(), toAddress, value, nonce, gasPrice, gasLimit);
         tx.sign(privateKey);
         return tx;
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStateTest.java
@@ -19,7 +19,7 @@
 package co.rsk.peg;
 
 import co.rsk.config.BridgeConstants;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.trie.TrieStoreImpl;
 import org.ethereum.core.Repository;
@@ -36,7 +36,7 @@ import java.io.IOException;
 public class BridgeStateTest {
     @Test
     public void recreateFromEmptyStorageProvider() throws IOException {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         Repository repository = new RepositoryImpl(config, new TrieStoreImpl(new HashMapDB()));
         BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.config.BridgeConstants;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryImpl;
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ BridgeSerializationUtils.class, RskAddress.class })
 public class BridgeStorageProviderTest {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final NetworkParameters networkParameters = config.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
     private int transactionOffset;
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -29,7 +29,7 @@ import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -103,7 +103,7 @@ public class BridgeSupportTest {
 
     private static BridgeConstants bridgeConstants;
     private static NetworkParameters btcParams;
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     private static final String TO_ADDRESS = "0000000000000000000000000000000000000006";
     private static final BigInteger DUST_AMOUNT = new BigInteger("1");
@@ -115,7 +115,7 @@ public class BridgeSupportTest {
 
     @Before
     public void setUpOnEachTest(){
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
         bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         btcParams = bridgeConstants.getBtcParams();
@@ -135,7 +135,7 @@ public class BridgeSupportTest {
 
     @Test
     public void testInitialChainHeadWithBtcCheckpoints() throws Exception {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new TestNetConfig());
         bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         btcParams = bridgeConstants.getBtcParams();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -24,7 +24,7 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.peg.bitcoin.SimpleBtcTransaction;
@@ -64,7 +64,7 @@ public class BridgeTest {
     private static final BigInteger GAS_PRICE = new BigInteger("100");
     private static final BigInteger GAS_LIMIT = new BigInteger("1000");
     private static final String DATA = "80af2871";
-    private static RskSystemProperties config = new RskSystemProperties();
+    private static TestSystemProperties config = new TestSystemProperties();
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -27,7 +27,7 @@ import co.rsk.bitcoinj.wallet.CoinSelector;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.BridgeRegTestConstants;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
 import org.ethereum.config.blockchain.RegTestConfig;
@@ -67,11 +67,11 @@ public class BridgeUtilsTest {
     private static final BigInteger GAS_PRICE = new BigInteger("100");
     private static final BigInteger GAS_LIMIT = new BigInteger("1000");
     private static final String DATA = "80af2871";
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     @Before
     public void setupConfig(){
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/RepositoryBlockStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RepositoryBlockStoreTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.BtcBlock;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.StoredBlock;
 import co.rsk.bitcoinj.params.RegTestParams;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.db.RepositoryImplForTesting;
 import org.apache.commons.lang3.tuple.Triple;
 import org.ethereum.core.Repository;
@@ -82,7 +82,7 @@ public class RepositoryBlockStoreTest {
         InputStream fileInputStream = ClassLoader.getSystemResourceAsStream("peg/RepositoryBlockStore_data.ser");
         ObjectInputStream objectInputStream = new ObjectInputStream(fileInputStream);
         Repository repository = new RepositoryImplForTesting();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         RepositoryBlockStore store = new RepositoryBlockStore(config, repository, PrecompiledContracts.BRIDGE_ADDR);
         for (int i = 0; i < 614; i++) {
             Triple<byte[], BigInteger , Integer> tripleStoredBlock = (Triple<byte[], BigInteger , Integer>) objectInputStream.readObject();

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.AddressFormatException;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.params.RegTestParams;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.test.World;
@@ -50,11 +50,11 @@ import java.util.List;
 
 public class RskForksBridgeTest {
     private static BlockchainNetConfig blockchainNetConfigOriginal;
-    private static RskSystemProperties config;
+    private static TestSystemProperties config;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/SamplePrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/SamplePrecompiledContractTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.peg;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import org.apache.commons.lang3.StringUtils;
 import org.ethereum.core.CallTransaction;
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertNull;
  */
 public class SamplePrecompiledContractTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
@@ -20,7 +20,7 @@ package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.crypto.Keccak256;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
@@ -40,7 +40,7 @@ public class StateForFederatorTest {
     private static final String SHA3_3 = "3333333333333333333333333333333333333333333333333333333333333333";
     private static final String SHA3_4 = "4444444444444444444444444444444444444444444444444444444444444444";
 
-    private static final NetworkParameters NETWORK_PARAMETERS = new RskSystemProperties().getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
+    private static final NetworkParameters NETWORK_PARAMETERS = new TestSystemProperties().getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams();
 
     @Test
     public void serialize() {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
@@ -20,7 +20,7 @@ package co.rsk.peg.performance;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.config.BridgeConstants;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.db.RepositoryTrackWithBenchmarking;
 import co.rsk.peg.Bridge;
@@ -52,7 +52,7 @@ import java.util.Random;
 public abstract class BridgePerformanceTestCase {
     protected static NetworkParameters networkParameters;
     protected static BridgeConstants bridgeConstants;
-    private static RskSystemProperties config;
+    private static TestSystemProperties config;
 
     private boolean oldCpuTimeEnabled;
     private ThreadMXBean thread;
@@ -98,7 +98,7 @@ public abstract class BridgePerformanceTestCase {
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
         bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         networkParameters = bridgeConstants.getBtcParams();

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BtcBlockchainTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BtcBlockchainTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.BtcBlockChain;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.RepositoryBlockStore;
@@ -56,7 +56,7 @@ public class BtcBlockchainTest extends BridgePerformanceTestCase {
         final int maxBtcBlocks = 2000;
 
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new RskSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new TestSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/LockWhitelistTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/LockWhitelistTest.java
@@ -21,7 +21,7 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.LockWhitelist;
@@ -122,7 +122,7 @@ public class LockWhitelistTest extends BridgePerformanceTestCase {
         final int maxBtcBlocks = 1000;
 
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new RskSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new TestSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
@@ -23,7 +23,7 @@ import co.rsk.bitcoinj.core.BtcBlockChain;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.RepositoryBlockStore;
@@ -46,7 +46,7 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
         final int maxBtcBlocks = 2000;
 
         BridgeStorageProviderInitializer storageInitializer = (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new RskSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new TestSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.RepositoryBlockStore;
@@ -97,7 +97,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
 
     private BridgeStorageProviderInitializer generateInitializerForLock(int minBtcBlocks, int maxBtcBlocks, int numberOfLockConfirmations, boolean markAsAlreadyProcessed) {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new RskSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new TestSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascContractExecuteTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascContractExecuteTest.java
@@ -20,7 +20,7 @@ package co.rsk.remasc;
 
 import co.rsk.config.RemascConfig;
 import co.rsk.config.RemascConfigFactory;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
 import org.ethereum.vm.PrecompiledContracts;
@@ -34,11 +34,11 @@ public class RemascContractExecuteTest {
 
     private static BlockchainNetConfig blockchainNetConfigOriginal;
     private static RemascConfig remascConfig;
-    private static RskSystemProperties config;
+    private static TestSystemProperties config;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
         remascConfig = new RemascConfigFactory(RemascContract.REMASC_CONFIG).createRemascConfig("regtest");
     }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
@@ -2,7 +2,7 @@ package co.rsk.remasc;
 
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.peg.BridgeSupport;
 import co.rsk.test.builders.BlockChainBuilder;
 import org.ethereum.core.Blockchain;
@@ -38,10 +38,10 @@ public class RemascFederationProviderTest {
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
         Blockchain blockchain = builder.build();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(new RskSystemProperties(), blockchain.getRepository(),
-                null,
-                PrecompiledContracts.BRIDGE_ADDR,
-                null);
+        BridgeSupport bridgeSupport = new BridgeSupport(new TestSystemProperties(), blockchain.getRepository(),
+                                                        null,
+                                                        PrecompiledContracts.BRIDGE_ADDR,
+                                                        null);
         RemascFederationProvider provider = null;
 
         try {

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.RemascConfig;
 import co.rsk.config.RemascConfigFactory;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockExecutor;
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertNull;
 public class RemascProcessMinerFeesTest {
 
     private static RemascConfig remascConfig;
-    private static RskSystemProperties config;
+    private static TestSystemProperties config;
 
     private Coin cowInitialBalance = new Coin(new BigInteger("1000000000000000000"));
     private long initialGasLimit = 10000000L;
@@ -72,7 +72,7 @@ public class RemascProcessMinerFeesTest {
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
         remascConfig = new RemascConfigFactory(RemascContract.REMASC_CONFIG).createRemascConfig("regtest");
 

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -19,7 +19,7 @@
 package co.rsk.remasc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryImpl;
@@ -40,7 +40,7 @@ import java.util.SortedMap;
  */
 public class RemascStorageProviderTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void getDefautRewardBalance() {

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -18,7 +18,7 @@
 
 package co.rsk.remasc;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
@@ -105,8 +105,8 @@ class RemascTestRunner {
         List<Block> mainChainBlocks = new ArrayList<>();
         this.blockchain.tryToConnect(this.genesis);
 
-        BlockExecutor blockExecutor = new BlockExecutor(new RskSystemProperties(), blockchain.getRepository(),
-                null, blockchain.getBlockStore(), null);
+        BlockExecutor blockExecutor = new BlockExecutor(new TestSystemProperties(), blockchain.getRepository(),
+                                                        null, blockchain.getBlockStore(), null);
 
         for(int i = 0; i <= this.initialHeight; i++) {
             int finalI = i;
@@ -186,7 +186,7 @@ class RemascTestRunner {
                 new ECKey().getAddress() ,
                 BigInteger.valueOf(txValue).toByteArray(),
                 null,
-                new RskSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
+                new TestSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
 
         tx.sign(txSigningKey.getPrivKeyBytes());
         //createBlook 1

--- a/rskj-core/src/test/java/co/rsk/rpc/CorsConfigurationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/CorsConfigurationTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -47,7 +47,7 @@ public class CorsConfigurationTest {
 
     @Test
     public void hasHeaderFromTestConfig() {
-        CorsConfiguration config = new CorsConfiguration(new RskSystemProperties().corsDomains());
+        CorsConfiguration config = new CorsConfiguration(new TestSystemProperties().corsDomains());
 
         Assert.assertNotNull(config.getHeader());
         Assert.assertEquals(EXPECTED_CORS_CONFIG, config.getHeader());

--- a/rskj-core/src/test/java/co/rsk/rpc/ModuleDescriptionTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/ModuleDescriptionTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -181,7 +181,7 @@ public class ModuleDescriptionTest {
 
     @Test
     public void getModulesFromTestNewRskSystemProperties() {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         List<ModuleDescription> modules = config.getRpcModules();
 
         Assert.assertNotNull(modules);

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
 import org.ethereum.core.Blockchain;
@@ -43,8 +43,9 @@ public class Web3ImplRpcTest {
         TransactionPool transactionPool = Web3Mocks.getMockTransactionPool();
         PersonalModule pm = new PersonalModuleWalletDisabled();
         Repository repository = Web3Mocks.getMockRepository();
-        Web3Impl web3 = new Web3RskImpl(eth, blockchain, transactionPool, new RskSystemProperties(), null, null, pm, null, null,
-                null, repository, null, null, null, null, null, null, null, null);
+        Web3Impl web3 = new Web3RskImpl(eth, blockchain, transactionPool,
+                                        new TestSystemProperties(), null, null, pm, null, null,
+                                        null, repository, null, null, null, null, null, null, null, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.NetworkStateExporter;
 import co.rsk.core.Rsk;
 import co.rsk.core.Wallet;
@@ -70,7 +70,7 @@ public class Web3RskImplTest {
         Mockito.when(blockchain.getBestBlock()).thenReturn(block);
 
         Wallet wallet = WalletFactory.createWallet();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         PersonalModule pm = new PersonalModuleWalletEnabled(config, rsk, wallet, null);
         EthModule em = new EthModule(config, blockchain, null, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, rsk, wallet, null));
         TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -18,7 +18,7 @@
 
 package co.rsk.test;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockChainImplTest;
 import co.rsk.core.bc.BlockExecutor;
@@ -70,7 +70,7 @@ public class World {
         BlockStore store = new BlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockChain, nodeInformation, syncConfiguration);
         this.blockProcessor = new NodeBlockProcessor(store, blockChain, nodeInformation, blockSyncService, syncConfiguration);
     }
@@ -79,7 +79,7 @@ public class World {
 
     public BlockExecutor getBlockExecutor() {
         if (this.blockExecutor == null)
-            this.blockExecutor = new BlockExecutor(new RskSystemProperties(), this.getRepository(), null, this.getBlockChain().getBlockStore(), null);
+            this.blockExecutor = new BlockExecutor(new TestSystemProperties(), this.getRepository(), null, this.getBlockChain().getBlockStore(), null);
 
         return this.blockExecutor;
     }

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
@@ -19,7 +19,7 @@
 package co.rsk.test.builders;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.test.World;
@@ -97,7 +97,7 @@ public class BlockBuilder {
         Block block = blockGenerator.createChildBlock(parent, txs, uncles, difficulty, this.minGasPrice, gasLimit);
 
         if (blockChain != null) {
-            BlockExecutor executor = new BlockExecutor(new RskSystemProperties(), blockChain.getRepository(), null, blockChain.getBlockStore(), blockChain.getListener());
+            BlockExecutor executor = new BlockExecutor(new TestSystemProperties(), blockChain.getRepository(), null, blockChain.getBlockStore(), blockChain.getListener());
             executor.executeAndFill(block, parent);
         }
 

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -19,7 +19,7 @@
 package co.rsk.test.builders;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.*;
@@ -45,7 +45,7 @@ import java.util.List;
  * Created by ajlopez on 8/6/2016.
  */
 public class BlockChainBuilder {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private boolean testing;
 
     private List<Block> blocks;

--- a/rskj-core/src/test/java/co/rsk/test/builders/TransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/TransactionBuilder.java
@@ -18,7 +18,7 @@
 
 package co.rsk.test.builders;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.core.Account;
 import org.ethereum.core.ImmutableTransaction;
 import org.ethereum.core.Transaction;
@@ -92,7 +92,7 @@ public class TransactionBuilder {
 
     public Transaction build() {
         Transaction tx = Transaction.create(
-                new RskSystemProperties(), receiver != null ? Hex.toHexString(receiver.getAddress().getBytes()) : (receiverAddress != null ? Hex.toHexString(receiverAddress) : null),
+                new TestSystemProperties(), receiver != null ? Hex.toHexString(receiver.getAddress().getBytes()) : (receiverAddress != null ? Hex.toHexString(receiverAddress) : null),
                 value, nonce, gasPrice, gasLimit, data);
         tx.sign(sender.getEcKey().getPrivKeyBytes());
 

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -18,7 +18,7 @@
 
 package co.rsk.test.dsl;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.StringTokenizer;
 
 /**
@@ -225,8 +224,8 @@ public class WorldDslProcessor {
                 difficulty = difficultyTokenizer.hasMoreTokens()?parseDifficulty(difficultyTokenizer.nextToken(),k):k;
             }
             Block block = blockBuilder.difficulty(difficulty).parent(parent).build();
-            BlockExecutor executor = new BlockExecutor(new RskSystemProperties(), world.getRepository(),
-                    null, world.getBlockChain().getBlockStore(), null);
+            BlockExecutor executor = new BlockExecutor(new TestSystemProperties(), world.getRepository(),
+                                                       null, world.getBlockChain().getBlockStore(), null);
             executor.executeAndFill(block, parent);
             world.saveBlock(name, block);
             parent = block;

--- a/rskj-core/src/test/java/co/rsk/validators/BlockDifficultyValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockDifficultyValidationRuleTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.validators;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.RskAddress;
@@ -37,11 +37,11 @@ import java.math.BigInteger;
  */
 public class BlockDifficultyValidationRuleTest {
 
-    private static RskSystemProperties config;
+    private static TestSystemProperties config;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
     }
 

--- a/rskj-core/src/test/java/co/rsk/validators/BlockUnclesValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockUnclesValidationRuleTest.java
@@ -1,7 +1,7 @@
 package co.rsk.validators;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockChainImplTest;
@@ -20,7 +20,7 @@ import java.util.List;
  */
 public class BlockUnclesValidationRuleTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void rejectBlockWithSiblingUncle() {

--- a/rskj-core/src/test/java/co/rsk/validators/GasLimitRuleTests.java
+++ b/rskj-core/src/test/java/co/rsk/validators/GasLimitRuleTests.java
@@ -18,7 +18,7 @@
 
 package co.rsk.validators;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
  * @since 02.23.2016
  */
 public class GasLimitRuleTests {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private GasLimitRule rule = new GasLimitRule(3000000);
 
     @Test // pass rule

--- a/rskj-core/src/test/java/co/rsk/validators/RemascValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/RemascValidationRuleTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.validators;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public class RemascValidationRuleTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void noTxInTheBlock() {

--- a/rskj-core/src/test/java/co/rsk/vm/BlockchainVMTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/BlockchainVMTest.java
@@ -19,7 +19,7 @@
 package co.rsk.vm;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.test.World;
@@ -79,7 +79,7 @@ public class BlockchainVMTest {
                 dstAddress ,
                 transferAmount.getBytes(),
                 null,
-                new RskSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
+                new TestSystemProperties().getBlockchainConfig().getCommonConstants().getChainId());
 
         t.sign(binfo.faucetKey.getPrivKeyBytes());
         txs.add(t);

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -18,7 +18,7 @@
 
 package co.rsk.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.mine.GasLimitCalculator;
@@ -39,7 +39,7 @@ import java.util.List;
 public class MinerHelper {
     private static final Logger logger = LoggerFactory.getLogger("minerhelper");
     private static final PanicProcessor panicProcessor = new PanicProcessor();
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     private final Blockchain blockchain;
     private final Repository repository;

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.peg.Bridge;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class PrecompiledContractTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import org.ethereum.config.BlockchainConfig;
 import org.ethereum.vm.DataWord;
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
  * Created by ajlopez on 25/01/2017.
  */
 public class VMExecutionTest {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
     private ProgramInvokeMockImpl invoke;

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -18,7 +18,7 @@
 
 package co.rsk.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import org.ethereum.config.BlockchainConfig;
 import org.ethereum.config.blockchain.RegTestConfig;
@@ -54,7 +54,7 @@ import static org.junit.Assert.assertEquals;
  * Created by Sergio on 03/07/2016.
  */
 public class VMPerformanceTest {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
     private final BlockchainConfig blockchainConfig = new RegTestConfig();

--- a/rskj-core/src/test/java/org/ethereum/cli/ClIInterfaceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/cli/ClIInterfaceTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.cli;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.rpc.CorsConfigurationTest;
 import org.ethereum.config.SystemProperties;
 import org.junit.Assert;
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class ClIInterfaceTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void callPrintHelp() {

--- a/rskj-core/src/test/java/org/ethereum/config/ConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/ConfigTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.config;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import com.typesafe.config.*;
 import org.junit.Assert;
 import org.junit.Test;
@@ -76,7 +76,7 @@ public class ConfigTest {
 
     @Test
     public void ethereumjConfTest() {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         System.out.println("'" + config.databaseDir() + "'");
         System.out.println(config.peerActive());
     }

--- a/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/SystemPropertiesTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.config;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,7 +31,7 @@ import java.net.InetAddress;
 public class SystemPropertiesTest {
     @Test
     public void punchBindIpTest() {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         config.overrideParams("bind.address", "");
         long st = System.currentTimeMillis();
         InetAddress ip = config.getBindAddress();
@@ -43,7 +43,7 @@ public class SystemPropertiesTest {
 
     @Test
     public void externalIpTest() {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         config.overrideParams("public.ip", "");
         long st = System.currentTimeMillis();
         String ip = config.getPublicIp();

--- a/rskj-core/src/test/java/org/ethereum/core/ABITest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ABITest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.core;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import org.ethereum.crypto.Keccak256Helper;
 import org.junit.Assert;
@@ -34,7 +34,7 @@ import org.spongycastle.util.encoders.Hex;
 public class ABITest {
 
     private static final Logger logger = LoggerFactory.getLogger("test");
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void testTransactionCreate() {

--- a/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.core;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
@@ -45,7 +45,7 @@ import java.util.HashMap;
 public class ImportLightTest {
 
     public static BlockChainImpl createBlockchain(Genesis genesis) {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         config.setBlockchainConfig(new GenesisConfig(new GenesisConfig.GenesisConstants() {
             @Override
             public BlockDifficulty getMinimumDifficulty() {

--- a/rskj-core/src/test/java/org/ethereum/core/StateTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/StateTest.java
@@ -20,7 +20,7 @@
 package org.ethereum.core;
 
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -132,7 +132,7 @@ public class StateTest {
 
     private Trie generateGenesisState() {
         Trie trie = new TrieImpl();
-        Genesis genesis = (Genesis)Genesis.getInstance(new RskSystemProperties());
+        Genesis genesis = (Genesis)Genesis.getInstance(new TestSystemProperties());
 
         for (RskAddress addr : genesis.getPremine().keySet()) {
             trie = trie.put(addr.getBytes(), genesis.getPremine().get(addr).getAccountState().getEncoded());

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.core;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.config.blockchain.GenesisConfig;
@@ -54,7 +54,7 @@ import static org.junit.Assert.assertNull;
 
 public class TransactionTest {
 
-    private RskSystemProperties config = new RskSystemProperties();
+    private TestSystemProperties config = new TestSystemProperties();
 
     @Test /* sign transaction  https://tools.ietf.org/html/rfc6979 */
     public void test1() throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeyException, IOException {

--- a/rskj-core/src/test/java/org/ethereum/core/genesis/BlockchainLoaderTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/genesis/BlockchainLoaderTest.java
@@ -19,15 +19,13 @@
 
 package org.ethereum.core.genesis;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
-import co.rsk.core.bc.BlockChainImplTest;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.trie.TrieStoreImpl;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.Constants;
-import org.ethereum.core.Blockchain;
 import org.ethereum.core.Repository;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
@@ -46,7 +44,7 @@ public class BlockchainLoaderTest {
     public void testLoadBlockchainEmptyBlockchain() throws IOException {
         String jsonFile = "blockchain_loader_genesis.json";
 
-        RskSystemProperties systemProperties = Mockito.mock(RskSystemProperties.class);
+        TestSystemProperties systemProperties = Mockito.mock(TestSystemProperties.class);
 
         Constants constants = Mockito.mock(Constants.class);
         Mockito.when(constants.getInitialNonce()).thenReturn(BigInteger.ZERO);
@@ -54,7 +52,7 @@ public class BlockchainLoaderTest {
         BlockchainNetConfig blockchainNetConfig = Mockito.mock(BlockchainNetConfig.class);
         Mockito.when(blockchainNetConfig.getCommonConstants()).thenReturn(constants);
 
-        Mockito.when(systemProperties.databaseDir()).thenReturn(new RskSystemProperties().databaseDir());
+        Mockito.when(systemProperties.databaseDir()).thenReturn(new TestSystemProperties().databaseDir());
         Mockito.when(systemProperties.getBlockchainConfig()).thenReturn(blockchainNetConfig);
         Mockito.when(systemProperties.genesisInfo()).thenReturn(jsonFile);
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.datasource;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -34,11 +34,11 @@ import static org.junit.Assert.assertNotNull;
 @Ignore
 public class LevelDbDataSourceTest {
 
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     @Before
     public void setup(){
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.db;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.db.ContractDetailsImpl;
 import org.ethereum.datasource.HashMapDB;
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertNull;
 
 public class DetailsDataStoreTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void test1(){

--- a/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.db;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
@@ -57,7 +57,7 @@ public class IndexedBlockStoreTest {
     private static final Logger logger = LoggerFactory.getLogger("test");
     private List<Block> blocks = new ArrayList<>();
     private BlockDifficulty cumDifficulty = ZERO;
-    private RskSystemProperties config;
+    private TestSystemProperties config;
 
     @Before
     public void setup() throws URISyntaxException, IOException {
@@ -67,7 +67,7 @@ public class IndexedBlockStoreTest {
 
         File file = new File(scenario1.toURI());
         List<String> strData = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         Block genesis = Genesis.getInstance(config);
         blocks.add(genesis);
         cumDifficulty = cumDifficulty.add(genesis.getCumulativeDifficulty());

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.config.net.MainNetConfig;
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 @Ignore
 public class GitHubBasicTest {
 
-    private static RskSystemProperties config = new RskSystemProperties();
+    private static TestSystemProperties config = new TestSystemProperties();
     private static final Logger logger = LoggerFactory.getLogger("TCK-Test");
     private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config);
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBlockTest.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBlockTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.config.net.MainNetConfig;
 import org.json.simple.parser.ParseException;
@@ -41,7 +41,7 @@ public class GitHubBlockTest {
     @Ignore // test for conveniently running a single test
     @Test
     public void runSingleTest() throws ParseException, IOException {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         config.setGenesisInfo("frontier.json");
         config.setBlockchainConfig(new GenesisConfig());
 
@@ -56,7 +56,7 @@ public class GitHubBlockTest {
 
     private void runHomestead(String name) throws IOException, ParseException {
         String json = JSONReader.loadJSONFromCommit("BlockchainTests/Homestead/" + name + ".json", shacommit);
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         config.setBlockchainConfig(new GenesisConfig());
         try {
             GitHubJSONTestSuite.runGitHubJsonBlockTest(json, Collections.EMPTY_SET);
@@ -100,7 +100,7 @@ public class GitHubBlockTest {
     @Ignore
     @Test
     public void runBCValidBlockTest() throws ParseException, IOException {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         config.setGenesisInfo("frontier.json");
         run("bcValidBlockTest", true, true);
     }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubStateTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.config.blockchain.GenesisConfig;
 import org.ethereum.config.net.AbstractNetConfig;
 import org.json.simple.parser.ParseException;
@@ -43,13 +43,13 @@ public class GitHubStateTest {
 
 
     private long oldForkValue;
-    private static RskSystemProperties config;
+    private static TestSystemProperties config;
 
     @BeforeClass
     public void setup() {
         // TODO remove this after Homestead launch and shacommit update with actual block number
         // for this JSON test commit the Homestead block was defined as 900000
-        config = new RskSystemProperties();
+        config = new TestSystemProperties();
         config.setBlockchainConfig(new AbstractNetConfig() {{
             add(0, new GenesisConfig());
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/JSONReader.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/JSONReader.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.apache.commons.codec.binary.Base64;
 import org.h2.util.IOUtils;
 import org.json.simple.JSONArray;
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class JSONReader {
 
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
 
     public static String loadJSON(String filename) {

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.mock;
  */
 public class TestRunner {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
     private Logger logger = LoggerFactory.getLogger("TCK-Test");

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/AccountBuilder.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/AccountBuilder.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite.builder;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.db.ContractDetailsImpl;
 import org.ethereum.core.AccountState;
@@ -38,7 +38,7 @@ public class AccountBuilder {
 
     public static StateWrap build(AccountTck account) {
 
-        ContractDetailsImpl details = new ContractDetailsImpl(new RskSystemProperties());
+        ContractDetailsImpl details = new ContractDetailsImpl(new TestSystemProperties());
         details.setCode(parseData(account.getCode()));
         details.setStorage(convertStorage(account.getStorage()));
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/RepositoryBuilder.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/RepositoryBuilder.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite.builder;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.trie.TrieStoreImpl;
@@ -56,7 +56,7 @@ public class RepositoryBuilder {
             detailsBatch.put(addr, detailsCache);
         }
 
-        RepositoryImpl repositoryDummy = new RepositoryImpl(new RskSystemProperties(), new TrieStoreImpl(new HashMapDB()));
+        RepositoryImpl repositoryDummy = new RepositoryImpl(new TestSystemProperties(), new TrieStoreImpl(new HashMapDB()));
         Repository track = repositoryDummy.startTracking();
         track.updateBatch(stateBatch, detailsBatch);
         track.commit();

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite.runners;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
 import org.ethereum.core.Block;
@@ -51,7 +51,7 @@ import java.util.List;
 public class StateTestRunner {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     public static List<String> run(StateTestCase stateTestCase2) {
         return new StateTestRunner(stateTestCase2).runImpl();

--- a/rskj-core/src/test/java/org/ethereum/net/TransactionsMessageTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/TransactionsMessageTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.net;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class TransactionsMessageTest {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     /* TRANSACTIONS */
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
@@ -19,10 +19,9 @@
 package org.ethereum.rpc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.test.World;
-import co.rsk.test.builders.BlockBuilder;
 import org.ethereum.core.Block;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,7 +30,7 @@ import org.junit.Test;
  * Created by ajlopez on 17/01/2018.
  */
 public class LogFilterTest {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void noEvents() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -18,7 +18,7 @@
 
 package org.ethereum.rpc;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
@@ -84,7 +84,7 @@ public class Web3ImplLogsTest {
     private final static String GET_VALUED_EVENT_SIGNATURE = "1ee041944547858a75ebef916083b6d4f5ae04bea9cd809334469dd07dbf441b";
     private final static String INCREMENT_METHOD_SIGNATURE = "371303c0";
     private final static String GET_VALUE_METHOD_SIGNATURE = "20965255";
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
 
     //20965255 getValue()
     //371303c0 inc()
@@ -779,11 +779,11 @@ public class Web3ImplLogsTest {
         return web3;
     }
 
-    public static World getWorld3WithBlockWithEventInContractCreation(RskSystemProperties config) {
+    public static World getWorld3WithBlockWithEventInContractCreation(TestSystemProperties config) {
         return getWorld3WithBlockWithEventInContractCreation(config, null);
     }
 
-    public static World getWorld3WithBlockWithEventInContractCreation(RskSystemProperties config, ReceiptStore receiptStore) {
+    public static World getWorld3WithBlockWithEventInContractCreation(TestSystemProperties config, ReceiptStore receiptStore) {
         World world = new World(receiptStore);
         Account acc1 = new AccountBuilder(world).name("notDefault").balance(Coin.valueOf(10000000)).build();
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -18,7 +18,7 @@
 
 package org.ethereum.rpc;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.net.NodeID;
@@ -355,7 +355,7 @@ public class Web3ImplScoringTest {
         rsk.blockchain = world.getBlockChain();
 
         Wallet wallet = WalletFactory.createWallet();
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         PersonalModule pm = new PersonalModuleWalletEnabled(config, rsk, wallet, null);
         EthModule em = new EthModule(config, world.getBlockChain(), null, new ExecutionBlockRetriever(world.getBlockChain(), null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, rsk, wallet, null));
         TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -20,7 +20,7 @@ package org.ethereum.rpc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.ConfigUtils;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.bc.BlockChainStatus;
 import co.rsk.mine.*;
@@ -44,7 +44,7 @@ import java.util.List;
  */
 public class Web3ImplSnapshotTest {
 
-    private static final RskSystemProperties config = new RskSystemProperties();
+    private static final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void takeFirstSnapshot() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -19,6 +19,7 @@
 package org.ethereum.rpc;
 
 import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.*;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.TransactionPoolImpl;
@@ -78,7 +79,7 @@ import java.util.stream.Collectors;
  */
 public class Web3ImplTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     Wallet wallet;
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -1,7 +1,7 @@
 package org.ethereum.util;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainImpl;
@@ -106,9 +106,9 @@ public class ContractRunner {
 
     private TransactionExecutor executeTransaction(Transaction transaction) {
         Repository track = repository.startTracking();
-        TransactionExecutor executor = new TransactionExecutor(new RskSystemProperties(), transaction, 0, RskAddress.nullAddress(),
-                repository, blockStore, receiptStore,
-                new ProgramInvokeFactoryImpl(), blockchain.getBestBlock());
+        TransactionExecutor executor = new TransactionExecutor(new TestSystemProperties(), transaction, 0, RskAddress.nullAddress(),
+                                                               repository, blockStore, receiptStore,
+                                                               new ProgramInvokeFactoryImpl(), blockchain.getBestBlock());
         executor.init();
         executor.execute();
         executor.go();

--- a/rskj-core/src/test/java/org/ethereum/util/RskTestFactory.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RskTestFactory.java
@@ -1,7 +1,7 @@
 package org.ethereum.util;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.ReversibleTransactionExecutor;
 import co.rsk.core.RskAddress;
@@ -31,7 +31,7 @@ import java.util.HashMap;
  * tests yet.
  */
 public class RskTestFactory {
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private BlockChainImpl blockchain;
     private IndexedBlockStore blockStore;
     private TransactionPool transactionPool;

--- a/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
@@ -18,7 +18,7 @@
 
 package org.ethereum.validator;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.RskAddress;
 import org.ethereum.core.BlockHeader;
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
  * @since 02.23.2016
  */
 public class DifficultyRuleTest {
-    private final DifficultyRule rule = new DifficultyRule(new DifficultyCalculator(new RskSystemProperties()));
+    private final DifficultyRule rule = new DifficultyRule(new DifficultyCalculator(new TestSystemProperties()));
 
     @Ignore
     @Test // pass rule

--- a/rskj-core/src/test/java/org/ethereum/validator/ProofOfWorkRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/ProofOfWorkRuleTest.java
@@ -22,7 +22,7 @@ package org.ethereum.validator;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.blockchain.utils.BlockMiner;
 import co.rsk.config.RskMiningConstants;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.crypto.Keccak256;
 import co.rsk.mine.MinerUtils;
 import co.rsk.util.DifficultyUtils;
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ProofOfWorkRuleTest {
 
-    private ProofOfWorkRule rule = new ProofOfWorkRule(new RskSystemProperties()).setFallbackMiningEnabled(false);
+    private ProofOfWorkRule rule = new ProofOfWorkRule(new TestSystemProperties()).setFallbackMiningEnabled(false);
 
     @Test
     public void test_1() {

--- a/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.util.BIUtil;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts.PrecompiledContract;
@@ -37,7 +37,7 @@ import static org.junit.Assert.*;
 public class PrecompiledContractTest {
 
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.config.BlockchainConfig;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.program.Program;
@@ -39,7 +39,7 @@ public class ProgramMemoryTest {
 
     @Before
     public void createProgram() {
-        RskSystemProperties config = new RskSystemProperties();
+        TestSystemProperties config = new TestSystemProperties();
         program = new Program(config.getVmConfig(), new PrecompiledContracts(config), mock(BlockchainConfig.class), ByteUtil.EMPTY_BYTE_ARRAY, pi, null);
     }
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.mock;
 public class VMComplexTest {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class VMCustomTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
     private ProgramInvokeMockImpl invoke;

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -20,7 +20,7 @@
 package org.ethereum.vm;
 
 import co.rsk.asm.EVMAssembler;
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
 import org.ethereum.config.BlockchainConfig;
@@ -51,7 +51,7 @@ public class VMTest {
 
     private ProgramInvokeMockImpl invoke;
     private Program program;
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMUtilsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMUtilsTest.java
@@ -1,6 +1,6 @@
 package org.ethereum.vm;
 
-import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
 import org.ethereum.vm.trace.ProgramTrace;
 import org.ethereum.vm.trace.Serializers;
 import org.junit.Assert;
@@ -18,7 +18,7 @@ import static org.hamcrest.core.Is.is;
 
 public class VMUtilsTest {
 
-    private final RskSystemProperties config = new RskSystemProperties();
+    private final TestSystemProperties config = new TestSystemProperties();
     @Rule
     public TemporaryFolder tempRule = new TemporaryFolder();
 

--- a/rskj-core/src/test/resources/test-rskj.conf
+++ b/rskj-core/src/test/resources/test-rskj.conf
@@ -147,6 +147,9 @@ vm.structured.trace = false
 vm.structured.dir = vmtrace
 vm.structured.storage.dictionary.enabled = false
 
+miner.client.enabled = false
+miner.server.enabled = false
+
 # eth sync process
 sync {
 


### PR DESCRIPTION
**TL;DR;** we can now do this:

* Launch mainnet: `java -cp path/to/node.jar co.rsk.Start`
* Launch testnet: `java -cp path/to/node.jar -Dblockchain.config.name=testnet co.rsk.Start`
* Launch regtest: `java -cp path/to/node.jar -Dblockchain.config.name=regtest co.rsk.Start`

### Details

* Adds a `reference.conf` file, with shared configuration for all networks
* Adds `config/[network].conf`, one per network, with defaults that work out of the box
* The node joins mainnet by default
* A different network can be chosen with just a system property (e.g. `java -cp path/to/jar -Dblockchain.config.name=testnet`, to be improved in a future PR)
* By default, the database dir is now `$HOME/.rsk/[network]/database`
* All configuration options can be overrode:
  * Providing a path to a config file with overrides (`-Drsk.conf.file path/to/file.conf`)
  * Through explicit system properties (`-Drpc.enabled=false`), which in turn take precedence over any other configuration

Improvements in the base configuration files (secure defaults, sane defaults, better documentation) are also scheduled for a future PR (@herrerameri you'll have to help me with that!)