### PR TITLE
Remove setters from blockchain

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
@@ -416,11 +416,6 @@ public class BlockChainImpl implements Blockchain {
     public Block getBlockByNumber(long number) { return blockStore.getChainBlockByNumber(number); }
 
     @Override
-    public void setBestBlock(Block block) {
-        this.setStatus(block, status.getTotalDifficulty());
-    }
-
-    @Override
     public Block getBestBlock() {
         return this.status.getBestBlock();
     }
@@ -452,11 +447,6 @@ public class BlockChainImpl implements Blockchain {
     @Override
     public BlockDifficulty getTotalDifficulty() {
         return status.getTotalDifficulty();
-    }
-
-    @Override
-    public void setTotalDifficulty(BlockDifficulty totalDifficulty) {
-        setStatus(status.getBestBlock(), totalDifficulty);
     }
 
     @Override @VisibleForTesting

--- a/rskj-core/src/main/java/org/ethereum/core/Blockchain.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Blockchain.java
@@ -64,16 +64,12 @@ public interface Blockchain {
 
     ImportResult tryToConnect(Block block);
 
-    void setBestBlock(Block block);
-
     void setStatus(Block block, BlockDifficulty totalDifficulty);
 
     BlockChainStatus getStatus();
 
     @Nullable
     TransactionInfo getTransactionInfo(byte[] hash);
-
-    void setTotalDifficulty(BlockDifficulty totalDifficulty);
 
     byte[] getBestBlockHash();
 

--- a/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
@@ -142,18 +142,15 @@ public class BlockChainLoader {
             genesis.flushRLP();
 
             blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
-            blockchain.setBestBlock(genesis);
-            blockchain.setTotalDifficulty(genesis.getCumulativeDifficulty());
+            blockchain.setStatus(genesis, genesis.getCumulativeDifficulty());
 
-            listener.onBlock(genesis, new ArrayList<TransactionReceipt>() );
+            listener.onBlock(genesis, new ArrayList<>() );
             repository.dumpState(genesis, 0, 0, null);
 
             logger.info("Genesis block loaded");
         } else {
             BlockDifficulty totalDifficulty = blockStore.getTotalDifficultyForHash(bestBlock.getHash().getBytes());
-
-            blockchain.setBestBlock(bestBlock);
-            blockchain.setTotalDifficulty(totalDifficulty);
+            blockchain.setStatus(bestBlock, totalDifficulty);
 
             logger.info("*** Loaded up to block [{}] totalDifficulty [{}] with stateRoot [{}]",
                     blockchain.getBestBlock().getNumber(),

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
@@ -153,8 +153,7 @@ public class BlockChainImplTest {
         BlockChainImpl blockChain = createBlockChain();
         Block genesis = BlockChainImplTest.getGenesisBlock(blockChain);
 
-        blockChain.setBestBlock(genesis);
-        blockChain.setTotalDifficulty(genesis.getCumulativeDifficulty());
+        blockChain.setStatus(genesis, genesis.getCumulativeDifficulty());
         BlockChainStatus status = blockChain.getStatus();
 
         Assert.assertNotNull(status);

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
@@ -306,8 +306,7 @@ public class NodeBlockProcessorTest {
         Assert.assertTrue(processor.hasBetterBlockToSync());
         Assert.assertTrue(processor.hasBetterBlockToSync());
 
-        blockchain.setBestBlock(block);
-        blockchain.setTotalDifficulty(new BlockDifficulty(BigInteger.valueOf(30)));
+        blockchain.setStatus(block, new BlockDifficulty(BigInteger.valueOf(30)));
 
         Assert.assertFalse(processor.hasBetterBlockToSync());
         Assert.assertFalse(processor.hasBetterBlockToSync());

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -183,9 +183,7 @@ public class BlockChainBuilder {
 
             this.genesis.setStateRoot(this.repository.getRoot());
             this.genesis.flushRLP();
-            blockChain.setBestBlock(this.genesis);
-
-            blockChain.setTotalDifficulty(this.genesis.getCumulativeDifficulty());
+            blockChain.setStatus(this.genesis, this.genesis.getCumulativeDifficulty());
         }
 
         if (this.blocks != null) {

--- a/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -119,9 +119,7 @@ public class ImportLightTest {
         genesis.flushRLP();
 
         blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
-
-        blockchain.setBestBlock(genesis);
-        blockchain.setTotalDifficulty(genesis.getCumulativeDifficulty());
+        blockchain.setStatus(genesis, genesis.getCumulativeDifficulty());
 
         return blockchain;
     }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -144,9 +144,7 @@ public class TestRunner {
         )));
 
         blockchain.setNoValidation(true);
-
-        blockchain.setBestBlock(genesis);
-        blockchain.setTotalDifficulty(genesis.getCumulativeDifficulty());
+        blockchain.setStatus(genesis, genesis.getCumulativeDifficulty());
 
         /* 2 */ // Create block traffic list
         List<Block> blockTraffic = new ArrayList<>();

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.bouncycastle.util.encoders.Hex;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -151,7 +152,7 @@ public class StateTestRunner {
         block.setStateRoot(repository.getRoot());
         block.flushRLP();
 
-        blockchain.setBestBlock(block);
+        blockchain.setStatus(block, block.getCumulativeDifficulty());
         //blockchain.setProgramInvokeFactory(invokeFactory);
         //blockchain.startTracking();
 

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -52,7 +52,7 @@ public class ContractRunner {
         Block block = new BlockBuilder(blockchain, new BlockGenerator())
                 .gasLimit(BigInteger.valueOf(10_000_000))
                 .build();
-        blockchain.setBestBlock(block);
+        blockchain.setStatus(block, block.getCumulativeDifficulty());
         // create a test sender account with a large balance for running any contract
         this.sender = new AccountBuilder(blockchain)
                 .name("sender")

--- a/rskj-core/src/test/java/org/ethereum/util/RskTestFactory.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RskTestFactory.java
@@ -63,8 +63,8 @@ public class RskTestFactory {
         Genesis genesis = new BlockGenerator().getGenesisBlock();
         genesis.setStateRoot(getRepository().getRoot());
         genesis.flushRLP();
-        getBlockchain().setBestBlock(genesis);
-        getBlockchain().setTotalDifficulty(genesis.getCumulativeDifficulty());
+        BlockChainImpl blockchain = getBlockchain();
+        blockchain.setStatus(genesis, genesis.getCumulativeDifficulty());
     }
 
     public ProgramResult executeRawContract(byte[] bytecode, byte[] encodedCall, BigInteger value) {


### PR DESCRIPTION
In order to have a cleaner and safer interface for blockchain we need to remove methods that allow changing it's internal state. This is a first step towards that direction.