### PR TITLE
Don't close UDP channel on exception

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/discovery/UDPChannel.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/UDPChannel.java
@@ -64,7 +64,6 @@ public class UDPChannel extends SimpleChannelInboundHandler<DiscoveryEvent> {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         logger.debug("Discover channel error", cause);
-        ctx.close();
         // We don't close the channel because we can keep serving requests.
     }
 


### PR DESCRIPTION
We don't need to close the channel because UDP is connection-less.

There was a comment stating this, but someone ignored it at some point
in the EthereumJ codebase: https://github.com/ethereum/ethereumj/commit/65fd770e1ec821c3edcc6770f502e5731a90ac06#diff-364a0e29f783aa2c9c709bc8ae663b9dR60