### PR TITLE
Second iteration adding automine

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -132,6 +132,10 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getDuration("miner.client.delayBetweenRefreshes");
     }
 
+    public boolean minerClientAutoMine() {
+        return configFromFiles.getBoolean("miner.client.autoMine");
+    }
+
     public boolean isMinerServerEnabled() {
         return configFromFiles.getBoolean("miner.server.enabled");
     }

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -23,6 +23,7 @@ import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.TransactionPoolImpl;
 import co.rsk.metrics.HashRateCalculator;
 import co.rsk.mine.MinerClient;
+import co.rsk.mine.MinerClientImpl;
 import co.rsk.mine.MinerServer;
 import co.rsk.net.*;
 import co.rsk.net.eth.RskWireProtocol;
@@ -339,6 +340,11 @@ public class RskFactory {
             logger.debug("Solidity compiler unavailable", e);
             return new EthModuleSolidityDisabled();
         }
+    }
+
+    @Bean
+    public MinerClient getMinerClient(RskSystemProperties config, Rsk rsk, MinerServer minerServer) {
+        return new MinerClientImpl(rsk, minerServer, config.minerClientDelayBetweenBlocks(), config.minerClientDelayBetweenRefreshes());
     }
 
     @Bean

--- a/rskj-core/src/main/java/co/rsk/core/SnapshotManager.java
+++ b/rskj-core/src/main/java/co/rsk/core/SnapshotManager.java
@@ -18,6 +18,7 @@
 
 package co.rsk.core;
 
+import co.rsk.mine.MinerServer;
 import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
