### PR TITLE
Add missing logs for proof of work failed validation checks

### DIFF
--- a/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
@@ -118,7 +118,7 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
         if (isFallbackMiningPossibleAndBlockSigned(header)) {
             boolean isValidFallbackSignature = validFallbackBlockSignature(constants, header, header.getBitcoinMergedMiningHeader());
             if (!isValidFallbackSignature) {
-                logger.warn("Fallback sign failed for header {}", header.getHash());
+                logger.warn("Fallback signature failed. Header {}", header.getShortHash());
             }
             return isValidFallbackSignature;
         }
@@ -127,18 +127,18 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
         byte[] bitcoinMergedMiningCoinbaseTransactionCompressed = header.getBitcoinMergedMiningCoinbaseTransaction();
 
         if (bitcoinMergedMiningCoinbaseTransactionCompressed == null) {
-            logger.warn("Compressed coinbase transaction does not exist");
+            logger.warn("Compressed coinbase transaction does not exist. Header {}", header.getShortHash());
             return false;
         }
 
         if (header.getBitcoinMergedMiningHeader() == null) {
-            logger.warn("Bitcoin merged mining header does not exist");
+            logger.warn("Bitcoin merged mining header does not exist. Header {}", header.getShortHash());
             return false;
         }
 
         byte[] pmtSerialized = header.getBitcoinMergedMiningMerkleProof();
         if (!PartialMerkleTreeFormatUtils.hasExpectedSize(pmtSerialized)) {
-            logger.warn("Partial merkle tree does not have the expected size");
+            logger.warn("Partial merkle tree does not have the expected size. Header {}", header.getShortHash());
             return false;
         }
 

--- a/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
@@ -116,22 +116,29 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
         // TODO: Make ProofOfWorkRule one of the classes that inherits from AuthenticationRule.
 
         if (isFallbackMiningPossibleAndBlockSigned(header)) {
-            return validFallbackBlockSignature(constants, header, header.getBitcoinMergedMiningHeader());
+            boolean isValidFallbackSignature = validFallbackBlockSignature(constants, header, header.getBitcoinMergedMiningHeader());
+            if (!isValidFallbackSignature) {
+                logger.warn("Fallback sign failed for header {}", header.getHash());
+            }
+            return isValidFallbackSignature;
         }
 
         co.rsk.bitcoinj.core.NetworkParameters bitcoinNetworkParameters = bridgeConstants.getBtcParams();
         byte[] bitcoinMergedMiningCoinbaseTransactionCompressed = header.getBitcoinMergedMiningCoinbaseTransaction();
 
-        if (bitcoinMergedMiningCoinbaseTransactionCompressed==null) {
+        if (bitcoinMergedMiningCoinbaseTransactionCompressed == null) {
+            logger.warn("Compressed coinbase transaction does not exist");
             return false;
         }
 
-        if (header.getBitcoinMergedMiningHeader()==null) {
+        if (header.getBitcoinMergedMiningHeader() == null) {
+            logger.warn("Bitcoin merged mining header does not exist");
             return false;
         }
 
         byte[] pmtSerialized = header.getBitcoinMergedMiningMerkleProof();
         if (!PartialMerkleTreeFormatUtils.hasExpectedSize(pmtSerialized)) {
+            logger.warn("Partial merkle tree does not have the expected size");
             return false;
         }
 


### PR DESCRIPTION
Some validation checks don't write a message on failure. By adding the missing logs might help debug these cases or diagnose other type of problems.