### PR TITLE
Make RPC's hashrate an integer value to be more compatible

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -24,6 +24,7 @@ import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
 
+import java.math.BigInteger;
 import java.util.Map;
 
 public interface Web3EthModule {
@@ -65,7 +66,7 @@ public interface Web3EthModule {
 
     boolean eth_mining();
 
-    String eth_hashrate();
+    BigInteger eth_hashrate();
 
     String eth_gasPrice();
 
@@ -127,7 +128,7 @@ public interface Web3EthModule {
 
     Object[] eth_getLogs(Web3.FilterRequest fr) throws Exception;
 
-    String eth_netHashrate();
+    BigInteger eth_netHashrate();
 
     boolean eth_submitWork(String nonce, String header, String mince);
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -60,13 +60,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 import static java.lang.Math.max;
 import static org.ethereum.rpc.TypeConverter.*;
@@ -312,33 +309,23 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
-    public String eth_hashrate() {
+    public BigInteger eth_hashrate() {
         BigInteger hashesPerHour = hashRateCalculator.calculateNodeHashRate(Duration.ofHours(1));
-        BigDecimal hashesPerSecond = new BigDecimal(hashesPerHour)
-                .divide(new BigDecimal(TimeUnit.HOURS.toSeconds(1)), 3, RoundingMode.HALF_UP);
+        BigInteger hashesPerSecond = hashesPerHour.divide(BigInteger.valueOf(Duration.ofHours(1).getSeconds()));
 
-        String result = hashesPerSecond.toString();
+        logger.debug("eth_hashrate(): {}", hashesPerSecond);
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("eth_hashrate(): {}", result);
-        }
-
-        return result;
+        return hashesPerSecond;
     }
 
     @Override
-    public String eth_netHashrate() {
+    public BigInteger eth_netHashrate() {
         BigInteger hashesPerHour = hashRateCalculator.calculateNetHashRate(Duration.ofHours(1));
-        BigDecimal hashesPerSecond = new BigDecimal(hashesPerHour)
-                .divide(new BigDecimal(TimeUnit.HOURS.toSeconds(1)), 3, RoundingMode.HALF_UP);
+        BigInteger hashesPerSecond = hashesPerHour.divide(BigInteger.valueOf(Duration.ofHours(1).getSeconds()));
 
-        String result = hashesPerSecond.toString();
+        logger.debug("eth_netHashrate(): {}", hashesPerSecond);
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("eth_netHashrate(): {}", result);
-        }
-
-        return result;
+        return hashesPerSecond;
     }
 
     @Override


### PR DESCRIPTION
`web3.js` assumes it's an integer, and the `eth_hashrate` RPC call fails if we return a decimal.

https://github.com/ethereum/web3.js/blob/c0e727eac7c16826c39fd43a03a4930b5ff6fff8/packages/web3-eth/src/index.js#L196

You can also see that `go-ethereum`'s API returns an integer:

https://github.com/ethereum/go-ethereum/blob/f9c456e02d6b8320389a7ea95c0eef3e10a87e2e/eth/api.go#L65