### PR TITLE
Update com.typesafe:config to 1.3.3

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     compile ("org.springframework:spring-context:${springVersion}") {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
-    compile "com.typesafe:config:1.3.1"
+    compile "com.typesafe:config:1.3.3"
     compile "org.mapdb:mapdb:2.0-beta13"
     compile "co.rsk.bitcoinj:bitcoinj-thin:${bitcoinjVersion}"
     compile 'com.github.briandilley.jsonrpc4j:jsonrpc4j:1.5.1'
@@ -133,7 +133,7 @@ dependencyVerification {
         'com.madgag.spongycastle:prov:becbb70797b0103517693d2a97ce93174cc4d1f732897ed965a24e32dd99503e',
         'com.squareup.okhttp:okhttp:b4c943138fcef2bcc9d2006b2250c4aabbedeafc5947ed7c0af7fd103ceb2707',
         'com.squareup.okio:okio:114bdc1f47338a68bcbc95abf2f5cdc72beeec91812f2fcd7b521c1937876266',
-        'com.typesafe:config:e6fadfc6108220d3a6b86aa7e4e16c9e7bb857ba58955886308bb13972264af0',
+        'com.typesafe:config:b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621',
         'commons-codec:commons-codec:4241dfa94e711d435f29a4604a3e2de5c4aa3c165e23bd066be6fc1fc4309569',
         'commons-io:commons-io:a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474',
         'commons-logging:commons-logging:daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636',


### PR DESCRIPTION
cc @juli

This updates the configuration dependency to fix a bug with environment variables (see https://github.com/lightbend/config/issues/559)

I looked at the code changes and everything seems to be in order. I also re-built the code from scratch using the following Docker image and the diffoscope report shows no binary differences with the version published in Maven Central: [report](https://github.com/rsksmart/rskj/files/2064150/diffoscope.pdf).

```Dockerfile
FROM frolvlad/alpine-oraclejdk8:8.144.1-slim

RUN apk add --no-cache bash curl openrc git
RUN curl -sL "https://piccolo.link/sbt-1.1.6.tgz" | gunzip | tar -x -C /usr/local && \
    ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt

WORKDIR /code
RUN git clone https://github.com/lightbend/config.git

WORKDIR /code/config
RUN git checkout v1.3.3
RUN sbt package
```