### PR TITLE
Make eth_sign compatible with Ethereum

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
@@ -22,11 +22,14 @@ import co.rsk.core.RskAddress;
 import co.rsk.core.Wallet;
 import org.ethereum.core.Account;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class EthModuleWalletEnabled implements EthModuleWallet {
@@ -66,10 +69,19 @@ public class EthModuleWalletEnabled implements EthModuleWallet {
 
     private String sign(String data, ECKey ecKey) {
         byte[] dataHash = TypeConverter.stringHexToByteArray(data);
-        ECKey.ECDSASignature signature = ecKey.sign(dataHash);
+        // 0x19 = 25, length should be an ascii decimals, message - original
+        String prefix = (char) 25 + "Ethereum Signed Message:\n" + dataHash.length;
 
-        String signatureAsString = signature.r.toString() + signature.s.toString() + signature.v;
+        byte[] messageHash = HashUtil.keccak256(ByteUtil.merge(
+                prefix.getBytes(StandardCharsets.UTF_8),
+                dataHash
+        ));
+        ECKey.ECDSASignature signature = ecKey.sign(messageHash);
 
-        return TypeConverter.toJsonHex(signatureAsString);
+        return TypeConverter.toJsonHex(ByteUtil.merge(
+                ByteUtil.bigIntegerToBytes(signature.r),
+                ByteUtil.bigIntegerToBytes(signature.s),
+                new byte[] {signature.v}
+        ));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -986,21 +986,15 @@ public class Web3ImplTest {
         Web3Impl web3 = createWeb3();
 
         String addr1 = web3.personal_newAccountWithSeed("sampleSeed1");
-        String addr2 = web3.personal_newAccountWithSeed("sampleSeed2");
 
         byte[] hash = Keccak256Helper.keccak256("this is the data to hash".getBytes());
 
-        String signature = "";
-        try {
-            signature = web3.eth_sign(addr1, "0x" + Hex.toHexString(hash));
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
+        String signature = web3.eth_sign(addr1, "0x" + Hex.toHexString(hash));
 
-        String expectedSignature = "0x" + wallet.getAccount(new RskAddress(addr1)).getEcKey().sign(hash).r.toString() + wallet.getAccount(new RskAddress(addr1)).getEcKey().sign(hash).s.toString() + wallet.getAccount(new RskAddress(addr1)).getEcKey().sign(hash).v;
-
-        Assert.assertTrue("Signature is not the same one returned by the key", expectedSignature.compareTo(signature) == 0);
+        Assert.assertThat(
+                signature,
+                is("0xc8be87722c6452172a02a62fdea70c8b25cfc9613d28647bf2aeb3c7d1faa1a91b861fccc05bb61e25ff4300502812750706ca8df189a0b8163540b9bccabc9f1b")
+        );
     }
 
     @Test


### PR DESCRIPTION
This makes OpenZeppelin's `ECDSA` and `SignatureBouncer` tests pass (7 tests).