### PR TITLE
Return an error when sendTransaction fails instead of the transaction hash

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -469,7 +469,7 @@ public class TransactionPoolImpl implements TransactionPool {
         }
 
         AccountState state = repository.getAccountState(tx.getSender());
-        return validator.isValid(tx, bestBlock, state);
+        return validator.isValid(tx, bestBlock, state).transactionIsValid();
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/net/TransactionValidationResult.java
+++ b/rskj-core/src/main/java/co/rsk/net/TransactionValidationResult.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.net;
+
+public class TransactionValidationResult {
+    private final boolean transactionIsValid;
+    private final String errorMessage;
+
+    private TransactionValidationResult(boolean isValid, String errorMessage) {
+        this.transactionIsValid = isValid;
+        this.errorMessage = errorMessage;
+    }
+
+    public boolean transactionIsValid() {
+        return transactionIsValid;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public static TransactionValidationResult ok() {
+        return new TransactionValidationResult(true, null);
+    }
+
+    public static TransactionValidationResult withError(String errorMessage) {
+        return new TransactionValidationResult(false, errorMessage);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
@@ -71,7 +71,7 @@ public class TxPendingValidator {
         for (TxValidatorStep step : validatorSteps) {
             TransactionValidationResult validationResult = step.validate(tx, state, blockGasLimit, minimumGasPrice, bestBlockNumber, basicTxCost == 0);
             if (!validationResult.transactionIsValid()) {
-                logger.info("[tx={}] {} failed", tx.getHash(), step.getClass());
+                logger.info("[tx={}] validation failed with error: {}", tx.getHash(), validationResult.getErrorMessage());
                 return validationResult;
             }
         }

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
@@ -20,6 +20,7 @@ package co.rsk.net.handler;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import co.rsk.net.handler.txvalidator.*;
 import org.ethereum.core.*;
 import org.slf4j.Logger;
@@ -56,7 +57,7 @@ public class TxPendingValidator {
         validatorSteps.add(new TxValidatorIntrinsicGasLimitValidator(config));
     }
 
-    public boolean isValid(Transaction tx, Block executionBlock, @Nullable AccountState state) {
+    public TransactionValidationResult isValid(Transaction tx, Block executionBlock, @Nullable AccountState state) {
         BigInteger blockGasLimit = BigIntegers.fromUnsignedByteArray(executionBlock.getGasLimit());
         Coin minimumGasPrice = executionBlock.getMinimumGasPrice();
         long bestBlockNumber = executionBlock.getNumber();
@@ -64,16 +65,17 @@ public class TxPendingValidator {
 
         if (state == null && basicTxCost != 0) {
             logger.trace("[tx={}, sender={}] account doesn't exist", tx.getHash(), tx.getSender());
-            return false;
+            return TransactionValidationResult.withError("the sender account doesn't exist");
         }
 
         for (TxValidatorStep step : validatorSteps) {
-            if (!step.validate(tx, state, blockGasLimit, minimumGasPrice, bestBlockNumber, basicTxCost == 0)) {
+            TransactionValidationResult validationResult = step.validate(tx, state, blockGasLimit, minimumGasPrice, bestBlockNumber, basicTxCost == 0);
+            if (!validationResult.transactionIsValid()) {
                 logger.info("[tx={}] {} failed", tx.getHash(), step.getClass());
-                return false;
+                return validationResult;
             }
         }
 
-        return true;
+        return TransactionValidationResult.ok();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxNotNullValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxNotNullValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 
@@ -33,7 +34,12 @@ import java.math.BigInteger;
 public class TxNotNullValidator implements  TxValidatorStep {
 
     @Override
-    public boolean validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
-        return tx != null;
+    public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
+        if (tx != null) {
+            return TransactionValidationResult.ok();
+        }
+
+        return TransactionValidationResult.withError("transaction is null");
     }
+
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 
@@ -31,17 +32,22 @@ import java.math.BigInteger;
 public class TxValidatorAccountBalanceValidator implements TxValidatorStep {
 
     @Override
-    public boolean validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
+    public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
         if (isFreeTx) {
-            return true;
+            return TransactionValidationResult.ok();
         }
 
         if (state == null) {
-            return false;
+            return TransactionValidationResult.withError("the sender account doesn't exist");
         }
 
         BigInteger txGasLimit = tx.getGasLimitAsInteger();
         Coin maximumPrice = tx.getGasPrice().multiply(txGasLimit);
-        return state.getBalance().compareTo(maximumPrice) >= 0;
+        if (state.getBalance().compareTo(maximumPrice) >= 0) {
+            return TransactionValidationResult.ok();
+        }
+
+        return TransactionValidationResult.withError("insufficient funds");
     }
+
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorAccountStateValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorAccountStateValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 
@@ -31,8 +32,19 @@ import java.math.BigInteger;
 public class TxValidatorAccountStateValidator implements TxValidatorStep {
 
     @Override
-    public boolean validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
-        return isFreeTx || (state != null && !state.isDeleted());
-    }
+    public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
+        if (isFreeTx) {
+            return TransactionValidationResult.ok();
+        }
 
+        if (state == null) {
+            return TransactionValidationResult.withError("the sender account doesn't exist");
+        }
+
+        if (state.isDeleted()) {
+            return TransactionValidationResult.withError("the sender account is deleted");
+        }
+
+        return TransactionValidationResult.ok();
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import org.ethereum.config.Constants;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
@@ -37,15 +38,20 @@ public class TxValidatorGasLimitValidator implements TxValidatorStep {
     private static final Logger logger = LoggerFactory.getLogger("txvalidator");
 
     @Override
-    public boolean validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
+    public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
         BigInteger txGasLimit = tx.getGasLimitAsInteger();
 
         if (txGasLimit.compareTo(gasLimit) <= 0 && txGasLimit.compareTo(Constants.getTransactionGasCap()) <= 0) {
-            return true;
+            return TransactionValidationResult.ok();
         }
 
         logger.warn("Invalid transaction {}: its gas limit {} is higher than the block gas limit {}", tx.getHash(), txGasLimit, gasLimit);
 
-        return false;
+        return TransactionValidationResult.withError(String.format(
+                "transaction's gas limit of %s is higher than the block's gas limit of %s",
+                txGasLimit,
+                gasLimit
+        ));
     }
+
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidator.java
@@ -23,8 +23,6 @@ import co.rsk.net.TransactionValidationResult;
 import org.ethereum.config.Constants;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.math.BigInteger;
@@ -35,8 +33,6 @@ import java.math.BigInteger;
  * Also Checks that the transaction gas limit is not higher than the max allowed value
  */
 public class TxValidatorGasLimitValidator implements TxValidatorStep {
-    private static final Logger logger = LoggerFactory.getLogger("txvalidator");
-
     @Override
     public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
         BigInteger txGasLimit = tx.getGasLimitAsInteger();
@@ -44,8 +40,6 @@ public class TxValidatorGasLimitValidator implements TxValidatorStep {
         if (txGasLimit.compareTo(gasLimit) <= 0 && txGasLimit.compareTo(Constants.getTransactionGasCap()) <= 0) {
             return TransactionValidationResult.ok();
         }
-
-        logger.warn("Invalid transaction {}: its gas limit {} is higher than the block gas limit {}", tx.getHash(), txGasLimit, gasLimit);
 
         return TransactionValidationResult.withError(String.format(
                 "transaction's gas limit of %s is higher than the block's gas limit of %s",

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidator.java
@@ -20,6 +20,7 @@ package co.rsk.net.handler.txvalidator;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import org.ethereum.core.*;
 
 import javax.annotation.Nullable;
@@ -38,7 +39,7 @@ public class TxValidatorIntrinsicGasLimitValidator implements TxValidatorStep {
     }
 
     @Override
-    public boolean validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
+    public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
         BlockHeader blockHeader = new BlockHeader(new byte[]{},
                 new byte[]{},
                 new byte[20],
@@ -56,6 +57,12 @@ public class TxValidatorIntrinsicGasLimitValidator implements TxValidatorStep {
                 0
         );
         Block block = new Block(blockHeader);
-        return BigInteger.valueOf(tx.transactionCost(block, config.getBlockchainConfig())).compareTo(tx.getGasLimitAsInteger()) <= 0;
+
+        if (BigInteger.valueOf(tx.transactionCost(block, config.getBlockchainConfig())).compareTo(tx.getGasLimitAsInteger()) <= 0) {
+            return TransactionValidationResult.ok();
+        }
+
+        return TransactionValidationResult.withError("transaction's basic cost is above the gas limit");
     }
+
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorMinimuGasPriceValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorMinimuGasPriceValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 
@@ -30,8 +31,13 @@ import java.math.BigInteger;
  */
 public class TxValidatorMinimuGasPriceValidator implements TxValidatorStep {
     @Override
-    public boolean validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
+    public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
         Coin gasPrice = tx.getGasPrice();
-        return gasPrice != null && gasPrice.compareTo(minimumGasPrice) >= 0;
+        if (gasPrice != null && gasPrice.compareTo(minimumGasPrice) >= 0) {
+            return TransactionValidationResult.ok();
+        }
+
+        return TransactionValidationResult.withError("transaction's gas price lower than block's minimum");
     }
+
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorNotRemascTxValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorNotRemascTxValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
@@ -37,14 +38,13 @@ public class TxValidatorNotRemascTxValidator implements TxValidatorStep {
     private static final Logger logger = LoggerFactory.getLogger("txvalidator");
 
     @Override
-    public boolean validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
+    public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
         if (!(tx instanceof RemascTransaction)) {
-            return true;
+            return TransactionValidationResult.ok();
         }
 
         logger.warn("Invalid transaction {}: it is a Remasc transaction", tx.getHash());
 
-        return false;
+        return TransactionValidationResult.withError("transaction is a remasc transaction");
     }
-
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorNotRemascTxValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorNotRemascTxValidator.java
@@ -23,8 +23,6 @@ import co.rsk.net.TransactionValidationResult;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.math.BigInteger;
@@ -35,15 +33,11 @@ import java.math.BigInteger;
  * Transaction must not be null
  */
 public class TxValidatorNotRemascTxValidator implements TxValidatorStep {
-    private static final Logger logger = LoggerFactory.getLogger("txvalidator");
-
     @Override
     public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
         if (!(tx instanceof RemascTransaction)) {
             return TransactionValidationResult.ok();
         }
-
-        logger.warn("Invalid transaction {}: it is a Remasc transaction", tx.getHash());
 
         return TransactionValidationResult.withError("transaction is a remasc transaction");
     }

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorStep.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorStep.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
+import co.rsk.net.TransactionValidationResult;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Transaction;
 
@@ -31,6 +32,6 @@ import java.math.BigInteger;
  */
 public interface TxValidatorStep {
 
-    boolean validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx);
+    TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx);
 
 }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionPool.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionPool.java
@@ -33,7 +33,7 @@ public interface TransactionPool {
      *
      * @param tx transaction
      */
-    boolean addTransaction(Transaction tx);
+    TransactionPoolAddResult addTransaction(Transaction tx);
 
     /**
      * Adds a list of transactions to the list of pending state txs or

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionPoolAddResult.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionPoolAddResult.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.core;
+
+import java.util.function.Consumer;
+
+public class TransactionPoolAddResult {
+    private final boolean transactionWasAdded;
+    private final String errorMessage;
+
+    private TransactionPoolAddResult(boolean transactionWasAdded, String errorMessage) {
+        this.transactionWasAdded = transactionWasAdded;
+        this.errorMessage = errorMessage;
+    }
+
+    public boolean transactionWasAdded() {
+        return transactionWasAdded;
+    }
+
+    /**
+     * This is mainly used to throw exceptions on the RPC avoiding the use of getters
+     */
+    public void ifTransactionWasNotAdded(Consumer<String> errorConsumer) {
+        if (!transactionWasAdded) {
+            errorConsumer.accept(errorMessage);
+        }
+    }
+
+    public static TransactionPoolAddResult ok() {
+        return new TransactionPoolAddResult(true, null);
+    }
+
+    public static TransactionPoolAddResult withError(String errorMessage) {
+        return new TransactionPoolAddResult(false, errorMessage);
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
@@ -33,4 +33,8 @@ public class RskJsonRpcRequestException extends RuntimeException{
         return new RskJsonRpcRequestException(-32015, String.format("VM execution error: %s", message));
     }
 
+    public static RskJsonRpcRequestException transactionError(String message) {
+        return new RskJsonRpcRequestException(-32010, message);
+    }
+
 }

--- a/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
@@ -21,12 +21,9 @@ package co.rsk.core.bc;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
+import co.rsk.remasc.RemascTransaction;
 import co.rsk.test.builders.BlockBuilder;
-import org.ethereum.core.Account;
-import org.ethereum.core.Block;
-import org.ethereum.core.Repository;
-import org.ethereum.core.Transaction;
-import org.ethereum.db.RepositoryTrack;
+import org.ethereum.core.*;
 import org.ethereum.listener.TestCompositeEthereumListener;
 import org.ethereum.util.RskTestFactory;
 import org.ethereum.vm.DataWord;
@@ -176,8 +173,8 @@ public class TransactionPoolImplTest {
         Transaction tx1 = createSampleTransaction(1, 2, 1000, 1);
         Transaction tx2 = createSampleTransaction(1, 2, 1000, 2);
 
-        Assert.assertFalse(transactionPool.addTransaction(tx1));
-        Assert.assertFalse(transactionPool.addTransaction(tx2));
+        Assert.assertTrue(transactionPool.addTransaction(tx1).transactionWasAdded());
+        Assert.assertTrue(transactionPool.addTransaction(tx2).transactionWasAdded());
 
         List<Transaction> transactionsToProcess = new ArrayList<>();
         transactionsToProcess.add(tx0);
@@ -217,19 +214,6 @@ public class TransactionPoolImplTest {
 
         PendingState pendingState = transactionPool.getPendingState();
         Assert.assertEquals(BigInteger.valueOf(1001000), pendingState.getBalance(receiver.getAddress()).asBigInteger());
-    }
-
-    @Test
-    public void rejectTransactionPoolTransaction() {
-        Coin balance = Coin.valueOf(1000000);
-        createTestAccounts(2, balance);
-        Transaction tx = createSampleTransaction(1, 2, 1000, 0, BigInteger.valueOf(3000001));
-        Account receiver = createAccount(2);
-
-        transactionPool.addTransaction(tx);
-
-        PendingState pendingState = transactionPool.getPendingState();
-        Assert.assertEquals(BigInteger.valueOf(1000000), pendingState.getBalance(receiver.getAddress()).asBigInteger());
     }
 
     @Test
@@ -482,8 +466,32 @@ public class TransactionPoolImplTest {
         Transaction tx = createSampleTransaction(1, 2, 1000, 0);
 
         transactionPool.addTransaction(tx);
-        transactionPool.addTransaction(tx);
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("pending transaction with same hash already exists", msg));
+
         List<Transaction> transactions = transactionPool.getPendingTransactions();
+
+        Assert.assertNotNull(transactions);
+        Assert.assertFalse(transactions.isEmpty());
+        Assert.assertEquals(1, transactions.size());
+        Assert.assertTrue(transactions.contains(tx));
+    }
+
+    @Test
+    public void addTwiceAndGetQueuedTransaction() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(1, balance);
+        Transaction tx = createSampleTransaction(1, 2, 1000, 1);
+
+        transactionPool.addTransaction(tx);
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("queued transaction with same hash already exists", msg));
+
+        List<Transaction> transactions = transactionPool.getQueuedTransactions();
 
         Assert.assertNotNull(transactions);
         Assert.assertFalse(transactions.isEmpty());
@@ -498,7 +506,7 @@ public class TransactionPoolImplTest {
         Assert.assertNotNull(transactions);
         Assert.assertTrue(transactions.isEmpty());
     }
-    
+
     @Test
     public void executeContractWithFakeBlock() {
         Coin balance = Coin.valueOf(1000000);
@@ -522,7 +530,11 @@ public class TransactionPoolImplTest {
         Transaction tx2 = createSampleTransaction(1, 0, 2000, 0);
 
         transactionPool.addTransaction(tx);
-        Assert.assertFalse(transactionPool.addTransaction(tx2));
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx2);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("gas price not enough to bump transaction", msg));
     }
 
     @Test
@@ -533,9 +545,146 @@ public class TransactionPoolImplTest {
         Transaction tx2 = createSampleTransactionWithGasPrice(1, 0, 2000, 0, 2);
 
         transactionPool.addTransaction(tx1);
-        Assert.assertTrue(transactionPool.addTransaction(tx2));
+        Assert.assertTrue(transactionPool.addTransaction(tx2).transactionWasAdded());
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx2.getHash())));
         Assert.assertFalse(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx1.getHash())));
+    }
+
+    @Test
+    public void checkTxWithHighGasLimitIsRejected() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+        Transaction tx = createSampleTransaction(1, 2, 1000, 0, BigInteger.valueOf(3000001));
+        Account receiver = createAccount(2);
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("transaction's gas limit of 3000001 is higher than the block's gas limit of 3000000", msg));
+
+        List<Transaction> pending = transactionPool.getPendingTransactions();
+        Assert.assertTrue(pending.isEmpty());
+    }
+
+    @Test
+    public void checkTxWithHighNonceIsRejected() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+        Transaction tx = createSampleTransaction(1, 2, 1000, 5);
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("transaction nonce too high", msg));
+
+        Assert.assertTrue(transactionPool.getPendingTransactions().isEmpty());
+        Assert.assertTrue(transactionPool.getQueuedTransactions().isEmpty());
+    }
+
+    @Test
+    public void checkTxWithLowNonceIsRejected() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+
+        Transaction tx = createSampleTransaction(1, 2, 3000, 0);
+
+        blockChain.getRepository().increaseNonce(tx.getSender());
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("transaction nonce too low", msg));
+
+        Assert.assertTrue(transactionPool.getPendingTransactions().isEmpty());
+        Assert.assertTrue(transactionPool.getQueuedTransactions().isEmpty());
+    }
+
+    @Test
+    public void checkRemascTxIsRejected() {
+        RemascTransaction tx = new RemascTransaction(10);
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("transaction is a remasc transaction", msg));
+    }
+
+    @Test
+    public void checkTxWithLowGasPriceIsRejected() {
+        Block newBest = new BlockBuilder().parent(transactionPool.getBestBlock()).minGasPrice(BigInteger.valueOf(100)).build();
+        transactionPool.processBest(newBest);
+
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+        Transaction tx = createSampleTransactionWithGasPrice(1, 2, 1000, 0, 1);
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("transaction's gas price lower than block's minimum", msg));
+
+        Assert.assertTrue(transactionPool.getPendingTransactions().isEmpty());
+    }
+
+    @Test
+    public void checkTxFromAccountWithLowBalanceIsRejected() {
+        Coin balance = Coin.valueOf(1000);
+        createTestAccounts(2, balance);
+        Transaction tx = createSampleTransaction(1, 2, 10000, 0);
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("insufficient funds", msg));
+
+        Assert.assertTrue(transactionPool.getPendingTransactions().isEmpty());
+    }
+
+    @Test
+    public void checkTxFromNullStateIsRejected() {
+        Transaction tx = createSampleTransaction(1, 2, 1000, 0);
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("the sender account doesn't exist", msg));
+
+        Assert.assertTrue(transactionPool.getPendingTransactions().isEmpty());
+    }
+
+    @Test
+    public void checkTxWithHighIntrinsicGasIsRejected() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+
+        // basic tx cost is 21000, set the gas limit below that
+        Transaction tx = createSampleTransaction(1, 2, 1000, 0, BigInteger.valueOf(20000));
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("transaction's basic cost is above the gas limit", msg));
+
+        Assert.assertTrue(transactionPool.getPendingTransactions().isEmpty());
+    }
+
+    @Test
+    public void checkTxWhichCanNotBePaidIsRejected() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+
+        // basic tx cost is 21000
+        Transaction tx1 = createSampleTransaction(1, 2, 500000 - 21000, 0);
+        Transaction tx2 = createSampleTransaction(1, 2, 500001 - 21000, 1);
+
+        transactionPool.addTransaction(tx1);
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx2);
+
+        Assert.assertFalse(result.transactionWasAdded());
+        result.ifTransactionWasNotAdded(msg -> Assert.assertEquals("insufficient funds to pay for pending and new transaction", msg));
+
+        Assert.assertEquals(1, transactionPool.getPendingTransactions().size());
+        Assert.assertTrue(transactionPool.getQueuedTransactions().isEmpty());
     }
 
     private void createTestAccounts(int naccounts, Coin balance) {
@@ -551,5 +700,4 @@ public class TransactionPoolImplTest {
 
         track.commit();
     }
-
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountBalanceValidatorTest.java
@@ -49,9 +49,9 @@ public class TxValidatorAccountBalanceValidatorTest {
 
         TxValidatorAccountBalanceValidator tvabv = new TxValidatorAccountBalanceValidator();
 
-        Assert.assertTrue(tvabv.validate(tx1, as, null, null, Long.MAX_VALUE, false));
-        Assert.assertTrue(tvabv.validate(tx2, as, null, null, Long.MAX_VALUE, false));
-        Assert.assertTrue(tvabv.validate(tx3, as, null, null, Long.MAX_VALUE, false));
+        Assert.assertTrue(tvabv.validate(tx1, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvabv.validate(tx2, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvabv.validate(tx3, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 
     @Test
@@ -68,8 +68,8 @@ public class TxValidatorAccountBalanceValidatorTest {
 
         TxValidatorAccountBalanceValidator tvabv = new TxValidatorAccountBalanceValidator();
 
-        Assert.assertFalse(tvabv.validate(tx1, as, null, null, Long.MAX_VALUE, false));
-        Assert.assertFalse(tvabv.validate(tx2, as, null, null, Long.MAX_VALUE, false));
+        Assert.assertFalse(tvabv.validate(tx1, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvabv.validate(tx2, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class TxValidatorAccountBalanceValidatorTest {
 
         TxValidatorAccountBalanceValidator tv = new TxValidatorAccountBalanceValidator();
 
-        Assert.assertTrue(tv.validate(tx, new AccountState(), BigInteger.ONE, Coin.valueOf(1L), Long.MAX_VALUE, true));
+        Assert.assertTrue(tv.validate(tx, new AccountState(), BigInteger.ONE, Coin.valueOf(1L), Long.MAX_VALUE, true).transactionIsValid());
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountStateValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorAccountStateValidatorTest.java
@@ -31,7 +31,7 @@ public class TxValidatorAccountStateValidatorTest {
         Mockito.when(state.isDeleted()).thenReturn(false);
 
         TxValidatorAccountStateValidator tvasv = new TxValidatorAccountStateValidator();
-        Assert.assertTrue(tvasv.validate(null, state, null, null, Long.MAX_VALUE, false));
+        Assert.assertTrue(tvasv.validate(null, state, null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 
     @Test
@@ -40,6 +40,6 @@ public class TxValidatorAccountStateValidatorTest {
         Mockito.when(state.isDeleted()).thenReturn(true);
 
         TxValidatorAccountStateValidator tvasv = new TxValidatorAccountStateValidator();
-        Assert.assertFalse(tvasv.validate(null, state, null, null, Long.MAX_VALUE, false));
+        Assert.assertFalse(tvasv.validate(null, state, null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorGasLimitValidatorTest.java
@@ -39,8 +39,8 @@ public class TxValidatorGasLimitValidatorTest {
 
         TxValidatorGasLimitValidator tvglv = new TxValidatorGasLimitValidator();
 
-        Assert.assertTrue(tvglv.validate(tx1, null, gl, null, Long.MAX_VALUE, false));
-        Assert.assertTrue(tvglv.validate(tx2, null, gl, null, Long.MAX_VALUE, false));
+        Assert.assertTrue(tvglv.validate(tx1, null, gl, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvglv.validate(tx2, null, gl, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 
     @Test
@@ -55,6 +55,6 @@ public class TxValidatorGasLimitValidatorTest {
 
         TxValidatorGasLimitValidator tvglv = new TxValidatorGasLimitValidator();
 
-        Assert.assertFalse(tvglv.validate(tx1, null, gl, null, Long.MAX_VALUE, false));
+        Assert.assertFalse(tvglv.validate(tx1, null, gl, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
@@ -83,10 +83,10 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
 
         TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(config);
 
-        Assert.assertTrue(tvigpv.validate(tx1, new AccountState(), null, null, Long.MAX_VALUE, false));
-        Assert.assertTrue(tvigpv.validate(tx2, new AccountState(), null, null, Long.MAX_VALUE, false));
-        Assert.assertTrue(tvigpv.validate(tx3, new AccountState(), null, null, Long.MAX_VALUE, false));
-        Assert.assertTrue(tvigpv.validate(tx4, new AccountState(), null, null, Long.MAX_VALUE, false));
+        Assert.assertTrue(tvigpv.validate(tx1, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvigpv.validate(tx2, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvigpv.validate(tx3, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvigpv.validate(tx4, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 
 
@@ -131,9 +131,9 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
 
         TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(config);
 
-        Assert.assertFalse(tvigpv.validate(tx1, new AccountState(), null, null, Long.MAX_VALUE, false));
-        Assert.assertFalse(tvigpv.validate(tx2, new AccountState(), null, null, Long.MAX_VALUE, false));
-        Assert.assertFalse(tvigpv.validate(tx3, new AccountState(), null, null, Long.MAX_VALUE, false));
-        Assert.assertFalse(tvigpv.validate(tx4, new AccountState(), null, null, Long.MAX_VALUE, false));
+        Assert.assertFalse(tvigpv.validate(tx1, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvigpv.validate(tx2, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvigpv.validate(tx3, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvigpv.validate(tx4, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorMinimumGasPriceValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorMinimumGasPriceValidatorTest.java
@@ -39,9 +39,9 @@ public class TxValidatorMinimumGasPriceValidatorTest {
         TxValidatorMinimuGasPriceValidator tvmgpv = new TxValidatorMinimuGasPriceValidator();
 
 
-        Assert.assertTrue(tvmgpv.validate(tx1, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false));
-        Assert.assertTrue(tvmgpv.validate(tx2, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false));
-        Assert.assertTrue(tvmgpv.validate(tx3, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false));
+        Assert.assertTrue(tvmgpv.validate(tx1, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvmgpv.validate(tx2, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvmgpv.validate(tx3, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false).transactionIsValid());
     }
 
     @Test
@@ -56,9 +56,9 @@ public class TxValidatorMinimumGasPriceValidatorTest {
 
         TxValidatorMinimuGasPriceValidator tvmgpv = new TxValidatorMinimuGasPriceValidator();
 
-        Assert.assertFalse(tvmgpv.validate(tx1, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false));
-        Assert.assertFalse(tvmgpv.validate(tx2, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false));
-        Assert.assertFalse(tvmgpv.validate(tx3, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false));
+        Assert.assertFalse(tvmgpv.validate(tx1, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvmgpv.validate(tx2, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvmgpv.validate(tx3, null, null, Coin.valueOf(10L), Long.MAX_VALUE, false).transactionIsValid());
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidatorTest.java
@@ -39,8 +39,8 @@ public class TxValidatorNonceRangeValidatorTest {
         Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(0));
 
         TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator();
-        Assert.assertTrue(tvnrv.validate(tx1, as, null, null, Long.MAX_VALUE, false));
-        Assert.assertTrue(tvnrv.validate(tx2, as, null, null, Long.MAX_VALUE, false));
+        Assert.assertTrue(tvnrv.validate(tx1, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvnrv.validate(tx2, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class TxValidatorNonceRangeValidatorTest {
         Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(1));
 
         TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator();
-        Assert.assertFalse(tvnrv.validate(tx1, as, null, null, Long.MAX_VALUE, false));
-        Assert.assertFalse(tvnrv.validate(tx2, as, null, null, Long.MAX_VALUE, false));
+        Assert.assertFalse(tvnrv.validate(tx1, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvnrv.validate(tx2, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNotNullValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNotNullValidatorTest.java
@@ -23,18 +23,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.math.BigInteger;
-
 public class TxValidatorNotNullValidatorTest {
     @Test
     public void nullTx() {
         TxNotNullValidator validator = new TxNotNullValidator();
-        Assert.assertFalse(validator.validate(null, null, null, null, 0, false));
+        Assert.assertFalse(validator.validate(null, null, null, null, 0, false).transactionIsValid());
     }
 
     @Test
     public void tx() {
         TxNotNullValidator validator = new TxNotNullValidator();
-        Assert.assertTrue(validator.validate(Mockito.mock(Transaction.class), null, null, null, 0, false));
+        Assert.assertTrue(validator.validate(Mockito.mock(Transaction.class), null, null, null, 0, false).transactionIsValid());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNotRemascTxValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNotRemascTxValidatorTest.java
@@ -32,12 +32,12 @@ public class TxValidatorNotRemascTxValidatorTest {
         TxValidatorNotRemascTxValidator validator = new TxValidatorNotRemascTxValidator();
         Transaction tx1 = Mockito.mock(RemascTransaction.class);
         Mockito.when(tx1.getHash()).thenReturn(Keccak256.ZERO_HASH);
-        Assert.assertFalse(validator.validate(tx1, null, null, null, 0, false));
+        Assert.assertFalse(validator.validate(tx1, null, null, null, 0, false).transactionIsValid());
     }
 
     @Test
     public void commonTx() {
         TxValidatorNotRemascTxValidator validator = new TxValidatorNotRemascTxValidator();
-        Assert.assertTrue(validator.validate(Mockito.mock(Transaction.class), null, null, null, 0, false));
+        Assert.assertTrue(validator.validate(Mockito.mock(Transaction.class), null, null, null, 0, false).transactionIsValid());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -1184,7 +1184,9 @@ public class Web3ImplTest {
         BigInteger nonce = BigInteger.ONE;
         ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
         World world = new World(receiptStore);
-        Web3Impl web3 = createWeb3(world, receiptStore);
+        BlockChainImpl blockChain = world.getBlockChain();
+        TransactionPool transactionPool = new TransactionPoolImpl(config, world.getRepository(), blockChain.getBlockStore(), null, null, null, 10, 100);
+        Web3Impl web3 = createWeb3(world, transactionPool, receiptStore);
 
         // **** Initializes data ******************
         String addr1 = web3.personal_newAccountWithSeed("sampleSeed1");


### PR DESCRIPTION
**Motivation**
As of now, the addTransaction method in TransactionPoolImpl returns a boolean value indicating if the transaction was added or not. However, in case the transaction was not added, it does not provide any information about why the transaction was rejected.

This lack of information is most perceived when sending a transaction through either sendTransaction or sendRawTransaction. Current behaviour returns a normal RPC result with the transaction hash instead of an RPC error, regardless the transaction was added or not. This causes both confusion or uncertainty in the user since the tx won't show in the explorer and problems with tools such as Truffle, which considers a transaction added when its hash is returned and waits for it to be mined.

**Description**
This PR adds a TransactionPoolAddResult class which replaces the returned boolean value and allows to query for both the result of the operation and, if any, the error message which may be provided in case of error. Changes to the validation methods (shouldAcceptTx in TransactionPoolImpl) and classes (TxPendingValidator and the several validation steps used within it) were made in order to communicate the failed validation rule message.

In addition, a change was made on the RPC layer to throw an RskJsonRpcRequestException when the Add operation fails. Thus, an RPC error is returned, informing the user the motive of failure.

The error messages may need a bit of work, I'm open to any suggestion to make them better.

PD: Thanks to @tinchou for the initial directions and tips for this feature