### PR TITLE
Wrong condition in setLockWhitelistDisableBlockDelay

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1829,7 +1829,7 @@ public class BridgeSupport {
         }
         int disableBlockDelay = disableBlockDelayBI.intValueExact();
         int bestChainHeight = getBtcBlockchainBestChainHeight();
-        if (bestChainHeight < 0 || Integer.MAX_VALUE - disableBlockDelay < bestChainHeight) {
+        if (disableBlockDelay < 0 || Integer.MAX_VALUE - disableBlockDelay < bestChainHeight) {
             return -2;
         }
         lockWhitelist.setDisableBlockHeight(bestChainHeight + disableBlockDelay);


### PR DESCRIPTION
The condition `bestChainHeight < 0` will always give false as `bestChainHeight` is taken from bitcoin blockchain best chain height.
It can never be less than 0 as genesis is always 0. The condition should check if `disableBlockDelay < 0`.