### PR TITLE
Increase block's timestamp when Automine=false

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1264,7 +1264,9 @@ public class RskContext implements NodeBootstrapper {
     private MinerClock getMinerClock() {
         if (minerClock == null) {
             minerClock = new MinerClock(
-                    getRskSystemProperties().getBlockchainConfig() instanceof RegTestConfig, Clock.systemUTC()
+                    getRskSystemProperties().getBlockchainConfig() instanceof RegTestConfig,
+                    getRskSystemProperties().minerClientAutoMine(),
+                    Clock.systemUTC()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
@@ -23,22 +23,30 @@ import java.time.Clock;
 
 public class MinerClock {
     private final boolean isRegtest;
+    private final boolean isAutoMine;
     private final Clock clock;
 
     private long timeAdjustment;
 
-    public MinerClock(boolean isRegtest, Clock clock) {
+    public MinerClock(boolean isRegtest, boolean isAutoMine, Clock clock) {
         this.isRegtest = isRegtest;
+        this.isAutoMine = isAutoMine;
         this.clock = clock;
     }
 
     public long calculateTimestampForChild(Block parent) {
         long previousTimestamp = parent.getTimestamp();
+        long ret = clock.instant().getEpochSecond();
+
         if (isRegtest) {
-            return previousTimestamp + timeAdjustment;
+
+            if(isAutoMine) {
+                return previousTimestamp + timeAdjustment;
+            }
+
+            ret = ret + timeAdjustment;
         }
 
-        long ret = clock.instant().plusSeconds(timeAdjustment).getEpochSecond();
         return Long.max(ret, previousTimestamp + 1);
     }
 

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -73,7 +73,7 @@ public class MainNetMinerTest {
 
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
 
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -134,7 +134,7 @@ public class MainNetMinerTest {
         EthereumImpl ethereumImpl = Mockito.mock(EthereumImpl.class);
         Mockito.when(ethereumImpl.addNewMinedBlock(Mockito.any())).thenReturn(ImportResult.IMPORTED_BEST);
 
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -193,7 +193,7 @@ public class MainNetMinerTest {
     private BlockToMineBuilder blockToMineBuilder() {
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         return new BlockToMineBuilder(
                 ConfigUtils.getDefaultMiningConfig(),
                 repository,

--- a/rskj-core/src/test/java/co/rsk/mine/MinerClockTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerClockTest.java
@@ -40,7 +40,7 @@ public class MinerClockTest {
 
     @Test
     public void timestampForChildIsParentTimestampIfRegtest() {
-        MinerClock minerClock = new MinerClock(true, clock);
+        MinerClock minerClock = new MinerClock(true, true, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(54L);
@@ -53,7 +53,7 @@ public class MinerClockTest {
 
     @Test
     public void timestampForChildIsClockTimeIfNotRegtest() {
-        MinerClock minerClock = new MinerClock(false, clock);
+        MinerClock minerClock = new MinerClock(false, false, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(54L);
@@ -66,7 +66,7 @@ public class MinerClockTest {
 
     @Test
     public void timestampForChildIsTimestampPlusOneIfNotRegtest() {
-        MinerClock minerClock = new MinerClock(false, clock);
+        MinerClock minerClock = new MinerClock(false, false, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(clock.instant().getEpochSecond());
@@ -79,7 +79,7 @@ public class MinerClockTest {
 
     @Test
     public void adjustTimeIfRegtest() {
-        MinerClock minerClock = new MinerClock(true, clock);
+        MinerClock minerClock = new MinerClock(true, true, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(33L);
@@ -94,7 +94,7 @@ public class MinerClockTest {
 
     @Test
     public void adjustTimeIfNotRegtest() {
-        MinerClock minerClock = new MinerClock(false, clock);
+        MinerClock minerClock = new MinerClock(false, false, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(33L);
@@ -102,14 +102,27 @@ public class MinerClockTest {
         minerClock.increaseTime(5392L);
 
         assertEquals(
-                clock.instant().getEpochSecond() + 5392L,
+                clock.instant().getEpochSecond(),
+                minerClock.calculateTimestampForChild(parent)
+        );
+    }
+
+    @Test
+    public void automineTimestampShouldnotIncrease() {
+        MinerClock minerClock = new MinerClock(true, true, clock);
+
+        Block parent = mock(Block.class);
+        when(parent.getTimestamp()).thenReturn(33L);
+
+        assertEquals(
+                33L,
                 minerClock.calculateTimestampForChild(parent)
         );
     }
 
     @Test
     public void clearTimeIncrease() {
-        MinerClock minerClock = new MinerClock(true, clock);
+        MinerClock minerClock = new MinerClock(true, true, clock);
 
         Block parent = mock(Block.class);
         when(parent.getTimestamp()).thenReturn(33L);
@@ -119,6 +132,19 @@ public class MinerClockTest {
 
         assertEquals(
                 33L,
+                minerClock.calculateTimestampForChild(parent)
+        );
+    }
+
+    @Test
+    public void timestampForChildIsTimestampPlusOneIfAutomineIsAnable() {
+        MinerClock minerClock = new MinerClock(true, false, clock);
+
+        Block parent = mock(Block.class);
+        when(parent.getTimestamp()).thenReturn(clock.instant().getEpochSecond());
+
+        assertEquals(
+                clock.instant().getEpochSecond() + 1,
                 minerClock.calculateTimestampForChild(parent)
         );
     }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -266,7 +266,7 @@ public class MinerManagerTest {
         ethereum.repository = repository;
         ethereum.blockchain = blockchain;
         DifficultyCalculator difficultyCalculator = new DifficultyCalculator(config);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         return new MinerServerImpl(
                 config,
                 ethereum,

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -103,7 +103,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServerImpl minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -145,7 +145,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -211,7 +211,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -262,7 +262,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -316,7 +316,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -377,7 +377,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -430,7 +430,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -488,7 +488,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -528,7 +528,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -568,7 +568,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -612,7 +612,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         BlockUnclesValidationRule unclesValidationRule = Mockito.mock(BlockUnclesValidationRule.class);
         Mockito.when(unclesValidationRule.isValid(Mockito.any())).thenReturn(true);
-        MinerClock clock = new MinerClock(true, Clock.systemUTC());
+        MinerClock clock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 ethereumImpl,
@@ -700,7 +700,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 null,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 getBuilderWithMocks(),
-                new MinerClock(true, Clock.systemUTC()),
+                new MinerClock(true, false, Clock.systemUTC()),
                 ConfigUtils.getDefaultMiningConfig()
         );
     }

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -258,7 +258,7 @@ public class TransactionModuleTest {
         ConfigCapabilities configCapabilities = new SimpleConfigCapabilities();
         CompositeEthereumListener compositeEthereumListener = new CompositeEthereumListener();
         Ethereum eth = new EthereumImpl(new ChannelManagerImpl(config, new SyncPool(compositeEthereumListener, blockchain, config, null)), transactionPool, compositeEthereumListener, blockchain);
-        MinerClock minerClock = new MinerClock(true, Clock.systemUTC());
+        MinerClock minerClock = new MinerClock(true, false, Clock.systemUTC());
 
         MinerServer minerServer = new MinerServerImpl(
                 config,

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -151,7 +151,7 @@ public class Web3ImplSnapshotTest {
 
 
     private Web3Impl createWeb3(SimpleEthereum ethereum) {
-        MinerClock minerClock = new MinerClock(true, Clock.systemUTC());
+        MinerClock minerClock = new MinerClock(true, false, Clock.systemUTC());
         MinerServer minerServer = getMinerServerForTest(ethereum, minerClock);
         MinerClientImpl minerClient = new MinerClientImpl(null, minerServer, config.minerClientDelayBetweenBlocks(), config.minerClientDelayBetweenRefreshes());
         EvmModule evmModule = new EvmModuleImpl(minerServer, minerClient, minerClock, blockchain, factory.getTransactionPool());


### PR DESCRIPTION
Now when Regtest is enabled and Automine is disabled, block timestamp will increase as used to.
Also timeAjustment  won't be compute when Regtest is disabled