### PR TITLE
Remove JsonSimple from compile dependencies

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -141,15 +141,13 @@ dependencies {
     compile "org.mapdb:mapdb:2.0-beta13"
     compile "co.rsk.bitcoinj:bitcoinj-thin:${bitcoinjVersion}"
     compile 'com.github.briandilley.jsonrpc4j:jsonrpc4j:1.5.1'
-    compile("com.googlecode.json-simple:json-simple:1.1.1") {
-        exclude group: 'junit', module: 'junit'
-    }
 
     runtime "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     runtime "org.slf4j:log4j-over-slf4j:${slf4jVersion}"
     runtime "ch.qos.logback:logback-classic:${logbackVersion}"
     runtime "ch.qos.logback:logback-core:${logbackVersion}"
 
+    testCompile "com.googlecode.json-simple:json-simple:1.1.1"
     testCompile "junit:junit:${junitVersion}"
     testCompile "org.springframework:spring-test:${springVersion}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"

--- a/rskj-core/src/main/java/co/rsk/config/RemascConfigFactory.java
+++ b/rskj-core/src/main/java/co/rsk/config/RemascConfigFactory.java
@@ -19,14 +19,12 @@
 package co.rsk.config;
 
 import co.rsk.remasc.RemascException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
-import java.io.InputStreamReader;
 
 /**
  * Created by mario on 12/12/16.
@@ -45,14 +43,9 @@ public class RemascConfigFactory {
     public RemascConfig createRemascConfig(String config) {
         RemascConfig remascConfig;
 
-        try (InputStream is = RemascConfigFactory.class.getClassLoader()
-                .getResourceAsStream(this.configPath); InputStreamReader fileReader = new InputStreamReader(is)){
-
-            JSONParser parser = new JSONParser();
-            JSONObject jsonObject = (JSONObject) parser.parse(fileReader);
-            JSONObject jsonConfig = (JSONObject) jsonObject.get(config);
-            String remascString = jsonConfig.toString();
-            remascConfig = mapper.readValue(remascString, RemascConfig.class);
+        try (InputStream is = RemascConfigFactory.class.getClassLoader().getResourceAsStream(this.configPath)){
+            JsonNode node = mapper.readTree(is);
+            remascConfig = mapper.treeToValue(node.get(config), RemascConfig.class);
         } catch (Exception ex) {
             logger.error("Error reading REMASC configuration[{}]: {}", config, ex);
             throw new RemascException("Error reading REMASC configuration[" + config +"]: ", ex);


### PR DESCRIPTION
This uses Jackson for the only production code usage of JsonSimple that we had, and leaves the dependency for tests only.