### PR TITLE
 Remove TrieStore::getSaveCount and ::getRetrieveCount

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/TrieStore.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStore.java
@@ -26,11 +26,7 @@ import org.ethereum.datasource.KeyValueDataSource;
 public interface TrieStore {
     void save(Trie trie);
 
-    int getSaveCount();
-
     Trie retrieve(byte[] hash);
-
-    int getRetrieveCount();
 
     byte[] serialize();
 

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -50,10 +50,6 @@ public class TrieStoreImpl implements TrieStore {
     // a key value data source to use
     private KeyValueDataSource store;
 
-    // internal variables, count of saves and retrieves
-    private int saveCount = 0;
-    private int retrieveCount = 0;
-
     public TrieStoreImpl(KeyValueDataSource store) {
         this.store = store;
     }
@@ -64,17 +60,12 @@ public class TrieStoreImpl implements TrieStore {
      */
     @Override
     public void save(Trie trie) {
-        this.saveCount++;
         this.store.put(trie.getHash().getBytes(), trie.toMessage());
 
         if (trie.hasLongValue()) {
-            this.saveCount++;
             this.store.put(trie.getValueHash(), trie.getValue());
         }
     }
-
-    @Override
-    public int getSaveCount() { return this.saveCount; }
 
     /**
      * retrieve retrieves a Trie instance from store, using hash a key
@@ -85,8 +76,6 @@ public class TrieStoreImpl implements TrieStore {
      */
     @Override
     public Trie retrieve(byte[] hash) {
-        this.retrieveCount++;
-
         byte[] message = this.store.get(hash);
 
         return TrieImpl.fromMessage(message, this);
@@ -99,9 +88,6 @@ public class TrieStoreImpl implements TrieStore {
     public byte[] storeValue(byte[] key, byte[] value) {
         return this.store.put(key, value);
     }
-
-    @Override
-    public int getRetrieveCount() { return this.retrieveCount; }
 
     @Override
     public byte[] serialize() {


### PR DESCRIPTION
Replace `TrieStore::getSaveCount` and `::getRetrieveCount` with mockito validators. These methods were created just for testing, and are unnecessary in production code.