### PR TITLE
Upgrade to Mockito 2

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -62,8 +62,8 @@ ext {
     slf4jVersion = '1.7.25'
     leveldbVersion = '0.9'
     junitVersion = '4.12'
-    mockitoVersion = '1.10.19'
-    powermockitoVersion = '1.6.4'
+    mockitoVersion = '2.8.9'
+    powermockitoVersion = '1.7.4'
     rskLllVersion = '0.0.2'
     logbackVersion = '1.2.2'
     bitcoinjVersion = '0.14.4-rsk-5'
@@ -92,9 +92,8 @@ dependencies {
     testCompile "com.googlecode.json-simple:json-simple:1.1.1"
     testCompile "junit:junit:${junitVersion}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
-    testCompile "org.powermock:powermock-core:${powermockitoVersion}"
     testCompile "org.powermock:powermock-module-junit4:${powermockitoVersion}"
-    testCompile "org.powermock:powermock-api-mockito:${powermockitoVersion}"
+    testCompile "org.powermock:powermock-api-mockito2:${powermockitoVersion}"
     testCompile "co.rsk:lll-compiler:${rskLllVersion}"
     testCompile "org.awaitility:awaitility:3.0.0"
     testCompile 'commons-io:commons-io:2.5'
@@ -139,16 +138,17 @@ dependencyVerification {
         'org.hamcrest:hamcrest-library:711d64522f9ec410983bd310934296da134be4254a125080a0416ec178dfad1c',
         'org.iq80.leveldb:leveldb-api:279e3a5649cde0bf0d4e09fd1369ec0e9ee80344ec06527c37148c9a58684140',
         'org.iq80.leveldb:leveldb:0dcc623fcb8450e736b9d2b1b8d91b980e44920d6a22cec8c00f703548b3747f',
-        'org.javassist:javassist:d7691062fb779c2381640c8f72acba2c23873b01c243866d41c15dc4c8848ea2',
+        'org.javassist:javassist:7aa59e031f941984af07dacc6ca85e6dc9bd3a485e9aa2494cbc034efa1225d0',
         'org.mapdb:mapdb:1268e9ec22ff770ef7e63d7cc72563406ad239422c791acc8b9ee4fdfba0bb1e',
-        'org.mockito:mockito-core:d5831ee4f71055800821a34a3051cf1ed5b3702f295ffebd50f65fb5d81a71b8',
+        'org.mockito:mockito-core:a2bb9b8b40d81bb02ccb84259524c0f4911f73c6577bfc7ddd940b8fc729b6e6',
         'org.objenesis:objenesis:b043f03e466752f7f03e2326a3b13a49b7c649f8f2a2dc87715827e24f73d9c6',
-        'org.powermock:powermock-api-mockito:68667e82c0e5d8c65e7030403c56ddc8595bbd723bf04719976106c03a022b85',
-        'org.powermock:powermock-api-support:ade74743df908ebd859591c2136ce400443e57bbd8abdc0703871ac7309ac09b',
-        'org.powermock:powermock-core:9b4da42d513500dda03f4d90e303647f6a7b50c6bc5ed88cd39118680f6b329f',
-        'org.powermock:powermock-module-junit4-common:1b4928d42a8e6f0aa196d0f6fcf7831e0bc29b8a925ce755479b4bd29b3643bb',
-        'org.powermock:powermock-module-junit4:a90e4bc135e349852eaebed9f1a14d404e14c5a8a7248b4e20e062879a97e63f',
-        'org.powermock:powermock-reflect:14e3b046621ddb6a39113f145c5c129709d3af3d36caad2df7d547778d271c3e',
+        'org.powermock:powermock-api-mockito2:ee560b1562c25242e9a445d5d877c5489fedf4d2d0d9bc672131244716343109',
+        'org.powermock:powermock-api-mockito-common:9b216ae6583ae2b073a30677307c661a5548d3bdf5b5999daae080a735894bb3',
+        'org.powermock:powermock-api-support:faa0ef7f926dc1e27764dfb0d3da34dd8b37ed6d870cabcca9c3ca808dc2d278',
+        'org.powermock:powermock-core:72d96da61d697f1834f05912d4d73f3697ee33e86716244b22902f251f19232f',
+        'org.powermock:powermock-module-junit4:8271bc70cc8d396360d600396c795825c0121f72a537f25b23e0e86c0278fccc',
+        'org.powermock:powermock-module-junit4-common:af14d42765e1d09fe0aa362a5470e100aecb0274e0c2fa8d32c99035b2771039',
+        'org.powermock:powermock-reflect:01970886cf822f44fc0815c46b7fcf6d67efcc21d5dc2f8985ff1dbbfe3f24c6',
         'org.slf4j:log4j-over-slf4j:c84c5ce4bbb661369ccd4c7b99682027598a0fb2e3d63a84259dbe5c0bf1f949',
         'org.slf4j:slf4j-api:18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79',
     ]

--- a/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
+++ b/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
@@ -30,8 +30,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Random;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 
 
 public class Tx {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
@@ -45,7 +45,7 @@ import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mapdb.DB;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.powermock.reflect.Whitebox;
 
 import java.math.BigInteger;
 import java.util.ArrayList;

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -37,7 +37,7 @@ import org.ethereum.db.IndexedBlockStore;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.powermock.reflect.Whitebox;
 
 import java.math.BigInteger;
 import java.util.*;

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -294,7 +294,7 @@ public class NodeMessageHandlerTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final Message[] msg = new Message[1];
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            msg[0] = invocation.getArgumentAt(1, Message.class);
+            msg[0] = invocation.getArgument(1);
             return true;
         });
         final NodeMessageHandler handler = NodeMessageHandlerUtil.createHandlerWithSyncProcessor(SyncConfiguration.IMMEDIATE_FOR_TESTING, channelManager);

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
@@ -16,7 +16,7 @@ import org.ethereum.sync.SyncPool;
 import org.ethereum.util.RskMockFactory;
 import org.mockito.Mockito;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 
 public class NodeMessageHandlerUtil {

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -36,8 +36,8 @@ import java.math.BigInteger;
 import java.time.Duration;
 import java.util.*;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -86,7 +86,7 @@ public class SyncProcessorTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final List<Message> messages = new ArrayList<>();
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            messages.add(invocation.getArgumentAt(1, Message.class));
+            messages.add(invocation.getArgument(1));
             return true;
         });
 
