### PR TITLE
Remove fallback mining signing, but not validation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -349,10 +349,6 @@ public class RskSystemProperties extends SystemProperties {
         return getBoolean("forcegaslimit", true);
     }
 
-    public int getAverageFallbackMiningTime() {
-        return getInt("fallbackMining.blockTime", 0);
-    }
-
     // Sync config properties
     public int getExpectedPeers() {
         return configFromFiles.getInt("sync.expectedPeers");

--- a/rskj-core/src/main/java/co/rsk/core/RskFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskFactory.java
@@ -22,10 +22,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.TransactionPoolImpl;
 import co.rsk.metrics.HashRateCalculator;
-import co.rsk.mine.MinerClient;
-import co.rsk.mine.MinerClientImpl;
-import co.rsk.mine.AutoMinerClient;
-import co.rsk.mine.MinerServer;
+import co.rsk.mine.*;
 import co.rsk.net.*;
 import co.rsk.net.eth.RskWireProtocol;
 import co.rsk.net.sync.SyncConfiguration;
@@ -44,6 +41,7 @@ import co.rsk.scoring.PeerScoringManager;
 import co.rsk.scoring.PunishmentParameters;
 import co.rsk.validators.ProofOfWorkRule;
 import org.ethereum.config.SystemProperties;
+import org.ethereum.config.net.RegTestConfig;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Repository;
 import org.ethereum.core.TransactionPool;
@@ -80,6 +78,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Properties;
 
 @Configuration
@@ -426,5 +425,10 @@ public class RskFactory {
         }
 
         return new BuildInfo(props.getProperty("build.hash"), props.getProperty("build.branch"));
+    }
+
+    @Bean
+    public MinerClock getMinerClock(RskSystemProperties config){
+        return new MinerClock(config.getBlockchainConfig() instanceof RegTestConfig, Clock.systemUTC());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/mine/AutoMinerClient.java
+++ b/rskj-core/src/main/java/co/rsk/mine/AutoMinerClient.java
@@ -74,11 +74,6 @@ public class AutoMinerClient implements MinerClient {
     }
 
     @Override
-    public boolean fallbackMineBlock() {
-        throw new RuntimeException("Fallback mining is deprecated");
-    }
-
-    @Override
     public void stop() {
         stop = true;
         isMining = false;

--- a/rskj-core/src/main/java/co/rsk/mine/MinerClient.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClient.java
@@ -24,9 +24,6 @@ public interface MinerClient {
     // Mines a PoW block
     boolean mineBlock();
 
-    // Mines a privately-signed block (only accepted if block difficulty is very low)
-    boolean fallbackMineBlock();
-
     void stop();
 
     boolean isMining();

--- a/rskj-core/src/main/java/co/rsk/mine/MinerClientImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClientImpl.java
@@ -155,37 +155,6 @@ public class MinerClientImpl implements MinerClient {
         return foundNonce;
     }
 
-    @Override
-    public boolean fallbackMineBlock() {
-        // This is not used now. In the future this method could allow
-        // a HSM to provide the signature for an RSK block here.
-
-        if (this.rsk != null) {
-            if (this.rsk.hasBetterBlockToSync()) {
-                try {
-                    Thread.sleep(10000);
-                } catch (InterruptedException ex) {
-                    logger.error("Interrupted mining sleep", ex);
-                }
-                return false;
-            }
-
-            if (this.rsk.isPlayingBlocks()) {
-                try {
-                    Thread.sleep(10000);
-                } catch (InterruptedException ex) {
-                    logger.error("Interrupted mining sleep", ex);
-                }
-                return false;
-            }
-        }
-        if (stop) {
-            logger.info("Interrupted mining because MinerClient was stopped");
-        }
-
-        return minerServer.generateFallbackBlock();
-
-    }
     /**
      * findNonce will try to find a valid nonce for bitcoinMergedMiningBlock, that satisfies the given target difficulty.
      *

--- a/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
@@ -17,27 +17,17 @@
  */
 package co.rsk.mine;
 
-import co.rsk.config.RskSystemProperties;
-import org.ethereum.config.net.RegTestConfig;
 import org.ethereum.core.Block;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 
-@Component
 public class MinerClock {
     private final boolean isRegtest;
     private final Clock clock;
 
     private long timeAdjustment;
 
-    @Autowired
-    public MinerClock(RskSystemProperties config) {
-        this(config.getBlockchainConfig() instanceof RegTestConfig, Clock.systemUTC());
-    }
-
-    MinerClock(boolean isRegtest, Clock clock) {
+    public MinerClock(boolean isRegtest, Clock clock) {
         this.isRegtest = isRegtest;
         this.clock = clock;
     }

--- a/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
@@ -20,7 +20,6 @@ package co.rsk.mine;
 import co.rsk.config.RskSystemProperties;
 import org.ethereum.config.net.RegTestConfig;
 import org.ethereum.core.Block;
-import org.ethereum.core.Blockchain;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -28,28 +27,19 @@ import java.time.Clock;
 
 @Component
 public class MinerClock {
-    private final Blockchain blockchain;
     private final boolean isRegtest;
     private final Clock clock;
 
     private long timeAdjustment;
 
     @Autowired
-    public MinerClock(Blockchain blockchain, RskSystemProperties config) {
-        this(blockchain, config.getBlockchainConfig() instanceof RegTestConfig, Clock.systemUTC());
+    public MinerClock(RskSystemProperties config) {
+        this(config.getBlockchainConfig() instanceof RegTestConfig, Clock.systemUTC());
     }
 
-    MinerClock(Blockchain blockchain, boolean isRegtest, Clock clock) {
-        this.blockchain = blockchain;
+    MinerClock(boolean isRegtest, Clock clock) {
         this.isRegtest = isRegtest;
         this.clock = clock;
-    }
-
-    /**
-     * @deprecated this is here for compatibility but should be removed along with the fallback mining feature
-     */
-    public long getCurrentTimeInSeconds() {
-        return calculateTimestampForChild(blockchain.getBestBlock());
     }
 
     public long calculateTimestampForChild(Block parent) {

--- a/rskj-core/src/main/java/co/rsk/mine/MinerManager.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerManager.java
@@ -28,9 +28,4 @@ public class MinerManager {
         minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
         minerClient.mineBlock();
     }
-
-    public void fallbackMineBlock(Blockchain blockchain, MinerClient minerClient, MinerServer minerServer) {
-        minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
-        minerClient.fallbackMineBlock();
-    }
 }

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
@@ -53,14 +53,6 @@ public interface MinerServer {
 
     SubmitBlockResult submitBitcoinBlock(String blockHashForMergedMining, BtcBlock bitcoinMergedMiningBlock);
 
-    boolean generateFallbackBlock();
-
-    void setFallbackMining(boolean p);
-
-    void setAutoSwitchBetweenNormalAndFallbackMining(boolean p);
-
-    boolean isFallbackMining();
-
     RskAddress getCoinbaseAddress();
 
     MinerWork getWork();

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
@@ -61,9 +61,5 @@ public interface MinerServer {
 
     void setExtraData(byte[] extraData);
 
-    long getCurrentTimeInSeconds();
-
-    long increaseTime(long seconds);
-
     Optional<Block> getLatestBlock();
 }

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -450,16 +450,6 @@ public class MinerServerImpl implements MinerServer {
         return Optional.ofNullable(latestBlock);
     }
 
-    @Override
-    public long getCurrentTimeInSeconds() {
-        return clock.getCurrentTimeInSeconds();
-    }
-
-    @Override
-    public long increaseTime(long seconds) {
-        return clock.increaseTime(seconds);
-    }
-
     class NewBlockListener extends EthereumListenerAdapter {
 
         @Override

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -23,9 +23,7 @@ import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.config.MiningConfig;
 import co.rsk.config.RskMiningConstants;
 import co.rsk.config.RskSystemProperties;
-import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
-import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.net.BlockProcessor;
@@ -38,22 +36,16 @@ import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.util.Arrays;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.core.*;
-import org.ethereum.crypto.ECKey;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.rpc.TypeConverter;
-import org.ethereum.util.RLP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
@@ -83,11 +75,7 @@ public class MinerServerImpl implements MinerServer {
     private final BlockchainNetConfig blockchainConfig;
     private final MinerClock clock;
 
-    private boolean isFallbackMining;
-    private int fallbackBlocksGenerated;
-    private Timer fallbackMiningTimer;
     private Timer refreshWorkTimer;
-    private int secsBetweenFallbackMinedBlocks;
     private NewBlockListener blockListener;
 
     private boolean started;
@@ -111,11 +99,6 @@ public class MinerServerImpl implements MinerServer {
     private final BigDecimal gasUnitInDollars;
 
     private final BlockProcessor nodeBlockProcessor;
-    private final DifficultyCalculator difficultyCalculator;
-
-    private boolean autoSwitchBetweenNormalAndFallbackMining;
-    private boolean fallbackMiningScheduled;
-    private final RskSystemProperties config;
 
     @Autowired
     public MinerServerImpl(
@@ -123,16 +106,13 @@ public class MinerServerImpl implements MinerServer {
             Ethereum ethereum,
             Blockchain blockchain,
             BlockProcessor nodeBlockProcessor,
-            DifficultyCalculator difficultyCalculator,
             ProofOfWorkRule powRule,
             BlockToMineBuilder builder,
             MinerClock clock,
             MiningConfig miningConfig) {
-        this.config = config;
         this.ethereum = ethereum;
         this.blockchain = blockchain;
         this.nodeBlockProcessor = nodeBlockProcessor;
-        this.difficultyCalculator = difficultyCalculator;
         this.powRule = powRule;
         this.builder = builder;
         this.clock = clock;
@@ -145,23 +125,6 @@ public class MinerServerImpl implements MinerServer {
         coinbaseAddress = miningConfig.getCoinbaseAddress();
         minFeesNotifyInDollars = BigDecimal.valueOf(miningConfig.getMinFeesNotifyInDollars());
         gasUnitInDollars = BigDecimal.valueOf(miningConfig.getMinFeesNotifyInDollars());
-
-        // One more second to force continuous reduction in difficulty
-        // TODO(mc) move to MiningConstants
-
-        // It's not so important to add one because the timer has an average delay of 1 second.
-        secsBetweenFallbackMinedBlocks =
-                config.getAverageFallbackMiningTime();
-        // default
-        if (secsBetweenFallbackMinedBlocks == 0) {
-            secsBetweenFallbackMinedBlocks = (blockchainConfig.getCommonConstants().getDurationLimit());
-        }
-        autoSwitchBetweenNormalAndFallbackMining = !blockchainConfig.getCommonConstants().getFallbackMiningDifficulty().equals(BlockDifficulty.ZERO);
-    }
-
-    // This method is used for tests
-    public void setSecsBetweenFallbackMinedBlocks(int m) {
-        secsBetweenFallbackMinedBlocks = m;
     }
 
     private LinkedHashMap<Keccak256, Block> createNewBlocksWaitingList() {
@@ -171,62 +134,6 @@ public class MinerServerImpl implements MinerServer {
                 return size() > CACHE_SIZE;
             }
         };
-
-    }
-
-    public int getFallbackBlocksGenerated() {
-        return fallbackBlocksGenerated;
-    }
-
-    public boolean isFallbackMining() {
-        return isFallbackMining;
-    }
-
-    public void setFallbackMiningState() {
-        if (isFallbackMining) {
-            // setFallbackMining() can be called before start
-            if (started) {
-                if (fallbackMiningTimer == null) {
-                    fallbackMiningTimer = new Timer("Private mining timer");
-                }
-                if (!fallbackMiningScheduled) {
-                    fallbackMiningTimer.schedule(new FallbackMiningTask(), 1000, 1000);
-                    fallbackMiningScheduled = true;
-                }
-                // Because the Refresh occurs only once every minute,
-                // we need to create at least one first block to mine
-                Block bestBlock = blockchain.getBestBlock();
-                buildBlockToMine(bestBlock, false);
-            } else {
-                if (fallbackMiningTimer != null) {
-                    fallbackMiningTimer.cancel();
-                    fallbackMiningTimer = null;
-                }
-            }
-        } else {
-            fallbackMiningScheduled = false;
-            if (fallbackMiningTimer != null) {
-                fallbackMiningTimer.cancel();
-                fallbackMiningTimer = null;
-            }
-        }
-    }
-
-    @Override
-    public void setAutoSwitchBetweenNormalAndFallbackMining(boolean p) {
-        autoSwitchBetweenNormalAndFallbackMining = p;
-    }
-
-    public void setFallbackMining(boolean p) {
-        synchronized (lock) {
-            if (isFallbackMining == p) {
-                return;
-            }
-
-            isFallbackMining = p;
-            setFallbackMiningState();
-
-        }
 
     }
 
@@ -251,7 +158,6 @@ public class MinerServerImpl implements MinerServer {
             ethereum.removeListener(blockListener);
             refreshWorkTimer.cancel();
             refreshWorkTimer = null;
-            setFallbackMiningState();
         }
     }
 
@@ -273,114 +179,7 @@ public class MinerServerImpl implements MinerServer {
 
             refreshWorkTimer = new Timer("Refresh work for mining");
             refreshWorkTimer.schedule(new RefreshBlock(), DELAY_BETWEEN_BUILD_BLOCKS_MS, DELAY_BETWEEN_BUILD_BLOCKS_MS);
-            setFallbackMiningState();
         }
-    }
-
-    @Nullable
-    public static byte[] readFromFile(File aFile) {
-        try {
-            try (FileInputStream fis = new FileInputStream(aFile)) {
-                byte[] array = new byte[1024];
-                int r = fis.read(array);
-                array = java.util.Arrays.copyOfRange(array, 0, r);
-                fis.close();
-                return array;
-            }
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    static byte[] privKey0;
-    static byte[] privKey1;
-
-    @Override
-    public boolean generateFallbackBlock() {
-        Block newBlock;
-        synchronized (lock) {
-            if (latestBlock == null) {
-                return false;
-            }
-
-            // Iterate and find a block that can be privately mined.
-            Block workingBlock = latestBlock;
-            newBlock = workingBlock.cloneBlock();
-        }
-
-        boolean isEvenBlockNumber = (newBlock.getNumber() % 2) == 0;
-
-
-        String path = config.fallbackMiningKeysDir();
-
-        if (privKey0 == null) {
-            privKey0 = readFromFile(new File(path, "privkey0.bin"));
-        }
-
-        if (privKey1 == null) {
-            privKey1 = readFromFile(new File(path, "privkey1.bin"));
-        }
-
-        if (!isEvenBlockNumber && privKey1 == null) {
-            return false;
-        }
-
-        if (isEvenBlockNumber && privKey0 == null) {
-            return false;
-        }
-
-        ECKey privateKey;
-
-        if (isEvenBlockNumber) {
-            privateKey = ECKey.fromPrivate(privKey0);
-        } else {
-            privateKey = ECKey.fromPrivate(privKey1);
-        }
-
-        //
-        // Set the timestamp now to control mining interval better
-        //
-        BlockHeader newHeader = newBlock.getHeader();
-
-        newHeader.setTimestamp(this.getCurrentTimeInSeconds());
-        Block parentBlock = blockchain.getBlockByHash(newHeader.getParentHash().getBytes());
-        newHeader.setDifficulty(
-                difficultyCalculator.calcDifficulty(newHeader, parentBlock.getHeader()));
-
-        // fallback mining marker
-        newBlock.setExtraData(new byte[]{42});
-        byte[] signature = fallbackSign(newBlock.getHashForMergedMining(), privateKey);
-
-        newBlock.setBitcoinMergedMiningHeader(signature);
-
-        newBlock.seal();
-
-        if (!isValid(newBlock)) {
-            String message = "Invalid fallback block supplied by miner: " + newBlock.getShortHash() + " " + newBlock.getShortHashForMergedMining() + " at height " + newBlock.getNumber();
-            logger.error(message);
-            return false;
-        } else {
-            latestBlock = null; // never reuse if block is valid
-            ImportResult importResult = ethereum.addNewMinedBlock(newBlock);
-            fallbackBlocksGenerated++;
-            logger.info("Mined block import result is {}: {} {} at height {}", importResult, newBlock.getShortHash(), newBlock.getShortHashForMergedMining(), newBlock.getNumber());
-            return importResult.isSuccessful();
-        }
-
-    }
-
-    private byte[] fallbackSign(byte[] hash, ECKey privKey) {
-        ECKey.ECDSASignature signature = privKey.sign(hash);
-
-        byte vdata = signature.v;
-        byte[] rdata = signature.r.toByteArray();
-        byte[] sdata = signature.s.toByteArray();
-
-        byte[] vencoded = RLP.encodeByte(vdata);
-        byte[] rencoded = RLP.encodeElement(rdata);
-        byte[] sencoded = RLP.encodeElement(sdata);
-
-        return RLP.encodeList(vencoded, rencoded, sencoded);
     }
 
     @Override
@@ -599,10 +398,6 @@ public class MinerServerImpl implements MinerServer {
         final Block newBlock = builder.build(newBlockParent, extraData);
         clock.clearIncreaseTime();
 
-        if (autoSwitchBetweenNormalAndFallbackMining) {
-            setFallbackMining(ProofOfWorkRule.isFallbackMiningPossible(config, newBlock.getHeader()));
-        }
-
         synchronized (lock) {
             Keccak256 parentHash = newBlockParent.getHash();
             boolean notify = this.getNotify(newBlock, parentHash);
@@ -697,24 +492,6 @@ public class MinerServerImpl implements MinerServer {
 
         private boolean isSyncing() {
             return nodeBlockProcessor.hasBetterBlockToSync();
-        }
-    }
-
-    private class FallbackMiningTask extends TimerTask {
-        @Override
-        public void run() {
-            try {
-                Block bestBlock = blockchain.getBestBlock();
-                long curtimestampSeconds = getCurrentTimeInSeconds();
-
-
-                if (curtimestampSeconds > bestBlock.getTimestamp() + secsBetweenFallbackMinedBlocks) {
-                    generateFallbackBlock();
-                }
-            } catch (Throwable th) {
-                logger.error("Unexpected error: {}", th);
-                panicProcessor.panic("mserror", th.getMessage());
-            }
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/evm/EvmModuleImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/evm/EvmModuleImpl.java
@@ -20,6 +20,7 @@ package co.rsk.rpc.modules.evm;
 
 import co.rsk.core.SnapshotManager;
 import co.rsk.mine.MinerClient;
+import co.rsk.mine.MinerClock;
 import co.rsk.mine.MinerManager;
 import co.rsk.mine.MinerServer;
 import org.ethereum.core.Blockchain;
@@ -39,6 +40,7 @@ public class EvmModuleImpl implements EvmModule {
     private final MinerManager minerManager;
     private final MinerServer minerServer;
     private final MinerClient minerClient;
+    private final MinerClock minerClock;
     private final Blockchain blockchain;
     private final SnapshotManager snapshotManager;
 
@@ -46,11 +48,13 @@ public class EvmModuleImpl implements EvmModule {
     public EvmModuleImpl(
             MinerServer minerServer,
             MinerClient minerClient,
+            MinerClock minerClock,
             Blockchain blockchain,
             TransactionPool transactionPool) {
         this.minerManager = new MinerManager();
         this.minerServer = minerServer;
         this.minerClient = minerClient;
+        this.minerClock = minerClock;
         this.blockchain = blockchain;
         this.snapshotManager = new SnapshotManager(blockchain, transactionPool, minerServer);
     }
@@ -102,7 +106,7 @@ public class EvmModuleImpl implements EvmModule {
     public String evm_increaseTime(String seconds) {
         try {
             long nseconds = stringNumberAsBigInt(seconds).longValue();
-            String result = toJsonHex(minerServer.increaseTime(nseconds));
+            String result = toJsonHex(minerClock.increaseTime(nseconds));
             logger.debug("evm_increaseTime({}): {}", nseconds, result);
             return result;
         } catch (NumberFormatException | StringIndexOutOfBoundsException e) {

--- a/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
@@ -25,6 +25,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.RskMiningConstants;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.util.DifficultyUtils;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.ArrayUtils;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.util.Pack;
@@ -69,6 +70,7 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
         this.constants = blockchainConfig.getCommonConstants();
     }
 
+    @VisibleForTesting
     public ProofOfWorkRule setFallbackMiningEnabled(boolean e) {
         fallbackMiningEnabled = e;
         return this;
@@ -79,15 +81,12 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
         return isValid(block.getHeader());
     }
 
-    public static boolean isFallbackMiningPossible(RskSystemProperties config, BlockHeader header) {
+    private boolean isFallbackMiningPossible(BlockHeader header) {
         if (config.getBlockchainConfig().getConfigForBlock(header.getNumber()).isRskip98()) {
             return false;
         }
 
         Constants constants = config.getBlockchainConfig().getCommonConstants();
-        if (header.getNumber() >= constants.getEndOfFallbackMiningBlockNumber()) {
-            return false;
-        }
 
         if (header.getDifficulty().compareTo(constants.getFallbackMiningDifficulty()) > 0) {
             return false;
@@ -100,7 +99,7 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
         return true;
     }
 
-    public boolean isFallbackMiningPossibleAndBlockSigned(BlockHeader header) {
+    private boolean isFallbackMiningPossibleAndBlockSigned(BlockHeader header) {
 
         if (header.getBitcoinMergedMiningCoinbaseTransaction() != null) {
             return false;
@@ -115,7 +114,7 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
             return false;
         }
 
-        return isFallbackMiningPossible(config, header);
+        return isFallbackMiningPossible(header);
 
     }
 

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -46,10 +46,6 @@ public class Constants {
     // Private mining is allowed if difficulty is lower or equal than this value
     private final BlockDifficulty fallbackMiningDifficulty = new BlockDifficulty(BigInteger.valueOf((long) 14E15)); // 14 peta evert 14 secs = 1 peta/s.
 
-    private static long blockPerDay = 24*3600 / 14;
-
-    private long endOfFallbackMiningBlockNumber = blockPerDay*30*6; // Approximately 6 months of private mining fallback, then you're free my child. Fly, fly away.
-
     // 0.5 peta/s. This means that on reset difficulty will allow private mining.
     private final BlockDifficulty minimumDifficulty = new BlockDifficulty(BigInteger.valueOf((long) 14E15 / 2 )); // 0.5 peta/s.
 
@@ -126,8 +122,6 @@ public class Constants {
     }
 
     public BlockDifficulty getFallbackMiningDifficulty() { return fallbackMiningDifficulty; }
-
-    public long getEndOfFallbackMiningBlockNumber() { return endOfFallbackMiningBlockNumber; }
 
     public BigInteger getDifficultyBoundDivisor() {
         return difficultyBoundDivisor;

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -23,7 +23,6 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.config.ConfigLoader;
 import com.google.common.annotations.VisibleForTesting;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigRenderOptions;
 import org.bouncycastle.util.encoders.Hex;
@@ -121,7 +120,6 @@ public abstract class SystemProperties {
 
     // mutable options for tests
     private String databaseDir = null;
-    private String fallbackMiningKeysDir = null;
     private String projectVersion = null;
     private String projectVersionModifier = null;
 
@@ -360,16 +358,6 @@ public abstract class SystemProperties {
     @ValidateMe
     public String databaseDir() {
         return databaseDir == null ? configFromFiles.getString("database.dir") : databaseDir;
-    }
-
-    // can be missing
-    public String fallbackMiningKeysDir() {
-        try {
-            return fallbackMiningKeysDir == null ? configFromFiles.getString("fallbackMining.keysDir") : fallbackMiningKeysDir;
-        } catch(ConfigException.Missing e) {
-            fallbackMiningKeysDir ="";
-            return fallbackMiningKeysDir;
-        }
     }
 
     public void setDataBaseDir(String dataBaseDir) {

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/FallbackMainNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/FallbackMainNetConfig.java
@@ -1,10 +1,7 @@
 package org.ethereum.config.blockchain;
 
-import org.ethereum.config.Constants;
-import org.ethereum.config.blockchain.mainnet.MainNetAfterBridgeSyncConfig;
 import org.bouncycastle.util.encoders.Hex;
-
-import java.math.BigInteger;
+import org.ethereum.config.blockchain.mainnet.MainNetAfterBridgeSyncConfig;
 
 /**
  * Created by SerAdmin on 1/4/2018.
@@ -12,13 +9,9 @@ import java.math.BigInteger;
 public class FallbackMainNetConfig extends GenesisConfig  {
 
     public static class FallbackMainNetConstants extends MainNetAfterBridgeSyncConfig.MainNetConstants {
-        private static final BigInteger DIFFICULTY_BOUND_DIVISOR = BigInteger.valueOf(50);
-        private static final byte CHAIN_ID = 30;
 
         private byte[] newfallbackMiningPubKey0 = Hex.decode("04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7");
         private byte[] newfallbackMiningPubKey1 = Hex.decode("04774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cbd984a032eb6b5e190243dd56d7b7b365372db1e2dff9d6a8301d74c9c953c61b");
-
-
 
         @Override
         public byte[] getFallbackMiningPubKey0() {
@@ -34,10 +27,6 @@ public class FallbackMainNetConfig extends GenesisConfig  {
 
     public FallbackMainNetConfig() {
         super(new FallbackMainNetConfig.FallbackMainNetConstants());
-    }
-
-    protected FallbackMainNetConfig(Constants constants) {
-        super(constants);
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
+++ b/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
@@ -31,15 +31,14 @@ import co.rsk.peg.simples.SimpleRskTransaction;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieImpl;
 import org.apache.commons.collections4.CollectionUtils;
+import org.bouncycastle.pqc.math.linearalgebra.ByteUtils;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.*;
 import org.ethereum.core.genesis.InitialAddressState;
-import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
-import org.bouncycastle.pqc.math.linearalgebra.ByteUtils;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -361,66 +360,6 @@ public class BlockGenerator {
                 txs,       // transaction list
                 null        // uncle list
         );
-    }
-
-    public Block createFallbackMinedChildBlockWithTimeStamp(Block parent, byte[] difficulty, long timeStamp, boolean goodSig) {
-        List<Transaction> txs = new ArrayList<>();
-        Block block = new Block(
-                parent.getHash().getBytes(), // parent hash
-                EMPTY_LIST_HASH, // uncle hash
-                parent.getCoinbase().getBytes(),
-                ByteUtils.clone(new Bloom().getData()),
-                difficulty, // difficulty
-                parent.getNumber() + 1,
-                parent.getGasLimit(),
-                parent.getGasUsed(),
-                timeStamp,
-                EMPTY_BYTE_ARRAY,   // extraData
-                EMPTY_BYTE_ARRAY,   // mixHash
-                BigInteger.ZERO.toByteArray(),  // provisory nonce
-                EMPTY_TRIE_HASH,   // receipts root
-                BlockChainImpl.calcTxTrie(txs),  // transaction root
-                ByteUtils.clone(parent.getStateRoot()), //EMPTY_TRIE_HASH,   // state root
-                txs,       // transaction list
-                null,        // uncle list
-                null,
-                Coin.ZERO
-        );
-
-        ECKey fallbackMiningKey0 = ECKey.fromPrivate(BigInteger.TEN);
-        ECKey fallbackMiningKey1 = ECKey.fromPrivate(BigInteger.TEN.add(BigInteger.ONE));
-
-        ECKey fallbackKey;
-
-        if (block.getNumber() % 2 == 0) {
-            fallbackKey = fallbackMiningKey0;
-        } else {
-            fallbackKey = fallbackMiningKey1;
-        }
-
-        byte[] signature = fallbackSign(block.getHashForMergedMining(), fallbackKey);
-
-        if (!goodSig) {
-            // just make it a little bad
-            signature[5] = (byte) (signature[5]+1);
-        }
-
-        block.setBitcoinMergedMiningHeader(signature);
-        return block;
-    }
-
-    byte[] fallbackSign(byte[] hash, ECKey privKey) {
-        ECKey.ECDSASignature signature = privKey.sign(hash);
-
-        byte vdata = signature.v;
-        byte[] rdata = signature.r.toByteArray();
-        byte[] sdata = signature.s.toByteArray();
-
-        byte[] vencoded =  RLP.encodeByte(vdata);
-        byte[] rencoded = RLP.encodeElement(rdata);
-        byte[] sencoded = RLP.encodeElement(sdata);
-
-        return RLP.encodeList(vencoded, rencoded, sencoded);
     }
 
     public List<Block> getBlockChain(int size) {

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.time.Clock;
 
 /**
  * Created by SerAdmin on 1/3/2018.
@@ -72,7 +73,7 @@ public class MainNetMinerTest {
 
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
 
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -133,7 +134,7 @@ public class MainNetMinerTest {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
         Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
 
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -192,7 +193,7 @@ public class MainNetMinerTest {
     private BlockToMineBuilder blockToMineBuilder() {
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         return new BlockToMineBuilder(
                 ConfigUtils.getDefaultMiningConfig(),
                 repository,

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -72,7 +72,7 @@ public class MainNetMinerTest {
 
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
 
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -133,7 +133,7 @@ public class MainNetMinerTest {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
         Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
 
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -192,7 +192,7 @@ public class MainNetMinerTest {
     private BlockToMineBuilder blockToMineBuilder() {
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         return new BlockToMineBuilder(
                 ConfigUtils.getDefaultMiningConfig(),
                 repository,

--- a/rskj-core/src/test/java/co/rsk/mine/MinerClockTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerClockTest.java
@@ -18,7 +18,6 @@
 package co.rsk.mine;
 
 import org.ethereum.core.Block;
-import org.ethereum.core.Blockchain;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,32 +31,16 @@ import static org.mockito.Mockito.when;
 
 public class MinerClockTest {
 
-    private Blockchain blockchain;
     private Clock clock;
 
     @Before
     public void setUp() {
-        blockchain = mock(Blockchain.class);
         clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
     }
 
     @Test
-    public void currentTimeIsBestBlocksChildTimestamp() {
-        MinerClock minerClock = new MinerClock(blockchain, true, clock);
-
-        Block bestBlock = mock(Block.class);
-        when(bestBlock.getTimestamp()).thenReturn(54L);
-        when(blockchain.getBestBlock()).thenReturn(bestBlock);
-
-        assertEquals(
-                minerClock.calculateTimestampForChild(bestBlock),
-                minerClock.getCurrentTimeInSeconds()
-        );
-    }
-
-    @Test
     public void timestampForChildIsParentTimestampIfRegtest() {
-        MinerClock minerClock = new MinerClock(blockchain, true, clock);
+        MinerClock minerClock = new MinerClock(true, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(54L);
@@ -70,7 +53,7 @@ public class MinerClockTest {
 
     @Test
     public void timestampForChildIsClockTimeIfNotRegtest() {
-        MinerClock minerClock = new MinerClock(blockchain, false, clock);
+        MinerClock minerClock = new MinerClock(false, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(54L);
@@ -83,7 +66,7 @@ public class MinerClockTest {
 
     @Test
     public void timestampForChildIsTimestampPlusOneIfNotRegtest() {
-        MinerClock minerClock = new MinerClock(blockchain, false, clock);
+        MinerClock minerClock = new MinerClock(false, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(clock.instant().getEpochSecond());
@@ -96,7 +79,7 @@ public class MinerClockTest {
 
     @Test
     public void adjustTimeIfRegtest() {
-        MinerClock minerClock = new MinerClock(blockchain, true, clock);
+        MinerClock minerClock = new MinerClock(true, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(33L);
@@ -111,7 +94,7 @@ public class MinerClockTest {
 
     @Test
     public void adjustTimeIfNotRegtest() {
-        MinerClock minerClock = new MinerClock(blockchain, false, clock);
+        MinerClock minerClock = new MinerClock(false, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(33L);
@@ -126,7 +109,7 @@ public class MinerClockTest {
 
     @Test
     public void clearTimeIncrease() {
-        MinerClock minerClock = new MinerClock(blockchain, true, clock);
+        MinerClock minerClock = new MinerClock(true, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(33L);

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -269,28 +269,6 @@ public class MinerManagerTest {
         Assert.assertTrue(transactionPool.getPendingTransactions().isEmpty());
     }
 
-    @Test
-    public void mineBlockUsingTimeTravel() {
-        Assert.assertEquals(0, blockchain.getBestBlock().getNumber());
-
-        MinerManager manager = new MinerManager();
-
-        MinerServerImpl minerServer = getMinerServer();
-        MinerClientImpl minerClient = getMinerClient(minerServer);
-
-        long currentTime = minerServer.getCurrentTimeInSeconds();
-
-        minerServer.increaseTime(10);
-
-        manager.mineBlock(blockchain, minerClient, minerServer);
-
-        Block block = blockchain.getBestBlock();
-        Assert.assertEquals(1, block.getNumber());
-
-        Assert.assertTrue(currentTime + 10 <= block.getTimestamp());
-        Assert.assertTrue(currentTime + 11 > block.getTimestamp());
-    }
-
     private static MinerClientImpl getMinerClient(MinerServerImpl minerServer) {
         return getMinerClient(new RskImplForTest() {
             @Override
@@ -314,7 +292,7 @@ public class MinerManagerTest {
         ethereum.repository = repository;
         ethereum.blockchain = blockchain;
         DifficultyCalculator difficultyCalculator = new DifficultyCalculator(config);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         return new MinerServerImpl(
                 config,
                 ethereum,

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -39,6 +39,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -292,7 +293,7 @@ public class MinerManagerTest {
         ethereum.repository = repository;
         ethereum.blockchain = blockchain;
         DifficultyCalculator difficultyCalculator = new DifficultyCalculator(config);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         return new MinerServerImpl(
                 config,
                 ethereum,

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -320,7 +320,6 @@ public class MinerManagerTest {
                 ethereum,
                 blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -104,7 +104,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServerImpl minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -145,7 +145,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -210,7 +210,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -260,7 +260,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -313,7 +313,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -373,7 +373,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -425,7 +425,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -482,7 +482,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -521,7 +521,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -560,7 +560,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -603,7 +603,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(blockchain, config);
+        MinerClock clock = new MinerClock(config);
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -640,60 +640,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
         } finally {
             minerServer.stop();
         }
-    }
-
-    @Test
-    public void getCurrentTimeInMilliseconds() {
-        long current = blockStore.getBestBlock().getTimestamp();
-
-        MinerServer server = getMinerServerWithMocks();
-
-        long result = server.getCurrentTimeInSeconds();
-
-        Assert.assertTrue(result >= current);
-        Assert.assertTrue(result <= current + 1);
-    }
-
-    @Test
-    public void increaseTime() {
-        long current = blockStore.getBestBlock().getTimestamp();
-
-        MinerServer server = getMinerServerWithMocks();
-
-        Assert.assertEquals(10, server.increaseTime(10));
-
-        long result = server.getCurrentTimeInSeconds();
-
-        Assert.assertTrue(result >= current + 10);
-        Assert.assertTrue(result <= current + 11);
-    }
-
-    @Test
-    public void increaseTimeUsingNegativeNumberHasNoEffect() {
-        long current = blockStore.getBestBlock().getTimestamp();
-
-        MinerServer server = getMinerServerWithMocks();
-
-        Assert.assertEquals(0, server.increaseTime(-10));
-
-        long result = server.getCurrentTimeInSeconds();
-
-        Assert.assertTrue(result >= current);
-    }
-
-    @Test
-    public void increaseTimeTwice() {
-        long current = blockStore.getBestBlock().getTimestamp();
-
-        MinerServer server = getMinerServerWithMocks();
-
-        Assert.assertEquals(5, server.increaseTime(5));
-        Assert.assertEquals(10, server.increaseTime(5));
-
-        long result = server.getCurrentTimeInSeconds();
-
-        Assert.assertTrue(result >= current + 10);
-        Assert.assertTrue(result <= current + 11);
     }
 
     private BtcBlock getMergedMiningBlockWithOnlyCoinbase(MinerWork work) {
@@ -744,7 +690,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 null,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 getBuilderWithMocks(),
-                new MinerClock(blockchain, config),
+                new MinerClock(config),
                 ConfigUtils.getDefaultMiningConfig()
         );
     }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -110,7 +110,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 this.blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -152,7 +151,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -218,7 +216,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -269,7 +266,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -323,7 +319,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -384,7 +379,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -437,7 +431,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -495,7 +488,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 this.blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -535,7 +527,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 this.blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -575,7 +566,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 this.blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -619,7 +609,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ethereumImpl,
                 this.blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),
@@ -753,7 +742,6 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 Mockito.mock(Ethereum.class),
                 blockchain,
                 null,
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 getBuilderWithMocks(),
                 new MinerClock(blockchain, config),

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -45,6 +45,7 @@ import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -104,7 +105,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServerImpl minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -145,7 +146,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -210,7 +211,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -260,7 +261,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -313,7 +314,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -373,7 +374,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -425,7 +426,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -482,7 +483,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -521,7 +522,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -560,7 +561,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -603,7 +604,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(config);
+        MinerClock clock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -690,7 +691,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 null,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 getBuilderWithMocks(),
-                new MinerClock(config),
+                new MinerClock(true, Clock.systemUTC()),
                 ConfigUtils.getDefaultMiningConfig()
         );
     }

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -65,6 +65,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.math.BigInteger;
+import java.time.Clock;
 
 public class TransactionModuleTest {
     Wallet wallet;
@@ -255,7 +256,7 @@ public class TransactionModuleTest {
         ConfigCapabilities configCapabilities = new SimpleConfigCapabilities();
         CompositeEthereumListener compositeEthereumListener = new CompositeEthereumListener();
         Ethereum eth = new EthereumImpl(new ChannelManagerImpl(config, new SyncPool(compositeEthereumListener, blockchain, config, null)), transactionPool, compositeEthereumListener, blockchain);
-        MinerClock minerClock = new MinerClock(config);
+        MinerClock minerClock = new MinerClock(true, Clock.systemUTC());
 
         MinerServer minerServer = new MinerServerImpl(
                 config,

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -262,7 +262,6 @@ public class TransactionModuleTest {
                 eth,
                 blockchain,
                 null,
-                new DifficultyCalculator(config),
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -255,7 +255,7 @@ public class TransactionModuleTest {
         ConfigCapabilities configCapabilities = new SimpleConfigCapabilities();
         CompositeEthereumListener compositeEthereumListener = new CompositeEthereumListener();
         Ethereum eth = new EthereumImpl(new ChannelManagerImpl(config, new SyncPool(compositeEthereumListener, blockchain, config, null)), transactionPool, compositeEthereumListener, blockchain);
-        MinerClock minerClock = new MinerClock(blockchain, config);
+        MinerClock minerClock = new MinerClock(config);
 
         MinerServer minerServer = new MinerServerImpl(
                 config,

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleMinerClient.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleMinerClient.java
@@ -31,10 +31,6 @@ public class SimpleMinerClient implements MinerClient {
         isMining = true;
     }
 
-    public boolean fallbackMineBlock() {
-        return false;
-    }
-
     public boolean mineBlock() {
         // Unused
         return false;

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -43,6 +43,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Clock;
 import java.util.List;
 
 /**
@@ -148,7 +149,7 @@ public class Web3ImplSnapshotTest {
 
 
     private Web3Impl createWeb3(SimpleEthereum ethereum) {
-        MinerClock minerClock = new MinerClock(config);
+        MinerClock minerClock = new MinerClock(true, Clock.systemUTC());
         MinerServer minerServer = getMinerServerForTest(ethereum, minerClock);
         MinerClientImpl minerClient = new MinerClientImpl(null, minerServer, config.minerClientDelayBetweenBlocks(), config.minerClientDelayBetweenRefreshes());
         EvmModule evmModule = new EvmModuleImpl(minerServer, minerClient, minerClock, blockchain, factory.getTransactionPool());

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -247,7 +247,6 @@ public class Web3ImplSnapshotTest {
                 ethereum,
                 blockchain,
                 factory.getBlockProcessor(),
-                difficultyCalculator,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockToMineBuilder(
                         ConfigUtils.getDefaultMiningConfig(),


### PR DESCRIPTION
Since both networks have enabled RSKIP98, we will never again sign blocks with the fallback mechanism.