### PR TITLE
Allow setting the genesis federation in the config file for RegTest and DevNet

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -181,7 +181,7 @@ public class BridgeSupport {
                 bridgeConstants,
                 eventLogger,
                 btcContext,
-                new FederationSupport(provider, bridgeConstants, executionBlock),
+                new FederationSupport(provider, config.getBlockchainConfig(), executionBlock),
                 btcBlockStore,
                 btcBlockChain
         );

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -232,7 +232,7 @@ public class BridgeUtils {
                netConfig.getConfigForBlock(blockNumber).areBridgeTxsFree() &&
                rskTx.acceptTransactionSignature(netConfig.getCommonConstants().getChainId()) &&
                (
-                       isFromFederateMember(rskTx, bridgeConstants.getGenesisFederation()) ||
+                       isFromFederateMember(rskTx, netConfig.getGenesisFederation()) ||
                        isFromFederationChangeAuthorizedSender(rskTx, bridgeConstants) ||
                        isFromLockWhitelistChangeAuthorizedSender(rskTx, bridgeConstants) ||
                        isFromFeePerKbChangeAuthorizedSender(rskTx, bridgeConstants)

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -20,6 +20,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.config.BridgeConstants;
+import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.core.Block;
 
 import javax.annotation.Nullable;
@@ -33,11 +34,13 @@ public class FederationSupport {
 
     private final BridgeStorageProvider provider;
     private final BridgeConstants bridgeConstants;
+    private final BlockchainNetConfig blockchainNetConfig;
     private final Block executionBlock;
 
-    public FederationSupport(BridgeStorageProvider provider, BridgeConstants bridgeConstants, Block executionBlock) {
+    public FederationSupport(BridgeStorageProvider provider, BlockchainNetConfig netConfig, Block executionBlock) {
         this.provider = provider;
-        this.bridgeConstants = bridgeConstants;
+        this.blockchainNetConfig = netConfig;
+        this.bridgeConstants = netConfig.getCommonConstants().getBridgeConstants();
         this.executionBlock = executionBlock;
     }
 
@@ -78,7 +81,7 @@ public class FederationSupport {
                 return provider.getOldFederation();
             case GENESIS:
             default:
-                return bridgeConstants.getGenesisFederation();
+                return blockchainNetConfig.getGenesisFederation();
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
@@ -47,7 +47,7 @@ public class RemascFederationProvider {
         );
         this.federationSupport = new FederationSupport(
                 bridgeStorageProvider,
-                bridgeConstants,
+                config.getBlockchainConfig(),
                 processingBlock
         );
     }

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainNetConfig.java
@@ -19,6 +19,8 @@
 
 package org.ethereum.config;
 
+import co.rsk.peg.Federation;
+
 /**
  * Describes a set of configs for a specific blockchain depending on the block number
  *
@@ -35,4 +37,9 @@ public interface BlockchainNetConfig {
      * Returns the constants common for all the blocks in this blockchain
      */
     Constants getCommonConstants();
+
+    /**
+    * Returns the genesis  federation for all the blocks in this blockchain
+    */
+    Federation getGenesisFederation();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
@@ -38,10 +38,6 @@ import static org.ethereum.util.BIUtil.max;
 public abstract class AbstractConfig implements BlockchainConfig, BlockchainNetConfig {
     protected Constants constants;
 
-    public AbstractConfig() {
-        this(new Constants());
-    }
-
     public AbstractConfig(Constants constants) {
         this.constants = constants;
     }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/GenesisConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/GenesisConfig.java
@@ -20,6 +20,7 @@
 package org.ethereum.config.blockchain;
 
 import co.rsk.core.BlockDifficulty;
+import co.rsk.peg.Federation;
 import org.ethereum.config.Constants;
 import org.ethereum.core.BlockHeader;
 
@@ -29,13 +30,6 @@ import java.math.BigInteger;
  * Created by Anton Nashatyrev on 25.02.2016.
  */
 public class GenesisConfig extends AbstractConfig {
-
-    public static class GenesisConstants extends Constants {
-        @Override
-        public int getDurationLimit() {
-            return 13;
-        }
-    };
 
     // IMPORTANT NOTICE
     // This class contains two methods "NEW_*" containing the latest hard-forks in Ethereum
@@ -47,6 +41,18 @@ public class GenesisConfig extends AbstractConfig {
 
     public GenesisConfig(Constants constants) {
         super(constants);
+    }
+
+    public static class GenesisConstants extends Constants {
+        @Override
+        public int getDurationLimit() {
+            return 13;
+        }
+    }
+
+    @Override
+    public Federation getGenesisFederation() {
+        return getConstants().getBridgeConstants().getGenesisFederation();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/config/net/AbstractNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/net/AbstractNetConfig.java
@@ -19,17 +19,24 @@
 
 package org.ethereum.config.net;
 
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.config.BridgeConstants;
+import co.rsk.peg.Federation;
 import org.ethereum.config.BlockchainConfig;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.Constants;
+
+import java.util.List;
 
 /**
  * Created by Anton Nashatyrev on 25.02.2016.
  */
 public class AbstractNetConfig implements BlockchainNetConfig {
     private long[] blockNumbers = new long[64];
+    protected Federation genesisFederation;
     private BlockchainConfig[] configs = new BlockchainConfig[64];
     private int count;
+
 
     public final void add(long startBlockNumber, BlockchainConfig config) {
         if (count >= blockNumbers.length) {
@@ -61,5 +68,27 @@ public class AbstractNetConfig implements BlockchainNetConfig {
     public Constants getCommonConstants() {
         // TODO make a guard wrapper which throws exception if the requested constant differs among configs
         return configs[0].getConstants();
+    }
+
+    @Override
+    public Federation getGenesisFederation() {
+        if(genesisFederation == null) {
+            genesisFederation = getCommonConstants().getBridgeConstants().getGenesisFederation();
+        }
+        return genesisFederation;
+    }
+
+    protected void setGenesisFederationPublicKeys(List<BtcECKey> configFederationPublicKeys) {
+        BridgeConstants bridgeConstants = getCommonConstants().getBridgeConstants();
+        if(configFederationPublicKeys == null || configFederationPublicKeys.isEmpty()) {
+            genesisFederation = bridgeConstants.getGenesisFederation();
+        } else{
+            genesisFederation = new Federation(
+                    configFederationPublicKeys,
+                    bridgeConstants.getGenesisFederation().getCreationTime(),
+                    1L,
+                    bridgeConstants.getBtcParams()
+            );
+        }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/net/DevNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/net/DevNetConfig.java
@@ -19,9 +19,12 @@
 
 package org.ethereum.config.net;
 
+import co.rsk.bitcoinj.core.BtcECKey;
 import org.ethereum.config.blockchain.HardForkActivationConfig;
-import org.ethereum.config.blockchain.devnet.DevNetOrchidConfig;
 import org.ethereum.config.blockchain.devnet.DevNetGenesisConfig;
+import org.ethereum.config.blockchain.devnet.DevNetOrchidConfig;
+
+import java.util.List;
 
 
 /**
@@ -35,12 +38,17 @@ public class DevNetConfig extends AbstractNetConfig {
      */
     public static DevNetConfig getDefaultDevNetConfig() {
         DevNetConfig config = new DevNetConfig();
-
         config.add(0, new DevNetOrchidConfig());
         return config;
     }
 
-    public static DevNetConfig getFromConfig(HardForkActivationConfig hardForkActivationConfig) {
+    public static DevNetConfig getFromConfig(HardForkActivationConfig hardForkActivationConfig, List<BtcECKey> genesisFederatorsPublicKeys) {
+        DevNetConfig customConfig = getHardForkConfig(hardForkActivationConfig);
+        customConfig.setGenesisFederationPublicKeys(genesisFederatorsPublicKeys);
+        return customConfig;
+    }
+
+    public static DevNetConfig getHardForkConfig(HardForkActivationConfig hardForkActivationConfig) {
         if (hardForkActivationConfig == null) {
             return getDefaultDevNetConfig();
         }

--- a/rskj-core/src/main/java/org/ethereum/config/net/RegTestConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/net/RegTestConfig.java
@@ -19,9 +19,11 @@
 
 package org.ethereum.config.net;
 
+import co.rsk.bitcoinj.core.BtcECKey;
 import org.ethereum.config.blockchain.HardForkActivationConfig;
 import org.ethereum.config.blockchain.regtest.RegTestOrchidConfig;
 
+import java.util.List;
 
 /**
  * Created by Anton Nashatyrev on 25.02.2016.
@@ -34,12 +36,18 @@ public class RegTestConfig extends AbstractNetConfig {
      */
     public static RegTestConfig getDefaultRegTestConfig() {
         RegTestConfig config = new RegTestConfig();
-
         config.add(0, new RegTestOrchidConfig());
         return config;
     }
 
-    public static RegTestConfig getFromConfig(HardForkActivationConfig hardForkActivationConfig) {
+    public static RegTestConfig getFromConfig(HardForkActivationConfig hardForkActivationConfig, List<BtcECKey> genesisFederatorsPublicKeys) {
+        RegTestConfig customConfig = getHardForkConfig(hardForkActivationConfig);
+        customConfig.setGenesisFederationPublicKeys(genesisFederatorsPublicKeys);
+        return customConfig;
+    }
+
+    private static RegTestConfig getHardForkConfig(HardForkActivationConfig hardForkActivationConfig) {
+
         if (hardForkActivationConfig == null) {
             return getDefaultRegTestConfig();
         }

--- a/rskj-core/src/main/java/org/ethereum/config/net/TestNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/net/TestNetConfig.java
@@ -24,7 +24,6 @@ import org.ethereum.config.blockchain.testnet.TestNetBeforeBridgeSyncConfig;
 import org.ethereum.config.blockchain.testnet.TestNetDifficultyDropEnabledConfig;
 
 public class TestNetConfig extends AbstractNetConfig {
-    public static final TestNetConfig INSTANCE = new TestNetConfig();
 
     public TestNetConfig() {
         add(0, new TestNetBeforeBridgeSyncConfig());

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -8,6 +8,7 @@ import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockChainImplTest;
 import co.rsk.net.NodeBlockProcessor;
+import co.rsk.peg.Federation;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.validators.BlockUnclesValidationRule;
 import co.rsk.validators.ProofOfWorkRule;
@@ -162,6 +163,11 @@ public class MainNetMinerTest {
                                 return privateMiningKey1.getPubKey();
                             }
                         };
+                    }
+
+                    @Override
+                    public Federation getGenesisFederation() {
+                        return blockchainNetConfig.getGenesisFederation();
                     }
                 };
             }

--- a/rskj-core/src/test/java/co/rsk/mine/ParameterizedNetworkUpgradeTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/ParameterizedNetworkUpgradeTest.java
@@ -37,12 +37,13 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public abstract class ParameterizedNetworkUpgradeTest {
 
+
     @Parameterized.Parameters(name = "Network version: {0}")
     public static Object[] data() {
         TestSystemProperties bambooConfig = new TestSystemProperties() {
             @Override
             protected BlockchainNetConfig buildBlockchainConfig() {
-                return RegTestConfig.getFromConfig(new HardForkActivationConfig(Integer.MAX_VALUE));
+                return RegTestConfig.getFromConfig(new HardForkActivationConfig(Integer.MAX_VALUE), null);
             }
 
             @Override
@@ -53,7 +54,7 @@ public abstract class ParameterizedNetworkUpgradeTest {
         TestSystemProperties orchidConfig = new TestSystemProperties() {
             @Override
             protected BlockchainNetConfig buildBlockchainConfig() {
-                return RegTestConfig.getFromConfig(new HardForkActivationConfig(0));
+                return RegTestConfig.getFromConfig(new HardForkActivationConfig(0), null);
             }
 
             @Override

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -47,7 +47,6 @@ import co.rsk.peg.whitelist.LockWhitelistEntry;
 import co.rsk.peg.whitelist.OneOffWhiteListEntry;
 import co.rsk.peg.whitelist.UnlimitedWhiteListEntry;
 import co.rsk.test.builders.BlockChainBuilder;
-import co.rsk.trie.TrieStoreImpl;
 import com.google.common.collect.Lists;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.ec.CustomNamedCurves;
@@ -57,14 +56,14 @@ import org.bouncycastle.crypto.signers.ECDSASigner;
 import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.BlockchainNetConfig;
-import org.ethereum.config.blockchain.regtest.RegTestOrchidConfig;
 import org.ethereum.config.blockchain.regtest.RegTestGenesisConfig;
+import org.ethereum.config.blockchain.regtest.RegTestOrchidConfig;
+import org.ethereum.config.net.RegTestConfig;
 import org.ethereum.config.net.TestNetConfig;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.Keccak256Helper;
-import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
@@ -1339,13 +1338,15 @@ public class BridgeSupportTest {
 
         BridgeConstants bridgeConstants = mock(BridgeConstants.class);
         doReturn(btcParams).when(bridgeConstants).getBtcParams();
+        TestSystemProperties mockSystemProperties = mock(TestSystemProperties.class);
+        when(mockSystemProperties.getBlockchainConfig()).thenReturn(config.getBlockchainConfig());
         StoredBlock storedBlock = mock(StoredBlock.class);
         doReturn(btcTxHeight - 1).when(storedBlock).getHeight();
         BtcBlockstoreWithCache btcBlockStore = mock(BtcBlockstoreWithCache.class);
         doReturn(storedBlock).when(btcBlockStore).getChainHead();
 
         BridgeSupport bridgeSupport = new BridgeSupport(
-                mock(TestSystemProperties.class),
+                mockSystemProperties,
                 mock(Repository.class),
                 mock(BridgeEventLogger.class),
                 bridgeConstants,
@@ -3173,6 +3174,7 @@ public class BridgeSupportTest {
 
         BridgeConstants constantsMock = mock(BridgeConstants.class);
         when(constantsMock.getGenesisFederation()).thenReturn(mockedGenesisFederation);
+
         when(constantsMock.getBtcParams()).thenReturn(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         when(constantsMock.getFederationChangeAuthorizer()).thenReturn(BridgeRegTestConstants.getInstance().getFederationChangeAuthorizer());
         when(constantsMock.getFederationActivationAge()).thenReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge());
@@ -3236,6 +3238,10 @@ public class BridgeSupportTest {
             holder.setPendingFederation(m.getArgumentAt(0, PendingFederation.class));
             return null;
         }).when(providerMock).setPendingFederation(any());
+
+        BlockchainNetConfig blockchainNetConfig = spy(RegTestConfig.getDefaultRegTestConfig());
+        when(blockchainNetConfig.getGenesisFederation()).thenReturn(mockedGenesisFederation);
+        config.setBlockchainConfig(blockchainNetConfig);
 
         return new BridgeSupport(config, null, eventLogger, constantsMock, providerMock, null, null, executionBlock);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -18,6 +18,8 @@
 package co.rsk.peg;
 
 import co.rsk.config.BridgeConstants;
+import org.ethereum.config.BlockchainNetConfig;
+import org.ethereum.config.Constants;
 import org.ethereum.core.Block;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,16 +32,23 @@ import static org.mockito.Mockito.when;
 public class FederationSupportTest {
 
     private FederationSupport federationSupport;
+    private BlockchainNetConfig blockchainNetConfig;
+    private Constants commonConstants;
     private BridgeConstants bridgeConstants;
     private BridgeStorageProvider provider;
     private Block executionBlock;
 
+
     @Before
     public void setUp() {
         provider = mock(BridgeStorageProvider.class);
+        blockchainNetConfig = mock(BlockchainNetConfig.class);
+        commonConstants = mock(Constants.class);
+        when(blockchainNetConfig.getCommonConstants()).thenReturn(commonConstants);
         bridgeConstants = mock(BridgeConstants.class);
+        when(commonConstants.getBridgeConstants()).thenReturn(bridgeConstants);
         executionBlock = mock(Block.class);
-        federationSupport = new FederationSupport(provider, bridgeConstants, executionBlock);
+        federationSupport = new FederationSupport(provider, blockchainNetConfig, executionBlock);
     }
 
     @Test
@@ -47,7 +56,7 @@ public class FederationSupportTest {
         Federation genesisFederation = mock(Federation.class);
         when(provider.getNewFederation())
                 .thenReturn(null);
-        when(bridgeConstants.getGenesisFederation())
+        when(blockchainNetConfig.getGenesisFederation())
                 .thenReturn(genesisFederation);
 
         assertThat(federationSupport.getActiveFederation(), is(genesisFederation));


### PR DESCRIPTION
Confi example
```
blockchain.config.name = "regtest"

genesis_constants.federationPublicKeys = [
	"02a364011ddf807157465ade342ba385753930921eecbeb5c675543c7e70f09f9b",
	"0278a0128e398dbcd726f9b08eb0e5e0b98acce842cd7c585110b9f0d47353ed3b",
	"02c173fc28b9b5d5c2599397ae2fd0bf05c6ec1b8c09a1627d3d6b72e1dae09ca1"
]
```