### PR TITLE
Move getCheckPoints() out of the BridgeSupport and into BridgeConstants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ samples/tokenapp/node_modules/
 rskdump.json
 
 rskj-core/keyfiletest.txt
-rskj-core/java/nodeId.properties
+rskj-core/java/
 
 #GradleJARS
 rskj-core/libs/gradle-witness.jar

--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -23,6 +23,8 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
 
+import java.io.InputStream;
+
 public class BridgeConstants {
     protected String btcParamsString;
 
@@ -31,7 +33,6 @@ public class BridgeConstants {
     protected int btc2RskMinimumAcceptableConfirmations;
     protected int btc2RskMinimumAcceptableConfirmationsOnRsk;
     protected int rsk2BtcMinimumAcceptableConfirmations;
-    protected int btcBroadcastingMinimumAcceptableBlocks;
 
     protected int updateBridgeExecutionPeriod;
 
@@ -52,6 +53,9 @@ public class BridgeConstants {
     protected AddressBasedAuthorizer feePerKbChangeAuthorizer;
 
     protected Coin genesisFeePerKb;
+
+    protected InputStream checkpoints;
+
 
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
@@ -100,4 +104,15 @@ public class BridgeConstants {
     public AddressBasedAuthorizer getFeePerKbChangeAuthorizer() { return feePerKbChangeAuthorizer; }
 
     public Coin getGenesisFeePerKb() { return genesisFeePerKb; }
+
+    public InputStream getCheckPoints() {
+        if(checkpoints == null) {
+            checkpoints = BridgeConstants.class.getResourceAsStream("/rskbitcoincheckpoints/" + this.getBtcParams().getId() + ".checkpoints");
+            if (checkpoints == null) {
+                // If we don't have a custom checkpoints file, try to use bitcoinj's default checkpoints for that network
+                checkpoints = BridgeConstants.class.getResourceAsStream("/" + this.getBtcParams().getId() + ".checkpoints");
+            }
+        }
+        return checkpoints;
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -186,12 +186,7 @@ public class BridgeSupport {
 
     @VisibleForTesting
     InputStream getCheckPoints() {
-        InputStream checkpoints = BridgeSupport.class.getResourceAsStream("/rskbitcoincheckpoints/" + bridgeConstants.getBtcParams().getId() + ".checkpoints");
-        if (checkpoints == null) {
-            // If we don't have a custom checkpoints file, try to use bitcoinj's default checkpoints for that network
-            checkpoints = BridgeSupport.class.getResourceAsStream("/" + bridgeConstants.getBtcParams().getId() + ".checkpoints");
-        }
-        return checkpoints;
+        return bridgeConstants.getCheckPoints();
     }
 
     public void save() throws IOException {

--- a/rskj-core/src/test/java/co/rsk/config/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/BridgeConstantsTest.java
@@ -1,0 +1,41 @@
+package co.rsk.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.List;
+
+public class BridgeConstantsTest {
+    @Test
+    public void getCheckPoints() {
+
+        BridgeRegTestConstants bridgeRegTestConstants = new BridgeRegTestConstants();
+        InputStream regTestCheckpoints = bridgeRegTestConstants.getCheckPoints();
+        Assert.assertNull(regTestCheckpoints);
+        InputStream regTestCheckpointsSecondCall = bridgeRegTestConstants.getCheckPoints();
+        Assert.assertNull(regTestCheckpointsSecondCall);
+
+        BridgeDevNetConstants bridgeDevNetConstants = new BridgeDevNetConstants();
+        InputStream devNetCheckpoints = bridgeDevNetConstants.getCheckPoints();
+        Assert.assertNotNull(devNetCheckpoints);
+        InputStream devNetCheckpointsSecondCall = bridgeDevNetConstants.getCheckPoints();
+        Assert.assertNotNull(devNetCheckpointsSecondCall);
+        Assert.assertEquals(devNetCheckpoints, devNetCheckpointsSecondCall);
+
+        BridgeTestNetConstants bridgeTestNetConstants = new BridgeTestNetConstants();
+        InputStream testNetCheckpoints = bridgeTestNetConstants.getCheckPoints();
+        Assert.assertNotNull(testNetCheckpoints);
+        InputStream testNetCheckpointsSecondCall = bridgeTestNetConstants.getCheckPoints();
+        Assert.assertNotNull(testNetCheckpointsSecondCall);
+        Assert.assertEquals(testNetCheckpoints, testNetCheckpointsSecondCall);
+
+        BridgeMainNetConstants bridgeMainNetConstants = new BridgeMainNetConstants();
+        InputStream mainNetCheckpoints = bridgeMainNetConstants.getCheckPoints();
+        Assert.assertNotNull(mainNetCheckpoints);
+        InputStream mainNetCheckpointsSecondCall = bridgeMainNetConstants.getCheckPoints();
+        Assert.assertNotNull(mainNetCheckpoints);
+        Assert.assertEquals(mainNetCheckpoints, mainNetCheckpointsSecondCall);
+    }
+}


### PR DESCRIPTION
Now we only need to load the checkpoints once.
Add rskj-core/java/  to git ignore