### PR TITLE
Make DataWord Great Again

### DIFF
--- a/rskj-core/src/main/java/co/rsk/db/ContractDetailsImpl.java
+++ b/rskj-core/src/main/java/co/rsk/db/ContractDetailsImpl.java
@@ -141,7 +141,7 @@ public class ContractDetailsImpl implements ContractDetails {
             return null;
         }
 
-        return new DataWord(value);
+        return DataWord.valueOf(value);
     }
 
     @Override
@@ -278,7 +278,7 @@ public class ContractDetailsImpl implements ContractDetails {
         Set<DataWord> result = new HashSet<>();
 
         for (ByteArrayWrapper key : keys) {
-            result.add(new DataWord(key));
+            result.add(DataWord.valueOf(key.getData()));
         }
 
         return result;
@@ -290,7 +290,7 @@ public class ContractDetailsImpl implements ContractDetails {
 
         if (keys == null) {
             for (ByteArrayWrapper keyBytes : this.keys) {
-                DataWord key = new DataWord(keyBytes);
+                DataWord key = DataWord.valueOf(keyBytes.getData());
                 DataWord value = get(key);
 
                 // we check if the value is not null,

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -48,7 +48,6 @@ import org.bouncycastle.util.encoders.Hex;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 
@@ -173,10 +172,10 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final int LOCK_WHITELIST_INVALID_ADDRESS_FORMAT_ERROR_CODE = -2;
 
     // Log topics used by Bridge Contract
-    public static final DataWord RELEASE_BTC_TOPIC = new DataWord("release_btc_topic".getBytes(StandardCharsets.UTF_8));
-    public static final DataWord UPDATE_COLLECTIONS_TOPIC = new DataWord("update_collections_topic".getBytes(StandardCharsets.UTF_8));
-    public static final DataWord ADD_SIGNATURE_TOPIC = new DataWord("add_signature_topic".getBytes(StandardCharsets.UTF_8));
-    public static final DataWord COMMIT_FEDERATION_TOPIC = new DataWord("commit_federation_topic".getBytes(StandardCharsets.UTF_8));
+    public static final DataWord RELEASE_BTC_TOPIC = DataWord.fromString("release_btc_topic");
+    public static final DataWord UPDATE_COLLECTIONS_TOPIC = DataWord.fromString("update_collections_topic");
+    public static final DataWord ADD_SIGNATURE_TOPIC = DataWord.fromString("add_signature_topic");
+    public static final DataWord COMMIT_FEDERATION_TOPIC = DataWord.fromString("commit_federation_topic");
 
     private final RskSystemProperties config;
     private final BridgeConstants bridgeConstants;

--- a/rskj-core/src/main/java/co/rsk/peg/RepositoryBlockStore.java
+++ b/rskj-core/src/main/java/co/rsk/peg/RepositoryBlockStore.java
@@ -27,7 +27,6 @@ import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -71,13 +70,13 @@ public class RepositoryBlockStore implements BtcBlockstoreWithCache {
     public synchronized void put(StoredBlock block) throws BlockStoreException {
         Sha256Hash hash = block.getHeader().getHash();
         byte[] ba = storedBlockToByteArray(block);
-        repository.addStorageBytes(contractAddress, new DataWord(hash.toString()), ba);
+        repository.addStorageBytes(contractAddress, DataWord.valueFromHex(hash.toString()), ba);
         knownBlocks.put(hash, block);
     }
 
     @Override
     public synchronized StoredBlock get(Sha256Hash hash) throws BlockStoreException {
-        byte[] ba = repository.getStorageBytes(contractAddress, new DataWord(hash.toString()));
+        byte[] ba = repository.getStorageBytes(contractAddress, DataWord.valueFromHex(hash.toString()));
 
         if (ba==null) {
             return null;
@@ -95,7 +94,7 @@ public class RepositoryBlockStore implements BtcBlockstoreWithCache {
             return storedBlock;
         }
 
-        byte[] ba = repository.getStorageBytes(contractAddress, new DataWord(hash.toString()));
+        byte[] ba = repository.getStorageBytes(contractAddress, DataWord.valueFromHex(hash.toString()));
 
         if (ba==null) {
             return null;
@@ -110,7 +109,7 @@ public class RepositoryBlockStore implements BtcBlockstoreWithCache {
 
     @Override
     public StoredBlock getChainHead() throws BlockStoreException {
-        byte[] ba = repository.getStorageBytes(contractAddress, new DataWord(BLOCK_STORE_CHAIN_HEAD_KEY.getBytes(StandardCharsets.UTF_8)));
+        byte[] ba = repository.getStorageBytes(contractAddress, DataWord.fromString(BLOCK_STORE_CHAIN_HEAD_KEY));
         if (ba==null) {
             return null;
         }
@@ -121,7 +120,7 @@ public class RepositoryBlockStore implements BtcBlockstoreWithCache {
     @Override
     public void setChainHead(StoredBlock chainHead) throws BlockStoreException {
         byte[] ba = storedBlockToByteArray(chainHead);
-        repository.addStorageBytes(contractAddress, new DataWord(BLOCK_STORE_CHAIN_HEAD_KEY.getBytes(StandardCharsets.UTF_8)), ba);
+        repository.addStorageBytes(contractAddress, DataWord.fromString(BLOCK_STORE_CHAIN_HEAD_KEY), ba);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/SamplePrecompiledContract.java
+++ b/rskj-core/src/main/java/co/rsk/peg/SamplePrecompiledContract.java
@@ -20,6 +20,7 @@ package co.rsk.peg;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
@@ -29,10 +30,8 @@ import org.ethereum.db.ReceiptStore;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -108,10 +107,10 @@ public class SamplePrecompiledContract extends PrecompiledContracts.PrecompiledC
         Coin balance = Coin.valueOf(50000);
         repository.addBalance(addr, balance);
 
-        DataWord keyWord = new DataWord("result".getBytes(StandardCharsets.UTF_8));
+        DataWord keyWord = DataWord.fromString("result");
         DataWord storedValue = repository.getStorageValue(contractAddress, keyWord);
         int result = (storedValue != null ? storedValue.intValue() : 0) + 1;
-        DataWord valWord = new DataWord(result);
+        DataWord valWord = DataWord.valueOf(result);
         repository.addStorageRow(contractAddress, keyWord, valWord);
 
         logs.add(new LogInfo(contractAddress.getBytes(), null, null));
@@ -136,16 +135,16 @@ public class SamplePrecompiledContract extends PrecompiledContracts.PrecompiledC
 
     public void IncrementResult(Object... args)
     {
-        DataWord keyWord = new DataWord("result".getBytes(StandardCharsets.UTF_8));
+        DataWord keyWord = DataWord.fromString("result");
         DataWord storedValue = repository.getStorageValue(contractAddress, keyWord);
         int result = (storedValue != null ? storedValue.intValue() : 0) + 1;
-        DataWord valWord = new DataWord(result);
+        DataWord valWord = DataWord.valueOf(result);
         repository.addStorageRow(contractAddress, keyWord, valWord);
     }
 
     public int GetResult(Object... args)
     {
-        DataWord keyWord = new DataWord("result".getBytes(StandardCharsets.UTF_8));
+        DataWord keyWord = DataWord.fromString("result");
         DataWord storedValue = repository.getStorageValue(contractAddress, keyWord);
         int result = (storedValue != null ? storedValue.intValue() : 0);
 

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascContract.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascContract.java
@@ -22,6 +22,7 @@ import co.rsk.config.RemascConfig;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.panic.PanicProcessor;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
@@ -29,14 +30,12 @@ import org.ethereum.core.Transaction;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.db.ReceiptStore;
-import org.ethereum.rpc.TypeConverter;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.Program;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -59,7 +58,7 @@ public class RemascContract extends PrecompiledContracts.PrecompiledContract {
     private static final CallTransaction.Function PROCESS_MINERS_FEES = CallTransaction.Function.fromSignature("processMinersFees", new String[]{}, new String[]{});
     public static final CallTransaction.Function GET_STATE_FOR_DEBUGGING = CallTransaction.Function.fromSignature("getStateForDebugging", new String[]{}, new String[]{"bytes"});
 
-    static final DataWord MINING_FEE_TOPIC = new DataWord(TypeConverter.stringToByteArray("mining_fee_topic"));
+    public static final DataWord MINING_FEE_TOPIC = DataWord.fromString("mining_fee_topic");
     public static final String REMASC_CONFIG = "remasc.json";
 
     private final RskSystemProperties config;

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascFeesPayer.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascFeesPayer.java
@@ -57,7 +57,7 @@ class RemascFeesPayer {
     private void logPayment(byte[] blockHash, Coin value, RskAddress toAddress, List<LogInfo> logs) {
 
         byte[] loggerContractAddress = this.contractAddress.getBytes();
-        List<DataWord> topics = Arrays.asList(RemascContract.MINING_FEE_TOPIC, new DataWord(toAddress.getBytes()));
+        List<DataWord> topics = Arrays.asList(RemascContract.MINING_FEE_TOPIC, DataWord.valueOf(toAddress.getBytes()));
         byte[] data = RLP.encodeList(RLP.encodeElement(blockHash), RLP.encodeCoin(value));
 
         logs.add(new LogInfo(loggerContractAddress, topics, data));

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascStorageProvider.java
@@ -24,8 +24,6 @@ import org.ethereum.core.Repository;
 import org.ethereum.util.RLP;
 import org.ethereum.vm.DataWord;
 
-import java.nio.charset.StandardCharsets;
-
 /**
  * Responsible for persisting the remasc state into the contract state
  * @see co.rsk.peg.BridgeStorageProvider
@@ -58,7 +56,7 @@ class RemascStorageProvider {
             return federationBalance ;
         }
 
-        DataWord address = new DataWord(FEDERATION_BALANCE_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(FEDERATION_BALANCE_KEY);
 
         DataWord value = this.repository.getStorageValue(this.contractAddress, address);
 
@@ -75,7 +73,7 @@ class RemascStorageProvider {
             return rewardBalance;
         }
 
-        DataWord address = new DataWord(REWARD_BALANCE_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(REWARD_BALANCE_KEY);
 
         DataWord value = this.repository.getStorageValue(this.contractAddress, address);
 
@@ -96,9 +94,9 @@ class RemascStorageProvider {
             return;
         }
 
-        DataWord address = new DataWord(FEDERATION_BALANCE_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(FEDERATION_BALANCE_KEY);
 
-        this.repository.addStorageRow(this.contractAddress, address, new DataWord(this.federationBalance.getBytes()));
+        this.repository.addStorageRow(this.contractAddress, address, DataWord.valueOf(this.federationBalance.getBytes()));
     }
 
     public void setRewardBalance(Coin rewardBalance) {
@@ -110,9 +108,9 @@ class RemascStorageProvider {
             return;
         }
 
-        DataWord address = new DataWord(REWARD_BALANCE_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(REWARD_BALANCE_KEY);
 
-        this.repository.addStorageRow(this.contractAddress, address, new DataWord(this.rewardBalance.getBytes()));
+        this.repository.addStorageRow(this.contractAddress, address, DataWord.valueOf(this.rewardBalance.getBytes()));
     }
 
     public Coin getBurnedBalance() {
@@ -120,7 +118,7 @@ class RemascStorageProvider {
             return burnedBalance;
         }
 
-        DataWord address = new DataWord(BURNED_BALANCE_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(BURNED_BALANCE_KEY);
 
         DataWord value = this.repository.getStorageValue(this.contractAddress, address);
 
@@ -144,13 +142,13 @@ class RemascStorageProvider {
             return;
         }
 
-        DataWord address = new DataWord(BURNED_BALANCE_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(BURNED_BALANCE_KEY);
 
-        this.repository.addStorageRow(this.contractAddress, address, new DataWord(this.burnedBalance.getBytes()));
+        this.repository.addStorageRow(this.contractAddress, address, DataWord.valueOf(this.burnedBalance.getBytes()));
     }
 
     private void saveSiblings() {
-        DataWord address = new DataWord(SIBLINGS_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(SIBLINGS_KEY);
 
         // we add an empty list because Remasc state expects to have an empty siblings list after 0.5.0 activation
         this.repository.addStorageBytes(this.contractAddress, address, RLP.encodedEmptyList());
@@ -161,7 +159,7 @@ class RemascStorageProvider {
             return brokenSelectionRule;
         }
 
-        DataWord address = new DataWord(BROKEN_SELECTION_RULE_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(BROKEN_SELECTION_RULE_KEY);
 
         byte[] bytes = this.repository.getStorageBytes(this.contractAddress, address);
 
@@ -185,7 +183,7 @@ class RemascStorageProvider {
             return;
         }
 
-        DataWord address = new DataWord(BROKEN_SELECTION_RULE_KEY.getBytes(StandardCharsets.UTF_8));
+        DataWord address = DataWord.fromString(BROKEN_SELECTION_RULE_KEY);
 
         byte[] bytes = new byte[1];
 

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -259,7 +259,7 @@ public class TransactionExecutor {
         // if targetAddress size is greater than 32 bytes.
         // But init() will detect this earlier
         BlockchainConfig blockchainConfig = netConfig.getConfigForBlock(executionBlock.getNumber());
-        precompiledContract = precompiledContracts.getContractForAddress(blockchainConfig, new DataWord(targetAddress.getBytes()));
+        precompiledContract = precompiledContracts.getContractForAddress(blockchainConfig, DataWord.valueOf(targetAddress.getBytes()));
 
         if (precompiledContract != null) {
             precompiledContract.init(tx, executionBlock, track, blockStore, receiptStore, result.getLogInfoList());

--- a/rskj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/genesis/GenesisLoader.java
@@ -117,7 +117,7 @@ public class GenesisLoader {
                     acctState.setCodeHash(code == null ? EMPTY_DATA_HASH : Keccak256Helper.keccak256(code));
                     Map<DataWord, byte[]> storage = new HashMap<>(contract.getData().size());
                     for (Map.Entry<String, String> storageData : contract.getData().entrySet()) {
-                        storage.put(new DataWord(Hex.decode(storageData.getKey())), Hex.decode(storageData.getValue()));
+                        storage.put(DataWord.valueFromHex(storageData.getKey()), Hex.decode(storageData.getValue()));
                     }
                     storages.put(address, storage);
                     acctState.setStateRoot(calculateStateRoot(storage));

--- a/rskj-core/src/main/java/org/ethereum/db/ContractDetailsCacheImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/db/ContractDetailsCacheImpl.java
@@ -71,15 +71,14 @@ public class ContractDetailsCacheImpl implements ContractDetails {
     public DataWord get(DataWord key) {
 
         DataWord value = storage.get(key);
-        if (value != null) {
-            value = value.clone();
-        } else{
+
+        if (value == null) {
             if (origContract == null) {
                 return null;
             }
 
             value = origContract.get(key);
-            storage.put(key.clone(), value == null ? DataWord.ZERO.clone() : value.clone());
+            storage.put(key, value == null ? DataWord.ZERO : value);
         }
 
         if (value == null || value.isZero()) {
@@ -101,7 +100,7 @@ public class ContractDetailsCacheImpl implements ContractDetails {
             }
 
             value = origContract.getBytes(key);
-            bytesStorage.put(key.clone(), value == null ? null : value.clone());
+            bytesStorage.put(key, value);
         }
 
         if (value == null) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/AddressesTopicsFilter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/AddressesTopicsFilter.java
@@ -148,7 +148,7 @@ public class AddressesTopicsFilter {
 
     private boolean matchTopic(DataWord logTopic, Topic[] orTopics) {
         for (Topic orTopic : orTopics) {
-            if (new DataWord(orTopic.getBytes()).equals(logTopic)) {
+            if (DataWord.valueOf(orTopic.getBytes()).equals(logTopic)) {
                 return true;
             }
         }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -410,7 +410,7 @@ public class Web3Impl implements Web3 {
             }
 
             DataWord storageValue = accountInformationProvider.
-                    getStorageValue(addr, new DataWord(stringHexToByteArray(storageIdx)));
+                    getStorageValue(addr, DataWord.valueOf(stringHexToByteArray(storageIdx)));
             if (storageValue != null) {
                 return s = TypeConverter.toJsonHex(storageValue.getData());
             } else {

--- a/rskj-core/src/main/java/org/ethereum/solidity/SolidityType.java
+++ b/rskj-core/src/main/java/org/ethereum/solidity/SolidityType.java
@@ -367,7 +367,7 @@ public abstract class SolidityType {
         @Override
         public Object decode(byte[] encoded, int offset) {
             BigInteger asBigInteger = (BigInteger) super.decode(encoded, offset);
-            return new DataWord(asBigInteger.toByteArray());
+            return DataWord.valueOf(asBigInteger.toByteArray());
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/DataWord.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/DataWord.java
@@ -262,11 +262,6 @@ public final class DataWord implements Comparable<DataWord> {
         return new DataWord(newdata, false);
     }
 
-    public DataWord negate() {
-        if (this.isZero()) return ZERO;
-        return bnot().add(DataWord.ONE);
-    }
-
     public DataWord bnot() {
         byte[] newdata = new byte[32];
 

--- a/rskj-core/src/main/java/org/ethereum/vm/LogInfo.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/LogInfo.java
@@ -59,7 +59,7 @@ public class LogInfo {
 
         for (RLPElement topic1 : topics) {
             byte[] topic = topic1.getRLPData();
-            this.topics.add(new DataWord(topic));
+            this.topics.add(DataWord.valueOf(topic));
         }
 
         rlpEncoded = rlp;

--- a/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
@@ -63,14 +63,14 @@ public class PrecompiledContracts {
     public static final RskAddress REMASC_ADDR = new RskAddress(REMASC_ADDR_STR);
     public static final RskAddress SAMPLE_ADDR = new RskAddress(SAMPLE_ADDR_STR);
 
-    public static final DataWord BRIDGE_ADDR_DW = new DataWord(BRIDGE_ADDR.getBytes());
-    public static final DataWord IDENTITY_ADDR_DW = new DataWord(IDENTITY_ADDR.getBytes());
-    public static final DataWord REMASC_ADDR_DW  = new DataWord(REMASC_ADDR.getBytes());
-    public static final DataWord SAMPLE_ADDR_DW = new DataWord(SAMPLE_ADDR.getBytes());
-    public static final DataWord ECRECOVER_ADDR_DW = new DataWord(ECRECOVER_ADDR);
-    public static final DataWord RIPEMPD160_ADDR_DW = new DataWord(RIPEMPD160_ADDR);
-    public static final DataWord BIG_INT_MODEXP_ADDR_DW = new DataWord(BIG_INT_MODEXP_ADDR);
-    public static final DataWord SHA256_ADDR_DW = new DataWord(SHA256_ADDR);
+    public static final DataWord BRIDGE_ADDR_DW = DataWord.valueOf(BRIDGE_ADDR.getBytes());
+    public static final DataWord IDENTITY_ADDR_DW = DataWord.valueOf(IDENTITY_ADDR.getBytes());
+    public static final DataWord REMASC_ADDR_DW  = DataWord.valueOf(REMASC_ADDR.getBytes());
+    public static final DataWord SAMPLE_ADDR_DW = DataWord.valueOf(SAMPLE_ADDR.getBytes());
+    public static final DataWord ECRECOVER_ADDR_DW = DataWord.valueFromHex(ECRECOVER_ADDR);
+    public static final DataWord RIPEMPD160_ADDR_DW = DataWord.valueFromHex(RIPEMPD160_ADDR);
+    public static final DataWord BIG_INT_MODEXP_ADDR_DW = DataWord.valueFromHex(BIG_INT_MODEXP_ADDR);
+    public static final DataWord SHA256_ADDR_DW = DataWord.valueFromHex(SHA256_ADDR);
 
     private static ECRecover ecRecover = new ECRecover();
     private static Sha256 sha256 = new Sha256();
@@ -203,7 +203,7 @@ public class PrecompiledContracts {
                 result = HashUtil.ripemd160(data);
             }
 
-            return new DataWord(result).getData();
+            return DataWord.valueOf(result).getData();
         }
     }
 
@@ -237,7 +237,7 @@ public class PrecompiledContracts {
                     ECKey.ECDSASignature signature = ECKey.ECDSASignature.fromComponents(r, s, v[31]);
 
                     ECKey key = ECKey.signatureToKey(h, signature);
-                    out = new DataWord(key.getAddress());
+                    out = DataWord.valueOf(key.getAddress());
                 }
             } catch (Exception any) {
             }
@@ -374,7 +374,7 @@ public class PrecompiledContracts {
 
         private int parseLen(byte[] data, int idx) {
             byte[] bytes = parseBytes(data, 32 * idx, 32);
-            return new DataWord(bytes).intValueSafe();
+            return DataWord.valueOf(bytes).intValueSafe();
         }
 
         private BigInteger parseArg(byte[] data, int offset, int len) {

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1875,7 +1875,6 @@ public class VM {
                     program.saveOpGasCost(gasCost);
                 }
 
-                program.setPreviouslyExecutedOp(op.val());
                 logOpCode();
                 vmCounter++;
             } // for

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -519,7 +519,7 @@ public class VM {
             byte tmp = word2.getData()[(int) wvalue];
             byte[] newdata = new byte[32];
             newdata[31] = tmp;
-            result = new DataWord(newdata);
+            result = DataWord.valueOf(newdata);
         } else {
             result = DataWord.ZERO;
         }
@@ -574,7 +574,7 @@ public class VM {
         byte[] buffer = program.memoryChunk(memOffsetData.intValue(), lengthData.intValue());
 
         byte[] encoded = HashUtil.keccak256(buffer);
-        DataWord word = new DataWord(encoded);
+        DataWord word = DataWord.valueOf(encoded);
 
         if (isLogEnabled) {
             hint = word.toString();
@@ -720,15 +720,15 @@ public class VM {
         // EXECUTION PHASE
         DataWord codeLength;
         if (op == OpCode.CODESIZE) {
-            codeLength = new DataWord(program.getCode().length); // during initialization it will return the initialization code size
+            codeLength = DataWord.valueOf(program.getCode().length); // during initialization it will return the initialization code size
         } else {
             DataWord address = program.stackPop();
-            codeLength = new DataWord(program.getCodeAt(address).length);
+            codeLength = DataWord.valueOf(program.getCodeAt(address).length);
             BlockchainConfig blockchainConfig = program.getBlockchainConfig();
             if (blockchainConfig.isRskip90()) {
                 PrecompiledContracts.PrecompiledContract precompiledContract = precompiledContracts.getContractForAddress(blockchainConfig, address);
                 if (precompiledContract != null) {
-                    codeLength = new DataWord(BigIntegers.asUnsignedByteArray(DataWord.MAX_VALUE));
+                    codeLength = DataWord.valueOf(BigIntegers.asUnsignedByteArray(DataWord.MAX_VALUE));
                 }
             }
         }
@@ -1238,7 +1238,7 @@ public class VM {
         spendOpCodeGas();
         // EXECUTION PHASE
         int pc = program.getPC();
-        DataWord pcWord = new DataWord(pc);
+        DataWord pcWord = DataWord.valueOf(pc);
 
         if (isLogEnabled) {
             hint = pcWord.toString();
@@ -1252,7 +1252,7 @@ public class VM {
         spendOpCodeGas();
         // EXECUTION PHASE
         int memSize = program.getMemSize();
-        DataWord wordMemSize = new DataWord(memSize);
+        DataWord wordMemSize = DataWord.valueOf(memSize);
 
         if (isLogEnabled) {
             hint = Integer.toString(memSize);
@@ -1265,7 +1265,7 @@ public class VM {
     protected void doGAS(){
         spendOpCodeGas();
         // EXECUTION PHASE
-        DataWord gas = new DataWord(program.getRemainingGas());
+        DataWord gas = DataWord.valueOf(program.getRemainingGas());
 
         if (isLogEnabled) {
             hint = "" + gas;
@@ -1407,7 +1407,7 @@ public class VM {
 
         MessageCall msg = new MessageCall(
                 MsgType.fromOpcode(op),
-                new DataWord(calleeGas), codeAddress, value, inDataOffs, inDataSize,
+                DataWord.valueOf(calleeGas), codeAddress, value, inDataOffs, inDataSize,
                 outDataOffs, outDataSize);
 
         callToAddress(codeAddress, msg);
@@ -1554,7 +1554,7 @@ public class VM {
         byte[] buffer = program.memoryChunk(memOffsetData.intValue(), lengthData.intValue());
         int resultInt = program.replaceCode(buffer);
 
-        DataWord result = new DataWord(resultInt);
+        DataWord result = DataWord.valueOf(resultInt);
 
         if (isLogEnabled) {
             hint = result.toString();
@@ -1964,7 +1964,7 @@ public class VM {
                     break;
             }
             String addressString = Hex.toHexString(program.getOwnerAddress().getLast20Bytes());
-            String pcString = Hex.toHexString(new DataWord(program.getPC()).getNoLeadZeroesData());
+            String pcString = Hex.toHexString(DataWord.valueOf(program.getPC()).getNoLeadZeroesData());
             String opString = Hex.toHexString(new byte[]{op.val()});
             String gasString = Long.toHexString(program.getRemainingGas());
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -216,7 +216,6 @@ public class VM {
         }
 
         word1.add(word2);
-        program.disposeWord(word2);
         program.stackPush(word1);
         program.step();
 
@@ -233,7 +232,6 @@ public class VM {
         }
 
         word1.mul(word2);
-        program.disposeWord(word2);
         program.stackPush(word1);
         program.step();
     }
@@ -249,7 +247,6 @@ public class VM {
         }
 
         word1.sub(word2);
-        program.disposeWord(word2);
         program.stackPush(word1);
         program.step();
     }
@@ -265,7 +262,6 @@ public class VM {
         }
 
         word1.div(word2);
-        program.disposeWord(word2);
         program.stackPush(word1);
         program.step();
     }
@@ -281,7 +277,6 @@ public class VM {
         }
 
         word1.sDiv(word2);
-        program.disposeWord(word2);
         program.stackPush(word1);
         program.step();
     }
@@ -297,7 +292,6 @@ public class VM {
         }
 
         word1.mod(word2);
-        program.disposeWord(word2);
         program.stackPush(word1);
         program.step();
     }
@@ -313,7 +307,6 @@ public class VM {
         }
 
         word1.sMod(word2);
-        program.disposeWord(word2);
         program.stackPush(word1);
         program.step();
     }
@@ -334,7 +327,6 @@ public class VM {
         }
 
         word1.exp(word2);
-        program.disposeWord(word2);
         program.stackPush(word1);
         program.step();
     }
@@ -353,7 +345,6 @@ public class VM {
             word2.signExtend((byte) k);
             program.stackPush(word2);
         }
-        program.disposeWord(word1);
         program.step();
     }
 
@@ -389,7 +380,6 @@ public class VM {
             word1.zero();
         }
         program.stackPush(word1);
-        program.disposeWord(word2);
         program.step();
     }
 
@@ -410,7 +400,6 @@ public class VM {
             word1.zero();
         }
         program.stackPush(word1);
-        program.disposeWord(word2);
         program.step();
     }
 
@@ -431,10 +420,8 @@ public class VM {
             word1.zero();
         }
         program.stackPush(word1);
-        program.disposeWord(word2);
         program.step();
     }
-
 
     protected void doGT() {
         spendOpCodeGas();
@@ -453,7 +440,6 @@ public class VM {
             word1.zero();
         }
         program.stackPush(word1);
-        program.disposeWord(word2);
         program.step();
     }
 
@@ -473,7 +459,6 @@ public class VM {
             word1.zero();
         }
         program.stackPush(word1);
-        program.disposeWord(word2);
         program.step();
     }
 
@@ -509,7 +494,6 @@ public class VM {
 
         word1.and(word2);
         program.stackPush(word1);
-        program.disposeWord(word2);
         program.step();
     }
 
@@ -525,7 +509,6 @@ public class VM {
 
         word1.or(word2);
         program.stackPush(word1);
-        program.disposeWord(word2);
         program.step();
     }
 
@@ -541,7 +524,6 @@ public class VM {
 
         word1.xor(word2);
         program.stackPush(word1);
-        program.disposeWord(word2);
         program.step();
     }
 
@@ -567,7 +549,6 @@ public class VM {
         }
 
         program.stackPush(result);
-        program.disposeWord(word1);
         program.step();
     }
 
@@ -579,8 +560,6 @@ public class VM {
         DataWord word3 = program.stackPop();
         word1.addmod(word2, word3);
         program.stackPush(word1);
-        program.disposeWord(word2);
-        program.disposeWord(word3);
         program.step();
     }
 
@@ -592,8 +571,6 @@ public class VM {
         DataWord word3 = program.stackPop();
         word1.mulmod(word2, word3);
         program.stackPush(word1);
-        program.disposeWord(word2);
-        program.disposeWord(word3);
         program.step();
     }
 
@@ -626,8 +603,6 @@ public class VM {
         }
 
         program.stackPush(word);
-        program.disposeWord(memOffsetData);
-        program.disposeWord(lengthData);
         program.step();
     }
 
@@ -661,7 +636,6 @@ public class VM {
         }
 
         program.stackPush(balance);
-        program.disposeWord(address);
         program.step();
     }
 
@@ -715,7 +689,6 @@ public class VM {
         }
 
         program.stackPush(value);
-        program.disposeWord(dataOffs);
         program.step();
     }
 
@@ -749,9 +722,6 @@ public class VM {
         }
 
         program.memorySave(memOffsetData.intValue(), msgData);
-        program.disposeWord(memOffsetData);
-        program.disposeWord(dataOffsetData);
-        program.disposeWord(lengthData);
         program.step();
     }
 
@@ -784,7 +754,6 @@ public class VM {
                     codeLength = new DataWord(BigIntegers.asUnsignedByteArray(DataWord.MAX_VALUE));
                 }
             }
-            program.disposeWord(address);
         }
 
         if (isLogEnabled) {
@@ -830,7 +799,6 @@ public class VM {
         if (op == OpCode.EXTCODECOPY) {
             DataWord address = program.stackPop();
             fullCode = program.getCodeAt(address);
-            program.disposeWord(address);
         }
 
         DataWord memOffsetDW = program.stackPop();
@@ -875,9 +843,6 @@ public class VM {
         // to receive a byte[] buffer and a length, and to create another method memoryZero(offset,length)
         // to fill the gap.
         program.memorySave(memOffset, codeCopy);
-        program.disposeWord(memOffsetDW);
-        program.disposeWord(codeOffsetDW);
-        program.disposeWord(lengthDataDW);
 
         program.step();
     }
@@ -1029,7 +994,7 @@ public class VM {
     protected void doPOP(){
         spendOpCodeGas();
         // EXECUTION PHASE
-        program.disposeWord(program.stackPop());
+        program.stackPop();
         program.step();
     }
 
@@ -1134,8 +1099,6 @@ public class VM {
 
         program.getResult().addLogInfo(logInfo);
         // Log topics taken from the stack are lost and never returned to the DataWord pool
-        program.disposeWord(memStart);
-        program.disposeWord(memOffset);
         program.step();
     }
 
@@ -1156,7 +1119,6 @@ public class VM {
         }
 
         program.stackPush(data);
-        program.disposeWord(addr);
         program.step();
     }
 
@@ -1177,8 +1139,6 @@ public class VM {
         }
 
         program.memorySave(addr, value);
-        program.disposeWord(addr);
-        program.disposeWord(value);
         program.step();
     }
 
@@ -1197,8 +1157,6 @@ public class VM {
         byte[] byteVal = {value.getData()[31]};
         //TODO: non-standard single byte memory storage, this should be documented
         program.memorySave(addr.intValue(), byteVal);
-        program.disposeWord(addr);
-        program.disposeWord(value);
         program.step();
     }
 
@@ -1263,8 +1221,6 @@ public class VM {
         }
 
         program.storageSave(addr, value);
-        program.disposeWord(addr);
-        program.disposeWord(value);
         program.step();
     }
 
@@ -1279,8 +1235,6 @@ public class VM {
         }
 
         program.setPC(nextPC);
-        program.disposeWord(pos);
-
     }
 
     protected void doJUMPI(){
@@ -1301,8 +1255,6 @@ public class VM {
         } else {
             program.step();
         }
-        program.disposeWord(pos);
-        program.disposeWord(cond);
     }
 
     protected void doPC(){
@@ -1400,9 +1352,6 @@ public class VM {
         }
 
         program.createContract(value, inOffset, inSize);
-        program.disposeWord(value);
-        program.disposeWord(inOffset);
-        program.disposeWord(inSize);
         program.step();
     }
 
@@ -1486,22 +1435,6 @@ public class VM {
 
         callToAddress(codeAddress, msg);
 
-        program.disposeWord(inDataOffs);
-        program.disposeWord(inDataSize);
-        program.disposeWord(outDataOffs);
-        program.disposeWord(outDataSize);
-        program.disposeWord(codeAddress);
-        program.disposeWord(gas);
-        if (config.isRskip103()) {
-            if (op != OpCode.DELEGATECALL && op != OpCode.STATICCALL) {
-                program.disposeWord(value);
-            }
-        } else {
-            if (!op.equals(OpCode.DELEGATECALL)) {
-                program.disposeWord(value);
-            }
-        }
-
         program.step();
     }
 
@@ -1579,8 +1512,6 @@ public class VM {
         }
 
         program.step();
-        program.disposeWord(offset);
-        program.disposeWord(size);
         program.stop();
     }
 
@@ -1605,7 +1536,6 @@ public class VM {
             hint = "address: " + Hex.toHexString(program.getOwnerAddress().getLast20Bytes());
         }
 
-        program.disposeWord(address);
         program.stop();
     }
 
@@ -1654,8 +1584,6 @@ public class VM {
         }
 
         program.stackPush(result);
-        program.disposeWord(memOffsetData);
-        program.disposeWord(lengthData);
         program.step();
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -476,8 +476,7 @@ public class VM {
             hint = word1.value() + " && " + word2.value();
         }
 
-        word1.and(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.and(word2));
         program.step();
     }
 
@@ -589,13 +588,12 @@ public class VM {
         spendOpCodeGas();
         // EXECUTION PHASE
         DataWord address = program.getOwnerAddress();
-        DataWord dwAddress = program.newDataWord(address);
 
         if (isLogEnabled) {
             hint = "address: " + Hex.toHexString(address.getLast20Bytes());
         }
 
-        program.stackPush(dwAddress);
+        program.stackPush(address);
         program.step();
     }
 
@@ -982,7 +980,7 @@ public class VM {
         // EXECUTION PHASE
         int n = op.val() - OpCode.DUP1.val() + 1;
         DataWord word1 = stack.get(stack.size() - n);
-        program.stackPush(program.newDataWord(word1));
+        program.stackPush(word1);
         program.step();
     }
 
@@ -997,7 +995,7 @@ public class VM {
         program.verifyStackOverflow(n, n + 1);
 
         DataWord word1 = stack.get(stack.size() - n);
-        program.stackPush(program.newDataWord(word1));
+        program.stackPush(word1);
         program.step();
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -215,8 +215,7 @@ public class VM {
             hint = word1.value() + " + " + word2.value();
         }
 
-        word1.add(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.add(word2));
         program.step();
 
     }
@@ -231,8 +230,7 @@ public class VM {
             hint = word1.value() + " * " + word2.value();
         }
 
-        word1.mul(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.mul(word2));
         program.step();
     }
 
@@ -246,8 +244,7 @@ public class VM {
             hint = word1.value() + " - " + word2.value();
         }
 
-        word1.sub(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.sub(word2));
         program.step();
     }
 
@@ -261,8 +258,7 @@ public class VM {
             hint = word1.value() + " / " + word2.value();
         }
 
-        word1.div(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.div(word2));
         program.step();
     }
 
@@ -276,8 +272,7 @@ public class VM {
             hint = word1.sValue() + " / " + word2.sValue();
         }
 
-        word1.sDiv(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.sDiv(word2));
         program.step();
     }
 
@@ -291,8 +286,7 @@ public class VM {
             hint = word1.value() + " % " + word2.value();
         }
 
-        word1.mod(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.mod(word2));
         program.step();
     }
 
@@ -306,8 +300,7 @@ public class VM {
             hint = word1.sValue() + " #% " + word2.sValue();
         }
 
-        word1.sMod(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.sMod(word2));
         program.step();
     }
 
@@ -326,8 +319,7 @@ public class VM {
             hint = word1.value() + " ** " + word2.value();
         }
 
-        word1.exp(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.exp(word2));
         program.step();
     }
 
@@ -342,17 +334,17 @@ public class VM {
             if (isLogEnabled) {
                 hint = word1 + "  " + word2.value();
             }
-            word2.signExtend((byte) k);
-            program.stackPush(word2);
+
+            program.stackPush(word2.signExtend((byte) k));
         }
+
         program.step();
     }
 
     protected void doNOT() {
         spendOpCodeGas();
         // EXECUTION PHASE
-        DataWord word1 = program.stackPop();
-        word1.bnot();
+        DataWord word1 = program.stackPop().bnot();
 
         if (isLogEnabled) {
             hint = "" + word1.value();
@@ -375,11 +367,10 @@ public class VM {
 
         // TODO: We should compare the performance of BigInteger comparison with DataWord comparison:
         if (word1.compareTo(word2) < 0) {
-            word1.setTrue();
+            program.stackPush(DataWord.ONE);
         } else {
-            word1.zero();
+            program.stackPush(DataWord.ZERO);
         }
-        program.stackPush(word1);
         program.step();
     }
 
@@ -395,11 +386,10 @@ public class VM {
         }
 
         if (word1.sValue().compareTo(word2.sValue()) < 0) {
-            word1.setTrue();
+            program.stackPush(DataWord.ONE);
         } else {
-            word1.zero();
+            program.stackPush(DataWord.ZERO);
         }
-        program.stackPush(word1);
         program.step();
     }
 
@@ -415,11 +405,10 @@ public class VM {
         }
 
         if (word1.sValue().compareTo(word2.sValue()) > 0) {
-            word1.setTrue();
+            program.stackPush(DataWord.ONE);
         } else {
-            word1.zero();
+            program.stackPush(DataWord.ZERO);
         }
-        program.stackPush(word1);
         program.step();
     }
 
@@ -435,11 +424,11 @@ public class VM {
         }
 
         if (word1.value().compareTo(word2.value()) > 0) {
-            word1.setTrue();
+            program.stackPush(DataWord.ONE);
         } else {
-            word1.zero();
+            program.stackPush(DataWord.ZERO);
         }
-        program.stackPush(word1);
+
         program.step();
     }
 
@@ -454,11 +443,11 @@ public class VM {
         }
 
         if (word1.equalValue(word2)) {
-            word1.setTrue();
+            program.stackPush(DataWord.ONE);
         } else {
-            word1.zero();
+            program.stackPush(DataWord.ZERO);
         }
-        program.stackPush(word1);
+
         program.step();
     }
 
@@ -466,19 +455,14 @@ public class VM {
         spendOpCodeGas();
         // EXECUTION PHASE
         DataWord word1 = program.stackPop();
-        if (word1.isZero()) {
-            // This is an optimization: since word1 is zero, then setting only the last byte
-            // to 1 is equivalent to setTrue().
-            word1.getData()[31] = 1;
-        } else {
-            word1.zero();
-        }
+
+        DataWord result = word1.isZero() ? DataWord.ONE : DataWord.ZERO;
 
         if (isLogEnabled) {
-            hint = "" + word1.value();
+            hint = "" + result.value();
         }
 
-        program.stackPush(word1);
+        program.stackPush(result);
         program.step();
     }
 
@@ -507,8 +491,7 @@ public class VM {
             hint = word1.value() + " || " + word2.value();
         }
 
-        word1.or(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.or(word2));
         program.step();
     }
 
@@ -522,8 +505,7 @@ public class VM {
             hint = word1.value() + " ^ " + word2.value();
         }
 
-        word1.xor(word2);
-        program.stackPush(word1);
+        program.stackPush(word1.xor(word2));
         program.step();
     }
 
@@ -536,12 +518,11 @@ public class VM {
         long wvalue = Program.limitToMaxLong(word1);
         if (wvalue<32) {
             byte tmp = word2.getData()[(int) wvalue];
-            word2.zero();
-            word2.getData()[31] = tmp;
-            result = word2;
+            byte[] newdata = new byte[32];
+            newdata[31] = tmp;
+            result = new DataWord(newdata);
         } else {
-            word2.zero();
-            result = word2;
+            result = DataWord.ZERO;
         }
 
         if (isLogEnabled) {
@@ -558,8 +539,7 @@ public class VM {
         DataWord word1 = program.stackPop();
         DataWord word2 = program.stackPop();
         DataWord word3 = program.stackPop();
-        word1.addmod(word2, word3);
-        program.stackPush(word1);
+        program.stackPush(word1.addmod(word2, word3));
         program.step();
     }
 
@@ -569,8 +549,7 @@ public class VM {
         DataWord word1 = program.stackPop();
         DataWord word2 = program.stackPop();
         DataWord word3 = program.stackPop();
-        word1.mulmod(word2, word3);
-        program.stackPush(word1);
+        program.stackPush(word1.mulmod(word2, word3));
         program.step();
     }
 
@@ -596,7 +575,7 @@ public class VM {
         byte[] buffer = program.memoryChunk(memOffsetData.intValue(), lengthData.intValue());
 
         byte[] encoded = HashUtil.keccak256(buffer);
-        DataWord word = program.newDataWord(encoded);
+        DataWord word = new DataWord(encoded);
 
         if (isLogEnabled) {
             hint = word.toString();
@@ -1174,7 +1153,7 @@ public class VM {
         }
 
         if (val == null) {
-            val = key.zero();
+            val = DataWord.ZERO;
         }
 
         program.stackPush(val);
@@ -1261,7 +1240,7 @@ public class VM {
         spendOpCodeGas();
         // EXECUTION PHASE
         int pc = program.getPC();
-        DataWord pcWord = program.newDataWord(pc);
+        DataWord pcWord = new DataWord(pc);
 
         if (isLogEnabled) {
             hint = pcWord.toString();
@@ -1275,7 +1254,7 @@ public class VM {
         spendOpCodeGas();
         // EXECUTION PHASE
         int memSize = program.getMemSize();
-        DataWord wordMemSize = program.newDataWord(memSize);
+        DataWord wordMemSize = new DataWord(memSize);
 
         if (isLogEnabled) {
             hint = Integer.toString(memSize);
@@ -1288,7 +1267,7 @@ public class VM {
     protected void doGAS(){
         spendOpCodeGas();
         // EXECUTION PHASE
-        DataWord gas = program.newDataWord(program.getRemainingGas());
+        DataWord gas = new DataWord(program.getRemainingGas());
 
         if (isLogEnabled) {
             hint = "" + gas;
@@ -1577,7 +1556,7 @@ public class VM {
         byte[] buffer = program.memoryChunk(memOffsetData.intValue(), lengthData.intValue());
         int resultInt = program.replaceCode(buffer);
 
-        DataWord result = program.newDataWord(resultInt);
+        DataWord result = new DataWord(resultInt);
 
         if (isLogEnabled) {
             hint = result.toString();

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Memory.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Memory.java
@@ -143,7 +143,7 @@ public class Memory implements ProgramListenerAware {
     }
 
     public DataWord readWord(int address) {
-        return new DataWord(read(address, 32));
+        return DataWord.valueOf(read(address, 32));
     }
 
     // just access expecting all data valid

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -233,19 +233,6 @@ public class Program {
         stack.clear();
     }
 
-    public DataWord newDataWord(byte[] data) {
-        DataWord dw=getNewDataWordFast();
-        dw.assignData(data);
-        return dw;
-    }
-    public DataWord newDataWord(int  v) {
-        return new DataWord(v);
-    }
-
-    public DataWord newDataWord(long  v) {
-        return new DataWord(v);
-    }
-
     public DataWord newDataWord(DataWord idw) {
         DataWord dw= idw.clone();
         return dw;
@@ -300,8 +287,7 @@ public class Program {
               // Asummes LSBs are zero. assignDataRange undestands this semantics.
           }
 
-        DataWord dw = getNewDataWordFast();
-        dw.assignDataRange(ops, pc, n);
+        DataWord dw = new DataWord(ops, pc, n);
         pc += n;
         if (pc >= ops.length) {
             stop();

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -111,71 +111,6 @@ public class Program {
     private int startAddr;
 
     private BitSet jumpdestSet;
-    /**********************************************************************************************************
-     * About DataWord Pool:
-     *---------------------------------------------------------------------------------------------------------
-     * Preliminaries:
-     * (source: http://programmers.stackexchange.com/questions/149563/should-we-avoid-object-creation-in-java)
-     *
-     * There is a misconception that creating many small short lived objects causes the JVM to pause
-     * for long periods of time, this is now false as well. Current GC algorithms are actually optimized
-     * for creating many many small objects that are short lived, that is basically the 99% heuristic
-     * for Java objects in every program. Object Pooling will actually make the JVM preform worse in most
-     * cases.
-     * The modern GC algorithms don't have this problem because they don't deallocate on a schedule, they
-     * deallocate when free memory is needed in a certain generation.
-     *
-     * SDL analysis:
-     *
-     * THIS IS NOT THE CASE for an application that creates millions of objects per second (as the VM can do).
-     *
-     * Here are the results of runs of the VMPerformaceTest.testFibonacciLongTime() that show a mixed result:
-     *----------------------------------------------------------------
-     * CASE 1: HIGH MEMORY USE / useDataWordPool =  false
-     * Creating 10000000 linked  objects..
-     * Program.useDataWordPool =  false
-     * Time elapsed [ms]: 28969 [s]:28
-     * RealTime elapsed [ms]: 39626 [s]:39
-     * GCTime elapsed [ms]: 10372 [s]:10
-     * Instructions executed: : 170400032
-     *----------------------------------------------------------------
-     * CASE 2: HIGH MEMORY USE / useDataWordPool =  true
-     * Creating 10000000 linked  objects..
-     * Program.useDataWordPool =  true
-     * Time elapsed [ms]: 35724 [s]:35
-     * RealTime elapsed [ms]: 35783 [s]:35
-     * GCTime elapsed [ms]: 0 [s]:0
-     * Instructions executed: : 170400032
-     *----------------------------------------------------------------
-     * CASE 3: VERY LOW MEMORY USE / useDataWordPool =  false
-     * Creating 0 linked  objects..
-     * Program.useDataWordPool =  false
-     * Time elapsed [ms]: 28516 [s]:28
-     * RealTime elapsed [ms]: 29287 [s]:29
-     * GCTime elapsed [ms]: 291 [s]:0
-     * Instructions executed: : 170400032
-     *----------------------------------------------------------------
-     * If we compare the cases where memory is full of objects (1 and 2), using the memory pool resulted
-     * in 35 seconds of processing (RealTime) while not using the pool resulted in 38 seconds (realTime).
-     * Using useDataWordPool makes the VM go 8% faster.
-     *
-     * In case 2 the time dedicated to GC was actually zero.
-     *
-     * In case 3, there was no use of memory (apart from the VM itself). In this case using the pool took takes also 35
-     * seconds (actual run not shown), but not using the pool takes only 29 seconds (RealTime). Therefore not using the
-     * pool makes the VM faster by 17%.
-     *
-     * However the speedup the DataWord pool provides depends in the application that is run (the real full-node).
-     * Garbage collection time depends on the number of live object pointers. In a test-case that number
-     * is low, therefore garbage collecting is fast. The full-node stores in memory a huge amount of interrelated
-     * objects (such as the Trie). That increases the GC time. To determine if dataWordPool should be activated by
-     * default or disabled by default , additional test cases involving a real full-node with a large worldstate must be
-     * performed. Until that moment, dataWordPool is enabled by setting useDataWordPool=true
-     *
-     *******************************************************************************************************************/
-    private final java.util.Stack<DataWord> dataWordPool;
-
-    private static Boolean useDataWordPool = true;
 
     private final VmConfig config;
     private final PrecompiledContracts precompiledContracts;
@@ -215,30 +150,13 @@ public class Program {
         this.stack.ensureCapacity(1024); // faster?
         this.storage = setupProgramListener(new Storage(programInvoke));
 
-        if (useDataWordPool) {
-            this.dataWordPool = new java.util.Stack<>();
-            this.dataWordPool.ensureCapacity(1024); // faster?
-        } else {
-            this.dataWordPool = null;
-        }
-
         precompile();
         traceListener = new ProgramTraceListener(config);
-    }
-
-    public static void setUseDataWordPool(Boolean value) {
-        useDataWordPool = value;
-    }
-
-    public static Boolean getUseDataWordPool() {
-        return useDataWordPool;
     }
 
     public int getCallDeep() {
         return invoke.getCallDeep();
     }
-
-
 
     private InternalTransaction addInternalTx(byte[] nonce, DataWord gasLimit, RskAddress senderAddress, RskAddress receiveAddress,
                                               Coin value, byte[] data, String note) {
@@ -300,44 +218,19 @@ public class Program {
     }
 
     private DataWord getNewDataWordFast() {
-        if (dataWordPool==null) {
-            return new DataWord();
-        }
-        if (dataWordPool.empty()) {
-            return new DataWord();
-        } else {
-            return dataWordPool.pop();
-        }
-    }
-
-    public void stackPush(byte[] data) {
-        DataWord dw=getNewDataWordFast();
-        dw.assign(data);
-        stackPush(dw);
+        return new DataWord();
     }
 
     private void stackPushZero() {
-        DataWord dw=getNewDataWordFast();
-        dw.zero();
-        stackPush(dw);
+        stackPush(DataWord.ZERO);
     }
 
     private void stackPushOne() {
-        DataWord stackWord=getNewDataWordFast();
-        stackWord.assignData(DataWord.ONE.getData());
-        stackPush(stackWord);
+        stackPush(DataWord.ONE);
     }
 
     private void stackClear(){
-        if (dataWordPool==null) {
-            stack.clear();
-            return;
-        }
-
-        while (!stack.isEmpty()) {
-            disposeWord(stack.pop());
-        }
-
+        stack.clear();
     }
 
     public DataWord newDataWord(byte[] data) {
@@ -346,46 +239,21 @@ public class Program {
         return dw;
     }
     public DataWord newDataWord(int  v) {
-        DataWord dw=getNewDataWordFast();
-        dw.assign(v);
-        return dw;
+        return new DataWord(v);
     }
 
     public DataWord newDataWord(long  v) {
-        DataWord dw=getNewDataWordFast();
-        dw.assign(v);
-        return dw;
-    }
-    public DataWord newDataWord(DataWord idw) {
-        DataWord dw=getNewDataWordFast();
-        dw.assignData(idw.getData());
-        return dw;
+        return new DataWord(v);
     }
 
-    public DataWord newEmptyDataWord() {
-        DataWord dw=getNewDataWordFast();
-        dw.zero();
+    public DataWord newDataWord(DataWord idw) {
+        DataWord dw= idw.clone();
         return dw;
     }
 
     public void stackPush(DataWord stackWord) {
         verifyStackOverflow(0, 1); //Sanity Check
         stack.push(stackWord);
-    }
-
-    public void disposeWord(DataWord dw) {
-        if (dataWordPool == null) {
-            return ;
-        }
-
-        if (dw == DataWord.ZERO || dw == DataWord.ONE) {
-            throw new IllegalArgumentException("Can't dispose a global DataWord");
-        }
-
-        // If there are enough cached values, just really dispose
-        if (dataWordPool.size() < 1024) {
-            dataWordPool.push(dw);
-        }
     }
 
     public Stack getStack() {
@@ -424,21 +292,6 @@ public class Program {
         setPC(pc + 1);
     }
 
-
-    public byte[] byteSweep(int n) {
-
-        if (pc + n > ops.length) {
-            stop();
-        }
-
-        byte[] data = Arrays.copyOfRange(ops, pc, pc + n);
-        pc += n;
-        if (pc >= ops.length) {
-            stop();
-        }
-
-        return data;
-    }
 
     public DataWord sweepGetDataWord(int n) {
           if (pc + n > ops.length) {
@@ -1012,12 +865,6 @@ public class Program {
         DataWord keyWord = new DataWord(key);
         DataWord valWord = new DataWord(val);
 
-        // If DataWords will be reused, then we must clone them.
-        if (useDataWordPool) {
-            keyWord = keyWord.clone();
-            valWord = valWord.clone();
-        }
-
         getStorage().addStorageRow(new RskAddress(getOwnerAddress()), keyWord, valWord);
     }
 
@@ -1274,16 +1121,6 @@ public class Program {
 
     public void saveOpGasCost(long gasCost) {
         trace.saveGasCost(gasCost);
-    }
-
-    public static int getScriptVersionInCode(byte[] ops){
-        if (ops.length >= 4) {
-            OpCode op = OpCode.code(ops[0]);
-            if ((op!=null) && op == OpCode.HEADER) {
-                return ops[2];
-            }
-        }
-        return 0;
     }
 
     public ProgramTrace getTrace() {

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -263,7 +263,7 @@ public class Program {
               // Asummes LSBs are zero. assignDataRange undestands this semantics.
           }
 
-        DataWord dw = new DataWord(ops, pc, n);
+        DataWord dw = DataWord.valueOf(ops, pc, n);
         pc += n;
         if (pc >= ops.length) {
             stop();
@@ -468,7 +468,7 @@ public class Program {
         // [5] COOK THE INVOKE AND EXECUTE
         InternalTransaction internalTx = addInternalTx(nonce, getGasLimit(), senderAddress, RskAddress.nullAddress(), endowment, programCode, "create");
         ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(
-                this, new DataWord(newAddressBytes), getOwnerAddress(), value, gasLimit,
+                this, DataWord.valueOf(newAddressBytes), getOwnerAddress(), value, gasLimit,
                 newBalance, null, track, this.invoke.getBlockStore(), false, byTestingSuite());
 
         ProgramResult programResult = ProgramResult.empty();
@@ -531,7 +531,7 @@ public class Program {
             getResult().addLogInfos(programResult.getLogInfoList());
 
             // IN SUCCESS PUSH THE ADDRESS INTO THE STACK
-            stackPush(new DataWord(newAddressBytes));
+            stackPush(DataWord.valueOf(newAddressBytes));
         }
 
         // 5. REFUND THE REMAIN GAS
@@ -696,7 +696,7 @@ public class Program {
         ProgramResult childResult = null;
 
         ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(
-                this, new DataWord(contextAddress.getBytes()),
+                this, DataWord.valueOf(contextAddress.getBytes()),
                 msg.getType() == MsgType.DELEGATECALL ? getCallerAddress() : getOwnerAddress(),
                 msg.getType() == MsgType.DELEGATECALL ? getCallValue() : msg.getEndowment(),
                 limitToMaxLong(msg.getGas()), contextBalance, data, track, this.invoke.getBlockStore(),
@@ -824,8 +824,8 @@ public class Program {
     private void storageSave(byte[] key, byte[] val) {
         // DataWord constructor some times reference the passed byte[] instead
         // of making a copy.
-        DataWord keyWord = new DataWord(key);
-        DataWord valWord = new DataWord(val);
+        DataWord keyWord = DataWord.valueOf(key);
+        DataWord valWord = DataWord.valueOf(val);
 
         getStorage().addStorageRow(new RskAddress(getOwnerAddress()), keyWord, valWord);
     }
@@ -858,7 +858,7 @@ public class Program {
     public DataWord getBlockHash(long index) {
        long bn = this.getNumber().longValue();
         if ((index <  bn) && (index >= Math.max(0, bn - 256))) {
-            return new DataWord(this.invoke.getBlockStore().getBlockHashByNumber(index, getPrevHash().getData()));
+            return DataWord.valueOf(this.invoke.getBlockStore().getBlockHashByNumber(index, getPrevHash().getData()));
         } else {
             return DataWord.ZERO;
         }
@@ -866,7 +866,7 @@ public class Program {
 
     public DataWord getBalance(DataWord address) {
         Coin balance = getStorage().getBalance(new RskAddress(address));
-        return new DataWord(balance.getBytes());
+        return DataWord.valueOf(balance.getBytes());
     }
 
     public DataWord getOriginAddress() {
@@ -1145,7 +1145,7 @@ public class Program {
     }
 
     public DataWord getReturnDataBufferSize() {
-        return new DataWord(getReturnDataBufferSizeI());
+        return DataWord.valueOf(getReturnDataBufferSizeI());
     }
 
     private int getReturnDataBufferSizeI() {

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -104,7 +104,6 @@ public class Program {
     private final byte[] ops;
     private int pc;
     private byte lastOp;
-    private byte previouslyExecutedOp;
     private boolean stopped;
     private byte exeVersion;    // currently limited to 0..127
     private byte scriptVersion; // currently limited to 0..127
@@ -201,13 +200,6 @@ public class Program {
      */
     public void setLastOp(byte op) {
         this.lastOp = op;
-    }
-
-    /**
-     * Should be set only after the OP is fully executed.
-     */
-    public void setPreviouslyExecutedOp(byte op) {
-        this.previouslyExecutedOp = op;
     }
 
     private void stackPushZero() {

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -210,17 +210,6 @@ public class Program {
         this.previouslyExecutedOp = op;
     }
 
-    /**
-     * Returns the last fully executed OP.
-     */
-    public byte getPreviouslyExecutedOp() {
-        return this.previouslyExecutedOp;
-    }
-
-    private DataWord getNewDataWordFast() {
-        return new DataWord();
-    }
-
     private void stackPushZero() {
         stackPush(DataWord.ZERO);
     }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -233,11 +233,6 @@ public class Program {
         stack.clear();
     }
 
-    public DataWord newDataWord(DataWord idw) {
-        DataWord dw= idw.clone();
-        return dw;
-    }
-
     public void stackPush(DataWord stackWord) {
         verifyStackOverflow(0, 1); //Sanity Check
         stack.push(stackWord);
@@ -882,9 +877,9 @@ public class Program {
     public DataWord getBlockHash(long index) {
        long bn = this.getNumber().longValue();
         if ((index <  bn) && (index >= Math.max(0, bn - 256))) {
-            return new DataWord(this.invoke.getBlockStore().getBlockHashByNumber(index, getPrevHash().getData())).clone();
+            return new DataWord(this.invoke.getBlockStore().getBlockHashByNumber(index, getPrevHash().getData()));
         } else {
-            return DataWord.ZERO.clone();
+            return DataWord.ZERO;
         }
     }
 
@@ -894,15 +889,15 @@ public class Program {
     }
 
     public DataWord getOriginAddress() {
-        return invoke.getOriginAddress().clone();
+        return invoke.getOriginAddress();
     }
 
     public DataWord getCallerAddress() {
-        return invoke.getCallerAddress().clone();
+        return invoke.getCallerAddress();
     }
 
     public DataWord getGasPrice() {
-        return invoke.getMinGasPrice().clone();
+        return invoke.getMinGasPrice();
     }
 
     public long getRemainingGas() {
@@ -910,11 +905,11 @@ public class Program {
     }
 
     public DataWord getCallValue() {
-            return invoke.getCallValue().clone();
+            return invoke.getCallValue();
     }
 
     public DataWord getDataSize() {
-        return invoke.getDataSize().clone();
+        return invoke.getDataSize();
     }
 
     public DataWord getDataValue(DataWord index) {
@@ -930,31 +925,31 @@ public class Program {
     }
 
     public DataWord getPrevHash() {
-        return invoke.getPrevHash().clone();
+        return invoke.getPrevHash();
     }
 
     public DataWord getCoinbase() {
-        return invoke.getCoinbase().clone();
+        return invoke.getCoinbase();
     }
 
     public DataWord getTimestamp() {
-        return invoke.getTimestamp().clone();
+        return invoke.getTimestamp();
     }
 
     public DataWord getNumber() {
-        return invoke.getNumber().clone();
+        return invoke.getNumber();
     }
 
     public DataWord getTransactionIndex() {
-        return invoke.getTransactionIndex().clone();
+        return invoke.getTransactionIndex();
     }
 
     public DataWord getDifficulty() {
-        return invoke.getDifficulty().clone();
+        return invoke.getDifficulty();
     }
 
     public DataWord getGasLimit() {
-        return invoke.getGaslimit().clone();
+        return invoke.getGaslimit();
     }
 
     public boolean isStaticCall() {

--- a/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
@@ -151,7 +151,7 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
         DataWord origin = program.getOriginAddress();
         DataWord caller = callerAddress;
 
-        DataWord balance = new DataWord(balanceInt.getBytes());
+        DataWord balance = DataWord.valueOf(balanceInt.getBytes());
         DataWord gasPrice = program.getGasPrice();
         long agas = inGas;
         DataWord callValue = inValue;

--- a/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeImpl.java
@@ -124,23 +124,23 @@ public class ProgramInvokeImpl implements ProgramInvoke {
                              Repository repository, BlockStore blockStore) {
 
         // Transaction env
-        this.address = new DataWord(address);
-        this.origin = new DataWord(origin);
-        this.caller = new DataWord(caller);
-        this.balance = new DataWord(balance);
-        this.gasPrice = new DataWord(gasPrice);
-        this.gas = Program.limitToMaxLong(new DataWord(gas));
-        this.callValue = new DataWord(callValue);
+        this.address = DataWord.valueOf(address);
+        this.origin = DataWord.valueOf(origin);
+        this.caller = DataWord.valueOf(caller);
+        this.balance = DataWord.valueOf(balance);
+        this.gasPrice = DataWord.valueOf(gasPrice);
+        this.gas = Program.limitToMaxLong(DataWord.valueOf(gas));
+        this.callValue = DataWord.valueOf(callValue);
         this.msgData = msgData;
 
         // last Block env
-        this.prevHash = new DataWord(lastHash);
-        this.coinbase = new DataWord(coinbase);
-        this.timestamp = new DataWord(timestamp);
-        this.number = new DataWord(number);
-        this.transactionIndex = new DataWord(transactionIndex);
-        this.difficulty = new DataWord(difficulty);
-        this.gaslimit = new DataWord(gaslimit);
+        this.prevHash = DataWord.valueOf(lastHash);
+        this.coinbase = DataWord.valueOf(coinbase);
+        this.timestamp = DataWord.valueOf(timestamp);
+        this.number = DataWord.valueOf(number);
+        this.transactionIndex = DataWord.valueOf(transactionIndex);
+        this.difficulty = DataWord.valueOf(difficulty);
+        this.gaslimit = DataWord.valueOf(gaslimit);
 
         this.repository = repository;
         this.blockStore = blockStore;
@@ -198,7 +198,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
 
         if (msgData == null || index >= msgData.length
                 || tempIndex.compareTo(maxMsgData) == 1) {
-            return new DataWord();
+            return DataWord.ZERO;
         }
         if (index + size > msgData.length) {
             size = msgData.length - index;
@@ -206,7 +206,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
 
         byte[] data = new byte[32];
         System.arraycopy(msgData, index, data, 0, size);
-        return new DataWord(data);
+        return DataWord.valueOf(data);
     }
 
     /*  CALLDATASIZE */
@@ -216,7 +216,7 @@ public class ProgramInvokeImpl implements ProgramInvoke {
             return DataWord.ZERO;
         }
         int size = msgData.length;
-        return new DataWord(size);
+        return DataWord.valueOf(size);
     }
 
     /*  CALLDATACOPY */

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
@@ -202,7 +202,7 @@ public class ProgramTrace {
                 this.currentStorage.put(this.storageKey.toString(), value.toString());
             }
             else {
-                this.currentStorage.remove(this.storageKey);
+                this.currentStorage.remove(this.storageKey.toString());
             }
 
             this.storageSize = this.currentStorage.size();

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
@@ -210,7 +210,7 @@ public class ProgramTrace {
         }
 
         if (opcode == OpCode.SSTORE || opcode == OpCode.SLOAD) {
-            this.storageKey = stack.peek().clone();
+            this.storageKey = stack.peek();
         }
 
         op.setStorage(this.currentStorage);

--- a/rskj-core/src/test/java/co/rsk/asm/EVMDissasembler.java
+++ b/rskj-core/src/test/java/co/rsk/asm/EVMDissasembler.java
@@ -57,8 +57,7 @@ public class EVMDissasembler {
             // Asummes LSBs are zero. assignDataRange undestands this semantics.
         }
 
-        DataWord dw = new DataWord();
-        dw.assignDataRange(ops, pc, n);
+        DataWord dw = new DataWord(ops, pc, n);
         pc += n;
         if (pc >= ops.length) stop();
 

--- a/rskj-core/src/test/java/co/rsk/asm/EVMDissasembler.java
+++ b/rskj-core/src/test/java/co/rsk/asm/EVMDissasembler.java
@@ -57,7 +57,7 @@ public class EVMDissasembler {
             // Asummes LSBs are zero. assignDataRange undestands this semantics.
         }
 
-        DataWord dw = new DataWord(ops, pc, n);
+        DataWord dw = DataWord.valueOf(ops, pc, n);
         pc += n;
         if (pc >= ops.length) stop();
 

--- a/rskj-core/src/test/java/co/rsk/db/ContractDetailsImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/ContractDetailsImplTest.java
@@ -72,7 +72,7 @@ public class ContractDetailsImplTest {
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
         for (int k = 1; k <= nkeys + 1; k++)
-            details.put(new DataWord(k), new DataWord(k * 2));
+            details.put(DataWord.valueOf(k), DataWord.valueOf(k * 2));
 
         Assert.assertTrue(details.hasExternalStorage());
     }
@@ -84,7 +84,7 @@ public class ContractDetailsImplTest {
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
         for (int k = 1; k <= nkeys + 1; k++)
-            details.putBytes(new DataWord(k), randomData());
+            details.putBytes(DataWord.valueOf(k), randomData());
 
         Assert.assertTrue(details.hasExternalStorage());
     }
@@ -116,9 +116,9 @@ public class ContractDetailsImplTest {
     public void putAndGetDataWord() {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
-        details.put(DataWord.ONE, new DataWord(42));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
 
-        Assert.assertEquals(new DataWord(42), details.get(DataWord.ONE));
+        Assert.assertEquals(DataWord.valueOf(42), details.get(DataWord.ONE));
         Assert.assertTrue(details.isDirty());
         Assert.assertEquals(1, details.getStorageSize());
     }
@@ -127,7 +127,7 @@ public class ContractDetailsImplTest {
     public void putDataWordWithoutLeadingZeroes() {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
-        details.put(DataWord.ONE, new DataWord(42));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
 
         Trie trie = details.getTrie();
 
@@ -143,7 +143,7 @@ public class ContractDetailsImplTest {
     public void putDataWordZeroAsDeleteValue() {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
-        details.put(DataWord.ONE, new DataWord(42));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
         details.put(DataWord.ONE, DataWord.ZERO);
 
         Trie trie = details.getTrie();
@@ -193,8 +193,8 @@ public class ContractDetailsImplTest {
     public void getStorageRoot() {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
-        details.put(DataWord.ONE, new DataWord(42));
-        details.put(DataWord.ZERO, new DataWord(1));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
+        details.put(DataWord.ZERO, DataWord.valueOf(1));
 
         Trie trie = details.getTrie();
 
@@ -233,7 +233,7 @@ public class ContractDetailsImplTest {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
         details.put(DataWord.ZERO, DataWord.ONE);
-        details.put(DataWord.ONE, new DataWord(42));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
 
         Assert.assertEquals(2, details.getStorageSize());
     }
@@ -243,7 +243,7 @@ public class ContractDetailsImplTest {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
         details.put(DataWord.ZERO, DataWord.ONE);
-        details.put(DataWord.ONE, new DataWord(42));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
 
         Set<DataWord> keys = details.getStorageKeys();
 
@@ -258,7 +258,7 @@ public class ContractDetailsImplTest {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
         details.put(DataWord.ZERO, DataWord.ONE);
-        details.put(DataWord.ONE, new DataWord(42));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
         details.put(DataWord.ONE, DataWord.ZERO);
 
         Set<DataWord> keys = details.getStorageKeys();
@@ -293,7 +293,7 @@ public class ContractDetailsImplTest {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
         details.put(DataWord.ZERO, DataWord.ONE);
-        details.put(DataWord.ONE, new DataWord(42));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
 
         Map<DataWord, DataWord> map = details.getStorage();
 
@@ -304,7 +304,7 @@ public class ContractDetailsImplTest {
         Assert.assertTrue(map.containsKey(DataWord.ONE));
 
         Assert.assertEquals(DataWord.ONE, map.get(DataWord.ZERO));
-        Assert.assertEquals(new DataWord(42), map.get(DataWord.ONE));
+        Assert.assertEquals(DataWord.valueOf(42), map.get(DataWord.ONE));
     }
 
     @Test
@@ -312,13 +312,13 @@ public class ContractDetailsImplTest {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
         details.put(DataWord.ZERO, DataWord.ONE);
-        details.put(DataWord.ONE, new DataWord(42));
-        details.put(new DataWord(3), new DataWord(144));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
+        details.put(DataWord.valueOf(3), DataWord.valueOf(144));
 
         Collection<DataWord> keys = new HashSet<>();
 
         keys.add(DataWord.ZERO);
-        keys.add(new DataWord(3));
+        keys.add(DataWord.valueOf(3));
 
         Map<DataWord, DataWord> map = details.getStorage(keys);
 
@@ -328,10 +328,10 @@ public class ContractDetailsImplTest {
         Assert.assertEquals(2, map.size());
 
         Assert.assertTrue(map.containsKey(DataWord.ZERO));
-        Assert.assertTrue(map.containsKey(new DataWord(3)));
+        Assert.assertTrue(map.containsKey(DataWord.valueOf(3)));
 
         Assert.assertEquals(DataWord.ONE, map.get(DataWord.ZERO));
-        Assert.assertEquals(new DataWord(144), map.get(new DataWord(3)));
+        Assert.assertEquals(DataWord.valueOf(144), map.get(DataWord.valueOf(3)));
     }
 
     @Test
@@ -384,7 +384,7 @@ public class ContractDetailsImplTest {
     public void contractDetailsWithStorageDataIsNotNullObject() {
         ContractDetailsImpl details = buildContractDetails(new HashMapDB());
 
-        details.put(DataWord.ONE, new DataWord(42));
+        details.put(DataWord.ONE, DataWord.valueOf(42));
 
         Assert.assertFalse(details.isNullObject());
     }
@@ -395,13 +395,13 @@ public class ContractDetailsImplTest {
 
         Map<DataWord, DataWord> map = new HashMap<>();
 
-        map.put(DataWord.ZERO, new DataWord(42));
-        map.put(DataWord.ONE, new DataWord(144));
+        map.put(DataWord.ZERO, DataWord.valueOf(42));
+        map.put(DataWord.ONE, DataWord.valueOf(144));
 
         details.setStorage(map);
 
-        Assert.assertEquals(new DataWord(42), details.get(DataWord.ZERO));
-        Assert.assertEquals(new DataWord(144), details.get(DataWord.ONE));
+        Assert.assertEquals(DataWord.valueOf(42), details.get(DataWord.ZERO));
+        Assert.assertEquals(DataWord.valueOf(144), details.get(DataWord.ONE));
     }
 
     @Test
@@ -411,32 +411,32 @@ public class ContractDetailsImplTest {
         byte[] initialRoot = details.getStorageHash();
 
         Map<DataWord, DataWord> firstStorage = new HashMap<>();
-        firstStorage.put(DataWord.ZERO, new DataWord(42));
-        firstStorage.put(DataWord.ONE, new DataWord(144));
+        firstStorage.put(DataWord.ZERO, DataWord.valueOf(42));
+        firstStorage.put(DataWord.ONE, DataWord.valueOf(144));
         details.setStorage(firstStorage);
 
         byte[] root = details.getStorageHash();
 
         Map<DataWord, DataWord> secondStorage = new HashMap<>();
 
-        secondStorage.put(new DataWord(2), new DataWord(1));
-        secondStorage.put(new DataWord(3), new DataWord(2));
+        secondStorage.put(DataWord.valueOf(2), DataWord.valueOf(1));
+        secondStorage.put(DataWord.valueOf(3), DataWord.valueOf(2));
 
         details.setStorage(secondStorage);
 
         ContractDetails result = details.getSnapshotTo(root);
 
-        Assert.assertEquals(new DataWord(42), result.get(DataWord.ZERO));
-        Assert.assertEquals(new DataWord(144), result.get(DataWord.ONE));
-        Assert.assertEquals(null, result.get(new DataWord(2)));
-        Assert.assertEquals(null, result.get(new DataWord(3)));
+        Assert.assertEquals(DataWord.valueOf(42), result.get(DataWord.ZERO));
+        Assert.assertEquals(DataWord.valueOf(144), result.get(DataWord.ONE));
+        Assert.assertEquals(null, result.get(DataWord.valueOf(2)));
+        Assert.assertEquals(null, result.get(DataWord.valueOf(3)));
 
         ContractDetails result2 = details.getSnapshotTo(initialRoot);
 
         Assert.assertEquals(null, result2.get(DataWord.ZERO));
         Assert.assertEquals(null, result2.get(DataWord.ONE));
-        Assert.assertEquals(null, result2.get(new DataWord(2)));
-        Assert.assertEquals(null, result2.get(new DataWord(3)));
+        Assert.assertEquals(null, result2.get(DataWord.valueOf(2)));
+        Assert.assertEquals(null, result2.get(DataWord.valueOf(3)));
     }
 
     @Test
@@ -445,8 +445,8 @@ public class ContractDetailsImplTest {
         ContractDetailsImpl details = buildContractDetails(store);
 
         Map<DataWord, DataWord> storage = new HashMap<>();
-        storage.put(DataWord.ZERO, new DataWord(42));
-        storage.put(DataWord.ONE, new DataWord(144));
+        storage.put(DataWord.ZERO, DataWord.valueOf(42));
+        storage.put(DataWord.ONE, DataWord.valueOf(144));
 
         details.setStorage(storage);
         details.syncStorage();
@@ -457,10 +457,10 @@ public class ContractDetailsImplTest {
 
         ContractDetailsImpl result = new ContractDetailsImpl(encoded, new TrieStorePoolOnMemory(() -> store), config.detailsInMemoryStorageLimit());
 
-        Assert.assertEquals(new DataWord(42), result.get(DataWord.ZERO));
-        Assert.assertEquals(new DataWord(144), result.get(DataWord.ONE));
-        Assert.assertEquals(null, result.get(new DataWord(2)));
-        Assert.assertEquals(null, result.get(new DataWord(3)));
+        Assert.assertEquals(DataWord.valueOf(42), result.get(DataWord.ZERO));
+        Assert.assertEquals(DataWord.valueOf(144), result.get(DataWord.ONE));
+        Assert.assertEquals(null, result.get(DataWord.valueOf(2)));
+        Assert.assertEquals(null, result.get(DataWord.valueOf(3)));
     }
 
     @Test
@@ -469,8 +469,8 @@ public class ContractDetailsImplTest {
         ContractDetailsImpl details = buildContractDetails(store);
 
         Map<DataWord, DataWord> storage = new HashMap<>();
-        storage.put(DataWord.ZERO, new DataWord(42));
-        storage.put(DataWord.ONE, new DataWord(144));
+        storage.put(DataWord.ZERO, DataWord.valueOf(42));
+        storage.put(DataWord.ONE, DataWord.valueOf(144));
 
         details.setStorage(storage);
 
@@ -480,10 +480,10 @@ public class ContractDetailsImplTest {
 
         ContractDetailsImpl result = new ContractDetailsImpl(encoded, new TrieStorePoolOnMemory(), config.detailsInMemoryStorageLimit());
 
-        Assert.assertEquals(new DataWord(42), result.get(DataWord.ZERO));
-        Assert.assertEquals(new DataWord(144), result.get(DataWord.ONE));
-        Assert.assertEquals(null, result.get(new DataWord(2)));
-        Assert.assertEquals(null, result.get(new DataWord(3)));
+        Assert.assertEquals(DataWord.valueOf(42), result.get(DataWord.ZERO));
+        Assert.assertEquals(DataWord.valueOf(144), result.get(DataWord.ONE));
+        Assert.assertEquals(null, result.get(DataWord.valueOf(2)));
+        Assert.assertEquals(null, result.get(DataWord.valueOf(3)));
 
         Assert.assertArrayEquals(details.getStorageHash(), result.getStorageHash());
     }
@@ -507,16 +507,16 @@ public class ContractDetailsImplTest {
         HashMapDB store = new HashMapDB();
         ContractDetailsImpl details = buildContractDetails(store);
 
-        DataWord value0 = new DataWord(42);
-        DataWord value1 = new DataWord(144);
+        DataWord value0 = DataWord.valueOf(42);
+        DataWord value1 = DataWord.valueOf(144);
 
         details.put(DataWord.ZERO, value0);
         details.put(DataWord.ONE, value1);
 
         byte[] hash1 = details.getStorageHash();
 
-        details.put(new DataWord(10), value0);
-        details.put(new DataWord(11), value1);
+        details.put(DataWord.valueOf(10), value0);
+        details.put(DataWord.valueOf(11), value1);
 
         byte[] hash2 = details.getStorageHash();
 
@@ -551,11 +551,11 @@ public class ContractDetailsImplTest {
         byte[] accountAddress = randomAddress();
         ContractDetailsImpl details = new ContractDetailsImpl(accountAddress, trie, null, new TrieStorePoolOnMemory(() -> store), config.detailsInMemoryStorageLimit());
 
-        details.put(new DataWord(42), DataWord.ONE);
+        details.put(DataWord.valueOf(42), DataWord.ONE);
 
         details.syncStorage();
 
-        Assert.assertNotNull(details.get(new DataWord(42)));
+        Assert.assertNotNull(details.get(DataWord.valueOf(42)));
     }
 
     @Test
@@ -568,7 +568,7 @@ public class ContractDetailsImplTest {
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
         for (int k = 1; k <= nkeys + 1; k++)
-            details.put(new DataWord(k), new DataWord(k * 2));
+            details.put(DataWord.valueOf(k), DataWord.valueOf(k * 2));
 
         Assert.assertTrue(details.hasExternalStorage());
 
@@ -583,9 +583,9 @@ public class ContractDetailsImplTest {
         Assert.assertTrue(details2.hasExternalStorage());
 
         for (int k = 1; k <= nkeys + 1; k++)
-            Assert.assertNotNull(details1.get(new DataWord(k)));
+            Assert.assertNotNull(details1.get(DataWord.valueOf(k)));
         for (int k = 1; k <= nkeys + 1; k++)
-            Assert.assertNotNull(details2.get(new DataWord(k)));
+            Assert.assertNotNull(details2.get(DataWord.valueOf(k)));
 
         details1.syncStorage();
         details2.syncStorage();
@@ -602,7 +602,7 @@ public class ContractDetailsImplTest {
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
         for (int k = 1; k <= nkeys + 1; k++)
-            details.put(new DataWord(k), new DataWord(k * 2));
+            details.put(DataWord.valueOf(k), DataWord.valueOf(k * 2));
 
         Assert.assertTrue(details.hasExternalStorage());
 
@@ -615,7 +615,7 @@ public class ContractDetailsImplTest {
         Assert.assertEquals(ssize, details.getStorageSize());
 
         for (int k = 1; k <= nkeys + 1; k++)
-            Assert.assertNotNull(details.get(new DataWord(k)));
+            Assert.assertNotNull(details.get(DataWord.valueOf(k)));
 
         ContractDetailsImpl clone = new ContractDetailsImpl(details.getEncoded(), trieStorePool, config.detailsInMemoryStorageLimit());
 
@@ -624,10 +624,10 @@ public class ContractDetailsImplTest {
         Assert.assertEquals(details.getStorageSize(), clone.getStorageSize());
 
         for (int k = 1; k <= nkeys + 1; k++)
-            Assert.assertNotNull(clone.get(new DataWord(k)));
+            Assert.assertNotNull(clone.get(DataWord.valueOf(k)));
 
         for (int k = 1; k <= nkeys + 1; k++)
-            clone.put(new DataWord(k), new DataWord(k * 3));
+            clone.put(DataWord.valueOf(k), DataWord.valueOf(k * 3));
 
         Assert.assertTrue(clone.hasExternalStorage());
         Assert.assertEquals(details.getStorageSize(), clone.getStorageSize());
@@ -647,14 +647,14 @@ public class ContractDetailsImplTest {
         int nkeys = IN_MEMORY_STORAGE_LIMIT;
 
         for (int k = 1; k <= nkeys + 1; k++)
-            details.put(new DataWord(k), new DataWord(k * 2));
+            details.put(DataWord.valueOf(k), DataWord.valueOf(k * 2));
 
         Assert.assertTrue(details.hasExternalStorage());
 
         details.syncStorage();
 
         for (int k = 1; k <= nkeys + 1; k++)
-            Assert.assertNotNull(details.get(new DataWord(k)));
+            Assert.assertNotNull(details.get(DataWord.valueOf(k)));
 
         ContractDetailsImpl clone = new ContractDetailsImpl(details.getEncoded(), new TrieStorePoolOnMemory(() -> store), config.detailsInMemoryStorageLimit());
 
@@ -663,10 +663,10 @@ public class ContractDetailsImplTest {
         Assert.assertEquals(details.getStorageSize(), clone.getStorageSize());
 
         for (int k = 1; k <= nkeys + 1; k++)
-            Assert.assertNotNull(clone.get(new DataWord(k)));
+            Assert.assertNotNull(clone.get(DataWord.valueOf(k)));
 
         for (int k = 1; k <= nkeys + 1; k++)
-            clone.put(new DataWord(k), new DataWord(k * 3));
+            clone.put(DataWord.valueOf(k), DataWord.valueOf(k * 3));
 
         Assert.assertTrue(clone.hasExternalStorage());
         Assert.assertEquals(details.getStorageSize(), clone.getStorageSize());
@@ -774,8 +774,8 @@ public class ContractDetailsImplTest {
 
         ContractDetailsImpl contractDetails = buildContractDetails(pool);
         contractDetails.setCode(code);
-        contractDetails.put(new DataWord(key_1), new DataWord(val_1));
-        contractDetails.put(new DataWord(key_2), new DataWord(val_2));
+        contractDetails.put(DataWord.valueOf(key_1), DataWord.valueOf(val_1));
+        contractDetails.put(DataWord.valueOf(key_2), DataWord.valueOf(val_2));
         contractDetails.syncStorage();
 
         byte[] data = contractDetails.getEncoded();
@@ -786,10 +786,10 @@ public class ContractDetailsImplTest {
                 Hex.toHexString(contractDetails_.getCode()));
 
         Assert.assertEquals(Hex.toHexString(val_1),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_1)).getNoLeadZeroesData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_1)).getNoLeadZeroesData()));
 
         Assert.assertEquals(Hex.toHexString(val_2),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_2)).getNoLeadZeroesData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_2)).getNoLeadZeroesData()));
     }
 
     @Test
@@ -845,20 +845,20 @@ public class ContractDetailsImplTest {
         ContractDetailsImpl contractDetails = buildContractDetails(store);
         contractDetails.setCode(code);
         contractDetails.setAddress(address);
-        contractDetails.put(new DataWord(key_0), new DataWord(val_0));
-        contractDetails.put(new DataWord(key_1), new DataWord(val_1));
-        contractDetails.put(new DataWord(key_2), new DataWord(val_2));
-        contractDetails.put(new DataWord(key_3), new DataWord(val_3));
-        contractDetails.put(new DataWord(key_4), new DataWord(val_4));
-        contractDetails.put(new DataWord(key_5), new DataWord(val_5));
-        contractDetails.put(new DataWord(key_6), new DataWord(val_6));
-        contractDetails.put(new DataWord(key_7), new DataWord(val_7));
-        contractDetails.put(new DataWord(key_8), new DataWord(val_8));
-        contractDetails.put(new DataWord(key_9), new DataWord(val_9));
-        contractDetails.put(new DataWord(key_10), new DataWord(val_10));
-        contractDetails.put(new DataWord(key_11), new DataWord(val_11));
-        contractDetails.put(new DataWord(key_12), new DataWord(val_12));
-        contractDetails.put(new DataWord(key_13), new DataWord(val_13));
+        contractDetails.put(DataWord.valueOf(key_0), DataWord.valueOf(val_0));
+        contractDetails.put(DataWord.valueOf(key_1), DataWord.valueOf(val_1));
+        contractDetails.put(DataWord.valueOf(key_2), DataWord.valueOf(val_2));
+        contractDetails.put(DataWord.valueOf(key_3), DataWord.valueOf(val_3));
+        contractDetails.put(DataWord.valueOf(key_4), DataWord.valueOf(val_4));
+        contractDetails.put(DataWord.valueOf(key_5), DataWord.valueOf(val_5));
+        contractDetails.put(DataWord.valueOf(key_6), DataWord.valueOf(val_6));
+        contractDetails.put(DataWord.valueOf(key_7), DataWord.valueOf(val_7));
+        contractDetails.put(DataWord.valueOf(key_8), DataWord.valueOf(val_8));
+        contractDetails.put(DataWord.valueOf(key_9), DataWord.valueOf(val_9));
+        contractDetails.put(DataWord.valueOf(key_10), DataWord.valueOf(val_10));
+        contractDetails.put(DataWord.valueOf(key_11), DataWord.valueOf(val_11));
+        contractDetails.put(DataWord.valueOf(key_12), DataWord.valueOf(val_12));
+        contractDetails.put(DataWord.valueOf(key_13), DataWord.valueOf(val_13));
         contractDetails.syncStorage();
 
         byte[] data = contractDetails.getEncoded();
@@ -872,43 +872,43 @@ public class ContractDetailsImplTest {
                 Hex.toHexString(contractDetails_.getAddress()));
 
         Assert.assertEquals(Hex.toHexString(val_1),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_1)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_1)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_2),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_2)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_2)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_3),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_3)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_3)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_4),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_4)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_4)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_5),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_5)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_5)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_6),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_6)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_6)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_7),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_7)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_7)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_8),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_8)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_8)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_9),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_9)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_9)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_10),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_10)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_10)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_11),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_11)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_11)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_12),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_12)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_12)).getData()));
 
         Assert.assertEquals(Hex.toHexString(val_13),
-                Hex.toHexString(contractDetails_.get(new DataWord(key_13)).getData()));
+                Hex.toHexString(contractDetails_.get(DataWord.valueOf(key_13)).getData()));
     }
 
     private static byte[] randomData() {

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
@@ -110,12 +110,12 @@ public class RepositoryImplOriginalTest {
         byte[] horseKey = Hex.decode("B1B2B3");
         byte[] horseValue = Hex.decode("B4B5B6");
 
-        track.addStorageRow(COW, new DataWord(cowKey), new DataWord(cowValue));
-        track.addStorageRow(HORSE, new DataWord(horseKey), new DataWord(horseValue));
+        track.addStorageRow(COW, DataWord.valueOf(cowKey), DataWord.valueOf(cowValue));
+        track.addStorageRow(HORSE, DataWord.valueOf(horseKey), DataWord.valueOf(horseValue));
         track.commit();
 
-        assertEquals(new DataWord(cowValue), repository.getStorageValue(COW, new DataWord(cowKey)));
-        assertEquals(new DataWord(horseValue), repository.getStorageValue(HORSE, new DataWord(horseKey)));
+        assertEquals(DataWord.valueOf(cowValue), repository.getStorageValue(COW, DataWord.valueOf(cowKey)));
+        assertEquals(DataWord.valueOf(horseValue), repository.getStorageValue(HORSE, DataWord.valueOf(horseKey)));
     }
 
     @Test
@@ -265,11 +265,11 @@ public class RepositoryImplOriginalTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        DataWord cowKey = new DataWord(Hex.decode("A1A2A3"));
-        DataWord cowValue = new DataWord(Hex.decode("A4A5A6"));
+        DataWord cowKey = DataWord.valueOf(Hex.decode("A1A2A3"));
+        DataWord cowValue = DataWord.valueOf(Hex.decode("A4A5A6"));
 
-        DataWord horseKey = new DataWord(Hex.decode("B1B2B3"));
-        DataWord horseValue = new DataWord(Hex.decode("B4B5B6"));
+        DataWord horseKey = DataWord.valueOf(Hex.decode("B1B2B3"));
+        DataWord horseValue = DataWord.valueOf(Hex.decode("B4B5B6"));
 
         track.addStorageRow(COW, cowKey, cowValue);
         track.addStorageRow(HORSE, horseKey, horseValue);
@@ -288,11 +288,11 @@ public class RepositoryImplOriginalTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        DataWord cowKey = new DataWord(Hex.decode("A1A2A3"));
-        DataWord cowValue = new DataWord(Hex.decode("A4A5A6"));
+        DataWord cowKey = DataWord.valueOf(Hex.decode("A1A2A3"));
+        DataWord cowValue = DataWord.valueOf(Hex.decode("A4A5A6"));
 
-        DataWord horseKey = new DataWord(Hex.decode("B1B2B3"));
-        DataWord horseValue = new DataWord(Hex.decode("B4B5B6"));
+        DataWord horseKey = DataWord.valueOf(Hex.decode("B1B2B3"));
+        DataWord horseValue = DataWord.valueOf(Hex.decode("B4B5B6"));
 
         track.addStorageRow(COW, cowKey, cowValue);
         track.addStorageRow(HORSE, horseKey, horseValue);
@@ -444,40 +444,40 @@ public class RepositoryImplOriginalTest {
 
         // changes level_1
         Repository track1 = repository.startTracking();
-        track1.addStorageRow(COW, new DataWord(cowKey1), new DataWord(cowValue1));
-        track1.addStorageRow(HORSE, new DataWord(horseKey1), new DataWord(horseValue1));
+        track1.addStorageRow(COW, DataWord.valueOf(cowKey1), DataWord.valueOf(cowValue1));
+        track1.addStorageRow(HORSE, DataWord.valueOf(horseKey1), DataWord.valueOf(horseValue1));
 
-        assertEquals(new DataWord(cowValue1), track1.getStorageValue(COW, new DataWord(cowKey1)));
-        assertEquals(new DataWord(horseValue1), track1.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertEquals(DataWord.valueOf(cowValue1), track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(DataWord.valueOf(horseValue1), track1.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageRow(COW, new DataWord(cowKey2), new DataWord(cowValue2));
-        track2.addStorageRow(HORSE, new DataWord(horseKey2), new DataWord(horseValue2));
+        track2.addStorageRow(COW, DataWord.valueOf(cowKey2), DataWord.valueOf(cowValue2));
+        track2.addStorageRow(HORSE, DataWord.valueOf(horseKey2), DataWord.valueOf(horseValue2));
 
-        assertEquals(new DataWord(cowValue1), track2.getStorageValue(COW, new DataWord(cowKey1)));
-        assertEquals(new DataWord(horseValue1), track2.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertEquals(DataWord.valueOf(cowValue1), track2.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(DataWord.valueOf(horseValue1), track2.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertEquals(new DataWord(cowValue2), track2.getStorageValue(COW, new DataWord(cowKey2)));
-        assertEquals(new DataWord(horseValue2), track2.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertEquals(DataWord.valueOf(cowValue2), track2.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertEquals(DataWord.valueOf(horseValue2), track2.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
 
         track2.commit();
         // leaving level_2
 
-        assertEquals(new DataWord(cowValue1), track1.getStorageValue(COW, new DataWord(cowKey1)));
-        assertEquals(new DataWord(horseValue1), track1.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertEquals(DataWord.valueOf(cowValue1), track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(DataWord.valueOf(horseValue1), track1.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertEquals(new DataWord(cowValue2), track1.getStorageValue(COW, new DataWord(cowKey2)));
-        assertEquals(new DataWord(horseValue2), track1.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertEquals(DataWord.valueOf(cowValue2), track1.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertEquals(DataWord.valueOf(horseValue2), track1.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
 
         track1.commit();
         // leaving level_1
 
-        assertEquals(new DataWord(cowValue1), repository.getStorageValue(COW, new DataWord(cowKey1)));
-        assertEquals(new DataWord(horseValue1), repository.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertEquals(DataWord.valueOf(cowValue1), repository.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(DataWord.valueOf(horseValue1), repository.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertEquals(new DataWord(cowValue2), repository.getStorageValue(COW, new DataWord(cowKey2)));
-        assertEquals(new DataWord(horseValue2), repository.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertEquals(DataWord.valueOf(cowValue2), repository.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertEquals(DataWord.valueOf(horseValue2), repository.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
     }
 
     @Test
@@ -501,32 +501,32 @@ public class RepositoryImplOriginalTest {
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageRow(COW, new DataWord(cowKey2), new DataWord(cowValue2));
-        track2.addStorageRow(HORSE, new DataWord(horseKey2), new DataWord(horseValue2));
+        track2.addStorageRow(COW, DataWord.valueOf(cowKey2), DataWord.valueOf(cowValue2));
+        track2.addStorageRow(HORSE, DataWord.valueOf(horseKey2), DataWord.valueOf(horseValue2));
 
-        assertNull(track2.getStorageValue(COW, new DataWord(cowKey1)));
-        assertNull(track2.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertNull(track2.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track2.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertEquals(new DataWord(cowValue2), track2.getStorageValue(COW, new DataWord(cowKey2)));
-        assertEquals(new DataWord(horseValue2), track2.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertEquals(DataWord.valueOf(cowValue2), track2.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertEquals(DataWord.valueOf(horseValue2), track2.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
 
         track2.commit();
         // leaving level_2
 
-        assertNull(track1.getStorageValue(COW, new DataWord(cowKey1)));
-        assertNull(track1.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertNull(track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track1.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertEquals(new DataWord(cowValue2), track1.getStorageValue(COW, new DataWord(cowKey2)));
-        assertEquals(new DataWord(horseValue2), track1.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertEquals(DataWord.valueOf(cowValue2), track1.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertEquals(DataWord.valueOf(horseValue2), track1.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
 
         track1.commit();
         // leaving level_1
 
-        assertEquals(null, repository.getStorageValue(COW, new DataWord(cowKey1)));
-        assertEquals(null, repository.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertEquals(null, repository.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(null, repository.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertEquals(new DataWord(cowValue2), repository.getStorageValue(COW, new DataWord(cowKey2)));
-        assertEquals(new DataWord(horseValue2), repository.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertEquals(DataWord.valueOf(cowValue2), repository.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertEquals(DataWord.valueOf(horseValue2), repository.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
     }
 
     @Test
@@ -550,32 +550,32 @@ public class RepositoryImplOriginalTest {
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageRow(COW, new DataWord(cowKey2), new DataWord(cowValue2));
-        track2.addStorageRow(HORSE, new DataWord(horseKey2), new DataWord(horseValue2));
+        track2.addStorageRow(COW, DataWord.valueOf(cowKey2), DataWord.valueOf(cowValue2));
+        track2.addStorageRow(HORSE, DataWord.valueOf(horseKey2), DataWord.valueOf(horseValue2));
 
-        assertNull(track2.getStorageValue(COW, new DataWord(cowKey1)));
-        assertNull(track2.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertNull(track2.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track2.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertEquals(new DataWord(cowValue2), track2.getStorageValue(COW, new DataWord(cowKey2)));
-        assertEquals(new DataWord(horseValue2), track2.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertEquals(DataWord.valueOf(cowValue2), track2.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertEquals(DataWord.valueOf(horseValue2), track2.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
 
         track2.commit();
         // leaving level_2
 
-        assertNull(track1.getStorageValue(COW, new DataWord(cowKey1)));
-        assertNull(track1.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertNull(track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track1.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertEquals(new DataWord(cowValue2), track1.getStorageValue(COW, new DataWord(cowKey2)));
-        assertEquals(new DataWord(horseValue2), track1.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertEquals(DataWord.valueOf(cowValue2), track1.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertEquals(DataWord.valueOf(horseValue2), track1.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
 
         track1.rollback();
         // leaving level_1
 
-        assertNull(track1.getStorageValue(COW, new DataWord(cowKey1)));
-        assertNull(track1.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertNull(track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track1.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertNull(track1.getStorageValue(COW, new DataWord(cowKey2)));
-        assertNull(track1.getStorageValue(HORSE, new DataWord(horseKey2)));
+        assertNull(track1.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertNull(track1.getStorageValue(HORSE, DataWord.valueOf(horseKey2)));
     }
 
     @Test
@@ -595,7 +595,7 @@ public class RepositoryImplOriginalTest {
         byte[] horseValue2 = "val-h-2".getBytes();
 
         Repository track = repository.startTracking();
-        track.addStorageRow(COW, new DataWord(cowKey1), new DataWord(cowValue1));
+        track.addStorageRow(COW, DataWord.valueOf(cowKey1), DataWord.valueOf(cowValue1));
         track.commit();
 
         // changes level_1
@@ -603,7 +603,7 @@ public class RepositoryImplOriginalTest {
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageRow(COW, new DataWord(cowKey2), new DataWord(cowValue2));
+        track2.addStorageRow(COW, DataWord.valueOf(cowKey2), DataWord.valueOf(cowValue2));
 
         track2.commit();
         // leaving level_2
@@ -611,8 +611,8 @@ public class RepositoryImplOriginalTest {
         track1.commit();
         // leaving level_1
 
-        assertEquals(new DataWord(cowValue1), track1.getStorageValue(COW, new DataWord(cowKey1)));
-        assertEquals(new DataWord(cowValue2), track1.getStorageValue(COW, new DataWord(cowKey2)));
+        assertEquals(DataWord.valueOf(cowValue1), track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(DataWord.valueOf(cowValue2), track1.getStorageValue(COW, DataWord.valueOf(cowKey2)));
     }
 
 
@@ -634,12 +634,12 @@ public class RepositoryImplOriginalTest {
 
         // changes level_1
         Repository track1 = repository.startTracking();
-        track1.addStorageRow(COW, new DataWord(cowKey2), new DataWord(cowValue2));
+        track1.addStorageRow(COW, DataWord.valueOf(cowKey2), DataWord.valueOf(cowValue2));
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        assertEquals(new DataWord(cowValue2), track1.getStorageValue(COW, new DataWord(cowKey2)));
-        assertNull(track1.getStorageValue(COW, new DataWord(cowKey1)));
+        assertEquals(DataWord.valueOf(cowValue2), track1.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertNull(track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
 
         track2.commit();
         // leaving level_2
@@ -647,8 +647,8 @@ public class RepositoryImplOriginalTest {
         track1.commit();
         // leaving level_1
 
-        assertEquals(new DataWord(cowValue2), track1.getStorageValue(COW, new DataWord(cowKey2)));
-        assertNull(track1.getStorageValue(COW, new DataWord(cowKey1)));
+        assertEquals(DataWord.valueOf(cowValue2), track1.getStorageValue(COW, DataWord.valueOf(cowKey2)));
+        assertNull(track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
     }
 
     @Test
@@ -663,8 +663,8 @@ public class RepositoryImplOriginalTest {
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageRow(COW, new DataWord(cowKey1), new DataWord(cowValue1));
-        assertEquals(new DataWord(cowValue1), track2.getStorageValue(COW, new DataWord(cowKey1)));
+        track2.addStorageRow(COW, DataWord.valueOf(cowKey1), DataWord.valueOf(cowValue1));
+        assertEquals(DataWord.valueOf(cowValue1), track2.getStorageValue(COW, DataWord.valueOf(cowKey1)));
         track2.rollback();
         // leaving level_2
 
@@ -701,13 +701,13 @@ public class RepositoryImplOriginalTest {
         Repository repository = createRepositoryImpl(config);
         Repository track = repository.startTracking();
 
-        DataWord cowKey1 = new DataWord("c1");
-        DataWord cowVal1 = new DataWord("c0a1");
-        DataWord cowVal0 = new DataWord("c0a0");
+        DataWord cowKey1 = DataWord.valueFromHex("c1");
+        DataWord cowVal1 = DataWord.valueFromHex("c0a1");
+        DataWord cowVal0 = DataWord.valueFromHex("c0a0");
 
-        DataWord horseKey1 = new DataWord("e1");
-        DataWord horseVal1 = new DataWord("c0a1");
-        DataWord horseVal0 = new DataWord("c0a0");
+        DataWord horseKey1 = DataWord.valueFromHex("e1");
+        DataWord horseVal1 = DataWord.valueFromHex("c0a1");
+        DataWord horseVal0 = DataWord.valueFromHex("c0a0");
 
         track.addStorageRow(COW, cowKey1, cowVal0);
         track.addStorageRow(HORSE, horseKey1, horseVal0);
@@ -734,15 +734,15 @@ public class RepositoryImplOriginalTest {
         Repository repository = new RepositoryImpl(new Trie(store, true), new HashMapDB(), new TrieStorePoolOnMemory(), config.detailsInMemoryStorageLimit());
         byte[] root = repository.getRoot();
 
-        DataWord cowKey1 = new DataWord("c1");
-        DataWord cowKey2 = new DataWord("c2");
-        DataWord cowVal1 = new DataWord("c0a1");
-        DataWord cowVal0 = new DataWord("c0a0");
+        DataWord cowKey1 = DataWord.valueFromHex("c1");
+        DataWord cowKey2 = DataWord.valueFromHex("c2");
+        DataWord cowVal1 = DataWord.valueFromHex("c0a1");
+        DataWord cowVal0 = DataWord.valueFromHex("c0a0");
 
-        DataWord horseKey1 = new DataWord("e1");
-        DataWord horseKey2 = new DataWord("e2");
-        DataWord horseVal1 = new DataWord("c0a1");
-        DataWord horseVal0 = new DataWord("c0a0");
+        DataWord horseKey1 = DataWord.valueFromHex("e1");
+        DataWord horseKey2 = DataWord.valueFromHex("e2");
+        DataWord horseVal1 = DataWord.valueFromHex("c0a1");
+        DataWord horseVal0 = DataWord.valueFromHex("c0a0");
 
         Repository track2 = repository.startTracking(); //track
         track2.addStorageRow(COW, cowKey1, cowVal1);
@@ -784,9 +784,9 @@ public class RepositoryImplOriginalTest {
         TrieStore store = new TrieStoreImpl(new HashMapDB());
         final Repository repository = new RepositoryImpl(new Trie(store, true), new HashMapDB(), new TrieStorePoolOnMemory(), config.detailsInMemoryStorageLimit());
 
-        final DataWord cowKey1 = new DataWord("c1");
-        final DataWord cowKey2 = new DataWord("c2");
-        final DataWord cowVal0 = new DataWord("c0a0");
+        final DataWord cowKey1 = DataWord.valueFromHex("c1");
+        final DataWord cowKey2 = DataWord.valueFromHex("c2");
+        final DataWord cowVal0 = DataWord.valueFromHex("c0a0");
 
         Repository track2 = repository.startTracking();
         track2.addStorageRow(COW, cowKey2, cowVal0);
@@ -803,7 +803,7 @@ public class RepositoryImplOriginalTest {
                     while (running) {
                         Repository snap = repository.getSnapshotTo(repository.getRoot()).startTracking();
                         snap.addBalance(COW, Coin.valueOf(10L));
-                        snap.addStorageRow(COW, cowKey1, new DataWord(cnt));
+                        snap.addStorageRow(COW, cowKey1, DataWord.valueOf(cnt));
                         snap.rollback();
                         cnt++;
                     }
@@ -819,7 +819,7 @@ public class RepositoryImplOriginalTest {
             try {
                 while(running) {
                     Repository track21 = repository.startTracking();
-                    DataWord cVal = new DataWord(cnt);
+                    DataWord cVal = DataWord.valueOf(cnt);
                     track21.addStorageRow(COW, cowKey1, cVal);
                     track21.addBalance(COW, Coin.valueOf(1L));
                     track21.commit();
@@ -832,7 +832,7 @@ public class RepositoryImplOriginalTest {
             } catch (Throwable e) {
                 e.printStackTrace();
                 try {
-                    repository.addStorageRow(COW, cowKey1, new DataWord(123));
+                    repository.addStorageRow(COW, cowKey1, DataWord.valueOf(123));
                 } catch (Exception e1) {
                     e1.printStackTrace();
                 }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTest.java
@@ -63,12 +63,12 @@ public class RepositoryTest {
         byte[] horseKey = Hex.decode("B1B2B3");
         byte[] horseValue = Hex.decode("B4B5B6");
 
-        track.addStorageBytes(COW, new DataWord(cowKey), cowValue);
-        track.addStorageBytes(HORSE, new DataWord(horseKey), horseValue);
+        track.addStorageBytes(COW, DataWord.valueOf(cowKey), cowValue);
+        track.addStorageBytes(HORSE, DataWord.valueOf(horseKey), horseValue);
         track.commit();
 
-        assertArrayEquals(cowValue, repository.getStorageBytes(COW, new DataWord(cowKey)));
-        assertArrayEquals(horseValue, repository.getStorageBytes(HORSE, new DataWord(horseKey)));
+        assertArrayEquals(cowValue, repository.getStorageBytes(COW, DataWord.valueOf(cowKey)));
+        assertArrayEquals(horseValue, repository.getStorageBytes(HORSE, DataWord.valueOf(horseKey)));
     }
 
     @Test
@@ -80,10 +80,10 @@ public class RepositoryTest {
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
 
-        DataWord cowKey = new DataWord(Hex.decode("A1A2A3"));
+        DataWord cowKey = DataWord.valueOf(Hex.decode("A1A2A3"));
         byte[] cowValue = Hex.decode("A4A5A6");
 
-        DataWord horseKey = new DataWord(Hex.decode("B1B2B3"));
+        DataWord horseKey = DataWord.valueOf(Hex.decode("B1B2B3"));
         byte[] horseValue = Hex.decode("B4B5B6");
 
         track.addStorageBytes(COW, cowKey, cowValue);
@@ -107,10 +107,10 @@ public class RepositoryTest {
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
 
-        DataWord cowKey = new DataWord(Hex.decode("A1A2A3"));
+        DataWord cowKey = DataWord.valueOf(Hex.decode("A1A2A3"));
         byte[] cowValue = Hex.decode("A4A5A6");
 
-        DataWord horseKey = new DataWord(Hex.decode("B1B2B3"));
+        DataWord horseKey = DataWord.valueOf(Hex.decode("B1B2B3"));
         byte[] horseValue = Hex.decode("B4B5B6");
 
         track.addStorageBytes(COW, cowKey, cowValue);
@@ -146,40 +146,40 @@ public class RepositoryTest {
 
         // changes level_1
         Repository track1 = repository.startTracking();
-        track1.addStorageBytes(COW, new DataWord(cowKey1), cowValue1);
-        track1.addStorageBytes(HORSE, new DataWord(horseKey1), horseValue1);
+        track1.addStorageBytes(COW, DataWord.valueOf(cowKey1), cowValue1);
+        track1.addStorageBytes(HORSE, DataWord.valueOf(horseKey1), horseValue1);
 
-        assertArrayEquals(cowValue1, track1.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertArrayEquals(horseValue1, track1.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertArrayEquals(cowValue1, track1.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertArrayEquals(horseValue1, track1.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageBytes(COW, new DataWord(cowKey2), cowValue2);
-        track2.addStorageBytes(HORSE, new DataWord(horseKey2), horseValue2);
+        track2.addStorageBytes(COW, DataWord.valueOf(cowKey2), cowValue2);
+        track2.addStorageBytes(HORSE, DataWord.valueOf(horseKey2), horseValue2);
 
-        assertArrayEquals(cowValue1, track2.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertArrayEquals(horseValue1, track2.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertArrayEquals(cowValue1, track2.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertArrayEquals(horseValue1, track2.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertArrayEquals(cowValue2, track2.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertArrayEquals(horseValue2, track2.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertArrayEquals(cowValue2, track2.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertArrayEquals(horseValue2, track2.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
 
         track2.commit();
         // leaving level_2
 
-        assertArrayEquals(cowValue1, track1.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertArrayEquals(horseValue1, track1.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertArrayEquals(cowValue1, track1.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertArrayEquals(horseValue1, track1.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertArrayEquals(horseValue2, track1.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertArrayEquals(horseValue2, track1.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
 
         track1.commit();
         // leaving level_1
 
-        assertArrayEquals(cowValue1, repository.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertArrayEquals(horseValue1, repository.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertArrayEquals(cowValue1, repository.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertArrayEquals(horseValue1, repository.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertArrayEquals(cowValue2, repository.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertArrayEquals(horseValue2, repository.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertArrayEquals(cowValue2, repository.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertArrayEquals(horseValue2, repository.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
     }
 
     @Test
@@ -206,43 +206,43 @@ public class RepositoryTest {
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageBytes(COW, new DataWord(cowKey2), cowValue2);
-        track2.addStorageBytes(HORSE, new DataWord(horseKey2), horseValue2);
+        track2.addStorageBytes(COW, DataWord.valueOf(cowKey2), cowValue2);
+        track2.addStorageBytes(HORSE, DataWord.valueOf(horseKey2), horseValue2);
 
-        assertNull(track2.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertNull(track2.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertNull(track2.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track2.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertArrayEquals(cowValue2, track2.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertArrayEquals(horseValue2, track2.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertArrayEquals(cowValue2, track2.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertArrayEquals(horseValue2, track2.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
 
-        assertEquals(null, repository.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertEquals(null, repository.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertEquals(null, repository.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(null, repository.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
         track2.commit();
 
-        assertEquals(null, repository.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertEquals(null, repository.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertEquals(null, repository.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(null, repository.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
         // leaving level_2
 
-        assertNull(track1.getStorageValue(COW, new DataWord(cowKey1)));
-        assertNull(track1.getStorageValue(HORSE, new DataWord(horseKey1)));
+        assertNull(track1.getStorageValue(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track1.getStorageValue(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertArrayEquals(horseValue2, track1.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertArrayEquals(horseValue2, track1.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
 
-        assertEquals(null, repository.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertEquals(null, repository.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertEquals(null, repository.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(null, repository.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
         track1.commit();
 
         // leaving level_1
 
-        assertEquals(null, repository.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertEquals(null, repository.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertEquals(null, repository.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertEquals(null, repository.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertArrayEquals(cowValue2, repository.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertArrayEquals(horseValue2, repository.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertArrayEquals(cowValue2, repository.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertArrayEquals(horseValue2, repository.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
     }
 
     @Test
@@ -269,32 +269,32 @@ public class RepositoryTest {
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageBytes(COW, new DataWord(cowKey2), cowValue2);
-        track2.addStorageBytes(HORSE, new DataWord(horseKey2), horseValue2);
+        track2.addStorageBytes(COW, DataWord.valueOf(cowKey2), cowValue2);
+        track2.addStorageBytes(HORSE, DataWord.valueOf(horseKey2), horseValue2);
 
-        assertNull(track2.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertNull(track2.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertNull(track2.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track2.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertArrayEquals(cowValue2, track2.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertArrayEquals(horseValue2, track2.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertArrayEquals(cowValue2, track2.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertArrayEquals(horseValue2, track2.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
 
         track2.commit();
         // leaving level_2
 
-        assertNull(track1.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertNull(track1.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertNull(track1.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track1.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertArrayEquals(horseValue2, track1.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertArrayEquals(horseValue2, track1.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
 
         track1.rollback();
         // leaving level_1
 
-        assertNull(track1.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertNull(track1.getStorageBytes(HORSE, new DataWord(horseKey1)));
+        assertNull(track1.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertNull(track1.getStorageBytes(HORSE, DataWord.valueOf(horseKey1)));
 
-        assertNull(track1.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertNull(track1.getStorageBytes(HORSE, new DataWord(horseKey2)));
+        assertNull(track1.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertNull(track1.getStorageBytes(HORSE, DataWord.valueOf(horseKey2)));
     }
 
     @Test
@@ -317,7 +317,7 @@ public class RepositoryTest {
         byte[] horseValue2 = "val-h-2".getBytes();
 
         Repository track = repository.startTracking();
-        track.addStorageBytes(COW, new DataWord(cowKey1), cowValue1);
+        track.addStorageBytes(COW, DataWord.valueOf(cowKey1), cowValue1);
         track.commit();
 
         // changes level_1
@@ -325,7 +325,7 @@ public class RepositoryTest {
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageBytes(COW, new DataWord(cowKey2), cowValue2);
+        track2.addStorageBytes(COW, DataWord.valueOf(cowKey2), cowValue2);
 
         track2.commit();
         // leaving level_2
@@ -333,8 +333,8 @@ public class RepositoryTest {
         track1.commit();
         // leaving level_1
 
-        assertArrayEquals(cowValue1, track1.getStorageBytes(COW, new DataWord(cowKey1)));
-        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, new DataWord(cowKey2)));
+        assertArrayEquals(cowValue1, track1.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
+        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
     }
 
     @Test
@@ -358,12 +358,12 @@ public class RepositoryTest {
 
         // changes level_1
         Repository track1 = repository.startTracking();
-        track1.addStorageBytes(COW, new DataWord(cowKey2), cowValue2);
+        track1.addStorageBytes(COW, DataWord.valueOf(cowKey2), cowValue2);
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertNull(track1.getStorageBytes(COW, new DataWord(cowKey1)));
+        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertNull(track1.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
 
         track2.commit();
         // leaving level_2
@@ -371,8 +371,8 @@ public class RepositoryTest {
         track1.commit();
         // leaving level_1
 
-        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, new DataWord(cowKey2)));
-        assertNull(track1.getStorageBytes(COW, new DataWord(cowKey1)));
+        assertArrayEquals(cowValue2, track1.getStorageBytes(COW, DataWord.valueOf(cowKey2)));
+        assertNull(track1.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
     }
 
     @Test
@@ -389,8 +389,8 @@ public class RepositoryTest {
 
         // changes level_2
         Repository track2 = track1.startTracking();
-        track2.addStorageBytes(COW, new DataWord(cowKey1), cowValue1);
-        assertArrayEquals(cowValue1, track2.getStorageBytes(COW, new DataWord(cowKey1)));
+        track2.addStorageBytes(COW, DataWord.valueOf(cowKey1), cowValue1);
+        assertArrayEquals(cowValue1, track2.getStorageBytes(COW, DataWord.valueOf(cowKey1)));
         track2.rollback();
         // leaving level_2
 
@@ -408,11 +408,11 @@ public class RepositoryTest {
         byte[] cow = Hex.decode("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
         byte[] horse = Hex.decode("13978AEE95F38490E9769C39B2773ED763D9CD5F");
 
-        DataWord cowKey1 = new DataWord("c1");
+        DataWord cowKey1 = DataWord.valueFromHex("c1");
         byte[] cowVal1 = Hex.decode("c0a1");
         byte[] cowVal0 = Hex.decode("c0a0");
 
-        DataWord horseKey1 = new DataWord("e1");
+        DataWord horseKey1 = DataWord.valueFromHex("e1");
         byte[] horseVal1 = Hex.decode("c0a1");
         byte[] horseVal0 = Hex.decode("c0a0");
 
@@ -445,8 +445,8 @@ public class RepositoryTest {
                 config.detailsInMemoryStorageLimit()
         );
 
-        final DataWord cowKey1 = new DataWord("c1");
-        final DataWord cowKey2 = new DataWord("c2");
+        final DataWord cowKey1 = DataWord.valueFromHex("c1");
+        final DataWord cowKey2 = DataWord.valueFromHex("c2");
         final byte[] cowVal0 = Hex.decode("c0a0");
 
         Repository track2 = repository.startTracking(); //track

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -127,12 +127,12 @@ public class BridgeStorageProviderTest {
         RskAddress contractAddress = PrecompiledContracts.BRIDGE_ADDR;
 
         Assert.assertThat(repository.isContract(contractAddress), is(true));
-        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("btcTxHashesAP".getBytes())));
-        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("releaseRequestQueue".getBytes())));
-        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("releaseTransactionSet".getBytes())));
-        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("rskTxsWaitingFS".getBytes())));
-        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("newFederationBtcUTXOs".getBytes())));
-        Assert.assertNotNull(repository.getStorageBytes(contractAddress, new DataWord("oldFederationBtcUTXOs".getBytes())));
+        Assert.assertNotNull(repository.getStorageBytes(contractAddress, DataWord.valueOf("btcTxHashesAP".getBytes())));
+        Assert.assertNotNull(repository.getStorageBytes(contractAddress, DataWord.valueOf("releaseRequestQueue".getBytes())));
+        Assert.assertNotNull(repository.getStorageBytes(contractAddress, DataWord.valueOf("releaseTransactionSet".getBytes())));
+        Assert.assertNotNull(repository.getStorageBytes(contractAddress, DataWord.valueOf("rskTxsWaitingFS".getBytes())));
+        Assert.assertNotNull(repository.getStorageBytes(contractAddress, DataWord.valueOf("newFederationBtcUTXOs".getBytes())));
+        Assert.assertNotNull(repository.getStorageBytes(contractAddress, DataWord.valueOf("oldFederationBtcUTXOs".getBytes())));
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
 
@@ -272,7 +272,7 @@ public class BridgeStorageProviderTest {
             DataWord address = invocation.getArgumentAt(1, DataWord.class);
             // Make sure the bytes are get from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("newFederation".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("newFederation".getBytes(StandardCharsets.UTF_8)), address);
             return new byte[]{(byte)0xaa};
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeFederation(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
@@ -304,7 +304,7 @@ public class BridgeStorageProviderTest {
             DataWord address = invocation.getArgumentAt(1, DataWord.class);
             // Make sure the bytes are get from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("newFederation".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("newFederation".getBytes(StandardCharsets.UTF_8)), address);
             return null;
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeFederation(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
@@ -340,7 +340,7 @@ public class BridgeStorageProviderTest {
             byte[] data = invocation.getArgumentAt(2, byte[].class);
             // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("newFederation".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("newFederation".getBytes(StandardCharsets.UTF_8)), address);
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xbb}, data));
             return null;
         }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
@@ -370,7 +370,7 @@ public class BridgeStorageProviderTest {
             DataWord address = invocation.getArgumentAt(1, DataWord.class);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("federationElection".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("federationElection".getBytes(StandardCharsets.UTF_8)), address);
             return new byte[]{(byte)0xaa};
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeElection(any(byte[].class), any(AddressBasedAuthorizer.class))).then((InvocationOnMock invocation) -> {
@@ -402,7 +402,7 @@ public class BridgeStorageProviderTest {
             DataWord address = invocation.getArgumentAt(1, DataWord.class);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("federationElection".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("federationElection".getBytes(StandardCharsets.UTF_8)), address);
             return null;
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeElection(any(byte[].class), any(AddressBasedAuthorizer.class))).then((InvocationOnMock invocation) -> {
@@ -438,7 +438,7 @@ public class BridgeStorageProviderTest {
             byte[] data = invocation.getArgumentAt(2, byte[].class);
             // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("federationElection".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("federationElection".getBytes(StandardCharsets.UTF_8)), address);
             Assert.assertTrue(Arrays.equals(Hex.decode("aabb"), data));
             return null;
         }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
@@ -467,24 +467,24 @@ public class BridgeStorageProviderTest {
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants(),
                 BridgeStorageConfiguration.fromBlockchainConfig(config.getBlockchainConfig().getConfigForBlock(500)));
 
-        when(repositoryMock.getStorageBytes(any(RskAddress.class), eq(new DataWord("lockWhitelist".getBytes(StandardCharsets.UTF_8)))))
+        when(repositoryMock.getStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)))))
         .then((InvocationOnMock invocation) -> {
             calls.add(0);
             RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
             DataWord address = invocation.getArgumentAt(1, DataWord.class);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
             return new byte[]{(byte)0xaa};
         });
-        when(repositoryMock.getStorageBytes(any(RskAddress.class), eq(new DataWord("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)))))
+        when(repositoryMock.getStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)))))
                 .then((InvocationOnMock invocation) -> {
                     calls.add(0);
                     RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
                     DataWord address = invocation.getArgumentAt(1, DataWord.class);
                     // Make sure the bytes are got from the correct address in the repo
                     Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-                    Assert.assertEquals(new DataWord("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
+                    Assert.assertEquals(DataWord.valueOf("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
                     return new byte[]{(byte)0xbb};
                 });
         PowerMockito
@@ -533,7 +533,7 @@ public class BridgeStorageProviderTest {
                 DataWord address = invocation.getArgumentAt(1, DataWord.class);
                 // Make sure the bytes are got from the correct address in the repo
                 Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-                Assert.assertEquals(new DataWord("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
+                Assert.assertEquals(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
                 return null;
             });
         PowerMockito
@@ -586,11 +586,11 @@ public class BridgeStorageProviderTest {
                 byte[] data = invocation.getArgumentAt(2, byte[].class);
                 // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
                 Assert.assertTrue(Arrays.equals(Hex.decode("aabbccdd"), contractAddress.getBytes()));
-                Assert.assertEquals(new DataWord("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
+                Assert.assertEquals(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
                 Assert.assertTrue(Arrays.equals(Hex.decode("ccdd"), data));
                 return null;
             })
-            .when(repositoryMock).addStorageBytes(any(RskAddress.class), eq(new DataWord("lockWhitelist".getBytes(StandardCharsets.UTF_8))), any(byte[].class));
+            .when(repositoryMock).addStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8))), any(byte[].class));
 
         // Mock the Unlimited serialization
         PowerMockito
@@ -610,11 +610,11 @@ public class BridgeStorageProviderTest {
                 byte[] data = invocation.getArgumentAt(2, byte[].class);
                 // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
                 Assert.assertTrue(Arrays.equals(Hex.decode("aabbccdd"), contractAddress.getBytes()));
-                Assert.assertEquals(new DataWord("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
+                Assert.assertEquals(DataWord.valueOf("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
                 Assert.assertTrue(Arrays.equals(Hex.decode("bbcc"), data));
                 return null;
             })
-            .when(repositoryMock).addStorageBytes(any(RskAddress.class), eq(new DataWord("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8))), any(byte[].class));
+            .when(repositoryMock).addStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8))), any(byte[].class));
 
         storageProvider.saveLockWhitelist();
         // Shouldn't have tried to save nor serialize anything
@@ -636,7 +636,7 @@ public class BridgeStorageProviderTest {
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants(),
                 BridgeStorageConfiguration.fromBlockchainConfig(config.getBlockchainConfig().getConfigForBlock(500)));
 
-        when(repositoryMock.getStorageBytes(any(RskAddress.class), eq(new DataWord("lockWhitelist".getBytes(StandardCharsets.UTF_8)))))
+        when(repositoryMock.getStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)))))
                 .then((InvocationOnMock invocation) -> new byte[]{(byte)0xaa});
 
         PowerMockito
@@ -652,7 +652,7 @@ public class BridgeStorageProviderTest {
                     storageCalled.set(Boolean.TRUE);
                     return null;
                 })
-                .when(repositoryMock).addStorageBytes(any(RskAddress.class), eq(new DataWord("lockWhitelist".getBytes(StandardCharsets.UTF_8))), any(byte[].class));
+                .when(repositoryMock).addStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8))), any(byte[].class));
 
         Assert.assertTrue(storageProvider.getLockWhitelist().getSize() > 0);
 
@@ -675,7 +675,7 @@ public class BridgeStorageProviderTest {
             DataWord address = invocation.getArgumentAt(1, DataWord.class);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("releaseRequestQueue".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("releaseRequestQueue".getBytes(StandardCharsets.UTF_8)), address);
             return new byte[]{(byte)0xaa};
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeReleaseRequestQueue(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
@@ -706,7 +706,7 @@ public class BridgeStorageProviderTest {
             DataWord address = invocation.getArgumentAt(1, DataWord.class);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
-            Assert.assertEquals(new DataWord("releaseTransactionSet".getBytes(StandardCharsets.UTF_8)), address);
+            Assert.assertEquals(DataWord.valueOf("releaseTransactionSet".getBytes(StandardCharsets.UTF_8)), address);
             return new byte[]{(byte)0xaa};
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeReleaseTransactionSet(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1184,8 +1184,8 @@ public class BridgeSupportTest {
         org.ethereum.core.Transaction tx = new InternalTransaction(
                 null, 0, 0,
                 BigIntegers.asUnsignedByteArray(NONCE),
-                new DataWord(BigIntegers.asUnsignedByteArray(GAS_PRICE)),
-                new DataWord(BigIntegers.asUnsignedByteArray(GAS_LIMIT)),
+                DataWord.valueOf(BigIntegers.asUnsignedByteArray(GAS_PRICE)),
+                DataWord.valueOf(BigIntegers.asUnsignedByteArray(GAS_LIMIT)),
                 new RskAddress(org.ethereum.crypto.ECKey.fromPrivate(new BtcECKey().getPrivKey()).getAddress()).getBytes(),
                 Hex.decode(TO_ADDRESS),
                 BigIntegers.asUnsignedByteArray(AMOUNT),

--- a/rskj-core/src/test/java/co/rsk/peg/SamplePrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/SamplePrecompiledContractTest.java
@@ -59,7 +59,7 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractMethod1Ok()
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(false), addr);
 
 
@@ -89,7 +89,7 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractMethod1WrongData()
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(false), addr);
 
 
@@ -117,7 +117,7 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractMethodDoesNotExist()
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(false), addr);
 
 
@@ -146,7 +146,7 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractMethod1LargeData()
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(false), addr);
 
 
@@ -174,7 +174,7 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractAddBalanceOk()
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(false), addr);
 
 
@@ -209,7 +209,7 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractIncrementResultOk()
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(false), addr);
 
 
@@ -245,7 +245,7 @@ public class SamplePrecompiledContractTest {
 
     private int GetBalance(Repository repository)
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(false), addr);
 
 
@@ -272,7 +272,7 @@ public class SamplePrecompiledContractTest {
 
     private int GetResult(Repository repository)
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(false), addr);
 
 
@@ -300,7 +300,7 @@ public class SamplePrecompiledContractTest {
     @Test
     public void samplePrecompiledContractPostRskIp93DoesntExist()
     {
-        DataWord addr = new DataWord(PrecompiledContracts.SAMPLE_ADDR.getBytes());
+        DataWord addr = DataWord.valueOf(PrecompiledContracts.SAMPLE_ADDR.getBytes());
         SamplePrecompiledContract contract = (SamplePrecompiledContract) precompiledContracts.getContractForAddress(getRskIp93ConfigMock(true), addr);
 
         Assert.assertNull(contract);

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -24,7 +24,6 @@ import co.rsk.core.Rsk;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.crypto.Keccak256;
-import co.rsk.logfilter.BlocksBloomStore;
 import co.rsk.peg.PegTestUtils;
 import co.rsk.rpc.modules.debug.DebugModule;
 import co.rsk.rpc.modules.debug.DebugModuleImpl;
@@ -113,8 +112,8 @@ public class Web3RskImplTest {
         byte[] valueToTest = HashUtil.keccak256(new byte[]{1});
         Mockito.when(logInfo.getData()).thenReturn(valueToTest);
         List<DataWord> topics = new ArrayList<>();
-        topics.add(new DataWord("c1"));
-        topics.add(new DataWord("c2"));
+        topics.add(DataWord.valueFromHex("c1"));
+        topics.add(DataWord.valueFromHex("c2"));
         Mockito.when(logInfo.getTopics()).thenReturn(topics);
         Block block = Mockito.mock(Block.class);
         Mockito.when(block.getHash()).thenReturn(new Keccak256(valueToTest));

--- a/rskj-core/src/test/java/co/rsk/validators/GasLimitRuleTests.java
+++ b/rskj-core/src/test/java/co/rsk/validators/GasLimitRuleTests.java
@@ -20,7 +20,6 @@ package co.rsk.validators;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
-import co.rsk.core.RskAddress;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
@@ -57,7 +56,7 @@ public class GasLimitRuleTests {
     }
 
     private static Block getBlock(long gasLimitValue) {
-        byte[] gasLimit = new DataWord(gasLimitValue).getData();
+        byte[] gasLimit = DataWord.valueOf(gasLimitValue).getData();
 
         BlockHeader header = new BlockHeader(null, null, TestUtils.randomAddress().getBytes(),
                 null, BlockDifficulty.ZERO.getBytes(), 0, gasLimit, 0,

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractAddressTests.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractAddressTests.java
@@ -57,13 +57,7 @@ public class PrecompiledContractAddressTests {
     void checkAddr(PrecompiledContracts pcList,String addr,String className) {
         RskAddress a;
         a = new RskAddress(addr);
-        PrecompiledContracts.PrecompiledContract pc = pcList.getContractForAddress(null,new DataWord(a.getBytes()));
+        PrecompiledContracts.PrecompiledContract pc = pcList.getContractForAddress(null, DataWord.valueOf(a.getBytes()));
         Assert.assertEquals(className,pc.getClass().getSimpleName());
-        // Do not get precompiles if the 12-byte prefix is non-zero.
-        DataWord dw = new DataWord(a.getBytes());
-        dw.getData()[0] = (byte) 0xff; // MSB
-        PrecompiledContracts.PrecompiledContract pc2 = pcList.getContractForAddress(null,dw);
-        Assert.assertEquals(null,pc2);
-
     }
 }

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
@@ -33,7 +33,7 @@ public class PrecompiledContractTest {
 
     @Test
     public void getBridgeContract() {
-        DataWord bridgeAddress = new DataWord(PrecompiledContracts.BRIDGE_ADDR.getBytes());
+        DataWord bridgeAddress = DataWord.valueOf(PrecompiledContracts.BRIDGE_ADDR.getBytes());
         PrecompiledContract bridge = precompiledContracts.getContractForAddress(null, bridgeAddress);
 
         Assert.assertNotNull(bridge);
@@ -42,7 +42,7 @@ public class PrecompiledContractTest {
 
     @Test
     public void getBridgeContractTwice() {
-        DataWord bridgeAddress = new DataWord(PrecompiledContracts.BRIDGE_ADDR.getBytes());
+        DataWord bridgeAddress = DataWord.valueOf(PrecompiledContracts.BRIDGE_ADDR.getBytes());
         PrecompiledContract bridge1 = precompiledContracts.getContractForAddress(null, bridgeAddress);
         PrecompiledContract bridge2 = precompiledContracts.getContractForAddress(null, bridgeAddress);
 

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -60,7 +60,7 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(1, stack.size());
-        Assert.assertEquals(new DataWord(0xa0), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(0xa0), stack.peek());
     }
 
     @Test
@@ -69,7 +69,7 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(1, stack.size());
-        Assert.assertEquals(new DataWord(3), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(3), stack.peek());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(1, stack.size());
-        Assert.assertEquals(new DataWord(6), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(6), stack.peek());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(1, stack.size());
-        Assert.assertEquals(new DataWord(1), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(1), stack.peek());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(1, stack.size());
-        Assert.assertEquals(new DataWord(1), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(1), stack.peek());
     }
 
     @Test
@@ -105,8 +105,8 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(2, stack.size());
-        Assert.assertEquals(new DataWord(1), stack.peek());
-        Assert.assertEquals(new DataWord(1), stack.get(0));
+        Assert.assertEquals(DataWord.valueOf(1), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(1), stack.get(0));
     }
 
     @Test
@@ -115,10 +115,10 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(5, stack.size());
-        Assert.assertEquals(new DataWord(1), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(1), stack.peek());
 
         for (int k = 0; k < 4; k++)
-            Assert.assertEquals(new DataWord(k + 1), stack.get(k));
+            Assert.assertEquals(DataWord.valueOf(k + 1), stack.get(k));
     }
 
     @Test
@@ -127,10 +127,10 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(21, stack.size());
-        Assert.assertEquals(new DataWord(1), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(1), stack.peek());
 
         for (int k = 0; k < 20; k++)
-            Assert.assertEquals(new DataWord(k + 1), stack.get(k));
+            Assert.assertEquals(DataWord.valueOf(k + 1), stack.get(k));
     }
 
     @Test(expected = Program.StackTooSmallException.class)
@@ -149,8 +149,8 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(2, stack.size());
-        Assert.assertEquals(new DataWord(1), stack.peek());
-        Assert.assertEquals(new DataWord(2), stack.get(0));
+        Assert.assertEquals(DataWord.valueOf(1), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(2), stack.get(0));
     }
 
     @Test
@@ -159,10 +159,10 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(4, stack.size());
-        Assert.assertEquals(new DataWord(1), stack.peek());
-        Assert.assertEquals(new DataWord(4), stack.get(0));
-        Assert.assertEquals(new DataWord(2), stack.get(1));
-        Assert.assertEquals(new DataWord(3), stack.get(2));
+        Assert.assertEquals(DataWord.valueOf(1), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(4), stack.get(0));
+        Assert.assertEquals(DataWord.valueOf(2), stack.get(1));
+        Assert.assertEquals(DataWord.valueOf(3), stack.get(2));
     }
 
     @Test
@@ -171,11 +171,11 @@ public class VMExecutionTest {
         Stack stack = program.getStack();
 
         Assert.assertEquals(20, stack.size());
-        Assert.assertEquals(new DataWord(1), stack.peek());
-        Assert.assertEquals(new DataWord(20), stack.get(0));
+        Assert.assertEquals(DataWord.valueOf(1), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(20), stack.get(0));
 
         for (int k = 1; k < 19; k++)
-            Assert.assertEquals(new DataWord(k + 1), stack.get(k));
+            Assert.assertEquals(DataWord.valueOf(k + 1), stack.get(k));
     }
 
     @Test(expected = Program.StackTooSmallException.class)
@@ -190,12 +190,12 @@ public class VMExecutionTest {
 
     @Test
     public void txindexExecution() {
-        invoke.setTransactionIndex(new DataWord(42));
+        invoke.setTransactionIndex(DataWord.valueOf(42));
         Program program = executeCode("TXINDEX", 1);
         Stack stack = program.getStack();
 
         Assert.assertEquals(1, stack.size());
-        Assert.assertEquals(new DataWord(42), stack.peek());
+        Assert.assertEquals(DataWord.valueOf(42), stack.peek());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -101,8 +101,6 @@ public class VMPerformanceTest {
     }
 
     static Boolean shortArg = false;
-    static boolean tesUsingDataWordPool = false;
-
 
     @Ignore
     @Test
@@ -111,12 +109,8 @@ public class VMPerformanceTest {
     }
 
     private void testVMPerformance1(ResultLogger resultLogger) {
-
-        if (!tesUsingDataWordPool) {
-            maxLLSize = 1000*1000*10;
-            Program.setUseDataWordPool(false);
-            createLarseSetOfMemoryObjects();
-        }
+        maxLLSize = 1000*1000*10;
+        createLarseSetOfMemoryObjects();
 
         thread = ManagementFactory.getThreadMXBean();
         if (!thread.isThreadCpuTimeSupported()) return;
@@ -127,7 +121,6 @@ public class VMPerformanceTest {
         if (useProfiler)
             waitForProfiler();
 
-        System.out.println("Configuration: Program.useDataWordPool =  " + Program.getUseDataWordPool().toString());
         System.out.println("Configuration: shortArg =  " + shortArg.toString());
 
         // Program
@@ -171,9 +164,6 @@ public class VMPerformanceTest {
         measureOpcode(OpCode.ISZERO, false, refTime11, resultLogger);
         measureOpcode(OpCode.NOT, false, refTime11, resultLogger);
     }
-
-
-
 
     public long measureOpcode(OpCode opcode, Boolean reference, long refTime, ResultLogger resultLogger) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -582,10 +572,6 @@ public class VMPerformanceTest {
         createLarseSetOfMemoryObjects();
         System.out.println("done.");
 
-        // now measure with and without Data Word Pool
-        Program.setUseDataWordPool(true);
-        testRunTime(code, s_expected);
-        Program.setUseDataWordPool(false);
         testRunTime(code, s_expected);
     }
     /****************** RESULTS 30/12/2016 ******************************************
@@ -617,7 +603,6 @@ public class VMPerformanceTest {
         program = new Program(vmConfig, precompiledContracts, blockchainConfig, code, invoke, null);
         System.out.println("-----------------------------------------------------------------------------");
         System.out.println("Starting test....");
-        System.out.println("Configuration: Program.useDataWordPool =  " + Program.getUseDataWordPool().toString());
         startMeasure();
         vm.steps(program, Long.MAX_VALUE);
         endMeasure();

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -168,8 +168,7 @@ public class VMPerformanceTest {
     public long measureOpcode(OpCode opcode, Boolean reference, long refTime, ResultLogger resultLogger) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         int iCount = 0;
-        DataWord maxValue = new DataWord();
-        maxValue.bnot();
+        DataWord maxValue = new DataWord().bnot();
         // PUSH
         for (int inp = 0; inp < opcode.require(); inp++) {
             if (shortArg) {
@@ -180,7 +179,7 @@ public class VMPerformanceTest {
                 try {
                     baos.write(maxValue.getData());
                     // decrement maxValue so that each value pushed is a little different
-                    maxValue.sub(DataWord.ONE);
+                    maxValue = maxValue.sub(DataWord.ONE);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -168,7 +168,7 @@ public class VMPerformanceTest {
     public long measureOpcode(OpCode opcode, Boolean reference, long refTime, ResultLogger resultLogger) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         int iCount = 0;
-        DataWord maxValue = new DataWord().bnot();
+        DataWord maxValue = DataWord.ZERO;
         // PUSH
         for (int inp = 0; inp < opcode.require(); inp++) {
             if (shortArg) {

--- a/rskj-core/src/test/java/org/ethereum/TestUtils.java
+++ b/rskj-core/src/test/java/org/ethereum/TestUtils.java
@@ -53,7 +53,7 @@ public final class TestUtils {
     }
 
     public static DataWord randomDataWord() {
-        return new DataWord(randomBytes(32));
+        return DataWord.valueOf(randomBytes(32));
     }
 
     public static RskAddress randomAddress() {

--- a/rskj-core/src/test/java/org/ethereum/core/genesis/BlockchainLoaderTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/genesis/BlockchainLoaderTest.java
@@ -56,7 +56,7 @@ public class BlockchainLoaderTest {
         Assert.assertEquals(Coin.valueOf(10), repository.getBalance(address));
         Assert.assertEquals(BigInteger.valueOf(25), repository.getNonce(address));
         Assert.assertEquals(DataWord.ONE, repository.getStorageValue(address, DataWord.ZERO));
-        Assert.assertEquals(new DataWord(3), repository.getStorageValue(address, DataWord.ONE));
+        Assert.assertEquals(DataWord.valueOf(3), repository.getStorageValue(address, DataWord.ONE));
         Assert.assertEquals(274, repository.getCode(address).length);
 
     }

--- a/rskj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/DetailsDataStoreTest.java
@@ -60,7 +60,7 @@ public class DetailsDataStoreTest {
             config.detailsInMemoryStorageLimit()
         );
         contractDetails.setCode(code);
-        contractDetails.put(new DataWord(key), new DataWord(value));
+        contractDetails.put(DataWord.valueOf(key), DataWord.valueOf(value));
 
         dds.update(c_key, contractDetails);
 
@@ -100,7 +100,7 @@ public class DetailsDataStoreTest {
             config.detailsInMemoryStorageLimit()
         );
         contractDetails.setCode(code);
-        contractDetails.put(new DataWord(key), new DataWord(value));
+        contractDetails.put(DataWord.valueOf(key), DataWord.valueOf(value));
 
         dds.update(c_key, contractDetails);
 
@@ -145,7 +145,7 @@ public class DetailsDataStoreTest {
             config.detailsInMemoryStorageLimit()
         );
         contractDetails.setCode(code);
-        contractDetails.put(new DataWord(key), new DataWord(value));
+        contractDetails.put(DataWord.valueOf(key), DataWord.valueOf(value));
 
         dds.update(c_key, contractDetails);
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/AccountState.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/AccountState.java
@@ -71,7 +71,7 @@ public class AccountState {
 
             byte[] key = org.ethereum.json.Utils.parseData(keyS);
             byte[] value = org.ethereum.json.Utils.parseData(valS);
-            storage.put(new DataWord(key), new DataWord(value));
+            storage.put(DataWord.valueOf(key), DataWord.valueOf(value));
         }
     }
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/Logs.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/Logs.java
@@ -45,7 +45,7 @@ public class Logs {
             JSONArray jTopics = (JSONArray) jLog.get("topics");
             for (Object t : jTopics.toArray()) {
                 byte[] topic = Hex.decode(((String) t));
-                topics.add(new DataWord(topic));
+                topics.add(DataWord.valueOf(topic));
             }
 
             LogInfo li = new LogInfo(address, topics, data);

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/AccountBuilder.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/AccountBuilder.java
@@ -69,8 +69,8 @@ public class AccountBuilder {
         for (String keyTck : storageTck.keySet()) {
             String valueTck = storageTck.get(keyTck);
 
-            DataWord key = new DataWord(parseData(keyTck));
-            DataWord value = new DataWord(parseData(valueTck));
+            DataWord key = DataWord.valueOf(parseData(keyTck));
+            DataWord value = DataWord.valueOf(parseData(valueTck));
 
             storage.put(key, value);
         }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/LogBuilder.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/builder/LogBuilder.java
@@ -37,7 +37,7 @@ public class LogBuilder {
 
         List<DataWord> topics = new ArrayList<>();
         for (String topicTck : logTck.getTopics())
-            topics.add(new DataWord(parseData(topicTck)));
+            topics.add(DataWord.valueOf(parseData(topicTck)));
 
         return new LogInfo(address, topics, data);
     }

--- a/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
@@ -20,7 +20,6 @@ package org.ethereum.validator;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
-import co.rsk.core.RskAddress;
 import org.ethereum.TestUtils;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.vm.DataWord;
@@ -53,7 +52,7 @@ public class DifficultyRuleTest {
     }
 
     private static BlockHeader getHeader(long difficultyValue) {
-        byte[] difficulty = new DataWord(difficultyValue).getData();
+        byte[] difficulty = DataWord.valueOf(difficultyValue).getData();
 
         BlockHeader header = new BlockHeader(null, null, TestUtils.randomAddress().getBytes(), null, difficulty, 0,
                 null, 0,

--- a/rskj-core/src/test/java/org/ethereum/validator/ParentGasLimitRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/ParentGasLimitRuleTest.java
@@ -77,7 +77,7 @@ public class ParentGasLimitRuleTest {
 
     // Used also by GasLimitCalculatorTest
     public static BlockHeader getHeader(long gasLimitValue) {
-        byte[] gasLimit = new DataWord(gasLimitValue).getData();
+        byte[] gasLimit = DataWord.valueOf(gasLimitValue).getData();
 
         BlockHeader header = new BlockHeader(null, null, TestUtils.randomAddress().getBytes(),
                 null, BlockDifficulty.ZERO.getBytes(), 0, gasLimit, 0,

--- a/rskj-core/src/test/java/org/ethereum/vm/DataWordTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/DataWordTest.java
@@ -39,10 +39,10 @@ public class DataWordTest {
             three[i] = (byte) 0xff;
         }
 
-        DataWord x = new DataWord(three);
+        DataWord x = DataWord.valueOf(three);
         byte[] xdata = x.getData();
 
-        DataWord result = x.add(new DataWord(three));
+        DataWord result = x.add(DataWord.valueOf(three));
 
         assertArrayEquals(xdata, x.getData());
         assertEquals(32, result.getData().length);
@@ -61,9 +61,9 @@ public class DataWordTest {
         }
         two[31] = 0x56; // 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff56
 
-        DataWord x = new DataWord(one);
+        DataWord x = DataWord.valueOf(one);
         byte[] xdata = x.getData();
-        DataWord y = new DataWord(two);
+        DataWord y = DataWord.valueOf(two);
         byte[] ydata = y.getData();
 
         DataWord result = y.mod(x);
@@ -82,8 +82,8 @@ public class DataWordTest {
         byte[] two = new byte[32];
         two[11] = 0x1; // 0x0000000000000000000000010000000000000000000000000000000000000000
 
-        DataWord x = new DataWord(one);
-        DataWord y = new DataWord(two);
+        DataWord x = DataWord.valueOf(one);
+        DataWord y = DataWord.valueOf(two);
         byte[] xdata = x.getData();
         byte[] ydata = y.getData();
 
@@ -105,8 +105,8 @@ public class DataWordTest {
         byte[] two = new byte[32];
         two[0] = 0x1; //  0x1000000000000000000000000000000000000000000000000000000000000000
 
-        DataWord x = new DataWord(one);
-        DataWord y = new DataWord(two);
+        DataWord x = DataWord.valueOf(one);
+        DataWord y = DataWord.valueOf(two);
         byte[] xdata = x.getData();
         byte[] ydata = y.getData();
 
@@ -129,8 +129,8 @@ public class DataWordTest {
         byte[] two = new byte[32];
         two[31] = 0x0f; // 0x000000000000000000000000000000000000000000000000000000000000000f
 
-        DataWord x = new DataWord(one);
-        DataWord y = new DataWord(two);
+        DataWord x = DataWord.valueOf(one);
+        DataWord y = DataWord.valueOf(two);
         byte[] xdata = x.getData();
         byte[] ydata = y.getData();
 
@@ -149,8 +149,8 @@ public class DataWordTest {
 
         byte[] two = new byte[32];
 
-        DataWord x = new DataWord(one);
-        DataWord y = new DataWord(two);
+        DataWord x = DataWord.valueOf(one);
+        DataWord y = DataWord.valueOf(two);
         byte[] xdata = x.getData();
         byte[] ydata = y.getData();
 
@@ -170,8 +170,8 @@ public class DataWordTest {
         byte[] two = new byte[32];
         two[31] = 0x0f;
 
-        DataWord x = new DataWord(one);
-        DataWord y = new DataWord(two);
+        DataWord x = DataWord.valueOf(one);
+        DataWord y = DataWord.valueOf(two);
         byte[] xdata = x.getData();
         byte[] ydata = y.getData();
 
@@ -194,7 +194,7 @@ public class DataWordTest {
 
     @Test
     public void testSignExtend1() {
-        DataWord x = new DataWord(Hex.decode("f2"));
+        DataWord x = DataWord.valueOf(Hex.decode("f2"));
         byte[] xdata = x.getData();
 
         byte k = 0;
@@ -208,7 +208,7 @@ public class DataWordTest {
 
     @Test
     public void testSignExtend2() {
-        DataWord x = new DataWord(Hex.decode("f2"));
+        DataWord x = DataWord.valueOf(Hex.decode("f2"));
         byte[] xdata = x.getData();
 
         byte k = 1;
@@ -224,7 +224,7 @@ public class DataWordTest {
     public void testSignExtend3() {
         byte k = 1;
 
-        DataWord x = new DataWord(Hex.decode("0f00ab"));
+        DataWord x = DataWord.valueOf(Hex.decode("0f00ab"));
         byte[] xdata = x.getData();
 
         String expected = "00000000000000000000000000000000000000000000000000000000000000ab";
@@ -239,7 +239,7 @@ public class DataWordTest {
     public void testSignExtend4() {
         byte k = 1;
 
-        DataWord x = new DataWord(Hex.decode("ffff"));
+        DataWord x = DataWord.valueOf(Hex.decode("ffff"));
         byte[] xdata = x.getData();
 
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
@@ -254,7 +254,7 @@ public class DataWordTest {
     public void testSignExtend5() {
         byte k = 3;
 
-        DataWord x = new DataWord(Hex.decode("ffffffff"));
+        DataWord x = DataWord.valueOf(Hex.decode("ffffffff"));
         byte[] xdata = x.getData();
 
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
@@ -269,7 +269,7 @@ public class DataWordTest {
     public void testSignExtend6() {
         byte k = 3;
 
-        DataWord x = new DataWord(Hex.decode("ab02345678"));
+        DataWord x = DataWord.valueOf(Hex.decode("ab02345678"));
         byte[] xdata = x.getData();
 
         String expected = "0000000000000000000000000000000000000000000000000000000002345678";
@@ -284,7 +284,7 @@ public class DataWordTest {
     public void testSignExtend7() {
         byte k = 3;
 
-        DataWord x = new DataWord(Hex.decode("ab82345678"));
+        DataWord x = DataWord.valueOf(Hex.decode("ab82345678"));
         byte[] xdata = x.getData();
 
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff82345678";
@@ -299,7 +299,7 @@ public class DataWordTest {
     public void testSignExtend8() {
         byte k = 30;
 
-        DataWord x = new DataWord(Hex.decode("ff34567882345678823456788234567882345678823456788234567882345678"));
+        DataWord x = DataWord.valueOf(Hex.decode("ff34567882345678823456788234567882345678823456788234567882345678"));
         byte[] xdata = x.getData();
 
         String expected = "0034567882345678823456788234567882345678823456788234567882345678";
@@ -314,7 +314,7 @@ public class DataWordTest {
     public void testSignExtendException1() {
         byte k = -1;
 
-        DataWord x = new DataWord();
+        DataWord x = DataWord.ZERO;
 
         x.signExtend(k); // should throw an exception
     }
@@ -323,7 +323,7 @@ public class DataWordTest {
     public void testLongValue1() {
         byte[] negative = new byte[]{-1, -1, -1, -1,-1,-1,-1,-1};
 
-        DataWord x = new DataWord(negative);
+        DataWord x = DataWord.valueOf(negative);
 
         long l = x.longValue();
         assertEquals(l, -1);
@@ -333,7 +333,7 @@ public class DataWordTest {
     public void testSignExtendException2() {
         byte k = 32;
 
-        DataWord x = new DataWord();
+        DataWord x = DataWord.ZERO;
 
         x.signExtend(k); // should throw an exception
     }
@@ -357,9 +357,9 @@ public class DataWordTest {
     }
 
     void testAddMod(String v1, String v2, String v3) {
-        DataWord dv1 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v1));
-        DataWord dv2 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v2));
-        DataWord dv3 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v3));
+        DataWord dv1 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode(v1));
+        DataWord dv2 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode(v2));
+        DataWord dv3 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode(v3));
 
         byte[] datadv1 = dv1.getData();
         byte[] datadv2 = dv2.getData();
@@ -382,9 +382,9 @@ public class DataWordTest {
 
     @Test
     public void testMulMod1() {
-        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
-        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("01"));
-        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999998"));
+        DataWord wr = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w1 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("01"));
+        DataWord w2 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999998"));
 
         byte[] datawr = wr.getData();
         byte[] dataw1 = w1.getData();
@@ -401,9 +401,9 @@ public class DataWordTest {
 
     @Test
     public void testMulMod2() {
-        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
-        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("01"));
-        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord wr = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w1 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("01"));
+        DataWord w2 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
 
         byte[] datawr = wr.getData();
         byte[] dataw1 = w1.getData();
@@ -420,9 +420,9 @@ public class DataWordTest {
 
     @Test
     public void testMulModZero() {
-        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("00"));
-        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
-        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord wr = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("00"));
+        DataWord w1 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w2 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
         byte[] datawr = wr.getData();
         byte[] dataw1 = w1.getData();
@@ -439,9 +439,9 @@ public class DataWordTest {
 
     @Test
     public void testMulModZeroWord1() {
-        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
-        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("00"));
-        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord wr = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w1 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("00"));
+        DataWord w2 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
         byte[] datawr = wr.getData();
         byte[] dataw1 = w1.getData();
@@ -458,9 +458,9 @@ public class DataWordTest {
 
     @Test
     public void testMulModZeroWord2() {
-        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
-        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
-        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("00"));
+        DataWord wr = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w1 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord w2 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("00"));
 
         byte[] datawr = wr.getData();
         byte[] dataw1 = w1.getData();
@@ -477,9 +477,9 @@ public class DataWordTest {
 
     @Test
     public void testMulModOverflow() {
-        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
-        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
-        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord wr = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord w1 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord w2 = DataWord.valueOf(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
         byte[] datawr = wr.getData();
         byte[] dataw1 = w1.getData();

--- a/rskj-core/src/test/java/org/ethereum/vm/DataWordTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/DataWordTest.java
@@ -47,42 +47,23 @@ public class DataWordTest {
                 DataWord x = new DataWord(one);
                 x.add(x);
             }
-            System.out.println("Add1: " + (System.currentTimeMillis() - now1) + "ms");
 
-            long now2 = System.currentTimeMillis();
-            for (int i = 0; i < ITERATIONS; i++) {
-                DataWord x = new DataWord(one);
-                x.add2(x);
-            }
-            System.out.println("Add2: " + (System.currentTimeMillis() - now2) + "ms");
+            System.out.println("Add1: " + (System.currentTimeMillis() - now1) + "ms");
         } else {
             System.out.println("ADD performance test is disabled.");
         }
     }
 
     @Test
-    public void testAdd2() {
-        byte[] two = new byte[32];
-        two[31] = (byte) 0xff; // 0x000000000000000000000000000000000000000000000000000000000000ff
-
-        DataWord x = new DataWord(two);
-        x.add(new DataWord(two));
-        System.out.println(Hex.toHexString(x.getData()));
-
-        DataWord y = new DataWord(two);
-        y.add2(new DataWord(two));
-        System.out.println(Hex.toHexString(y.getData()));
-    }
-
-    @Test
     public void testAdd3() {
         byte[] three = new byte[32];
+
         for (int i = 0; i < three.length; i++) {
             three[i] = (byte) 0xff;
         }
 
         DataWord x = new DataWord(three);
-        x.add(new DataWord(three));
+        x = x.add(new DataWord(three));
         assertEquals(32, x.getData().length);
         System.out.println(Hex.toHexString(x.getData()));
 
@@ -107,9 +88,9 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);// System.out.println(x.value());
         DataWord y = new DataWord(two);// System.out.println(y.value());
-        y.mod(x);
-        assertEquals(32, y.getData().length);
-        assertEquals(expected, Hex.toHexString(y.getData()));
+        DataWord result = y.mod(x);
+        assertEquals(32, result.getData().length);
+        assertEquals(expected, Hex.toHexString(result.getData()));
     }
 
     @Test
@@ -122,9 +103,11 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);// System.out.println(x.value());
         DataWord y = new DataWord(two);// System.out.println(y.value());
-        x.mul(y);
+        DataWord result = x.mul(y);
         assertEquals(32, y.getData().length);
         assertEquals("0000000000000000000000010000000000000000000000000000000000000000", Hex.toHexString(y.getData()));
+        assertEquals(32, result.getData().length);
+        assertEquals("0000000000000000000000010000000000000000000000000000000000000000", Hex.toHexString(result.getData()));
     }
 
     @Test
@@ -138,9 +121,11 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);// System.out.println(x.value());
         DataWord y = new DataWord(two);// System.out.println(y.value());
-        x.mul(y);
+        DataWord result = x.mul(y);
         assertEquals(32, y.getData().length);
         assertEquals("0100000000000000000000000000000000000000000000000000000000000000", Hex.toHexString(y.getData()));
+        assertEquals(32, result.getData().length);
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000000", Hex.toHexString(result.getData()));
     }
 
     @Test
@@ -154,10 +139,10 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
-        x.div(y);
+        DataWord result =x.div(y);
 
-        assertEquals(32, x.getData().length);
-        assertEquals("0000000000000000000000000000000000000000000000000000000000000014", Hex.toHexString(x.getData()));
+        assertEquals(32, result.getData().length);
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000014", Hex.toHexString(result.getData()));
     }
 
     @Test
@@ -169,10 +154,10 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
-        x.div(y);
+        DataWord result = x.div(y);
 
-        assertEquals(32, x.getData().length);
-        assertTrue(x.isZero());
+        assertEquals(32, result.getData().length);
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -186,10 +171,10 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
-        x.sDiv(y);
+        DataWord result = x.sDiv(y);
 
-        assertEquals(32, x.getData().length);
-        assertEquals("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffec", x.toString());
+        assertEquals(32, result.getData().length);
+        assertEquals("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffec", result.toString());
     }
 
     @Test
@@ -211,9 +196,9 @@ public class DataWordTest {
         byte k = 0;
         String expected = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff2";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -222,9 +207,9 @@ public class DataWordTest {
         byte k = 1;
         String expected = "00000000000000000000000000000000000000000000000000000000000000f2";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -234,9 +219,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("0f00ab"));
         String expected = "00000000000000000000000000000000000000000000000000000000000000ab";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -246,9 +231,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ffff"));
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -258,9 +243,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ffffffff"));
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -270,9 +255,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ab02345678"));
         String expected = "0000000000000000000000000000000000000000000000000000000002345678";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -282,9 +267,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ab82345678"));
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff82345678";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test
@@ -294,9 +279,9 @@ public class DataWordTest {
         DataWord x = new DataWord(Hex.decode("ff34567882345678823456788234567882345678823456788234567882345678"));
         String expected = "0034567882345678823456788234567882345678823456788234567882345678";
 
-        x.signExtend(k);
-        System.out.println(x.toString());
-        assertEquals(expected, x.toString());
+        DataWord result = x.signExtend(k);
+        System.out.println(result.toString());
+        assertEquals(expected, result.toString());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -317,6 +302,7 @@ public class DataWordTest {
         System.out.println(l);
         assertEquals(l, -1);
     }
+
     @Test(expected = IndexOutOfBoundsException.class)
     public void testSignExtendException2() {
 
@@ -332,6 +318,101 @@ public class DataWordTest {
         DataWord parsed = DataWord.fromString("01234567890123456789012345678901");
 
         assertEquals(new String(parsed.getData()),"01234567890123456789012345678901");
+    }
+
+    @Test
+    public void testAddModOverflow() {
+        testAddMod("9999999999999999999999999999999999999999999999999999999999999999",
+                "8888888888888888888888888888888888888888888888888888888888888888",
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        testAddMod("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    }
+
+    void testAddMod(String v1, String v2, String v3) {
+        DataWord dv1 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v1));
+        DataWord dv2 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v2));
+        DataWord dv3 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v3));
+        BigInteger bv1 = new BigInteger(v1, 16);
+        BigInteger bv2 = new BigInteger(v2, 16);
+        BigInteger bv3 = new BigInteger(v3, 16);
+
+        DataWord actual = dv1.addmod(dv2, dv3);
+        BigInteger br = bv1.add(bv2).mod(bv3);
+        assertEquals(actual.value(), br);
+    }
+
+    @Test
+    public void testMulMod1() {
+        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("01"));
+        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999998"));
+
+        DataWord actual = wr.mulmod(w1, w2);
+
+        assertEquals(32, actual.getData().length);
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000001", org.spongycastle.util.encoders.Hex.toHexString(actual.getData()));
+    }
+
+    @Test
+    public void testMulMod2() {
+        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("01"));
+        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+
+        DataWord actual = wr.mulmod(w1, w2);
+
+        assertEquals(32, actual.getData().length);
+        assertTrue(actual.isZero());
+    }
+
+    @Test
+    public void testMulModZero() {
+        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("00"));
+        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+
+        wr = wr.mulmod(w1, w2);
+
+        assertEquals(32, wr.getData().length);
+        assertTrue(wr.isZero());
+    }
+
+    @Test
+    public void testMulModZeroWord1() {
+        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("00"));
+        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+
+        DataWord actual = wr.mulmod(w1, w2);
+
+        assertEquals(32, wr.getData().length);
+        assertTrue(actual.isZero());
+    }
+
+    @Test
+    public void testMulModZeroWord2() {
+        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
+        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("00"));
+
+        DataWord actual = wr.mulmod(w1, w2);
+
+        assertEquals(32, wr.getData().length);
+        assertTrue(actual.isZero());
+    }
+
+    @Test
+    public void testMulModOverflow() {
+        DataWord wr = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+
+        DataWord actual = wr.mulmod(w1, w2);
+
+        assertEquals(32, wr.getData().length);
+        assertTrue(actual.isZero());
     }
 
     public static BigInteger pow(BigInteger x, BigInteger y) {
@@ -352,6 +433,7 @@ public class DataWordTest {
                 z = z.multiply(z);
             }
         }
+
         return result;
     }
 

--- a/rskj-core/src/test/java/org/ethereum/vm/DataWordTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/DataWordTest.java
@@ -25,37 +25,14 @@ import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class DataWordTest {
 
     @Test
-    public void testAddPerformance() {
-        boolean enabled = false;
-
-        if (enabled) {
-            byte[] one = new byte[]{0x01, 0x31, 0x54, 0x41, 0x01, 0x31, 0x54,
-                    0x41, 0x01, 0x31, 0x54, 0x41, 0x01, 0x31, 0x54, 0x41, 0x01,
-                    0x31, 0x54, 0x41, 0x01, 0x31, 0x54, 0x41, 0x01, 0x31, 0x54,
-                    0x41, 0x01, 0x31, 0x54, 0x41}; // Random value
-
-            int ITERATIONS = 10000000;
-
-            long now1 = System.currentTimeMillis();
-            for (int i = 0; i < ITERATIONS; i++) {
-                DataWord x = new DataWord(one);
-                x.add(x);
-            }
-
-            System.out.println("Add1: " + (System.currentTimeMillis() - now1) + "ms");
-        } else {
-            System.out.println("ADD performance test is disabled.");
-        }
-    }
-
-    @Test
-    public void testAdd3() {
+    public void testAdd() {
         byte[] three = new byte[32];
 
         for (int i = 0; i < three.length; i++) {
@@ -63,14 +40,12 @@ public class DataWordTest {
         }
 
         DataWord x = new DataWord(three);
-        x = x.add(new DataWord(three));
-        assertEquals(32, x.getData().length);
-        System.out.println(Hex.toHexString(x.getData()));
+        byte[] xdata = x.getData();
 
-        // FAIL
-//      DataWord y = new DataWord(three);
-//      y.add2(new DataWord(three));
-//      System.out.println(Hex.toHexString(y.getData()));
+        DataWord result = x.add(new DataWord(three));
+
+        assertArrayEquals(xdata, x.getData());
+        assertEquals(32, result.getData().length);
     }
 
     @Test
@@ -86,9 +61,15 @@ public class DataWordTest {
         }
         two[31] = 0x56; // 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff56
 
-        DataWord x = new DataWord(one);// System.out.println(x.value());
-        DataWord y = new DataWord(two);// System.out.println(y.value());
+        DataWord x = new DataWord(one);
+        byte[] xdata = x.getData();
+        DataWord y = new DataWord(two);
+        byte[] ydata = y.getData();
+
         DataWord result = y.mod(x);
+
+        assertArrayEquals(xdata, x.getData());
+        assertArrayEquals(ydata, y.getData());
         assertEquals(32, result.getData().length);
         assertEquals(expected, Hex.toHexString(result.getData()));
     }
@@ -101,9 +82,15 @@ public class DataWordTest {
         byte[] two = new byte[32];
         two[11] = 0x1; // 0x0000000000000000000000010000000000000000000000000000000000000000
 
-        DataWord x = new DataWord(one);// System.out.println(x.value());
-        DataWord y = new DataWord(two);// System.out.println(y.value());
+        DataWord x = new DataWord(one);
+        DataWord y = new DataWord(two);
+        byte[] xdata = x.getData();
+        byte[] ydata = y.getData();
+
         DataWord result = x.mul(y);
+
+        assertArrayEquals(xdata, x.getData());
+        assertArrayEquals(ydata, y.getData());
         assertEquals(32, y.getData().length);
         assertEquals("0000000000000000000000010000000000000000000000000000000000000000", Hex.toHexString(y.getData()));
         assertEquals(32, result.getData().length);
@@ -112,16 +99,21 @@ public class DataWordTest {
 
     @Test
     public void testMulOverflow() {
-
         byte[] one = new byte[32];
         one[30] = 0x1; // 0x0000000000000000000000000000000000000000000000000000000000000100
 
         byte[] two = new byte[32];
         two[0] = 0x1; //  0x1000000000000000000000000000000000000000000000000000000000000000
 
-        DataWord x = new DataWord(one);// System.out.println(x.value());
-        DataWord y = new DataWord(two);// System.out.println(y.value());
+        DataWord x = new DataWord(one);
+        DataWord y = new DataWord(two);
+        byte[] xdata = x.getData();
+        byte[] ydata = y.getData();
+
         DataWord result = x.mul(y);
+
+        assertArrayEquals(xdata, x.getData());
+        assertArrayEquals(ydata, y.getData());
         assertEquals(32, y.getData().length);
         assertEquals("0100000000000000000000000000000000000000000000000000000000000000", Hex.toHexString(y.getData()));
         assertEquals(32, result.getData().length);
@@ -139,8 +131,13 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
+        byte[] xdata = x.getData();
+        byte[] ydata = y.getData();
+
         DataWord result =x.div(y);
 
+        assertArrayEquals(xdata, x.getData());
+        assertArrayEquals(ydata, y.getData());
         assertEquals(32, result.getData().length);
         assertEquals("0000000000000000000000000000000000000000000000000000000000000014", Hex.toHexString(result.getData()));
     }
@@ -154,15 +151,19 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
+        byte[] xdata = x.getData();
+        byte[] ydata = y.getData();
+
         DataWord result = x.div(y);
 
+        assertArrayEquals(xdata, x.getData());
+        assertArrayEquals(ydata, y.getData());
         assertEquals(32, result.getData().length);
         assertTrue(result.isZero());
     }
 
     @Test
     public void testSDivNegative() {
-
         // one is -300 as 256-bit signed integer:
         byte[] one = Hex.decode("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed4");
 
@@ -171,123 +172,148 @@ public class DataWordTest {
 
         DataWord x = new DataWord(one);
         DataWord y = new DataWord(two);
+        byte[] xdata = x.getData();
+        byte[] ydata = y.getData();
+
         DataWord result = x.sDiv(y);
 
+        assertArrayEquals(xdata, x.getData());
+        assertArrayEquals(ydata, y.getData());
         assertEquals(32, result.getData().length);
         assertEquals("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffec", result.toString());
     }
 
     @Test
     public void testPow() {
-
         BigInteger x = BigInteger.valueOf(Integer.MAX_VALUE);
         BigInteger y = BigInteger.valueOf(1000);
 
         BigInteger result1 = x.modPow(x, y);
         BigInteger result2 = pow(x, y);
-        System.out.println(result1);
-        System.out.println(result2);
     }
 
     @Test
     public void testSignExtend1() {
-
         DataWord x = new DataWord(Hex.decode("f2"));
+        byte[] xdata = x.getData();
+
         byte k = 0;
         String expected = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff2";
 
         DataWord result = x.signExtend(k);
-        System.out.println(result.toString());
+
+        assertArrayEquals(xdata, x.getData());
         assertEquals(expected, result.toString());
     }
 
     @Test
     public void testSignExtend2() {
         DataWord x = new DataWord(Hex.decode("f2"));
+        byte[] xdata = x.getData();
+
         byte k = 1;
         String expected = "00000000000000000000000000000000000000000000000000000000000000f2";
 
         DataWord result = x.signExtend(k);
-        System.out.println(result.toString());
+
+        assertArrayEquals(xdata, x.getData());
         assertEquals(expected, result.toString());
     }
 
     @Test
     public void testSignExtend3() {
-
         byte k = 1;
+
         DataWord x = new DataWord(Hex.decode("0f00ab"));
+        byte[] xdata = x.getData();
+
         String expected = "00000000000000000000000000000000000000000000000000000000000000ab";
 
         DataWord result = x.signExtend(k);
-        System.out.println(result.toString());
+
+        assertArrayEquals(xdata, x.getData());
         assertEquals(expected, result.toString());
     }
 
     @Test
     public void testSignExtend4() {
-
         byte k = 1;
+
         DataWord x = new DataWord(Hex.decode("ffff"));
+        byte[] xdata = x.getData();
+
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
         DataWord result = x.signExtend(k);
-        System.out.println(result.toString());
+
+        assertArrayEquals(xdata, x.getData());
         assertEquals(expected, result.toString());
     }
 
     @Test
     public void testSignExtend5() {
-
         byte k = 3;
+
         DataWord x = new DataWord(Hex.decode("ffffffff"));
+        byte[] xdata = x.getData();
+
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
         DataWord result = x.signExtend(k);
-        System.out.println(result.toString());
+
+        assertArrayEquals(xdata, x.getData());
         assertEquals(expected, result.toString());
     }
 
     @Test
     public void testSignExtend6() {
-
         byte k = 3;
+
         DataWord x = new DataWord(Hex.decode("ab02345678"));
+        byte[] xdata = x.getData();
+
         String expected = "0000000000000000000000000000000000000000000000000000000002345678";
 
         DataWord result = x.signExtend(k);
-        System.out.println(result.toString());
+
+        assertArrayEquals(xdata, x.getData());
         assertEquals(expected, result.toString());
     }
 
     @Test
     public void testSignExtend7() {
-
         byte k = 3;
+
         DataWord x = new DataWord(Hex.decode("ab82345678"));
+        byte[] xdata = x.getData();
+
         String expected = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff82345678";
 
         DataWord result = x.signExtend(k);
-        System.out.println(result.toString());
+
+        assertArrayEquals(xdata, x.getData());
         assertEquals(expected, result.toString());
     }
 
     @Test
     public void testSignExtend8() {
-
         byte k = 30;
+
         DataWord x = new DataWord(Hex.decode("ff34567882345678823456788234567882345678823456788234567882345678"));
+        byte[] xdata = x.getData();
+
         String expected = "0034567882345678823456788234567882345678823456788234567882345678";
 
         DataWord result = x.signExtend(k);
-        System.out.println(result.toString());
+
+        assertArrayEquals(xdata, x.getData());
         assertEquals(expected, result.toString());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testSignExtendException1() {
-
         byte k = -1;
+
         DataWord x = new DataWord();
 
         x.signExtend(k); // should throw an exception
@@ -298,15 +324,15 @@ public class DataWordTest {
         byte[] negative = new byte[]{-1, -1, -1, -1,-1,-1,-1,-1};
 
         DataWord x = new DataWord(negative);
+
         long l = x.longValue();
-        System.out.println(l);
         assertEquals(l, -1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testSignExtendException2() {
-
         byte k = 32;
+
         DataWord x = new DataWord();
 
         x.signExtend(k); // should throw an exception
@@ -334,13 +360,24 @@ public class DataWordTest {
         DataWord dv1 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v1));
         DataWord dv2 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v2));
         DataWord dv3 = new DataWord(org.spongycastle.util.encoders.Hex.decode(v3));
+
+        byte[] datadv1 = dv1.getData();
+        byte[] datadv2 = dv2.getData();
+        byte[] datadv3 = dv3.getData();
+
         BigInteger bv1 = new BigInteger(v1, 16);
         BigInteger bv2 = new BigInteger(v2, 16);
         BigInteger bv3 = new BigInteger(v3, 16);
 
-        DataWord actual = dv1.addmod(dv2, dv3);
+        DataWord result = dv1.addmod(dv2, dv3);
+
         BigInteger br = bv1.add(bv2).mod(bv3);
-        assertEquals(actual.value(), br);
+
+        assertArrayEquals(datadv1, dv1.getData());
+        assertArrayEquals(datadv2, dv2.getData());
+        assertArrayEquals(datadv3, dv3.getData());
+
+        assertEquals(result.value(), br);
     }
 
     @Test
@@ -349,10 +386,17 @@ public class DataWordTest {
         DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("01"));
         DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999998"));
 
-        DataWord actual = wr.mulmod(w1, w2);
+        byte[] datawr = wr.getData();
+        byte[] dataw1 = w1.getData();
+        byte[] dataw2 = w2.getData();
 
-        assertEquals(32, actual.getData().length);
-        assertEquals("0000000000000000000000000000000000000000000000000000000000000001", org.spongycastle.util.encoders.Hex.toHexString(actual.getData()));
+        DataWord result = wr.mulmod(w1, w2);
+
+        assertArrayEquals(datawr, wr.getData());
+        assertArrayEquals(dataw1, w1.getData());
+        assertArrayEquals(dataw2, w2.getData());
+        assertEquals(32, result.getData().length);
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000001", org.spongycastle.util.encoders.Hex.toHexString(result.getData()));
     }
 
     @Test
@@ -361,10 +405,17 @@ public class DataWordTest {
         DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("01"));
         DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
 
-        DataWord actual = wr.mulmod(w1, w2);
+        byte[] datawr = wr.getData();
+        byte[] dataw1 = w1.getData();
+        byte[] dataw2 = w2.getData();
 
-        assertEquals(32, actual.getData().length);
-        assertTrue(actual.isZero());
+        DataWord result = wr.mulmod(w1, w2);
+
+        assertArrayEquals(datawr, wr.getData());
+        assertArrayEquals(dataw1, w1.getData());
+        assertArrayEquals(dataw2, w2.getData());
+        assertEquals(32, result.getData().length);
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -373,10 +424,17 @@ public class DataWordTest {
         DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("9999999999999999999999999999999999999999999999999999999999999999"));
         DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
-        wr = wr.mulmod(w1, w2);
+        byte[] datawr = wr.getData();
+        byte[] dataw1 = w1.getData();
+        byte[] dataw2 = w2.getData();
 
-        assertEquals(32, wr.getData().length);
-        assertTrue(wr.isZero());
+        DataWord result = wr.mulmod(w1, w2);
+
+        assertArrayEquals(datawr, wr.getData());
+        assertArrayEquals(dataw1, w1.getData());
+        assertArrayEquals(dataw2, w2.getData());
+        assertEquals(32, result.getData().length);
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -385,10 +443,17 @@ public class DataWordTest {
         DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("00"));
         DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
-        DataWord actual = wr.mulmod(w1, w2);
+        byte[] datawr = wr.getData();
+        byte[] dataw1 = w1.getData();
+        byte[] dataw2 = w2.getData();
 
+        DataWord result = wr.mulmod(w1, w2);
+
+        assertArrayEquals(datawr, wr.getData());
+        assertArrayEquals(dataw1, w1.getData());
+        assertArrayEquals(dataw2, w2.getData());
         assertEquals(32, wr.getData().length);
-        assertTrue(actual.isZero());
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -397,10 +462,17 @@ public class DataWordTest {
         DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
         DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("00"));
 
-        DataWord actual = wr.mulmod(w1, w2);
+        byte[] datawr = wr.getData();
+        byte[] dataw1 = w1.getData();
+        byte[] dataw2 = w2.getData();
 
+        DataWord result = wr.mulmod(w1, w2);
+
+        assertArrayEquals(datawr, wr.getData());
+        assertArrayEquals(dataw1, w1.getData());
+        assertArrayEquals(dataw2, w2.getData());
         assertEquals(32, wr.getData().length);
-        assertTrue(actual.isZero());
+        assertTrue(result.isZero());
     }
 
     @Test
@@ -409,10 +481,17 @@ public class DataWordTest {
         DataWord w1 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
         DataWord w2 = new DataWord(org.spongycastle.util.encoders.Hex.decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
-        DataWord actual = wr.mulmod(w1, w2);
+        byte[] datawr = wr.getData();
+        byte[] dataw1 = w1.getData();
+        byte[] dataw2 = w2.getData();
 
+        DataWord result = wr.mulmod(w1, w2);
+
+        assertArrayEquals(datawr, wr.getData());
+        assertArrayEquals(dataw1, w1.getData());
+        assertArrayEquals(dataw2, w2.getData());
         assertEquals(32, wr.getData().length);
-        assertTrue(actual.isZero());
+        assertTrue(result.isZero());
     }
 
     public static BigInteger pow(BigInteger x, BigInteger y) {

--- a/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
@@ -43,7 +43,7 @@ public class PrecompiledContractTest {
     @Test
     public void identityTest1() {
 
-        DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000004");
+        DataWord addr = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000004");
         PrecompiledContract contract = precompiledContracts.getContractForAddress(null, addr);
         byte[] data = Hex.decode("112233445566");
         byte[] expected = Hex.decode("112233445566");
@@ -57,7 +57,7 @@ public class PrecompiledContractTest {
     @Test
     public void sha256Test1() {
 
-        DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
+        DataWord addr = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000002");
         PrecompiledContract contract = precompiledContracts.getContractForAddress(null, addr);
         byte[] data = null;
         String expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -70,7 +70,7 @@ public class PrecompiledContractTest {
     @Test
     public void sha256Test2() {
 
-        DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
+        DataWord addr = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000002");
         PrecompiledContract contract = precompiledContracts.getContractForAddress(null, addr);
         byte[] data = ByteUtil.EMPTY_BYTE_ARRAY;
         String expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -83,7 +83,7 @@ public class PrecompiledContractTest {
     @Test
     public void sha256Test3() {
 
-        DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000002");
+        DataWord addr = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000002");
         PrecompiledContract contract = precompiledContracts.getContractForAddress(null, addr);
         byte[] data = Hex.decode("112233");
         String expected = "49ee2bf93aac3b1fb4117e59095e07abe555c3383b38d608da37680a406096e8";
@@ -96,7 +96,7 @@ public class PrecompiledContractTest {
     @Test
     public void Ripempd160Test1() {
 
-        DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000003");
+        DataWord addr = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000003");
         PrecompiledContract contract = precompiledContracts.getContractForAddress(null, addr);
         byte[] data = Hex.decode("0000000000000000000000000000000000000000000000000000000000000001");
         String expected = "000000000000000000000000ae387fcfeb723c3f5964509af111cf5a67f30661";
@@ -110,7 +110,7 @@ public class PrecompiledContractTest {
     public void ecRecoverTest1() {
 
         byte[] data = Hex.decode("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549");
-        DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000001");
+        DataWord addr = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000001");
         PrecompiledContract contract = precompiledContracts.getContractForAddress(null, addr);
         String expected = "000000000000000000000000ae387fcfeb723c3f5964509af111cf5a67f30661";
 
@@ -122,7 +122,7 @@ public class PrecompiledContractTest {
     @Test
     public void modExpTest() {
 
-        DataWord addr = new DataWord("0000000000000000000000000000000000000000000000000000000000000005");
+        DataWord addr = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000005");
 
         PrecompiledContract contract = precompiledContracts.getContractForAddress(null, addr);
         assertNotNull(contract);

--- a/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
@@ -75,8 +75,8 @@ public class VMComplexTest {
 
         int expectedGas = 436;
 
-        DataWord key1 = new DataWord(999);
-        DataWord value1 = new DataWord(3);
+        DataWord key1 = DataWord.valueOf(999);
+        DataWord value1 = DataWord.valueOf(3);
 
         // Set contract into Database
         String callerAddr = "cd2a3d9f938e13cd947ec05abc7fe734df8dd826";
@@ -207,8 +207,8 @@ public class VMComplexTest {
         System.out.println("*** Used gas: " + program.getResult().getGasUsed());
 
 
-        DataWord value_1 = repository.getStorageValue(contractA_addr, new DataWord(00));
-        DataWord value_2 = repository.getStorageValue(contractA_addr, new DataWord(01));
+        DataWord value_1 = repository.getStorageValue(contractA_addr, DataWord.valueOf(00));
+        DataWord value_2 = repository.getStorageValue(contractA_addr, DataWord.valueOf(01));
 
 
         assertEquals(expectedVal_1, value_1.longValue());
@@ -291,12 +291,12 @@ public class VMComplexTest {
         System.out.println("============ Results ============");
         System.out.println("*** Used gas: " + program.getResult().getGasUsed());
 
-        DataWord value1 = program.memoryLoad(new DataWord(32));
-        DataWord value2 = program.memoryLoad(new DataWord(64));
-        DataWord value3 = program.memoryLoad(new DataWord(96));
-        DataWord value4 = program.memoryLoad(new DataWord(128));
-        DataWord value5 = program.memoryLoad(new DataWord(160));
-        DataWord value6 = program.memoryLoad(new DataWord(192));
+        DataWord value1 = program.memoryLoad(DataWord.valueOf(32));
+        DataWord value2 = program.memoryLoad(DataWord.valueOf(64));
+        DataWord value3 = program.memoryLoad(DataWord.valueOf(96));
+        DataWord value4 = program.memoryLoad(DataWord.valueOf(128));
+        DataWord value5 = program.memoryLoad(DataWord.valueOf(160));
+        DataWord value6 = program.memoryLoad(DataWord.valueOf(192));
 
         assertEquals(expectedVal_1, value1.longValue());
         assertEquals(expectedVal_2, value2.longValue());
@@ -440,10 +440,10 @@ public class VMComplexTest {
         System.out.println("============ Results ============");
         System.out.println("*** Used gas: " + program.getResult().getGasUsed());
 
-        DataWord memValue1 = program.memoryLoad(new DataWord(0));
-        DataWord memValue2 = program.memoryLoad(new DataWord(32));
+        DataWord memValue1 = program.memoryLoad(DataWord.valueOf(0));
+        DataWord memValue2 = program.memoryLoad(DataWord.valueOf(32));
 
-        DataWord storeValue1 = repository.getStorageValue(contractB_addr, new DataWord(00));
+        DataWord storeValue1 = repository.getStorageValue(contractB_addr, DataWord.valueOf(00));
 
         assertEquals("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", memValue1.toString());
         assertEquals("aaffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffaa", memValue2.toString());
@@ -460,8 +460,8 @@ public class VMComplexTest {
 
         int expectedGas = 357;
 
-        DataWord key1 = new DataWord(999);
-        DataWord value1 = new DataWord(3);
+        DataWord key1 = DataWord.valueOf(999);
+        DataWord value1 = DataWord.valueOf(3);
 
         // Set contract into Database
         String callerAddr = "cd1722f3947def4cf144679da39c4c32bdc35681";
@@ -519,8 +519,8 @@ public class VMComplexTest {
 
         int expectedGas = 354;
 
-        DataWord key1 = new DataWord(999);
-        DataWord value1 = new DataWord(3);
+        DataWord key1 = DataWord.valueOf(999);
+        DataWord value1 = DataWord.valueOf(3);
 
         // Set contract into Database
         String callerAddr = "cd1722f3947def4cf144679da39c4c32bdc35681";
@@ -578,8 +578,8 @@ public class VMComplexTest {
 
         int expectedGas = 356;
 
-        DataWord key1 = new DataWord(9999);
-        DataWord value1 = new DataWord(3);
+        DataWord key1 = DataWord.valueOf(9999);
+        DataWord value1 = DataWord.valueOf(3);
 
         // Set contract into Database
         String callerAddr = "cd1722f3947def4cf144679da39c4c32bdc35681";
@@ -637,8 +637,8 @@ public class VMComplexTest {
 
         int expectedGas = 313;
 
-        DataWord key1 = new DataWord(999);
-        DataWord value1 = new DataWord(3);
+        DataWord key1 = DataWord.valueOf(999);
+        DataWord value1 = DataWord.valueOf(3);
 
         // Set contract into Database
         String callerAddr = "cd1722f3947def4cf144679da39c4c32bdc35681";

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -187,7 +187,7 @@ public class VMTest {
         assertEquals(DataWord.ONE, program.stackPop());
         assertFalse(program.getStack().isEmpty());
         assertEquals(1, program.getStack().size());
-        assertEquals(new DataWord(42), program.getStack().pop());
+        assertEquals(DataWord.valueOf(42), program.getStack().pop());
     }
 
     @Test  // PUSH1 OP
@@ -1241,7 +1241,7 @@ public class VMTest {
         byte operation = (byte) (OpCode.SWAP1.val() + n - 1);
 
         String programCode = "";
-        String top = new DataWord(0x10 + n).toString();
+        String top = DataWord.valueOf(0x10 + n).toString();
         for (int i = n; i > -1; --i) {
             programCode += "60" + oneByteToHexString((byte) (0x10 + i));
 
@@ -1697,7 +1697,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        DataWord key = new DataWord(Hex.decode(s_expected_key));
+        DataWord key = DataWord.valueOf(Hex.decode(s_expected_key));
         DataWord val = program.getStorage().getStorageValue(new RskAddress(invoke.getOwnerAddress()), key);
 
         assertEquals(s_expected_val, Hex.toHexString(val.getData()).toUpperCase());
@@ -1718,7 +1718,7 @@ public class VMTest {
         vm.step(program);
 
         Repository repository = program.getStorage();
-        DataWord key = new DataWord(Hex.decode(s_expected_key));
+        DataWord key = DataWord.valueOf(Hex.decode(s_expected_key));
         DataWord val = repository.getStorageValue(new RskAddress(invoke.getOwnerAddress()), key);
 
         assertEquals(s_expected_val, Hex.toHexString(val.getData()).toUpperCase());
@@ -1927,7 +1927,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        DataWord key = new DataWord(Hex.decode(s_expected_key));
+        DataWord key = DataWord.valueOf(Hex.decode(s_expected_key));
         DataWord val = program.getStorage().getStorageValue(new RskAddress(invoke.getOwnerAddress()), key);
 
         assertTrue(program.isStopped());
@@ -1950,7 +1950,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        DataWord key = new DataWord(Hex.decode(s_expected_key));
+        DataWord key = DataWord.valueOf(Hex.decode(s_expected_key));
         DataWord val = program.getStorage().getStorageValue(new RskAddress(invoke.getOwnerAddress()), key);
 
         assertTrue(program.isStopped());

--- a/rskj-core/src/test/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -92,13 +92,13 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
 
     /*           ADDRESS op         */
     public DataWord getOwnerAddress() {
-        return new DataWord(ownerAddress.getBytes());
+        return DataWord.valueOf(ownerAddress.getBytes());
     }
 
     /*           BALANCE op         */
     public DataWord getBalance() {
         byte[] balance = Hex.decode("0DE0B6B3A7640000");
-        return new DataWord(balance);
+        return DataWord.valueOf(balance);
     }
 
     /*           ORIGIN op         */
@@ -107,7 +107,7 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
         byte[] cowPrivKey = HashUtil.keccak256("horse".getBytes(StandardCharsets.UTF_8));
         byte[] addr = ECKey.fromPrivate(cowPrivKey).getAddress();
 
-        return new DataWord(addr);
+        return DataWord.valueOf(addr);
     }
 
     /*           CALLER op         */
@@ -116,14 +116,14 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
         byte[] cowPrivKey = HashUtil.keccak256("monkey".getBytes(StandardCharsets.UTF_8));
         byte[] addr = ECKey.fromPrivate(cowPrivKey).getAddress();
 
-        return new DataWord(addr);
+        return DataWord.valueOf(addr);
     }
 
     /*           GASPRICE op       */
     public DataWord getMinGasPrice() {
 
         byte[] minGasPrice = Hex.decode("09184e72a000");
-        return new DataWord(minGasPrice);
+        return DataWord.valueOf(minGasPrice);
     }
 
     /*           GAS op       */
@@ -139,7 +139,7 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     /*          CALLVALUE op    */
     public DataWord getCallValue() {
         byte[] balance = Hex.decode("0DE0B6B3A7640000");
-        return new DataWord(balance);
+        return DataWord.valueOf(balance);
     }
 
     /*****************/
@@ -156,21 +156,21 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
         int index = indexData.value().intValue();
         int size = 32;
 
-        if (msgData == null) return new DataWord(data);
-        if (index > msgData.length) return new DataWord(data);
+        if (msgData == null) return DataWord.valueOf(data);
+        if (index > msgData.length) return DataWord.valueOf(data);
         if (index + 32 > msgData.length) size = msgData.length - index;
 
         System.arraycopy(msgData, index, data, 0, size);
 
-        return new DataWord(data);
+        return DataWord.valueOf(data);
     }
 
     /*  CALLDATASIZE */
     public DataWord getDataSize() {
 
-        if (msgData == null || msgData.length == 0) return new DataWord(new byte[32]);
+        if (msgData == null || msgData.length == 0) return DataWord.valueOf(new byte[32]);
         int size = msgData.length;
-        return new DataWord(size);
+        return DataWord.valueOf(size);
     }
 
     /*  CALLDATACOPY */
@@ -193,25 +193,25 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     @Override
     public DataWord getPrevHash() {
         byte[] prevHash = Hex.decode("961CB117ABA86D1E596854015A1483323F18883C2D745B0BC03E87F146D2BB1C");
-        return new DataWord(prevHash);
+        return DataWord.valueOf(prevHash);
     }
 
     @Override
     public DataWord getCoinbase() {
         byte[] coinBase = Hex.decode("E559DE5527492BCB42EC68D07DF0742A98EC3F1E");
-        return new DataWord(coinBase);
+        return DataWord.valueOf(coinBase);
     }
 
     @Override
     public DataWord getTimestamp() {
         long timestamp = 1401421348;
-        return new DataWord(timestamp);
+        return DataWord.valueOf(timestamp);
     }
 
     @Override
     public DataWord getNumber() {
         long number = 33;
-        return new DataWord(number);
+        return DataWord.valueOf(number);
     }
 
     @Override
@@ -226,12 +226,12 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     @Override
     public DataWord getDifficulty() {
         byte[] difficulty = Hex.decode("3ED290");
-        return new DataWord(difficulty);
+        return DataWord.valueOf(difficulty);
     }
 
     @Override
     public DataWord getGaslimit() {
-        return new DataWord(gasLimit);
+        return DataWord.valueOf(gasLimit);
     }
 
 


### PR DESCRIPTION
Internal data byte array is final.

Arithmetic operations returns a new DataWord, so the original data word is not changed.

Internal pool was removed

Many methods were remove, like clone()