@@ -35,10 +36,12 @@ public class SnapshotManager {
     private List<Long> snapshots = new ArrayList<>();
     private final Blockchain blockchain;
     private final TransactionPool transactionPool;
+    private final MinerServer minerServer;
 
-    public SnapshotManager(Blockchain blockchain, TransactionPool transactionPool) {
+    public SnapshotManager(Blockchain blockchain, TransactionPool transactionPool, MinerServer minerServer) {
         this.blockchain = blockchain;
         this.transactionPool = transactionPool;
+        this.minerServer = minerServer;
     }
 
     public int takeSnapshot() {
@@ -68,6 +71,9 @@ public class SnapshotManager {
         for (long nb = blockchain.getBestBlock().getNumber() + 1; nb <= bestNumber; nb++) {
             blockchain.removeBlocksByNumber(nb);
         }
+
+        // start mining on top of the new best block
+        minerServer.buildBlockToMine(block, false);
 
         return true;
     }
@@ -104,6 +110,9 @@ public class SnapshotManager {
         for (long nb = blockchain.getBestBlock().getNumber() + 1; nb <= currentBestBlockNumber; nb++) {
             blockchain.removeBlocksByNumber(nb);
         }
+
+        // start mining on top of the new best block
+        minerServer.buildBlockToMine(block, false);
 
         return true;
     }

--- a/rskj-core/src/main/java/co/rsk/core/bc/FamilyUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/FamilyUtils.java
@@ -156,11 +156,6 @@ public class FamilyUtils {
             List<Block> uncles = store.getChainBlocksByNumber(ancestor.getNumber());
 
             for (Block uncle : uncles) {
-                // TODO quick fix, the block storage should be reviewed
-                if (uncle == null) {
-                    continue;
-                }
-
                 if (!ancestorParent.getHash().equals(uncle.getParentHash())) {
                     continue;
                 }

--- a/rskj-core/src/main/java/co/rsk/mine/AutoMinerClient.java
+++ b/rskj-core/src/main/java/co/rsk/mine/AutoMinerClient.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.mine;
+
+import org.ethereum.rpc.TypeConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+
+/**
+ * MinerClient for automine setting
+ */
+public class AutoMinerClient implements MinerClient {
+    private static final Logger logger = LoggerFactory.getLogger("minerClient");
+
+    private final MinerServer minerServer;
+
+    private volatile boolean stop = false;
+    private volatile boolean isMining = false;
+
+    public AutoMinerClient(MinerServer minerServer) {
+        this.minerServer = minerServer;
+    }
+
+    @Override
+    public void mine() {
+        isMining = true;
+    }
+
+    @Override
+    public boolean isMining() {
+        return this.isMining;
+    }
+
+    @Override
+    public boolean mineBlock() {
+        // if miner server was stopped for some reason, we don't mine.
+        if (stop) {
+            return false;
+        }
+
+        MinerWork work = minerServer.getWork();
+
+        co.rsk.bitcoinj.core.NetworkParameters bitcoinNetworkParameters = co.rsk.bitcoinj.params.RegTestParams.get();
+        co.rsk.bitcoinj.core.BtcTransaction bitcoinMergedMiningCoinbaseTransaction = MinerUtils.getBitcoinMergedMiningCoinbaseTransaction(bitcoinNetworkParameters, work);
+        co.rsk.bitcoinj.core.BtcBlock bitcoinMergedMiningBlock = MinerUtils.getBitcoinMergedMiningBlock(bitcoinNetworkParameters, bitcoinMergedMiningCoinbaseTransaction);
+
+        BigInteger target = new BigInteger(1, TypeConverter.stringHexToByteArray(work.getTarget()));
+        boolean foundNonce = findNonce(bitcoinMergedMiningBlock, target);
+
+        if (foundNonce) {
+            logger.info("Mined block: {}", work.getBlockHashForMergedMining());
+            minerServer.submitBitcoinBlock(work.getBlockHashForMergedMining(), bitcoinMergedMiningBlock);
+        }
+
+        return foundNonce;
+    }
+
+    @Override
+    public boolean fallbackMineBlock() {
+        throw new RuntimeException("Fallback mining is deprecated");
+    }
+
+    @Override
+    public void stop() {
+        stop = true;
+        isMining = false;
+    }
+
+    /**
+     * Find a valid nonce for bitcoinMergedMiningBlock, that satisfies the given target difficulty.
+     */
+    private boolean findNonce(
+            co.rsk.bitcoinj.core.BtcBlock bitcoinMergedMiningBlock,
+            BigInteger target) {
+        long nextNonceToUse = 0;
+        bitcoinMergedMiningBlock.setNonce(nextNonceToUse++);
+
+        while (true) {
+            // Is our proof of work valid yet?
+            BigInteger blockHashBI = bitcoinMergedMiningBlock.getHash().toBigInteger();
+            if (blockHashBI.compareTo(target) <= 0) {
+                return true;
+            }
+            // No, so increment the nonce and try again.
+            bitcoinMergedMiningBlock.setNonce(nextNonceToUse++);
+            if (bitcoinMergedMiningBlock.getNonce() % 100000 == 0) {
+                logger.debug("Solving block. Nonce: {}", bitcoinMergedMiningBlock.getNonce());
+            }
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/mine/MinerClientImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClientImpl.java
@@ -18,14 +18,11 @@
 
 package co.rsk.mine;
 
-import co.rsk.config.RskSystemProperties;
-import co.rsk.core.Rsk;
 import co.rsk.panic.PanicProcessor;
+import co.rsk.core.Rsk;
 import org.ethereum.rpc.TypeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
 import java.math.BigInteger;
@@ -39,8 +36,6 @@ import java.util.TimerTask;
  * uses MinerServer to build blocks to mine and publish blocks once a valid nonce was found.
  * @author Oscar Guindzberg
  */
-
-@Component("MinerClient")
 public class MinerClientImpl implements MinerClient {
     private long nextNonceToUse = 0;
 
@@ -61,12 +56,11 @@ public class MinerClientImpl implements MinerClient {
     private volatile MinerWork work;
     private Timer aTimer;
 
-    @Autowired
-    public MinerClientImpl(Rsk rsk, MinerServer minerServer, RskSystemProperties config) {
+    public MinerClientImpl(Rsk rsk, MinerServer minerServer, Duration delayBetweenBlocks, Duration delayBetweenRefreshes) {
         this.rsk = rsk;
         this.minerServer = minerServer;
-        this.delayBetweenBlocks = config.minerClientDelayBetweenBlocks();
-        this.delayBetweenRefreshes = config.minerClientDelayBetweenRefreshes();
+        this.delayBetweenBlocks = delayBetweenBlocks;
+        this.delayBetweenRefreshes = delayBetweenRefreshes;
     }
 
     public void mine() {

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -36,10 +36,6 @@ public interface Web3EthModule {
         return getEthModule().sign(addr, data);
     }
 
-    default String eth_sendTransaction(Web3.CallArguments args) {
-        return getEthModule().sendTransaction(args);
-    }
-
     default String eth_call(Web3.CallArguments args, String bnOrId) {
         return getEthModule().call(args, bnOrId);
     }
@@ -90,7 +86,13 @@ public interface Web3EthModule {
 
     String eth_getCode(String addr, String bnOrId)throws Exception;
 
-    String eth_sendRawTransaction(String rawData) throws Exception;
+    default String eth_sendRawTransaction(String rawData) {
+        return getEthModule().sendRawTransaction(rawData);
+    }
+
+    default String eth_sendTransaction(Web3.CallArguments args) {
+        return getEthModule().sendTransaction(args);
+    }
 
     Web3.BlockResult eth_getBlockByHash(String blockHash, Boolean fullTransactionObjects) throws Exception;
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -45,7 +45,7 @@ import static org.ethereum.rpc.TypeConverter.toJsonHex;
 // TODO add all RPC methods
 @Component
 public class EthModule
-    implements EthModuleSolidity, EthModuleWallet {
+    implements EthModuleSolidity, EthModuleWallet, EthModuleTransaction {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("web3");
 
@@ -55,6 +55,7 @@ public class EthModule
     private final ExecutionBlockRetriever executionBlockRetriever;
     private final EthModuleSolidity ethModuleSolidity;
     private final EthModuleWallet ethModuleWallet;
+    private final EthModuleTransaction ethModuleTransaction;
 
     @Autowired
     public EthModule(
@@ -63,13 +64,15 @@ public class EthModule
             ReversibleTransactionExecutor reversibleTransactionExecutor,
             ExecutionBlockRetriever executionBlockRetriever,
             EthModuleSolidity ethModuleSolidity,
-            EthModuleWallet ethModuleWallet) {
+            EthModuleWallet ethModuleWallet,
+            EthModuleTransaction ethModuleTransaction) {
         this.config = config;
         this.blockchain = blockchain;
         this.reversibleTransactionExecutor = reversibleTransactionExecutor;
         this.executionBlockRetriever = executionBlockRetriever;
         this.ethModuleSolidity = ethModuleSolidity;
         this.ethModuleWallet = ethModuleWallet;
+        this.ethModuleTransaction = ethModuleTransaction;
     }
 
     @Override
@@ -123,7 +126,12 @@ public class EthModule
 
     @Override
     public String sendTransaction(Web3.CallArguments args) {
-        return ethModuleWallet.sendTransaction(args);
+        return ethModuleTransaction.sendTransaction(args);
+    }
+
+    @Override
+    public String sendRawTransaction(String rawData) {
+        return ethModuleTransaction.sendRawTransaction(rawData);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransaction.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransaction.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of RskJ
- * Copyright (C) 2017 RSK Labs Ltd.
+ * Copyright (C) 2018 RSK Labs Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -18,26 +18,10 @@
 
 package co.rsk.rpc.modules.eth;
 
-import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.ethereum.rpc.Web3;
 
-import java.util.Arrays;
+public interface EthModuleTransaction {
+    String sendTransaction(Web3.CallArguments args);
 
-public class EthModuleWalletDisabled implements EthModuleWallet {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger("web3");
-
-    @Override
-    public String[] accounts() {
-        String[] accounts = {};
-        LOGGER.debug("eth_accounts(): {}", Arrays.toString(accounts));
-        return accounts;
-    }
-
-    @Override
-    public String sign(String addr, String data) {
-        LOGGER.debug("eth_sign({}, {}): {}", addr, data, null);
-        throw new JsonRpcInvalidParamException("Local wallet is disabled in this node");
-    }
+    String sendRawTransaction(String rawData);
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Account;
+import org.ethereum.core.ImmutableTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
+import org.ethereum.vm.GasCost;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+
+import static org.ethereum.rpc.TypeConverter.stringHexToByteArray;
+
+public class EthModuleTransactionBase implements EthModuleTransaction {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger("web3");
+
+    private final RskSystemProperties config;
+    private final Wallet wallet;
+    private final TransactionPool transactionPool;
+
+    public EthModuleTransactionBase(RskSystemProperties config, Wallet wallet, TransactionPool transactionPool) {
+        this.config = config;
+        this.wallet = wallet;
+        this.transactionPool = transactionPool;
+    }
+
+    @Override
+    public synchronized String sendTransaction(Web3.CallArguments args) {
+        Account account = this.wallet.getAccount(new RskAddress(args.from));
+        String s = null;
+        try {
+            String toAddress = args.to != null ? Hex.toHexString(stringHexToByteArray(args.to)) : null;
+
+            BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
+            BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
+            BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
+
+            if (args.data != null && args.data.startsWith("0x")) {
+                args.data = args.data.substring(2);
+            }
+
+            synchronized (transactionPool) {
+                BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : transactionPool.getPendingState().getNonce(account.getAddress());
+                Transaction tx = Transaction.create(config, toAddress, value, accountNonce, gasPrice, gasLimit, args.data);
+                tx.sign(account.getEcKey().getPrivKeyBytes());
+                transactionPool.addTransaction(tx.toImmutableTransaction());
+                s = tx.getHash().toJsonString();
+            }
+
+            return s;
+
+        } finally {
+            LOGGER.debug("eth_sendTransaction({}): {}", args, s);
+        }
+    }
+
+    @Override
+    public String sendRawTransaction(String rawData) {
+        String s = null;
+        try {
+            Transaction tx = new ImmutableTransaction(stringHexToByteArray(rawData));
+
+            if (null == tx.getGasLimit()
+                    || null == tx.getGasPrice()
+                    || null == tx.getValue()) {
+                throw new JsonRpcInvalidParamException("Missing parameter, gasPrice, gas or value");
+            }
+
+            transactionPool.addTransaction(tx);
+
+            return s = tx.getHash().toJsonString();
+        } finally {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("eth_sendRawTransaction({}): {}", rawData, s);
+            }
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionDisabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionDisabled.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of RskJ
- * Copyright (C) 2017 RSK Labs Ltd.
+ * Copyright (C) 2018 RSK Labs Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -18,26 +18,24 @@
 
 package co.rsk.rpc.modules.eth;
 
+import co.rsk.config.RskSystemProperties;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+/**
+ * This module disables sendTransaction because it needs a local wallet, but sendRawTransaction should still work.
+ */
+public class EthModuleTransactionDisabled extends EthModuleTransactionBase {
 
-public class EthModuleWalletDisabled implements EthModuleWallet {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger("web3");
-
-    @Override
-    public String[] accounts() {
-        String[] accounts = {};
-        LOGGER.debug("eth_accounts(): {}", Arrays.toString(accounts));
-        return accounts;
+    public EthModuleTransactionDisabled(RskSystemProperties config, TransactionPool transactionPool) {
+        // wallet is only used from EthModuleTransactionBase::sendTransaction, which is overrode
+        super(config, null, transactionPool);
     }
 
     @Override
-    public String sign(String addr, String data) {
-        LOGGER.debug("eth_sign({}, {}): {}", addr, data, null);
+    public String sendTransaction(Web3.CallArguments args) {
+        LOGGER.debug("eth_sendTransaction({}): {}", args, null);
         throw new JsonRpcInvalidParamException("Local wallet is disabled in this node");
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionInstant.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionInstant.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.Wallet;
+import co.rsk.mine.MinerClient;
+import co.rsk.mine.MinerServer;
+import org.ethereum.core.Blockchain;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.rpc.Web3;
+
+public class EthModuleTransactionInstant extends EthModuleTransactionBase {
+
+    private final MinerServer minerServer;
+    private final MinerClient minerClient;
+    private final Blockchain blockchain;
+
+    public EthModuleTransactionInstant(RskSystemProperties config, Wallet wallet, TransactionPool transactionPool, MinerServer minerServer, MinerClient minerClient, Blockchain blockchain) {
+        super(config,wallet, transactionPool);
+
+        this.minerServer = minerServer;
+        this.minerClient = minerClient;
+        this.blockchain = blockchain;
+    }
+
+    @Override
+    public synchronized String sendTransaction(Web3.CallArguments args) {
+        String txHash = super.sendTransaction(args);
+        mineTransaction();
+        return txHash;
+    }
+
+    @Override
+    public String sendRawTransaction(String rawData) {
+        String txHash = super.sendRawTransaction(rawData);
+        mineTransaction();
+        return txHash;
+    }
+
+    private void mineTransaction() {
+        minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
+        minerClient.mineBlock();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWallet.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWallet.java
@@ -18,13 +18,9 @@
 
 package co.rsk.rpc.modules.eth;
 
-import org.ethereum.rpc.Web3;
-
 public interface EthModuleWallet {
 
     String[] accounts();
-
-    String sendTransaction(Web3.CallArguments args);
 
     String sign(String addr, String data);
 }

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -510,7 +510,10 @@ public class IndexedBlockStore implements BlockStore {
             byte[] hash = blockInfo.getHash().getBytes();
             Block block = getBlockByHash(hash);
 
-            result.add(block);
+            // TODO(mc) investigate and fix this, probably a cache invalidation problem
+            if (block != null) {
+                result.add(block);
+            }
         }
 
         return result;

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -148,7 +148,7 @@ public class Web3Impl implements Web3 {
         this.configCapabilities = configCapabilities;
         this.config = config;
         filterManager = new FilterManager(eth);
-        snapshotManager = new SnapshotManager(blockchain, transactionPool);
+        snapshotManager = new SnapshotManager(blockchain, transactionPool, minerServer);
         initialBlockNumber = this.blockchain.getBestBlock().getNumber();
 
         personalModule.init(this.config);

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -58,6 +58,10 @@ miner {
     client {
         enabled = false
 
+        # If autoMine is true, it will set delayBetweenBlocks in 0
+        # otherwise it will use what is define in delayBetweenBlocks setting.
+        autoMine = false
+
         # The time the miner client will wait after mining a block and before mining the next one.
         # This allows mining a sane number of blocks per minute when the difficulty is low (e.g. for regtest).
         delayBetweenBlocks = 0 seconds

--- a/rskj-core/src/test/java/co/rsk/core/SnapshotManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/SnapshotManagerTest.java
@@ -21,6 +21,7 @@ package co.rsk.core;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockChainStatus;
+import co.rsk.mine.MinerServer;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import org.ethereum.core.*;
@@ -31,6 +32,8 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.List;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by ajlopez on 15/04/2017.
@@ -50,7 +53,7 @@ public class SnapshotManagerTest {
         transactionPool = factory.getTransactionPool();
         // don't call start to avoid creating threads
         transactionPool.processBest(blockchain.getBestBlock());
-        manager = new SnapshotManager(blockchain, transactionPool);
+        manager = new SnapshotManager(blockchain, transactionPool, mock(MinerServer.class));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -306,7 +306,7 @@ public class MinerManagerTest {
     }
 
     private static MinerClientImpl getMinerClient(RskImplForTest rsk, MinerServerImpl minerServer) {
-        return new MinerClientImpl(rsk, minerServer, config);
+        return new MinerClientImpl(rsk, minerServer, config.minerClientDelayBetweenBlocks(), config.minerClientDelayBetweenRefreshes());
     }
 
     private MinerServerImpl getMinerServer() {

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -252,7 +252,7 @@ public class MinerManagerTest {
         Assert.assertEquals(1, blockchain.getBestBlock().getNumber());
         Assert.assertFalse(blockchain.getBestBlock().getTransactionsList().isEmpty());
 
-        SnapshotManager snapshotManager = new SnapshotManager(blockchain, transactionPool);
+        SnapshotManager snapshotManager = new SnapshotManager(blockchain, transactionPool, minerServer);
         snapshotManager.resetSnapshots();
 
         Assert.assertEquals(0, blockchain.getBestBlock().getNumber());

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -1,0 +1,322 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.mine;
+
+import co.rsk.config.ConfigUtils;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.*;
+import co.rsk.core.bc.BlockChainImpl;
+import co.rsk.core.bc.TransactionPoolImpl;
+import co.rsk.rpc.ExecutionBlockRetriever;
+import co.rsk.rpc.Web3RskImpl;
+import co.rsk.rpc.modules.debug.DebugModule;
+import co.rsk.rpc.modules.debug.DebugModuleImpl;
+import co.rsk.rpc.modules.eth.*;
+import co.rsk.rpc.modules.personal.PersonalModuleWalletEnabled;
+import co.rsk.rpc.modules.txpool.TxPoolModule;
+import co.rsk.rpc.modules.txpool.TxPoolModuleImpl;
+import co.rsk.test.World;
+import co.rsk.test.builders.AccountBuilder;
+import co.rsk.test.builders.TransactionBuilder;
+import co.rsk.validators.BlockUnclesValidationRule;
+import co.rsk.validators.ProofOfWorkRule;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Account;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.Keccak256Helper;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.db.ReceiptStoreImpl;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.facade.EthereumImpl;
+import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.net.client.ConfigCapabilities;
+import org.ethereum.net.server.ChannelManager;
+import org.ethereum.net.server.ChannelManagerImpl;
+import org.ethereum.rpc.Simples.SimpleChannelManager;
+import org.ethereum.rpc.Simples.SimpleConfigCapabilities;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.Web3Impl;
+import org.ethereum.rpc.Web3Mocks;
+import org.ethereum.sync.SyncPool;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.math.BigInteger;
+
+public class TransactionModuleTest {
+    Wallet wallet;
+    private final TestSystemProperties config = new TestSystemProperties();
+
+    @Test
+    public void sendTransactionMustNotBeMined() {
+        World world = new World();
+        BlockChainImpl blockchain = world.getBlockChain();
+
+        Repository repository = world.getRepository();
+
+        BlockStore blockStore = world.getBlockChain().getBlockStore();
+
+        TransactionPool transactionPool = new TransactionPoolImpl(config, repository, blockStore, null, null, null, 10, 100);
+
+        Web3Impl web3 = createEnvironment(blockchain, null, repository, transactionPool, blockStore, false);
+
+        String tx = sendTransaction(web3, repository);
+
+        Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
+
+        Transaction txInBlock = getTransactionFromBlockWhichWasSend(blockchain, tx);
+
+        //Transaction tx must not be in block
+        Assert.assertNull(txInBlock);
+    }
+
+    @Test
+    public void sendTransactionMustBeMined() {
+        World world = new World();
+        BlockChainImpl blockchain = world.getBlockChain();
+
+        Repository repository = blockchain.getRepository();
+
+        BlockStore blockStore = world.getBlockChain().getBlockStore();
+
+        TransactionPool transactionPool = new TransactionPoolImpl(config, repository, blockStore, null, null, null, 10, 100);
+
+        Web3Impl web3 = createEnvironment(blockchain, null, repository, transactionPool, blockStore, true);
+
+        String tx = sendTransaction(web3, repository);
+
+        Assert.assertEquals(1, blockchain.getBestBlock().getNumber());
+        Assert.assertEquals(2, blockchain.getBestBlock().getTransactionsList().size());
+
+        Transaction txInBlock = getTransactionFromBlockWhichWasSend(blockchain, tx);
+
+        //Transaction tx must be in the block mined.
+        Assert.assertEquals(tx, txInBlock.getHash().toJsonString());
+    }
+
+    /**
+     * This test send a several transactions, and should be mine 1 transaction in each block.
+     */
+    @Test
+    public void sendSeveralTransactionsWithAutoMining() {
+
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = new World(receiptStore);
+        BlockChainImpl blockchain = world.getBlockChain();
+
+        Repository repository = blockchain.getRepository();
+
+        BlockStore blockStore = world.getBlockChain().getBlockStore();
+
+        TransactionPool transactionPool = new TransactionPoolImpl(config, repository, blockStore, receiptStore, null, null, 10, 100);
+
+        Web3Impl web3 = createEnvironment(blockchain, receiptStore, repository, transactionPool, blockStore, true);
+
+        for (int i = 1; i < 100; i++) {
+            String tx = sendTransaction(web3, repository);
+            Transaction txInBlock = getTransactionFromBlockWhichWasSend(blockchain, tx);
+
+            Assert.assertEquals(i, blockchain.getBestBlock().getNumber());
+            Assert.assertEquals(2, blockchain.getBestBlock().getTransactionsList().size());
+            Assert.assertEquals(tx, txInBlock.getHash().toJsonString());
+        }
+    }
+
+    @Test
+    public void sendRawTransactionWithAutoMining() throws Exception {
+
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = new World(receiptStore);
+        BlockChainImpl blockchain = world.getBlockChain();
+
+        Repository repository = blockchain.getRepository();
+
+        BlockStore blockStore = world.getBlockChain().getBlockStore();
+
+        TransactionPool transactionPool = new TransactionPoolImpl(config, repository, blockStore, receiptStore, null, null, 10, 100);
+
+        Web3Impl web3 = createEnvironment(blockchain, receiptStore, repository, transactionPool, blockStore, true);
+
+        String txHash = sendRawTransaction(web3);
+
+        Assert.assertEquals(1, blockchain.getBestBlock().getNumber());
+        Assert.assertEquals(2, blockchain.getBestBlock().getTransactionsList().size());
+
+        Transaction txInBlock = getTransactionFromBlockWhichWasSend(blockchain, txHash);
+
+        //Transaction tx must be in the block mined.
+        Assert.assertEquals(txHash, txInBlock.getHash().toJsonString());
+    }
+
+    @Test
+    public void sendRawTransactionWithoutAutoMining() {
+
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = new World(receiptStore);
+        BlockChainImpl blockchain = world.getBlockChain();
+
+        Repository repository = blockchain.getRepository();
+
+        BlockStore blockStore = world.getBlockChain().getBlockStore();
+
+        TransactionPool transactionPool = new TransactionPoolImpl(config, repository, blockStore, receiptStore, null, null, 10, 100);
+
+        Web3Impl web3 = createEnvironment(blockchain, receiptStore, repository, transactionPool, blockStore, false);
+
+        String txHash = sendRawTransaction(web3);
+
+        Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
+        Assert.assertEquals(1, transactionPool.getPendingTransactions().size());
+        Assert.assertEquals(txHash, transactionPool.getPendingTransactions().get(0).getHash().toJsonString());
+    }
+
+    private String sendRawTransaction(Web3Impl web3) {
+        Account sender = new AccountBuilder().name("cow").build();
+        Account receiver = new AccountBuilder().name("addr2").build();
+
+        Transaction tx = new TransactionBuilder()
+                .sender(sender)
+                .receiver(receiver)
+                .gasPrice(BigInteger.valueOf(8))
+                .gasLimit(BigInteger.valueOf(50000))
+                .value(BigInteger.valueOf(7))
+                .nonce(0)
+                .build();
+
+        String rawData = Hex.toHexString(tx.getEncoded());
+
+        return web3.eth_sendRawTransaction(rawData);
+    }
+
+    private Transaction getTransactionFromBlockWhichWasSend(BlockChainImpl blockchain, String tx) {
+        Transaction txInBlock = null;
+
+        for (Transaction x : blockchain.getBestBlock().getTransactionsList()) {
+            if (x.getHash().toJsonString().equals(tx)) {
+                txInBlock = x;
+                break;
+            }
+        }
+        return txInBlock;
+    }
+
+    private String sendTransaction(Web3Impl web3, Repository repository) {
+
+        Web3.CallArguments args = getTransactionParameters(web3, repository);
+
+        return web3.eth_sendTransaction(args);
+    }
+
+    private Web3.CallArguments getTransactionParameters(Web3Impl web3, Repository repository) {
+        RskAddress addr1 = new RskAddress(ECKey.fromPrivate(Keccak256Helper.keccak256("cow".getBytes())).getAddress());
+        String addr2 = web3.personal_newAccountWithSeed("addr2");
+        BigInteger value = BigInteger.valueOf(7);
+        BigInteger gasPrice = BigInteger.valueOf(8);
+        BigInteger gasLimit = BigInteger.valueOf(50000);
+        String data = "0xff";
+
+        Web3.CallArguments args = new Web3.CallArguments();
+        args.from = TypeConverter.toJsonHex(addr1.getBytes());
+        args.to = addr2;
+        args.data = data;
+        args.gas = TypeConverter.toJsonHex(gasLimit);
+        args.gasPrice = TypeConverter.toJsonHex(gasPrice);
+        args.value = value.toString();
+        args.nonce = repository.getAccountState(addr1).getNonce().toString();
+
+        return args;
+    }
+
+    private Web3Impl createEnvironment(BlockChainImpl blockchain, ReceiptStore receiptStore, Repository repository, TransactionPool transactionPool, BlockStore blockStore, boolean mineInstant) {
+
+        ConfigCapabilities configCapabilities = new SimpleConfigCapabilities();
+        CompositeEthereumListener compositeEthereumListener = new CompositeEthereumListener();
+        Ethereum eth = new EthereumImpl(new ChannelManagerImpl(config, new SyncPool(compositeEthereumListener, blockchain, config, null)), transactionPool, compositeEthereumListener, blockchain);
+
+        MinerServer minerServer = new MinerServerImpl(
+                config,
+                eth,
+                blockchain,
+                null,
+                new DifficultyCalculator(config),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
+                new BlockToMineBuilder(
+                        ConfigUtils.getDefaultMiningConfig(),
+                        repository,
+                        blockStore,
+                        transactionPool,
+                        new DifficultyCalculator(config),
+                        new GasLimitCalculator(config),
+                        Mockito.mock(BlockUnclesValidationRule.class),
+                        config,
+                        receiptStore
+                ),
+                ConfigUtils.getDefaultMiningConfig()
+        );
+
+        wallet = WalletFactory.createWallet();
+        PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, transactionPool);
+        MinerClient minerClient = new MinerClientImpl(null, minerServer, config.minerClientDelayBetweenBlocks(), config.minerClientDelayBetweenRefreshes());
+        EthModuleTransaction transactionModule = null;
+
+        ReversibleTransactionExecutor reversibleTransactionExecutor1 = new ReversibleTransactionExecutor(config, repository, blockStore, receiptStore, null);
+
+        if (mineInstant) {
+            transactionModule = new EthModuleTransactionInstant(config, wallet, transactionPool, minerServer, minerClient, blockchain);
+        } else {
+            transactionModule = new EthModuleTransactionBase(config, wallet, transactionPool);
+        }
+
+        EthModule ethModule = new EthModule(config, blockchain, reversibleTransactionExecutor1, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), transactionModule);
+        TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool);
+        DebugModule debugModule = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
+
+        ChannelManager channelManager = new SimpleChannelManager();
+        return new Web3RskImpl(
+                eth,
+                blockchain,
+                transactionPool,
+                config,
+                minerClient,
+                Web3Mocks.getMockMinerServer(),
+                personalModule,
+                ethModule,
+                txPoolModule,
+                null,
+                debugModule,
+                channelManager,
+                Web3Mocks.getMockRepository(),
+                null,
+                null,
+                blockStore,
+                receiptStore,
+                null,
+                null,
+                null,
+                configCapabilities
+        );
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -74,7 +74,7 @@ public class Web3RskImplTest {
         Wallet wallet = WalletFactory.createWallet();
         TestSystemProperties config = new TestSystemProperties();
         PersonalModule pm = new PersonalModuleWalletEnabled(config, rsk, wallet, null);
-        EthModule em = new EthModule(config, blockchain, null, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, rsk, wallet, null));
+        EthModule em = new EthModule(config, blockchain, null, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), null);
         TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
         DebugModule dm = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
         Web3RskImpl web3 = new Web3RskImpl(

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -57,6 +57,7 @@ public class EthModuleTest {
                 executor,
                 retriever,
                 null,
+                null,
                 null
         );
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -573,7 +573,7 @@ public class Web3ImplLogsTest {
     private Web3Impl createWeb3() {
         Wallet wallet = WalletFactory.createWallet();
         PersonalModule personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, transactionPool);
-        EthModule ethModule = new EthModule(config, blockChain, null, new ExecutionBlockRetriever(blockChain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, eth, wallet, transactionPool));
+        EthModule ethModule = new EthModule(config, blockChain, null, new ExecutionBlockRetriever(blockChain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), null);
         TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool);
         DebugModule debugModule = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
         return new Web3RskImpl(

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -356,7 +356,7 @@ public class Web3ImplScoringTest {
         Wallet wallet = WalletFactory.createWallet();
         TestSystemProperties config = new TestSystemProperties();
         PersonalModule pm = new PersonalModuleWalletEnabled(config, rsk, wallet, null);
-        EthModule em = new EthModule(config, world.getBlockChain(), null, new ExecutionBlockRetriever(world.getBlockChain(), null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, rsk, wallet, null));
+        EthModule em = new EthModule(config, world.getBlockChain(), null, new ExecutionBlockRetriever(world.getBlockChain(), null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), null);
         TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
         DebugModule dm = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
         return new Web3RskImpl(

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -196,7 +196,7 @@ public class Web3ImplSnapshotTest {
     }
 
     private Web3Impl createWeb3(SimpleEthereum ethereum, MinerServer minerServer) {
-        MinerClientImpl minerClient = new MinerClientImpl(null, minerServer, config);
+        MinerClientImpl minerClient = new MinerClientImpl(null, minerServer, config.minerClientDelayBetweenBlocks(), config.minerClientDelayBetweenRefreshes());
         PersonalModule pm = new PersonalModuleWalletDisabled();
         TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
         DebugModule dm = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -31,10 +31,7 @@ import co.rsk.rpc.ExecutionBlockRetriever;
 import co.rsk.rpc.Web3RskImpl;
 import co.rsk.rpc.modules.debug.DebugModule;
 import co.rsk.rpc.modules.debug.DebugModuleImpl;
-import co.rsk.rpc.modules.eth.EthModule;
-import co.rsk.rpc.modules.eth.EthModuleSolidityDisabled;
-import co.rsk.rpc.modules.eth.EthModuleSolidityEnabled;
-import co.rsk.rpc.modules.eth.EthModuleWalletEnabled;
+import co.rsk.rpc.modules.eth.*;
 import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletEnabled;
@@ -298,27 +295,6 @@ public class Web3ImplTest {
         String expectedValue = Hex.toHexString(new BigInteger("20000000000").toByteArray());
         expectedValue = "0x" + (expectedValue.startsWith("0") ? expectedValue.substring(1) : expectedValue);
         org.junit.Assert.assertEquals(expectedValue, web3.eth_gasPrice());
-    }
-
-    @Test
-    public void sendRawTransaction() throws Exception {
-        Web3Impl web3 = createWeb3();
-        SimpleEthereum eth = new SimpleEthereum();
-        web3.eth = eth;
-
-        Account acc1 = new AccountBuilder().name("acc1").build();
-        Account acc2 = new AccountBuilder().name("acc2").build();
-        Transaction tx = new TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
-
-        String rawData = Hex.toHexString(tx.getEncoded());
-
-        String trxHash = web3.eth_sendRawTransaction(rawData);
-
-        org.junit.Assert.assertNotNull(trxHash);
-        org.junit.Assert.assertNotNull(eth.tx);
-        org.junit.Assert.assertArrayEquals(acc1.getAddress().getBytes(), eth.tx.getSender().getBytes());
-        org.junit.Assert.assertArrayEquals(acc2.getAddress().getBytes(), eth.tx.getReceiveAddress().getBytes());
-        org.junit.Assert.assertEquals(BigInteger.valueOf(1000000), eth.tx.getValue().asBigInteger());
     }
 
     @Test
@@ -1199,6 +1175,10 @@ public class Web3ImplTest {
         org.junit.Assert.assertNull(account1);
     }
 
+    private Web3Impl createWeb3() {
+        return createWeb3(Web3Mocks.getMockEthereum(), Web3Mocks.getMockBlockchain(), Web3Mocks.getMockTransactionPool(), Web3Mocks.getMockBlockStore(), null, null, null);
+    }
+
     @Test
     public void eth_sendTransaction()
     {
@@ -1244,10 +1224,6 @@ public class Web3ImplTest {
         Assert.assertTrue("Method is not creating the expected transaction", expectedHash.compareTo(txHash) == 0);
     }
 
-    private Web3Impl createWeb3() {
-        return createWeb3(Web3Mocks.getMockEthereum(), Web3Mocks.getMockBlockchain(), Web3Mocks.getMockTransactionPool(), Web3Mocks.getMockBlockStore(), null, null, null);
-    }
-
     private Web3Impl createWeb3(World world) {
         return createWeb3(world, null);
     }
@@ -1270,7 +1246,7 @@ public class Web3ImplTest {
         Blockchain blockchain = Web3Mocks.getMockBlockchain();
         TransactionPool transactionPool = Web3Mocks.getMockTransactionPool();
         PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, null);
-        EthModule ethModule = new EthModule(config, blockchain, null, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, eth, wallet, null));
+        EthModule ethModule = new EthModule(config, blockchain, null, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), null);
         TxPoolModule txPoolModule = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
         DebugModule debugModule = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
         MinerClient minerClient = new SimpleMinerClient();
@@ -1323,7 +1299,7 @@ public class Web3ImplTest {
         ProgramResult res = new ProgramResult();
         res.setHReturn(TypeConverter.stringHexToByteArray("0x0000000000000000000000000000000000000000000000000000000064617665"));
         Mockito.when(executor.executeTransaction(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(res);
-        EthModule ethModule = new EthModule(config, blockchain, executor, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, eth, wallet, transactionPool));
+        EthModule ethModule = new EthModule(config, blockchain, executor, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), new EthModuleTransactionBase(config, wallet, transactionPool));
         TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool);
         DebugModule debugModule = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
         MinerClient minerClient = new SimpleMinerClient();
@@ -1363,7 +1339,7 @@ public class Web3ImplTest {
 
         Mockito.when(systemProperties.customSolcPath()).thenReturn(solc);
         Ethereum eth = Mockito.mock(Ethereum.class);
-        EthModule ethModule = new EthModule(config, null, null, new ExecutionBlockRetriever(null, null, null), new EthModuleSolidityEnabled(new SolidityCompiler(systemProperties)), null);
+        EthModule ethModule = new EthModule(config, null, null, new ExecutionBlockRetriever(null, null, null), new EthModuleSolidityEnabled(new SolidityCompiler(systemProperties)), null, null);
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
         TxPoolModule txPoolModule = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
         DebugModule debugModule = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
@@ -1417,7 +1393,7 @@ public class Web3ImplTest {
         Ethereum eth = Web3Mocks.getMockEthereum();
         Blockchain blockchain = Web3Mocks.getMockBlockchain();
         TransactionPool transactionPool = Web3Mocks.getMockTransactionPool();
-        EthModule ethModule = new EthModule(config, blockchain, null, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(config, eth, wallet, null));
+        EthModule ethModule = new EthModule(config, blockchain, null, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), null);
         TxPoolModule txPoolModule = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
         DebugModule debugModule = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
         Web3Impl web3 = new Web3RskImpl(


### PR DESCRIPTION
### Overview

The idea for this feature is mine a block every time an incoming transaction arrives to `MinerServer`. 
So, if the transaction is valid, we will get a new block with that transaction mined.
This new feature will be triggered both in `eth_sendTransaction` and `eth_sendRawTransaction`.

### How to use it

To turn on this feature you need to configure as follows:
* `miner.client.autoMine=true`
* `miner.client.enabled=true`.

For example, you can pass in a VM option like `-Dminer.client.autoMine=true`, or set it in the configuration file.

### Code changes

- To achieve this change was necessary to create a new `MinerClient` called `AutoMinerClient` which is simpler than `MinerClientImpl`, why ? it basically removes all the code its needed to mine a block every X time.
- Create a test set to check if the block was mined correctly after send a valid transaction when automine is enable, otherwise (automine = false) we verify that blocks are not generated
