### PR TITLE
Jacoco plugin

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -14,6 +14,7 @@ plugins {
 
 apply plugin: 'witness'
 apply plugin: 'maven'
+apply plugin: 'jacoco'
 
 test {
     beforeTest { descriptor ->
@@ -26,6 +27,7 @@ test {
         events "failed"
         exceptionFormat "short"
     }
+    finalizedBy jacocoTestReport
 }
 
 tasks.withType(Javadoc) {


### PR DESCRIPTION
This puts in the `rskj-core/build/reports/jacoco/test/html/` directory the HTML output of the coverage report. Let me know if Jenkins needs the output in a different format (available options: xml, csv)