### PR TITLE
btc block header length 80-byte

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -91,7 +91,7 @@ public class BlockHeader {
      * With the exception of the genesis block, this must be 32 bytes or fewer */
     private byte[] extraData;
 
-    /* The 81-byte bitcoin block header for merged mining */
+    /* The 80-byte bitcoin block header for merged mining */
     private byte[] bitcoinMergedMiningHeader;
     /* The bitcoin merkle proof of coinbase tx for merged mining */
     private byte[] bitcoinMergedMiningMerkleProof;

--- a/rskj-core/src/test/java/co/rsk/core/FreeBlockHeader.java
+++ b/rskj-core/src/test/java/co/rsk/core/FreeBlockHeader.java
@@ -67,7 +67,7 @@ public class FreeBlockHeader {
     * With the exception of the genesis block, this must be 32 bytes or fewer */
     private byte[] extraData;
 
-    /* The 81-byte bitcoin block header for merged mining */
+    /* The 80-byte bitcoin block header for merged mining */
     private byte[] bitcoinMergedMiningHeader;
     /* The bitcoin merkle proof of coinbase tx for merged mining */
     private byte[] bitcoinMergedMiningMerkleProof;


### PR DESCRIPTION
The bitcoin block header for merged mining is 80 bytes