### PR TITLE
RFS-258 - Make receiveHeaders method public

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -371,6 +371,10 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         }
     }
 
+    public boolean receiveHeadersIsPublic() {
+        return blockchainConfig.isRskipPublicReceiveHeaders();
+    }
+
     public long receiveHeadersGetCost(Object[] args) {
         // Old, private method fixed cost. Only applies before the corresponding RSKIP
         if (!blockchainConfig.isRskipPublicReceiveHeaders()) {
@@ -1020,7 +1024,6 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return bridgeSupport.getFeePerKb().getValue();
     }
 
-
     public static BridgeMethods.BridgeMethodExecutor activeAndRetiringFederationOnly(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {
         return (self, args) -> {
             Federation retiringFederation = self.bridgeSupport.getRetiringFederation();
@@ -1034,6 +1037,21 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
             return decoratee.execute(self, args);
         };
     }
+
+    public static BridgeMethods.BridgeMethodExecutor executeIfElse(
+            BridgeMethods.BridgeCondition condition,
+            BridgeMethods.BridgeMethodExecutor ifTrue,
+            BridgeMethods.BridgeMethodExecutor ifFalse) {
+
+        return (self, args) -> {
+            if (condition.isTrue(self)) {
+                return ifTrue.execute(self, args);
+            } else {
+                return ifFalse.execute(self, args);
+            }
+        };
+    }
+
 
     private boolean isLocalCall() {
         return rskTx.isLocalCallTransaction();

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -229,10 +229,10 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         Long functionCost;
         Long totalCost;
         if (bridgeParsedData == null) {
-            functionCost = BridgeMethods.RELEASE_BTC.getCost();
+            functionCost = BridgeMethods.RELEASE_BTC.getCost(this, blockchainConfig, new Object[0]);
             totalCost = functionCost;
         } else {
-            functionCost = bridgeParsedData.bridgeMethod.getCost();
+            functionCost = bridgeParsedData.bridgeMethod.getCost(this, blockchainConfig, bridgeParsedData.args);
             int dataCost = data == null ? 0 : data.length * 2;
 
             totalCost = functionCost + dataCost;
@@ -369,6 +369,19 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
             logger.warn("Exception onBlock", e);
             throw new RuntimeException("Exception onBlock", e);
         }
+    }
+
+    public long receiveHeadersGetCost(Object[] args) {
+        // Old, private method fixed cost. Only applies before the corresponding RSKIP
+        if (!blockchainConfig.isRskipPublicReceiveHeaders()) {
+            return 22000L;
+        }
+
+        // Dynamic cost based on the number of headers
+        // TODO: define and implement this. At the moment the cost is set to a higher fixed value
+        // TODO: plus the number of headers actually received times 100
+        final int numberOfHeaders = ((Object[]) args[0]).length;
+        return 100_000L + numberOfHeaders * 100;
     }
 
     public void receiveHeaders(Object[] args)

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -454,7 +454,11 @@ public enum BridgeMethods {
                     new String[]{}
             ),
             fromMethod(Bridge::receiveHeadersGetCost),
-            Bridge.activeAndRetiringFederationOnly((BridgeMethodExecutorVoid) Bridge::receiveHeaders, "receiveHeaders"),
+            Bridge.executeIfElse(
+                    Bridge::receiveHeadersIsPublic,
+                    (BridgeMethodExecutorVoid) Bridge::receiveHeaders,
+                    Bridge.activeAndRetiringFederationOnly((BridgeMethodExecutorVoid) Bridge::receiveHeaders, "receiveHeaders")
+            ),
             false
     ),
     REGISTER_BTC_TRANSACTION(
@@ -588,6 +592,10 @@ public enum BridgeMethods {
 
     public boolean onlyAllowsLocalCalls() {
         return onlyAllowsLocalCalls;
+    }
+
+    public interface BridgeCondition {
+        boolean isTrue(Bridge bridge);
     }
 
     public interface BridgeMethodExecutor {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -37,7 +37,7 @@ public enum BridgeMethods {
                     new String[]{"bytes"},
                     new String[]{"int256"}
             ),
-            13000L,
+            fixedCost(13000L),
             (BridgeMethodExecutorTyped) Bridge::addFederatorPublicKey,
             blockchainConfig -> !blockchainConfig.isRskipMultipleKeyFederateMembers(),
             false
@@ -48,7 +48,7 @@ public enum BridgeMethods {
                     new String[]{"bytes", "bytes", "bytes"},
                     new String[]{"int256"}
             ),
-            13000L,
+            fixedCost(13000L),
             (BridgeMethodExecutorTyped) Bridge::addFederatorPublicKeyMultikey,
             blockchainConfig -> blockchainConfig.isRskipMultipleKeyFederateMembers(),
             false
@@ -59,7 +59,7 @@ public enum BridgeMethods {
                     new String[]{"string", "int256"},
                     new String[]{"int256"}
             ),
-            25000L,
+            fixedCost(25000L),
             (BridgeMethodExecutorTyped) Bridge::addOneOffLockWhitelistAddress,
             blockChainConfig -> !blockChainConfig.isRskip87(),
             false
@@ -70,7 +70,7 @@ public enum BridgeMethods {
                     new String[]{"string", "int256"},
                     new String[]{"int256"}
             ),
-            25000L, // using same gas estimation as ADD_LOCK_WHITELIST_ADDRESS
+            fixedCost(25000L), // using same gas estimation as ADD_LOCK_WHITELIST_ADDRESS
             (BridgeMethodExecutorTyped) Bridge::addOneOffLockWhitelistAddress,
             blockChainConfig -> blockChainConfig.isRskip87(),
             false
@@ -81,7 +81,7 @@ public enum BridgeMethods {
                     new String[]{"string"},
                     new String[]{"int256"}
             ),
-            25000L, // using same gas estimation as ADD_LOCK_WHITELIST_ADDRESS
+            fixedCost(25000L), // using same gas estimation as ADD_LOCK_WHITELIST_ADDRESS
             (BridgeMethodExecutorTyped) Bridge::addUnlimitedLockWhitelistAddress,
             blockChainConfig -> blockChainConfig.isRskip87(),
             false
@@ -92,7 +92,7 @@ public enum BridgeMethods {
                     new String[]{"bytes", "bytes[]", "bytes"},
                     new String[]{}
             ),
-            70000L,
+            fixedCost(70000L),
             Bridge.activeAndRetiringFederationOnly((BridgeMethodExecutorVoid) Bridge::addSignature, "addSignature"),
             false
     ),
@@ -102,7 +102,7 @@ public enum BridgeMethods {
                     new String[]{"bytes"},
                     new String[]{"int256"}
             ),
-            38000L,
+            fixedCost(38000L),
             (BridgeMethodExecutorTyped) Bridge::commitFederation,
             false
     ),
@@ -112,7 +112,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            11000L,
+            fixedCost(11000L),
             (BridgeMethodExecutorTyped) Bridge::createFederation,
             false
     ),
@@ -122,7 +122,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int"}
             ),
