### PR TITLE
Decouple Remasc from BridgeSupport

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -66,8 +66,6 @@ public class BridgeSupport {
     private static final Logger logger = LoggerFactory.getLogger("BridgeSupport");
     private static final PanicProcessor panicProcessor = new PanicProcessor();
 
-    private enum StorageFederationReference { NONE, NEW, OLD, GENESIS;}
-
     private final List<String> FEDERATION_CHANGE_FUNCTIONS = Collections.unmodifiableList(Arrays.asList(
             "create",
             "add",
@@ -83,8 +81,10 @@ public class BridgeSupport {
     private final RskSystemProperties config;
 
     private final BridgeEventLogger eventLogger;
-    private org.ethereum.core.Block rskExecutionBlock;
+    private final org.ethereum.core.Block rskExecutionBlock;
     private StoredBlock initialBtcStoredBlock;
+
+    private final FederationSupport federationSupport;
 
     // Used by bridge
     public BridgeSupport(RskSystemProperties config, Repository repository, BridgeEventLogger eventLogger, RskAddress contractAddress, Block rskExecutionBlock) throws IOException, BlockStoreException {
@@ -104,9 +104,11 @@ public class BridgeSupport {
         this.btcContext = new Context(btcParams);
 
         this.btcBlockStore = new RepositoryBlockStore(config, repository, PrecompiledContracts.BRIDGE_ADDR);
+        this.federationSupport = new FederationSupport(provider, this.bridgeConstants, rskExecutionBlock);
+
         if (btcBlockStore.getChainHead().getHeader().getHash().equals(btcParams.getGenesisBlock().getHash())) {
             // We are building the blockstore for the first time, so we have not set the checkpoints yet.
-            long time = getActiveFederation().getCreationTime().toEpochMilli();
+            long time = federationSupport.getActiveFederation().getCreationTime().toEpochMilli();
             InputStream checkpoints = this.getCheckPoints();
             if (time > 0 && checkpoints != null) {
                 CheckpointManager.checkpoint(btcParams, checkpoints, btcBlockStore, time);
@@ -127,6 +129,8 @@ public class BridgeSupport {
         this.btcBlockChain = btcBlockChain;
         this.rskRepository = repository;
         this.eventLogger = eventLogger;
+        this.rskExecutionBlock = null;
+        this.federationSupport = new FederationSupport(provider, bridgeConstants, this.rskExecutionBlock);
     }
 
     @VisibleForTesting
@@ -1003,100 +1007,12 @@ public class BridgeSupport {
     }
 
     /**
-     * Returns the currently active federation reference.
-     * Logic is as follows:
-     * When no "new" federation is recorded in the blockchain, then return GENESIS
-     * When a "new" federation is present and no "old" federation is present, then return NEW
-     * When both "new" and "old" federations are present, then
-     * 1) If the "new" federation is at least bridgeConstants::getFederationActivationAge() blocks old,
-     * return the NEW
-     * 2) Otherwise, return OLD
-     * @return a reference to where the currently active federation is stored.
-     */
-    private StorageFederationReference getActiveFederationReference() {
-        Federation newFederation = provider.getNewFederation();
-
-        // No new federation in place, then the active federation
-        // is the genesis federation
-        if (newFederation == null) {
-            return StorageFederationReference.GENESIS;
-        }
-
-        Federation oldFederation = provider.getOldFederation();
-
-        // No old federation in place, then the active federation
-        // is the new federation
-        if (oldFederation == null) {
-            return StorageFederationReference.NEW;
-        }
-
-        // Both new and old federations in place
-        // If the minimum age has gone by for the new federation's
-        // activation, then that federation is the currently active.
-        // Otherwise, the old federation is still the currently active.
-        if (shouldFederationBeActive(newFederation)) {
-            return StorageFederationReference.NEW;
-        }
-
-        return StorageFederationReference.OLD;
-    }
-
-    /**
-     * Returns the currently retiring federation reference.
-     * Logic is as follows:
-     * When no "new" or "old" federation is recorded in the blockchain, then return empty.
-     * When both "new" and "old" federations are present, then
-     * 1) If the "new" federation is at least bridgeConstants::getFederationActivationAge() blocks old,
-     * return OLD
-     * 2) Otherwise, return empty
-     * @return the retiring federation.
-     */
-    private StorageFederationReference getRetiringFederationReference() {
-        Federation newFederation = provider.getNewFederation();
-        Federation oldFederation = provider.getOldFederation();
-
-        if (oldFederation == null || newFederation == null) {
-            return StorageFederationReference.NONE;
-        }
-
-        // Both new and old federations in place
-        // If the minimum age has gone by for the new federation's
-        // activation, then the old federation is the currently retiring.
-        // Otherwise, there is no retiring federation.
-        if (shouldFederationBeActive(newFederation)) {
-            return StorageFederationReference.OLD;
-        }
-
-        return StorageFederationReference.NONE;
-    }
-
-    private boolean shouldFederationBeActive(Federation federation) {
-        long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
-        return federationAge >= bridgeConstants.getFederationActivationAge();
-    }
-
-    private boolean amAwaitingFederationActivation() {
-        Federation newFederation = provider.getNewFederation();
-        Federation oldFederation = provider.getOldFederation();
-
-        return newFederation != null && oldFederation != null && !shouldFederationBeActive(newFederation);
-    }
-
-    /**
      * Returns the currently active federation.
      * See getActiveFederationReference() for details.
      * @return the currently active federation.
      */
-    public Federation getActiveFederation() {
-        switch (getActiveFederationReference()) {
-            case NEW:
-                return provider.getNewFederation();
-            case OLD:
-                return provider.getOldFederation();
-            case GENESIS:
-            default:
-                return bridgeConstants.getGenesisFederation();
-        }
+    private Federation getActiveFederation() {
+        return federationSupport.getActiveFederation();
     }
 
     /**
@@ -1106,34 +1022,15 @@ public class BridgeSupport {
      */
     @Nullable
     private Federation getRetiringFederation() {
-        switch (getRetiringFederationReference()) {
-            case OLD:
-                return provider.getOldFederation();
-            case NONE:
-            default:
-                return null;
-        }
+        return federationSupport.getRetiringFederation();
     }
 
     private List<UTXO> getActiveFederationBtcUTXOs() throws IOException {
-        switch (getActiveFederationReference()) {
-            case OLD:
-                return provider.getOldFederationBtcUTXOs();
-            case NEW:
-            case GENESIS:
-            default:
-                return provider.getNewFederationBtcUTXOs();
-        }
+        return federationSupport.getActiveFederationBtcUTXOs();
     }
 
     private List<UTXO> getRetiringFederationBtcUTXOs() throws IOException {
-        switch (getRetiringFederationReference()) {
-            case OLD:
-                return provider.getOldFederationBtcUTXOs();
-            case NONE:
-            default:
-                return Collections.emptyList();
-        }
+        return federationSupport.getRetiringFederationBtcUTXOs();
     }
 
     /**
@@ -1149,7 +1046,7 @@ public class BridgeSupport {
      * @return the federation size
      */
     public Integer getFederationSize() {
-        return getActiveFederation().getPublicKeys().size();
+        return federationSupport.getFederationSize();
     }
 
     /**
@@ -1166,13 +1063,7 @@ public class BridgeSupport {
      * @return the federator's public key
      */
     public byte[] getFederatorPublicKey(int index) {
-        List<BtcECKey> publicKeys = getActiveFederation().getPublicKeys();
-
-        if (index < 0 || index >= publicKeys.size()) {
-            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and {}", publicKeys.size() - 1));
-        }
-
-        return publicKeys.get(index).getPubKey();
+        return federationSupport.getFederatorPublicKey(index);
     }
 
     /**
@@ -1312,7 +1203,7 @@ public class BridgeSupport {
             return -1;
         }
 
-        if (amAwaitingFederationActivation()) {
+        if (federationSupport.amAwaitingFederationActivation()) {
             return -2;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  *
  * @author Ariel Mendelzon
  */
-public final class Federation {
+public class Federation {
     private final List<BtcECKey> publicKeys;
     private final List<ECKey> rskPublicKeys;
     private final Instant creationTime;

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -1,0 +1,204 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.config.BridgeConstants;
+import org.ethereum.core.Block;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+public class FederationSupport {
+
+    private enum StorageFederationReference { NONE, NEW, OLD, GENESIS }
+
+    private final BridgeStorageProvider provider;
+    private final BridgeConstants bridgeConstants;
+    private final Block executionBlock;
+
+    public FederationSupport(BridgeStorageProvider provider, BridgeConstants bridgeConstants, Block executionBlock) {
+        this.provider = provider;
+        this.bridgeConstants = bridgeConstants;
+        this.executionBlock = executionBlock;
+    }
+
+    /**
+     * Returns the federation's size
+     * @return the federation size
+     */
+    public int getFederationSize() {
+        return getActiveFederation().getPublicKeys().size();
+    }
+
+    /**
+     * Returns the public key of the federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @return the federator's public key
+     */
+    public byte[] getFederatorPublicKey(int index) {
+        List<BtcECKey> publicKeys = getActiveFederation().getPublicKeys();
+
+        if (index < 0 || index >= publicKeys.size()) {
+            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", publicKeys.size() - 1));
+        }
+
+        return publicKeys.get(index).getPubKey();
+    }
+
+    /**
+     * Returns the currently active federation.
+     * See getActiveFederationReference() for details.
+     *
+     * @return the currently active federation.
+     */
+    public Federation getActiveFederation() {
+        switch (getActiveFederationReference()) {
+            case NEW:
+                return provider.getNewFederation();
+            case OLD:
+                return provider.getOldFederation();
+            case GENESIS:
+            default:
+                return bridgeConstants.getGenesisFederation();
+        }
+    }
+
+    /**
+     * Returns the currently retiring federation.
+     * See getRetiringFederationReference() for details.
+     *
+     * @return the retiring federation.
+     */
+    @Nullable
+    public Federation getRetiringFederation() {
+        switch (getRetiringFederationReference()) {
+            case OLD:
+                return provider.getOldFederation();
+            case NONE:
+            default:
+                return null;
+        }
+    }
+
+    public List<UTXO> getActiveFederationBtcUTXOs() throws IOException {
+        switch (getActiveFederationReference()) {
+            case OLD:
+                return provider.getOldFederationBtcUTXOs();
+            case NEW:
+            case GENESIS:
+            default:
+                return provider.getNewFederationBtcUTXOs();
+        }
+    }
+
+    public List<UTXO> getRetiringFederationBtcUTXOs() throws IOException {
+        switch (getRetiringFederationReference()) {
+            case OLD:
+                return provider.getOldFederationBtcUTXOs();
+            case NONE:
+            default:
+                return Collections.emptyList();
+        }
+    }
+
+    public boolean amAwaitingFederationActivation() {
+        Federation newFederation = provider.getNewFederation();
+        Federation oldFederation = provider.getOldFederation();
+
+        return newFederation != null && oldFederation != null && !shouldFederationBeActive(newFederation);
+    }
+
+    /**
+     * Returns the currently active federation reference.
+     * Logic is as follows:
+     * When no "new" federation is recorded in the blockchain, then return GENESIS
+     * When a "new" federation is present and no "old" federation is present, then return NEW
+     * When both "new" and "old" federations are present, then
+     * 1) If the "new" federation is at least bridgeConstants::getFederationActivationAge() blocks old,
+     * return the NEW
+     * 2) Otherwise, return OLD
+     *
+     * @return a reference to where the currently active federation is stored.
+     */
+    private StorageFederationReference getActiveFederationReference() {
+        Federation newFederation = provider.getNewFederation();
+
+        // No new federation in place, then the active federation
+        // is the genesis federation
+        if (newFederation == null) {
+            return StorageFederationReference.GENESIS;
+        }
+
+        Federation oldFederation = provider.getOldFederation();
+
+        // No old federation in place, then the active federation
+        // is the new federation
+        if (oldFederation == null) {
+            return StorageFederationReference.NEW;
+        }
+
+        // Both new and old federations in place
+        // If the minimum age has gone by for the new federation's
+        // activation, then that federation is the currently active.
+        // Otherwise, the old federation is still the currently active.
+        if (shouldFederationBeActive(newFederation)) {
+            return StorageFederationReference.NEW;
+        }
+
+        return StorageFederationReference.OLD;
+    }
+
+    /**
+     * Returns the currently retiring federation reference.
+     * Logic is as follows:
+     * When no "new" or "old" federation is recorded in the blockchain, then return empty.
+     * When both "new" and "old" federations are present, then
+     * 1) If the "new" federation is at least bridgeConstants::getFederationActivationAge() blocks old,
+     * return OLD
+     * 2) Otherwise, return empty
+     *
+     * @return the retiring federation.
+     */
+    private StorageFederationReference getRetiringFederationReference() {
+        Federation newFederation = provider.getNewFederation();
+        Federation oldFederation = provider.getOldFederation();
+
+        if (oldFederation == null || newFederation == null) {
+            return StorageFederationReference.NONE;
+        }
+
+        // Both new and old federations in place
+        // If the minimum age has gone by for the new federation's
+        // activation, then the old federation is the currently retiring.
+        // Otherwise, there is no retiring federation.
+        if (shouldFederationBeActive(newFederation)) {
+            return StorageFederationReference.OLD;
+        }
+
+        return StorageFederationReference.NONE;
+    }
+
+    private boolean shouldFederationBeActive(Federation federation) {
+        long federationAge = executionBlock.getNumber() - federation.getCreationBlockNumber();
+        return federationAge >= bridgeConstants.getFederationActivationAge();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
@@ -24,16 +24,13 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.SelectionRule;
-import co.rsk.peg.BridgeSupport;
 import org.apache.commons.collections4.CollectionUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.db.BlockStore;
-import org.ethereum.db.RepositoryTrack;
 import org.ethereum.vm.LogInfo;
-import org.ethereum.vm.PrecompiledContracts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,24 +126,7 @@ public class Remasc {
         feesPayer.payMiningFees(processingBlockHeader.getHash().getBytes(), payToRskLabs, remascConstants.getRskLabsAddress(), logs);
         fullBlockReward = fullBlockReward.subtract(payToRskLabs);
 
-        // TODO to improve
-        // this type choreography is only needed because the RepositoryTrack support the
-        // get snapshot to method
-        Repository processingRepository = ((RepositoryTrack)repository).getOriginRepository().getSnapshotTo(processingBlockHeader.getStateRoot());
-        // TODO to improve
-        // and we need a RepositoryTrack to feed RemascFederationProvider
-        // because it supports the update of bytes (notably, RepositoryImpl don't)
-        // the update of bytes is needed, because BridgeSupport creation could alter
-        // the storage when getChainHead is null (specially in production)
-        processingRepository = processingRepository.startTracking();
-        BridgeSupport bridgeSupport = new BridgeSupport(
-                config,
-                processingRepository,
-                null,
-                PrecompiledContracts.BRIDGE_ADDR,
-                processingBlock
-        );
-        RemascFederationProvider federationProvider = new RemascFederationProvider(bridgeSupport);
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config, repository, processingBlock);
 
         Coin payToFederation = fullBlockReward.divide(BigInteger.valueOf(remascConstants.getFederationDivisor()));
 

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
@@ -1,28 +1,61 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.remasc;
 
-import co.rsk.bitcoinj.store.BlockStoreException;
+import co.rsk.config.BridgeConstants;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
-import co.rsk.peg.BridgeSupport;
+import co.rsk.peg.BridgeStorageProvider;
+import co.rsk.peg.FederationSupport;
+import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
 import org.ethereum.crypto.ECKey;
-
-import java.io.IOException;
+import org.ethereum.vm.PrecompiledContracts;
 
 /**
  * Created by ajlopez on 14/11/2017.
  */
 public class RemascFederationProvider {
-    private BridgeSupport bridgeSupport;
+    private final FederationSupport federationSupport;
 
-    public RemascFederationProvider(BridgeSupport bridgeSupport) throws IOException, BlockStoreException {
-        this.bridgeSupport = bridgeSupport;
+    public RemascFederationProvider(
+            RskSystemProperties config,
+            Repository repository,
+            Block processingBlock) {
+        BridgeConstants bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
+                repository,
+                PrecompiledContracts.BRIDGE_ADDR,
+                bridgeConstants
+        );
+        this.federationSupport = new FederationSupport(
+                bridgeStorageProvider,
+                bridgeConstants,
+                processingBlock
+        );
     }
 
-    public int getFederationSize() throws IOException {
-        return this.bridgeSupport.getFederationSize().intValue();
+    public int getFederationSize() {
+        return this.federationSupport.getFederationSize();
     }
 
     public RskAddress getFederatorAddress(int n) {
-        byte[] publicKey = this.bridgeSupport.getFederatorPublicKey(n);
+        byte[] publicKey = this.federationSupport.getFederatorPublicKey(n);
         return new RskAddress(ECKey.fromPublicOnly(publicKey).getAddress());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.peg;
+
+import co.rsk.config.BridgeConstants;
+import org.ethereum.core.Block;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FederationSupportTest {
+
+    private FederationSupport federationSupport;
+    private BridgeConstants bridgeConstants;
+    private BridgeStorageProvider provider;
+    private Block executionBlock;
+
+    @Before
+    public void setUp() {
+        provider = mock(BridgeStorageProvider.class);
+        bridgeConstants = mock(BridgeConstants.class);
+        executionBlock = mock(Block.class);
+        federationSupport = new FederationSupport(provider, bridgeConstants, executionBlock);
+    }
+
+    @Test
+    public void whenNewFederationIsNullThenActiveFederationIsGenesisFederation() {
+        Federation genesisFederation = mock(Federation.class);
+        when(provider.getNewFederation())
+                .thenReturn(null);
+        when(bridgeConstants.getGenesisFederation())
+                .thenReturn(genesisFederation);
+
+        assertThat(federationSupport.getActiveFederation(), is(genesisFederation));
+    }
+
+    @Test
+    public void whenOldFederationIsNullThenActiveFederationIsNewFederation() {
+        Federation newFederation = mock(Federation.class);
+        when(provider.getNewFederation())
+                .thenReturn(newFederation);
+        when(provider.getOldFederation())
+                .thenReturn(null);
+
+        assertThat(federationSupport.getActiveFederation(), is(newFederation));
+    }
+
+    @Test
+    public void whenOldAndNewFederationArePresentReturnOldFederationByActivationAge() {
+        Federation newFederation = mock(Federation.class);
+        Federation oldFederation = mock(Federation.class);
+        when(provider.getNewFederation())
+                .thenReturn(newFederation);
+        when(provider.getOldFederation())
+                .thenReturn(oldFederation);
+        when(executionBlock.getNumber())
+                .thenReturn(80L);
+        when(bridgeConstants.getFederationActivationAge())
+                .thenReturn(10L);
+        when(newFederation.getCreationBlockNumber())
+                .thenReturn(75L);
+
+        assertThat(federationSupport.getActiveFederation(), is(oldFederation));
+    }
+
+    @Test
+    public void whenOldAndNewFederationArePresentReturnNewFederationByActivationAge() {
+        Federation newFederation = mock(Federation.class);
+        Federation oldFederation = mock(Federation.class);
+        when(provider.getNewFederation())
+                .thenReturn(newFederation);
+        when(provider.getOldFederation())
+                .thenReturn(oldFederation);
+        when(executionBlock.getNumber())
+                .thenReturn(80L);
+        when(bridgeConstants.getFederationActivationAge())
+                .thenReturn(10L);
+        when(newFederation.getCreationBlockNumber())
+                .thenReturn(65L);
+
+        assertThat(federationSupport.getActiveFederation(), is(newFederation));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
@@ -1,30 +1,25 @@
 package co.rsk.remasc;
 
-import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.TestSystemProperties;
-import co.rsk.peg.BridgeSupport;
 import co.rsk.test.builders.BlockChainBuilder;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Genesis;
-import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
 
 /**
  * Created by ajlopez on 14/11/2017.
  */
 public class RemascFederationProviderTest {
     @Test
-    public void getDefaultFederationSize() throws IOException, BlockStoreException {
+    public void getDefaultFederationSize() {
         RemascFederationProvider provider = getRemascFederationProvider();
         Assert.assertEquals(3, provider.getFederationSize());
     }
 
     @Test
-    public void getFederatorAddress() throws IOException, BlockStoreException {
+    public void getFederatorAddress() {
         RemascFederationProvider provider = getRemascFederationProvider();
 
         byte[] address = provider.getFederatorAddress(0).getBytes();
@@ -33,23 +28,11 @@ public class RemascFederationProviderTest {
         Assert.assertEquals(20, address.length);
     }
 
-    private static RemascFederationProvider getRemascFederationProvider() throws IOException, BlockStoreException {
+    private static RemascFederationProvider getRemascFederationProvider() {
         Genesis genesisBlock = new BlockGenerator().getGenesisBlock();
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
         Blockchain blockchain = builder.build();
 
-        BridgeSupport bridgeSupport = new BridgeSupport(new TestSystemProperties(), blockchain.getRepository(),
-                                                        null,
-                                                        PrecompiledContracts.BRIDGE_ADDR,
-                                                        null);
-        RemascFederationProvider provider = null;
-
-        try {
-            provider = new RemascFederationProvider(bridgeSupport);
-        } catch (BlockStoreException | IOException e) {
-            e.printStackTrace();
-        }
-
-        return provider;
+        return new RemascFederationProvider(new TestSystemProperties(), blockchain.getRepository(), null);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -18,7 +18,6 @@
 
 package co.rsk.remasc;
 
-import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.RemascConfig;
 import co.rsk.config.RemascConfigFactory;
@@ -27,7 +26,6 @@ import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.BridgeSupport;
 import co.rsk.peg.PegTestUtils;
 import co.rsk.test.builders.BlockChainBuilder;
 import com.google.common.collect.Lists;
@@ -41,7 +39,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
-import java.io.IOException;
 import java.math.BigInteger;
 import java.util.*;
 
@@ -71,7 +68,7 @@ public class RemascProcessMinerFeesTest {
     private Genesis genesisBlock = (Genesis) (new BlockGenerator()).getNewGenesisBlock(initialGasLimit, preMineMap);
 
     @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
+    public static void setUpBeforeClass() {
         config = new TestSystemProperties();
         config.setBlockchainConfig(new RegTestConfig());
         remascConfig = new RemascConfigFactory(RemascContract.REMASC_CONFIG).createRemascConfig("regtest");
@@ -84,7 +81,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void processMinersFeesWithoutRequiredMaturity() throws IOException {
+    public void processMinersFeesWithoutRequiredMaturity() {
         List<Block> blocks = createSimpleBlocks(genesisBlock, 1);
         Block blockWithOneTx = RemascTestRunner.createBlock(this.genesisBlock, blocks.get(blocks.size()-1), PegTestUtils.createHash3(), coinbaseA, null, minerFee, 0, txValue, cowKey);
         blocks.add(blockWithOneTx);
@@ -97,7 +94,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void processMinersFeesWithoutMinimumSyntheticSpan() throws IOException {
+    public void processMinersFeesWithoutMinimumSyntheticSpan() {
         BlockChainBuilder builder = new BlockChainBuilder();
         Blockchain blockchain = builder.setTesting(true).setGenesis(genesisBlock).build();
 
@@ -140,7 +137,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void processMinersFeesWithNoSiblings() throws IOException, BlockStoreException {
+    public void processMinersFeesWithNoSiblings() {
         BlockChainBuilder builder = new BlockChainBuilder();
         Blockchain blockchain = builder.setTesting(true).setGenesis(genesisBlock).build();
 
@@ -195,7 +192,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void processMinersFeesWithOneSibling() throws IOException, BlockStoreException {
+    public void processMinersFeesWithOneSibling() {
         BlockChainBuilder builder = new BlockChainBuilder();
         Blockchain blockchain = builder.setTesting(true).setGenesis(genesisBlock).build();
 
@@ -266,23 +263,21 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void processMinersFeesWithOneSiblingBrokenSelectionRuleBlockWithHigherFees() throws IOException, BlockStoreException {
+    public void processMinersFeesWithOneSiblingBrokenSelectionRuleBlockWithHigherFees() {
         processMinersFeesWithOneSiblingBrokenSelectionRule("higherFees");
     }
 
     /**
      * From RSKIP15, one of the three selection rules hash
-     * @throws IOException
-     * @throws ClassNotFoundException
      */
     @Test
-    public void processMinersFeesWithOneSiblingBrokenSelectionRuleBlockWithLowerHash() throws IOException, ClassNotFoundException, BlockStoreException {
+    public void processMinersFeesWithOneSiblingBrokenSelectionRuleBlockWithLowerHash() {
         processMinersFeesWithOneSiblingBrokenSelectionRule("lowerHash");
     }
 
     
     @Test
-    public void siblingThatBreaksSelectionRuleGetsPunished() throws IOException, BlockStoreException {
+    public void siblingThatBreaksSelectionRuleGetsPunished() {
         BlockChainBuilder builder = new BlockChainBuilder();
         Blockchain blockchain = builder.setTesting(true).setGenesis(genesisBlock).build();
 
@@ -408,7 +403,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void noPublisherFeeIsPaidWhenThePublisherHasNoSiblings() throws IOException, BlockStoreException {
+    public void noPublisherFeeIsPaidWhenThePublisherHasNoSiblings() {
         BlockChainBuilder builder = new BlockChainBuilder();
         Blockchain blockchain = builder.setTesting(true).setGenesis(genesisBlock).build();
 
@@ -464,7 +459,7 @@ public class RemascProcessMinerFeesTest {
     }
 
 
-    private void processMinersFeesWithOneSiblingBrokenSelectionRule(String reasonForBrokenSelectionRule) throws IOException, BlockStoreException {
+    private void processMinersFeesWithOneSiblingBrokenSelectionRule(String reasonForBrokenSelectionRule) {
         BlockChainBuilder builder = new BlockChainBuilder();
         Blockchain blockchain = builder.setTesting(true).setGenesis(genesisBlock).build();
 
@@ -575,7 +570,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void processMinersFeesFromTxThatIsNotTheLatestTx() throws IOException, BlockStoreException {
+    public void processMinersFeesFromTxThatIsNotTheLatestTx() {
         BlockChainBuilder builder = new BlockChainBuilder();
         Blockchain blockchain = builder.setTesting(true).setGenesis(genesisBlock).build();
 
@@ -639,7 +634,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void processMinersFeesFromTxInvokedByAnotherContract() throws IOException, BlockStoreException {
+    public void processMinersFeesFromTxInvokedByAnotherContract() {
         BlockChainBuilder builder = new BlockChainBuilder();
         Blockchain blockchain = builder.setTesting(true).setGenesis(genesisBlock).build();
 
@@ -727,7 +722,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void siblingIncludedOneBlockLater() throws IOException {
+    public void siblingIncludedOneBlockLater() {
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
 
         List<SiblingElement> siblings = Lists.newArrayList(new SiblingElement(5, 7, this.minerFee));
@@ -752,7 +747,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void oneSiblingIncludedOneBlockLaterAndAnotherIncludedRightAfter() throws IOException {
+    public void oneSiblingIncludedOneBlockLaterAndAnotherIncludedRightAfter() {
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
 
         List<SiblingElement> siblings = Lists.newArrayList(new SiblingElement(5, 6, this.minerFee), new SiblingElement(5, 7, this.minerFee));
@@ -783,7 +778,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void siblingIncludedSevenBlocksLater() throws IOException {
+    public void siblingIncludedSevenBlocksLater() {
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
 
         List<SiblingElement> siblings = Lists.newArrayList(new SiblingElement(5, 12, this.minerFee));
@@ -813,7 +808,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void siblingsFeeForMiningBlockMustBeRoundedAndTheRoundedSurplusBurned() throws IOException {
+    public void siblingsFeeForMiningBlockMustBeRoundedAndTheRoundedSurplusBurned() {
         BlockChainBuilder builder = new BlockChainBuilder()
                 .setTesting(true)
                 .setGenesis(genesisBlock);
@@ -854,7 +849,7 @@ public class RemascProcessMinerFeesTest {
     }
 
     @Test
-    public void unclesPublishingFeeMustBeRoundedAndTheRoundedSurplusBurned() throws IOException {
+    public void unclesPublishingFeeMustBeRoundedAndTheRoundedSurplusBurned() {
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
         long minerFee = 21000;
 
@@ -912,13 +907,8 @@ public class RemascProcessMinerFeesTest {
         return accountsWithExpectedBalance;
     }
 
-    private void validateFederatorsBalanceIsCorrect(Repository repository, long federationReward) throws IOException, BlockStoreException {
-        BridgeSupport bridgeSupport = new BridgeSupport(
-                config, repository,
-                null,
-            PrecompiledContracts.BRIDGE_ADDR,
-            null);
-        RemascFederationProvider provider = new RemascFederationProvider(bridgeSupport);
+    private void validateFederatorsBalanceIsCorrect(Repository repository, long federationReward) {
+        RemascFederationProvider provider = new RemascFederationProvider(config, repository, null);
 
         int nfederators = provider.getFederationSize();
 
@@ -954,7 +944,7 @@ public class RemascProcessMinerFeesTest {
         assertEquals(expectedSiblingsSize, provider.getSiblings().size());
     }
 
-    private RemascStorageProvider getRemascStorageProvider(Blockchain blockchain) throws IOException {
+    private RemascStorageProvider getRemascStorageProvider(Blockchain blockchain) {
         return new RemascStorageProvider(blockchain.getRepository(), PrecompiledContracts.REMASC_ADDR);
     }
 }


### PR DESCRIPTION
`Remasc` was using the `BridgeSupport` class for retrieving very basic information of the federation. This introduces a new abstraction (`FederationSupport`), which `RemascFederationProvider` can use directly.

Note that this doesn't include refactoring to make these classes components because it's harder than it seems. If we keep taking responsibilities from the big classes, it will eventually be much easier.