### PR TITLE
Need to check the if the registered node may not have a status yet

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -375,11 +375,15 @@ public class SyncProcessor implements SyncEventsHandler {
         @Override
         public boolean hasLowerDifficulty(NodeID nodeID) {
             Status status = getPeerStatus(nodeID).getStatus();
+            if (status == null) {
+                return false;
+            }
 
             boolean hasTotalDifficulty = status.getTotalDifficulty() != null;
-            return  (hasTotalDifficulty && blockchain.getStatus().hasLowerTotalDifficultyThan(status)) ||
-                    // this works only for testing purposes, real status without difficulty dont reach this far
-                    (!hasTotalDifficulty && blockchain.getStatus().getBestBlockNumber() < status.getBestBlockNumber());
+            BlockChainStatus nodeStatus = blockchain.getStatus();
+            // this works only for testing purposes, real status without difficulty don't reach this far
+            return  (hasTotalDifficulty && nodeStatus.hasLowerTotalDifficultyThan(status)) ||
+                (!hasTotalDifficulty && nodeStatus.getBestBlockNumber() < status.getBestBlockNumber());
         }
 
         @Override


### PR DESCRIPTION
This fix checks an status is already there when a node is considered to be a candidate for syncing.

In a next version we should improve this code so peers without status information can't be counted as a possible candidate. No candidate should have incomplete information.