-            19000L,
+            fixedCost(19000L),
             (BridgeMethodExecutorTyped) Bridge::getBtcBlockchainBestChainHeight,
             true
     ),
@@ -132,7 +132,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int"}
             ),
-            20000L,
+            fixedCost(20000L),
             (BridgeMethodExecutorTyped) Bridge::getBtcBlockchainInitialBlockHeight,
             blockchainConfig -> blockchainConfig.isRskip89(),
             true
@@ -143,7 +143,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"string[]"}
             ),
-            76000L,
+            fixedCost(76000L),
             (BridgeMethodExecutorTyped) Bridge::getBtcBlockchainBlockLocator,
             blockchainConfig -> !blockchainConfig.isRskip89(),
             true
@@ -154,7 +154,7 @@ public enum BridgeMethods {
                     new String[]{"int256"},
                     new String[]{"bytes"}
             ),
-            20000L,
+            fixedCost(20000L),
             (BridgeMethodExecutorTyped) Bridge::getBtcBlockchainBlockHashAtDepth,
             blockchainConfig -> blockchainConfig.isRskip89(),
             true
@@ -165,7 +165,7 @@ public enum BridgeMethods {
                     new String[]{"bytes32", "bytes32", "uint256", "bytes32[]"},
                     new String[]{"int256"}
             ),
-            22000L, //TODO ESTIMATE GAS
+            fixedCost(22000L), //TODO ESTIMATE GAS
             (BridgeMethodExecutorTyped) Bridge::getBtcTransactionConfirmations,
             blockchainConfig -> blockchainConfig.isRskipGetBtcTransactionConfirmations(),
             false
@@ -176,7 +176,7 @@ public enum BridgeMethods {
                     new String[]{"string"},
                     new String[]{"int64"}
             ),