@@ -134,7 +134,7 @@ public class SyncProcessorTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final List<Message> messages = new ArrayList<>();
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            messages.add(invocation.getArgumentAt(1, Message.class));
+            messages.add(invocation.getArgument(1));
             return true;
         });
 
@@ -229,7 +229,7 @@ public class SyncProcessorTest {
             when(channel.getNodeId()).thenReturn(sender.getPeerNodeID());
             when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
             when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-                messagesByNode.get(sender.getPeerNodeID()).add(invocation.getArgumentAt(1, Message.class));
+                messagesByNode.get(sender.getPeerNodeID()).add(invocation.getArgument(1));
                 return true;
             });
         }
@@ -309,7 +309,7 @@ public class SyncProcessorTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final Message[] msg = new Message[1];
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            msg[0] = invocation.getArgumentAt(1, Message.class);
+            msg[0] = invocation.getArgument(1);
             return true;
         });
 
@@ -343,7 +343,7 @@ public class SyncProcessorTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final Message[] msg = new Message[1];
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            msg[0] = invocation.getArgumentAt(1, Message.class);
+            msg[0] = invocation.getArgument(1);
             return true;
         });
 
@@ -771,7 +771,7 @@ public class SyncProcessorTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final List<Message> messages = new ArrayList<>();
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            messages.add(invocation.getArgumentAt(1, Message.class));
+            messages.add(invocation.getArgument(1));
             return true;
         });
 
@@ -826,7 +826,7 @@ public class SyncProcessorTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final List<Message> messages = new ArrayList<>();
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            messages.add(invocation.getArgumentAt(1, Message.class));
+            messages.add(invocation.getArgument(1));
             return true;
         });
 
@@ -884,7 +884,7 @@ public class SyncProcessorTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final Message[] msg = new Message[1];
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            msg[0] = invocation.getArgumentAt(1, Message.class);
+            msg[0] = invocation.getArgument(1);
             return true;
         });
 
