### PR TITLE
Honor bind address in PeerServerImpl

### DIFF
--- a/rskj-core/src/main/java/co/rsk/DoPrune.java
+++ b/rskj-core/src/main/java/co/rsk/DoPrune.java
@@ -132,7 +132,6 @@ public class DoPrune {
 
     public void stop() {
         logger.info("Shutting down RSK node");
-        rsk.close();
     }
 
     private static String getDataSourceName(RskAddress contractAddress) {

--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -33,12 +33,13 @@ import co.rsk.net.MessageHandler;
 import co.rsk.net.Metrics;
 import co.rsk.net.discovery.UDPServer;
 import co.rsk.net.handler.TxHandler;
+import co.rsk.rpc.netty.Web3HttpServer;
 import org.ethereum.cli.CLIInterface;
 import org.ethereum.config.DefaultConfig;
 import org.ethereum.core.*;
 import org.ethereum.net.eth.EthVersion;
 import org.ethereum.net.server.ChannelManager;
-import co.rsk.rpc.netty.Web3HttpServer;
+import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.Web3;
 import org.ethereum.sync.SyncPool;
 import org.ethereum.util.BuildInfo;
@@ -72,6 +73,7 @@ public class Start {
     private final Web3 web3Service;
     private final BlockProcessor nodeBlockProcessor;
     private final TransactionPool transactionPool;
+    private final PeerServer peerServer;
     private final SyncPool.PeerClientFactory peerClientFactory;
 
     public static void main(String[] args) throws Exception {
@@ -97,6 +99,7 @@ public class Start {
                  TxHandler txHandler,
                  BlockProcessor nodeBlockProcessor,
                  TransactionPool transactionPool,
+                 PeerServer peerServer,
                  SyncPool.PeerClientFactory peerClientFactory) {
         this.rsk = rsk;
         this.udpServer = udpServer;
@@ -113,6 +116,7 @@ public class Start {
         this.txHandler = txHandler;
         this.nodeBlockProcessor = nodeBlockProcessor;
         this.transactionPool = transactionPool;
+        this.peerServer = peerServer;
         this.peerClientFactory = peerClientFactory;
     }
 
@@ -127,8 +131,8 @@ public class Start {
         transactionPool.start(blockchain.getBestBlock());
         channelManager.start();
         messageHandler.start();
+        peerServer.start();
 
-        rsk.init();
         if (logger.isInfoEnabled()) {
             String versions = EthVersion.supported().stream().map(EthVersion::name).collect(Collectors.joining(", "));
             logger.info("Capability eth version: [{}]", versions);
@@ -213,7 +217,7 @@ public class Start {
         if (rskSystemProperties.isRpcEnabled()) {
             web3Service.stop();
         }
-        rsk.close();
+        peerServer.stop();
         messageHandler.stop();
         channelManager.stop();
     }

--- a/rskj-core/src/main/java/co/rsk/core/RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskImpl.java
@@ -48,7 +48,6 @@ public class RskImpl extends EthereumImpl implements Rsk {
         super(
                 config,
                 channelManager,
-                peerServer,
                 transactionPool,
                 compositeEthereumListener,
                 blockchain

--- a/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -26,7 +26,6 @@ import org.ethereum.core.Transaction;
 import org.ethereum.listener.EthereumListener;
 
 import java.math.BigInteger;
-import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -40,8 +39,6 @@ public interface Ethereum {
     void removeListener(EthereumListener listener);
 
     ImportResult addNewMinedBlock(Block block);
-
-    void close();
 
     /**
      * Factory for general transaction
@@ -71,8 +68,6 @@ public interface Ethereum {
      *                    return this transaction as approved
      */
     Future<Transaction> submitTransaction(Transaction transaction);
-
-    void init();
 
     /**
      * Calculates a 'reasonable' Gas price based on statistics of the latest transaction's Gas prices

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -72,6 +72,8 @@ public class EthereumImpl implements Ethereum {
         this.config = config;
         this.compositeEthereumListener = compositeEthereumListener;
         this.blockchain = blockchain;
+
+        compositeEthereumListener.addListener(gasPriceTracker);
     }
 
     @Override
@@ -86,7 +88,6 @@ public class EthereumImpl implements Ethereum {
             });
             peerServiceExecutor.execute(() -> peerServer.start(config.getBindAddress(), config.getPeerPort()));
         }
-        compositeEthereumListener.addListener(gasPriceTracker);
 
         gLogger.info("RskJ node started: enode://{}@{}:{}" , Hex.toHexString(config.nodeId()), config.getPublicIp(), config.getPeerPort());
     }

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -27,7 +27,6 @@ import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.listener.GasPriceTracker;
 import org.ethereum.net.server.ChannelManager;
-import org.ethereum.net.server.PeerServer;
 import org.ethereum.net.submit.TransactionExecutor;
 import org.ethereum.net.submit.TransactionTask;
 import org.ethereum.util.ByteUtil;
@@ -42,7 +41,6 @@ import java.util.concurrent.Future;
 public class EthereumImpl implements Ethereum {
 
     private final ChannelManager channelManager;
-    private final PeerServer peerServer;
     private final TransactionPool transactionPool;
     private final RskSystemProperties config;
     private final CompositeEthereumListener compositeEthereumListener;
@@ -53,12 +51,10 @@ public class EthereumImpl implements Ethereum {
     public EthereumImpl(
             RskSystemProperties config,
             ChannelManager channelManager,
-            PeerServer peerServer,
             TransactionPool transactionPool,
             CompositeEthereumListener compositeEthereumListener,
             Blockchain blockchain) {
         this.channelManager = channelManager;
-        this.peerServer = peerServer;
         this.transactionPool = transactionPool;
 
         this.config = config;
@@ -66,11 +62,6 @@ public class EthereumImpl implements Ethereum {
         this.blockchain = blockchain;
 
         compositeEthereumListener.addListener(gasPriceTracker);
-    }
-
-    @Override
-    public void init() {
-        peerServer.start();
     }
 
     @Override
@@ -91,11 +82,6 @@ public class EthereumImpl implements Ethereum {
     @Override
     public void removeListener(EthereumListener listener) {
         compositeEthereumListener.removeListener(listener);
-    }
-
-    @Override
-    public void close() {
-        peerServer.stop();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -31,22 +31,15 @@ import org.ethereum.net.server.PeerServer;
 import org.ethereum.net.submit.TransactionExecutor;
 import org.ethereum.net.submit.TransactionTask;
 import org.ethereum.util.ByteUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.spongycastle.util.encoders.Hex;
 import org.springframework.util.concurrent.FutureAdapter;
 
 import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 public class EthereumImpl implements Ethereum {
-
-    private static final Logger gLogger = LoggerFactory.getLogger("general");
 
     private final ChannelManager channelManager;
     private final PeerServer peerServer;
@@ -56,7 +49,6 @@ public class EthereumImpl implements Ethereum {
     private final Blockchain blockchain;
 
     private GasPriceTracker gasPriceTracker = new GasPriceTracker();
-    private ExecutorService peerServiceExecutor;
 
     public EthereumImpl(
             RskSystemProperties config,
@@ -78,18 +70,7 @@ public class EthereumImpl implements Ethereum {
 
     @Override
     public void init() {
-        if (config.getPeerPort() > 0) {
-            peerServiceExecutor = Executors.newSingleThreadExecutor(runnable -> {
-                Thread thread = new Thread(runnable, "Peer Server");
-                thread.setUncaughtExceptionHandler((exceptionThread, exception) ->
-                    gLogger.error("Unable to start peer server", exception)
-                );
-                return thread;
-            });
-            peerServiceExecutor.execute(() -> peerServer.start(config.getBindAddress(), config.getPeerPort()));
-        }
-
-        gLogger.info("RskJ node started: enode://{}@{}:{}" , Hex.toHexString(config.nodeId()), config.getPublicIp(), config.getPeerPort());
+        peerServer.start();
     }
 
     @Override
@@ -114,9 +95,7 @@ public class EthereumImpl implements Ethereum {
 
     @Override
     public void close() {
-        if (peerServiceExecutor != null) {
-            peerServiceExecutor.shutdown();
-        }
+        peerServer.stop();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/net/server/PeerServer.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/PeerServer.java
@@ -19,8 +19,6 @@
 
 package org.ethereum.net.server;
 
-import java.net.InetAddress;
-
 /**
  * This class establishes a listener for incoming connections.
  * See <a href="http://netty.io">http://netty.io</a>.
@@ -31,7 +29,9 @@ import java.net.InetAddress;
 
 public interface PeerServer {
 
-    void start(InetAddress host, int port);
+    void start();
+
+    void stop();
 
     boolean isListening();
 }

--- a/rskj-core/src/main/java/org/ethereum/net/server/PeerServerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/PeerServerImpl.java
@@ -109,10 +109,10 @@ public class PeerServerImpl implements PeerServer {
             b.childHandler(ethereumChannelInitializer);
 
             // Start the client.
-            logger.info("Listening for incoming connections, port: [{}] ", port);
+            logger.info("Listening for incoming connections, host: {}, port: [{}] ", host, port);
             logger.info("NodeId: [{}] ", Hex.toHexString(config.nodeId()));
 
-            ChannelFuture f = b.bind(port).sync();
+            ChannelFuture f = b.bind(host, port).sync();
 
             // Wait until the connection is closed.
             f.channel().closeFuture().sync();

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -30,6 +30,7 @@ import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
+import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.rpc.Simples.SimpleEthereum;
 import org.junit.Assert;
 import org.junit.Test;
@@ -358,7 +359,7 @@ public class MinerManagerTest {
     private static class RskImplForTest extends RskImpl {
         public RskImplForTest() {
             super(null, null, null, null,
-                  null, null, null, null);
+                  new CompositeEthereumListener(), null, null, null);
         }
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
@@ -24,12 +24,9 @@ import org.ethereum.facade.Ethereum;
 import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.listener.GasPriceTracker;
-import org.ethereum.rpc.Web3;
-import org.ethereum.vm.program.ProgramResult;
 
 import javax.annotation.Nonnull;
 import java.math.BigInteger;
-import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -64,11 +61,6 @@ public class SimpleEthereum implements Ethereum {
     }
 
     @Override
-    public void close() {
-
-    }
-
-    @Override
     public ImportResult addNewMinedBlock(final @Nonnull Block block) {
         final ImportResult importResult = blockchain.tryToConnect(block);
 
@@ -88,11 +80,6 @@ public class SimpleEthereum implements Ethereum {
 
     public Repository getRepository() {
         return repository;
-    }
-
-    @Override
-    public void init() {
-
     }
 
     @Override

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimplePeerServer.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimplePeerServer.java
@@ -29,10 +29,15 @@ public class SimplePeerServer implements PeerServer {
 
     public boolean isListening = false;
 
-    public void start(InetAddress host, int port) {
+    @Override
+    public void start() {
 
     }
 
+    @Override
+    public void stop() {
+
+    }
 
     public boolean isListening() {
         return isListening;


### PR DESCRIPTION
As I was working on understanding the `PeerServerImpl`'s code, I discovered it wasn't honoring the `host` parameter (which is the `bind.address` configuration).

This PR:

* Fixes the bind address bug
* Moves the responsibility of starting the `PeerServer` to the `PeerServerImpl` class