-            22000L,
+            fixedCost(22000L),
             (BridgeMethodExecutorTyped) Bridge::getBtcTxHashProcessedHeight,
             true
     ),
@@ -186,7 +186,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"string"}
             ),
-            11000L,
+            fixedCost(11000L),
             (BridgeMethodExecutorTyped) Bridge::getFederationAddress,
             true
     ),
@@ -196,7 +196,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            10000L,
+            fixedCost(10000L),
             (BridgeMethodExecutorTyped) Bridge::getFederationCreationBlockNumber,
             true
     ),
@@ -206,7 +206,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            10000L,
+            fixedCost(10000L),
             (BridgeMethodExecutorTyped) Bridge::getFederationCreationTime,
             true
     ),
@@ -216,7 +216,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            10000L,
+            fixedCost(10000L),
             (BridgeMethodExecutorTyped) Bridge::getFederationSize,
             true
     ),
@@ -226,7 +226,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            11000L,
+            fixedCost(11000L),
             (BridgeMethodExecutorTyped) Bridge::getFederationThreshold,
             true
     ),
@@ -236,7 +236,7 @@ public enum BridgeMethods {
                     new String[]{"int256"},
                     new String[]{"bytes"}
             ),
-            10000L,
+            fixedCost(10000L),
             (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKey,
             blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
@@ -247,7 +247,7 @@ public enum BridgeMethods {
                     new String[]{"int256", "string"},
                     new String[]{"bytes"}
             ),
-            10000L,
+            fixedCost(10000L),
             (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKeyOfType,
             blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
@@ -258,7 +258,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            2000L,
+            fixedCost(2000L),
             (BridgeMethodExecutorTyped) Bridge::getFeePerKb,
             true
     ),
@@ -268,7 +268,7 @@ public enum BridgeMethods {
                     new String[]{"int256"},
                     new String[]{"string"}
             ),
-            16000L,
+            fixedCost(16000L),
             (BridgeMethodExecutorTyped) Bridge::getLockWhitelistAddress,
             true
     ),
@@ -278,7 +278,7 @@ public enum BridgeMethods {
                     new String[]{"string"},
                     new String[]{"int256"}
             ),
-            16000L,
+            fixedCost(16000L),
             (BridgeMethodExecutorTyped) Bridge::getLockWhitelistEntryByAddress,
             blockchainConfig -> blockchainConfig.isRskip87(),
             true
@@ -289,7 +289,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            16000L,
+            fixedCost(16000L),
             (BridgeMethodExecutorTyped) Bridge::getLockWhitelistSize,
             true
     ),
@@ -299,7 +299,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int"}
             ),
-            2000L,
+            fixedCost(2000L),
             (BridgeMethodExecutorTyped) Bridge::getMinimumLockTxValue,
             true
     ),
@@ -309,7 +309,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"bytes"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getPendingFederationHash,
             true
     ),
@@ -319,7 +319,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getPendingFederationSize,
             true
     ),
@@ -329,7 +329,7 @@ public enum BridgeMethods {
                     new String[]{"int256"},
                     new String[]{"bytes"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKey,
             blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
@@ -340,7 +340,7 @@ public enum BridgeMethods {
                     new String[]{"int256", "string"},
                     new String[]{"bytes"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKeyOfType,
             blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
@@ -351,7 +351,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"string"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederationAddress,
             true
     ),
@@ -361,7 +361,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederationCreationBlockNumber,
             true
     ),
@@ -371,7 +371,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederationCreationTime,
             true
     ),
@@ -381,7 +381,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederationSize,
             true
     ),
@@ -391,7 +391,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederationThreshold,
             true
     ),
@@ -401,7 +401,7 @@ public enum BridgeMethods {
                     new String[]{"int256"},
                     new String[]{"bytes"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKey,
             blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
@@ -412,7 +412,7 @@ public enum BridgeMethods {
                     new String[]{"int256", "string"},
                     new String[]{"bytes"}
             ),
-            3000L,
+            fixedCost(3000L),
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKeyOfType,
             blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
@@ -423,7 +423,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"bytes"}
             ),
-            4000L,
+            fixedCost(4000L),
             (BridgeMethodExecutorTyped) Bridge::getStateForBtcReleaseClient,
             true
     ),
@@ -433,7 +433,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"bytes"}
             ),
