### PR TITLE
Peer discovery messages has networkId 

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
@@ -53,6 +53,7 @@ public class PeerExplorer {
     private final Map<String, PeerDiscoveryRequest> pendingFindNodeRequests = new ConcurrentHashMap<>();
 
     private final Map<NodeID, Node> establishedConnections = new ConcurrentHashMap<>();
+    private final Integer networkId;
 
     private UDPChannel udpChannel;
 
@@ -70,12 +71,12 @@ public class PeerExplorer {
 
     private long requestTimeout;
 
-    public PeerExplorer(List<String> initialBootNodes, Node localNode, NodeDistanceTable distanceTable, ECKey key, long reqTimeOut, long refreshPeriod) {
+    public PeerExplorer(List<String> initialBootNodes, Node localNode, NodeDistanceTable distanceTable, ECKey key, long reqTimeOut, long refreshPeriod, Integer networkId) {
         this.localNode = localNode;
         this.key = key;
         this.distanceTable = distanceTable;
         this.updateEntryLock = new ReentrantLock();
-
+        this.networkId = networkId;
         loadInitialBootNodes(initialBootNodes);
 
         this.cleaner = new PeerExplorerCleaner(this, refreshPeriod);
@@ -109,6 +110,12 @@ public class PeerExplorer {
 
     public void handleMessage(DiscoveryEvent event) {
         DiscoveryMessageType type = event.getMessage().getMessageType();
+        //If this is not from my network ignore it. But if the messages do not
+        //have a networkId in the message yet, then just let them through, for now.
+        if (event.getMessage().getNetworkId() != null &&
+                event.getMessage().getNetworkId() != this.networkId) {
+            return;
+        }
         if (type == DiscoveryMessageType.PING) {
             this.handlePingMessage(event.getAddressIp(), (PingPeerMessage) event.getMessage());
         }
@@ -196,7 +203,7 @@ public class PeerExplorer {
 
         InetSocketAddress localAddress = this.localNode.getAddress();
         String id = UUID.randomUUID().toString();
-        nodeMessage = PingPeerMessage.create(localAddress.getAddress().getHostAddress(), localAddress.getPort(), id, this.key);
+        nodeMessage = PingPeerMessage.create(localAddress.getAddress().getHostAddress(), localAddress.getPort(), id, this.key, this.networkId);
         udpChannel.write(new DiscoveryEvent(nodeMessage, nodeAddress));
 
         PeerDiscoveryRequest request = PeerDiscoveryRequestBuilder.builder().messageId(id)
@@ -229,7 +236,7 @@ public class PeerExplorer {
 
     public PongPeerMessage sendPong(String ip, PingPeerMessage message) {
         InetSocketAddress localAddress = this.localNode.getAddress();
-        PongPeerMessage pongPeerMessage = PongPeerMessage.create(localAddress.getHostName(), localAddress.getPort(), message.getMessageId(), this.key);
+        PongPeerMessage pongPeerMessage = PongPeerMessage.create(localAddress.getHostName(), localAddress.getPort(), message.getMessageId(), this.key, this.networkId);
         InetSocketAddress nodeAddress = new InetSocketAddress(ip, message.getPort());
         udpChannel.write(new DiscoveryEvent(pongPeerMessage, nodeAddress));
 
@@ -239,7 +246,7 @@ public class PeerExplorer {
     public FindNodePeerMessage sendFindNode(Node node) {
         InetSocketAddress nodeAddress = node.getAddress();
         String id = UUID.randomUUID().toString();
-        FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(this.key.getNodeId(), id, this.key);
+        FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(this.key.getNodeId(), id, this.key, this.networkId);
         udpChannel.write(new DiscoveryEvent(findNodePeerMessage, nodeAddress));
         PeerDiscoveryRequest request = PeerDiscoveryRequestBuilder.builder().messageId(id).relatedNode(node)
                 .message(findNodePeerMessage).address(nodeAddress).expectedResponse(DiscoveryMessageType.NEIGHBORS)
@@ -251,7 +258,7 @@ public class PeerExplorer {
 
     public NeighborsPeerMessage sendNeighbors(InetSocketAddress nodeAddress, List<Node> nodes, String id) {
         List<Node> nodesToSend = getRandomizeLimitedList(nodes, MAX_NODES_PER_MSG, 5);
-        NeighborsPeerMessage sendNodesMessage = NeighborsPeerMessage.create(nodesToSend, id, this.key);
+        NeighborsPeerMessage sendNodesMessage = NeighborsPeerMessage.create(nodesToSend, id, this.key, networkId);
         udpChannel.write(new DiscoveryEvent(sendNodesMessage, nodeAddress));
         logger.debug(" [{}] Neighbors Sent to ip:[{}] port:[{}]", nodesToSend.size(), nodeAddress.getAddress().getHostAddress(), nodeAddress.getPort());
 

--- a/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
@@ -53,7 +53,7 @@ public class PeerExplorer {
     private final Map<String, PeerDiscoveryRequest> pendingFindNodeRequests = new ConcurrentHashMap<>();
 
     private final Map<NodeID, Node> establishedConnections = new ConcurrentHashMap<>();
-    private final Integer networkId;
+    private final OptionalInt networkId;
 
     private UDPChannel udpChannel;
 
@@ -71,7 +71,7 @@ public class PeerExplorer {
 
     private long requestTimeout;
 
-    public PeerExplorer(List<String> initialBootNodes, Node localNode, NodeDistanceTable distanceTable, ECKey key, long reqTimeOut, long refreshPeriod, Integer networkId) {
+    public PeerExplorer(List<String> initialBootNodes, Node localNode, NodeDistanceTable distanceTable, ECKey key, long reqTimeOut, long refreshPeriod, OptionalInt networkId) {
         this.localNode = localNode;
         this.key = key;
         this.distanceTable = distanceTable;
@@ -112,8 +112,8 @@ public class PeerExplorer {
         DiscoveryMessageType type = event.getMessage().getMessageType();
         //If this is not from my network ignore it. But if the messages do not
         //have a networkId in the message yet, then just let them through, for now.
-        if (event.getMessage().getNetworkId() != null &&
-                event.getMessage().getNetworkId() != this.networkId) {
+        if (event.getMessage().getNetworkId().isPresent() &&
+                event.getMessage().getNetworkId().getAsInt() != this.networkId.getAsInt()) {
             return;
         }
         if (type == DiscoveryMessageType.PING) {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/FindNodePeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/FindNodePeerMessage.java
@@ -20,16 +20,14 @@ package co.rsk.net.discovery.message;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.ethereum.crypto.ECKey;
-import org.ethereum.util.ByteUtil;
-import org.ethereum.util.RLP;
-import org.ethereum.util.RLPItem;
-import org.ethereum.util.RLPList;
+import org.ethereum.util.*;
 import org.spongycastle.util.encoders.Hex;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.OptionalInt;
 
-import static org.ethereum.util.ByteUtil.longToBytes;
+import static org.ethereum.util.ByteUtil.intToBytes;
 import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
 
 /**
@@ -48,7 +46,7 @@ public class FindNodePeerMessage extends PeerDiscoveryMessage {
     private FindNodePeerMessage() {
     }
 
-    public static FindNodePeerMessage create(byte[] nodeId, String check, ECKey privKey, Integer networkId) {
+    public static FindNodePeerMessage create(byte[] nodeId, String check, ECKey privKey, OptionalInt networkId) {
 
         /* RLP Encode data */
         byte[] rlpCheck = RLP.encodeElement(check.getBytes(StandardCharsets.UTF_8));
@@ -57,8 +55,8 @@ public class FindNodePeerMessage extends PeerDiscoveryMessage {
         byte[] type = new byte[]{(byte) DiscoveryMessageType.FIND_NODE.getTypeValue()};
 
         byte[] data;
-        if (networkId != null) {
-            byte[] rlpNetworkId = RLP.encodeElement(stripLeadingZeroes(longToBytes(networkId)));
+        if (networkId.isPresent()) {
+            byte[] rlpNetworkId = RLP.encodeElement(stripLeadingZeroes(intToBytes(networkId.getAsInt())));
             data = RLP.encodeList(rlpNodeId, rlpCheck, rlpNetworkId);
         } else {
             data = RLP.encodeList(rlpNodeId, rlpCheck);
@@ -85,9 +83,7 @@ public class FindNodePeerMessage extends PeerDiscoveryMessage {
 
         this.nodeId = nodeRlp.getRLPData();
 
-        if (dataList.get(2) != null) {
-            this.setNetworkId(ByteUtil.byteArrayToInt(dataList.get(2).getRLPData()));
-        }
+        this.setNetworkIdWithRLP(dataList.get(2));
     }
 
 

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/NeighborsPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/NeighborsPeerMessage.java
@@ -31,7 +31,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 
+import static org.ethereum.util.ByteUtil.intToBytes;
 import static org.ethereum.util.ByteUtil.longToBytes;
 import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
 
@@ -67,12 +69,10 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
 
         this.messageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
 
-        if (list.get(2) != null) {
-            this.setNetworkId(ByteUtil.byteArrayToInt(list.get(2).getRLPData()));
-        }
+        this.setNetworkIdWithRLP(list.get(2));
     }
 
-    public static NeighborsPeerMessage create(List<Node> nodes, String check, ECKey privKey, Integer networkId) {
+    public static NeighborsPeerMessage create(List<Node> nodes, String check, ECKey privKey, OptionalInt networkId) {
         byte[][] nodeRLPs = null;
 
         if (nodes != null) {
@@ -89,8 +89,8 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
 
         byte[] type = new byte[]{(byte) DiscoveryMessageType.NEIGHBORS.getTypeValue()};
         byte[] data;
-        if (networkId != null) {
-            byte[] tmpNetworkId = longToBytes(networkId);
+        if (networkId.isPresent()) {
+            byte[] tmpNetworkId = intToBytes(networkId.getAsInt());
             byte[] rlpNetworkId = RLP.encodeElement(stripLeadingZeroes(tmpNetworkId));
             data = RLP.encodeList(rlpListNodes, rlpCheck, rlpNetworkId);
         } else {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/NeighborsPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/NeighborsPeerMessage.java
@@ -22,6 +22,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.net.rlpx.Node;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
@@ -30,6 +31,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.ethereum.util.ByteUtil.longToBytes;
+import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
 
 /**
  * Created by mario on 16/02/17.
@@ -62,9 +66,13 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
         RLPItem chk = (RLPItem) list.get(1);
 
         this.messageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
+
+        if (list.get(2) != null) {
+            this.setNetworkId(ByteUtil.byteArrayToInt(list.get(2).getRLPData()));
+        }
     }
 
-    public static NeighborsPeerMessage create(List<Node> nodes, String check, ECKey privKey) {
+    public static NeighborsPeerMessage create(List<Node> nodes, String check, ECKey privKey, Integer networkId) {
         byte[][] nodeRLPs = null;
 
         if (nodes != null) {
@@ -80,10 +88,19 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
         byte[] rlpCheck = RLP.encodeElement(check.getBytes(StandardCharsets.UTF_8));
 
         byte[] type = new byte[]{(byte) DiscoveryMessageType.NEIGHBORS.getTypeValue()};
-        byte[] data = RLP.encodeList(rlpListNodes, rlpCheck);
+        byte[] data;
+        if (networkId != null) {
+            byte[] tmpNetworkId = longToBytes(networkId);
+            byte[] rlpNetworkId = RLP.encodeElement(stripLeadingZeroes(tmpNetworkId));
+            data = RLP.encodeList(rlpListNodes, rlpCheck, rlpNetworkId);
+        } else {
+            data = RLP.encodeList(rlpListNodes, rlpCheck);
+        }
+
 
         NeighborsPeerMessage neighborsMessage = new NeighborsPeerMessage();
         neighborsMessage.encode(type, data, privKey);
+        neighborsMessage.setNetworkId(networkId);
         neighborsMessage.nodes = nodes;
         neighborsMessage.messageId = check;
 
@@ -111,7 +128,8 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
     public String toString() {
         return new ToStringBuilder(this)
                 .append(this.nodes)
-                .append(this.messageId).toString();
+                .append(this.messageId)
+                .append(this.getNetworkId()).toString();
     }
 
 }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
@@ -18,16 +18,21 @@
 
 package co.rsk.net.discovery.message;
 
+import co.rsk.cli.OptionalizableArgument;
 import co.rsk.net.NodeID;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RLPElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.BigIntegers;
 import org.spongycastle.util.encoders.Hex;
 
 import java.security.SignatureException;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import static org.ethereum.crypto.HashUtil.keccak256;
 import static org.ethereum.util.ByteUtil.merge;
@@ -41,7 +46,7 @@ public abstract class PeerDiscoveryMessage {
     private byte[] signature;
     private byte[] type;
     private byte[] data;
-    private Integer networkId;
+    private OptionalInt networkId;
 
     public PeerDiscoveryMessage() {}
 
@@ -112,12 +117,20 @@ public abstract class PeerDiscoveryMessage {
         return outKey;
     }
 
-    public Integer getNetworkId() {
+    public OptionalInt getNetworkId() {
         return this.networkId;
     }
 
-    protected void setNetworkId(final Integer networkId) {
+    protected void setNetworkId(final OptionalInt networkId) {
         this.networkId = networkId;
+    }
+
+    protected void setNetworkIdWithRLP(final RLPElement networkId) {
+        Integer setValue = null;
+        if (networkId != null) {
+            setValue = ByteUtil.byteArrayToInt(networkId.getRLPData());
+        }
+        this.setNetworkId(Optional.ofNullable(setValue).map(OptionalInt::of).orElseGet(OptionalInt::empty));
     }
 
     public NodeID getNodeId() {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
@@ -41,6 +41,7 @@ public abstract class PeerDiscoveryMessage {
     private byte[] signature;
     private byte[] type;
     private byte[] data;
+    private Integer networkId;
 
     public PeerDiscoveryMessage() {}
 
@@ -51,6 +52,7 @@ public abstract class PeerDiscoveryMessage {
         this.data = data;
         this.wire = wire;
     }
+
     public PeerDiscoveryMessage encode(byte[] type, byte[] data, ECKey privKey) {
         /* [1] Calc sha3 - prepare for sig */
         byte[] payload = new byte[type.length + data.length];
@@ -108,6 +110,14 @@ public abstract class PeerDiscoveryMessage {
         }
 
         return outKey;
+    }
+
+    public Integer getNetworkId() {
+        return this.networkId;
+    }
+
+    protected void setNetworkId(final Integer networkId) {
+        this.networkId = networkId;
     }
 
     public NodeID getNodeId() {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PingPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PingPeerMessage.java
@@ -27,7 +27,9 @@ import org.ethereum.util.RLPList;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.OptionalInt;
 
+import static org.ethereum.util.ByteUtil.intToBytes;
 import static org.ethereum.util.ByteUtil.longToBytes;
 import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
 
@@ -46,7 +48,7 @@ public class PingPeerMessage extends PeerDiscoveryMessage {
 
     private PingPeerMessage() {}
 
-    public static PingPeerMessage create(String host, int port, String check, ECKey privKey, Integer networkId) {
+    public static PingPeerMessage create(String host, int port, String check, ECKey privKey, OptionalInt networkId) {
         /* RLP Encode data */
         byte[] rlpIp = RLP.encodeElement(host.getBytes(StandardCharsets.UTF_8));
 
@@ -61,8 +63,8 @@ public class PingPeerMessage extends PeerDiscoveryMessage {
         byte[] rlpToList = RLP.encodeList(rlpIpTo, rlpPortTo, rlpPortTo);
         byte[] rlpCheck = RLP.encodeElement(check.getBytes(StandardCharsets.UTF_8));
         byte[] data;
-        if (networkId != null) {
-            byte[] tmpNetworkId = longToBytes(networkId);
+        if (networkId.isPresent()) {
+            byte[] tmpNetworkId = intToBytes(networkId.getAsInt());
             byte[] rlpNetworkID = RLP.encodeElement(stripLeadingZeroes(tmpNetworkId));
             data = RLP.encodeList(rlpFromList, rlpToList, rlpCheck, rlpNetworkID);
         } else {
@@ -93,9 +95,7 @@ public class PingPeerMessage extends PeerDiscoveryMessage {
         this.messageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
 
         //Message from nodes that do not have this
-        if (dataList.get(3) != null) {
-            this.setNetworkId(ByteUtil.byteArrayToInt(dataList.get(3).getRLPData()));
-        }
+        this.setNetworkIdWithRLP(dataList.get(3));
     }
 
     public String getMessageId() {

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -208,6 +208,7 @@ public class DefaultConfig {
     @Bean
     public PeerExplorer peerExplorer(RskSystemProperties rskConfig) {
         ECKey key = rskConfig.getMyKey();
+        Integer networkId = rskConfig.networkId();
         Node localNode = new Node(key.getNodeId(), rskConfig.getPublicIp(), rskConfig.getPeerPort());
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, localNode);
         long msgTimeOut = rskConfig.peerDiscoveryMessageTimeOut();
@@ -220,7 +221,7 @@ public class DefaultConfig {
                 initialBootNodes.add(address.getHostName() + ":" + address.getPort());
             }
         }
-        return new PeerExplorer(initialBootNodes, localNode, distanceTable, key, msgTimeOut, refreshPeriod);
+        return new PeerExplorer(initialBootNodes, localNode, distanceTable, key, msgTimeOut, refreshPeriod, networkId);
     }
 
     @Bean

--- a/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/DefaultConfig.java
@@ -56,6 +56,8 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import static org.ethereum.db.IndexedBlockStore.BLOCK_INFO_SERIALIZER;
 
@@ -208,7 +210,7 @@ public class DefaultConfig {
     @Bean
     public PeerExplorer peerExplorer(RskSystemProperties rskConfig) {
         ECKey key = rskConfig.getMyKey();
-        Integer networkId = rskConfig.networkId();
+        OptionalInt networkId = Optional.ofNullable(rskConfig.networkId()).map(OptionalInt::of).orElseGet(OptionalInt::empty);
         Node localNode = new Node(key.getNodeId(), rskConfig.getPublicIp(), rskConfig.getPeerPort());
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, localNode);
         long msgTimeOut = rskConfig.peerDiscoveryMessageTimeOut();

--- a/rskj-core/src/test/java/co/rsk/net/discovery/NodeChallengeManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/NodeChallengeManagerTest.java
@@ -38,6 +38,7 @@ public class NodeChallengeManagerTest {
     private static final String KEY_1 = "bd1d20e480dfb1c9c07ba0bc8cf9052f89923d38b5128c5dbfc18d4eea38261f";
     private static final String HOST_1 = "localhost";
     private static final int PORT_1 = 44035;
+    private static final int NETWORK_ID = 1;
 
     private static final String KEY_2 = "bd2d20e480dfb1c9c07ba0bc8cf9052f89923d38b5128c5dbfc18d4eea38262f";
     private static final String HOST_2 = "localhost";
@@ -62,7 +63,7 @@ public class NodeChallengeManagerTest {
         Node node3 = new Node(key3.getNodeId(), HOST_3, PORT_3);
 
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node1);
-        PeerExplorer peerExplorer = new PeerExplorer(new ArrayList<>(), node1, distanceTable, new ECKey(), TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer = new PeerExplorer(new ArrayList<>(), node1, distanceTable, new ECKey(), TIMEOUT, REFRESH, NETWORK_ID);
         peerExplorer.setUDPChannel(Mockito.mock(UDPChannel.class));
 
         NodeChallengeManager manager = new NodeChallengeManager();

--- a/rskj-core/src/test/java/co/rsk/net/discovery/NodeChallengeManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/NodeChallengeManagerTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 import org.spongycastle.util.encoders.Hex;
 
 import java.util.ArrayList;
+import java.util.OptionalInt;
 import java.util.UUID;
 
 /**
@@ -38,7 +39,7 @@ public class NodeChallengeManagerTest {
     private static final String KEY_1 = "bd1d20e480dfb1c9c07ba0bc8cf9052f89923d38b5128c5dbfc18d4eea38261f";
     private static final String HOST_1 = "localhost";
     private static final int PORT_1 = 44035;
-    private static final int NETWORK_ID = 1;
+    private static final OptionalInt NETWORK_ID = OptionalInt.of(1);
 
     private static final String KEY_2 = "bd2d20e480dfb1c9c07ba0bc8cf9052f89923d38b5128c5dbfc18d4eea38262f";
     private static final String HOST_2 = "localhost";

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PacketDecoderTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PacketDecoderTest.java
@@ -31,6 +31,7 @@ import org.spongycastle.util.encoders.Hex;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.OptionalInt;
 import java.util.UUID;
 
 /**
@@ -38,7 +39,7 @@ import java.util.UUID;
  */
 public class PacketDecoderTest {
 
-    private static final int NETWORK_ID = 1;
+    private static final OptionalInt NETWORK_ID = OptionalInt.of(1);
     private static final String KEY_1 = "bd1d20e480dfb1c9c07ba0bc8cf9052f89923d38b5128c5dbfc18d4eea38261f";
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PacketDecoderTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PacketDecoderTest.java
@@ -38,6 +38,7 @@ import java.util.UUID;
  */
 public class PacketDecoderTest {
 
+    private static final int NETWORK_ID = 1;
     private static final String KEY_1 = "bd1d20e480dfb1c9c07ba0bc8cf9052f89923d38b5128c5dbfc18d4eea38261f";
 
     @Test
@@ -50,22 +51,22 @@ public class PacketDecoderTest {
         PacketDecoder decoder = new PacketDecoder();
 
         //Decode Ping Message
-        PingPeerMessage nodeMessage = PingPeerMessage.create("localhost", 44035, check, key1);
+        PingPeerMessage nodeMessage = PingPeerMessage.create("localhost", 44035, check, key1, NETWORK_ID);
         InetSocketAddress sender = new InetSocketAddress("localhost", 44035);
         this.assertDecodedMessage(decoder.decodeMessage(ctx, nodeMessage.getPacket(), sender), sender, DiscoveryMessageType.PING);
 
         //Decode Pong Message
-        PongPeerMessage pongPeerMessage = PongPeerMessage.create("localhost", 44036, check, key1);
+        PongPeerMessage pongPeerMessage = PongPeerMessage.create("localhost", 44036, check, key1, NETWORK_ID);
         sender = new InetSocketAddress("localhost", 44036);
         this.assertDecodedMessage(decoder.decodeMessage(ctx, pongPeerMessage.getPacket(), sender), sender, DiscoveryMessageType.PONG);
 
         //Decode Find Node Message
-        FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1);
+        FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1, NETWORK_ID);
         sender = new InetSocketAddress("localhost", 44037);
         this.assertDecodedMessage(decoder.decodeMessage(ctx, findNodePeerMessage.getPacket(), sender), sender, DiscoveryMessageType.FIND_NODE);
 
         //Decode Neighbors Message
-        NeighborsPeerMessage neighborsPeerMessage = NeighborsPeerMessage.create(new ArrayList<>(), check, key1);
+        NeighborsPeerMessage neighborsPeerMessage = NeighborsPeerMessage.create(new ArrayList<>(), check, key1, NETWORK_ID);
         sender = new InetSocketAddress("localhost", 44038);
         this.assertDecodedMessage(decoder.decodeMessage(ctx, neighborsPeerMessage.getPacket(), sender), sender, DiscoveryMessageType.NEIGHBORS);
 

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PeerDiscoveryRequestTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PeerDiscoveryRequestTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
+import java.util.OptionalInt;
 import java.util.UUID;
 
 /**
@@ -34,12 +35,14 @@ import java.util.UUID;
  */
 public class PeerDiscoveryRequestTest {
 
+    public static final OptionalInt NETWORK_ID = OptionalInt.of(1);
+
     @Test
     public void create() {
         ECKey key = new ECKey();
         String check = UUID.randomUUID().toString();
-        PingPeerMessage pingPeerMessage = PingPeerMessage.create("localhost", 80, check, key, 1);
-        PongPeerMessage pongPeerMessage = PongPeerMessage.create("localhost", 80, check, key, 1);
+        PingPeerMessage pingPeerMessage = PingPeerMessage.create("localhost", 80, check, key, NETWORK_ID);
+        PongPeerMessage pongPeerMessage = PongPeerMessage.create("localhost", 80, check, key, NETWORK_ID);
         InetSocketAddress address = new InetSocketAddress("localhost", 8080);
 
         PeerDiscoveryRequest request = PeerDiscoveryRequestBuilder.builder().messageId(check)

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PeerDiscoveryRequestTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PeerDiscoveryRequestTest.java
@@ -38,8 +38,8 @@ public class PeerDiscoveryRequestTest {
     public void create() {
         ECKey key = new ECKey();
         String check = UUID.randomUUID().toString();
-        PingPeerMessage pingPeerMessage = PingPeerMessage.create("localhost", 80, check, key);
-        PongPeerMessage pongPeerMessage = PongPeerMessage.create("localhost", 80, check, key);
+        PingPeerMessage pingPeerMessage = PingPeerMessage.create("localhost", 80, check, key, 1);
+        PongPeerMessage pongPeerMessage = PongPeerMessage.create("localhost", 80, check, key, 1);
         InetSocketAddress address = new InetSocketAddress("localhost", 8080);
 
         PeerDiscoveryRequest request = PeerDiscoveryRequestBuilder.builder().messageId(check)

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PeerExplorerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PeerExplorerTest.java
@@ -173,7 +173,7 @@ public class PeerExplorerTest {
         Assert.assertEquals(NETWORK_ID1, toSenderPong.getNetworkId());
 
         //After a pong returns from a node, when we receive a ping from that node, we only answer with a pong (no additional ping)
-        PongPeerMessage pongResponseFromSender = PongPeerMessage.create(HOST_1, PORT_1, toSenderPing.getMessageId(), key1, null);
+        PongPeerMessage pongResponseFromSender = PongPeerMessage.create(HOST_1, PORT_1, toSenderPing.getMessageId(), key1, OptionalInt.empty());
         DiscoveryEvent incomingPongEvent = new DiscoveryEvent(pongResponseFromSender, new InetSocketAddress(HOST_1, PORT_1));
         channel.channelRead0(ctx, incomingPongEvent);
         channel.clearEvents();
@@ -318,7 +318,7 @@ public class PeerExplorerTest {
         peerExplorer.startConversationWithNewNodes();
         sentEvents = channel.getEventsWritten();
         Assert.assertEquals(2, sentEvents.size());
-        incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1, null);
+        incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1, OptionalInt.empty());
         incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_1, PORT_1));
         channel.clearEvents();
         List<Node> addedNodes = peerExplorer.getNodes();

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PeerExplorerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PeerExplorerTest.java
@@ -60,12 +60,14 @@ public class PeerExplorerTest {
 
     private static final long TIMEOUT = 30000;
     private static final long REFRESH = 60000;
+    private static final Integer NETWORK_ID1 = 1;
+    private static final Integer NETWORK_ID2 = 2;
 
     @Test
     public void sendInitialMessageToNodesNoNodes() {
         Node node = new Node(new ECKey().getNodeId(), HOST_2, PORT_2);
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
-        PeerExplorer peerExplorer = new PeerExplorer(new ArrayList<>(), node, distanceTable, new ECKey(), TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer = new PeerExplorer(new ArrayList<>(), node, distanceTable, new ECKey(), TIMEOUT, REFRESH, NETWORK_ID1);
 
         peerExplorer.setUDPChannel(Mockito.mock(UDPChannel.class));
 
@@ -73,7 +75,7 @@ public class PeerExplorerTest {
 
         Assert.assertTrue(CollectionUtils.isEmpty(nodesWithMessage));
 
-        peerExplorer = new PeerExplorer(null, node, distanceTable, new ECKey(), TIMEOUT, REFRESH);
+        peerExplorer = new PeerExplorer(null, node, distanceTable, new ECKey(), TIMEOUT, REFRESH, NETWORK_ID1);
         peerExplorer.setUDPChannel(Mockito.mock(UDPChannel.class));
 
         nodesWithMessage = peerExplorer.startConversationWithNewNodes();
@@ -93,7 +95,7 @@ public class PeerExplorerTest {
 
         Node node = new Node(new ECKey().getNodeId(), HOST_1, PORT_1);
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
-        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, new ECKey(), TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, new ECKey(), TIMEOUT, REFRESH, NETWORK_ID1);
 
         UDPChannel channel = new UDPChannel(Mockito.mock(Channel.class), peerExplorer);
         peerExplorer.setUDPChannel(channel);
@@ -106,14 +108,14 @@ public class PeerExplorerTest {
     }
 
     @Test
-    public void handlePingMessage() throws Exception {
+    public void handlePingMessageFromDifferentNetwork() throws Exception {
         List<String> nodes = new ArrayList<>();
 
         ECKey key2 = ECKey.fromPrivate(Hex.decode(KEY_2)).decompress();
 
         Node node = new Node(key2.getNodeId(), HOST_2, PORT_2);
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
-        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH, NETWORK_ID1);
 
         Channel internalChannel = Mockito.mock(Channel.class);
         UDPTestChannel channel = new UDPTestChannel(internalChannel, peerExplorer);
@@ -124,7 +126,91 @@ public class PeerExplorerTest {
 
         ECKey key1 = ECKey.fromPrivate(Hex.decode(KEY_1)).decompress();
         String check = UUID.randomUUID().toString();
-        PingPeerMessage nodeMessage = PingPeerMessage.create(HOST_1, PORT_1, check, key1);
+        PingPeerMessage pingPeerMessageWithDifferentNetwork = PingPeerMessage.create(HOST_1, PORT_1, check, key1, this.NETWORK_ID2);
+        DiscoveryEvent incomingPingEvent = new DiscoveryEvent(pingPeerMessageWithDifferentNetwork, new InetSocketAddress(HOST_1, PORT_1));
+
+        //A message is received
+        channel.channelRead0(ctx, incomingPingEvent);
+        //There should be no response, since they are from different networks.
+        List<DiscoveryEvent> sentEvents = channel.getEventsWritten();
+        Assert.assertEquals(0, sentEvents.size());
+    }
+
+    @Test
+    public void handlePingMessageWithNullNetworkId() throws Exception {
+        List<String> nodes = new ArrayList<>();
+
+        ECKey key2 = ECKey.fromPrivate(Hex.decode(KEY_2)).decompress();
+
+        Node node = new Node(key2.getNodeId(), HOST_2, PORT_2);
+        NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH, NETWORK_ID1);
+
+        Channel internalChannel = Mockito.mock(Channel.class);
+        UDPTestChannel channel = new UDPTestChannel(internalChannel, peerExplorer);
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        peerExplorer.setUDPChannel(channel);
+
+        Assert.assertTrue(CollectionUtils.isEmpty(peerExplorer.getNodes()));
+
+        ECKey key1 = ECKey.fromPrivate(Hex.decode(KEY_1)).decompress();
+        String check = UUID.randomUUID().toString();
+        PingPeerMessage nodeMessage = PingPeerMessage.create(HOST_1, PORT_1, check, key1, null);
+        DiscoveryEvent incomingPingEvent = new DiscoveryEvent(nodeMessage, new InetSocketAddress(HOST_1, PORT_1));
+
+        //A message is received
+        channel.channelRead0(ctx, incomingPingEvent);
+        //As part of the ping response, a Ping and a Pong are sent to the sender.
+        List<DiscoveryEvent> sentEvents = channel.getEventsWritten();
+        Assert.assertEquals(2, sentEvents.size());
+        DiscoveryEvent pongEvent = sentEvents.get(0);
+        PongPeerMessage toSenderPong = (PongPeerMessage) pongEvent.getMessage();
+        Assert.assertEquals(DiscoveryMessageType.PONG, toSenderPong.getMessageType());
+        Assert.assertEquals(new InetSocketAddress(HOST_1, PORT_1), pongEvent.getAddress());
+        Assert.assertEquals(NETWORK_ID1, toSenderPong.getNetworkId());
+
+        DiscoveryEvent pingEvent = sentEvents.get(1);
+        PingPeerMessage toSenderPing = (PingPeerMessage) pingEvent.getMessage();
+        Assert.assertEquals(DiscoveryMessageType.PING, toSenderPing.getMessageType());
+        Assert.assertEquals(new InetSocketAddress(HOST_1, PORT_1), pingEvent.getAddress());
+        Assert.assertEquals(NETWORK_ID1, toSenderPong.getNetworkId());
+
+        //After a pong returns from a node, when we receive a ping from that node, we only answer with a pong (no additional ping)
+        PongPeerMessage pongResponseFromSender = PongPeerMessage.create(HOST_1, PORT_1, toSenderPing.getMessageId(), key1, null);
+        DiscoveryEvent incomingPongEvent = new DiscoveryEvent(pongResponseFromSender, new InetSocketAddress(HOST_1, PORT_1));
+        channel.channelRead0(ctx, incomingPongEvent);
+        channel.clearEvents();
+        channel.channelRead0(ctx, incomingPingEvent);
+        sentEvents = channel.getEventsWritten();
+        Assert.assertEquals(1, sentEvents.size());
+        pongEvent = sentEvents.get(0);
+        toSenderPong = (PongPeerMessage) pongEvent.getMessage();
+        Assert.assertEquals(DiscoveryMessageType.PONG, toSenderPong.getMessageType());
+        Assert.assertEquals(new InetSocketAddress(HOST_1, PORT_1), pongEvent.getAddress());
+        Assert.assertEquals(NODE_ID_2, Hex.toHexString(toSenderPong.getKey().getNodeId()));
+        Assert.assertEquals(NETWORK_ID1, toSenderPong.getNetworkId());
+    }
+
+    @Test
+    public void handlePingMessage() throws Exception {
+        List<String> nodes = new ArrayList<>();
+
+        ECKey key2 = ECKey.fromPrivate(Hex.decode(KEY_2)).decompress();
+
+        Node node = new Node(key2.getNodeId(), HOST_2, PORT_2);
+        NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH, NETWORK_ID1);
+
+        Channel internalChannel = Mockito.mock(Channel.class);
+        UDPTestChannel channel = new UDPTestChannel(internalChannel, peerExplorer);
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        peerExplorer.setUDPChannel(channel);
+
+        Assert.assertTrue(CollectionUtils.isEmpty(peerExplorer.getNodes()));
+
+        ECKey key1 = ECKey.fromPrivate(Hex.decode(KEY_1)).decompress();
+        String check = UUID.randomUUID().toString();
+        PingPeerMessage nodeMessage = PingPeerMessage.create(HOST_1, PORT_1, check, key1, this.NETWORK_ID1);
         DiscoveryEvent incomingPingEvent = new DiscoveryEvent(nodeMessage, new InetSocketAddress(HOST_1, PORT_1));
 
         //A message is received
@@ -143,7 +229,7 @@ public class PeerExplorerTest {
         Assert.assertEquals(new InetSocketAddress(HOST_1, PORT_1), pingEvent.getAddress());
 
         //After a pong returns from a node, when we receive a ping from that node, we only answer with a pong (no additional ping)
-        PongPeerMessage pongResponseFromSender = PongPeerMessage.create(HOST_1, PORT_1, toSenderPing.getMessageId(), key1);
+        PongPeerMessage pongResponseFromSender = PongPeerMessage.create(HOST_1, PORT_1, toSenderPing.getMessageId(), key1, NETWORK_ID1);
         DiscoveryEvent incomingPongEvent = new DiscoveryEvent(pongResponseFromSender, new InetSocketAddress(HOST_1, PORT_1));
         channel.channelRead0(ctx, incomingPongEvent);
         channel.clearEvents();
@@ -168,7 +254,7 @@ public class PeerExplorerTest {
 
         Node node = new Node(key2.getNodeId(), HOST_2, PORT_2);
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
-        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH, NETWORK_ID1);
 
         Channel internalChannel = Mockito.mock(Channel.class);
         UDPTestChannel channel = new UDPTestChannel(internalChannel, peerExplorer);
@@ -178,7 +264,7 @@ public class PeerExplorerTest {
 
         //A incoming pong for a Ping we did not sent.
         String check = UUID.randomUUID().toString();
-        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, check, key1);
+        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, check, key1, NETWORK_ID1);
         DiscoveryEvent incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_1, PORT_1));
         channel.clearEvents();
         channel.channelRead0(ctx, incomingPongEvent);
@@ -190,7 +276,52 @@ public class PeerExplorerTest {
         peerExplorer.startConversationWithNewNodes();
         sentEvents = channel.getEventsWritten();
         Assert.assertEquals(2, sentEvents.size());
-        incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1);
+        incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1, NETWORK_ID1);
+        incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_1, PORT_1));
+        channel.clearEvents();
+        List<Node> addedNodes = peerExplorer.getNodes();
+        Assert.assertEquals(0, addedNodes.size());
+        channel.channelRead0(ctx, incomingPongEvent);
+        Assert.assertEquals(1, peerExplorer.getNodes().size());
+        addedNodes = peerExplorer.getNodes();
+        Assert.assertEquals(1, addedNodes.size());
+    }
+
+
+    @Test
+    public void handlePongMessageWithNullNetwork() throws Exception {
+        List<String> nodes = new ArrayList<>();
+        nodes.add(HOST_1 + ":" + PORT_1);
+        nodes.add(HOST_3 + ":" + PORT_3);
+
+        ECKey key1 = ECKey.fromPrivate(Hex.decode(KEY_1)).decompress();
+        ECKey key2 = ECKey.fromPrivate(Hex.decode(KEY_2)).decompress();
+
+        Node node = new Node(key2.getNodeId(), HOST_2, PORT_2);
+        NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH, NETWORK_ID1);
+
+        Channel internalChannel = Mockito.mock(Channel.class);
+        UDPTestChannel channel = new UDPTestChannel(internalChannel, peerExplorer);
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        peerExplorer.setUDPChannel(channel);
+        Assert.assertTrue(CollectionUtils.isEmpty(peerExplorer.getNodes()));
+
+        //A incoming pong for a Ping we did not sent.
+        String check = UUID.randomUUID().toString();
+        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, check, key1, null);
+        DiscoveryEvent incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_1, PORT_1));
+        channel.clearEvents();
+        channel.channelRead0(ctx, incomingPongEvent);
+        List<DiscoveryEvent> sentEvents = channel.getEventsWritten();
+        Assert.assertEquals(0, sentEvents.size());
+        Assert.assertEquals(0, peerExplorer.getNodes().size());
+
+        //Now we send the ping first
+        peerExplorer.startConversationWithNewNodes();
+        sentEvents = channel.getEventsWritten();
+        Assert.assertEquals(2, sentEvents.size());
+        incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1, null);
         incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_1, PORT_1));
         channel.clearEvents();
         List<Node> addedNodes = peerExplorer.getNodes();
@@ -212,7 +343,7 @@ public class PeerExplorerTest {
 
         Node node = new Node(key2.getNodeId(), HOST_2, PORT_2);
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
-        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH, NETWORK_ID1);
 
         Channel internalChannel = Mockito.mock(Channel.class);
         UDPTestChannel channel = new UDPTestChannel(internalChannel, peerExplorer);
@@ -221,7 +352,7 @@ public class PeerExplorerTest {
 
         //We try to handle a findNode message from an unkown sender, no message should be send as a response
         String check = UUID.randomUUID().toString();
-        FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1);
+        FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1, NETWORK_ID1);
         channel.clearEvents();
         channel.channelRead0(ctx, new DiscoveryEvent(findNodePeerMessage, new InetSocketAddress(HOST_1, PORT_1)));
         List<DiscoveryEvent> sentEvents = channel.getEventsWritten();
@@ -229,16 +360,16 @@ public class PeerExplorerTest {
 
         //Now we send the ping first
         peerExplorer.startConversationWithNewNodes();
-        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1);
+        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1, NETWORK_ID1);
         DiscoveryEvent incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_1, PORT_1));
         channel.channelRead0(ctx, incomingPongEvent);
 
-        incomingPongMessage = PongPeerMessage.create(HOST_3, PORT_3, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1);
+        incomingPongMessage = PongPeerMessage.create(HOST_3, PORT_3, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1, NETWORK_ID1);
         incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_3, PORT_3));
         channel.channelRead0(ctx, incomingPongEvent);
 
         check = UUID.randomUUID().toString();
-        findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1);
+        findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1, NETWORK_ID1);
         channel.clearEvents();
         channel.channelRead0(ctx, new DiscoveryEvent(findNodePeerMessage, new InetSocketAddress(HOST_1, PORT_1)));
         sentEvents = channel.getEventsWritten();
@@ -259,7 +390,7 @@ public class PeerExplorerTest {
 
         Node node = new Node(key2.getNodeId(), HOST_2, PORT_2);
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node);
-        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node, distanceTable, key2, TIMEOUT, REFRESH, NETWORK_ID1);
 
         Channel internalChannel = Mockito.mock(Channel.class);
         UDPTestChannel channel = new UDPTestChannel(internalChannel, peerExplorer);
@@ -271,9 +402,9 @@ public class PeerExplorerTest {
         peerExplorer.startConversationWithNewNodes();
         List<DiscoveryEvent> sentEvents = channel.getEventsWritten();
         Assert.assertEquals(2, sentEvents.size());
-        PongPeerMessage incomingPongMessage1 = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1);
+        PongPeerMessage incomingPongMessage1 = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1, NETWORK_ID1);
         DiscoveryEvent incomingPongEvent1 = new DiscoveryEvent(incomingPongMessage1, new InetSocketAddress(HOST_1, PORT_1));
-        PongPeerMessage incomingPongMessage2 = PongPeerMessage.create(HOST_3, PORT_3, ((PingPeerMessage) sentEvents.get(1).getMessage()).getMessageId(), key3);
+        PongPeerMessage incomingPongMessage2 = PongPeerMessage.create(HOST_3, PORT_3, ((PingPeerMessage) sentEvents.get(1).getMessage()).getMessageId(), key3, NETWORK_ID1);
         DiscoveryEvent incomingPongEvent2 = new DiscoveryEvent(incomingPongMessage2, new InetSocketAddress(HOST_3, PORT_3));
 
         channel.clearEvents();
@@ -286,7 +417,7 @@ public class PeerExplorerTest {
         Assert.assertEquals(NODE_ID_1, Hex.toHexString(foundNodes.get(1).getId().getID()));
 
         String check = UUID.randomUUID().toString();
-        FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1);
+        FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1, NETWORK_ID1);
         channel.clearEvents();
         channel.channelRead0(ctx, new DiscoveryEvent(findNodePeerMessage, new InetSocketAddress(HOST_1, PORT_1)));
         sentEvents = channel.getEventsWritten();
@@ -304,6 +435,7 @@ public class PeerExplorerTest {
         }
         return false;
     }
+
     @Test
     public void handleNeighbors() throws Exception {
         List<String> nodes = new ArrayList<>();
@@ -315,7 +447,7 @@ public class PeerExplorerTest {
         Node node1 = new Node(key1.getNodeId(), HOST_1, PORT_1);
         Node node2 = new Node(key2.getNodeId(), HOST_2, PORT_2);
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node2);
-        PeerExplorer peerExplorer = new PeerExplorer(nodes, node2, distanceTable, key2, TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer = new PeerExplorer(nodes, node2, distanceTable, key2, TIMEOUT, REFRESH, NETWORK_ID1);
 
         Channel internalChannel = Mockito.mock(Channel.class);
         UDPTestChannel channel = new UDPTestChannel(internalChannel, peerExplorer);
@@ -326,7 +458,7 @@ public class PeerExplorerTest {
         //We try to process a Message without previous connection
         List<Node> newNodes = new ArrayList<>();
         newNodes.add(new Node(Hex.decode(NODE_ID_3), HOST_3, PORT_3));
-        NeighborsPeerMessage neighborsPeerMessage = NeighborsPeerMessage.create(newNodes, UUID.randomUUID().toString(), key1);
+        NeighborsPeerMessage neighborsPeerMessage = NeighborsPeerMessage.create(newNodes, UUID.randomUUID().toString(), key1, NETWORK_ID1);
         DiscoveryEvent neighborsEvent = new DiscoveryEvent(neighborsPeerMessage, new InetSocketAddress(HOST_1, PORT_1));
         channel.clearEvents();
         channel.channelRead0(ctx, neighborsEvent);
@@ -335,7 +467,7 @@ public class PeerExplorerTest {
 
         //we establish a connection but we dont send the findnode message.
         peerExplorer.startConversationWithNewNodes();
-        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1);
+        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, ((PingPeerMessage) sentEvents.get(0).getMessage()).getMessageId(), key1, NETWORK_ID1);
         DiscoveryEvent incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_1, PORT_1));
         channel.channelRead0(ctx, incomingPongEvent);
         channel.clearEvents();
@@ -348,7 +480,7 @@ public class PeerExplorerTest {
         channel.clearEvents();
         peerExplorer.sendFindNode(node1);
         FindNodePeerMessage findNodePeerMessage = (FindNodePeerMessage) channel.getEventsWritten().get(0).getMessage();
-        neighborsPeerMessage = NeighborsPeerMessage.create(newNodes, findNodePeerMessage.getMessageId(), key1);
+        neighborsPeerMessage = NeighborsPeerMessage.create(newNodes, findNodePeerMessage.getMessageId(), key1, NETWORK_ID1);
         neighborsEvent = new DiscoveryEvent(neighborsPeerMessage, new InetSocketAddress(HOST_1, PORT_1));
         channel.clearEvents();
         channel.channelRead0(ctx, neighborsEvent);

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PeerExplorerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PeerExplorerTest.java
@@ -33,10 +33,7 @@ import org.mockito.Mockito;
 import org.spongycastle.util.encoders.Hex;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Created by mario on 15/02/17.
@@ -60,8 +57,8 @@ public class PeerExplorerTest {
 
     private static final long TIMEOUT = 30000;
     private static final long REFRESH = 60000;
-    private static final Integer NETWORK_ID1 = 1;
-    private static final Integer NETWORK_ID2 = 2;
+    private static final OptionalInt NETWORK_ID1 = OptionalInt.of(1);
+    private static final OptionalInt NETWORK_ID2 = OptionalInt.of(2);
 
     @Test
     public void sendInitialMessageToNodesNoNodes() {
@@ -155,7 +152,7 @@ public class PeerExplorerTest {
 
         ECKey key1 = ECKey.fromPrivate(Hex.decode(KEY_1)).decompress();
         String check = UUID.randomUUID().toString();
-        PingPeerMessage nodeMessage = PingPeerMessage.create(HOST_1, PORT_1, check, key1, null);
+        PingPeerMessage nodeMessage = PingPeerMessage.create(HOST_1, PORT_1, check, key1, OptionalInt.empty());
         DiscoveryEvent incomingPingEvent = new DiscoveryEvent(nodeMessage, new InetSocketAddress(HOST_1, PORT_1));
 
         //A message is received
@@ -309,7 +306,7 @@ public class PeerExplorerTest {
 
         //A incoming pong for a Ping we did not sent.
         String check = UUID.randomUUID().toString();
-        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, check, key1, null);
+        PongPeerMessage incomingPongMessage = PongPeerMessage.create(HOST_1, PORT_1, check, key1, OptionalInt.empty());
         DiscoveryEvent incomingPongEvent = new DiscoveryEvent(incomingPongMessage, new InetSocketAddress(HOST_1, PORT_1));
         channel.clearEvents();
         channel.channelRead0(ctx, incomingPongEvent);

--- a/rskj-core/src/test/java/co/rsk/net/discovery/UDPChannelTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/UDPChannelTest.java
@@ -27,12 +27,15 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.net.InetSocketAddress;
+import java.util.OptionalInt;
 import java.util.UUID;
 
 /**
  * Created by mario on 15/02/17.
  */
 public class UDPChannelTest {
+
+    private static final OptionalInt NETWORK_ID = OptionalInt.of(1);
 
     @Test
     public void create() {
@@ -59,7 +62,7 @@ public class UDPChannelTest {
     public void write() {
         String check = UUID.randomUUID().toString();
         ECKey key = new ECKey();
-        PingPeerMessage nodeMessage = PingPeerMessage.create("localhost", 80, check, key, 1);
+        PingPeerMessage nodeMessage = PingPeerMessage.create("localhost", 80, check, key, NETWORK_ID);
 
         Channel channel = Mockito.mock(Channel.class);
         PeerExplorer peerExplorer = Mockito.mock(PeerExplorer.class);

--- a/rskj-core/src/test/java/co/rsk/net/discovery/UDPChannelTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/UDPChannelTest.java
@@ -59,7 +59,7 @@ public class UDPChannelTest {
     public void write() {
         String check = UUID.randomUUID().toString();
         ECKey key = new ECKey();
-        PingPeerMessage nodeMessage = PingPeerMessage.create("localhost", 80, check, key);
+        PingPeerMessage nodeMessage = PingPeerMessage.create("localhost", 80, check, key, 1);
 
         Channel channel = Mockito.mock(Channel.class);
         PeerExplorer peerExplorer = Mockito.mock(PeerExplorer.class);

--- a/rskj-core/src/test/java/co/rsk/net/discovery/UDPServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/UDPServerTest.java
@@ -49,6 +49,7 @@ public class UDPServerTest {
     private static final int PORT_1 = 40305;
     private static final int PORT_2 = 40306;
     private static final int PORT_3 = 40307;
+    private static final int NETWORK_ID = 1;
 
     private static final long TIMEOUT = 30000;
     private static final long REFRESH = 60000;
@@ -76,9 +77,9 @@ public class UDPServerTest {
         NodeDistanceTable distanceTable2 = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node2);
         NodeDistanceTable distanceTable3 = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node3);
 
-        PeerExplorer peerExplorer1 = new PeerExplorer(node1BootNode, node1, distanceTable1, key1, TIMEOUT, REFRESH);
-        PeerExplorer peerExplorer2 = new PeerExplorer(node2BootNode, node2, distanceTable2, key2, TIMEOUT, REFRESH);
-        PeerExplorer peerExplorer3 = new PeerExplorer(node3BootNode, node3, distanceTable3, key3, TIMEOUT, REFRESH);
+        PeerExplorer peerExplorer1 = new PeerExplorer(node1BootNode, node1, distanceTable1, key1, TIMEOUT, REFRESH, NETWORK_ID);
+        PeerExplorer peerExplorer2 = new PeerExplorer(node2BootNode, node2, distanceTable2, key2, TIMEOUT, REFRESH, NETWORK_ID);
+        PeerExplorer peerExplorer3 = new PeerExplorer(node3BootNode, node3, distanceTable3, key3, TIMEOUT, REFRESH, NETWORK_ID);
 
         Assert.assertEquals(0, peerExplorer1.getNodes().size());
         Assert.assertEquals(0, peerExplorer2.getNodes().size());

--- a/rskj-core/src/test/java/co/rsk/net/discovery/UDPServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/UDPServerTest.java
@@ -27,8 +27,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
+import javax.swing.text.html.Option;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -49,7 +51,7 @@ public class UDPServerTest {
     private static final int PORT_1 = 40305;
     private static final int PORT_2 = 40306;
     private static final int PORT_3 = 40307;
-    private static final int NETWORK_ID = 1;
+    private static final OptionalInt NETWORK_ID = OptionalInt.of(1);
 
     private static final long TIMEOUT = 30000;
     private static final long REFRESH = 60000;


### PR DESCRIPTION
Peer discovery messages from another networks are ignored. For now the `null` case will be tolerated until the network gets updated