### PR TITLE
Fix to allow mining reward address setting to be used in regtest

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -60,6 +60,8 @@ public class RskSystemProperties extends SystemProperties {
     private static final int PD_DEFAULT_TIMEOUT_MESSAGE = PD_DEFAULT_CLEAN_PERIOD - 1; //miliseconds
     private static final int PD_DEFAULT_REFRESH_PERIOD = 60000; //miliseconds
 
+    private static final String REGTEST_BLOCKCHAIN_CONFIG = "regtest";
+
     private static final String MINER_REWARD_ADDRESS_CONFIG = "miner.reward.address";
     private static final String MINER_COINBASE_SECRET_CONFIG = "miner.coinbase.secret";
     private static final int CHUNK_SIZE = 192;
@@ -99,6 +101,14 @@ public class RskSystemProperties extends SystemProperties {
     @Nullable
     public Account localCoinbaseAccount() {
         if (!isMinerServerEnabled()) {
+            return null;
+        }
+
+        // Regtest always has MINER_COINBASE_SECRET_CONFIG set in regtest.conf file. When MINER_REWARD_ADDRESS_CONFIG is set both values exist
+        // and that does not pass the checks below. If MINER_REWARD_ADDRESS_CONFIG exists, that value must be used so consider that
+        // special regtest case by adding this guard.
+        if(configFromFiles.getString(PROPERTY_BC_CONFIG_NAME).equals(REGTEST_BLOCKCHAIN_CONFIG) &&
+                configFromFiles.hasPath(MINER_REWARD_ADDRESS_CONFIG)) {
             return null;
         }
 


### PR DESCRIPTION
Config files are additive, that means that if more settings (not present in default config file) are needed to run a certain configuration those settings will override/add to the ones of the base config. For example, regtest.conf is the base config file while my_regtest.conf can be added with some custom settings.
The previous generates a problem because settings in regtest.conf can be overrided/added but not removed. For using `mining.reward.address` the setting `mining.coinbase.secret` should not exist (code validations check that). Since `mining.coinbase.secret` is set on regtest.conf there is no way to use `mining.reward.address` because both settings exist and validations fail.
This PR contemplates that special case in the settings validations so either `mining.coinbase.secret` or `mining.reward.address` can be used in regtest.
Another option that was considered was to remove `mining.coinbase.secret` from regtest.conf but that would have force users to create their own config and set one of the two variables. I believe it goes against usability and against the current use case (user runs the node with `--regtest` and is good to go)