### PR TITLE
RFS-332 - Remove version tally

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -67,7 +67,7 @@ ext {
     powermockitoVersion = '1.6.4'
     rskLllVersion = '0.0.2'
     logbackVersion = '1.2.2'
-    bitcoinjVersion = '0.14.4-rsk-6'
+    bitcoinjVersion = '0.14.4-rsk-7'
     nettyVersion = '4.0.56.Final'
 }
 
@@ -117,7 +117,7 @@ dependencyVerification {
         'aopalliance:aopalliance:0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08',
         'ch.qos.logback:logback-classic:48ade385bbae0222b2934b65738892117d8cb8366b3a3df442d3826c11cedff1',
         'ch.qos.logback:logback-core:280be7a9327e7434d214d6b9eb881c083c3e057a22d0ed7663a7ce81a718a494',
-        'co.rsk.bitcoinj:bitcoinj-thin:0855ffa3254a8fb98143cd22e9b8d3a0c50346a3d08894b20dfbc4323750586f',
+        'co.rsk.bitcoinj:bitcoinj-thin:1d7e79f543b6ce47e9f9471fa03575cadd49ef672dc367bad8a5b3660fbcfa24',
         'co.rsk:lll-compiler:a645fdb272f56721761f65dd32caa952453efc07d98d292259d99353b6f647d0',
         'com.fasterxml.jackson.core:jackson-annotations:4caf3936315439b509b8c3ef494d4e47eaa6d25c3b5299aadb0eafb3944ed32f',
         'com.fasterxml.jackson.core:jackson-core:256ff34118ab292d1b4f3ee4d2c3e5e5f0f609d8e07c57e8ad1f51c46d4fbb46',


### PR DESCRIPTION
Now using [bitcoinj-thin 0.14.4-rsk-7](https://github.com/rsksmart/bitcoinj-thin/releases/tag/v0.14.4-rsk-7) that removes the version tally entirely. See [this PR](https://github.com/rsksmart/bitcoinj-thin/pull/13) for details.