### PR TITLE
Fix corner case when loading the genesis

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
@@ -161,6 +161,9 @@ public class BlockChainLoader {
             BlockDifficulty totalDifficulty = blockStore.getTotalDifficultyForHash(bestBlock.getHash().getBytes());
             blockchain.setStatus(bestBlock, totalDifficulty);
 
+            // we need to do this because when bestBlock == null we touch the genesis' state root
+            genesis.setStateRoot(repository.getSnapshotTo(genesis.getStateRoot()).getRoot());
+
             logger.info("*** Loaded up to block [{}] totalDifficulty [{}] with stateRoot [{}]",
                     blockchain.getBestBlock().getNumber(),
                     blockchain.getTotalDifficulty().toString(),


### PR DESCRIPTION
This fixes a bug that loaded a wrong genesis block when the node already had a database (i.e not a fresh start).

This regression was introduced in #765.