### PR TITLE
New algorithm to  sort pending transactions

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
@@ -88,7 +88,7 @@ public class PendingState implements AccountInformationProvider {
     // for each individual list.
     // To order the price we use a heap to keep it fast.
 
-    //Note that this sort doesn't return the best solution, it is an approximation algorithm to find approximate
+    // Note that this sort doesn't return the best solution, it is an approximation algorithm to find approximate
     // solution. (No trivial solution)
     public static final List<Transaction> sortByPriceTakingIntoAccountSenderAndNonce(List<Transaction> transactions) {
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
@@ -94,10 +94,8 @@ public class PendingState implements AccountInformationProvider {
 
         long txsCount = transactions.size();
 
-        Map<RskAddress, List<Transaction>> mapSenderToTxs = new HashMap();
-
         //First create a map to separate txs by each sender.
-        mapSenderToTxs = transactions.stream().collect(Collectors.groupingBy(Transaction::getSender));
+        Map<RskAddress, List<Transaction>> mapSenderToTxs = transactions.stream().collect(Collectors.groupingBy(Transaction::getSender));
 
         //For each sender list order all txs by nonce and then by hash
         for (Map.Entry<RskAddress, List<Transaction>> entry : mapSenderToTxs.entrySet()) {

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -41,7 +41,6 @@ import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class MinerUtils {
 
@@ -150,10 +149,10 @@ public class MinerUtils {
     }
 
     public List<org.ethereum.core.Transaction> getAllTransactions(TransactionPool transactionPool) {
-        //TODO: optimize this by considering GasPrice (order by GasPrice/Nonce)
-        return transactionPool.getPendingTransactions().stream()
-                .sorted(PendingState.TRANSACTION_COMPARATOR)
-                .collect(Collectors.toCollection(LinkedList::new));
+
+        List<Transaction> txs = transactionPool.getPendingTransactions();
+
+        return PendingState.SortByPriceTakingIntoAccountSenderAndNonce(txs);
     }
 
     public List<org.ethereum.core.Transaction> filterTransactions(List<Transaction> txsToRemove, List<Transaction> txs, Map<RskAddress, BigInteger> accountNonces, Repository originalRepo, Coin minGasPrice) {

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -152,7 +152,7 @@ public class MinerUtils {
 
         List<Transaction> txs = transactionPool.getPendingTransactions();
 
-        return PendingState.SortByPriceTakingIntoAccountSenderAndNonce(txs);
+        return PendingState.sortByPriceTakingIntoAccountSenderAndNonce(txs);
     }
 
     public List<org.ethereum.core.Transaction> filterTransactions(List<Transaction> txsToRemove, List<Transaction> txs, Map<RskAddress, BigInteger> accountNonces, Repository originalRepo, Coin minGasPrice) {

--- a/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
@@ -51,12 +51,16 @@ public class MinerUtilsTest {
         s1[0] = 0;
         s2[0] = 1;
 
+        byte[] addressBytes = ByteUtil.leftPadBytes(BigInteger.valueOf(new Random(0).nextLong()).toByteArray(), 20);
+
         Mockito.when(tx1.getHash()).thenReturn(new Keccak256(s1));
         Mockito.when(tx2.getHash()).thenReturn(new Keccak256(s2));
         Mockito.when(tx1.getNonce()).thenReturn(ByteUtil.cloneBytes( BigInteger.ZERO.toByteArray()));
         Mockito.when(tx2.getNonce()).thenReturn(ByteUtil.cloneBytes( BigInteger.TEN.toByteArray()));
         Mockito.when(tx1.getGasPrice()).thenReturn(Coin.valueOf(1));
         Mockito.when(tx2.getGasPrice()).thenReturn(Coin.valueOf(1));
+        Mockito.when(tx1.getSender()).thenReturn(new RskAddress(addressBytes));
+        Mockito.when(tx2.getSender()).thenReturn(new RskAddress(addressBytes));
 
         List<Transaction> txs = new LinkedList<>();
 

--- a/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
@@ -53,6 +53,10 @@ public class MinerUtilsTest {
 
         Mockito.when(tx1.getHash()).thenReturn(new Keccak256(s1));
         Mockito.when(tx2.getHash()).thenReturn(new Keccak256(s2));
+        Mockito.when(tx1.getNonce()).thenReturn(ByteUtil.cloneBytes( BigInteger.ZERO.toByteArray()));
+        Mockito.when(tx2.getNonce()).thenReturn(ByteUtil.cloneBytes( BigInteger.TEN.toByteArray()));
+        Mockito.when(tx1.getGasPrice()).thenReturn(Coin.valueOf(1));
+        Mockito.when(tx2.getGasPrice()).thenReturn(Coin.valueOf(1));
 
         List<Transaction> txs = new LinkedList<>();
 
@@ -145,5 +149,119 @@ public class MinerUtilsTest {
         List<Transaction> res = new MinerUtils().filterTransactions(txsToRemove, txs, accountNounces, repository, minGasPrice);
         Assert.assertEquals(0, res.size());
         Assert.assertEquals(1, txsToRemove.size());
+    }
+
+    @Test
+    public void getAllTransactionsCheckOrderTest() {
+        TransactionPool transactionPool = Mockito.mock(TransactionPool.class);
+
+        Transaction tx1 = Mockito.mock(Transaction.class);
+        Transaction tx2 = Mockito.mock(Transaction.class);
+        Transaction tx3 = Mockito.mock(Transaction.class);
+
+        byte[] nonce0 = ByteUtil.cloneBytes( BigInteger.valueOf(0).toByteArray());
+        byte[] nonce1 = ByteUtil.cloneBytes( BigInteger.valueOf(1).toByteArray());
+        byte[] nonce2 = ByteUtil.cloneBytes( BigInteger.valueOf(2).toByteArray());
+
+        byte[] addressBytes = ByteUtil.leftPadBytes(BigInteger.valueOf(new Random(0).nextLong()).toByteArray(), 20);
+        Mockito.when(tx1.getSender()).thenReturn(new RskAddress(addressBytes));
+        Mockito.when(tx1.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce0));
+        Mockito.when(tx1.getGasPrice()).thenReturn(Coin.valueOf(1));
+
+        Mockito.when(tx2.getSender()).thenReturn(new RskAddress(addressBytes));
+        Mockito.when(tx2.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce1));
+        Mockito.when(tx2.getGasPrice()).thenReturn(Coin.valueOf(10));
+
+        Mockito.when(tx3.getSender()).thenReturn(new RskAddress(addressBytes));
+        Mockito.when(tx3.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce2));
+        Mockito.when(tx3.getGasPrice()).thenReturn(Coin.valueOf(100));
+
+        List<Transaction> txs = new LinkedList<>();
+
+        txs.add(tx3);
+        txs.add(tx1);
+        txs.add(tx2);
+
+        Mockito.when(transactionPool.getPendingTransactions()).thenReturn(txs);
+
+        List<Transaction> res = new MinerUtils().getAllTransactions(transactionPool);
+
+        Assert.assertEquals(3, res.size());
+        Assert.assertEquals(res.get(0).getNonce(), tx1.getNonce());
+        Assert.assertEquals(res.get(1).getNonce(), tx2.getNonce());
+        Assert.assertEquals(res.get(2).getNonce(), tx3.getNonce());
+        Assert.assertEquals(res.get(0).getGasPrice(), Coin.valueOf(1));
+        Assert.assertEquals(res.get(1).getGasPrice(), Coin.valueOf(10));
+        Assert.assertEquals(res.get(2).getGasPrice(), Coin.valueOf(100));
+
+        // Add new transactions
+        Transaction tx4 = Mockito.mock(Transaction.class);
+        Transaction tx5 = Mockito.mock(Transaction.class);
+        Transaction tx6 = Mockito.mock(Transaction.class);
+
+        byte[] addressBytes2 = ByteUtil.leftPadBytes(BigInteger.valueOf(new Random(100).nextLong()).toByteArray(), 20);
+        Mockito.when(tx4.getSender()).thenReturn(new RskAddress(addressBytes2));
+        Mockito.when(tx4.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce0));
+        Mockito.when(tx4.getGasPrice()).thenReturn(Coin.valueOf(50));
+
+        Mockito.when(tx5.getSender()).thenReturn(new RskAddress(addressBytes2));
+        Mockito.when(tx5.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce1));
+        Mockito.when(tx5.getGasPrice()).thenReturn(Coin.valueOf(1000));
+
+        Mockito.when(tx6.getSender()).thenReturn(new RskAddress(addressBytes2));
+        Mockito.when(tx6.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce2));
+        Mockito.when(tx6.getGasPrice()).thenReturn(Coin.valueOf(1));
+
+        txs.add(tx6);
+        txs.add(tx5);
+        txs.add(tx4);
+
+        Mockito.when(transactionPool.getPendingTransactions()).thenReturn(txs);
+
+        res = new MinerUtils().getAllTransactions(transactionPool);
+
+        Assert.assertEquals(6, res.size());
+        Assert.assertEquals(res.get(0).getGasPrice(), Coin.valueOf(50));
+        Assert.assertEquals(res.get(1).getGasPrice(), Coin.valueOf(1000));
+        Assert.assertEquals(res.get(2).getGasPrice(), Coin.valueOf(1));
+        Assert.assertEquals(res.get(3).getGasPrice(), Coin.valueOf(10));
+        Assert.assertEquals(res.get(4).getGasPrice(), Coin.valueOf(100));
+        Assert.assertEquals(res.get(5).getGasPrice(), Coin.valueOf(1));
+
+        Transaction tx7 = Mockito.mock(Transaction.class);
+        Transaction tx8 = Mockito.mock(Transaction.class);
+        Transaction tx9 = Mockito.mock(Transaction.class);
+
+        byte[] addressBytes3 = ByteUtil.leftPadBytes(BigInteger.valueOf(new Random(1000).nextLong()).toByteArray(), 20);
+        Mockito.when(tx7.getSender()).thenReturn(new RskAddress(addressBytes3));
+        Mockito.when(tx7.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce0));
+        Mockito.when(tx7.getGasPrice()).thenReturn(Coin.valueOf(500));
+
+        Mockito.when(tx8.getSender()).thenReturn(new RskAddress(addressBytes3));
+        Mockito.when(tx8.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce1));
+        Mockito.when(tx8.getGasPrice()).thenReturn(Coin.valueOf(500));
+
+        Mockito.when(tx9.getSender()).thenReturn(new RskAddress(addressBytes3));
+        Mockito.when(tx9.getNonce()).thenReturn(ByteUtil.cloneBytes(nonce2));
+        Mockito.when(tx9.getGasPrice()).thenReturn(Coin.valueOf(2000));
+
+        txs.add(tx7);
+        txs.add(tx8);
+        txs.add(tx9);
+
+        Mockito.when(transactionPool.getPendingTransactions()).thenReturn(txs);
+
+        res = new MinerUtils().getAllTransactions(transactionPool);
+
+        Assert.assertEquals(9, res.size());
+        Assert.assertEquals(res.get(0).getGasPrice(), Coin.valueOf(500));
+        Assert.assertEquals(res.get(1).getGasPrice(), Coin.valueOf(500));
+        Assert.assertEquals(res.get(2).getGasPrice(), Coin.valueOf(2000));
+        Assert.assertEquals(res.get(3).getGasPrice(), Coin.valueOf(50));
+        Assert.assertEquals(res.get(4).getGasPrice(), Coin.valueOf(1000));
+        Assert.assertEquals(res.get(5).getGasPrice(), Coin.valueOf(1));
+        Assert.assertEquals(res.get(6).getGasPrice(), Coin.valueOf(10));
+        Assert.assertEquals(res.get(7).getGasPrice(), Coin.valueOf(100));
+        Assert.assertEquals(res.get(8).getGasPrice(), Coin.valueOf(1));
     }
 }


### PR DESCRIPTION
- New algorithm to sort transactions by price, but taking into account  sender and then each cluster is order by nonce.
This method first sorts list of getPendingTransactions into individual sender and sorts those lists by nonce. After the nonce ordering is satisfied, the results are merged back together by price in a heap to make it fast.

- Also added some test to check the correct behaviour of the new ordering.