### PR TITLE
Txpool module json responses

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/Web3TxPoolModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3TxPoolModule.java
@@ -19,18 +19,19 @@
 package co.rsk.rpc;
 
 import co.rsk.rpc.modules.txpool.TxPoolModule;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public interface Web3TxPoolModule {
 
-    default String txpool_content() {
+    default JsonNode txpool_content() {
         return getTxPoolModule().content();
     }
 
-    default String txpool_inspect() {
+    default JsonNode txpool_inspect() {
         return getTxPoolModule().inspect();
     }
 
-    default String txpool_status() {
+    default JsonNode txpool_status() {
         return getTxPoolModule().status();
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/txpool/TxPoolModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/txpool/TxPoolModule.java
@@ -18,9 +18,11 @@
 
 package co.rsk.rpc.modules.txpool;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public interface TxPoolModule {
 
-    String content();
-    String inspect();
-    String status();
+    JsonNode content();
+    JsonNode inspect();
+    JsonNode status();
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/txpool/TxPoolModuleImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/txpool/TxPoolModuleImpl.java
@@ -23,13 +23,17 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.ethereum.core.TransactionPool;
 import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.rpc.TypeConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 @Component
@@ -84,17 +88,19 @@ public class TxPoolModuleImpl implements TxPoolModule {
 
     private JsonNode fullSerializer(Transaction tx) {
         ObjectNode txNode = jsonNodeFactory.objectNode();
-        txNode.put("blockhash", "0x0000000000000000000000000000000000000000000000000000000000000000");
-        txNode.putNull("blocknumber");
-        txNode.put("from", tx.getSender().toString());
-        txNode.put("gas", tx.getGasLimitAsInteger().toString());
-        txNode.put("gasPrice", tx.getGasPrice().toString());
-        txNode.put("hash", tx.getHash().toHexString());
-        txNode.put("input", tx.getData());
-        txNode.put("nonce", tx.getNonceAsInteger().toString());
-        txNode.put("to", tx.getReceiveAddress().toString());
+
+        txNode.put("blockHash", "0x0000000000000000000000000000000000000000000000000000000000000000");
+        txNode.putNull("blockNumber");
         txNode.putNull("transactionIndex");
-        txNode.put("value", tx.getValue().toString());
+
+        txNode.put("from", TypeConverter.toJsonHex(tx.getSender().getBytes()));
+        txNode.put("gas", TypeConverter.toJsonHex(tx.getGasLimitAsInteger()));
+        txNode.put("gasPrice", TypeConverter.toJsonHex(tx.getGasPrice().getBytes()));
+        txNode.put("hash", TypeConverter.toJsonHex(tx.getHash().toHexString()));
+        txNode.put("input", TypeConverter.toJsonHex(tx.getData()));
+        txNode.put("nonce", TypeConverter.toJsonHex(tx.getNonceAsInteger()));
+        txNode.put("to", TypeConverter.toJsonHex(tx.getReceiveAddress().getBytes()));
+        txNode.put("value", TypeConverter.toJsonHex(tx.getValue().getBytes()));
 
         return txNode;
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/txpool/TxPoolModuleImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/txpool/TxPoolModuleImpl.java
@@ -54,14 +54,14 @@ public class TxPoolModuleImpl implements TxPoolModule {
      * "{"pending": {}, "queued": {}}"
      */
     @Override
-    public String content() {
+    public JsonNode content() {
         Map<String, JsonNode> contentProps = new HashMap<>();
         Map<RskAddress, Map<BigInteger, List<Transaction>>> pendingGrouped = groupTransactions(transactionPool.getPendingTransactions());
         Map<RskAddress, Map<BigInteger, List<Transaction>>> queuedGrouped = groupTransactions(transactionPool.getQueuedTransactions());
         contentProps.put(PENDING, serializeTransactions(pendingGrouped, this::fullSerializer));
         contentProps.put(QUEUED, serializeTransactions(queuedGrouped, this::fullSerializer));
         JsonNode node = jsonNodeFactory.objectNode().setAll(contentProps);
-        return node.toString();
+        return node;
     }
 
     private JsonNode serializeTransactions(
@@ -137,14 +137,14 @@ public class TxPoolModuleImpl implements TxPoolModule {
      * "{"pending": {}, "queued": {}}"
      */
     @Override
-    public String inspect() {
+    public JsonNode inspect() {
         Map<String, JsonNode> contentProps = new HashMap<>();
         Map<RskAddress, Map<BigInteger, List<Transaction>>> pendingGrouped = groupTransactions(transactionPool.getPendingTransactions());
         Map<RskAddress, Map<BigInteger, List<Transaction>>> queuedGrouped = groupTransactions(transactionPool.getQueuedTransactions());
         contentProps.put(PENDING, serializeTransactions(pendingGrouped, this::summarySerializer));
         contentProps.put(QUEUED, serializeTransactions(queuedGrouped, this::summarySerializer));
         JsonNode node = jsonNodeFactory.objectNode().setAll(contentProps);
-        return node.toString();
+        return node;
     }
 
     /**
@@ -155,11 +155,11 @@ public class TxPoolModuleImpl implements TxPoolModule {
      * "{"pending": 0, "queued": 0}"
      */
     @Override
-    public String status() {
+    public JsonNode status() {
         Map<String, JsonNode> txProps = new HashMap<>();
         txProps.put(PENDING, jsonNodeFactory.numberNode(transactionPool.getPendingTransactions().size()));
         txProps.put(QUEUED, jsonNodeFactory.numberNode(transactionPool.getQueuedTransactions().size()));
         JsonNode node = jsonNodeFactory.objectNode().setAll(txProps);
-        return node.toString();
+        return node;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/txpool/TxPoolModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/txpool/TxPoolModuleImplTest.java
@@ -24,11 +24,11 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionPool;
+import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.Web3Mocks;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -368,28 +368,28 @@ public class TxPoolModuleImplTest {
     }
 
     private void assertFullTransaction(Transaction tx, JsonNode transactionNode) {
-        Assert.assertTrue(transactionNode.has("blockhash"));
-        Assert.assertEquals(transactionNode.get("blockhash").asText(), "0x0000000000000000000000000000000000000000000000000000000000000000");
-        Assert.assertTrue(transactionNode.has("blocknumber"));
-        Assert.assertEquals(transactionNode.get("blocknumber"), jsonNodeFactory.nullNode());
+        Assert.assertTrue(transactionNode.has("blockHash"));
+        Assert.assertEquals(transactionNode.get("blockHash").asText(), "0x0000000000000000000000000000000000000000000000000000000000000000");
+        Assert.assertTrue(transactionNode.has("blockNumber"));
+        Assert.assertEquals(transactionNode.get("blockNumber"), jsonNodeFactory.nullNode());
         Assert.assertTrue(transactionNode.has("from"));
-        Assert.assertEquals(transactionNode.get("from").asText(), tx.getSender().toString());
+        Assert.assertEquals(transactionNode.get("from").asText(), TypeConverter.toJsonHex(tx.getSender().getBytes()));
         Assert.assertTrue(transactionNode.has("gas"));
-        Assert.assertEquals(transactionNode.get("gas").asText(), tx.getGasLimitAsInteger().toString());
+        Assert.assertEquals(transactionNode.get("gas").asText(), TypeConverter.toJsonHex(tx.getGasLimitAsInteger()));
         Assert.assertTrue(transactionNode.has("gasPrice"));
-        Assert.assertEquals(transactionNode.get("gasPrice").asText(), tx.getGasPrice().toString());
+        Assert.assertEquals(transactionNode.get("gasPrice").asText(), TypeConverter.toJsonHex(tx.getGasPrice().getBytes()));
         Assert.assertTrue(transactionNode.has("hash"));
-        Assert.assertEquals(transactionNode.get("hash").asText(), tx.getHash().toHexString());
+        Assert.assertEquals(transactionNode.get("hash").asText(), TypeConverter.toJsonHex(tx.getHash().toHexString()));
         Assert.assertTrue(transactionNode.has("input"));
-        Assert.assertEquals(transactionNode.get("input").asText(), Hex.toHexString(tx.getData()));
+        Assert.assertEquals(transactionNode.get("input").asText(), TypeConverter.toJsonHex(tx.getData()));
         Assert.assertTrue(transactionNode.has("nonce"));
-        Assert.assertEquals(transactionNode.get("nonce").asText(), tx.getNonceAsInteger().toString());
+        Assert.assertEquals(transactionNode.get("nonce").asText(), TypeConverter.toJsonHex(tx.getNonceAsInteger()));
         Assert.assertTrue(transactionNode.has("to"));
-        Assert.assertEquals(transactionNode.get("to").asText(), tx.getReceiveAddress().toString());
+        Assert.assertEquals(transactionNode.get("to").asText(), TypeConverter.toJsonHex(tx.getReceiveAddress().getBytes()));
         Assert.assertTrue(transactionNode.has("transactionIndex"));
         Assert.assertEquals(transactionNode.get("transactionIndex"), jsonNodeFactory.nullNode());
         Assert.assertTrue(transactionNode.has("value"));
-        Assert.assertEquals(transactionNode.get("value").asText(), tx.getValue().toString());
+        Assert.assertEquals(transactionNode.get("value").asText(), TypeConverter.toJsonHex(tx.getValue().getBytes()));
     }
 
     private void assertSummaryTransaction(Transaction tx, JsonNode summaryNode) {

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/txpool/TxPoolModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/txpool/TxPoolModuleImplTest.java
@@ -20,11 +20,10 @@ package co.rsk.rpc.modules.txpool;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.ethereum.core.Account;
-import org.ethereum.core.TransactionPool;
 import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionPool;
 import org.ethereum.rpc.Web3Mocks;
 import org.junit.Assert;
 import org.junit.Before;
@@ -94,27 +93,21 @@ public class TxPoolModuleImplTest {
 
     @Test
     public void txpool_content_basic() throws IOException {
-        String result = txPoolModule.content();
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.content();
         checkFieldIsObject(node,"pending");
         checkFieldIsObject(node,"queued");
     }
 
     @Test
     public void txpool_inspect_basic() throws IOException {
-        String result = txPoolModule.inspect();
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.inspect();
         checkFieldIsObject(node,"pending");
         checkFieldIsObject(node,"queued");
     }
 
     @Test
     public void txpool_status_basic() throws IOException {
-        String result = txPoolModule.status();
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.status();
         checkFieldIsNumber(node,"pending");
         checkFieldIsNumber(node,"queued");
     }
@@ -123,10 +116,7 @@ public class TxPoolModuleImplTest {
     public void txpool_content_oneTx() throws Exception {
         Transaction tx = createSampleTransaction();
         when(transactionPool.getPendingTransactions()).thenReturn(Collections.singletonList(tx));
-        String result = txPoolModule.content();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.content();
 
         checkFieldIsEmpty(node, "queued");
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
@@ -139,10 +129,7 @@ public class TxPoolModuleImplTest {
     public void txpool_inspect_oneTx() throws Exception {
         Transaction tx = createSampleTransaction();
         when(transactionPool.getPendingTransactions()).thenReturn(Collections.singletonList(tx));
-        String result = txPoolModule.inspect();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.inspect();
 
         checkFieldIsEmpty(node, "queued");
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
@@ -158,10 +145,7 @@ public class TxPoolModuleImplTest {
         Transaction tx3 = createSampleTransaction();
         List<Transaction> transactions = Arrays.asList(tx1, tx2, tx3);
         when(transactionPool.getPendingTransactions()).thenReturn(transactions);
-        String result = txPoolModule.content();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.content();
 
         checkFieldIsEmpty(node, "queued");
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
@@ -183,10 +167,7 @@ public class TxPoolModuleImplTest {
         Transaction tx3 = createSampleTransaction();
         List<Transaction> transactions = Arrays.asList(tx1, tx2, tx3);
         when(transactionPool.getPendingTransactions()).thenReturn(transactions);
-        String result = txPoolModule.inspect();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.inspect();
 
         checkFieldIsEmpty(node, "queued");
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
@@ -213,10 +194,7 @@ public class TxPoolModuleImplTest {
         List<Transaction> txs = Arrays.asList(tx4, tx5);
         when(transactionPool.getPendingTransactions()).thenReturn(transactions);
         when(transactionPool.getQueuedTransactions()).thenReturn(txs);
-        String result = txPoolModule.content();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.content();
 
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
         JsonNode queuedNode = checkFieldIsObject(node, "queued");
@@ -237,10 +215,7 @@ public class TxPoolModuleImplTest {
         List<Transaction> txs = Arrays.asList(tx4, tx5);
         when(transactionPool.getPendingTransactions()).thenReturn(transactions);
         when(transactionPool.getQueuedTransactions()).thenReturn(txs);
-        String result = txPoolModule.inspect();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.inspect();
 
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
         JsonNode queuedNode = checkFieldIsObject(node, "queued");
@@ -264,10 +239,7 @@ public class TxPoolModuleImplTest {
         List<Transaction> txs = Arrays.asList(tx7, tx8, tx6);
         when(transactionPool.getPendingTransactions()).thenReturn(transactions);
         when(transactionPool.getQueuedTransactions()).thenReturn(txs);
-        String result = txPoolModule.content();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.content();
 
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
         JsonNode queuedNode = checkFieldIsObject(node, "queued");
@@ -291,10 +263,7 @@ public class TxPoolModuleImplTest {
         List<Transaction> txs = Arrays.asList(tx7, tx8, tx6);
         when(transactionPool.getPendingTransactions()).thenReturn(transactions);
         when(transactionPool.getQueuedTransactions()).thenReturn(txs);
-        String result = txPoolModule.inspect();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.inspect();
 
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
         JsonNode queuedNode = checkFieldIsObject(node, "queued");
@@ -307,10 +276,7 @@ public class TxPoolModuleImplTest {
     public void txpool_status_oneTx() throws Exception {
         Transaction tx = createSampleTransaction();
         when(transactionPool.getPendingTransactions()).thenReturn(Collections.singletonList(tx));
-        String result = txPoolModule.status();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.status();
 
         JsonNode queuedNode = checkFieldIsNumber(node, "queued");
         JsonNode pendingNode = checkFieldIsNumber(node, "pending");
@@ -325,10 +291,7 @@ public class TxPoolModuleImplTest {
         Transaction tx3 = createSampleTransaction();
         List<Transaction> transactions = Arrays.asList(tx1, tx2, tx3);
         when(transactionPool.getPendingTransactions()).thenReturn(transactions);
-        String result = txPoolModule.status();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.status();
 
         JsonNode queuedNode = checkFieldIsNumber(node, "queued");
         JsonNode pendingNode = checkFieldIsNumber(node, "pending");
@@ -347,10 +310,7 @@ public class TxPoolModuleImplTest {
 
         when(transactionPool.getPendingTransactions()).thenReturn(transactions);
         when(transactionPool.getQueuedTransactions()).thenReturn(txs);
-        String result = txPoolModule.status();
-
-        ObjectMapper om = new ObjectMapper();
-        JsonNode node = om.reader().forType(JsonNode.class).readValue(result);
+        JsonNode node = txPoolModule.status();
 
         JsonNode queuedNode = checkFieldIsNumber(node, "queued");
         JsonNode pendingNode = checkFieldIsNumber(node, "pending");


### PR DESCRIPTION
Addresses #689.

* Fix escaped-string response by returning a Jackson `JsonNode` object instead of a String
* Fix serialization issues through the use of the `TypeConverter` class