-            3_000_000L,
+            fixedCost(3_000_000L),
             (BridgeMethodExecutorTyped) Bridge::getStateForDebugging,
             true
     ),
@@ -443,7 +443,7 @@ public enum BridgeMethods {
                     new String[]{"string"},
                     new String[]{"bool"}
             ),
-            23000L,
+            fixedCost(23000L),
             (BridgeMethodExecutorTyped) Bridge::isBtcTxHashAlreadyProcessed,
             true
     ),
@@ -453,7 +453,7 @@ public enum BridgeMethods {
                     new String[]{"bytes[]"},
                     new String[]{}
             ),
-            22000L,
+            fromMethod(Bridge::receiveHeadersGetCost),
             Bridge.activeAndRetiringFederationOnly((BridgeMethodExecutorVoid) Bridge::receiveHeaders, "receiveHeaders"),
             false
     ),
@@ -463,7 +463,7 @@ public enum BridgeMethods {
                     new String[]{"bytes", "int", "bytes"},
                     new String[]{}
             ),
-            22000L,
+            fixedCost(22000L),
             Bridge.activeAndRetiringFederationOnly((BridgeMethodExecutorVoid) Bridge::registerBtcTransaction, "registerBtcTransaction"),
             false
     ),
@@ -473,7 +473,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{}
             ),
-            23000L,
+            fixedCost(23000L),
             (BridgeMethodExecutorVoid) Bridge::releaseBtc,
             false
     ),
@@ -483,7 +483,7 @@ public enum BridgeMethods {
                     new String[]{"string"},
                     new String[]{"int256"}
             ),
-            24000L,
+            fixedCost(24000L),
             (BridgeMethodExecutorTyped) Bridge::removeLockWhitelistAddress,
             false
     ),
@@ -493,7 +493,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{"int256"}
             ),
-            12000L,
+            fixedCost(12000L),
             (BridgeMethodExecutorTyped) Bridge::rollbackFederation,
             false
     ),
@@ -503,7 +503,7 @@ public enum BridgeMethods {
                     new String[]{"int256"},
                     new String[]{"int256"}
             ),
-            24000L,
+            fixedCost(24000L),
             (BridgeMethodExecutorTyped) Bridge::setLockWhitelistDisableBlockDelay,
             false
     ),
@@ -513,7 +513,7 @@ public enum BridgeMethods {
                     new String[]{},
                     new String[]{}
             ),
-            48000L,
+            fixedCost(48000L),
             Bridge.activeAndRetiringFederationOnly((BridgeMethodExecutorVoid) Bridge::updateCollections, "updateCollections"),
             false
     ),
@@ -523,10 +523,26 @@ public enum BridgeMethods {
                     new String[]{"int256"},
                     new String[]{"int256"}
             ),
-            10000L,
+            fixedCost(10000L),
             (BridgeMethodExecutorTyped) Bridge::voteFeePerKbChange,
             false
     );
