### PR TITLE
New precompiled contract to recover fields from BlockHeader

### DIFF
--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/BlockAccessor.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/BlockAccessor.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import org.ethereum.core.Block;
+
+import java.util.Optional;
+
+/**
+ * Helper class to provide Block access to the BlockHeaderContract native methods.
+ *
+ * @author Diego Masini
+ */
+public class BlockAccessor {
+    private final short maximumBlockDepth;
+
+    public BlockAccessor(short maximumBlockDepth) {
+        this.maximumBlockDepth = maximumBlockDepth;
+    }
+
+    public Optional<Block> getBlock(short blockDepth, ExecutionEnvironment environment) {
+        if (blockDepth < 0) {
+            throw new NativeContractIllegalArgumentException(String.format(
+                    "Invalid block depth '%d' (should be a non-negative value)",
+                    blockDepth
+            ));
+        }
+
+        // If blockDepth is bigger or equal to the max depth, return an empty optional instead of throwing an exception
+        // to allow users of this method to decide if they want to throw an exception or return a default
+        // (probably empty) value (e.g. an empty byte array).
+        if (blockDepth >= maximumBlockDepth) {
+            return Optional.empty();
+        }
+
+        // If block is null, return an empty optional instead of throwing an exception to allow users of this method to
+        // decide if they want to throw an exception or return a default (probably empty) value (e.g. an empty byte array).
+        Block block = environment.getBlockStore().getBlockAtDepthStartingAt(blockDepth, environment.getBlock().getParentHash().getBytes());
+        if (block == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(block);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/BlockHeaderContract.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/BlockHeaderContract.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.pcc.NativeContract;
+import co.rsk.pcc.NativeMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Precompiled contract that provides access to Block Header fields (coinbase, minimum gas price, block hash, merged
+ * mining tags, bitcoin header, gas limit, gas used, RSK difficulty and coinbase for uncles).
+ *
+ * @author Diego Masini
+ */
+public class BlockHeaderContract extends NativeContract {
+    // See: REMASC Maturity
+    private static final short MAX_DEPTH = 4000;
+
+    private final BlockAccessor blockAccessor;
+
+    public BlockHeaderContract(RskSystemProperties config, RskAddress contractAddress) {
+        super(config, contractAddress);
+        this.blockAccessor = new BlockAccessor(MAX_DEPTH);
+    }
+
+    @Override
+    public List<NativeMethod> getMethods() {
+        return Arrays.asList(
+                new GetCoinbaseAddress(getExecutionEnvironment(), this.blockAccessor),
+                new GetBlockHash(getExecutionEnvironment(), this.blockAccessor),
+                new GetMergedMiningTags(getExecutionEnvironment(), this.blockAccessor),
+                new GetMinimumGasPrice(getExecutionEnvironment(), this.blockAccessor),
+                new GetGasLimit(getExecutionEnvironment(), this.blockAccessor),
+                new GetGasUsed(getExecutionEnvironment(), this.blockAccessor),
+                new GetDifficulty(getExecutionEnvironment(), this.blockAccessor),
+                new GetBitcoinHeader(getExecutionEnvironment(), this.blockAccessor),
+                new GetUncleCoinbaseAddress(getExecutionEnvironment(), this.blockAccessor)
+        );
+    }
+
+    @Override
+    public Optional<NativeMethod> getDefaultMethod() {
+        return Optional.empty();
+    }
+}
+
+

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/BlockHeaderContractMethod.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/BlockHeaderContractMethod.java
@@ -1,0 +1,57 @@
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeMethod;
+import org.ethereum.core.Block;
+import org.ethereum.util.ByteUtil;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Base class of BlockHeader contract methods to provide common functionality to all methods.
+ *
+ * @author Diego Masini
+ */
+public abstract class BlockHeaderContractMethod extends NativeMethod {
+    private final BlockAccessor blockAccessor;
+
+    public BlockHeaderContractMethod(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+       super(executionEnvironment);
+        this.blockAccessor = blockAccessor;
+    }
+
+    @Override
+    public Object execute(Object[] arguments) {
+        short blockDepth;
+        try {
+            blockDepth = ((BigInteger) arguments[0]).shortValueExact();
+        } catch (ArithmeticException e) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        Optional<Block> block = blockAccessor.getBlock(blockDepth, getExecutionEnvironment());
+        if (block.isPresent()) {
+            return internalExecute(block.get(), arguments);
+        }
+
+        return ByteUtil.EMPTY_BYTE_ARRAY;
+    }
+
+    protected abstract Object internalExecute(Block block, Object[] arguments);
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean onlyAllowsLocalCalls() {
+        return false;
+    }
+
+    @Override
+    public long getGas(Object[] parsedArguments, byte[] originalData) {
+        return 1000L + super.getGas(parsedArguments, originalData);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetBitcoinHeader.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetBitcoinHeader.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+
+/**
+ * This implements the "getBitcoinHeader" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetBitcoinHeader extends BlockHeaderContractMethod {
+
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getBitcoinHeader",
+            new String[]{"int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetBitcoinHeader(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        return block.getBitcoinMergedMiningHeader();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetBlockHash.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetBlockHash.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+
+/**
+ * This implements the "getBlockHash" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetBlockHash extends BlockHeaderContractMethod {
+
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getBlockHash",
+            new String[]{"int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetBlockHash(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        return block.getHash().getBytes();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetCoinbaseAddress.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetCoinbaseAddress.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+
+/**
+ * This implements the "getCoinbaseAddress" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetCoinbaseAddress extends BlockHeaderContractMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getCoinbaseAddress",
+            new String[]{"int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetCoinbaseAddress(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        return block.getCoinbase().getBytes();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetDifficulty.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetDifficulty.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+
+/**
+ * This implements the "getDifficulty" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetDifficulty extends BlockHeaderContractMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getDifficulty",
+            new String[]{"int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetDifficulty(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        return block.getDifficulty().getBytes();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetGasLimit.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetGasLimit.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+
+/**
+ * This implements the "getGasLimit" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetGasLimit extends BlockHeaderContractMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getGasLimit",
+            new String[]{"int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetGasLimit(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        return block.getGasLimit();
+    }
+}
+

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetGasUsed.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetGasUsed.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+
+import java.math.BigInteger;
+
+/**
+ * This implements the "getGasUsed" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetGasUsed extends BlockHeaderContractMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getGasUsed",
+            new String[]{"int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetGasUsed(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        return BigInteger.valueOf(block.getGasUsed()).toByteArray();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetMergedMiningTags.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetMergedMiningTags.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.config.RskMiningConstants;
+import co.rsk.pcc.ExecutionEnvironment;
+import org.apache.commons.lang3.ArrayUtils;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.util.ByteUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This implements the "getMergedMiningTags" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetMergedMiningTags extends BlockHeaderContractMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getMergedMiningTags",
+            new String[]{"int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetMergedMiningTags(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        byte[] mergedMiningTx = block.getBitcoinMergedMiningCoinbaseTransaction();
+
+        List<Byte> mergedMiningTxAsList = Arrays.asList(ArrayUtils.toObject(mergedMiningTx));
+        List<Byte> rskTagBytesAsList = Arrays.asList(ArrayUtils.toObject(RskMiningConstants.RSK_TAG));
+
+        int rskTagPosition = Collections.lastIndexOfSubList(mergedMiningTxAsList, rskTagBytesAsList);
+
+        // if RSK Tag not found, return an empty byte array
+        if (rskTagPosition == -1) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        int additionalTagsStartIndex = rskTagPosition + RskMiningConstants.RSK_TAG.length + RskMiningConstants.BLOCK_HEADER_HASH_SIZE;
+        return Arrays.copyOfRange(mergedMiningTx, additionalTagsStartIndex, mergedMiningTx.length);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetMinimumGasPrice.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetMinimumGasPrice.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.core.Coin;
+import co.rsk.pcc.ExecutionEnvironment;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.util.ByteUtil;
+
+/**
+ * This implements the "getMinGasPrice" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetMinimumGasPrice extends BlockHeaderContractMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getMinGasPrice",
+            new String[]{"int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetMinimumGasPrice(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        Coin minGasPrice = block.getMinimumGasPrice();
+        if (minGasPrice == null) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        return minGasPrice.getBytes();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetUncleCoinbaseAddress.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetUncleCoinbaseAddress.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.util.ByteUtil;
+
+import java.math.BigInteger;
+import java.util.List;
+
+/**
+ * This implements the "getUncleCoinbaseAddress" method
+ * that belongs to the BlockHeaderContract native contract.
+ *
+ * @author Diego Masini
+ */
+public class GetUncleCoinbaseAddress extends BlockHeaderContractMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getUncleCoinbaseAddress",
+            new String[]{"int256", "int256"},
+            new String[]{"bytes"}
+    );
+
+    public GetUncleCoinbaseAddress(ExecutionEnvironment executionEnvironment, BlockAccessor blockAccessor) {
+        super(executionEnvironment, blockAccessor);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    protected Object internalExecute(Block block, Object[] arguments) {
+        List<BlockHeader> uncles = block.getUncleList();
+        if (uncles == null) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        short uncleIndex;
+        try {
+            uncleIndex = ((BigInteger) arguments[1]).shortValueExact();
+        } catch (ArithmeticException e) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        if (uncleIndex < 0) {
+            throw new NativeContractIllegalArgumentException(String.format(
+                    "Invalid uncle index '%d' (should be a non-negative value)",
+                    uncleIndex
+            ));
+        }
+
+        if (uncleIndex >= uncles.size()) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        BlockHeader uncle = uncles.get(uncleIndex);
+        return uncle.getCoinbase().getBytes();
+    }
+}
+

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -58,6 +58,8 @@ public interface BlockchainConfig {
 
     boolean isRskip98();
 
+    boolean isRskip119();
+
     boolean isRskip120();
 
     boolean isRskip123();

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/BlockchainConfigImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/BlockchainConfigImpl.java
@@ -116,6 +116,11 @@ public class BlockchainConfigImpl implements BlockchainConfig {
     }
 
     @Override
+    public boolean isRskip119() {
+        return activationConfig.isActive(RSKIP119, blockNumber);
+    }
+
+    @Override
     public boolean isRskip120() {
         return activationConfig.isActive(RSKIP120, blockNumber);
     }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -33,6 +33,7 @@ public enum ConsensusRule {
     RSKIP97("rskip97"),
     RSKIP98("rskip98"),
     RSKIP103("rskip103"),
+    RSKIP119("rskip119"),
     RSKIP120("rskip120"),
     RSKIP123("rskip123");
 

--- a/rskj-core/src/main/java/org/ethereum/db/BlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/BlockStore.java
@@ -50,6 +50,8 @@ public interface BlockStore extends RemascCache {
 
     Block getBlockByHashAndDepth(byte[] hash, long depth);
 
+    Block getBlockAtDepthStartingAt(long depth, byte[] hash);
+
     boolean isBlockExist(byte[] hash);
 
     List<byte[]> getListHashesEndWith(byte[] hash, long qty);

--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -21,6 +21,7 @@ blockchain.config {
         rskip97 = -1,
         rskip98 = orchid,
         rskip103 = orchid060,
+        rskip119 = secondFork,
         rskip120 = secondFork,
         rskip123 = secondFork
     }

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -21,6 +21,7 @@ blockchain.config {
         rskip97 = orchid,
         rskip98 = orchid,
         rskip103 = orchid060,
+        rskip119 = secondFork,
         rskip120 = secondFork,
         rskip123 = secondFork
     }

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -21,6 +21,7 @@ blockchain.config {
         rskip97 = -1,
         rskip98 = orchid,
         rskip103 = orchid060,
+        rskip119 = secondFork,
         rskip120 = secondFork,
         rskip123 = secondFork
     }

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -20,6 +20,7 @@ blockchain.config {
         rskip97 = genesis,
         rskip98 = genesis,
         rskip103 = orchid060,
+        rskip119 = secondFork,
         rskip120 = secondFork,
         rskip123 = secondFork
     }

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockAccessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockAccessorTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import org.ethereum.core.Block;
+import org.ethereum.db.BlockStore;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+
+public class BlockAccessorTest {
+    private static short MAXIMUM_BLOCK_DEPTH = 100;
+    private static short NEGATIVE_BLOCK_DEPTH = -1;
+    private static short ZERO_BLOCK_DEPTH = 0;
+    private static short ONE_BLOCK_DEPTH = 1;
+
+    private BlockStore blockStore;
+    private BlockAccessor blockAccessor;
+    private ExecutionEnvironment executionEnvironment;
+
+    @Before
+    public void createBlockAccessor() {
+        blockAccessor = new BlockAccessor(MAXIMUM_BLOCK_DEPTH);
+    }
+
+    @Test
+    public void getBlockBeyondMaximumBlockDepth() {
+        executionEnvironment = mock(ExecutionEnvironment.class);
+
+        Assert.assertFalse(blockAccessor.getBlock(MAXIMUM_BLOCK_DEPTH, executionEnvironment).isPresent());
+        Assert.assertFalse(blockAccessor.getBlock((short) (MAXIMUM_BLOCK_DEPTH + 1), executionEnvironment).isPresent());
+    }
+
+    @Test(expected = NativeContractIllegalArgumentException.class)
+    public void getBlockWithNegativeDepth() {
+        executionEnvironment = mock(ExecutionEnvironment.class);
+
+        blockAccessor.getBlock(NEGATIVE_BLOCK_DEPTH, executionEnvironment);
+    }
+
+    @Test
+    public void getGenesisBlock() {
+        ExecutionEnvironment executionEnvironment = EnvironmentUtils.getEnvironmentWithBlockchainOfLength(1);
+
+        Optional<Block> genesis = blockAccessor.getBlock(ZERO_BLOCK_DEPTH, executionEnvironment);
+        Optional<Block> firstBlock = blockAccessor.getBlock(ONE_BLOCK_DEPTH, executionEnvironment);
+
+        Assert.assertTrue(genesis.isPresent());
+        Assert.assertFalse(firstBlock.isPresent());
+
+        Assert.assertEquals(0, genesis.get().getNumber());
+    }
+
+    @Test
+    public void getTenBlocksFromTheTip() {
+        ExecutionEnvironment executionEnvironment = EnvironmentUtils.getEnvironmentWithBlockchainOfLength(100);
+
+        for(short i = 0; i < 10; i++) {
+            Optional<Block> block = blockAccessor.getBlock(i, executionEnvironment);
+            Assert.assertTrue(block.isPresent());
+            Assert.assertEquals(99 - i, block.get().getNumber());
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderContractTest.java
@@ -1,0 +1,597 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.bitcoinj.core.BtcBlock;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.params.RegTestParams;
+import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.blockchain.utils.BlockMiner;
+import co.rsk.config.RskMiningConstants;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import co.rsk.mine.MinerUtils;
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContract;
+import co.rsk.pcc.NativeMethod;
+import co.rsk.test.World;
+import co.rsk.test.builders.BlockChainBuilder;
+import co.rsk.util.DifficultyUtils;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.config.BlockchainConfig;
+import org.ethereum.config.Constants;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockFactory;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.vm.DataWord;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BlockHeaderContractTest {
+    private ExecutionEnvironment executionEnvironment;
+
+    private static final BigInteger AMOUNT = new BigInteger("1000000000000000000");
+    private static final BigInteger NONCE = new BigInteger("0");
+    private static final BigInteger GAS_PRICE = new BigInteger("100");
+    private static final BigInteger GAS_LIMIT = new BigInteger("3000000");
+    private static final BigInteger GAS_USED = new BigInteger("0");
+    private static final BigInteger MIN_GAS_PRICE = new BigInteger("500000000000000000");
+    private static final BigInteger RSK_DIFFICULTY = new BigInteger("1");
+    private static final long DIFFICULTY_TARGET = 562036735;
+    private static final String DATA = "80af2871";
+    private static final String BLOCK_HEADER_CONTRACT_ADDRESS = "0000000000000000000000000000000000000000000000000000000001000010";
+    private static final byte[] ADDITIONAL_TAG = {'A','L','T','B','L','O','C','K',':'};
+
+    private TestSystemProperties config;
+    private BlockFactory blockFactory;
+    private World world;
+    private Transaction rskTx;
+    private BlockHeaderContract contract;
+    private CallTransaction.Function getCoinbaseFunction;
+    private CallTransaction.Function getMinGasPriceFunction;
+    private CallTransaction.Function getBlockHashFunction;
+    private CallTransaction.Function getMergedMiningTagsFunction;
+    private CallTransaction.Function getGasLimitFunction;
+    private CallTransaction.Function getGasUsedFunction;
+    private CallTransaction.Function getDifficultyFunction;
+    private CallTransaction.Function getBitcoinHeaderFunction;
+    private CallTransaction.Function getUncleCoinbaseAddressFunction;
+
+    @Before
+    public void setUp() {
+        config = new TestSystemProperties();
+        blockFactory = new BlockFactory(config.getActivationConfig());
+        PrecompiledContracts precompiledContracts = new PrecompiledContracts(config);
+
+        BlockchainConfig bcConfig = mock(BlockchainConfig.class);
+
+        // Enabling necessary RSKIPs for every precompiled contract to be available
+        when(bcConfig.isRskip119()).thenReturn(true);
+
+        world = new World();
+        contract = (BlockHeaderContract) precompiledContracts.getContractForAddress(bcConfig, DataWord.valueFromHex(BLOCK_HEADER_CONTRACT_ADDRESS));
+
+        // contract methods
+        getCoinbaseFunction = getContractFunction(contract, GetCoinbaseAddress.class);
+        getMinGasPriceFunction = getContractFunction(contract, GetMinimumGasPrice.class);
+        getBlockHashFunction = getContractFunction(contract, GetBlockHash.class);
+        getMergedMiningTagsFunction = getContractFunction(contract, GetMergedMiningTags.class);
+        getGasLimitFunction = getContractFunction(contract, GetGasLimit.class);
+        getGasUsedFunction = getContractFunction(contract, GetGasUsed.class);
+        getDifficultyFunction = getContractFunction(contract, GetDifficulty.class);
+        getBitcoinHeaderFunction = getContractFunction(contract, GetBitcoinHeader.class);
+        getUncleCoinbaseAddressFunction = getContractFunction(contract, GetUncleCoinbaseAddress.class);
+
+        // invoke transaction
+        rskTx = new Transaction(PrecompiledContracts.BLOCK_HEADER_ADDR_STR, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA, Constants.REGTEST_CHAIN_ID);
+        rskTx.sign(new ECKey().getPrivKeyBytes());
+
+        executionEnvironment = mock(ExecutionEnvironment.class);
+        Whitebox.setInternalState(contract, "executionEnvironment", executionEnvironment);
+    }
+
+    @Test
+    public void getCoinbase() {
+        buildBlockchainOfLength(2);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getCoinbaseFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getCoinbaseFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] coinbase = (byte[]) decodedResult[0];
+        byte[] expected = "33333333333333333333".getBytes();
+
+        assertArrayEquals(expected, coinbase);
+    }
+
+    @Test
+    public void getMinimumGasPrice() {
+        buildBlockchainOfLength(2);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getMinGasPriceFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getMinGasPriceFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] minGasPriceBytes = (byte[]) decodedResult[0];
+
+        assertTrue(minGasPriceBytes.length > 0);
+        assertEquals(MIN_GAS_PRICE, new BigInteger(minGasPriceBytes));
+    }
+
+    @Test
+    public void getBlockHash() {
+        buildBlockchainOfLength(2);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+        byte[] expectedHash = world.getBlockChain().getBestBlock().getParentHash().getBytes();
+
+        byte[] encodedResult = contract.execute(getBlockHashFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getBlockHashFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] blockHash = (byte[]) decodedResult[0];
+
+        assertEquals(Hex.toHexString(expectedHash), Hex.toHexString(blockHash));
+    }
+
+    @Test
+    public void getMergedMiningTags() {
+        buildBlockchainOfLength(2);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getMergedMiningTagsFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getMergedMiningTagsFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] tags = (byte[]) decodedResult[0];
+
+        String tagsString = new String(tags, StandardCharsets.UTF_8);
+        String altTagString = new String(ADDITIONAL_TAG, StandardCharsets.UTF_8);
+
+        assertEquals(tagsString.indexOf(altTagString), 0);
+    }
+
+    @Test
+    public void getEmptyMergedMiningTags() {
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getMergedMiningTagsFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getMergedMiningTagsFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] tags = (byte[]) decodedResult[0];
+
+        assertArrayEquals(tags, ByteUtil.EMPTY_BYTE_ARRAY);
+    }
+
+    @Test
+    public void getGasLimit() {
+        buildBlockchainOfLength(2);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getGasLimitFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getGasLimitFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] gasLimitBytes = (byte[]) decodedResult[0];
+
+        assertTrue(gasLimitBytes.length > 0);
+        assertEquals(GAS_LIMIT, new BigInteger(gasLimitBytes));
+    }
+
+    @Test
+    public void getGasUsed() {
+        buildBlockchainOfLength(2);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getGasUsedFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getGasUsedFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] gasUsedBytes = (byte[]) decodedResult[0];
+
+        assertTrue(gasUsedBytes.length > 0);
+        assertEquals(GAS_USED, new BigInteger(gasUsedBytes));
+    }
+
+    @Test
+    public void getDifficulty() {
+        buildBlockchainOfLength(2);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getDifficultyFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getDifficultyFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] rskDifficulty = (byte[]) decodedResult[0];
+
+        assertTrue(rskDifficulty.length > 0);
+        assertEquals(RSK_DIFFICULTY, new BigInteger(rskDifficulty));
+    }
+
+    @Test
+    public void getBitcoinHeader() {
+        buildBlockchainOfLength(2);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getBitcoinHeaderFunction.encode(new BigInteger("0")));
+        Object[] decodedResult = getBitcoinHeaderFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] bitcoinHeader = (byte[]) decodedResult[0];
+
+        assertTrue(bitcoinHeader.length > 0);
+
+        NetworkParameters bitcoinNetworkParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+
+        assertNotNull(bitcoinNetworkParameters);
+
+        BtcBlock bitcoinMergedMiningBlock = bitcoinNetworkParameters.getDefaultSerializer().makeBlock(bitcoinHeader);
+
+        assertEquals(DIFFICULTY_TARGET, bitcoinMergedMiningBlock.getDifficultyTarget());
+        assertNull(bitcoinMergedMiningBlock.getTransactions());
+    }
+
+    @Test
+    public void getUncleCoinbaseAddress() {
+        // creates a blockchain where every block has two uncles
+        buildBlockchainOfLengthWithUncles(6);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        // getting first uncle
+        byte[] encodedResult = contract.execute(getUncleCoinbaseAddressFunction.encode(new BigInteger("1"), new BigInteger("0")));
+        Object[] decodedResult = getUncleCoinbaseAddressFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] uncleCoinbase = (byte[]) decodedResult[0];
+        byte[] expected = "33333333333333333333".getBytes();
+
+        assertArrayEquals(expected, uncleCoinbase);
+
+        // getting second uncle
+        encodedResult = contract.execute(getUncleCoinbaseAddressFunction.encode(new BigInteger("1"), new BigInteger("1")));
+        decodedResult = getUncleCoinbaseAddressFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        uncleCoinbase = (byte[]) decodedResult[0];
+        expected = "33333333333333333333".getBytes();
+
+        assertArrayEquals(expected, uncleCoinbase);
+
+        // should have no more uncles
+        encodedResult = contract.execute(getUncleCoinbaseAddressFunction.encode(new BigInteger("1"), new BigInteger("2")));
+        decodedResult = getUncleCoinbaseAddressFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        uncleCoinbase = (byte[]) decodedResult[0];
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, uncleCoinbase);
+    }
+
+    @Test
+    public void getDifficultyForBlockAtDepth1000() {
+        buildBlockchainOfLength(4000);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getDifficultyFunction.encode(new BigInteger("1000")));
+        Object[] decodedResult = getDifficultyFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] rskDifficulty = (byte[]) decodedResult[0];
+
+        assertTrue(rskDifficulty.length > 0);
+        assertEquals(RSK_DIFFICULTY, new BigInteger(rskDifficulty));
+    }
+
+    @Test
+    public void blockBeyondMaximumBlockDepth() {
+        buildBlockchainOfLength(5000);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getMergedMiningTagsFunction.encode(new BigInteger("4992")));
+        Object[] decodedResult = getMergedMiningTagsFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] tags = (byte[]) decodedResult[0];
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, tags);
+    }
+
+    @Test
+    public void invalidBlockDepth() {
+        buildBlockchainOfLength(300);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        byte[] encodedResult = contract.execute(getMergedMiningTagsFunction.encode(new BigInteger("500")));
+        Object[] decodedResult = getMergedMiningTagsFunction.decodeResult(encodedResult);
+
+        assertEquals(1, decodedResult.length);
+
+        byte[] tags = (byte[]) decodedResult[0];
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, tags);
+    }
+
+    @Test
+    public void getBlockHeaderFieldsFromBranch(){
+        String bestChainCoinbase = "22222222222222222222";
+        String initialChainCoinbase = "33333333333333333333";
+
+        // build initial chain with the third block using a different coinbase to differentiate it
+        buildBlockchainOfLengthUsingCoinbase(2, new RskAddress(initialChainCoinbase.getBytes()));
+        buildBlockchainOfLengthUsingCoinbase(1, new RskAddress(bestChainCoinbase.getBytes()));
+        buildBlockchainOfLengthUsingCoinbase(7, new RskAddress(initialChainCoinbase.getBytes()));
+
+        // keep a reference to the best block before adding a branch
+        Block initialBestBlock = world.getBlockChain().getBestBlock();
+
+        // best block number should be 10 at this moment
+        assertEquals(10, initialBestBlock.getNumber());
+
+        // extend chain from the third block to create a four-block branch, this branch becomes the best chain
+        BlockChainBuilder.extend(world.getBlockChain(), 4, true, true, 3);
+
+        // get a reference to new best block
+        Block bestBlock = world.getBlockChain().getBestBlock();
+
+        // best block number should be 7
+        assertEquals(7, bestBlock.getNumber());
+
+        // initialize contract with current best block
+        initContract(contract, rskTx, bestBlock, world);
+
+        // get coinbase of block at depth 1 from branch (current best chain), coinbase should be bestChainCoinbase
+        executeAndAssertCoinbase(new BigInteger("1"), bestChainCoinbase);
+
+        // get coinbase of block at depth 4 from branch (block belongs to initial chain), coinbase should be initialChainCoinbase
+        executeAndAssertCoinbase(new BigInteger("4"), initialChainCoinbase);
+
+        // initialize contract with best block from initial chain
+        initContract(contract, rskTx, initialBestBlock, world);
+
+        // get coinbase of block at depth 3 from branch (block belongs to initial chain), coinbase should be initialChainCoinbase
+        executeAndAssertCoinbase(new BigInteger("3"), initialChainCoinbase);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void negativeBlockDepth() {
+        buildBlockchainOfLength(10);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        contract.execute(getCoinbaseFunction.encode(new BigInteger("-1")));
+
+        Assert.fail("Trying to access a block using a negative block depth should throw an exception");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void negativeUncleIndex() {
+        buildBlockchainOfLength(10);
+
+        contract.init(rskTx, world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+        contract.execute(getUncleCoinbaseAddressFunction.encode(new BigInteger("1"), new BigInteger("-1")));
+
+        Assert.fail("Trying to access an uncle coinbase using a negative uncle index should throw an exception");
+    }
+
+    private void executeAndAssertCoinbase(BigInteger blockDepth, String expectedCoinbase){
+        byte[] encodedResult = contract.execute(getCoinbaseFunction.encode(blockDepth));
+        Object[] decodedResult = getCoinbaseFunction.decodeResult(encodedResult);
+
+        // coinbase should be expectedCoinbase
+        assertEquals(1, decodedResult.length);
+        byte[] coinbase = (byte[]) decodedResult[0];
+        byte[] expected = expectedCoinbase.getBytes();
+        assertArrayEquals(expected, coinbase);
+    }
+
+    private void initContract(BlockHeaderContract contract, Transaction tx, Block block, World world) {
+        contract.init(tx, block, world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+    }
+
+    private Block mineBlock(Block parent) {
+        return mineBlock(parent, parent.getCoinbase());
+    }
+
+    private Block mineBlock(Block parent, RskAddress coinbase) {
+        BlockGenerator blockGenerator = new BlockGenerator(config.getNetworkConstants(), config.getActivationConfig());
+        byte[] prefix = new byte[1000];
+        byte[] compressedTag = Arrays.concatenate(prefix, RskMiningConstants.RSK_TAG);
+
+        Keccak256 mergedMiningHash = new Keccak256(parent.getHashForMergedMining());
+
+        NetworkParameters networkParameters = RegTestParams.get();
+        BtcTransaction mergedMiningCoinbaseTransaction = MinerUtils.getBitcoinMergedMiningCoinbaseTransaction(networkParameters, mergedMiningHash.getBytes());
+        BtcBlock mergedMiningBlock = MinerUtils.getBitcoinMergedMiningBlock(networkParameters, mergedMiningCoinbaseTransaction);
+
+        BigInteger targetDifficulty = DifficultyUtils.difficultyToTarget(parent.getDifficulty());
+
+        new BlockMiner(config.getActivationConfig()).findNonce(mergedMiningBlock, targetDifficulty);
+
+        // We need to clone to allow modifications
+        Block newBlock = blockFactory.cloneBlockForModification(blockGenerator.createChildBlock(
+                parent, new ArrayList<>(), new ArrayList<>(), parent.getDifficulty().asBigInteger().longValue(),
+                MIN_GAS_PRICE, parent.getGasLimit(), coinbase
+        ));
+
+        newBlock.setBitcoinMergedMiningHeader(mergedMiningBlock.cloneAsHeader().bitcoinSerialize());
+
+        byte[] merkleProof = MinerUtils.buildMerkleProof(
+                config.getActivationConfig(),
+                pb -> pb.buildFromBlock(mergedMiningBlock),
+                newBlock.getNumber()
+        );
+
+        byte[] additionalTag = Arrays.concatenate(ADDITIONAL_TAG, mergedMiningHash.getBytes());
+        byte[] mergedMiningTx = org.bouncycastle.util.Arrays.concatenate(compressedTag, mergedMiningHash.getBytes(), additionalTag);
+
+        newBlock.setBitcoinMergedMiningCoinbaseTransaction(mergedMiningTx);
+        newBlock.setBitcoinMergedMiningMerkleProof(merkleProof);
+
+        return newBlock;
+    }
+
+    private void buildBlockchainOfLengthUsingCoinbase(int length, RskAddress coinbase) {
+        if (length < 0) return;
+
+        for (int i = 0; i < length; i++) {
+            Block block = mineBlock(world.getBlockChain().getBestBlock(), coinbase);
+            world.getBlockChain().tryToConnect(block);
+        }
+    }
+
+    // creates a blockchain where every block has two uncles
+    private void buildBlockchainOfLengthWithUncles(int length) {
+        if (length < 0) return;
+
+        BlockChainBuilder.extend(world.getBlockChain(), length, true, true);
+    }
+
+    private void buildBlockchainOfLength(int length) {
+        if (length < 0) return;
+
+        for (int i = 0; i < length; i++) {
+            Block block = mineBlock(world.getBlockChain().getBestBlock());
+            world.getBlockChain().tryToConnect(block);
+        }
+    }
+
+
+
+    private CallTransaction.Function getContractFunction(NativeContract contract, Class methodClass) {
+        Optional<NativeMethod> method = contract.getMethods().stream().filter(m -> m.getClass() == methodClass).findFirst();
+        assertTrue(method.isPresent());
+        return method.get().getFunction();
+    }
+
+    @Test
+    public void hasNoDefaultMethod() {
+        Assert.assertFalse(contract.getDefaultMethod().isPresent());
+    }
+
+    @Test
+    public void hasNineMethods() {
+        Assert.assertEquals(9, contract.getMethods().size());
+    }
+
+    @Test
+    public void hasGetCoinbaseAddress() {
+        assertHasMethod(GetCoinbaseAddress.class, true);
+    }
+
+    @Test
+    public void hasGetBlockHash() {
+        assertHasMethod(GetBlockHash.class, true);
+    }
+
+    @Test
+    public void hasGetMergedMiningTags() {
+        assertHasMethod(GetMergedMiningTags.class, true);
+    }
+
+    @Test
+    public void hasGetMinimumGasPrice() {
+        assertHasMethod(GetMinimumGasPrice.class, true);
+    }
+
+    @Test
+    public void hasGetGasLimit() {
+        assertHasMethod(GetGasLimit.class, true);
+    }
+
+    @Test
+    public void hasGetGasUsed() {
+        assertHasMethod(GetGasUsed.class, true);
+    }
+
+    @Test
+    public void hasGetDifficulty() {
+        assertHasMethod(GetDifficulty.class, true);
+    }
+
+    @Test
+    public void hasGetBitcoinHeader() {
+        assertHasMethod(GetBitcoinHeader.class, true);
+    }
+
+    @Test
+    public void hasGetUncleCoinbaseAddress() {
+        assertHasMethod(GetUncleCoinbaseAddress.class, true);
+    }
+
+    private void assertHasMethod(Class clazz, boolean withAccessor) {
+        Optional<NativeMethod> method = contract.getMethods().stream()
+                .filter(m -> m.getClass() == clazz).findFirst();
+        Assert.assertTrue(method.isPresent());
+        Assert.assertEquals(executionEnvironment, method.get().getExecutionEnvironment());
+        if (withAccessor) {
+            Object accessor = Whitebox.getInternalState(method.get(), "blockAccessor");
+            Assert.assertNotNull(accessor);
+            Assert.assertEquals(BlockAccessor.class, accessor.getClass());
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderPerformanceTest.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.peg.performance.PrecompiledContractPerformanceTest;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        GetCoinbasePerformanceTestCase.class,
+})
+@Ignore
+public class BlockHeaderPerformanceTest extends PrecompiledContractPerformanceTest {
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/EnvironmentUtils.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/EnvironmentUtils.java
@@ -1,0 +1,91 @@
+package co.rsk.pcc.blockheader;
+
+import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.blockchain.utils.BlockMiner;
+import co.rsk.config.RskMiningConstants;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.crypto.Keccak256;
+import co.rsk.mine.MinerUtils;
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.test.World;
+import co.rsk.util.DifficultyUtils;
+import org.bouncycastle.util.Arrays;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockFactory;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EnvironmentUtils {
+    private static final byte[] ADDITIONAL_TAG = {'A', 'L', 'T', 'B', 'L', 'O', 'C', 'K', ':'};
+    private static final BigInteger MIN_GAS_PRICE = new BigInteger("500000000000000000");
+
+    private static World world;
+    private static TestSystemProperties config;
+
+    public static ExecutionEnvironment getEnvironmentWithBlockchainOfLength(int blockchainLength) {
+        World world = new World();
+        TestSystemProperties config = new TestSystemProperties();
+
+        buildBlockchainOfLength(world, config, blockchainLength);
+
+        ExecutionEnvironment executionEnvironment = mock(ExecutionEnvironment.class);
+        when(executionEnvironment.getBlockStore()).thenReturn(world.getBlockChain().getBlockStore());
+        when(executionEnvironment.getBlock()).thenReturn(world.getBlockChain().getBestBlock());
+
+        return executionEnvironment;
+    }
+
+    private static void buildBlockchainOfLength(World world, TestSystemProperties config, int length) {
+        if (length < 0) return;
+
+        for (int i = 0; i < length; i++) {
+            Block block = mineBlockWithCoinbaseTransaction(config, world.getBlockChain().getBestBlock());
+            world.getBlockChain().tryToConnect(block);
+        }
+    }
+
+    private static Block mineBlockWithCoinbaseTransaction(TestSystemProperties config, Block parent) {
+        BlockGenerator blockGenerator = new BlockGenerator(config.getNetworkConstants(), config.getActivationConfig());
+        byte[] prefix = new byte[1000];
+        byte[] compressedTag = org.bouncycastle.util.Arrays.concatenate(prefix, RskMiningConstants.RSK_TAG);
+
+        Keccak256 blockMergedMiningHash = new Keccak256(parent.getHashForMergedMining());
+
+        co.rsk.bitcoinj.core.NetworkParameters bitcoinNetworkParameters = co.rsk.bitcoinj.params.RegTestParams.get();
+        co.rsk.bitcoinj.core.BtcTransaction bitcoinMergedMiningCoinbaseTransaction = MinerUtils.getBitcoinMergedMiningCoinbaseTransaction(bitcoinNetworkParameters, blockMergedMiningHash.getBytes());
+        co.rsk.bitcoinj.core.BtcBlock bitcoinMergedMiningBlock = MinerUtils.getBitcoinMergedMiningBlock(bitcoinNetworkParameters, bitcoinMergedMiningCoinbaseTransaction);
+
+        BigInteger targetBI = DifficultyUtils.difficultyToTarget(parent.getDifficulty());
+
+        new BlockMiner(config.getActivationConfig()).findNonce(bitcoinMergedMiningBlock, targetBI);
+
+        // We need to clone to allow modifications
+        Block newBlock = new BlockFactory(config.getActivationConfig()).cloneBlockForModification(
+                blockGenerator.createChildBlock(
+                        parent, new ArrayList<>(), new ArrayList<>(),
+                        parent.getDifficulty().asBigInteger().longValue(),
+                        MIN_GAS_PRICE, parent.getGasLimit()
+                )
+        );
+
+        newBlock.setBitcoinMergedMiningHeader(bitcoinMergedMiningBlock.cloneAsHeader().bitcoinSerialize());
+
+        byte[] merkleProof = MinerUtils.buildMerkleProof(
+                config.getActivationConfig(),
+                pb -> pb.buildFromBlock(bitcoinMergedMiningBlock),
+                newBlock.getNumber()
+        );
+
+        byte[] additionalTag = Arrays.concatenate(ADDITIONAL_TAG, blockMergedMiningHash.getBytes());
+        byte[] mergedMiningTx = org.bouncycastle.util.Arrays.concatenate(compressedTag, blockMergedMiningHash.getBytes(), additionalTag);
+
+        newBlock.setBitcoinMergedMiningCoinbaseTransaction(mergedMiningTx);
+        newBlock.setBitcoinMergedMiningMerkleProof(merkleProof);
+
+        return newBlock;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/GetCoinbasePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/GetCoinbasePerformanceTestCase.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.blockheader;
+
+import co.rsk.bitcoinj.core.BtcBlock;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.params.RegTestParams;
+import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.blockchain.utils.BlockMiner;
+import co.rsk.config.RskMiningConstants;
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import co.rsk.db.BenchmarkedRepository;
+import co.rsk.mine.MinerUtils;
+import co.rsk.peg.performance.ExecutionStats;
+import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
+import co.rsk.test.World;
+import co.rsk.util.DifficultyUtils;
+import org.bouncycastle.util.Arrays;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockFactory;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.crypto.ECKey;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.LinkedList;
+
+@Ignore
+public class GetCoinbasePerformanceTestCase extends PrecompiledContractPerformanceTestCase {
+
+    @Test
+    public void getCoinbase() throws IOException {
+        ExecutionStats stats = new ExecutionStats("getCoinbase");
+
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
+            @Override
+            public Environment initialize(int executionIndex, TxBuilder txBuilder, int height) {
+                World world = buildWorld(6000, 500, 6);
+                BlockHeaderContract contract = new BlockHeaderContract(config,  new RskAddress("0000000000000000000000000000000001000010"));
+                contract.init(txBuilder.build(executionIndex), world.getBlockChain().getBestBlock(), world.getRepository(), world.getBlockChain().getBlockStore(), null, new LinkedList<>());
+
+                return new EnvironmentBuilder.Environment(
+                        contract,
+                        () -> new BenchmarkedRepository.Statistics()
+                );
+            }
+
+            @Override
+            public void teardown() {
+            }
+        };
+
+        doGetCoinbase(environmentBuilder, stats, 4000);
+
+        BlockHeaderPerformanceTest.addStats(stats);
+    }
+
+    private void doGetCoinbase(EnvironmentBuilder environmentBuilder, ExecutionStats stats, int numCases) throws IOException {
+        CallTransaction.Function function = CallTransaction.Function.fromSignature(
+                "getCoinbaseAddress",
+                new String[]{"int256"},
+                new String[]{"bytes"}
+        );
+
+        ABIEncoder abiEncoder = (int executionIndex) -> function.encode(3999);
+
+        executeAndAverage(
+                "getCoinbase",
+                numCases,
+                environmentBuilder,
+                abiEncoder,
+                Helper.getZeroValueTxBuilder(new ECKey()),
+                Helper.getRandomHeightProvider(10),
+                stats,
+                null
+        );
+    }
+
+    private World buildWorld(int numBlocks, int txPerBlock, int unclesPerBlock){
+        World world = new World();
+
+        for (int i = 0; i < numBlocks; i++) {
+            Block block = mineBlock(world.getBlockChain().getBestBlock(), txPerBlock, unclesPerBlock);
+            world.getBlockChain().tryToConnect(block);
+        }
+
+        return world;
+    }
+
+    private Block mineBlock(Block parent, int txPerBlock, int unclesPerBlock) {
+        BlockGenerator blockGenerator = new BlockGenerator(config.getNetworkConstants(), config.getActivationConfig());
+        byte[] prefix = new byte[1000];
+        byte[] compressedTag = Arrays.concatenate(prefix, RskMiningConstants.RSK_TAG);
+
+        Keccak256 mergedMiningHash = new Keccak256(parent.getHashForMergedMining());
+
+        NetworkParameters networkParameters = RegTestParams.get();
+        BtcTransaction mergedMiningCoinbaseTransaction = MinerUtils.getBitcoinMergedMiningCoinbaseTransaction(networkParameters, mergedMiningHash.getBytes());
+        BtcBlock mergedMiningBlock = MinerUtils.getBitcoinMergedMiningBlock(networkParameters, mergedMiningCoinbaseTransaction);
+
+        BigInteger targetDifficulty = DifficultyUtils.difficultyToTarget(parent.getDifficulty());
+
+        new BlockMiner(config.getActivationConfig()).findNonce(mergedMiningBlock, targetDifficulty);
+
+        // We need to clone to allow modifications
+        Block newBlock = new BlockFactory(config.getActivationConfig()).cloneBlockForModification(
+                blockGenerator.createChildBlock(parent, txPerBlock, parent.getDifficulty().asBigInteger().longValue())
+        );
+
+        newBlock.setBitcoinMergedMiningHeader(mergedMiningBlock.cloneAsHeader().bitcoinSerialize());
+
+        byte[] merkleProof = MinerUtils.buildMerkleProof(
+                config.getActivationConfig(),
+                pb -> pb.buildFromBlock(mergedMiningBlock),
+                newBlock.getNumber()
+        );
+
+        byte[] additionalTag = Arrays.concatenate(new byte[]{'A','L','T','B','L','O','C','K',':'}, mergedMiningHash.getBytes());
+        byte[] mergedMiningTx = org.bouncycastle.util.Arrays.concatenate(compressedTag, mergedMiningHash.getBytes(), additionalTag);
+
+        newBlock.setBitcoinMergedMiningCoinbaseTransaction(mergedMiningTx);
+        newBlock.setBitcoinMergedMiningMerkleProof(merkleProof);
+
+        return newBlock;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PrecompiledContractPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PrecompiledContractPerformanceTestCase.java
@@ -18,6 +18,7 @@
 
 package co.rsk.peg.performance;
 
+import co.rsk.config.TestSystemProperties;
 import co.rsk.db.BenchmarkedRepository;
 import co.rsk.db.RepositoryTrackWithBenchmarking;
 import co.rsk.vm.VMPerformanceTest;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public abstract class PrecompiledContractPerformanceTestCase {
+    protected static TestSystemProperties config;
     protected static BlockchainNetConfig blockchainNetConfig;
 
     private boolean oldCpuTimeEnabled;
@@ -105,7 +107,9 @@ public abstract class PrecompiledContractPerformanceTestCase {
 
     @BeforeClass
     public static void setupA() throws Exception {
-        blockchainNetConfig = new RegtestBlockchainNetConfig(ActivationConfigsForTest.genesis());
+        config = new TestSystemProperties();
+        config.setBlockchainConfig(new RegtestBlockchainNetConfig(ActivationConfigsForTest.genesis()));
+        blockchainNetConfig = config.getBlockchainConfig();
     }
 
     @AfterClass

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -301,7 +301,16 @@ public class BlockChainBuilder {
 
     public static void extend(Blockchain blockchain, int size, boolean withUncles, boolean mining) {
         Block initial = blockchain.getBestBlock();
-        List<Block> blocks = new BlockGenerator().getBlockChain(initial, size, 0, withUncles, mining, null);
+        extend(blockchain, size, withUncles, mining, initial);
+    }
+
+    public static void extend(Blockchain blockchain, int size, boolean withUncles, boolean mining, long blockNumber) {
+        Block initial = blockchain.getBlockByNumber(blockNumber);
+        extend(blockchain, size, withUncles, mining, initial);
+    }
+
+    private static void extend(Blockchain blockchain, int size, boolean withUncles, boolean mining, Block initialBlock) {
+        List<Block> blocks = new BlockGenerator().getBlockChain(initialBlock, size, 0, withUncles, mining, null);
 
         for (Block block: blocks)
             blockchain.tryToConnect(block);

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractAddressTests.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractAddressTests.java
@@ -20,10 +20,14 @@ package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import org.ethereum.config.BlockchainConfig;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by Sergio Demian Lerner on 12/10/2018.
@@ -38,6 +42,7 @@ public class PrecompiledContractAddressTests {
     public static final String SAMPLE_ADDR_STR = "0000000000000000000000000000000001000005";
     public static final String BRIDGE_ADDR_STR = "0000000000000000000000000000000001000006";
     public static final String REMASC_ADDR_STR = "0000000000000000000000000000000001000008";
+    public static final String BLOCK_HEADER_ADDR_STR = "0000000000000000000000000000000001000010";
 
     private final TestSystemProperties config = new TestSystemProperties();
 
@@ -52,12 +57,18 @@ public class PrecompiledContractAddressTests {
         //checkAddr(pcList,SAMPLE_ADDR_STR ,"SamplePrecompiledContract");
         checkAddr(pcList,BRIDGE_ADDR_STR ,"Bridge");
         checkAddr(pcList,REMASC_ADDR_STR ,"RemascContract");
+        checkAddr(pcList,BLOCK_HEADER_ADDR_STR,"BlockHeaderContract");
     }
 
     void checkAddr(PrecompiledContracts pcList,String addr,String className) {
+        BlockchainConfig bcConfig = mock(BlockchainConfig.class);
+
+        // Enabling necessary RSKIPs for every precompiled contract to be available
+        when(bcConfig.isRskip119()).thenReturn(true);
+
         RskAddress a;
         a = new RskAddress(addr);
-        PrecompiledContracts.PrecompiledContract pc = pcList.getContractForAddress(null, DataWord.valueOf(a.getBytes()));
+        PrecompiledContracts.PrecompiledContract pc = pcList.getContractForAddress(bcConfig, DataWord.valueOf(a.getBytes()));
         Assert.assertEquals(className,pc.getClass().getSimpleName());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
@@ -19,12 +19,17 @@
 package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.pcc.blockheader.BlockHeaderContract;
 import co.rsk.peg.Bridge;
+import org.ethereum.config.BlockchainConfig;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.PrecompiledContracts.PrecompiledContract;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PrecompiledContractTest {
 
@@ -49,5 +54,30 @@ public class PrecompiledContractTest {
         Assert.assertNotNull(bridge1);
         Assert.assertNotNull(bridge2);
         Assert.assertNotSame(bridge1, bridge2);
+    }
+
+    @Test
+    public void getBlockHeaderContractBeforeRskip119() {
+        BlockchainConfig afterRskip119 = mock(BlockchainConfig.class);
+        when(afterRskip119.isRskip119()).thenReturn(false);
+        DataWord blockHeaderContractAddress = DataWord.valueOf(PrecompiledContracts.BLOCK_HEADER_ADDR.getBytes());
+        PrecompiledContract blockHeaderContract = precompiledContracts.getContractForAddress(afterRskip119, blockHeaderContractAddress);
+
+        Assert.assertNull(blockHeaderContract);
+    }
+
+    @Test
+    public void getBlockHeaderContractAfterRskip119() {
+        BlockchainConfig afterRskip119 = mock(BlockchainConfig.class);
+        when(afterRskip119.isRskip119()).thenReturn(true);
+        DataWord blockHeaderContractAddress = DataWord.valueOf(PrecompiledContracts.BLOCK_HEADER_ADDR.getBytes());
+        PrecompiledContract blockHeaderContract1 = precompiledContracts.getContractForAddress(afterRskip119, blockHeaderContractAddress);
+        PrecompiledContract blockHeaderContract2 = precompiledContracts.getContractForAddress(afterRskip119, blockHeaderContractAddress);
+
+        Assert.assertNotNull(blockHeaderContract1);
+        Assert.assertNotNull(blockHeaderContract2);
+        Assert.assertEquals(BlockHeaderContract.class, blockHeaderContract1.getClass());
+        Assert.assertEquals(BlockHeaderContract.class, blockHeaderContract2.getClass());
+        Assert.assertNotSame(blockHeaderContract1, blockHeaderContract2);
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -50,6 +50,7 @@ public class ActivationConfigTest {
             "    rskip97: orchid,",
             "    rskip98: orchid,",
             "    rskip103: orchid060,",
+            "    rskip119: secondFork,",
             "    rskip120: secondFork,",
             "    rskip123: secondFork",
             "}"

--- a/rskj-core/src/test/java/org/ethereum/db/BlockStoreDummy.java
+++ b/rskj-core/src/test/java/org/ethereum/db/BlockStoreDummy.java
@@ -58,6 +58,11 @@ public class BlockStoreDummy implements BlockStore {
     }
 
     @Override
+    public Block getBlockAtDepthStartingAt(long depth, byte[] hash) {
+        return null;
+    }
+
+    @Override
     public boolean isBlockExist(byte[] hash) {
         return false;
     }


### PR DESCRIPTION
Added new precompiled contract to recover fields from BlockHeader (BlockHeaderContract) based on NativeContract and NativeMethods, values that can be recovered are: coinbase, block hash, minimum gas price, merged mining tags, gas limit, gas used, RSK difficulty, merged mining bitcoin header, uncles' addresses.