### PR TITLE
Implemented a rule to accept a tx replacement on Transaction Pool

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -399,4 +399,8 @@ public class RskSystemProperties extends SystemProperties {
     public int getPeerP2PPingInterval(){
         return configFromFiles.getInt("peer.p2p.pingInterval");
     }
+
+    public Integer getGasPriceBump() {
+        return configFromFiles.getInt("transaction.gasPriceBump");
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionSet.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionSet.java
@@ -57,6 +57,16 @@ public class TransactionSet {
         if (txs == null) {
             txs = new ArrayList<>();
             this.transactionsByAddress.put(senderAddress, txs);
+        } else {
+            Optional<Transaction> optTxToRemove = txs.stream()
+                    .filter(tx -> tx.getNonceAsInteger().equals(transaction.getNonceAsInteger()))
+                    .findFirst();
+
+            if (optTxToRemove.isPresent()) {
+                Transaction txToRemove = optTxToRemove.get();
+                txs.remove(txToRemove);
+                this.transactionsByHash.remove(txToRemove.getHash());
+            }
         }
 
         txs.add(transaction);

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -89,6 +89,10 @@ transaction.outdated.threshold = 10
 # (suggested value: 10 blocks * 10 seconds by block = 100 seconds)
 transaction.outdated.timeout = 650
 
+# the percentage increase of gasPrice defined to accept a new transaction
+# with same nonce and sender while the previous one is not yet processed
+transaction.gasPriceBump = 40
+
 
 dump {
     # for testing purposes all the state will be dumped in JSON form to [dump.dir] if [dump.full] = true

--- a/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
@@ -514,6 +514,30 @@ public class TransactionPoolImplTest {
         Assert.assertEquals(DataWord.ONE, transactionPool.getPendingState().getStorageValue(tx.getContractAddress(), DataWord.ZERO));
     }
 
+    @Test
+    public void checkTxWithSameNonceIsRejected() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+        Transaction tx = createSampleTransaction(1, 0, 1000, 0);
+        Transaction tx2 = createSampleTransaction(1, 0, 2000, 0);
+
+        transactionPool.addTransaction(tx);
+        Assert.assertFalse(transactionPool.addTransaction(tx2));
+    }
+
+    @Test
+    public void checkTxWithSameNonceBumpedIsAccepted() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+        Transaction tx1 = createSampleTransactionWithGasPrice(1, 0, 1000, 0, 1);
+        Transaction tx2 = createSampleTransactionWithGasPrice(1, 0, 2000, 0, 2);
+
+        transactionPool.addTransaction(tx1);
+        Assert.assertTrue(transactionPool.addTransaction(tx2));
+        Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx2.getHash())));
+        Assert.assertFalse(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx1.getHash())));
+    }
+
     private void createTestAccounts(int naccounts, Coin balance) {
         Repository repository = blockChain.getRepository();
 

--- a/rskj-core/src/test/java/org/ethereum/util/TransactionFactoryHelper.java
+++ b/rskj-core/src/test/java/org/ethereum/util/TransactionFactoryHelper.java
@@ -23,26 +23,24 @@ public class TransactionFactoryHelper {
         Account sender = new AccountBuilder().name("sender").build();
         Account receiver = new AccountBuilder().name("receiver").build();
 
-        Transaction tx = new TransactionBuilder()
-                .nonce(nonce)
-                .sender(sender)
-                .receiver(receiver)
-                .value(BigInteger.TEN)
-                .build();
+        Transaction tx = getBuilder(sender, receiver, nonce, 10).build();
 
         return tx;
+    }
+
+    private static TransactionBuilder getBuilder(Account sender, Account receiver, long nonce, long value) {
+        return new TransactionBuilder()
+                .sender(sender)
+                .receiver(receiver)
+                .nonce(nonce)
+                .value(BigInteger.valueOf(value));
     }
 
     public static Transaction createSampleTransaction(int from, int to, long value, int nonce) {
         Account sender = createAccount(from);
         Account receiver = createAccount(to);
 
-        Transaction tx = new TransactionBuilder()
-                .sender(sender)
-                .receiver(receiver)
-                .nonce(nonce)
-                .value(BigInteger.valueOf(value))
-                .build();
+        Transaction tx = getBuilder(sender, receiver, nonce, value).build();
 
         return tx;
     }
@@ -51,12 +49,19 @@ public class TransactionFactoryHelper {
         Account sender = createAccount(from);
         Account receiver = createAccount(to);
 
-        Transaction tx = new TransactionBuilder()
-                .sender(sender)
-                .receiver(receiver)
-                .nonce(nonce)
-                .value(BigInteger.valueOf(value))
+        Transaction tx = getBuilder(sender, receiver, nonce, value)
                 .gasLimit(gasLimit)
+                .build();
+
+        return tx;
+    }
+
+    public static Transaction createSampleTransactionWithGasPrice(int from, int to, long value, int nonce, long gasPrice) {
+        Account sender = createAccount(from);
+        Account receiver = createAccount(to);
+
+        Transaction tx = getBuilder(sender, receiver, nonce, value)
+                .gasPrice(BigInteger.valueOf(gasPrice))
                 .build();
 
         return tx;


### PR DESCRIPTION
When a new transaction arrives from a sender that wants to replace another transaction not yet processed there is introduced a new rule to determine if it's paying enough gas to accept the new one.