### PR TITLE
Ignore rskj-core/java folder as it has Logs, Locks and Manifests that are local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ samples/tokenapp/node_modules/
 rskdump.json
 
 rskj-core/keyfiletest.txt
-rskj-core/java/nodeId.properties
+rskj-core/java/
 
 #GradleJARS
 rskj-core/libs/gradle-witness.jar


### PR DESCRIPTION
The following files are ignored:
rskj-core/java/nodeId.properties
rskj-core/java/state/CURRENT
rskj-core/java/state/LOCK
rskj-core/java/state/LOG
rskj-core/java/state/MANIFEST
rskj-core/java/details/CURRENT
rskj-core/java/details/LOCK
rskj-core/java/details/LOG
rskj-core/java/details/MANIFEST