### PR TITLE
Allowing contract method calls with explicit block numbers

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
@@ -22,6 +22,7 @@ import co.rsk.mine.BlockToMineBuilder;
 import co.rsk.mine.MinerServer;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
+import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
 import org.ethereum.rpc.exception.JsonRpcUnimplementedMethodException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -69,6 +70,21 @@ public class ExecutionBlockRetriever {
             }
 
             return cachedBlock;
+        }
+
+        if (bnOrId.startsWith("0x")) {
+            long executionBlockNumber;
+            try {
+                executionBlockNumber = Long.parseLong(bnOrId.substring(2), 16);
+            } catch (NumberFormatException e) {
+                throw new JsonRpcInvalidParamException(String.format("Not a number: %s", bnOrId), e);
+            }
+
+            Block executionBlock = blockchain.getBlockByNumber(executionBlockNumber);
+            if (executionBlock == null) {
+                throw new JsonRpcInvalidParamException(String.format("Invalid block number %d", executionBlockNumber));
+            }
+            return executionBlock;
         }
 
         throw new JsonRpcUnimplementedMethodException("Method only supports 'latest' and 'pending' as parameters so far.");

--- a/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
@@ -23,7 +23,7 @@ import co.rsk.mine.MinerServer;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
 import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
-import org.ethereum.rpc.exception.JsonRpcUnimplementedMethodException;
+import org.ethereum.util.Utils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -72,21 +72,27 @@ public class ExecutionBlockRetriever {
             return cachedBlock;
         }
 
-        if (bnOrId.startsWith("0x")) {
-            long executionBlockNumber;
-            try {
-                executionBlockNumber = Long.parseLong(bnOrId.substring(2), 16);
-            } catch (NumberFormatException e) {
-                throw new JsonRpcInvalidParamException(String.format("Not a number: %s", bnOrId), e);
-            }
+        // Is the block specifier either a hexadecimal or decimal number?
+        Optional<Long> executionBlockNumber = Optional.empty();
 
-            Block executionBlock = blockchain.getBlockByNumber(executionBlockNumber);
+        if (Utils.isHexadecimalString(bnOrId)) {
+            executionBlockNumber = Optional.of(Utils.hexadecimalStringToLong(bnOrId));
+        } else if (Utils.isDecimalString(bnOrId)) {
+            executionBlockNumber = Optional.of(Utils.decimalStringToLong(bnOrId));
+        }
+
+        if (executionBlockNumber.isPresent()) {
+            Block executionBlock = blockchain.getBlockByNumber(executionBlockNumber.get());
             if (executionBlock == null) {
-                throw new JsonRpcInvalidParamException(String.format("Invalid block number %d", executionBlockNumber));
+                throw new JsonRpcInvalidParamException(String.format("Invalid block number %d", executionBlockNumber.get()));
             }
             return executionBlock;
         }
 
-        throw new JsonRpcUnimplementedMethodException("Method only supports 'latest' and 'pending' as parameters so far.");
+        // If we got here, the specifier given is unsupported
+        throw new JsonRpcInvalidParamException(String.format(
+                "Unsupported block specifier '%s'. Can only be either 'latest', " +
+                "'pending' or a specific block number (either hex - prepending '0x' or decimal).",
+                bnOrId));
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/util/Utils.java
+++ b/rskj-core/src/main/java/org/ethereum/util/Utils.java
@@ -230,4 +230,33 @@ public class Utils {
         validateArrayAllegedSize(data, from, size);
         return Arrays.copyOfRange(data, from, from + size);
     }
+
+    public static boolean isDecimalString(String s) {
+        return s.matches("^\\d+$");
+    }
+
+    public static boolean isHexadecimalString(String s) {
+        return s.matches("^0x[\\da-fA-F]+$");
+    }
+
+    public static long decimalStringToLong(String s) {
+        try {
+            return Long.parseLong(s, 10);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format("Invalid decimal number: %s", s), e);
+        }
+    }
+
+    public static long hexadecimalStringToLong(String s) {
+        if (!s.startsWith("0x")) {
+            throw new IllegalArgumentException(String.format("Invalid hexadecimal number: %s", s));
+        }
+
+        try {
+            // Remove leading '0x' before parsing
+            return Long.parseLong(s.substring(2), 16);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format("Invalid hexadecimal number: %s", s), e);
+        }
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/ExecutionBlockRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/ExecutionBlockRetrieverTest.java
@@ -22,6 +22,7 @@ import co.rsk.mine.BlockToMineBuilder;
 import co.rsk.mine.MinerServer;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
+import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
 import org.ethereum.rpc.exception.JsonRpcUnimplementedMethodException;
 import org.junit.Before;
 import org.junit.Test;
@@ -154,8 +155,32 @@ public class ExecutionBlockRetrieverTest {
         assertThat(retriever.getExecutionBlock("pending"), is(builtBlock2));
     }
 
+    @Test
+    public void getByNumberBlockExists() {
+        Block myBlock = mock(Block.class);
+        when(blockchain.getBlockByNumber(123))
+                .thenReturn(myBlock);
+
+        assertThat(retriever.getExecutionBlock("0x7B"), is(myBlock));
+    }
+
+    @Test(expected = JsonRpcInvalidParamException.class)
+    public void getByNumberBlockDoesntExist() {
+        when(blockchain.getBlockByNumber(123))
+                .thenReturn(null);
+
+        retriever.getExecutionBlock("0x7B");
+    }
+
+    @Test(expected = JsonRpcInvalidParamException.class)
+    public void getByNumberInvalidHex() {
+        retriever.getExecutionBlock("0xzz");
+
+        verify(blockchain, never()).getBlockByNumber(any(long.class));
+    }
+
     @Test(expected = JsonRpcUnimplementedMethodException.class)
