### PR TITLE
Changes to make more zeppelin tests work

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/BlockToMineBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/mine/BlockToMineBuilder.java
@@ -28,6 +28,7 @@ import co.rsk.core.bc.FamilyUtils;
 import co.rsk.remasc.RemascTransaction;
 import co.rsk.validators.BlockValidationRule;
 import org.apache.commons.collections4.CollectionUtils;
+import org.ethereum.config.net.RegTestConfig;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockStore;
@@ -66,10 +67,10 @@ public class BlockToMineBuilder {
     private final MinerUtils minerUtils;
     private final BlockExecutor executor;
 
+    private final boolean isRegtest;
     private final Coin minerMinGasPriceTarget;
 
     private long timeAdjustment;
-    private long minimumAcceptableTime;
 
     @Autowired
     public BlockToMineBuilder(
@@ -89,7 +90,7 @@ public class BlockToMineBuilder {
         this.difficultyCalculator = Objects.requireNonNull(difficultyCalculator);
         this.gasLimitCalculator = Objects.requireNonNull(gasLimitCalculator);
         this.validationRules = Objects.requireNonNull(validationRules);
-
+        this.isRegtest = config.getBlockchainConfig() instanceof RegTestConfig;
         this.clock = Clock.systemUTC();
         this.minimumGasPriceCalculator = new MinimumGasPriceCalculator();
         this.minerUtils = new MinerUtils();
@@ -145,8 +146,6 @@ public class BlockToMineBuilder {
 
         final List<Transaction> txsToRemove = new ArrayList<>();
         final List<Transaction> txs = getTransactions(txsToRemove, newBlockParent, minimumGasPrice);
-        minimumAcceptableTime = newBlockParent.getTimestamp() + 1;
-
         final Block newBlock = createBlock(newBlockParent, uncles, txs, minimumGasPrice);
 
         newBlock.setExtraData(extraData);
@@ -191,7 +190,7 @@ public class BlockToMineBuilder {
             Coin minimumGasPrice) {
         final byte[] unclesListHash = HashUtil.keccak256(BlockHeader.getUnclesEncodedEx(uncles));
 
-        final long timestampSeconds = this.getCurrentTimeInSeconds();
+        final long timestampSeconds = this.getCurrentTimeInSeconds(newBlockParent);
 
         // Set gas limit before executing block
         BigInteger minGasLimit = BigInteger.valueOf(miningConfig.getGasLimit().getMininimum());
@@ -224,10 +223,18 @@ public class BlockToMineBuilder {
         return newHeader;
     }
 
-    // Note that this needs to be refactored.
     public long getCurrentTimeInSeconds() {
-        long ret = clock.millis() / 1000 + timeAdjustment;
-        return Long.max(ret, minimumAcceptableTime);
+        return getCurrentTimeInSeconds(blockStore.getBestBlock());
+    }
+
+    private long getCurrentTimeInSeconds(Block parent) {
+        long previousTimestamp = parent.getTimestamp();
+        if (isRegtest) {
+            return previousTimestamp + timeAdjustment;
+        }
+
+        long ret = clock.instant().plusSeconds(timeAdjustment).getEpochSecond();
+        return Long.max(ret, previousTimestamp + 1);
     }
 
     // Note that this needs to be refactored.
@@ -238,5 +245,9 @@ public class BlockToMineBuilder {
 
         timeAdjustment += seconds;
         return timeAdjustment;
+    }
+
+    public void clearIncreaseTime() {
+        timeAdjustment = 0;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.mine;
+
+import co.rsk.config.RskSystemProperties;
+import org.ethereum.config.net.RegTestConfig;
+import org.ethereum.core.Block;
+import org.ethereum.core.Blockchain;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+
+@Component
+public class MinerClock {
+    private final Blockchain blockchain;
+    private final boolean isRegtest;
+    private final Clock clock;
+
+    private long timeAdjustment;
+
+    @Autowired
+    public MinerClock(Blockchain blockchain, RskSystemProperties config) {
+        this(blockchain, config.getBlockchainConfig() instanceof RegTestConfig, Clock.systemUTC());
+    }
+
+    MinerClock(Blockchain blockchain, boolean isRegtest, Clock clock) {
+        this.blockchain = blockchain;
+        this.isRegtest = isRegtest;
+        this.clock = clock;
+    }
+
+    /**
+     * @deprecated this is here for compatibility but should be removed along with the fallback mining feature
+     */
+    public long getCurrentTimeInSeconds() {
+        return calculateTimestampForChild(blockchain.getBestBlock());
+    }
+
+    public long calculateTimestampForChild(Block parent) {
+        long previousTimestamp = parent.getTimestamp();
+        if (isRegtest) {
+            return previousTimestamp + timeAdjustment;
+        }
+
+        long ret = clock.instant().plusSeconds(timeAdjustment).getEpochSecond();
+        return Long.max(ret, previousTimestamp + 1);
+    }
+
+    public long increaseTime(long seconds) {
+        if (seconds <= 0) {
+            return timeAdjustment;
+        }
+
+        timeAdjustment += seconds;
+        return timeAdjustment;
+    }
+
+    public void clearIncreaseTime() {
+        timeAdjustment = 0;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -594,6 +594,7 @@ public class MinerServerImpl implements MinerServer {
         logger.info("Starting block to mine from parent {} {}", newBlockParent.getNumber(), newBlockParent.getHash());
 
         final Block newBlock = builder.build(newBlockParent, extraData);
+        builder.clearIncreaseTime();
 
         if (autoSwitchBetweenNormalAndFallbackMining) {
             setFallbackMining(ProofOfWorkRule.isFallbackMiningPossible(config, newBlock.getHeader()));

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -81,6 +81,7 @@ public class MinerServerImpl implements MinerServer {
     private final ProofOfWorkRule powRule;
     private final BlockToMineBuilder builder;
     private final BlockchainNetConfig blockchainConfig;
+    private final MinerClock clock;
 
     private boolean isFallbackMining;
     private int fallbackBlocksGenerated;
@@ -125,6 +126,7 @@ public class MinerServerImpl implements MinerServer {
             DifficultyCalculator difficultyCalculator,
             ProofOfWorkRule powRule,
             BlockToMineBuilder builder,
+            MinerClock clock,
             MiningConfig miningConfig) {
         this.config = config;
         this.ethereum = ethereum;
@@ -133,6 +135,7 @@ public class MinerServerImpl implements MinerServer {
         this.difficultyCalculator = difficultyCalculator;
         this.powRule = powRule;
         this.builder = builder;
+        this.clock = clock;
         this.blockchainConfig = config.getBlockchainConfig();
 
         blocksWaitingforPoW = createNewBlocksWaitingList();
@@ -594,7 +597,7 @@ public class MinerServerImpl implements MinerServer {
         logger.info("Starting block to mine from parent {} {}", newBlockParent.getNumber(), newBlockParent.getHash());
 
         final Block newBlock = builder.build(newBlockParent, extraData);
-        builder.clearIncreaseTime();
+        clock.clearIncreaseTime();
 
         if (autoSwitchBetweenNormalAndFallbackMining) {
             setFallbackMining(ProofOfWorkRule.isFallbackMiningPossible(config, newBlock.getHeader()));
@@ -653,16 +656,13 @@ public class MinerServerImpl implements MinerServer {
     }
 
     @Override
-    @VisibleForTesting
     public long getCurrentTimeInSeconds() {
-        // this is not great, but it was the simplest way to extract BlockToMineBuilder
-        return builder.getCurrentTimeInSeconds();
+        return clock.getCurrentTimeInSeconds();
     }
 
     @Override
     public long increaseTime(long seconds) {
-        // this is not great, but it was the simplest way to extract BlockToMineBuilder
-        return builder.increaseTime(seconds);
+        return clock.increaseTime(seconds);
     }
 
     class NewBlockListener extends EthereumListenerAdapter {

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -128,7 +128,7 @@ public class MinerUtils {
 
     public static co.rsk.bitcoinj.core.BtcBlock getBitcoinMergedMiningBlock(co.rsk.bitcoinj.core.NetworkParameters params, List<BtcTransaction> transactions) {
         co.rsk.bitcoinj.core.Sha256Hash prevBlockHash = co.rsk.bitcoinj.core.Sha256Hash.ZERO_HASH;
-        long time = System.currentTimeMillis() / 1000;
+        long time = System.currentTimeMillis() / 1000L;
         long difficultyTarget = co.rsk.bitcoinj.core.Utils.encodeCompactBits(params.getMaxTarget());
         return new co.rsk.bitcoinj.core.BtcBlock(params, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT), prevBlockHash, null, time, difficultyTarget, 0, transactions);
     }

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
@@ -44,7 +44,7 @@ public class BlockTimeStampValidationRule implements BlockParentDependantValidat
             return true;
         }
 
-        final long currentTime = System.currentTimeMillis() / 1000;
+        final long currentTime = System.currentTimeMillis() / 1000L;
         final long blockTime = block.getTimestamp();
 
         boolean result = blockTime - currentTime <= this.validPeriodLength;

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -79,6 +79,7 @@ public class MainNetMinerTest {
 
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
 
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -87,6 +88,7 @@ public class MainNetMinerTest {
                 DIFFICULTY_CALCULATOR,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 blockToMineBuilder(),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -178,6 +180,7 @@ public class MainNetMinerTest {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
         Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
 
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 tempConfig,
                 ethereumImpl,
@@ -186,6 +189,7 @@ public class MainNetMinerTest {
                 DIFFICULTY_CALCULATOR,
                 new ProofOfWorkRule(tempConfig).setFallbackMiningEnabled(true),
                 blockToMineBuilder(),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -250,6 +254,7 @@ public class MainNetMinerTest {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
         Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
 
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -258,6 +263,7 @@ public class MainNetMinerTest {
                 DIFFICULTY_CALCULATOR,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 blockToMineBuilder(),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -308,6 +314,7 @@ public class MainNetMinerTest {
     private BlockToMineBuilder blockToMineBuilder() {
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         return new BlockToMineBuilder(
                 ConfigUtils.getDefaultMiningConfig(),
                 repository,
@@ -317,7 +324,8 @@ public class MainNetMinerTest {
                 new GasLimitCalculator(config),
                 unclesValidationRule,
                 config,
-                null
+                null,
+                clock
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerClockTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerClockTest.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.mine;
+
+import org.ethereum.core.Block;
+import org.ethereum.core.Blockchain;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MinerClockTest {
+
+    private Blockchain blockchain;
+    private Clock clock;
+
+    @Before
+    public void setUp() {
+        blockchain = mock(Blockchain.class);
+        clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    }
+
+    @Test
+    public void currentTimeIsBestBlocksChildTimestamp() {
+        MinerClock minerClock = new MinerClock(blockchain, true, clock);
+
+        Block bestBlock = mock(Block.class);
+        when(bestBlock.getTimestamp()).thenReturn(54L);
+        when(blockchain.getBestBlock()).thenReturn(bestBlock);
+
+        assertEquals(
+                minerClock.calculateTimestampForChild(bestBlock),
+                minerClock.getCurrentTimeInSeconds()
+        );
+    }
+
+    @Test
+    public void timestampForChildIsParentTimestampIfRegtest() {
+        MinerClock minerClock = new MinerClock(blockchain, true, clock);
+
+        Block parent = mock(Block.class);
+        when(parent.getTimestamp()).thenReturn(54L);
+
+        assertEquals(
+                54L,
+                minerClock.calculateTimestampForChild(parent)
+        );
+    }
+
+    @Test
+    public void timestampForChildIsClockTimeIfNotRegtest() {
+        MinerClock minerClock = new MinerClock(blockchain, false, clock);
+
+        Block parent = mock(Block.class);
+        when(parent.getTimestamp()).thenReturn(54L);
+
+        assertEquals(
+                clock.instant().getEpochSecond(),
+                minerClock.calculateTimestampForChild(parent)
+        );
+    }
+
+    @Test
+    public void timestampForChildIsTimestampPlusOneIfNotRegtest() {
+        MinerClock minerClock = new MinerClock(blockchain, false, clock);
+
+        Block parent = mock(Block.class);
+        when(parent.getTimestamp()).thenReturn(clock.instant().getEpochSecond());
+
+        assertEquals(
+                clock.instant().getEpochSecond() + 1,
+                minerClock.calculateTimestampForChild(parent)
+        );
+    }
+
+    @Test
+    public void adjustTimeIfRegtest() {
+        MinerClock minerClock = new MinerClock(blockchain, true, clock);
+
+        Block parent = mock(Block.class);
+        when(parent.getTimestamp()).thenReturn(33L);
+
+        minerClock.increaseTime(5392L);
+
+        assertEquals(
+                33L + 5392L,
+                minerClock.calculateTimestampForChild(parent)
+        );
+    }
+
+    @Test
+    public void adjustTimeIfNotRegtest() {
+        MinerClock minerClock = new MinerClock(blockchain, false, clock);
+
+        Block parent = mock(Block.class);
+        when(parent.getTimestamp()).thenReturn(33L);
+
+        minerClock.increaseTime(5392L);
+
+        assertEquals(
+                clock.instant().getEpochSecond() + 5392L,
+                minerClock.calculateTimestampForChild(parent)
+        );
+    }
+
+    @Test
+    public void clearTimeIncrease() {
+        MinerClock minerClock = new MinerClock(blockchain, true, clock);
+
+        Block parent = mock(Block.class);
+        when(parent.getTimestamp()).thenReturn(33L);
+
+        minerClock.increaseTime(5392L);
+        minerClock.clearIncreaseTime();
+
+        assertEquals(
+                33L,
+                minerClock.calculateTimestampForChild(parent)
+        );
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -314,6 +314,7 @@ public class MinerManagerTest {
         ethereum.repository = repository;
         ethereum.blockchain = blockchain;
         DifficultyCalculator difficultyCalculator = new DifficultyCalculator(config);
+        MinerClock clock = new MinerClock(blockchain, config);
         return new MinerServerImpl(
                 config,
                 ethereum,
@@ -330,8 +331,10 @@ public class MinerManagerTest {
                         new GasLimitCalculator(config),
                         new BlockValidationRuleDummy(),
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
     }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -622,7 +622,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
     @Test
     public void getCurrentTimeInMilliseconds() {
-        long current = System.currentTimeMillis() / 1000;
+        long current = blockStore.getBestBlock().getTimestamp();
 
         MinerServer server = getMinerServerWithMocks();
 
@@ -634,7 +634,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
     @Test
     public void increaseTime() {
-        long current = System.currentTimeMillis() / 1000;
+        long current = blockStore.getBestBlock().getTimestamp();
 
         MinerServer server = getMinerServerWithMocks();
 
@@ -648,7 +648,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
     @Test
     public void increaseTimeUsingNegativeNumberHasNoEffect() {
-        long current = System.currentTimeMillis() / 1000;
+        long current = blockStore.getBestBlock().getTimestamp();
 
         MinerServer server = getMinerServerWithMocks();
 
@@ -661,7 +661,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
     @Test
     public void increaseTimeTwice() {
-        long current = System.currentTimeMillis() / 1000;
+        long current = blockStore.getBestBlock().getTimestamp();
 
         MinerServer server = getMinerServerWithMocks();
 
@@ -731,7 +731,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
         return new BlockToMineBuilder(
                 ConfigUtils.getDefaultMiningConfig(),
                 Mockito.mock(Repository.class),
-                Mockito.mock(BlockStore.class),
+                blockStore,
                 Mockito.mock(TransactionPool.class),
                 difficultyCalculator,
                 new GasLimitCalculator(config),

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -104,6 +104,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServerImpl minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -120,8 +121,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
 
@@ -143,6 +146,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -159,8 +163,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -206,6 +212,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -222,8 +229,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -254,6 +263,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -270,8 +280,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -305,6 +317,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -321,8 +334,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -363,6 +378,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -379,8 +395,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -413,6 +431,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -429,8 +448,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -468,6 +489,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -484,8 +506,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
 
@@ -505,6 +529,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -521,8 +546,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -542,6 +569,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -558,8 +586,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
 
@@ -583,6 +613,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
+        MinerClock clock = new MinerClock(blockchain, config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -599,8 +630,10 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                         new GasLimitCalculator(config),
                         unclesValidationRule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -718,11 +751,12 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
         return new MinerServerImpl(
                 config,
                 Mockito.mock(Ethereum.class),
-                Mockito.mock(Blockchain.class),
+                blockchain,
                 null,
                 difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 getBuilderWithMocks(),
+                new MinerClock(blockchain, config),
                 ConfigUtils.getDefaultMiningConfig()
         );
     }
@@ -737,7 +771,8 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 new GasLimitCalculator(config),
                 Mockito.mock(BlockValidationRule.class),
                 config,
-                Mockito.mock(ReceiptStore.class)
+                Mockito.mock(ReceiptStore.class),
+                Mockito.mock(MinerClock.class)
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -255,6 +255,7 @@ public class TransactionModuleTest {
         ConfigCapabilities configCapabilities = new SimpleConfigCapabilities();
         CompositeEthereumListener compositeEthereumListener = new CompositeEthereumListener();
         Ethereum eth = new EthereumImpl(new ChannelManagerImpl(config, new SyncPool(compositeEthereumListener, blockchain, config, null)), transactionPool, compositeEthereumListener, blockchain);
+        MinerClock minerClock = new MinerClock(blockchain, config);
 
         MinerServer minerServer = new MinerServerImpl(
                 config,
@@ -272,8 +273,10 @@ public class TransactionModuleTest {
                         new GasLimitCalculator(config),
                         Mockito.mock(BlockUnclesValidationRule.class),
                         config,
-                        receiptStore
+                        receiptStore,
+                        minerClock
                 ),
+                minerClock,
                 ConfigUtils.getDefaultMiningConfig()
         );
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -236,6 +236,7 @@ public class Web3ImplSnapshotTest {
     private MinerServer getMinerServerForTest(SimpleEthereum ethereum) {
         BlockValidationRule rule = new MinerManagerTest.BlockValidationRuleDummy();
         DifficultyCalculator difficultyCalculator = new DifficultyCalculator(config);
+        MinerClock clock = new MinerClock(blockchain, config);
         return new MinerServerImpl(
                 config,
                 ethereum,
@@ -252,8 +253,10 @@ public class Web3ImplSnapshotTest {
                         new GasLimitCalculator(config),
                         rule,
                         config,
-                        null
+                        null,
+                        clock
                 ),
+                clock,
                 ConfigUtils.getDefaultMiningConfig()
         );
     }


### PR DESCRIPTION
- remove global minimumAcceptableTime, now we just get that value from   blockStore.getBestBlock().getTimestamp()
- division should be between long. So we explicitly declare 100 as a long. It was lossing precision.
- Added the ability to clean IncreaseTime after submit to simulate what ganache does.

Changes in the fed integration test at *utils:fix-for-open-zeppelin*