### PR TITLE
RFS-270 - New federation key reading methods for multiple keys per federator

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -637,6 +637,23 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return bridgeSupport.getFederatorPublicKey(index);
     }
 
+    public byte[] getFederatorPublicKeyByType(Object[] args)
+    {
+        logger.trace("getFederatorPublicKey");
+
+        int index = ((BigInteger) args[0]).intValue();
+
+        FederationMember.KeyType keyType;
+        try {
+            keyType = FederationMember.KeyType.valueOf((String) args[1]);
+        } catch (Exception e) {
+            logger.warn("Exception in getFederatorPublicKeyByType", e);
+            throw new RuntimeException("Exception in getFederatorPublicKeyByType", e);
+        }
+
+        return bridgeSupport.getFederatorPublicKeyByType(index, keyType);
+    }
+
     public Long getFederationCreationTime(Object[] args)
     {
         logger.trace("getFederationCreationTime");
@@ -684,6 +701,30 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
         int index = ((BigInteger) args[0]).intValue();
         byte[] publicKey = bridgeSupport.getRetiringFederatorPublicKey(index);
+
+        if (publicKey == null) {
+            // Empty array is returned when public key is not found or there's no retiring federation
+            return new byte[]{};
+        }
+
+        return publicKey;
+    }
+
+    public byte[] getRetiringFederatorPublicKeyByType(Object[] args)
+    {
+        logger.trace("getRetiringFederatorPublicKeyByType");
+
+        int index = ((BigInteger) args[0]).intValue();
+
+        FederationMember.KeyType keyType;
+        try {
+            keyType = FederationMember.KeyType.valueOf((String) args[1]);
+        } catch (Exception e) {
+            logger.warn("Exception in getRetiringFederatorPublicKeyByType", e);
+            throw new RuntimeException("Exception in getRetiringFederatorPublicKeyByType", e);
+        }
+
+        byte[] publicKey = bridgeSupport.getRetiringFederatorPublicKeyByType(index, keyType);
 
         if (publicKey == null) {
             // Empty array is returned when public key is not found or there's no retiring federation
@@ -796,6 +837,30 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
         int index = ((BigInteger) args[0]).intValue();
         byte[] publicKey = bridgeSupport.getPendingFederatorPublicKey(index);
+
+        if (publicKey == null) {
+            // Empty array is returned when public key is not found
+            return new byte[]{};
+        }
+
+        return publicKey;
+    }
+
+    public byte[] getPendingFederatorPublicKeyByType(Object[] args)
+    {
+        logger.trace("getPendingFederatorPublicKeyByType");
+
+        int index = ((BigInteger) args[0]).intValue();
+
+        FederationMember.KeyType keyType;
+        try {
+            keyType = FederationMember.KeyType.valueOf((String) args[1]);
+        } catch (Exception e) {
+            logger.warn("Exception in getPendingFederatorPublicKeyByType", e);
+            throw new RuntimeException("Exception in getPendingFederatorPublicKeyByType", e);
+        }
+
+        byte[] publicKey = bridgeSupport.getPendingFederatorPublicKeyByType(index, keyType);
 
         if (publicKey == null) {
             // Empty array is returned when public key is not found

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -117,6 +117,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function GET_FEDERATION_THRESHOLD = BridgeMethods.GET_FEDERATION_THRESHOLD.getFunction();
     // Returns the public key of the federator at the specified index
     public static final CallTransaction.Function GET_FEDERATOR_PUBLIC_KEY = BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction();
+    // Returns the public key of given type of the federator at the specified index
+    public static final CallTransaction.Function GET_FEDERATOR_PUBLIC_KEY_OF_TYPE = BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction();
     // Returns the creation time of the federation
     public static final CallTransaction.Function GET_FEDERATION_CREATION_TIME = BridgeMethods.GET_FEDERATION_CREATION_TIME.getFunction();
     // Returns the block number of the creation of the federation
@@ -130,6 +132,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function GET_RETIRING_FEDERATION_THRESHOLD = BridgeMethods.GET_RETIRING_FEDERATION_THRESHOLD.getFunction();
     // Returns the public key of the retiring federation's federator at the specified index
     public static final CallTransaction.Function GET_RETIRING_FEDERATOR_PUBLIC_KEY = BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction();
+    // Returns the public key of given type of the retiring federation's federator at the specified index
+    public static final CallTransaction.Function GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE = BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction();
     // Returns the creation time of the retiring federation
     public static final CallTransaction.Function GET_RETIRING_FEDERATION_CREATION_TIME = BridgeMethods.GET_RETIRING_FEDERATION_CREATION_TIME.getFunction();
     // Returns the block number of the creation of the retiring federation
@@ -150,6 +154,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function GET_PENDING_FEDERATION_SIZE = BridgeMethods.GET_PENDING_FEDERATION_SIZE.getFunction();
     // Returns the public key of the federator at the specified index for the current pending federation
     public static final CallTransaction.Function GET_PENDING_FEDERATOR_PUBLIC_KEY = BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction();
+    // Returns the public key of given type the federator at the specified index for the current pending federation
+    public static final CallTransaction.Function GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE = BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction();
 
     // Returns the lock whitelist size
     public static final CallTransaction.Function GET_LOCK_WHITELIST_SIZE = BridgeMethods.GET_LOCK_WHITELIST_SIZE.getFunction();
@@ -637,21 +643,21 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return bridgeSupport.getFederatorPublicKey(index);
     }
 
-    public byte[] getFederatorPublicKeyByType(Object[] args)
+    public byte[] getFederatorPublicKeyOfType(Object[] args)
     {
-        logger.trace("getFederatorPublicKey");
+        logger.trace("getFederatorPublicKeyOfType");
 
         int index = ((BigInteger) args[0]).intValue();
 
         FederationMember.KeyType keyType;
         try {
-            keyType = FederationMember.KeyType.valueOf((String) args[1]);
+            keyType = FederationMember.KeyType.byValue((String) args[1]);
         } catch (Exception e) {
-            logger.warn("Exception in getFederatorPublicKeyByType", e);
-            throw new RuntimeException("Exception in getFederatorPublicKeyByType", e);
+            logger.warn("Exception in getFederatorPublicKeyOfType", e);
+            throw new RuntimeException("Exception in getFederatorPublicKeyOfType", e);
         }
 
-        return bridgeSupport.getFederatorPublicKeyByType(index, keyType);
+        return bridgeSupport.getFederatorPublicKeyOfType(index, keyType);
     }
 
     public Long getFederationCreationTime(Object[] args)
@@ -710,21 +716,21 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return publicKey;
     }
 
-    public byte[] getRetiringFederatorPublicKeyByType(Object[] args)
+    public byte[] getRetiringFederatorPublicKeyOfType(Object[] args)
     {
-        logger.trace("getRetiringFederatorPublicKeyByType");
+        logger.trace("getRetiringFederatorPublicKeyOfType");
 
         int index = ((BigInteger) args[0]).intValue();
 
         FederationMember.KeyType keyType;
         try {
-            keyType = FederationMember.KeyType.valueOf((String) args[1]);
+            keyType = FederationMember.KeyType.byValue((String) args[1]);
         } catch (Exception e) {
-            logger.warn("Exception in getRetiringFederatorPublicKeyByType", e);
-            throw new RuntimeException("Exception in getRetiringFederatorPublicKeyByType", e);
+            logger.warn("Exception in getRetiringFederatorPublicKeyOfType", e);
+            throw new RuntimeException("Exception in getRetiringFederatorPublicKeyOfType", e);
         }
 
-        byte[] publicKey = bridgeSupport.getRetiringFederatorPublicKeyByType(index, keyType);
+        byte[] publicKey = bridgeSupport.getRetiringFederatorPublicKeyOfType(index, keyType);
 
         if (publicKey == null) {
             // Empty array is returned when public key is not found or there's no retiring federation
@@ -846,21 +852,21 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return publicKey;
     }
 
-    public byte[] getPendingFederatorPublicKeyByType(Object[] args)
+    public byte[] getPendingFederatorPublicKeyOfType(Object[] args)
     {
-        logger.trace("getPendingFederatorPublicKeyByType");
+        logger.trace("getPendingFederatorPublicKeyOfType");
 
         int index = ((BigInteger) args[0]).intValue();
 
         FederationMember.KeyType keyType;
         try {
-            keyType = FederationMember.KeyType.valueOf((String) args[1]);
+            keyType = FederationMember.KeyType.byValue((String) args[1]);
         } catch (Exception e) {
-            logger.warn("Exception in getPendingFederatorPublicKeyByType", e);
-            throw new RuntimeException("Exception in getPendingFederatorPublicKeyByType", e);
+            logger.warn("Exception in getPendingFederatorPublicKeyOfType", e);
+            throw new RuntimeException("Exception in getPendingFederatorPublicKeyOfType", e);
         }
 
-        byte[] publicKey = bridgeSupport.getPendingFederatorPublicKeyByType(index, keyType);
+        byte[] publicKey = bridgeSupport.getPendingFederatorPublicKeyOfType(index, keyType);
 
         if (publicKey == null) {
             // Empty array is returned when public key is not found

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -226,6 +226,18 @@ public enum BridgeMethods {
             ),
             10000L,
             (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKey,
+            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            true
+    ),
+    GET_FEDERATOR_PUBLIC_KEY_BY_TYPE(
+            CallTransaction.Function.fromSignature(
+                    "getFederatorPublicKey",
+                    new String[]{"int256", "string"},
+                    new String[]{"bytes"}
+            ),
+            10000L,
+            (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKeyByType,
+            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
     GET_FEE_PER_KB(
@@ -307,6 +319,18 @@ public enum BridgeMethods {
             ),
             3000L,
             (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKey,
+            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            true
+    ),
+    GET_PENDING_FEDERATOR_PUBLIC_KEY_BY_TYPE(
+            CallTransaction.Function.fromSignature(
+                    "getPendingFederatorPublicKey",
+                    new String[]{"int256", "string"},
+                    new String[]{"bytes"}
+            ),
+            3000L,
+            (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKeyByType,
+            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
     GET_RETIRING_FEDERATION_ADDRESS(
@@ -367,6 +391,18 @@ public enum BridgeMethods {
             ),
             3000L,
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKey,
+            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            true
+    ),
+    GET_RETIRING_FEDERATOR_PUBLIC_KEY_BY_TYPE(
+            CallTransaction.Function.fromSignature(
+                    "getRetiringFederatorPublicKey",
+                    new String[]{"int256", "string"},
+                    new String[]{"bytes"}
+            ),
+            3000L,
+            (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKeyByType,
+            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
     GET_STATE_FOR_BTC_RELEASE_CLIENT(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -229,14 +229,14 @@ public enum BridgeMethods {
             blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
-    GET_FEDERATOR_PUBLIC_KEY_BY_TYPE(
+    GET_FEDERATOR_PUBLIC_KEY_OF_TYPE(
             CallTransaction.Function.fromSignature(
-                    "getFederatorPublicKey",
+                    "getFederatorPublicKeyOfType",
                     new String[]{"int256", "string"},
                     new String[]{"bytes"}
             ),
             10000L,
-            (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKeyByType,
+            (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKeyOfType,
             blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
@@ -322,14 +322,14 @@ public enum BridgeMethods {
             blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
-    GET_PENDING_FEDERATOR_PUBLIC_KEY_BY_TYPE(
+    GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE(
             CallTransaction.Function.fromSignature(
-                    "getPendingFederatorPublicKey",
+                    "getPendingFederatorPublicKeyOfType",
                     new String[]{"int256", "string"},
                     new String[]{"bytes"}
             ),
             3000L,
-            (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKeyByType,
+            (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKeyOfType,
             blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
@@ -394,14 +394,14 @@ public enum BridgeMethods {
             blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
-    GET_RETIRING_FEDERATOR_PUBLIC_KEY_BY_TYPE(
+    GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE(
             CallTransaction.Function.fromSignature(
-                    "getRetiringFederatorPublicKey",
+                    "getRetiringFederatorPublicKeyOfType",
                     new String[]{"int256", "string"},
                     new String[]{"bytes"}
             ),
             3000L,
-            (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKeyByType,
+            (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKeyOfType,
             blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1290,8 +1290,8 @@ public class BridgeSupport {
      * @param keyType the key type
      * @return the federator's public key
      */
-    public byte[] getFederatorPublicKeyByType(int index, FederationMember.KeyType keyType) {
-        return federationSupport.getFederatorPublicKeyByType(index, keyType);
+    public byte[] getFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
+        return federationSupport.getFederatorPublicKeyOfType(index, keyType);
     }
 
     /**
@@ -1376,7 +1376,7 @@ public class BridgeSupport {
      * @param keyType the key type
      * @return the retiring federator's public key of the given type, null if no retiring federation exists
      */
-    public byte[] getRetiringFederatorPublicKeyByType(int index, FederationMember.KeyType keyType) {
+    public byte[] getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
         Federation retiringFederation = getRetiringFederation();
         if (retiringFederation == null) {
             return null;
@@ -1732,7 +1732,7 @@ public class BridgeSupport {
      * @param keyType the key type
      * @return the pending federation's federator public key of given type
      */
-    public byte[] getPendingFederatorPublicKeyByType(int index, FederationMember.KeyType keyType) {
+    public byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
         PendingFederation currentPendingFederation = provider.getPendingFederation();
 
         if (currentPendingFederation == null) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1285,6 +1285,16 @@ public class BridgeSupport {
     }
 
     /**
+     * Returns the public key of given type of the federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @return the federator's public key
+     */
+    public byte[] getFederatorPublicKeyByType(int index, FederationMember.KeyType keyType) {
+        return federationSupport.getFederatorPublicKeyByType(index, keyType);
+    }
+
+    /**
      * Returns the federation's creation time
      * @return the federation creation time
      */
@@ -1358,6 +1368,27 @@ public class BridgeSupport {
         }
 
         return publicKeys.get(index).getPubKey();
+    }
+
+    /**
+     * Returns the public key of the given type of the retiring federation's federator at the given index
+     * @param index the retiring federator's index (zero-based)
+     * @param keyType the key type
+     * @return the retiring federator's public key of the given type, null if no retiring federation exists
+     */
+    public byte[] getRetiringFederatorPublicKeyByType(int index, FederationMember.KeyType keyType) {
+        Federation retiringFederation = getRetiringFederation();
+        if (retiringFederation == null) {
+            return null;
+        }
+
+        List<FederationMember> members = retiringFederation.getMembers();
+
+        if (index < 0 || index >= members.size()) {
+            throw new IndexOutOfBoundsException(String.format("Retiring federator index must be between 0 and %d", members.size() - 1));
+        }
+
+        return members.get(index).getPublicKey(keyType).getPubKey(true);
     }
 
     /**
@@ -1675,7 +1706,7 @@ public class BridgeSupport {
     }
 
     /**
-     * Returns the currently pending federation threshold, or null if none exists
+     * Returns the currently pending federation federator's public key at the given index, or null if none exists
      * @param index the federator's index (zero-based)
      * @return the pending federation's federator public key
      */
@@ -1693,6 +1724,28 @@ public class BridgeSupport {
         }
 
         return publicKeys.get(index).getPubKey();
+    }
+
+    /**
+     * Returns the public key of the given type of the pending federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @return the pending federation's federator public key of given type
+     */
+    public byte[] getPendingFederatorPublicKeyByType(int index, FederationMember.KeyType keyType) {
+        PendingFederation currentPendingFederation = provider.getPendingFederation();
+
+        if (currentPendingFederation == null) {
+            return null;
+        }
+
+        List<FederationMember> members = currentPendingFederation.getMembers();
+
+        if (index < 0 || index >= members.size()) {
+            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", members.size() - 1));
+        }
+
+        return members.get(index).getPublicKey(keyType).getPubKey(true);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -47,14 +47,27 @@ public final class FederationMember {
         RSK("rsk"),
         MST("mst");
 
-        private String name;
+        private String value;
 
-        KeyType(String name) {
-            this.name = name;
+        KeyType(String value) {
+            this.value = value;
         }
 
-        public String getName() {
-            return name;
+        public String getValue() {
+            return value;
+        }
+
+        public static KeyType byValue(String value) {
+            switch (value) {
+                case "rsk":
+                    return KeyType.RSK;
+                case "mst":
+                    return KeyType.MST;
+                case "btc":
+                    return KeyType.BTC;
+                default:
+                    throw new IllegalArgumentException(String.format("Invalid value for FederationMember.KeyType: %s", value));
+            }
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -120,9 +120,10 @@ public final class FederationMember {
 
     public FederationMember(BtcECKey btcPublicKey, ECKey rskPublicKey, ECKey mstPublicKey) {
         // Copy public keys to ensure effective immutability
-        this.btcPublicKey = BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
-        this.rskPublicKey = ECKey.fromPublicOnly(rskPublicKey.getPubKey());
-        this.mstPublicKey = ECKey.fromPublicOnly(mstPublicKey.getPubKey());
+        // Make sure we always use compressed versions of public keys
+        this.btcPublicKey = BtcECKey.fromPublicOnly(btcPublicKey.getPubKeyPoint().getEncoded(true));
+        this.rskPublicKey = ECKey.fromPublicOnly(rskPublicKey.getPubKey(true));
+        this.mstPublicKey = ECKey.fromPublicOnly(mstPublicKey.getPubKey(true));
     }
 
     BtcECKey getBtcPublicKey() {

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -42,6 +42,22 @@ public final class FederationMember {
     private final ECKey rskPublicKey;
     private final ECKey mstPublicKey;
 
+    public enum KeyType {
+        BTC("btc"),
+        RSK("rsk"),
+        MST("mst");
+
+        private String name;
+
+        KeyType(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
     // To be removed when different keys per federation member feature is implemented. These are just helper
     // methods to make it easier w.r.t. compatibility with the current approach
 
@@ -109,6 +125,18 @@ public final class FederationMember {
     ECKey getMstPublicKey() {
         // Return a copy
         return ECKey.fromPublicOnly(mstPublicKey.getPubKey());
+    }
+
+    ECKey getPublicKey(KeyType keyType) {
+        switch (keyType) {
+            case RSK:
+                return getRskPublicKey();
+            case MST:
+                return getMstPublicKey();
+            case BTC:
+            default:
+                return ECKey.fromPublicOnly(btcPublicKey.getPubKey());
+        }
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -87,7 +87,7 @@ public final class FederationMember {
      * Compares federation members based on their underlying keys.
      *
      * The total ordering is defined such that, for any two members M1, M2,
-     * 1) M1 < M2 iif BTC_PUB_KEY(M1) <lex BTC_PUB_KEY(M2) OR
+     * 1) M1 < M2 iff BTC_PUB_KEY(M1) <lex BTC_PUB_KEY(M2) OR
      *              (BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND
      *               RSK_PUB_KEY(M1) <lex RSK_PUB_KEY(M2)) OR
      *              (BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -73,7 +73,7 @@ public class FederationSupport {
      * @param keyType the key type
      * @return the federator's public key
      */
-    public byte[] getFederatorPublicKeyByType(int index, FederationMember.KeyType keyType) {
+    public byte[] getFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
         List<FederationMember> members = getActiveFederation().getMembers();
 
         if (index < 0 || index >= members.size()) {

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -68,6 +68,22 @@ public class FederationSupport {
     }
 
     /**
+     * Returns the public key of given type of the federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @return the federator's public key
+     */
+    public byte[] getFederatorPublicKeyByType(int index, FederationMember.KeyType keyType) {
+        List<FederationMember> members = getActiveFederation().getMembers();
+
+        if (index < 0 || index >= members.size()) {
+            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", members.size() - 1));
+        }
+
+        return members.get(index).getPublicKey(keyType).getPubKey(true);
+    }
+
+    /**
      * Returns the currently active federation.
      * See getActiveFederationReference() for details.
      *

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -64,4 +64,6 @@ public interface BlockchainConfig {
     boolean isRfs122();
 
     boolean isRskipGetBtcTransactionConfirmations();
+
+    boolean isRskipMultipleKeyFederateMembers();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
@@ -169,4 +169,9 @@ public abstract class AbstractConfig implements BlockchainConfig, BlockchainNetC
     public boolean isRskipGetBtcTransactionConfirmations() {
         return false;
     } //TODO set the correct name for the RskIp
+
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return false;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
@@ -29,4 +29,9 @@ public class DevNetSecondForkConfig extends DevNetOrchidConfig {
     public boolean isRskipGetBtcTransactionConfirmations() {
         return true;
     }
+
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
@@ -29,4 +29,9 @@ public class MainNetSecondForkConfig extends MainNetOrchidConfig {
     public boolean isRskipGetBtcTransactionConfirmations() {
         return true;
     }
+
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
@@ -29,4 +29,9 @@ public class RegTestSecondForkConfig extends RegTestOrchidConfig {
     public boolean isRskipGetBtcTransactionConfirmations() {
         return true;
     }
+
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
@@ -29,4 +29,9 @@ public class TestNetSecondForkConfig extends TestNetDifficultyDropEnabledConfig 
     public boolean isRskipGetBtcTransactionConfirmations() {
         return true;
     }
+
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return true;
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -26,6 +26,7 @@ import co.rsk.peg.whitelist.OneOffWhiteListEntry;
 import com.google.common.primitives.UnsignedBytes;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
@@ -134,8 +135,9 @@ public class BridgeSerializationUtilsTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
         };
 
+        // Only actual keys serialized are BTC keys, so we don't really care about RSK or MST keys
         Federation federation = new Federation(
-            FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+            FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                     BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[2]),
@@ -238,8 +240,9 @@ public class BridgeSerializationUtilsTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
         };
 
+        // Only actual keys serialized are BTC keys, so we don't really care about RSK or MST keys
         PendingFederation pendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+                FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[2]),
@@ -626,8 +629,9 @@ public class BridgeSerializationUtilsTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
         };
 
+        // Only actual keys serialized are BTC keys, so deserialization will fill RSK and MST keys with those
         Federation federation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(
+                FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                         BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[2]),

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -35,6 +35,7 @@ import co.rsk.peg.whitelist.UnlimitedWhiteListEntry;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Repository;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
@@ -53,6 +54,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -259,7 +261,7 @@ public class BridgeStorageProviderTest {
     public void getNewFederation() throws IOException {
         List<Integer> calls = new ArrayList<>();
         Context contextMock = mock(Context.class);
-        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))})), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = buildMockFederation(100, 200, 300);
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
@@ -321,7 +323,7 @@ public class BridgeStorageProviderTest {
 
     @Test
     public void saveNewFederation() throws IOException {
-        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))})), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = buildMockFederation(100, 200, 300);
         List<Integer> storageBytesCalls = new ArrayList<>();
         List<Integer> serializeCalls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
@@ -810,6 +812,14 @@ public class BridgeStorageProviderTest {
 
     private Address getBtcAddress(String addr) {
         return new Address(config.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams(), Hex.decode(addr));
+    }
+
+    private Federation buildMockFederation(Integer... pks) {
+        return new Federation(
+                FederationTestUtils.getFederationMembersFromPks(1, pks),
+                Instant.ofEpochMilli(1000),
+                0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
     }
 
     public static RepositoryImpl createRepositoryImpl(RskSystemProperties config) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -2056,6 +2056,9 @@ public class BridgeSupportTest {
         List<BtcECKey> publicKeys = getTestFederationPublicKeys(6);
         for (int i = 0; i < 6; i++) {
             Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2089,6 +2092,9 @@ public class BridgeSupportTest {
         List<BtcECKey> publicKeys = getTestFederationPublicKeys(3);
         for (int i = 0; i < 3; i++) {
             Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2126,6 +2132,9 @@ public class BridgeSupportTest {
         List<BtcECKey> publicKeys = getTestFederationPublicKeys(3);
         for (int i = 0; i < 3; i++) {
             Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2163,6 +2172,10 @@ public class BridgeSupportTest {
         List<BtcECKey> publicKeys = getTestFederationPublicKeys(6);
         for (int i = 0; i < 6; i++) {
             Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
+
         }
     }
 
@@ -2173,6 +2186,9 @@ public class BridgeSupportTest {
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationSize().intValue());
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationThreshold().intValue());
         Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKey(0));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
     }
 
     @Test
@@ -2207,6 +2223,9 @@ public class BridgeSupportTest {
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationSize().intValue());
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationThreshold().intValue());
         Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKey(0));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
     }
 
     @Test
@@ -2245,6 +2264,9 @@ public class BridgeSupportTest {
         List<BtcECKey> publicKeys = getTestFederationPublicKeys(4);
         for (int i = 0; i < 4; i++) {
             Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2254,6 +2276,9 @@ public class BridgeSupportTest {
 
         Assert.assertEquals(-1, bridgeSupport.getPendingFederationSize().intValue());
         Assert.assertNull(bridgeSupport.getPendingFederatorPublicKey(0));
+        Assert.assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
+        Assert.assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
+        Assert.assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
     }
 
     @Test
@@ -2267,6 +2292,9 @@ public class BridgeSupportTest {
         List<BtcECKey> publicKeys = getTestFederationPublicKeys(5);
         for (int i = 0; i < 5; i++) {
             Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2515,6 +2543,9 @@ public class BridgeSupportTest {
         Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
         Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
         Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKey(0)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)));
         verify(mocksProvider.getElection(), times(1)).clearWinners();
         verify(mocksProvider.getElection(), never()).clear();
     }
@@ -2550,7 +2581,15 @@ public class BridgeSupportTest {
         Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
         Assert.assertEquals(2, bridgeSupport.getPendingFederationSize().intValue());
         Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKey(0)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)));
+
         Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKey(1)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.MST)));
+
         verify(mocksProvider.getElection(), times(1)).clearWinners();
         verify(mocksProvider.getElection(), never()).clear();
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -523,7 +523,7 @@ public class BridgeSupportTest {
         BridgeConstants bridgeConstants = BridgeRegTestConstants.getInstance();
         Federation oldFederation = bridgeConstants.getGenesisFederation();
         BtcECKey key = new BtcECKey(new SecureRandom());
-        FederationMember member = FederationMember.getFederationMemberFromKey(key);
+        FederationMember member = new FederationMember(key, new ECKey(), new ECKey());
         Federation newFederation = new Federation(
                 Collections.singletonList(member),
                 Instant.EPOCH,
@@ -1506,14 +1506,14 @@ public class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation activeFederation = new Federation(FederationMember.getFederationMembersFromKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
+        Federation activeFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
 
         List<BtcECKey> retiringFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fb01")),
             BtcECKey.fromPrivate(Hex.decode("fb02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation retiringFederation = new Federation(FederationMember.getFederationMembersFromKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
+        Federation retiringFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
 
         Repository repository = createRepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1601,7 +1601,7 @@ public class BridgeSupportTest {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
         Federation activeFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(activeFederationKeys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
                 Instant.ofEpochMilli(1000L), 0L, params
         );
 
@@ -1611,7 +1611,7 @@ public class BridgeSupportTest {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
         Federation retiringFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(retiringFederationKeys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
                 Instant.ofEpochMilli(2000L), 0L, params
         );
 
@@ -1692,7 +1692,7 @@ public class BridgeSupportTest {
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
+        Federation federation1 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -1701,7 +1701,7 @@ public class BridgeSupportTest {
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
+        Federation federation2 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Repository repository = createRepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1818,7 +1818,7 @@ public class BridgeSupportTest {
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
         Federation federation = new Federation(
-                FederationMember.getFederationMembersFromKeys(federation1Keys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
                 Instant.ofEpochMilli(1000L), 0L, parameters
         );
 
@@ -1880,7 +1880,7 @@ public class BridgeSupportTest {
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
+        Federation federation1 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -1889,7 +1889,7 @@ public class BridgeSupportTest {
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
+        Federation federation2 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Repository repository = createRepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -2037,13 +2037,13 @@ public class BridgeSupportTest {
     @Test
     public void getFederationMethods_genesis() throws IOException {
         Federation activeFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
+                FederationTestUtils.getFederationMembers(3, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
+                FederationTestUtils.getFederationMembers(6, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2053,25 +2053,25 @@ public class BridgeSupportTest {
         Assert.assertEquals(6, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(4, bridgeSupport.getFederationThreshold().intValue());
         Assert.assertEquals(genesisFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(6);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(6, 1);
         for (int i = 0; i < 6; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
     @Test
     public void getFederationMethods_active() throws IOException {
         Federation activeFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
+                FederationTestUtils.getFederationMembers(3, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
+                FederationTestUtils.getFederationMembers(6, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2089,25 +2089,25 @@ public class BridgeSupportTest {
         Assert.assertEquals(3, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(2, bridgeSupport.getFederationThreshold().intValue());
         Assert.assertEquals(activeFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(3);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(3, 1);
         for (int i = 0; i < 3; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
     @Test
     public void getFederationMethods_newActivated() throws IOException {
         Federation newFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
+                FederationTestUtils.getFederationMembers(3, 1),
                 Instant.ofEpochMilli(1000),
                 15L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation oldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
+                FederationTestUtils.getFederationMembers(6, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2129,25 +2129,25 @@ public class BridgeSupportTest {
         Assert.assertEquals(3, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(2, bridgeSupport.getFederationThreshold().intValue());
         Assert.assertEquals(newFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(3);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(3, 1);
         for (int i = 0; i < 3; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
     @Test
     public void getFederationMethods_newNotActivated() throws IOException {
         Federation newFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
+                FederationTestUtils.getFederationMembers(3, 1),
                 Instant.ofEpochMilli(1000),
                 15L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation oldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
+                FederationTestUtils.getFederationMembers(6, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2169,12 +2169,12 @@ public class BridgeSupportTest {
         Assert.assertEquals(6, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(4, bridgeSupport.getFederationThreshold().intValue());
         Assert.assertEquals(oldFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(6);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(6, 1);
         for (int i = 0; i < 6; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
 
         }
     }
@@ -2194,14 +2194,14 @@ public class BridgeSupportTest {
     @Test
     public void getRetiringFederationMethods_presentNewInactive() throws IOException {
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2, 1),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
+                FederationTestUtils.getFederationMembers(4, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2231,14 +2231,14 @@ public class BridgeSupportTest {
     @Test
     public void getRetiringFederationMethods_presentNewActive() throws IOException {
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2, 1),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
+                FederationTestUtils.getFederationMembers(4, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2261,12 +2261,12 @@ public class BridgeSupportTest {
         Assert.assertEquals(3, bridgeSupport.getRetiringFederationThreshold().intValue());
         Assert.assertEquals(1000, bridgeSupport.getRetiringFederationCreationTime().toEpochMilli());
         Assert.assertEquals(mockedOldFederation.getAddress().toString(), bridgeSupport.getRetiringFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(4);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(4, 1);
         for (int i = 0; i < 4; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKey(i)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getRetiringFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2283,18 +2283,16 @@ public class BridgeSupportTest {
 
     @Test
     public void getPendingFederationMethods_present() throws IOException {
-        PendingFederation mockedPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(5))
-        );
+        PendingFederation mockedPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembers(5, 1));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, mockedPendingFederation, null, null);
 
         Assert.assertEquals(5, bridgeSupport.getPendingFederationSize().intValue());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(5);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(5, 1);
         for (int i = 0; i < 5; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKey(i)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getPendingFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2437,14 +2435,14 @@ public class BridgeSupportTest {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
 
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2, 1),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
+                FederationTestUtils.getFederationMembers(4, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2478,14 +2476,14 @@ public class BridgeSupportTest {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
 
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2, 1),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
+                FederationTestUtils.getFederationMembers(4, 1),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2556,7 +2554,7 @@ public class BridgeSupportTest {
                 Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")
         }, true);
 
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
@@ -2624,7 +2622,7 @@ public class BridgeSupportTest {
                 Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")
         }, false);
 
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
             BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
@@ -2673,7 +2671,7 @@ public class BridgeSupportTest {
     public void rollbackFederation_ok() throws IOException {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("rollback", new byte[][]{}, true);
 
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })));
@@ -2726,7 +2724,7 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_ok() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
@@ -2741,14 +2739,14 @@ public class BridgeSupportTest {
         when(executionBlock.getTimestamp()).thenReturn(15005L);
         when(executionBlock.getNumber()).thenReturn(15L);
 
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
+        Federation expectedFederation = new Federation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
                 BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49")))),
                 Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
-        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
+        Federation newFederation = new Federation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
                 BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
                 BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338")))),
@@ -2838,7 +2836,7 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_incompleteFederation() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })));
 
@@ -2866,7 +2864,7 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_hashMismatch() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12"))
         })));
@@ -2895,7 +2893,7 @@ public class BridgeSupportTest {
 
     @Test
     public void getActiveFederationWallet() throws IOException {
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
@@ -2928,13 +2926,13 @@ public class BridgeSupportTest {
     @Test
     public void getRetiringFederationWallet_nonEmpty() throws IOException {
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2, 1),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
@@ -3640,15 +3638,6 @@ public class BridgeSupportTest {
         when(providerMock.getLockWhitelist()).thenReturn(mockedWhitelist);
 
         return new BridgeSupport(config, null, null, constantsMock, providerMock, null, null, null);
-    }
-
-    private List<BtcECKey> getTestFederationPublicKeys(int amount) {
-        List<BtcECKey> result = new ArrayList<>();
-        for (int i = 0; i < amount; i++) {
-            result.add(BtcECKey.fromPrivate(BigInteger.valueOf((i+1) * 100)));
-        }
-        result.sort(BtcECKey.PUBKEY_COMPARATOR);
-        return result;
     }
 
     private BtcTransaction createTransaction() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -1358,17 +1358,99 @@ public class BridgeTest {
     }
 
     @Test
-    public void getFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, getGenesisBlock(), null, null, null, null);
+    public void getFederatorPublicKey_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toByteArray());
 
-        Assert.assertTrue(Arrays.equals(new byte[]{10}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(10)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{20}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(20)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{1, 0}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(256)})));
+        Assert.assertTrue(Arrays.equals(new byte[]{10},
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                    bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{20},
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(20)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{1, 0},
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(256)}))
+                )[0]
+        ));
+    }
+
+    @Test
+    public void getFederatorPublicKey_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
+        verify(bridgeSupportMock, never()).getFederatorPublicKey(any(int.class));
+    }
+
+    @Test
+    public void getFederatorPublicKeyOfType_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"})));
+        verify(bridgeSupportMock, never()).getFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class));
+    }
+
+    @Test
+    public void getFederatorPublicKeyOfType_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+        when(bridgeSupportMock.getFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
+                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
+                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+        );
+
+        Assert.assertTrue(Arrays.equals("10btc".getBytes(),
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("200rsk".getBytes(),
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(200), "rsk"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("172mst".getBytes(),
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(172), "mst"}))
+                )[0]
+        ));
     }
 
     @Test
@@ -1415,17 +1497,99 @@ public class BridgeTest {
     }
 
     @Test
-    public void getRetiringFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, getGenesisBlock(), null, null, null, null);
+    public void getRetiringFederatorPublicKey_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getRetiringFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toByteArray());
 
-        Assert.assertTrue(Arrays.equals(new byte[]{10}, bridge.getRetiringFederatorPublicKey(new Object[]{BigInteger.valueOf(10)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{20}, bridge.getRetiringFederatorPublicKey(new Object[]{BigInteger.valueOf(20)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{1, 0}, bridge.getRetiringFederatorPublicKey(new Object[]{BigInteger.valueOf(256)})));
+        Assert.assertTrue(Arrays.equals(new byte[]{10},
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{20},
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(20)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{1, 0},
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(256)}))
+                )[0]
+        ));
+    }
+
+    @Test
+    public void getRetiringFederatorPublicKey_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
+        verify(bridgeSupportMock, never()).getRetiringFederatorPublicKey(any(int.class));
+    }
+
+    @Test
+    public void getRetiringFederatorPublicKeyOfType_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"})));
+        verify(bridgeSupportMock, never()).getRetiringFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class));
+    }
+
+    @Test
+    public void getRetiringFederatorPublicKeyOfType_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+        when(bridgeSupportMock.getRetiringFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
+                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
+                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+        );
+
+        Assert.assertTrue(Arrays.equals("10btc".getBytes(),
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("105rsk".getBytes(),
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(105), "rsk"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("232mst".getBytes(),
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(232), "mst"}))
+                )[0]
+        ));
     }
 
     @Test
@@ -1440,17 +1604,99 @@ public class BridgeTest {
     }
 
     @Test
-    public void getPendingFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, getGenesisBlock(), null, null, null, null);
+    public void getPendingFederatorPublicKey_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getPendingFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toByteArray());
 
-        Assert.assertTrue(Arrays.equals(new byte[]{10}, bridge.getPendingFederatorPublicKey(new Object[]{BigInteger.valueOf(10)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{20}, bridge.getPendingFederatorPublicKey(new Object[]{BigInteger.valueOf(20)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{1, 0}, bridge.getPendingFederatorPublicKey(new Object[]{BigInteger.valueOf(256)})));
+        Assert.assertTrue(Arrays.equals(new byte[]{10},
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{20},
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(20)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{1, 0},
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(256)}))
+                )[0]
+        ));
+    }
+
+    @Test
+    public void getPendingFederatorPublicKey_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
+        verify(bridgeSupportMock, never()).getPendingFederatorPublicKey(any(int.class));
+    }
+
+    @Test
+    public void getPendingFederatorPublicKeyOfType_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"})));
+        verify(bridgeSupportMock, never()).getPendingFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class));
+    }
+
+    @Test
+    public void getPendingFederatorPublicKeyOfType_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+        when(bridgeSupportMock.getPendingFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
+                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
+                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+        );
+
+        Assert.assertTrue(Arrays.equals("10btc".getBytes(),
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("82rsk".getBytes(),
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(82), "rsk"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("123mst".getBytes(),
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(123), "mst"}))
+                )[0]
+        ));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -33,6 +33,7 @@ import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.regtest.RegTestGenesisConfig;
 import org.ethereum.core.*;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Before;
@@ -122,7 +123,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")),
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
+        Federation federation1 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -130,7 +131,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fb03")),
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
+        Federation federation2 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Address address1 = federation1.getAddress();
         Address address2 = federation2.getAddress();
@@ -240,14 +241,14 @@ public class BridgeUtilsTest {
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation activeFederation = new Federation(FederationMember.getFederationMembersFromKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
+        Federation activeFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
 
         List<BtcECKey> retiringFederationKeys = Stream.of(
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
                 BtcECKey.fromPrivate(Hex.decode("fb02")),
                 BtcECKey.fromPrivate(Hex.decode("fb03"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation retiringFederation = new Federation(FederationMember.getFederationMembersFromKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
+        Federation retiringFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
 
         Address activeFederationAddress = activeFederation.getAddress();
 
@@ -364,7 +365,7 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationNoSpendWallet() {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
@@ -379,7 +380,7 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationSpendWallet() throws UTXOProviderException {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
@@ -437,7 +438,7 @@ public class BridgeUtilsTest {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
         Federation federation1 = new Federation(
-                FederationMember.getFederationMembersFromKeys(federation1Keys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
                 Instant.ofEpochMilli(1000L), 0L, params
         );
 
@@ -447,7 +448,7 @@ public class BridgeUtilsTest {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
         Federation federation2 = new Federation(
-                FederationMember.getFederationMembersFromKeys(federation2Keys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
                 Instant.ofEpochMilli(2000L), 0L, params
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
@@ -101,4 +101,19 @@ public class FederationMemberTest {
 
         Assert.assertFalse(member.equals(otherMember));
     }
+
+    @Test
+    public void keyType_byValue() {
+        Assert.assertEquals(FederationMember.KeyType.BTC, FederationMember.KeyType.byValue("btc"));
+        Assert.assertEquals(FederationMember.KeyType.RSK, FederationMember.KeyType.byValue("rsk"));
+        Assert.assertEquals(FederationMember.KeyType.MST, FederationMember.KeyType.byValue("mst"));
+    }
+
+    @Test
+    public void keyType_byValueInvalid() {
+        try {
+            FederationMember.KeyType.byValue("whatever");
+            Assert.fail();
+        } catch (IllegalArgumentException e) {}
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
@@ -82,6 +82,24 @@ public class FederationMemberTest {
     }
 
     @Test
+    public void testEquals_sameKeysDifferentCompression() {
+        FederationMember uncompressedMember = new FederationMember(
+                BtcECKey.fromPublicOnly(btcKey.getPubKeyPoint().getEncoded(false)),
+                ECKey.fromPublicOnly(rskKey.getPubKey(false)),
+                ECKey.fromPublicOnly(mstKey.getPubKey(false))
+        );
+
+        FederationMember compressedMember = new FederationMember(
+                BtcECKey.fromPublicOnly(btcKey.getPubKeyPoint().getEncoded(true)),
+                ECKey.fromPublicOnly(rskKey.getPubKey(true)),
+                ECKey.fromPublicOnly(mstKey.getPubKey(true))
+        );
+
+        Assert.assertTrue(compressedMember.equals(uncompressedMember));
+        Assert.assertTrue(uncompressedMember.equals(compressedMember));
+    }
+
+    @Test
     public void testEquals_differentBtcKey() {
         FederationMember otherMember = new FederationMember(new BtcECKey(), rskKey, mstKey);
 

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -53,18 +53,12 @@ public class FederationTest {
     @Before
     public void createFederation() {
         federation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
+
         sortedPublicKeys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -73,8 +67,10 @@ public class FederationTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)),
         }).stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        rskAddresses = sortedPublicKeys.stream()
-                .map(FederationTest::getRskAddressFromBtcKey)
+
+        rskAddresses = Arrays.asList(101, 201, 301, 401, 501, 601)
+                .stream()
+                .map(i -> ECKey.fromPrivate(BigInteger.valueOf(i)).getAddress())
                 .collect(Collectors.toList());
     }
 
@@ -180,15 +176,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentNumberOfMembers() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600, 700),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -199,14 +187,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationTime() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -217,14 +198,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationBlockNumber() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(
-                    BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(600))
-                )),
+                FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
                 1L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -235,14 +209,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentNetworkParameters() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_TESTNET)
@@ -252,13 +219,7 @@ public class FederationTest {
 
     @Test
     public void testEquals_differentMembers() {
-        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-        }));
+        List<FederationMember> members = FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500);
 
         members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(620))));
         Federation otherFederation = new Federation(
@@ -285,14 +246,7 @@ public class FederationTest {
     @Test
     public void testEquals_same() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -322,17 +276,12 @@ public class FederationTest {
             Assert.assertTrue(federation.hasMemberWithRskAddress(rskAddresses.get(i)));
         }
 
-        BtcECKey nonFederateKey = BtcECKey.fromPrivate(BigInteger.valueOf(1234));
-        byte[] nonFederateRskAddress = getRskAddressFromBtcKey(nonFederateKey);
+        byte[] nonFederateRskAddress = ECKey.fromPrivate(BigInteger.valueOf(1234)).getAddress();
         Assert.assertFalse(federation.hasMemberWithRskAddress(nonFederateRskAddress));
     }
 
     @Test
     public void testToString() {
         Assert.assertEquals("4 of 6 signatures federation", federation.toString());
-    }
-
-    private static byte[] getRskAddressFromBtcKey(BtcECKey btcECKey) {
-        return ECKey.fromPublicOnly(btcECKey.getPubKey()).getAddress();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import org.ethereum.crypto.ECKey;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FederationTestUtils {
+    public static List<FederationMember> getFederationMembers(int amount, int offset) {
+        List<FederationMember> result = new ArrayList<>();
+        for (int i = 0; i < amount; i++) {
+            result.add(new FederationMember(
+                    BtcECKey.fromPrivate(BigInteger.valueOf((offset+i) * 100)),
+                    ECKey.fromPrivate(BigInteger.valueOf((offset+i) * 101)),
+                    ECKey.fromPrivate(BigInteger.valueOf((offset+i) * 102))
+            ));
+        }
+        result.sort(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR);
+        return result;
+    }
+
+    public static List<FederationMember> getFederationMembersFromPks(int offset, Integer... pks) {
+        return Arrays.stream(pks).map(n -> new FederationMember(
+                BtcECKey.fromPrivate(BigInteger.valueOf(n)),
+                ECKey.fromPrivate(BigInteger.valueOf(n+offset)),
+                ECKey.fromPrivate(BigInteger.valueOf(n+offset*2))
+        )).collect(Collectors.toList());
+    }
+
+    public static List<FederationMember> getFederationMembersWithBtcKeys(List<BtcECKey> keys) {
+        return keys.stream().map(btcKey ->
+                new FederationMember(btcKey, new ECKey(), new ECKey())
+        ).collect(Collectors.toList());
+    }
+
+    public static List<FederationMember> getFederationMembersWithKeys(List<BtcECKey> pks) {
+        return pks.stream().map(pk -> getFederationMemberWithKey(pk)).collect(Collectors.toList());
+    }
+
+    public static FederationMember getFederationMemberWithKey(BtcECKey pk) {
+        ECKey ethKey = ECKey.fromPublicOnly(pk.getPubKey());
+        return new FederationMember(pk, ethKey, ethKey);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -42,28 +42,10 @@ import static org.mockito.Matchers.any;
 @RunWith(PowerMockRunner.class)
 public class PendingFederationTest {
     private PendingFederation pendingFederation;
-    private List<BtcECKey> sortedPublicKeys;
 
     @Before
     public void createPendingFederation() {
-        pendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }))
-        );
-        sortedPublicKeys = Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-        }).stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600));
     }
 
     @Test
@@ -92,11 +74,7 @@ public class PendingFederationTest {
 
     @Test
     public void isComplete_not() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(1, 200));
         Assert.assertFalse(otherPendingFederation.isComplete());
     }
 
@@ -111,29 +89,13 @@ public class PendingFederationTest {
 
     @Test
     public void testEquals_differentNumberOfMembers() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600, 700));
         Assert.assertFalse(pendingFederation.equals(otherPendingFederation));
     }
 
     @Test
     public void testEquals_differentMembers() {
-        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-        }));
+        List<FederationMember> members = FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500);
 
         members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(620))));
         PendingFederation otherPendingFederation = new PendingFederation(members);
@@ -149,51 +111,26 @@ public class PendingFederationTest {
 
     @Test
     public void testEquals_same() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600));
         Assert.assertTrue(pendingFederation.equals(otherPendingFederation));
     }
 
     @Test
     public void testToString() {
         Assert.assertEquals("6 signatures pending federation (complete)", pendingFederation.toString());
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(1, 100));
         Assert.assertEquals("1 signatures pending federation (incomplete)", otherPendingFederation.toString());
     }
 
     @Test
     public void buildFederation_ok_a() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600));
 
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-        })), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation expectedFederation = new Federation(
+                FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600),
+                Instant.ofEpochMilli(1234L),
+                0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
 
         Assert.assertEquals(
                 expectedFederation,
@@ -207,31 +144,15 @@ public class PendingFederationTest {
 
     @Test
     public void buildFederation_ok_b() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(800)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(900)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(
+                1, 100, 200, 300, 400, 500, 600, 700, 800, 900
+        ));
 
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(800)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(900)),
-        })), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation expectedFederation = new Federation(
+                FederationTestUtils.getFederationMembersFromPks(1, 100, 200, 300, 400, 500, 600, 700, 800, 900),
+                Instant.ofEpochMilli(1234L), 0L,
+                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
 
         Assert.assertEquals(
                 expectedFederation,
@@ -245,11 +166,7 @@ public class PendingFederationTest {
 
     @Test
     public void buildFederation_incomplete() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(1, 100));
 
         try {
             otherPendingFederation.buildFederation(Instant.ofEpochMilli(12L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -38,6 +38,14 @@ import java.util.stream.Collectors;
 
 @Ignore
 public class ActiveFederationTest extends BridgePerformanceTestCase {
+    public static List<FederationMember> getNRandomFederationMembers(int n) {
+        List<FederationMember> result = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            result.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
+        }
+        return result;
+    }
+
     private Federation federation;
 
     @Test
@@ -103,12 +111,7 @@ public class ActiveFederationTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
             if (!genesis) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
-                List<BtcECKey> federatorKeys = new ArrayList<>();
-                for (int i = 0; i < numFederators; i++) {
-                    federatorKeys.add(new BtcECKey());
-                }
-
-                List<FederationMember> members = FederationMember.getFederationMembersFromKeys(federatorKeys);
+                List<FederationMember> members = getNRandomFederationMembers(numFederators);
 
                 federation = new Federation(
                         members,
@@ -122,6 +125,4 @@ public class ActiveFederationTest extends BridgePerformanceTestCase {
             }
         };
     }
-
-
 }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
@@ -192,11 +192,11 @@ public class FederationChangeTest extends BridgePerformanceTestCase {
                 final int maxKeys = 16;
                 int numKeys = Helper.randomInRange(minKeys, maxKeys);
 
-                List<BtcECKey> pendingFederationKeys = new ArrayList<>();
+                List<FederationMember> pendingFederationMembers = new ArrayList<>();
                 for (int i = 0; i < numKeys; i++) {
-                    pendingFederationKeys.add(new BtcECKey());
+                    pendingFederationMembers.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
                 }
-                pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(pendingFederationKeys));
+                pendingFederation = new PendingFederation(pendingFederationMembers);
                 provider.setPendingFederation(pendingFederation);
             }
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
@@ -30,7 +30,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -88,17 +90,11 @@ public class PendingFederationTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
             if (present) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
-                List<BtcECKey> federatorKeys = new ArrayList<>();
-                for (int i = 0; i < numFederators; i++) {
-                    federatorKeys.add(new BtcECKey());
-                }
-                pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(federatorKeys));
+                pendingFederation = new PendingFederation(ActiveFederationTest.getNRandomFederationMembers(numFederators));
                 provider.setPendingFederation(pendingFederation);
             } else {
                 pendingFederation = null;
             }
         };
     }
-
-
 }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -105,12 +105,8 @@ public class RetiringFederationTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
             if (present) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
-                List<BtcECKey> federatorKeys = new ArrayList<>();
-                for (int i = 0; i < numFederators; i++) {
-                    federatorKeys.add(new BtcECKey());
-                }
                 retiringFederation = new Federation(
-                        FederationMember.getFederationMembersFromKeys(federatorKeys),
+                        ActiveFederationTest.getNRandomFederationMembers(numFederators),
                         Instant.ofEpochMilli(new Random().nextLong()),
                         Helper.randomInRange(1, 10),
                         networkParameters

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -27,6 +27,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.Federation;
 import co.rsk.peg.FederationMember;
+import co.rsk.peg.FederationTestUtils;
 import org.ethereum.core.Block;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
@@ -75,7 +76,7 @@ public class BridgeEventLoggerImplTest {
                 BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))
         );
 
-        List<FederationMember> oldFederationMembers = FederationMember.getFederationMembersFromKeys(oldFederationKeys);
+        List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
 
         Federation oldFederation = new Federation(oldFederationMembers,
                 Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
@@ -86,7 +87,7 @@ public class BridgeEventLoggerImplTest {
                 BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
         );
 
-        List<FederationMember> newFederationMembers = FederationMember.getFederationMembersFromKeys(newFederationKeys);
+        List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
 
         Federation newFederation = new Federation(newFederationMembers,
                 Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));


### PR DESCRIPTION
As from the `secondFork` network upgrade forwards, the following changes to the `Bridge` precompiled contract take place:

- The `getFederatorPublicKey(int256)` is removed.
- The method `getFederatorPublicKeyOfType(int256,string)` is added. The first parameter, as with the previous method, indicates the index of the federator within the currently active federation, the second parameter indicates the key type one wishes to retrieve. It accepts the values `btc`, `rsk` and `mst` (case-sensitive).
- The method `getRetiringFederatorPublicKey(int256)` is removed.
- The method `getRetiringFederatorPublicKeyOfType(int256,string)` is added. It is analogue to the `getFederatorPublicKeyOfType` method, but retrieving keys from the currently retiring federation (if any).
- The method `getPendingFederatorPublicKey` is removed.
- The method `getPendingFederatorPublicKeyOfType(int256,string)` is added. It is analogue to the `getFederatorPublicKeyOfType` method, but retrieving keys from the currently pending federation (if any).