### PR TITLE
Optimized Performance

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/RepositoryBlockStore.java
+++ b/rskj-core/src/main/java/co/rsk/peg/RepositoryBlockStore.java
@@ -77,30 +77,20 @@ public class RepositoryBlockStore implements BtcBlockstoreWithCache {
 
     @Override
     public synchronized StoredBlock get(Sha256Hash hash) throws BlockStoreException {
-        byte[] ba = repository.getStorageBytes(contractAddress, new DataWord(hash.toString()));
+        return getFromCache(hash);
+    }
 
+    public synchronized StoredBlock getFromCache(Sha256Hash hash) throws BlockStoreException {
+        byte[] ba = repository.getStorageBytes(contractAddress, new DataWord(hash.toString()));
         if (ba==null) {
             return null;
         }
         
-        StoredBlock storedBlock = byteArrayToStoredBlock(ba);
-        knownBlocks.put(hash, storedBlock);
-        return storedBlock;
-    }
-
-    public synchronized StoredBlock getFromCache(Sha256Hash hash) throws BlockStoreException {
         StoredBlock storedBlock = knownBlocks.get(hash);
-
         if (storedBlock != null) {
             return storedBlock;
         }
-
-        byte[] ba = repository.getStorageBytes(contractAddress, new DataWord(hash.toString()));
-
-        if (ba==null) {
-            return null;
-        }
-
+        
         storedBlock = byteArrayToStoredBlock(ba);
 
         knownBlocks.put(hash, storedBlock);


### PR DESCRIPTION
The get(Sha256Hash hash) functions try to get storedBlock from the cache first. If storedBlock is not found then it computes the storedBlock from byteArrayToStoredblock(ba) which is slower.  The current function processes the BridgeSync Transaction much faster.