+
+    private interface CostProvider {
+        long getCost(Bridge bridge, BlockchainConfig config, Object[] args);
+    }
+
+    private interface BridgeCostProvider {
+        long getCost(Bridge bridge, Object[] args);
+    }
+
+    private static CostProvider fixedCost(long cost) {
+        return (Bridge bridge, BlockchainConfig config, Object[] args) -> cost;
+    }
+
+    private static CostProvider fromMethod(BridgeCostProvider bridgeCostProvider) {
+        return (Bridge bridge, BlockchainConfig config, Object[] args) -> bridgeCostProvider.getCost(bridge, args);
+    }
 
     private static final Map<ByteArrayWrapper, BridgeMethods> SIGNATURES = Stream.of(BridgeMethods.values())
                         .collect(Collectors.toMap(
@@ -534,18 +550,18 @@ public enum BridgeMethods {
                             Function.identity()
                         ));
     private final CallTransaction.Function function;
-    private final long cost;
+    private final CostProvider costProvider;
     private final Function<BlockchainConfig, Boolean> isEnabledFunction;
     private final BridgeMethodExecutor executor;
     private final boolean onlyAllowsLocalCalls;
 
-    BridgeMethods(CallTransaction.Function function, long cost, BridgeMethodExecutor executor, boolean onlyAllowsLocalCalls) {
-        this(function, cost, executor, blockchainConfig -> Boolean.TRUE, onlyAllowsLocalCalls);
+    BridgeMethods(CallTransaction.Function function, CostProvider costProvider, BridgeMethodExecutor executor, boolean onlyAllowsLocalCalls) {
+        this(function, costProvider, executor, blockchainConfig -> Boolean.TRUE, onlyAllowsLocalCalls);
     }
 
-    BridgeMethods(CallTransaction.Function function, long cost, BridgeMethodExecutor executor, Function<BlockchainConfig, Boolean> isEnabled, boolean onlyAllowsLocalCalls) {
+    BridgeMethods(CallTransaction.Function function, CostProvider costProvider, BridgeMethodExecutor executor, Function<BlockchainConfig, Boolean> isEnabled, boolean onlyAllowsLocalCalls) {
         this.function = function;
-        this.cost = cost;
+        this.costProvider = costProvider;
         this.executor = executor;
         this.isEnabledFunction = isEnabled;
         this.onlyAllowsLocalCalls = onlyAllowsLocalCalls;
@@ -562,8 +578,8 @@ public enum BridgeMethods {
         return this.isEnabledFunction.apply(blockchainConfig);
     }
 
-    public long getCost() {
-        return cost;
+    public long getCost(Bridge bridge, BlockchainConfig config, Object[] args) {
+        return costProvider.getCost(bridge, config, args);
     }
 
     public BridgeMethodExecutor getExecutor() {

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -70,4 +70,6 @@ public interface BlockchainConfig {
     boolean isRskipMultipleKeyFederateMembers();
 
     boolean isRskip106();
+
+    boolean isRskipPublicReceiveHeaders();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
@@ -182,4 +182,9 @@ public abstract class AbstractConfig implements BlockchainConfig, BlockchainNetC
     public boolean isRskip106() {
         return false;
     }
+
+    @Override
+    public boolean isRskipPublicReceiveHeaders() {
+        return false;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
@@ -39,4 +39,9 @@ public class DevNetSecondForkConfig extends DevNetOrchid060Config {
     public boolean isRskip106() {
         return true;
     }
+
+    @Override
+    public boolean isRskipPublicReceiveHeaders() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
@@ -39,4 +39,9 @@ public class MainNetSecondForkConfig extends MainNetOrchid060Config {
     public boolean isRskip106() {
         return true;
     }
+
+    @Override
+    public boolean isRskipPublicReceiveHeaders() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
@@ -39,4 +39,9 @@ public class RegTestSecondForkConfig extends RegTestOrchidConfig {
     public boolean isRskip106() {
         return true;
     }
+
+    @Override
+    public boolean isRskipPublicReceiveHeaders() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
@@ -39,4 +39,9 @@ public class TestNetSecondForkConfig extends TestNetOrchid060Config {
     public boolean isRskip106() {
         return true;
     }
+
+    @Override
+    public boolean isRskipPublicReceiveHeaders() {
+        return true;
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashPerformanceTestCase.java
@@ -19,12 +19,8 @@
 package co.rsk.pcc.bto;
 
 import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.crypto.DeterministicKey;
-import co.rsk.bitcoinj.crypto.HDKeyDerivation;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.config.TestSystemProperties;
-import co.rsk.db.BenchmarkedRepository;
 import co.rsk.peg.performance.CombinedExecutionStats;
 import co.rsk.peg.performance.ExecutionStats;
 import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
@@ -50,21 +46,11 @@ public class GetMultisigScriptHashPerformanceTestCase extends PrecompiledContrac
     public void getMultisigScriptHash() throws IOException {
         function = new GetMultisigScriptHash(null).getFunction();
 
-        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
-            @Override
-            public Environment initialize(int executionIndex, Transaction tx, int height) {
-                BTOUtils contract = new BTOUtils(new TestSystemProperties(), PrecompiledContracts.BTOUTILS_ADDR);
-                contract.init(tx, Helper.getMockBlock(1), null, null, null, null);
+        EnvironmentBuilder environmentBuilder = (int executionIndex, Transaction tx, int height) -> {
+            BTOUtils contract = new BTOUtils(new TestSystemProperties(), PrecompiledContracts.BTOUTILS_ADDR);
+            contract.init(tx, Helper.getMockBlock(1), null, null, null, null);
 
-                return new Environment(
-                        contract,
-                        () -> new BenchmarkedRepository.Statistics()
-                );
-            }
-
-            @Override
-            public void teardown() {
-            }
+            return EnvironmentBuilder.Environment.withContract(contract);
         };
 
         // Get rid of outliers by executing some cases beforehand
@@ -111,7 +97,7 @@ public class GetMultisigScriptHashPerformanceTestCase extends PrecompiledContrac
                 Helper.getZeroValueTxBuilder(new ECKey()),
                 Helper.getRandomHeightProvider(10),
                 stats,
-                (byte[] result) -> {
+                (EnvironmentBuilder.Environment environment, byte[] result) -> {
                     Object[] decodedResult = function.decodeResult(result);
                     Assert.assertEquals(byte[].class, decodedResult[0].getClass());
                     String hexHash = Hex.toHexString((byte[]) decodedResult[0]);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
@@ -95,7 +95,7 @@ public abstract class BridgePerformanceTestCase extends PrecompiledContractPerfo
                 try {
                     block = new BtcBlock(
                             networkParameters,
-                            BtcBlock.BLOCK_VERSION_BIP66,
+                            BtcBlock.BLOCK_VERSION_BIP65,
                             prevBlock.getHash(),
                             merkleRoot,
                             prevBlock.getTimeSeconds() + 10,

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
@@ -21,6 +21,7 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.RskSystemProperties;
+import co.rsk.db.BenchmarkedRepository;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.db.RepositoryTrackWithBenchmarking;
 import co.rsk.db.TrieStorePoolOnMemory;
@@ -164,24 +165,22 @@ public abstract class BridgePerformanceTestCase extends PrecompiledContractPerfo
             }
 
             @Override
-            public Environment initialize(int executionIndex, Transaction tx, int height) {
+            public Environment build(int executionIndex, Transaction tx, int height) {
                 RepositoryImpl repository = createRepositoryImpl(config);
-                Repository track = repository.startTracking();
                 BridgeStorageConfiguration bridgeStorageConfigurationAtThisHeight = BridgeStorageConfiguration.fromBlockchainConfig(config.getBlockchainConfig().getConfigForBlock(executionIndex));
-                BridgeStorageProvider storageProvider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants,bridgeStorageConfigurationAtThisHeight);
 
-                storageInitializer.initialize(storageProvider, track, executionIndex);
-
+                benchmarkerTrack = new RepositoryTrackWithBenchmarking(repository);
+                BridgeStorageProvider storageProvider = new BridgeStorageProvider(benchmarkerTrack, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants,bridgeStorageConfigurationAtThisHeight);
+                storageInitializer.initialize(storageProvider, benchmarkerTrack, executionIndex);
                 try {
                     storageProvider.save();
                 } catch (Exception e) {
                     throw new RuntimeException("Error trying to save the storage after initialization", e);
                 }
-                track.commit();
-
-                List<LogInfo> logs = new ArrayList<>();
+                benchmarkerTrack.commit();
 
                 benchmarkerTrack = new RepositoryTrackWithBenchmarking(repository);
+                List<LogInfo> logs = new ArrayList<>();
 
                 bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
                 Blockchain blockchain = BlockChainBuilder.ofSize(height);
@@ -204,16 +203,23 @@ public abstract class BridgePerformanceTestCase extends PrecompiledContractPerfo
                 tx.setLocalCallTransaction(oldLocalCall);
                 benchmarkerTrack.getStatistics().clear();
 
-                return new Environment(
-                        bridge,
-                        benchmarkerTrack
-                );
-            }
+                return new Environment() {
+                    @Override
+                    public PrecompiledContracts.PrecompiledContract getContract() {
+                        return bridge;
+                    }
 
-            @Override
-            public void teardown() {
-                benchmarkerTrack.commit();
-            }
+                    @Override
+                    public BenchmarkedRepository getBenchmarkedRepository() {
+                        return benchmarkerTrack;
+                    }
+
+                    @Override
+                    public void finalise() {
+                        benchmarkerTrack.commit();
+                    }
+                };
+            };
         };
 
         return super.executeAndAverage(name, times, environmentBuilder, abiEncoder, txBuilder, heightProvider, stats, resultCallback);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
@@ -87,7 +87,7 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
                 Helper.getZeroValueRandomSenderTxBuilder(),
                 Helper.getRandomHeightProvider(10),
                 stats,
-                (executionResult) -> {
+                (EnvironmentBuilder.Environment environment, byte[] executionResult) -> {
                     byte[] res = executionResult;
                     int numberOfConfirmations = new BigInteger(executionResult).intValueExact();
                     Assert.assertEquals(expectedConfirmations, numberOfConfirmations);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/IdentityPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/IdentityPerformanceTestCase.java
@@ -18,7 +18,6 @@
 
 package co.rsk.peg.performance;
 
-import co.rsk.db.BenchmarkedRepository;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
@@ -33,19 +32,8 @@ public class IdentityPerformanceTestCase extends PrecompiledContractPerformanceT
     public void identity() throws IOException {
         ExecutionStats stats = new ExecutionStats("identity");
 
-        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
-            @Override
-            public Environment initialize(int executionIndex, Transaction tx, int height) {
-                return new Environment(
-                        new PrecompiledContracts.Identity(),
-                        () -> new BenchmarkedRepository.Statistics()
-                );
-            }
-
-            @Override
-            public void teardown() {
-            }
-        };
+        EnvironmentBuilder environmentBuilder = (int executionIndex, Transaction tx, int height) ->
+                EnvironmentBuilder.Environment.withContract(new PrecompiledContracts.Identity());
 
         doIdentity(environmentBuilder, stats, 2000);
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
@@ -40,6 +40,21 @@ import java.util.List;
 public class ReceiveHeadersTest extends BridgePerformanceTestCase {
     private BtcBlock lastBlock;
 
+    // This is here for profiling with any external tools (e.g., visualVM)
+    public static void main(String args[]) throws Exception {
+        setupA();
+        setupB();
+        ReceiveHeadersTest test = new ReceiveHeadersTest();
+        test.setupCpuTime();
+
+        System.out.println("Ready\n");
+        System.in.read();
+        System.out.println("Going!\n");
+        test.receiveHeadersSingleBlock();
+
+        test.teardownCpuTime();
+    }
+
     @Test
     public void receiveHeadersSingleBlock() throws IOException {
         setQuietMode(true);
@@ -47,7 +62,6 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
         doReceiveHeaders(100, 1);
         setQuietMode(false);
         System.out.print("Done!\n");
-
 
         ExecutionStats stats = new ExecutionStats("receiveHeaders-singleBlock");
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
@@ -42,10 +42,17 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
 
     @Test
     public void receiveHeadersSingleBlock() throws IOException {
+        setQuietMode(true);
+        System.out.print("Doing a few initial passes... ");
+        doReceiveHeaders(100, 1);
+        setQuietMode(false);
+        System.out.print("Done!\n");
+
+
         ExecutionStats stats = new ExecutionStats("receiveHeaders-singleBlock");
 
         executeAndAverage(
-                "receiveHeaders-singleBlock", 200,
+                "receiveHeaders-singleBlock", 2000,
                 generateABIEncoder(1, 1),
                 buildInitializer(1000, 2000),
                 Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
@@ -21,6 +21,7 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.BtcBlock;
 import co.rsk.bitcoinj.core.BtcBlockChain;
 import co.rsk.bitcoinj.core.Context;
+import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.config.TestSystemProperties;
@@ -29,6 +30,7 @@ import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.RepositoryBlockStore;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -38,7 +40,9 @@ import java.util.List;
 
 @Ignore
 public class ReceiveHeadersTest extends BridgePerformanceTestCase {
+    private BtcBlockStore btcBlockStore;
     private BtcBlock lastBlock;
+    private BtcBlock expectedBestBlock;
 
     // This is here for profiling with any external tools (e.g., visualVM)
     public static void main(String args[]) throws Exception {
@@ -59,7 +63,7 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
     public void receiveHeadersSingleBlock() throws IOException {
         setQuietMode(true);
         System.out.print("Doing a few initial passes... ");
-        doReceiveHeaders(100, 1);
+        doReceiveHeaders(100, 1, 0);
         setQuietMode(false);
         System.out.print("Done!\n");
 
@@ -67,10 +71,11 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
 
         executeAndAverage(
                 "receiveHeaders-singleBlock", 2000,
-                generateABIEncoder(1, 1),
+                generateABIEncoder(1, 1, 0),
                 buildInitializer(1000, 2000),
                 Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
-                Helper.getRandomHeightProvider(10), stats
+                Helper.getRandomHeightProvider(10),
+                stats
         );
 
         BridgePerformanceTest.addStats(stats);
@@ -81,34 +86,74 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
         CombinedExecutionStats stats = new CombinedExecutionStats("receiveHeaders");
 
         for (int i = 1; i <= 500; i++) {
-            stats.add(doReceiveHeaders(10, i));
+            stats.add(doReceiveHeaders(10, i, 0));
         }
 
         BridgePerformanceTest.addStats(stats);
     }
 
-    private ExecutionStats doReceiveHeaders(int times, int numHeaders) {
-        String name = String.format("receiveHeaders-%s", numHeaders);
+    @Test
+    public void receiveHeadersWithForking() throws IOException {
+        setQuietMode(true);
+        doReceiveHeaders(100, 1, 0);
+        setQuietMode(false);
+
+        CombinedExecutionStats stats = new CombinedExecutionStats("receiveHeaders-withForking");
+
+        for (int numHeaders = 1; numHeaders < 10; numHeaders++) {
+            for (int depth = 0; depth <= 10; depth++) {
+                stats.add(doReceiveHeaders(50, numHeaders, depth));
+            }
+        }
+
+        BridgePerformanceTest.addStats(stats);
+    }
+
+    private ExecutionStats doReceiveHeaders(int times, int numHeaders, int forkDepth) {
+        String name = String.format("receiveHeaders-fork-%d-headers-%d", forkDepth, numHeaders);
         ExecutionStats stats = new ExecutionStats(name);
+        int totalHeaders = numHeaders + forkDepth;
         return executeAndAverage(
                 name, times,
-                generateABIEncoder(numHeaders, numHeaders),
+                generateABIEncoder(totalHeaders, totalHeaders, forkDepth),
                 buildInitializer(1000, 2000),
                 Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
-                Helper.getRandomHeightProvider(10), stats
+                Helper.getRandomHeightProvider(10),
+                stats,
+                (EnvironmentBuilder.Environment environment, byte[] result) -> {
+                    btcBlockStore = new RepositoryBlockStore(new TestSystemProperties(), (Repository) environment.getBenchmarkedRepository(), PrecompiledContracts.BRIDGE_ADDR);
+                    Sha256Hash bestBlockHash = null;
+                    try {
+                        bestBlockHash = btcBlockStore.getChainHead().getHeader().getHash();
+                    } catch (BlockStoreException e) {
+                        Assert.fail(e.getMessage());
+                    }
+                    Assert.assertEquals(expectedBestBlock.getHash(), bestBlockHash);
+                }
         );
     }
 
-    private ABIEncoder generateABIEncoder(int minBlocks, int maxBlocks) {
+    private ABIEncoder generateABIEncoder(int minBlocks, int maxBlocks, int forkDepth) {
         return (int executionIndex) -> {
             List<BtcBlock> headersToSendToBridge = new ArrayList<>();
 
             BtcBlock currentBlock = lastBlock;
+            int currentDepth = forkDepth;
+            while (currentDepth-- > 0) {
+                try {
+                    currentBlock = btcBlockStore.get(lastBlock.getPrevBlockHash()).getHeader();
+                } catch (BlockStoreException e) {
+                    throw new RuntimeException("Unexpected error trying to fetch previous block", e);
+                }
+            }
+
             int blocksToGenerate = Helper.randomInRange(minBlocks, maxBlocks);
             for (int i = 0; i < blocksToGenerate; i++) {
                 currentBlock = Helper.generateBtcBlock(currentBlock);
                 headersToSendToBridge.add(currentBlock);
             }
+
+            expectedBestBlock = currentBlock;
 
             Object[] headersEncoded = headersToSendToBridge.stream().map(h -> h.bitcoinSerialize()).toArray();
 
@@ -118,7 +163,7 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
 
     private BridgeStorageProviderInitializer buildInitializer(int minBlocks, int maxBlocks) {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBlockStore(new TestSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
+            btcBlockStore = new RepositoryBlockStore(new TestSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {


### PR DESCRIPTION
This PR does four main things:

1. The Bridge now allows for dynamic gas cost calculation in any of its methods. This feature is used in #3 below.
2. The Bridge method `receiveHeaders` can now be called by anyone (up to now it was only callable by members of either the active or retiring federation). This is programmed as a network update.
3. The Bridge method `receiveHeaders` has now got a dynamic cost calculation, dependant upon the data input. This is also programmed as a network update, under the same flag as #2.
4. The `ReceiveHeadersTest` gas estimation tests were updated to consider different input conditions. This will be used later to come up with a final function to calculate the cost of a call depending on the input. That is, the final cost function will be set in an upcoming PR.
