### PR TITLE
Transaction refactored

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/TxBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/mine/TxBuilder.java
@@ -122,7 +122,7 @@ public class TxBuilder {
     {
         String toAddress = Hex.toHexString(new ECKey(Utils.getRandom()).getAddress());
 
-        Transaction tx = Transaction.create(config, toAddress, BigInteger.valueOf(1000), txNonce, gasPrice, gasLimit);
+        Transaction tx = new Transaction(config, toAddress, BigInteger.valueOf(1000), txNonce, gasPrice, gasLimit);
         tx.sign(privateKeyBytes);
 
         return tx;

--- a/rskj-core/src/main/java/co/rsk/mine/TxBuilderEx.java
+++ b/rskj-core/src/main/java/co/rsk/mine/TxBuilderEx.java
@@ -161,7 +161,7 @@ public class TxBuilderEx {
 
     private Transaction createNewTransaction(byte[] privateKey, String toAddress, BigInteger value, BigInteger nonce) {
         long gasLimit = 21000L + random.nextInt(100);
-        Transaction tx = Transaction.create(config, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(gasLimit));
+        Transaction tx = new Transaction(config, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(gasLimit));
         tx.sign(privateKey);
         return tx;
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -68,7 +68,7 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
 
             synchronized (transactionPool) {
                 BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : transactionPool.getPendingState().getNonce(account.getAddress());
-                Transaction tx = Transaction.create(config, toAddress, value, accountNonce, gasPrice, gasLimit, args.data);
+                Transaction tx = new Transaction(config, toAddress, value, accountNonce, gasPrice, gasLimit, args.data);
                 tx.sign(account.getEcKey().getPrivKeyBytes());
                 transactionPool.addTransaction(tx.toImmutableTransaction());
                 s = tx.getHash().toJsonString();

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -191,7 +191,7 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
             args.data = args.data.substring(2);
         }
 
-        Transaction tx = Transaction.create(config, toAddress, value, accountNonce, gasPrice, gasLimit, args.data);
+        Transaction tx = new Transaction(config, toAddress, value, accountNonce, gasPrice, gasLimit, args.data);
 
         tx.sign(account.getEcKey().getPrivKeyBytes());
 

--- a/rskj-core/src/main/java/org/ethereum/core/ImmutableTransaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/ImmutableTransaction.java
@@ -13,11 +13,6 @@ public class ImmutableTransaction extends Transaction {
         throw new ImmutableTransactionException(String.format("trying to sign tx=%s", this.getHash()));
     }
 
-    @Override
-    public void setGasLimit(byte[] gasLimit) {
-        throw new ImmutableTransactionException(String.format("trying to set gas limit tx=%s", this.getHash()));
-    }
-
     public static class ImmutableTransactionException extends RuntimeException {
         public ImmutableTransactionException(String message) {
             super("Immutable transaction: " + message);

--- a/rskj-core/src/main/java/org/ethereum/vm/program/InternalTransaction.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/InternalTransaction.java
@@ -78,10 +78,6 @@ public class InternalTransaction extends Transaction {
 
     @Override
     public byte[] getEncoded() {
-        if (rlpEncoded != null) {
-            return rlpEncoded;
-        }
-
         byte[] nonce = getNonce();
         if (isEmpty(nonce) || getLength(nonce) == 1 && nonce[0] == 0) {
             nonce = RLP.encodeElement((byte[]) null);
@@ -100,20 +96,13 @@ public class InternalTransaction extends Transaction {
         byte[] index = RLP.encodeInt(this.index);
         byte[] rejected = RLP.encodeInt(this.rejected ? 1 : 0);
 
-        this.rlpEncoded = RLP.encodeList(nonce, parentHash, senderAddress, receiveAddress, value,
+        return RLP.encodeList(nonce, parentHash, senderAddress, receiveAddress, value,
                 gasPrice, gasLimit, data, type, deep, index, rejected);
-
-        return rlpEncoded;
     }
 
     @Override
     public byte[] getEncodedRaw() {
         return getEncoded();
-    }
-
-    @Override
-    public void rlpParse() {
-        // Internal transaction not uses as encoded data
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/core/ImmutableTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/ImmutableTransactionTest.java
@@ -26,18 +26,6 @@ public class ImmutableTransactionTest {
         }
     }
 
-    @Test
-    public void tryingToSetGasLimit() {
-        Transaction tx = createImmutableTransaction();
-
-        try {
-            tx.setGasLimit(new byte[32]);
-        }
-        catch (ImmutableTransaction.ImmutableTransactionException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Immutable transaction: trying to set gas limit"));
-        }
-    }
-
     private static Transaction createImmutableTransaction() {
         Account sender = new AccountBuilder().name("sender").build();
         Account receiver = new AccountBuilder().name("receiver").build();

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -38,6 +38,7 @@ import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class TransactionTest {
 
@@ -89,32 +90,24 @@ public class TransactionTest {
         System.out.println(tx.toString());
     }
 
-    @Test  /* achieve public key of the sender when signature manually set */
-    public void test3() throws Exception {
-        if (config.getBlockchainConfig().getCommonConstants().getChainId() != 0)
-            return;
-
-        // cat --> 79b08ad8787060333663d19704909ee7b1903e58
-        // cow --> cd2a3d9f938e13cd947ec05abc7fe734df8dd826
-
+    @Test  /* achieve public key of the sender */
+    public void testSenderShouldChangeWhenReSigningTx() throws Exception {
         BigInteger value = new BigInteger("1000000000000000000000");
 
-        byte[] privKey = HashUtil.keccak256("cat".getBytes());
-        ECKey ecKey = ECKey.fromPrivate(privKey);
+        byte[] privateKey = HashUtil.keccak256("cat".getBytes());
+        ECKey ecKey = ECKey.fromPrivate(privateKey);
 
-        byte[] senderPrivKey = HashUtil.keccak256("cow".getBytes());
+        byte[] senderPrivateKey = HashUtil.keccak256("cow".getBytes());
 
         byte[] gasPrice = Hex.decode("09184e72a000");
         byte[] gas = Hex.decode("4255");
 
-        // Tn (nonce); Tp(pgas); Tg(gaslimi); Tt(value); Tv(value); Ti(sender);  Tw; Tr; Ts
+        // Tn(nonce); Tp(pgas); Tg(gaslimit); Tt(value); Tv(value); Ti(sender);  Tw; Tr; Ts
         Transaction tx = new Transaction(null, gasPrice, gas, ecKey.getAddress(),
                 value.toByteArray(),
                 null);
 
-        Keccak256 hash = tx.getRawHash();
-        ECKey.ECDSASignature signature = ECKey.fromPrivate(senderPrivKey).sign(hash.getBytes());
-        tx.setSignature(signature);
+        tx.sign(senderPrivateKey);
 
         System.out.println("v\t\t\t: " + Hex.toHexString(new byte[]{tx.getSignature().v}));
         System.out.println("r\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().r)));
@@ -122,17 +115,18 @@ public class TransactionTest {
 
         System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
 
-        // retrieve the signer/sender of the transaction
-        ECKey key = ECKey.signatureToKey(tx.getHash().getBytes(), tx.getSignature().toBase64());
+        // Retrieve sender from transaction
+        RskAddress sender = tx.getSender();
 
-        System.out.println("Tx unsigned RLP\t\t: " + Hex.toHexString(tx.getEncodedRaw()));
-        System.out.println("Tx signed   RLP\t\t: " + Hex.toHexString(tx.getEncoded()));
+        // Re-sign transaction with a different sender's key
+        byte[] newSenderPrivateKey = HashUtil.keccak256("bat".getBytes());
+        tx.sign(newSenderPrivateKey);
 
-        System.out.println("Signature public key\t: " + Hex.toHexString(key.getPubKey()));
-        System.out.println("Sender is\t\t: " + Hex.toHexString(key.getAddress()));
+        // Retrieve new sender from transaction
+        RskAddress newSender = tx.getSender();
 
-        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826",
-                Hex.toHexString(key.getAddress()));
+        // Verify sender changed
+        assertNotEquals(sender, newSender);
 
         System.out.println(tx.toString());
     }
@@ -301,37 +295,52 @@ public class TransactionTest {
     }
 
     @Test
+    public void testTransaction() {
+        Transaction tx = new Transaction(9L, 20000000000L, 21000L,
+                "3535353535353535353535353535353535353535", 1000000000000000000L, new byte[0], (byte) 1);
+
+        byte[] encoded = tx.getEncodedRaw();
+        byte[] hash = tx.getRawHash().getBytes();
+        String strenc = Hex.toHexString(encoded);
+        Assert.assertEquals("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080", strenc);
+        String strhash = Hex.toHexString(hash);
+        Assert.assertEquals("daf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53", strhash);
+        System.out.println(strenc);
+        System.out.println(strhash);
+    }
+
+    @Test
     public void isContractCreationWhenReceiveAddressIsNull() {
-        Transaction tx = Transaction.create(config, null, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = new Transaction(config, null, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertTrue(tx.isContractCreation());
     }
 
     @Test
     public void isContractCreationWhenReceiveAddressIsEmptyString() {
-        Transaction tx = Transaction.create(config, "", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = new Transaction(config, "", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertTrue(tx.isContractCreation());
     }
 
     @Test(expected = RuntimeException.class)
     public void isContractCreationWhenReceiveAddressIs00() {
-        Transaction.create(config, "00", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        new Transaction(config, "00", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
     }
 
     @Test
     public void isContractCreationWhenReceiveAddressIsFortyZeroes() {
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000000", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000000", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertFalse(tx.isContractCreation());
     }
 
     @Test
     public void isNotContractCreationWhenReceiveAddressIsCowAddress() {
-        Transaction tx = Transaction.create(config, "cd2a3d9f938e13cd947ec05abc7fe734df8dd826", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = new Transaction(config, "cd2a3d9f938e13cd947ec05abc7fe734df8dd826", BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertFalse(tx.isContractCreation());
     }
 
     @Test
     public void isNotContractCreationWhenReceiveAddressIsBridgeAddress() {
-        Transaction tx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
+        Transaction tx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, BigInteger.ONE, BigInteger.TEN, BigInteger.ONE, BigInteger.valueOf(21000L));
         Assert.assertFalse(tx.isContractCreation());
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
@@ -826,7 +826,7 @@ public class BlockChainImplTest {
         Assert.assertEquals(ImportResult.INVALID_BLOCK, blockChain.tryToConnect(block));
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(1L), BigInteger.TEN);
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(1L), BigInteger.TEN);
         tx.sign(new byte[]{22, 11, 00});
         txs.add(tx);
 
@@ -855,7 +855,7 @@ public class BlockChainImplTest {
         track.commit();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000100", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.valueOf(22000L));
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000100", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.valueOf(22000L));
         tx.sign(account.getEcKey().getPrivKeyBytes());
         txs.add(tx);
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -686,7 +686,7 @@ public class BlockExecutorTest {
     private static Transaction createTransaction(Account sender, Account receiver, BigInteger value, BigInteger nonce) {
         String toAddress = Hex.toHexString(receiver.getAddress().getBytes());
         byte[] privateKeyBytes = sender.getEcKey().getPrivKeyBytes();
-        Transaction tx = Transaction.create(config, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
+        Transaction tx = new Transaction(config, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
         tx.sign(privateKeyBytes);
         return tx;
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -645,7 +645,7 @@ public class BlockValidatorTest {
                 .parent(new BlockGenerator().getGenesisBlock()).build();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN);
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN);
         tx.sign(new byte[]{22, 11, 00});
         txs.add(tx);
         Block block = new BlockBuilder().minGasPrice(BigInteger.TEN).transactions(txs)
@@ -697,7 +697,7 @@ public class BlockValidatorTest {
                 .parent(new BlockGenerator().getGenesisBlock()).build();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{22, 11, 00});
         txs.add(tx);
 
@@ -740,7 +740,7 @@ public class BlockValidatorTest {
         Block genesis = BlockChainImplTest.getGenesisBlock(blockChain);
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.TEN, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.TEN, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{});
         txs.add(tx);
         Block block = new BlockBuilder().parent(genesis).transactions(txs).build();
@@ -759,7 +759,7 @@ public class BlockValidatorTest {
         Block genesis = blockGenerator.getGenesisBlock();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{});
         txs.add(tx);
         Block block = new BlockBuilder().parent(genesis).transactions(txs).build();
@@ -783,7 +783,7 @@ public class BlockValidatorTest {
         Block genesis = blockGenerator.getGenesisBlock();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{});
         txs.add(new RemascTransaction(BigInteger.ONE.longValue()));
         txs.add(tx);
@@ -803,7 +803,7 @@ public class BlockValidatorTest {
         Block genesis = blockGenerator.getGenesisBlock();
 
         List<Transaction> txs = new ArrayList<>();
-        Transaction tx = Transaction.create(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
+        Transaction tx = new Transaction(config, "0000000000000000000000000000000000000006", BigInteger.ZERO, BigInteger.ZERO, BigInteger.valueOf(12L), BigInteger.TEN);
         tx.sign(new byte[]{});
         txs.add(tx);
         txs.add(new RemascTransaction(BigInteger.ONE.longValue()));

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -1006,7 +1006,7 @@ public class SyncProcessorTest {
     private static Transaction createTransaction(Account sender, Account receiver, BigInteger value, BigInteger nonce) {
         String toAddress = Hex.toHexString(receiver.getAddress().getBytes());
         byte[] privateKeyBytes = sender.getEcKey().getPrivKeyBytes();
-        Transaction tx = Transaction.create(config, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
+        Transaction tx = new Transaction(config, toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000));
         tx.sign(privateKeyBytes);
         return tx;
     }

--- a/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
@@ -57,7 +57,7 @@ public class TransactionUtils {
     }
 
     public static Transaction createTransaction(byte[] privateKey, String toAddress, BigInteger value, BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit) {
-        Transaction tx = Transaction.create(new TestSystemProperties(), toAddress, value, nonce, gasPrice, gasLimit);
+        Transaction tx = new Transaction(new TestSystemProperties(), toAddress, value, nonce, gasPrice, gasLimit);
         tx.sign(privateKey);
         return tx;
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -320,7 +320,7 @@ public class BridgeSupportTest {
         BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(bridgeConstants, eventLogs);
         BridgeSupport bridgeSupport = new BridgeSupport(config, track, eventLogger, PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
 
-        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = new Transaction(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         ECKey key = new ECKey();
         tx.sign(key.getPrivKeyBytes());
 
@@ -374,7 +374,7 @@ public class BridgeSupportTest {
         List<Block> blocks = blockGenerator.getSimpleBlockChain(blockGenerator.getGenesisBlock(), 10);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = new Transaction(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
         BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
@@ -435,7 +435,7 @@ public class BridgeSupportTest {
             blockchain.getBlockStore().saveBlock(block, TEST_DIFFICULTY, true);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = new Transaction(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
         BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
@@ -496,7 +496,7 @@ public class BridgeSupportTest {
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
         ReceiptStore rskReceiptStore = null;
         org.ethereum.db.BlockStore rskBlockStore = blockchain.getBlockStore();
-        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = new Transaction(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
         BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
@@ -543,7 +543,7 @@ public class BridgeSupportTest {
         BlockGenerator blockGenerator = new BlockGenerator();
         // Old federation will be in migration age at block 35
         org.ethereum.core.Block rskCurrentBlock = blockGenerator.createBlock(35, 1);
-        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = new Transaction(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
 
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
@@ -625,7 +625,7 @@ public class BridgeSupportTest {
         track.commit();
 
         track = repository.startTracking();
-        Transaction tx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction tx = new Transaction(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         tx.sign(new ECKey().getPrivKeyBytes());
 
         BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), PrecompiledContracts.BRIDGE_ADDR, rskCurrentBlock);
@@ -699,7 +699,7 @@ public class BridgeSupportTest {
             blockchain.getBlockStore().saveBlock(block, TEST_DIFFICULTY, true);
 
         org.ethereum.core.Block rskCurrentBlock = blocks.get(9);
-        Transaction rskTx = Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class), provider, rskCurrentBlock);
@@ -1131,7 +1131,7 @@ public class BridgeSupportTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
+        org.ethereum.core.Transaction tx = new org.ethereum.core.Transaction (config, TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
 
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
 
@@ -1155,7 +1155,7 @@ public class BridgeSupportTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
+        org.ethereum.core.Transaction tx = new org.ethereum.core.Transaction(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);;
 
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -130,7 +130,7 @@ public class BridgeTest {
 
         track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
         World world = new World();
@@ -164,7 +164,7 @@ public class BridgeTest {
         track.commit();
 
         track = repository.startTracking();
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -208,7 +208,7 @@ public class BridgeTest {
         List<Block> blocks = new BlockGenerator().getSimpleBlockChain(world.getBlockChain().getBestBlock(), 10);
 
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         world.getBlockChain().getBlockStore().saveBlock(blocks.get(1), new BlockDifficulty(BigInteger.ONE), true);
@@ -249,7 +249,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -265,7 +265,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -351,7 +351,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -371,7 +371,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -391,7 +391,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -443,7 +443,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -515,7 +515,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -537,7 +537,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -583,7 +583,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -627,7 +627,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -702,7 +702,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -723,7 +723,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -744,7 +744,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -821,7 +821,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -845,7 +845,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -864,7 +864,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -883,7 +883,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -902,7 +902,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
@@ -1765,7 +1765,7 @@ public class BridgeTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        Transaction rskTx = Transaction.create(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        Transaction rskTx = new Transaction(config, PrecompiledContracts.BRIDGE_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         // Setup bridge

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -279,7 +279,7 @@ public class BridgeUtilsTest {
 
     @Test
     public void getAddressFromEthTransaction() {
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        org.ethereum.core.Transaction tx = new org.ethereum.core.Transaction(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         byte[] privKey = generatePrivKey();
         tx.sign(privKey);
 
@@ -291,7 +291,7 @@ public class BridgeUtilsTest {
 
     @Test(expected = Exception.class)
     public void getAddressFromEthNotSignTransaction() {
-        org.ethereum.core.Transaction tx = org.ethereum.core.Transaction.create(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
+        org.ethereum.core.Transaction tx = new org.ethereum.core.Transaction(config, TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA);
         BridgeUtils.recoverBtcAddressFromEthTransaction(tx, RegTestParams.get());
     }
 
@@ -461,7 +461,7 @@ public class BridgeUtilsTest {
 
     @Test
     public void testIsContractTx() {
-        Assert.assertFalse(BridgeUtils.isContractTx(new Transaction(null, null, null, null, null, null)));
+        Assert.assertFalse(BridgeUtils.isContractTx(new Transaction((byte[]) null, null, null, null, null, null)));
         Assert.assertTrue(BridgeUtils.isContractTx(new org.ethereum.vm.program.InternalTransaction(null, 0, 0, null, null, null, null, null, null, null, null)));
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/simples/SimpleRskTransaction.java
+++ b/rskj-core/src/test/java/co/rsk/peg/simples/SimpleRskTransaction.java
@@ -39,9 +39,6 @@ public class SimpleRskTransaction extends Transaction {
     }
 
     @Override
-    public Keccak256 getHash() { return hash; }
-
-    @Override
     public Coin getValue() {
         return Coin.valueOf(10000000);
     }

--- a/rskj-core/src/test/java/co/rsk/test/builders/TransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/TransactionBuilder.java
@@ -91,7 +91,7 @@ public class TransactionBuilder {
     }
 
     public Transaction build() {
-        Transaction tx = Transaction.create(
+        Transaction tx = new Transaction(
                 new TestSystemProperties(), receiver != null ? Hex.toHexString(receiver.getAddress().getBytes()) : (receiverAddress != null ? Hex.toHexString(receiverAddress) : null),
                 value, nonce, gasPrice, gasLimit, data);
         tx.sign(sender.getEcKey().getPrivKeyBytes());

--- a/rskj-core/src/test/java/co/rsk/validators/RemascValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/RemascValidationRuleTest.java
@@ -50,7 +50,7 @@ public class RemascValidationRuleTest {
         Block b = Mockito.mock(Block.class);
 
         List<Transaction> tx = new ArrayList<>();
-        tx.add(Transaction.create(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
+        tx.add(new Transaction(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
 
         Mockito.when(b.getTransactionsList()).thenReturn(tx);
 
@@ -65,7 +65,7 @@ public class RemascValidationRuleTest {
 
         List<Transaction> tx = new ArrayList<>();
         tx.add(new RemascTransaction(1L));
-        tx.add(Transaction.create(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
+        tx.add(new Transaction(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
 
         Mockito.when(b.getTransactionsList()).thenReturn(tx);
 
@@ -79,7 +79,7 @@ public class RemascValidationRuleTest {
         Block b = Mockito.mock(Block.class);
 
         List<Transaction> tx = new ArrayList<>();
-        tx.add(Transaction.create(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
+        tx.add(new Transaction(config, "0000000000000000000000000000000000000001", BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN));
         tx.add(new RemascTransaction(1L));
 
         Mockito.when(b.getTransactionsList()).thenReturn(tx);

--- a/rskj-core/src/test/java/org/ethereum/db/ReceiptStoreImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/ReceiptStoreImplTest.java
@@ -288,7 +288,7 @@ public class ReceiptStoreImplTest {
         // TODO calculate cumulative gas
         TransactionReceipt receipt = new TransactionReceipt(stateRoot, gasUsed, gasUsed, bloom, logs, new byte[]{0x01});
 
-        receipt.setTransaction(new Transaction(null, null, null, null, null, null));
+        receipt.setTransaction(new Transaction((byte[]) null, null, null, null, null, null));
 
         return receipt;
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -1108,7 +1108,7 @@ public class Web3ImplTest {
         }
 
         // ***** Verifies tx hash
-        Transaction tx = Transaction.create(config, toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
+        Transaction tx = new Transaction(config, toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
         Account account = wallet.getAccount(new RskAddress(addr1), "passphrase1");
         tx.sign(account.getEcKey().getPrivKeyBytes());
 
@@ -1216,7 +1216,7 @@ public class Web3ImplTest {
         }
 
         // ***** Verifies tx hash
-        Transaction tx = Transaction.create(config, toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
+        Transaction tx = new Transaction(config, toAddress.substring(2), value, nonce, gasPrice, gasLimit, args.data);
         tx.sign(wallet.getAccount(new RskAddress(addr1)).getEcKey().getPrivKeyBytes());
 
         String expectedHash = tx.getHash().toJsonString();


### PR DESCRIPTION
Refactoring of Transaction class to avoid unnecessary recursion when parsing/encoding transaction from/to RLP.

To achieve this, the class was first refactored to a non-efficient version, where the RLP encoding/decoding and the hashing was computed every time, without caching any values. This made easy to remove all the lazy behavior of the class while preserving its interface. 

After checking all the existing tests passed against this version, a new simplified version of the lazy behavior was introduced. The only method that mutates the state of a transaction is the sign method, and it only affects the generation of the RLP representation of the transaction and the calculation of its hash. The raw hash (the hash of the transaction without its signature) and the raw RLP encoding (the encoding of the transaction without its signature) never change. Thus, the raw hash and the raw RLP encoding can be cached safely. 

The hash and the RLP encoding including the signature can be cached but need to be mark for regeneration every time the transaction is signed. These behavior was also introduced to preserve the lazy behavior of Transaction instances.