### PR TITLE
Return JSON-RPC error on eth_call revert

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -30,6 +30,7 @@ import org.ethereum.core.Repository;
 import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.converters.CallArgumentsToByteArray;
 import org.ethereum.rpc.dto.CompilationResultDTO;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
 import org.slf4j.Logger;
@@ -103,6 +104,10 @@ public class EthModule
         try {
             Block executionBlock = executionBlockRetriever.getExecutionBlock(bnOrId);
             ProgramResult res = callConstant(args, executionBlock);
+            if (res.isRevert()) {
+                throw RskJsonRpcRequestException.transactionRevertedExecutionError();
+            }
+
             return s = toJsonHex(res.getHReturn());
         } finally {
             LOGGER.debug("eth_call(): {}", s);

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
@@ -21,4 +21,12 @@ public class RskJsonRpcRequestException extends RuntimeException{
         return code;
     }
 
+    public static RskJsonRpcRequestException transactionRevertedExecutionError() {
+        return executionError("transaction reverted");
+    }
+
+    private static RskJsonRpcRequestException executionError(String message) {
+        return new RskJsonRpcRequestException(-32015, String.format("VM execution error: %s", message));
+    }
+
 }


### PR DESCRIPTION
Return a JSON-RPC error when calling `eth_call` results in `revert`. We decided to return the same error code and message as Parity: https://github.com/paritytech/parity-ethereum/blob/7fb33796b17a474242f24d364522ebe5c8a5beef/rpc/src/v1/helpers/errors.rs#L44.

We know this is not a full implementation, but it enables us to run more tests from the OpenZeppelin suite, in particular the ones that check the revert status. We decided to stop here because there's an [ongoing discussion about the RPC interface](https://github.com/ethereum/EIPs/issues/1442), and it'll be best for us to spend the resources when the dust is settled.

Here are some interesting links I found when investigating how to implement this:

* https://github.com/trufflesuite/truffle/issues/976
* https://ethereum-magicians.org/t/eip-remote-procedure-call-specification/1537/14
* https://github.com/ethereum/EIPs/issues/1442
* https://github.com/trufflesuite/ganache-cli/issues/521
* https://github.com/trufflesuite/ganache-core/issues/114
* https://github.com/trufflesuite/ganache-core/pull/115