### PR TITLE
RFS-328 - BTOUtils gas costs

### DIFF
--- a/rskj-core/src/main/java/co/rsk/pcc/bto/DeriveExtendedPublicKey.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/DeriveExtendedPublicKey.java
@@ -109,6 +109,11 @@ public class DeriveExtendedPublicKey extends NativeMethod {
         return false;
     }
 
+    @Override
+    public long getGas(Object[] parsedArguments, byte[] originalData) {
+        return 55_000L;
+    }
+
     private void throwInvalidPath(String path) {
         throw new NativeContractIllegalArgumentException(getInvalidPathErrorMessage(path));
     }

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKey.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKey.java
@@ -74,4 +74,9 @@ public class ExtractPublicKeyFromExtendedPublicKey extends NativeMethod {
     public boolean onlyAllowsLocalCalls() {
         return false;
     }
+
+    @Override
+    public long getGas(Object[] parsedArguments, byte[] originalData) {
+        return 6_800L;
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
@@ -48,8 +48,8 @@ public class GetMultisigScriptHash extends NativeMethod {
     private final static int COMPRESSED_PUBLIC_KEY_LENGTH = 33;
     private final static int UNCOMPRESSED_PUBLIC_KEY_LENGTH = 65;
 
-    private final static int BASE_COST = 13500;
-    private final static int COST_PER_EXTRA_KEY = 500;
+    private final static long BASE_COST = 13_500L;
+    private final static long COST_PER_EXTRA_KEY = 500L;
 
     private final static int MINIMUM_REQUIRED_KEYS = 2;
 
@@ -127,7 +127,7 @@ public class GetMultisigScriptHash extends NativeMethod {
 
         // Base cost is the cost for 2 keys (the minimum).
         // Then a fee is payed per additional key.
-        return BASE_COST + (numberOfKeys - 2)* COST_PER_EXTRA_KEY;
+        return BASE_COST + (numberOfKeys - 2) * COST_PER_EXTRA_KEY;
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
@@ -76,7 +76,7 @@ public class GetMultisigScriptHash extends NativeMethod {
         }
 
         if (publicKeys.length < MINIMUM_REQUIRED_KEYS) {
-            throw new NativeContractIllegalArgumentException("At least two public keys are required");
+            throw new NativeContractIllegalArgumentException(String.format("At least %d public keys are required", MINIMUM_REQUIRED_KEYS));
         }
 
         if (publicKeys.length < minimumSignatures) {

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
@@ -48,9 +48,14 @@ public class GetMultisigScriptHash extends NativeMethod {
     private final static int COMPRESSED_PUBLIC_KEY_LENGTH = 33;
     private final static int UNCOMPRESSED_PUBLIC_KEY_LENGTH = 65;
 
+    private final static int BASE_COST = 13500;
+    private final static int COST_PER_EXTRA_KEY = 500;
+
+    private final static int MINIMUM_REQUIRED_KEYS = 2;
+
     // Enforced by the 520-byte size limit of the redeem script
     // (see https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#520byte_limitation_on_serialized_script_size)
-    private final static int MAXIMUM_ALLOWED_SIGNATURES = 15;
+    private final static int MAXIMUM_ALLOWED_KEYS = 15;
 
     public GetMultisigScriptHash(ExecutionEnvironment executionEnvironment) {
         super(executionEnvironment);
@@ -70,8 +75,8 @@ public class GetMultisigScriptHash extends NativeMethod {
             throw new NativeContractIllegalArgumentException("Minimum required signatures must be greater than zero");
         }
 
-        if (publicKeys.length == 0) {
-            throw new NativeContractIllegalArgumentException("At least one public key is required");
+        if (publicKeys.length < MINIMUM_REQUIRED_KEYS) {
+            throw new NativeContractIllegalArgumentException("At least two public keys are required");
         }
 
         if (publicKeys.length < minimumSignatures) {
@@ -81,10 +86,10 @@ public class GetMultisigScriptHash extends NativeMethod {
             ));
         }
 
-        if (publicKeys.length > MAXIMUM_ALLOWED_SIGNATURES) {
+        if (publicKeys.length > MAXIMUM_ALLOWED_KEYS) {
             throw new NativeContractIllegalArgumentException(String.format(
                     "Given public keys (%d) are more than the maximum allowed signatures (%d)",
-                    publicKeys.length, MAXIMUM_ALLOWED_SIGNATURES
+                    publicKeys.length, MAXIMUM_ALLOWED_KEYS
             ));
         }
 
@@ -114,6 +119,15 @@ public class GetMultisigScriptHash extends NativeMethod {
         Script multisigScript = ScriptBuilder.createP2SHOutputScript(minimumSignatures, btcPublicKeys);
 
         return multisigScript.getPubKeyHash();
+    }
+
+    @Override
+    public long getGas(Object[] parsedArguments, byte[] originalData) {
+        int numberOfKeys = ((Object[]) parsedArguments[1]).length;
+
+        // Base cost is the cost for 2 keys (the minimum).
+        // Then a fee is payed per additional key.
+        return BASE_COST + (numberOfKeys - 2)* COST_PER_EXTRA_KEY;
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/ToBase58Check.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/ToBase58Check.java
@@ -83,4 +83,9 @@ public class ToBase58Check extends NativeMethod {
     public boolean onlyAllowsLocalCalls() {
         return false;
     }
+
+    @Override
+    public long getGas(Object[] parsedArguments, byte[] originalData) {
+        return 8_000L;
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
@@ -137,7 +137,7 @@ public class GetMultisigScriptHashTest {
                         BigInteger.ONE,
                         new Object[]{}
                 }),
-                "At least two public keys"
+                "At least 2 public keys"
         );
         assertFails(
                 () -> method.execute(new Object[]{
@@ -146,7 +146,7 @@ public class GetMultisigScriptHashTest {
                                 Hex.decode("03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6"),
                         }
                 }),
-                "At least two public keys"
+                "At least 2 public keys"
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
@@ -131,13 +131,22 @@ public class GetMultisigScriptHashTest {
     }
 
     @Test
-    public void mustProvideAtLeastOnePublicKey() {
+    public void mustProvideAtLeastTwoPublicKeys() {
         assertFails(
                 () -> method.execute(new Object[]{
                         BigInteger.ONE,
                         new Object[]{}
                 }),
-                "At least one public key"
+                "At least two public keys"
+        );
+        assertFails(
+                () -> method.execute(new Object[]{
+                        BigInteger.ONE,
+                        new Object[]{
+                                Hex.decode("03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6"),
+                        }
+                }),
+                "At least two public keys"
         );
     }
 


### PR DESCRIPTION
This PR sets the gas costs for each of the four methods of the `BTOUtils` native contract.

Additionally, there's minor validation changes on the `BTOUtils::GetMultisigScriptHash` method (namely, now the minimum required number of keys is two rather than just one).