### PR TITLE
Trie hashes invariant

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieImpl.java
@@ -849,8 +849,10 @@ public class TrieImpl implements Trie {
         }
 
         TrieImpl[] newNodes = new TrieImpl[ARITY];
+        Keccak256[] newHashes = new Keccak256[ARITY];
         int pos = sharedPath[nshared];
         newNodes[pos] = newChildTrie;
+        newHashes[pos] = newChildTrie.getHash();
 
         byte[] newTrieEncodedSharedPath = null;
         int newTrieSharedPathLength = 0;
@@ -866,7 +868,7 @@ public class TrieImpl implements Trie {
                 newTrieSharedPathLength,
                 null,
                 newNodes,
-                null,
+                newHashes,
                 this.store
         ).withSecure(
                 this.isSecure


### PR DESCRIPTION
Just a small gift before I go on vacations.

The idea of this PR is to break **two** cyclic dependencies between the following `TrieImpl` methods:

```
                                              put() +------+
                                                           |
                                                           v
getHash() +------------> serialize() +-------------> getNodeCount()
     ^                        +                            +
     |                        |                            |
     |                        |                            |
     |                        v                            |
     +------------------+ getHash(n) <---------------------+
```

This cycle made it impossible to cleanly extract the serialization behavior from `Trie`, which is needed to make the fork logic for the `unitrie` epic.

We realized that the `getHash(n)` logic should in fact be an invariant of this class (it must always contain its children's hashes). With the hashes being pre-populated, the flow is now:
```
                                              put() +------+
                                                           |
                                                           v
getHash() +------------> serialize() +-------------> getNodeCount()
```

Thanks @diega for driving this change!