-    public void getOtherThanLatestThrows() {
+    public void getOtherThanPendingLatestOrNumberThrows() {
         retriever.getExecutionBlock("other");
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/ExecutionBlockRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/ExecutionBlockRetrieverTest.java
@@ -156,20 +156,38 @@ public class ExecutionBlockRetrieverTest {
     }
 
     @Test
-    public void getByNumberBlockExists() {
+    public void getByNumberBlockExistsHex() {
         Block myBlock = mock(Block.class);
         when(blockchain.getBlockByNumber(123))
                 .thenReturn(myBlock);
 
         assertThat(retriever.getExecutionBlock("0x7B"), is(myBlock));
+        assertThat(retriever.getExecutionBlock("0x7b"), is(myBlock));
+    }
+
+    @Test
+    public void getByNumberBlockExistsDec() {
+        Block myBlock = mock(Block.class);
+        when(blockchain.getBlockByNumber(123))
+                .thenReturn(myBlock);
+
+        assertThat(retriever.getExecutionBlock("123"), is(myBlock));
     }
 
     @Test(expected = JsonRpcInvalidParamException.class)
-    public void getByNumberBlockDoesntExist() {
+    public void getByNumberInvalidBlockNumberHex() {
         when(blockchain.getBlockByNumber(123))
                 .thenReturn(null);
 
         retriever.getExecutionBlock("0x7B");
+    }
+
+    @Test(expected = JsonRpcInvalidParamException.class)
+    public void getByNumberInvalidBlockNumberDec() {
+        when(blockchain.getBlockByNumber(123))
+                .thenReturn(null);
+
+        retriever.getExecutionBlock("123");
     }
 
     @Test(expected = JsonRpcInvalidParamException.class)
@@ -179,7 +197,14 @@ public class ExecutionBlockRetrieverTest {
         verify(blockchain, never()).getBlockByNumber(any(long.class));
     }
 
-    @Test(expected = JsonRpcUnimplementedMethodException.class)
+    @Test(expected = JsonRpcInvalidParamException.class)
+    public void getByNumberInvalidDec() {
+        retriever.getExecutionBlock("zz");
+
+        verify(blockchain, never()).getBlockByNumber(any(long.class));
+    }
+
+    @Test(expected = JsonRpcInvalidParamException.class)
     public void getOtherThanPendingLatestOrNumberThrows() {
         retriever.getExecutionBlock("other");
     }

--- a/rskj-core/src/test/java/org/ethereum/util/UtilsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/UtilsTest.java
@@ -19,6 +19,8 @@
 
 package org.ethereum.util;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.spongycastle.util.Arrays;
@@ -185,5 +187,101 @@ public class UtilsTest {
         }
         catch (IllegalArgumentException e){
         }
+    }
+
+    @Test
+    public void isHexadecimalString() {
+        String[] hexStrings = new String[] {
+                "0x1",
+                "0xaaa",
+                "0xAAA",
+                "0xAFe1",
+                "0x10",
+                "0xA12"
+        };
+        java.util.Arrays.stream(hexStrings).forEach(s -> Assert.assertTrue(s, Utils.isHexadecimalString(s)));
+
+        String[] nonHexStrings = new String[] {
+                "hellothisisnotahex",
+                "123",
+                "AAA",
+                "AFe1",
+                "0xab123z",
+                "0xnothing"
+        };
+        java.util.Arrays.stream(nonHexStrings).forEach(s -> Assert.assertFalse(s, Utils.isHexadecimalString(s)));
+    }
+
+    @Test
+    public void isDecimalString() {
+        String[] decStrings = new String[] {
+                "1",
+                "123",
+                "045670",
+                "220",
+                "0",
+                "01"
+        };
+        java.util.Arrays.stream(decStrings).forEach(s -> Assert.assertTrue(s, Utils.isDecimalString(s)));
+
+        String[] nonDecStrings = new String[] {
+                "hellothisisnotadec",
+                "123a",
+                "0b",
+                "b1",
+                "AAA",
+                "0xabcd",
+                "0x123"
+        };
+        java.util.Arrays.stream(nonDecStrings).forEach(s -> Assert.assertFalse(s, Utils.isDecimalString(s)));
+    }
+
+    @Test
+    public void decimalStringToLong() {
+        Object[] cases = new Object[] {
+                "1", 1L,
+                "123", 123L,
+                "045670", 45670L,
+                "220", 220L,
+                "0", 0L,
+                "01", 1L
+        };
+        for (int i = 0; i < cases.length/2; i++) {
+            String s = (String) cases[i*2];
+            long expected = (long) cases[i*2+1];
+            Assert.assertEquals(expected, Utils.decimalStringToLong(s));
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decimalStringToLongFail() {
+        Utils.decimalStringToLong("zzz");
+    }
+
+    @Test
+    public void hexadecimalStringToLong() {
+        Object[] cases = new Object[] {
+                "0x1", 1L,
+                "0xaaa", 2730L,
+                "0xAAA", 2730L,
+                "0xAFe1", 45025L,
+                "0x10", 16L,
+                "0xA12", 2578L
+        };
+        for (int i = 0; i < cases.length/2; i++) {
+            String s = (String) cases[i*2];
+            long expected = (long) cases[i*2+1];
+            Assert.assertEquals(expected, Utils.hexadecimalStringToLong(s));
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void hexadecimalStringToLongFail() {
+        Utils.hexadecimalStringToLong("abcd");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void hexadecimalStringToLongFailBis() {
+        Utils.hexadecimalStringToLong("zzz");
     }
 }


### PR DESCRIPTION
- Added retrieval of a block by its number on `ExecutionBlockRetriever`
- Covered cases with unit tests