### PR TITLE
Move miner client delays configuration to the configuration file

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -42,6 +42,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -120,11 +121,19 @@ public class RskSystemProperties extends SystemProperties {
     }
 
     public boolean isMinerClientEnabled() {
-        return getBoolean("miner.client.enabled", false);
+        return configFromFiles.getBoolean("miner.client.enabled");
+    }
+
+    public Duration minerClientDelayBetweenBlocks() {
+        return configFromFiles.getDuration("miner.client.delayBetweenBlocks");
+    }
+
+    public Duration minerClientDelayBetweenRefreshes() {
+        return configFromFiles.getDuration("miner.client.delayBetweenRefreshes");
     }
 
     public boolean isMinerServerEnabled() {
-        return getBoolean("miner.server.enabled", false);
+        return configFromFiles.getBoolean("miner.server.enabled");
     }
 
     public long minerMinGasPrice() {

--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -4,6 +4,13 @@ peer {
     networkId = 44444444
 }
 
+miner {
+    client {
+        delayBetweenBlocks = 20 seconds
+    }
+}
+
+
 genesis = devnet-genesis.json
 
 hello.phrase = Dev

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -25,7 +25,12 @@ peer {
 
 miner {
     server.enabled = true
-    client.enabled = true
+
+    client {
+        enabled = true
+        delayBetweenBlocks = 1 second
+    }
+
     minGasPrice = 0
 
     # this is a secret passphrase that is used to derive the address where the miner gets the reward.

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -44,6 +44,21 @@ peer {
     maxActivePeers = 30
 }
 
+miner {
+    server.enabled = false
+
+    client {
+        enabled = false
+
+        # The time the miner client will wait after mining a block and before mining the next one.
+        # This allows mining a sane number of blocks per minute when the difficulty is low (e.g. for regtest).
+        delayBetweenBlocks = 0 seconds
+
+        # The time the miner client will wait to refresh the current work from the miner server
+        delayBetweenRefreshes = 1 second
+    }
+}
+
 database {
     # every time the application starts the existing database will be destroyed and all the data will be downloaded from peers again
     # having this set on true does NOT mean that the block chain will start from the last point


### PR DESCRIPTION
This maintains current behavior for all networks but allows configuration using environment variables and Java system properties.

This was necessary to speed up OpenZeppelin tests as seen [here](https://github.com/rsksmart/openzeppelin-solidity/blob/d7dc91f33eb1fc604064429c65a3de7a35c41f1c/.circleci/config.yml#L20):

```
docker run \
    -e "miner.client.delayBetweenBlocks=500" \
    -e "miner.client.delayBetweenRefreshes=500" \
    -d --name rskj rsksmart/rskj --regtest
 ```