### PR TITLE
Removed unnecesary conversions between Base64 and ECDSA signatures

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
@@ -108,7 +108,7 @@ public abstract class PeerDiscoveryMessage {
 
         ECKey outKey = null;
         try {
-            outKey = ECKey.signatureToKey(msgHash, ECKey.ECDSASignature.fromComponents(r, s, v).toBase64());
+            outKey = ECKey.signatureToKey(msgHash, ECKey.ECDSASignature.fromComponents(r, s, v));
         } catch (SignatureException e) {
             logger.error("Error generating key from message", e);
         }

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -375,7 +375,7 @@ public class Transaction {
         }
 
         try {
-            ECKey key = ECKey.signatureToKey(getRawHash().getBytes(), getSignature().toBase64());
+            ECKey key = ECKey.signatureToKey(getRawHash().getBytes(), getSignature());
             sender = new RskAddress(key.getAddress());
         } catch (SignatureException e) {
             logger.error(e.getMessage(), e);

--- a/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
@@ -236,7 +236,7 @@ public class PrecompiledContracts {
                 if (isValid(r, s, v)) {
                     ECKey.ECDSASignature signature = ECKey.ECDSASignature.fromComponents(r, s, v[31]);
 
-                    ECKey key = ECKey.signatureToKey(h, signature.toBase64());
+                    ECKey key = ECKey.signatureToKey(h, signature);
                     out = new DataWord(key.getAddress());
                 }
             } catch (Exception any) {

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -76,7 +76,7 @@ public class TransactionTest {
         System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
 
         // retrieve the signer/sender of the transaction
-        ECKey key = ECKey.signatureToKey(tx.getHash().getBytes(), tx.getSignature().toBase64());
+        ECKey key = ECKey.signatureToKey(tx.getHash().getBytes(), tx.getSignature());
 
         System.out.println("Tx unsigned RLP\t\t: " + Hex.toHexString(tx.getEncodedRaw()));
         System.out.println("Tx signed   RLP\t\t: " + Hex.toHexString(tx.getEncoded()));

--- a/rskj-core/src/test/java/co/rsk/crypto/ECKeyTest.java
+++ b/rskj-core/src/test/java/co/rsk/crypto/ECKeyTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.crypto;
 
+import org.ethereum.TestUtils;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.junit.Assert;
@@ -28,14 +29,6 @@ import static org.junit.Assert.*;
 
 public class ECKeyTest {
     private String exampleMessage = new String("This is an example of a signed message.");
-
-    @Test(expected = SignatureException.class)
-    public void testSignedMessageToKeyThrowsSignatureException() throws SignatureException {
-        byte[] messageHash = HashUtil.keccak256(exampleMessage.getBytes());
-        String signature = Base64.toBase64String(new byte[128]);
-        ECKey key = ECKey.signatureToKey(messageHash, signature);
-        assertNull(key);
-    }
 
     @Test
     public void fromComponentsWithRecoveryCalculation() {

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -74,7 +74,7 @@ public class TransactionTest {
         // step 2: hash = sha3(step1)
         byte[] txHash = HashUtil.keccak256(data);
 
-        String signature = key.doSign(txHash).toBase64();
+        ECKey.ECDSASignature signature = key.doSign(txHash);
         System.out.println(signature);
     }
 
@@ -109,7 +109,7 @@ public class TransactionTest {
         System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
 
         // retrieve the signer/sender of the transaction
-        ECKey key = ECKey.signatureToKey(tx.getHash().getBytes(), tx.getSignature().toBase64());
+        ECKey key = ECKey.signatureToKey(tx.getHash().getBytes(), tx.getSignature());
 
         System.out.println("Tx unsigned RLP\t\t: " + Hex.toHexString(tx.getEncodedRaw()));
         System.out.println("Tx signed   RLP\t\t: " + Hex.toHexString(tx.getEncoded()));
@@ -150,7 +150,7 @@ public class TransactionTest {
         System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
 
         // retrieve the signer/sender of the transaction
-        ECKey key = ECKey.signatureToKey(tx.getHash().getBytes(), tx.getSignature().toBase64());
+        ECKey key = ECKey.signatureToKey(tx.getHash().getBytes(), tx.getSignature());
 
         System.out.println("Tx unsigned RLP\t\t: " + Hex.toHexString(tx.getEncodedRaw()));
         System.out.println("Tx signed   RLP\t\t: " + Hex.toHexString(tx.getEncoded()));


### PR DESCRIPTION
The signatureToKey method in ECKey class expects a Base64 encoded signature. There are no uses that justify this encoding, which forces users of the class to encode the signature parameter just to be able to use the signatureToKey method. This pull request contains a refactor to remove the Base64 encoding from the method, the introduction of utility methods in ECDSASignature class to convert from / to Base64 in case it is needed and modifications to test cases to maintain compatibility with the existing test suite.