@@ -958,7 +958,7 @@ public class SyncProcessorTest {
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
         final Message[] msg = new Message[1];
         when(channelManager.sendMessageTo(eq(sender.getPeerNodeID()), any())).then((InvocationOnMock invocation) -> {
-            msg[0] = invocation.getArgumentAt(1, Message.class);
+            msg[0] = invocation.getArgument(1);
             return true;
         });
         SyncProcessor processor = new SyncProcessor(blockchain, blockSyncService, RskMockFactory.getPeerScoringManager(), channelManager,

--- a/rskj-core/src/test/java/co/rsk/peg/ABICallSpecTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ABICallSpecTest.java
@@ -18,10 +18,10 @@
 
 package co.rsk.peg;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
-import org.bouncycastle.util.encoders.Hex;
+import org.powermock.reflect.Whitebox;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -25,6 +25,7 @@ import co.rsk.peg.whitelist.LockWhitelistEntry;
 import co.rsk.peg.whitelist.OneOffWhiteListEntry;
 import com.google.common.primitives.UnsignedBytes;
 import org.apache.commons.lang3.tuple.Pair;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
@@ -36,7 +37,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -45,12 +45,9 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -859,7 +856,7 @@ public class BridgeSerializationUtilsTest {
     private void mock_RLP_encodeElement() {
         // Identity prepending byte '0xdd'
         when(RLP.encodeElement(any(byte[].class))).then((InvocationOnMock invocation) -> {
-            byte[] arg = invocation.getArgumentAt(0, byte[].class);
+            byte[] arg = invocation.<byte[]>getArgument(0);
             byte[] result = new byte[arg.length+1];
             result[0] = (byte) 0xdd;
             for (int i = 0; i < arg.length; i++)
@@ -871,7 +868,7 @@ public class BridgeSerializationUtilsTest {
     private void mock_RLP_encodeBigInteger() {
         // To byte array prepending byte '0xff'
         when(RLP.encodeBigInteger(any(BigInteger.class))).then((InvocationOnMock invocation) -> {
-            byte[] arg = (invocation.getArgumentAt(0, BigInteger.class)).toByteArray();
+            byte[] arg = (invocation.<BigInteger>getArgument(0)).toByteArray();
             byte[] result = new byte[arg.length+1];
             result[0] = (byte) 0xff;
             for (int i = 0; i < arg.length; i++)
@@ -882,7 +879,7 @@ public class BridgeSerializationUtilsTest {
 
     private void mock_RLP_encodeList() {
         // To flat byte array
-        when(RLP.encodeList(anyVararg())).then((InvocationOnMock invocation) -> {
+        when(RLP.encodeList(any())).then((InvocationOnMock invocation) -> {
             Object[] args = invocation.getArguments();
             byte[][] bytes = new byte[args.length][];
             for (int i = 0; i < args.length; i++)
@@ -898,7 +895,7 @@ public class BridgeSerializationUtilsTest {
         // 03050704[a bytes][b bytes][c bytes]
         when(RLP.decode2(any(byte[].class))).then((InvocationOnMock invocation) -> {
             RLPList result = new RLPList();
-            byte[] arg = invocation.getArgumentAt(0, byte[].class);
+            byte[] arg = invocation.<byte[]>getArgument(0);
             // Even byte -> hash of 64 bytes with same char from byte
             // Odd byte -> long from byte
             for (int i = 0; i < arg.length; i++) {
@@ -918,7 +915,7 @@ public class BridgeSerializationUtilsTest {
 
     private void mock_RLP_decode2(InnerListMode mode) {
         when(RLP.decode2(any(byte[].class))).then((InvocationOnMock invocation) -> {
-            byte[] bytes = invocation.getArgumentAt(0, byte[].class);
+            byte[] bytes = invocation.<byte[]>getArgument(0);
             return new ArrayList<>(Arrays.asList(decodeTwoMock(bytes, mode)));
         });
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -27,27 +27,27 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryImpl;
-import org.ethereum.db.TrieStorePoolOnMemory;
 import co.rsk.peg.whitelist.LockWhitelist;
 import co.rsk.peg.whitelist.LockWhitelistEntry;
 import co.rsk.peg.whitelist.OneOffWhiteListEntry;
 import co.rsk.peg.whitelist.UnlimitedWhiteListEntry;
 import co.rsk.trie.Trie;
 import org.apache.commons.lang3.tuple.Pair;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Repository;
 import org.ethereum.datasource.HashMapDB;
+import org.ethereum.db.TrieStorePoolOnMemory;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.mockito.invocation.InvocationOnMock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.bouncycastle.util.encoders.Hex;
+import org.powermock.reflect.Whitebox;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -59,8 +59,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -268,8 +268,8 @@ public class BridgeStorageProviderTest {
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
             // Make sure the bytes are get from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("newFederation".getBytes(StandardCharsets.UTF_8)), address);
@@ -277,8 +277,8 @@ public class BridgeStorageProviderTest {
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeFederation(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            byte[] data = invocation.getArgumentAt(0, byte[].class);
-            NetworkParameters networkParameters = invocation.getArgumentAt(1, NetworkParameters.class);
+            byte[] data = invocation.getArgument(0);
+            NetworkParameters networkParameters = invocation.getArgument(1);
             // Make sure we're deserializing what just came from the repo with the correct BTC context
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa}, data));
             Assert.assertEquals(networkParameters, config.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams());
@@ -300,8 +300,8 @@ public class BridgeStorageProviderTest {
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             storageBytesCalls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
             // Make sure the bytes are get from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("newFederation".getBytes(StandardCharsets.UTF_8)), address);
@@ -328,16 +328,16 @@ public class BridgeStorageProviderTest {
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
 
         PowerMockito.when(BridgeSerializationUtils.serializeFederation(any(Federation.class))).then((InvocationOnMock invocation) -> {
-            Federation federation = invocation.getArgumentAt(0, Federation.class);
+            Federation federation = invocation.getArgument(0);
             Assert.assertEquals(newFederation, federation);
             serializeCalls.add(0);
             return new byte[]{(byte)0xbb};
         });
         Mockito.doAnswer((InvocationOnMock invocation) -> {
             storageBytesCalls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
-            byte[] data = invocation.getArgumentAt(2, byte[].class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
+            byte[] data = invocation.getArgument(2);
             // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("newFederation".getBytes(StandardCharsets.UTF_8)), address);
@@ -366,8 +366,8 @@ public class BridgeStorageProviderTest {
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("federationElection".getBytes(StandardCharsets.UTF_8)), address);
@@ -375,8 +375,8 @@ public class BridgeStorageProviderTest {
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeElection(any(byte[].class), any(AddressBasedAuthorizer.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            byte[] data = invocation.getArgumentAt(0, byte[].class);
-            AddressBasedAuthorizer authorizer = invocation.getArgumentAt(1, AddressBasedAuthorizer.class);
+            byte[] data = invocation.getArgument(0);
+            AddressBasedAuthorizer authorizer = invocation.getArgument(1);
             // Make sure we're deserializing what just came from the repo with the correct AddressBasedAuthorizer
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa}, data));
             Assert.assertEquals(authorizerMock, authorizer);
@@ -398,8 +398,8 @@ public class BridgeStorageProviderTest {
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("federationElection".getBytes(StandardCharsets.UTF_8)), address);
@@ -426,16 +426,16 @@ public class BridgeStorageProviderTest {
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
 
         PowerMockito.when(BridgeSerializationUtils.serializeElection(any(ABICallElection.class))).then((InvocationOnMock invocation) -> {
-            ABICallElection election = invocation.getArgumentAt(0, ABICallElection.class);
+            ABICallElection election = invocation.getArgument(0);
             Assert.assertSame(electionMock, election);
             serializeCalls.add(0);
             return Hex.decode("aabb");
         });
         Mockito.doAnswer((InvocationOnMock invocation) -> {
             storageBytesCalls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
-            byte[] data = invocation.getArgumentAt(2, byte[].class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
+            byte[] data = invocation.getArgument(2);
             // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("federationElection".getBytes(StandardCharsets.UTF_8)), address);
@@ -470,8 +470,8 @@ public class BridgeStorageProviderTest {
         when(repositoryMock.getStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)))))
         .then((InvocationOnMock invocation) -> {
             calls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
@@ -480,8 +480,8 @@ public class BridgeStorageProviderTest {
         when(repositoryMock.getStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)))))
                 .then((InvocationOnMock invocation) -> {
                     calls.add(0);
-                    RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-                    DataWord address = invocation.getArgumentAt(1, DataWord.class);
+                    RskAddress contractAddress = invocation.getArgument(0);
+                    DataWord address = invocation.getArgument(1);
                     // Make sure the bytes are got from the correct address in the repo
                     Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
                     Assert.assertEquals(DataWord.valueOf("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
@@ -491,8 +491,8 @@ public class BridgeStorageProviderTest {
             .when(BridgeSerializationUtils.deserializeOneOffLockWhitelistAndDisableBlockHeight(any(byte[].class), any(NetworkParameters.class)))
             .then((InvocationOnMock invocation) -> {
                 calls.add(0);
-                byte[] data = invocation.getArgumentAt(0, byte[].class);
-                NetworkParameters parameters = invocation.getArgumentAt(1, NetworkParameters.class);
+                byte[] data = invocation.getArgument(0);
+                NetworkParameters parameters = invocation.getArgument(1);
                 Assert.assertEquals(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), parameters);
                 // Make sure we're deserializing what just came from the repo with the correct AddressBasedAuthorizer
                 Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa}, data));
@@ -504,8 +504,8 @@ public class BridgeStorageProviderTest {
                 .when(BridgeSerializationUtils.deserializeUnlimitedLockWhitelistEntries(any(byte[].class), any(NetworkParameters.class)))
                 .then((InvocationOnMock invocation) -> {
                     calls.add(0);
-                    byte[] unlimitedData = invocation.getArgumentAt(0, byte[].class);
-                    NetworkParameters parameters = invocation.getArgumentAt(1, NetworkParameters.class);
+                    byte[] unlimitedData = invocation.getArgument(0);
+                    NetworkParameters parameters = invocation.getArgument(1);
                     Assert.assertEquals(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), parameters);
                     // Make sure we're deserializing what just came from the repo with the correct AddressBasedAuthorizer
                     Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xbb}, unlimitedData));
@@ -529,12 +529,12 @@ public class BridgeStorageProviderTest {
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class)))
             .then((InvocationOnMock invocation) -> {
                 calls.add(0);
-                RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-                DataWord address = invocation.getArgumentAt(1, DataWord.class);
+                RskAddress contractAddress = invocation.getArgument(0);
+                DataWord address = invocation.getArgument(1);
                 // Make sure the bytes are got from the correct address in the repo
                 Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
                 Assert.assertEquals(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
-                return null;
+                return new byte[]{(byte)0xee};
             });
         PowerMockito
             .when(BridgeSerializationUtils.deserializeOneOffLockWhitelistAndDisableBlockHeight(any(byte[].class), any(NetworkParameters.class)))
@@ -571,7 +571,7 @@ public class BridgeStorageProviderTest {
         PowerMockito
             .when(BridgeSerializationUtils.serializeOneOffLockWhitelist(any(Pair.class)))
             .then((InvocationOnMock invocation) -> {
-                Pair<List<OneOffWhiteListEntry>, Integer> data = invocation.getArgumentAt(0, Pair.class);
+                Pair<List<OneOffWhiteListEntry>, Integer> data = invocation.getArgument(0);
                 Assert.assertEquals(whitelistMock.getAll(OneOffWhiteListEntry.class), data.getLeft());
                 Assert.assertSame(whitelistMock.getDisableBlockHeight(), data.getRight());
                 serializeCalls.add(0);
@@ -581,9 +581,9 @@ public class BridgeStorageProviderTest {
         Mockito
             .doAnswer((InvocationOnMock invocation) -> {
                 storageBytesCalls.add(0);
-                RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-                DataWord address = invocation.getArgumentAt(1, DataWord.class);
-                byte[] data = invocation.getArgumentAt(2, byte[].class);
+                RskAddress contractAddress = invocation.getArgument(0);
+                DataWord address = invocation.getArgument(1);
+                byte[] data = invocation.getArgument(2);
                 // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
                 Assert.assertTrue(Arrays.equals(Hex.decode("aabbccdd"), contractAddress.getBytes()));
                 Assert.assertEquals(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
@@ -596,7 +596,7 @@ public class BridgeStorageProviderTest {
         PowerMockito
             .when(BridgeSerializationUtils.serializeUnlimitedLockWhitelist(any(List.class)))
             .then((InvocationOnMock invocation) -> {
-                List<UnlimitedWhiteListEntry> unlimitedWhiteListEntries = invocation.getArgumentAt(0, List.class);
+                List<UnlimitedWhiteListEntry> unlimitedWhiteListEntries = invocation.getArgument(0);
                 Assert.assertEquals(whitelistMock.getAll(UnlimitedWhiteListEntry.class), unlimitedWhiteListEntries);
                 serializeCalls.add(0);
                 return Hex.decode("bbcc");
@@ -605,9 +605,9 @@ public class BridgeStorageProviderTest {
         Mockito
             .doAnswer((InvocationOnMock invocation) -> {
                 storageBytesCalls.add(0);
-                RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-                DataWord address = invocation.getArgumentAt(1, DataWord.class);
-                byte[] data = invocation.getArgumentAt(2, byte[].class);
+                RskAddress contractAddress = invocation.getArgument(0);
+                DataWord address = invocation.getArgument(1);
+                byte[] data = invocation.getArgument(2);
                 // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
                 Assert.assertTrue(Arrays.equals(Hex.decode("aabbccdd"), contractAddress.getBytes()));
                 Assert.assertEquals(DataWord.valueOf("unlimitedLockWhitelist".getBytes(StandardCharsets.UTF_8)), address);
@@ -647,12 +647,16 @@ public class BridgeStorageProviderTest {
                     return Pair.of(map, 0);
                 });
 
+        PowerMockito
+                .when(BridgeSerializationUtils.serializeOneOffLockWhitelist(any(Pair.class)))
+                .thenReturn(new byte[]{(byte)0xee});
+
         Mockito
                 .doAnswer((InvocationOnMock invocation) -> {
                     storageCalled.set(Boolean.TRUE);
                     return null;
                 })
-                .when(repositoryMock).addStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8))), any(byte[].class));
+                .when(repositoryMock).addStorageBytes(any(RskAddress.class), eq(DataWord.valueOf("lockWhitelist".getBytes(StandardCharsets.UTF_8))), eq(new byte[]{(byte)0xee}));
 
         Assert.assertTrue(storageProvider.getLockWhitelist().getSize() > 0);
 
@@ -671,8 +675,8 @@ public class BridgeStorageProviderTest {
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("releaseRequestQueue".getBytes(StandardCharsets.UTF_8)), address);
@@ -680,8 +684,8 @@ public class BridgeStorageProviderTest {
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeReleaseRequestQueue(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            byte[] data = invocation.getArgumentAt(0, byte[].class);
-            NetworkParameters parameters = invocation.getArgumentAt(1, NetworkParameters.class);
+            byte[] data = invocation.getArgument(0);
+            NetworkParameters parameters = invocation.getArgument(1);
             Assert.assertEquals(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), parameters);
             // Make sure we're deserializing what just came from the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa}, data));
@@ -702,8 +706,8 @@ public class BridgeStorageProviderTest {
 
         when(repositoryMock.getStorageBytes(any(RskAddress.class), any(DataWord.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            RskAddress contractAddress = invocation.getArgumentAt(0, RskAddress.class);
-            DataWord address = invocation.getArgumentAt(1, DataWord.class);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
             // Make sure the bytes are got from the correct address in the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa, (byte)0xbb, (byte)0xcc, (byte)0xdd}, contractAddress.getBytes()));
             Assert.assertEquals(DataWord.valueOf("releaseTransactionSet".getBytes(StandardCharsets.UTF_8)), address);
@@ -711,8 +715,8 @@ public class BridgeStorageProviderTest {
         });
         PowerMockito.when(BridgeSerializationUtils.deserializeReleaseTransactionSet(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
-            byte[] data = invocation.getArgumentAt(0, byte[].class);
-            NetworkParameters parameters = invocation.getArgumentAt(1, NetworkParameters.class);
+            byte[] data = invocation.getArgument(0);
+            NetworkParameters parameters = invocation.getArgument(1);
             Assert.assertEquals(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), parameters);
             // Make sure we're deserializing what just came from the repo
             Assert.assertTrue(Arrays.equals(new byte[]{(byte)0xaa}, data));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -36,7 +36,6 @@ import co.rsk.core.BlockDifficulty;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryImpl;
-import org.ethereum.db.TrieStorePoolOnMemory;
 import co.rsk.peg.simples.SimpleBlockChain;
 import co.rsk.peg.simples.SimpleRskTransaction;
 import co.rsk.peg.simples.SimpleWallet;
@@ -67,6 +66,7 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.ReceiptStore;
+import org.ethereum.db.TrieStorePoolOnMemory;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
@@ -83,11 +83,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.mockito.invocation.InvocationOnMock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import java.io.*;
 import java.math.BigInteger;
@@ -107,7 +107,6 @@ import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 /**
@@ -1627,8 +1626,8 @@ public class BridgeSupportTest {
 
         PowerMockito.spy(BridgeUtils.class);
         PowerMockito.doReturn(mockStoredBlock).when(BridgeUtils.class, "getStoredBlockAtHeight", any(BtcBlockstoreWithCache.class), anyInt());
-        PowerMockito.doReturn(false).when(BridgeUtils.class, "isLockTx", any(BtcTransaction.class), anyListOf(Federation.class), any(Context.class), any(BridgeConstants.class));
-        PowerMockito.doReturn(true).when(BridgeUtils.class, "isReleaseTx", any(BtcTransaction.class), anyListOf(Federation.class));
+        PowerMockito.doReturn(false).when(BridgeUtils.class, "isLockTx", any(BtcTransaction.class), anyList(), any(Context.class), any(BridgeConstants.class));
+        PowerMockito.doReturn(true).when(BridgeUtils.class, "isReleaseTx", any(BtcTransaction.class), anyList());
 
         BridgeSupport bridgeSupport = new BridgeSupport(
                 mock(Repository.class),
@@ -2780,9 +2779,9 @@ public class BridgeSupportTest {
         final Wallet expectedWallet = mock(Wallet.class);
         PowerMockito.mockStatic(BridgeUtils.class);
         PowerMockito.when(BridgeUtils.getFederationSpendWallet(any(), any(), any())).then((InvocationOnMock m) -> {
-            Assert.assertEquals(m.getArgumentAt(0, Context.class), expectedContext);
-            Assert.assertEquals(m.getArgumentAt(1, Federation.class), expectedFederation);
-            Assert.assertEquals(m.getArgumentAt(2, Object.class), expectedUtxos);
+            Assert.assertEquals(m.<Context>getArgument(0), expectedContext);
+            Assert.assertEquals(m.<Federation>getArgument(1), expectedFederation);
+            Assert.assertEquals(m.<Object>getArgument(2), expectedUtxos);
             return expectedWallet;
         });
 
@@ -2823,9 +2822,9 @@ public class BridgeSupportTest {
         final Wallet expectedWallet = mock(Wallet.class);
         PowerMockito.mockStatic(BridgeUtils.class);
         PowerMockito.when(BridgeUtils.getFederationSpendWallet(any(), any(), any())).then((InvocationOnMock m) -> {
-            Assert.assertEquals(m.getArgumentAt(0, Context.class), expectedContext);
-            Assert.assertEquals(m.getArgumentAt(1, Federation.class), expectedFederation);
-            Assert.assertEquals(m.getArgumentAt(2, Object.class), expectedUtxos);
+            Assert.assertEquals(m.<Context>getArgument(0), expectedContext);
+            Assert.assertEquals(m.<Federation>getArgument(1), expectedFederation);
+            Assert.assertEquals(m.<Object>getArgument(2), expectedUtxos);
             return expectedWallet;
         });
 
@@ -2870,7 +2869,7 @@ public class BridgeSupportTest {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
         when(mockedWhitelist.put(any(Address.class), any(OneOffWhiteListEntry.class))).then((InvocationOnMock m) -> {
-            Address address = m.getArgumentAt(0, Address.class);
+            Address address = m.<Address>getArgument(0);
             Assert.assertEquals("mwKcYS3H8FUgrPtyGMv3xWvf4jgeZUkCYN", address.toBase58());
             return true;
         });
@@ -3092,7 +3091,7 @@ public class BridgeSupportTest {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
         when(mockedWhitelist.remove(any(Address.class))).then((InvocationOnMock m) -> {
-            Address address = m.getArgumentAt(0, Address.class);
+            Address address = m.<Address>getArgument(0);
             Assert.assertEquals("mwKcYS3H8FUgrPtyGMv3xWvf4jgeZUkCYN", address.toBase58());
             return true;
         });
@@ -3113,7 +3112,7 @@ public class BridgeSupportTest {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForWhitelistTests(mockedWhitelist);
 
         when(mockedWhitelist.remove(any(Address.class))).then((InvocationOnMock m) -> {
-            Address address = m.getArgumentAt(0, Address.class);
+            Address address = m.<Address>getArgument(0);
             Assert.assertEquals("mwKcYS3H8FUgrPtyGMv3xWvf4jgeZUkCYN", address.toBase58());
             return false;
         });
@@ -3374,22 +3373,22 @@ public class BridgeSupportTest {
             }
 
             if (holder.getFederationElection() == null) {
-                AddressBasedAuthorizer auth = m.getArgumentAt(0, AddressBasedAuthorizer.class);
+                AddressBasedAuthorizer auth = m.<AddressBasedAuthorizer>getArgument(0);
                 holder.setFederationElection(new ABICallElection(auth));
             }
 
             return holder.getFederationElection();
         });
         Mockito.doAnswer((InvocationOnMock m) -> {
-            holder.setActiveFederation(m.getArgumentAt(0, Federation.class));
+            holder.setActiveFederation(m.<Federation>getArgument(0));
             return null;
         }).when(providerMock).setNewFederation(any());
         Mockito.doAnswer((InvocationOnMock m) -> {
-            holder.setRetiringFederation(m.getArgumentAt(0, Federation.class));
+            holder.setRetiringFederation(m.<Federation>getArgument(0));
             return null;
         }).when(providerMock).setOldFederation(any());
         Mockito.doAnswer((InvocationOnMock m) -> {
-            holder.setPendingFederation(m.getArgumentAt(0, PendingFederation.class));
+            holder.setPendingFederation(m.<PendingFederation>getArgument(0));
             return null;
         }).when(providerMock).setPendingFederation(any());
 

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 
 @RunWith(PowerMockRunner.class)
 public class FederationTest {
@@ -103,8 +103,8 @@ public class FederationTest {
         PowerMockito.mockStatic(ScriptBuilder.class);
         PowerMockito.when(ScriptBuilder.createRedeemScript(any(int.class), any(List.class))).thenAnswer((invocationOnMock) -> {
             calls.add(1);
-            int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
-            List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
+            int numberOfSignaturesRequired = invocationOnMock.<Integer>getArgument(0);
+            List<BtcECKey> publicKeys = invocationOnMock.getArgument(1);
             Assert.assertEquals(4, numberOfSignaturesRequired);
             Assert.assertEquals(6, publicKeys.size());
             for (int i = 0; i < sortedPublicKeys.size(); i++) {
@@ -125,8 +125,8 @@ public class FederationTest {
         PowerMockito.mockStatic(ScriptBuilder.class);
         PowerMockito.when(ScriptBuilder.createP2SHOutputScript(any(int.class), any(List.class))).thenAnswer((invocationOnMock) -> {
             calls.add(0);
-            int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
-            List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
+            int numberOfSignaturesRequired = invocationOnMock.<Integer>getArgument(0);
+            List<BtcECKey> publicKeys = invocationOnMock.getArgument(1);
             Assert.assertEquals(4, numberOfSignaturesRequired);
             Assert.assertEquals(6, publicKeys.size());
             for (int i = 0; i < sortedPublicKeys.size();i ++) {
@@ -151,8 +151,8 @@ public class FederationTest {
         PowerMockito.mockStatic(ScriptBuilder.class);
         PowerMockito.when(ScriptBuilder.createP2SHOutputScript(any(int.class), any(List.class))).thenAnswer((invocationOnMock) -> {
             calls.add(0);
-            int numberOfSignaturesRequired = invocationOnMock.getArgumentAt(0, int.class);
-            List<BtcECKey> publicKeys = invocationOnMock.getArgumentAt(1, List.class);
+            int numberOfSignaturesRequired = invocationOnMock.<Integer>getArgument(0);
+            List<BtcECKey> publicKeys = invocationOnMock.getArgument(1);
             Assert.assertEquals(4, numberOfSignaturesRequired);
             Assert.assertEquals(6, publicKeys.size());
             for (int i = 0; i < sortedPublicKeys.size();i ++) {

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 
 @RunWith(PowerMockRunner.class)
 public class PendingFederationTest {

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
@@ -78,13 +77,13 @@ public class ReleaseTransactionBuilderTest {
         when(wallet.getUTXOProvider()).thenReturn(utxoProvider);
         when(wallet.getWatchedAddresses()).thenReturn(Arrays.asList(changeAddress));
         when(utxoProvider.getOpenTransactionOutputs(any(List.class))).then((InvocationOnMock m) -> {
-            List<Address> addresses = m.getArgumentAt(0, List.class);
+            List<Address> addresses = m.<List>getArgument(0);
             Assert.assertEquals(Arrays.asList(changeAddress), addresses);
             return availableUTXOs;
         });
 
         Mockito.doAnswer((InvocationOnMock m) -> {
-            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+            SendRequest sr = m.<SendRequest>getArgument(0);
 
             Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
             Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
@@ -192,13 +191,13 @@ public class ReleaseTransactionBuilderTest {
         when(wallet.getUTXOProvider()).thenReturn(utxoProvider);
         when(wallet.getWatchedAddresses()).thenReturn(Arrays.asList(changeAddress));
         when(utxoProvider.getOpenTransactionOutputs(any(List.class))).then((InvocationOnMock m) -> {
-            List<Address> addresses = m.getArgumentAt(0, List.class);
+            List<Address> addresses = m.<List>getArgument(0);
             Assert.assertEquals(Arrays.asList(changeAddress), addresses);
             throw new UTXOProviderException();
         });
 
         Mockito.doAnswer((InvocationOnMock m) -> {
-            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+            SendRequest sr = m.<SendRequest>getArgument(0);
 
             Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
             Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
@@ -240,13 +239,13 @@ public class ReleaseTransactionBuilderTest {
         when(wallet.getUTXOProvider()).thenReturn(utxoProvider);
         when(wallet.getWatchedAddresses()).thenReturn(Arrays.asList(to));
         when(utxoProvider.getOpenTransactionOutputs(any(List.class))).then((InvocationOnMock m) -> {
-            List<Address> addresses = m.getArgumentAt(0, List.class);
+            List<Address> addresses = m.<List>getArgument(0);
             Assert.assertEquals(Arrays.asList(to), addresses);
             return availableUTXOs;
         });
 
         Mockito.doAnswer((InvocationOnMock m) -> {
-            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+            SendRequest sr = m.<SendRequest>getArgument(0);
 
             Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
             Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
@@ -358,13 +357,13 @@ public class ReleaseTransactionBuilderTest {
         when(wallet.getUTXOProvider()).thenReturn(utxoProvider);
         when(wallet.getWatchedAddresses()).thenReturn(Arrays.asList(to));
         when(utxoProvider.getOpenTransactionOutputs(any(List.class))).then((InvocationOnMock m) -> {
-            List<Address> addresses = m.getArgumentAt(0, List.class);
+            List<Address> addresses = m.<List>getArgument(0);
             Assert.assertEquals(Arrays.asList(to), addresses);
             throw new UTXOProviderException();
         });
 
         Mockito.doAnswer((InvocationOnMock m) -> {
-            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+            SendRequest sr = m.<SendRequest>getArgument(0);
 
             Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
             Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
@@ -394,7 +393,7 @@ public class ReleaseTransactionBuilderTest {
 
     private void mockCompleteTxWithThrowForBuildToAmount(Wallet wallet, Coin expectedAmount, Address expectedAddress, Throwable t) throws InsufficientMoneyException {
         Mockito.doAnswer((InvocationOnMock m) -> {
-            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+            SendRequest sr = m.<SendRequest>getArgument(0);
 
             Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
             Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);
@@ -414,7 +413,7 @@ public class ReleaseTransactionBuilderTest {
 
     private void mockCompleteTxWithThrowForEmptying(Wallet wallet, Address expectedAddress, Throwable t) throws InsufficientMoneyException {
         Mockito.doAnswer((InvocationOnMock m) -> {
-            SendRequest sr = m.getArgumentAt(0, SendRequest.class);
+            SendRequest sr = m.<SendRequest>getArgument(0);
 
             Assert.assertEquals(Coin.MILLICOIN.multiply(2), sr.feePerKb);
             Assert.assertEquals(Wallet.MissingSigsMode.USE_OP_ZERO, sr.missingSigsMode);

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -53,9 +53,7 @@ import java.math.BigInteger;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by usuario on 13/04/2017.

--- a/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
@@ -32,7 +32,6 @@ import org.mockito.ArgumentCaptor;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class EthSubscriptionNotificationEmitterTest {

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -28,10 +28,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class EthModuleTest {
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/RskJsonRpcHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/RskJsonRpcHandlerTest.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class RskJsonRpcHandlerTest {

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
@@ -48,9 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class Web3WebSocketServerTest {
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieSnapshotTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieSnapshotTest.java
@@ -27,10 +27,7 @@ import org.junit.Test;
 
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by ajlopez on 05/04/2017.

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -23,13 +23,13 @@ import co.rsk.core.Coin;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.mine.GasLimitCalculator;
 import co.rsk.panic.PanicProcessor;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.*;
 import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.vm.PrecompiledContracts;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.util.ArrayList;

--- a/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
@@ -11,8 +11,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
 
 public class DataSourceWithCacheTest {
@@ -166,7 +166,7 @@ public class DataSourceWithCacheTest {
         dataSourceWithCache.flush();
 
         ArgumentCaptor<Set<ByteArrayWrapper>> keysToDeleteArgument = ArgumentCaptor.forClass((Class)Set.class);
-        verify(baseDataSource, times(1)).updateBatch(any(Map.class), keysToDeleteArgument.capture());
+        verify(baseDataSource, times(1)).updateBatch(anyMap(), keysToDeleteArgument.capture());
         assertThat(keysToDeleteArgument.getValue(), is(empty()));
     }
 
@@ -178,7 +178,7 @@ public class DataSourceWithCacheTest {
         dataSourceWithCache.flush();
 
         ArgumentCaptor<Set<ByteArrayWrapper>> keysToDeleteArgument = ArgumentCaptor.forClass((Class)Set.class);
-        verify(baseDataSource, times(1)).updateBatch(any(Map.class), keysToDeleteArgument.capture());
+        verify(baseDataSource, times(1)).updateBatch(anyMap(), keysToDeleteArgument.capture());
         Set<ByteArrayWrapper> keysToDelete = keysToDeleteArgument.getValue();
         assertThat(keysToDelete, hasSize(1));
         assertThat(keysToDelete, hasItem(ByteUtil.wrap(randomKey)));

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -66,14 +66,13 @@ import org.ethereum.vm.program.ProgramResult;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by Ruben Altman on 09/06/2016.
@@ -926,8 +925,8 @@ public class Web3ImplTest {
     @Test
     public void eth_coinbase()  {
         String originalCoinbase = "1dcc4de8dec75d7aab85b513f0a142fd40d49347";
-        MinerServer minerServerMock = Mockito.mock(MinerServer.class);
-        Mockito.when(minerServerMock.getCoinbaseAddress()).thenReturn(new RskAddress(originalCoinbase));
+        MinerServer minerServerMock = mock(MinerServer.class);
+        when(minerServerMock.getCoinbaseAddress()).thenReturn(new RskAddress(originalCoinbase));
 
         Ethereum ethMock = Web3Mocks.getMockEthereum();
         Blockchain blockchain = Web3Mocks.getMockBlockchain();
@@ -962,7 +961,7 @@ public class Web3ImplTest {
         );
 
         Assert.assertEquals("0x" + originalCoinbase, web3.eth_coinbase());
-        Mockito.verify(minerServerMock, Mockito.times(1)).getCoinbaseAddress();
+        verify(minerServerMock, times(1)).getCoinbaseAddress();
     }
 
     @Test
@@ -1236,7 +1235,7 @@ public class Web3ImplTest {
     }
 
     private Web3Impl createWeb3Mocked(World world) {
-        Ethereum ethMock = Mockito.mock(Ethereum.class);
+        Ethereum ethMock = mock(Ethereum.class);
         return createWeb3(ethMock, world, null);
     }
 
@@ -1301,10 +1300,10 @@ public class Web3ImplTest {
     private Web3Impl createWeb3(Ethereum eth, Blockchain blockchain, TransactionPool transactionPool, BlockStore blockStore, BlockProcessor nodeBlockProcessor, ConfigCapabilities configCapabilities, ReceiptStore receiptStore) {
         wallet = WalletFactory.createWallet();
         PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, transactionPool);
-        ReversibleTransactionExecutor executor = Mockito.mock(ReversibleTransactionExecutor.class);
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
         ProgramResult res = new ProgramResult();
         res.setHReturn(TypeConverter.stringHexToByteArray("0x0000000000000000000000000000000000000000000000000000000064617665"));
-        Mockito.when(executor.executeTransaction(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(res);
+        when(executor.executeTransaction(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(res);
         EthModule ethModule = new EthModule(config, blockchain, executor, new ExecutionBlockRetriever(blockchain, null, null), new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), new EthModuleTransactionBase(config, wallet, transactionPool));
         TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool);
         DebugModule debugModule = new DebugModuleImpl(Web3Mocks.getMockMessageHandler());
@@ -1341,13 +1340,13 @@ public class Web3ImplTest {
     @Test
     @Ignore
     public void eth_compileSolidity() throws Exception {
-        RskSystemProperties systemProperties = Mockito.mock(RskSystemProperties.class);
+        RskSystemProperties systemProperties = mock(RskSystemProperties.class);
         String solc = System.getProperty("solc");
         if (solc == null || solc.isEmpty())
             solc = "/usr/bin/solc";
 
-        Mockito.when(systemProperties.customSolcPath()).thenReturn(solc);
-        Ethereum eth = Mockito.mock(Ethereum.class);
+        when(systemProperties.customSolcPath()).thenReturn(solc);
+        Ethereum eth = mock(Ethereum.class);
         EthModule ethModule = new EthModule(config, null, null, new ExecutionBlockRetriever(null, null, null), new EthModuleSolidityEnabled(new SolidityCompiler(systemProperties)), null, null);
         PersonalModule personalModule = new PersonalModuleWalletDisabled();
         TxPoolModule txPoolModule = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
@@ -1394,12 +1393,12 @@ public class Web3ImplTest {
 
     @Test
     public void eth_compileSolidityWithoutSolidity() throws Exception {
-        SystemProperties systemProperties = Mockito.mock(SystemProperties.class);
+        SystemProperties systemProperties = mock(SystemProperties.class);
         String solc = System.getProperty("solc");
         if (solc == null || solc.isEmpty())
             solc = "/usr/bin/solc";
 
-        Mockito.when(systemProperties.customSolcPath()).thenReturn(solc);
+        when(systemProperties.customSolcPath()).thenReturn(solc);
 
         Wallet wallet = WalletFactory.createWallet();
         Ethereum eth = Web3Mocks.getMockEthereum();

--- a/rskj-core/src/test/java/org/ethereum/util/RskMockFactory.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RskMockFactory.java
@@ -5,9 +5,7 @@ import co.rsk.scoring.PeerScoring;
 import co.rsk.scoring.PeerScoringManager;
 import org.ethereum.net.server.ChannelManager;
 
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class RskMockFactory {
 


### PR DESCRIPTION
This is just a stepping stone in the long way of supporting Java 11. Dependencies weren't reproduced because they are test dependencies, but the hashes were updated anyway.