### PR TITLE
RFS-327 - Dynamic gas cost for getBtcTransactionConfirmations

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -290,6 +290,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         this.repository = repository;
         this.logs = logs;
         this.blockchainConfig = blockchainNetConfig.getConfigForBlock(rskExecutionBlock.getNumber());
+        this.bridgeSupport = setup();
     }
 
     @Override
@@ -321,8 +322,6 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
                 logger.info(errorMessage);
                 throw new BridgeIllegalArgumentException(errorMessage);
             }
-
-            this.bridgeSupport = setup();
 
             Optional<?> result;
             try {
@@ -577,6 +576,12 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         }
 
         return blockHash.getBytes();
+    }
+
+    public long getBtcTransactionConfirmationsGetCost(Object[] args) {
+        Sha256Hash btcBlockHash = Sha256Hash.wrap((byte[]) args[1]);
+
+        return bridgeSupport.getBtcTransactionConfirmationsGetCost(btcBlockHash);
     }
 
     public int getBtcTransactionConfirmations(Object[] args)

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -165,7 +165,7 @@ public enum BridgeMethods {
                     new String[]{"bytes32", "bytes32", "uint256", "bytes32[]"},
                     new String[]{"int256"}
             ),
-            fixedCost(22000L), //TODO ESTIMATE GAS
+            fromMethod(Bridge::getBtcTransactionConfirmationsGetCost),
             (BridgeMethodExecutorTyped) Bridge::getBtcTransactionConfirmations,
             blockchainConfig -> blockchainConfig.isRskipGetBtcTransactionConfirmations(),
             false

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1133,7 +1133,7 @@ public class BridgeSupport {
     }
 
     public Long getBtcTransactionConfirmationsGetCost(Sha256Hash btcBlockHash) {
-        final long BASIC_COST = 13_500;
+        final long BASIC_COST = 17_500;
         final long STEP_COST = 20;
 
         // Dynamic cost based on the depth of the block that contains

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1133,8 +1133,8 @@ public class BridgeSupport {
     }
 
     public Long getBtcTransactionConfirmationsGetCost(Sha256Hash btcBlockHash) {
-        final long BASIC_COST = 17_500;
-        final long STEP_COST = 20;
+        final long BASIC_COST = 13_600;
+        final long STEP_COST = 70;
 
         // Dynamic cost based on the depth of the block that contains
         // the transaction. Find such depth first, then calculate

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1132,6 +1132,40 @@ public class BridgeSupport {
         return current.getHeader().getHash();
     }
 
+    public Long getBtcTransactionConfirmationsGetCost(Sha256Hash btcBlockHash) {
+        final long BASIC_COST = 13_500;
+        final long STEP_COST = 20;
+
+        // Dynamic cost based on the depth of the block that contains
+        // the transaction. Find such depth first, then calculate
+        // the cost.
+        Context.propagate(btcContext);
+        try {
+            this.ensureBtcBlockStore();
+            final StoredBlock block = btcBlockStore.getFromCache(btcBlockHash);
+
+            // Block not found, default to basic cost
+            if (block == null) {
+                return BASIC_COST;
+            }
+
+            final int bestChainHeight = getBtcBlockchainBestChainHeight();
+            final int blockDepth = bestChainHeight - block.getHeight();
+
+            // Block too deep, default to basic cost
+            if (blockDepth > BTC_TRANSACTION_CONFIRMATION_MAX_DEPTH) {
+                return BASIC_COST;
+            }
+
+            return BASIC_COST + blockDepth*STEP_COST;
+        } catch (IOException | BlockStoreException e) {
+            logger.warn("getBtcTransactionConfirmations: there was a problem " +
+                    "gathering the block depth while calculating the gas cost. " +
+                    "Defaulting to basic cost.", e);
+            return BASIC_COST;
+        }
+    }
+
     /**
      * @param btcTxHash The BTC transaction Hash
      * @param btcBlockHash The BTC block hash

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1150,7 +1150,9 @@ public class BridgeSupport {
             }
 
             final int bestChainHeight = getBtcBlockchainBestChainHeight();
-            final int blockDepth = bestChainHeight - block.getHeight();
+
+            // Make sure calculated depth is >= 0
+            final int blockDepth = Math.max(0, bestChainHeight - block.getHeight());
 
             // Block too deep, default to basic cost
             if (blockDepth > BTC_TRANSACTION_CONFIRMATION_MAX_DEPTH) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -115,7 +115,7 @@ import static org.mockito.Mockito.*;
  * Created by ajlopez on 6/9/2016.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ BridgeUtils.class, BtcBlockChain.class })
+@PrepareForTest({ BridgeUtils.class, BtcBlockChain.class, BridgeSupport.class })
 public class BridgeSupportTest {
     private static final co.rsk.core.Coin LIMIT_MONETARY_BASE = new co.rsk.core.Coin(new BigInteger("21000000000000000000000000"));
     private static final RskAddress contractAddress = PrecompiledContracts.BRIDGE_ADDR;
@@ -3918,6 +3918,148 @@ public class BridgeSupportTest {
         int confirmations = bridgeSupport.getBtcTransactionConfirmations(btcTransactionHash, blockHash, merkleBranch);
 
         Assert.assertEquals(BridgeSupport.BTC_TRANSACTION_CONFIRMATION_INVALID_MERKLE_BRANCH_ERROR_CODE.intValue(), confirmations);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmationsGetCost_ok() throws BlockStoreException, IOException {
+        config.setBlockchainConfig(new RegTestOrchidConfig());
+
+        Repository repository = createRepositoryImpl(config);
+        Repository track = repository.startTracking();
+
+        Sha256Hash blockHash = Sha256Hash.of(Hex.decode("aabbcc"));
+        StoredBlock block = new StoredBlock(null, new BigInteger("0"), 50);
+
+        BtcBlockstoreWithCache btcBlockStore = mock(RepositoryBlockStore.class);
+        when(btcBlockStore.getFromCache(blockHash)).thenReturn(block);
+
+        StoredBlock chainHead = new StoredBlock(null, new BigInteger("0"), 60);
+        when(btcBlockStore.getChainHead()).thenReturn(chainHead);
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class),
+                BridgeRegTestConstants.getInstance(), provider, btcBlockStore, mock(BtcBlockChain.class), null);
+
+        long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
+
+        Assert.assertEquals(17_500 + 10*20, cost);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmationsGetCost_blockStoreInitializationError() throws Exception {
+        config.setBlockchainConfig(new RegTestOrchidConfig());
+
+        Repository repository = createRepositoryImpl(config);
+        Repository track = repository.startTracking();
+
+        Sha256Hash blockHash = Sha256Hash.of(Hex.decode("aabbcc"));
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class),
+                BridgeRegTestConstants.getInstance(), provider, null, mock(BtcBlockChain.class), null);
+
+        PowerMockito.whenNew(RepositoryBlockStore.class).withAnyArguments().thenThrow(new IOException());
+
+        long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
+
+        Assert.assertEquals(17_500, cost);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmationsGetCost_getFromBlockStoreError() throws BlockStoreException, IOException {
+        config.setBlockchainConfig(new RegTestOrchidConfig());
+
+        Repository repository = createRepositoryImpl(config);
+        Repository track = repository.startTracking();
+
+        Sha256Hash blockHash = Sha256Hash.of(Hex.decode("aabbcc"));
+
+        BtcBlockstoreWithCache btcBlockStore = mock(RepositoryBlockStore.class);
+        when(btcBlockStore.getFromCache(blockHash)).thenThrow(new BlockStoreException(""));
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class),
+                BridgeRegTestConstants.getInstance(), provider, btcBlockStore, mock(BtcBlockChain.class), null);
+
+        long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
+
+        Assert.assertEquals(17_500, cost);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmationsGetCost_blockDoesNotExist() throws BlockStoreException, IOException {
+        config.setBlockchainConfig(new RegTestOrchidConfig());
+
+        Repository repository = createRepositoryImpl(config);
+        Repository track = repository.startTracking();
+
+        Sha256Hash blockHash = Sha256Hash.of(Hex.decode("aabbcc"));
+
+        BtcBlockstoreWithCache btcBlockStore = mock(RepositoryBlockStore.class);
+        when(btcBlockStore.getFromCache(blockHash)).thenReturn(null);
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class),
+                BridgeRegTestConstants.getInstance(), provider, btcBlockStore, mock(BtcBlockChain.class), null);
+
+        long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
+
+        Assert.assertEquals(17_500, cost);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmationsGetCost_getBestChainHeightError() throws BlockStoreException, IOException {
+        config.setBlockchainConfig(new RegTestOrchidConfig());
+
+        Repository repository = createRepositoryImpl(config);
+        Repository track = repository.startTracking();
+
+        Sha256Hash blockHash = Sha256Hash.of(Hex.decode("aabbcc"));
+        StoredBlock block = new StoredBlock(null, new BigInteger("0"), 50);
+
+        BtcBlockstoreWithCache btcBlockStore = mock(RepositoryBlockStore.class);
+        when(btcBlockStore.getFromCache(blockHash)).thenReturn(block);
+
+        when(btcBlockStore.getChainHead()).thenThrow(new BlockStoreException(""));
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class),
+                BridgeRegTestConstants.getInstance(), provider, btcBlockStore, mock(BtcBlockChain.class), null);
+
+        long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
+
+        Assert.assertEquals(17_500, cost);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmationsGetCost_blockTooDeep() throws BlockStoreException, IOException {
+        config.setBlockchainConfig(new RegTestOrchidConfig());
+
+        Repository repository = createRepositoryImpl(config);
+        Repository track = repository.startTracking();
+
+        Sha256Hash blockHash = Sha256Hash.of(Hex.decode("aabbcc"));
+        StoredBlock block = new StoredBlock(null, new BigInteger("0"), 50);
+
+        BtcBlockstoreWithCache btcBlockStore = mock(RepositoryBlockStore.class);
+        when(btcBlockStore.getFromCache(blockHash)).thenReturn(block);
+
+        StoredBlock chainHead = new StoredBlock(null, new BigInteger("0"), 6000);
+        when(btcBlockStore.getChainHead()).thenReturn(chainHead);
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
+        BridgeSupport bridgeSupport = new BridgeSupport(config, track, mock(BridgeEventLogger.class),
+                BridgeRegTestConstants.getInstance(), provider, btcBlockStore, mock(BtcBlockChain.class), null);
+
+        long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
+
+        Assert.assertEquals(17_500, cost);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -3943,7 +3943,7 @@ public class BridgeSupportTest {
 
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
 
-        Assert.assertEquals(17_500 + 10*20, cost);
+        Assert.assertEquals(13_600 + 10*70, cost);
     }
 
     @Test
@@ -3964,7 +3964,7 @@ public class BridgeSupportTest {
 
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
 
-        Assert.assertEquals(17_500, cost);
+        Assert.assertEquals(13_600, cost);
     }
 
     @Test
@@ -3986,7 +3986,7 @@ public class BridgeSupportTest {
 
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
 
-        Assert.assertEquals(17_500, cost);
+        Assert.assertEquals(13_600, cost);
     }
 
     @Test
@@ -4008,7 +4008,7 @@ public class BridgeSupportTest {
 
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
 
-        Assert.assertEquals(17_500, cost);
+        Assert.assertEquals(13_600, cost);
     }
 
     @Test
@@ -4033,7 +4033,7 @@ public class BridgeSupportTest {
 
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
 
-        Assert.assertEquals(17_500, cost);
+        Assert.assertEquals(13_600, cost);
     }
 
     @Test
@@ -4059,7 +4059,7 @@ public class BridgeSupportTest {
 
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(blockHash);
 
-        Assert.assertEquals(17_500, cost);
+        Assert.assertEquals(13_600, cost);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -404,7 +404,6 @@ public class BridgeTest {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         final int numBlocks = 10;
         co.rsk.bitcoinj.core.BtcBlock[] headers = new co.rsk.bitcoinj.core.BtcBlock[numBlocks];
@@ -436,6 +435,8 @@ public class BridgeTest {
         when(btcParamsMock.getDefaultSerializer()).thenReturn(spySerializer);
 
         Whitebox.setInternalState(bridge, "bridgeConstants", bridgeConstantsMock);
+
+        bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         bridge.execute(Bridge.RECEIVE_HEADERS.encode(new Object[]{headersSerialized}));
 
@@ -1372,11 +1373,11 @@ public class BridgeTest {
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
-        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toByteArray());
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
 
         Assert.assertTrue(Arrays.equals(new byte[]{10},
                 (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
@@ -1434,13 +1435,13 @@ public class BridgeTest {
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
-        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
                         .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
         );
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
 
         Assert.assertTrue(Arrays.equals("10btc".getBytes(),
                 (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
@@ -1511,11 +1512,11 @@ public class BridgeTest {
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
-        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getRetiringFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toByteArray());
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
 
         Assert.assertTrue(Arrays.equals(new byte[]{10},
                 (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
@@ -1573,13 +1574,13 @@ public class BridgeTest {
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
-        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getRetiringFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
                         .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
         );
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
 
         Assert.assertTrue(Arrays.equals("10btc".getBytes(),
                 (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
@@ -1618,11 +1619,11 @@ public class BridgeTest {
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
-        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getPendingFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toByteArray());
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
 
         Assert.assertTrue(Arrays.equals(new byte[]{10},
                 (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
@@ -1680,13 +1681,13 @@ public class BridgeTest {
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
-        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getPendingFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
                         .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
         );
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
 
         Assert.assertTrue(Arrays.equals("10btc".getBytes(),
                 (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
@@ -1727,11 +1728,11 @@ public class BridgeTest {
 
         Transaction txMock = mock(Transaction.class);
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
-        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("add", new byte[][] { Hex.decode("aabbccdd") })))
                 .thenReturn(123);
+        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
 
         Assert.assertEquals(123,
                 ((BigInteger)BridgeMethods.ADD_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
@@ -1788,12 +1789,12 @@ public class BridgeTest {
 
         Transaction txMock = mock(Transaction.class);
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
-        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.voteFederationChange(txMock, new ABICallSpec("add-multi", new byte[][] {
                 Hex.decode("aabb"), Hex.decode("ccdd"), Hex.decode("eeff")
         }))).thenReturn(123);
+        bridge.init(txMock, getGenesisBlock(), null, null, null, null);
 
         Assert.assertEquals(123,
                 ((BigInteger)BridgeMethods.ADD_FEDERATOR_PUBLIC_KEY_MULTIKEY.getFunction().decodeResult(
@@ -2159,12 +2160,12 @@ public class BridgeTest {
         Transaction tx = mock(Transaction.class);
         when(tx.isLocalCallTransaction()).thenReturn(true);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(tx, getGenesisBlock(), null, null, null, null);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.whenNew(BridgeSupport.class).withAnyArguments().thenReturn(bridgeSupportMock);
         Address address = new BtcECKey().toAddress(networkParameters);
         when(bridgeSupportMock.getFederationAddress()).thenReturn(address);
+        bridge.init(tx, getGenesisBlock(), null, null, null, null);
 
         byte[] data = BridgeMethods.GET_FEDERATION_ADDRESS.getFunction().encode(new Object[]{});
         bridge.execute(data);
@@ -2229,11 +2230,11 @@ public class BridgeTest {
         Transaction tx = mock(Transaction.class);
         when(tx.isLocalCallTransaction()).thenReturn(localCall);
         Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(tx, getGenesisBlock(), null, null, null, null);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.whenNew(BridgeSupport.class).withAnyArguments().thenReturn(bridgeSupportMock);
         when(bridgeSupportMock.voteFeePerKbChange(tx, Coin.CENT)).thenReturn(1);
+        bridge.init(tx, getGenesisBlock(), null, null, null, null);
 
         byte[] data = BridgeMethods.VOTE_FEE_PER_KB.getFunction().encode(new Object[]{ Coin.CENT.longValue() });
         bridge.execute(data);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
@@ -4,10 +4,13 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.BridgeSupport;
 import co.rsk.peg.RepositoryBlockStore;
 import co.rsk.peg.bitcoin.MerkleBranch;
+import org.ethereum.config.SystemProperties;
 import org.ethereum.config.blockchain.regtest.RegTestSecondForkConfig;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
@@ -35,6 +38,17 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
     private List<Sha256Hash> merkleBranchHashes;
     private int expectedConfirmations;
 
+    private class DiskAccessRepositoryBlockStore extends RepositoryBlockStore {
+        public DiskAccessRepositoryBlockStore(SystemProperties config, Repository repository, RskAddress contractAddress) {
+            super(config, repository, contractAddress);
+        }
+
+        @Override
+        public synchronized StoredBlock getFromCache(Sha256Hash hash) throws BlockStoreException {
+            return this.get(hash);
+        }
+    }
+
     @Before
     public void setRskipToTrue() {
         config.setBlockchainConfig(new RegTestSecondForkConfig());
@@ -46,30 +60,48 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
         // so that we get even numbers at the end
         System.out.print("Doing an initial pass... ");
         setQuietMode(true);
-        estimateGetBtcTransactionConfirmations("foo", 20, 4000, 750, 1000);
+        estimateGetBtcTransactionConfirmations("foo", 10, 4000, 750, 1000, true);
+        estimateGetBtcTransactionConfirmations("foo", 10, 4000, 750, 1000, false);
         setQuietMode(false);
         System.out.print("Done!\n");
     }
 
     @Test
-    public void getBtcTransactionConfirmations_Weighed() {
+    public void getBtcTransactionConfirmations_Weighed_Cache() {
         final String CASE_NAME = "getBtcTransactionConfirmations-weighed";
         CombinedExecutionStats stats = new CombinedExecutionStats(CASE_NAME);
 
         // We always consider the average BTC block case from https://www.blockchain.com/charts/n-transactions-per-block
 
         // One day of BTC blocks
-        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 300, 144, 750, 3000));
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 300, 144, 750, 3000, true));
         // Maximum number of confirmations
-        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 10, BridgeSupport.BTC_TRANSACTION_CONFIRMATION_MAX_DEPTH, 750, 3000));
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 10, BridgeSupport.BTC_TRANSACTION_CONFIRMATION_MAX_DEPTH, 750, 3000, true));
         // Single confirmation
-        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 10, 0,750,3000));
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 10, 0,750,3000, true));
 
         BridgePerformanceTest.addStats(stats);
     }
 
     @Test
-    public void getBtcTransactionConfirmations_Even() {
+    public void getBtcTransactionConfirmations_Weighed_Disk() {
+        final String CASE_NAME = "getBtcTransactionConfirmations-weighed";
+        CombinedExecutionStats stats = new CombinedExecutionStats(CASE_NAME);
+
+        // We always consider the average BTC block case from https://www.blockchain.com/charts/n-transactions-per-block
+
+        // One day of BTC blocks
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 300, 144, 750, 3000, false));
+        // Maximum number of confirmations
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 10, BridgeSupport.BTC_TRANSACTION_CONFIRMATION_MAX_DEPTH, 750, 3000, false));
+        // Single confirmation
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 10, 0,750,3000, false));
+
+        BridgePerformanceTest.addStats(stats);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmations_Even_Cache() {
         final String CASE_NAME = "getBtcTransactionConfirmations-even";
         CombinedExecutionStats stats = new CombinedExecutionStats(CASE_NAME);
 
@@ -77,7 +109,22 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
         final int MAX_CONFIRMATIONS = 6*24*2;
 
         for (int numConfirmations = 0; numConfirmations <= MAX_CONFIRMATIONS; numConfirmations++) {
-            stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 100, numConfirmations, 750, 3000));
+            stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 100, numConfirmations, 750, 3000, true));
+        }
+
+        BridgePerformanceTest.addStats(stats);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmations_Even_Disk() {
+        final String CASE_NAME = "getBtcTransactionConfirmations-even";
+        CombinedExecutionStats stats = new CombinedExecutionStats(CASE_NAME);
+
+        // Up to two days of confirmations (average of 6 blocks per hour)
+        final int MAX_CONFIRMATIONS = 6*24*2;
+
+        for (int numConfirmations = 0; numConfirmations <= MAX_CONFIRMATIONS; numConfirmations++) {
+            stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 100, numConfirmations, 750, 3000, false));
         }
 
         BridgePerformanceTest.addStats(stats);
@@ -87,7 +134,12 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
     public void getBtcTransactionConfirmations_Zero() {
         BridgePerformanceTest.addStats(estimateGetBtcTransactionConfirmations(
                 "getBtcTransactionConfirmations-zero",
-                2000, 0, 750, 3000
+                2000, 0, 750, 3000, true
+        ));
+
+        BridgePerformanceTest.addStats(estimateGetBtcTransactionConfirmations(
+                "getBtcTransactionConfirmations-zero",
+                2000, 0, 750, 3000, false
         ));
     }
 
@@ -95,14 +147,19 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
     public void getBtcTransactionConfirmations_Hundred() {
         BridgePerformanceTest.addStats(estimateGetBtcTransactionConfirmations(
                 "getBtcTransactionConfirmations-hundred",
-                2000, 100, 750, 3000
+                2000, 100, 750, 3000, true
+        ));
+
+        BridgePerformanceTest.addStats(estimateGetBtcTransactionConfirmations(
+                "getBtcTransactionConfirmations-hundred",
+                2000, 100, 750, 3000, false
         ));
     }
 
     private ExecutionStats estimateGetBtcTransactionConfirmations(
             String caseName,
             int times, int confirmations, int  minTransactions,
-            int maxTransactions) {
+            int maxTransactions, boolean useCache) {
 
         BridgeStorageProviderInitializer storageInitializer = generateBlockChainInitializer(
                 1000,
@@ -112,7 +169,7 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
                 maxTransactions
         );
 
-        String name = String.format("%s-%d", caseName, confirmations);
+        String name = String.format("%s-%d-%s", caseName, confirmations, useCache ? "cache" : "disk");
         ExecutionStats stats = new ExecutionStats(name);
 
         executeAndAverage(
@@ -127,6 +184,15 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
                     byte[] res = executionResult;
                     int numberOfConfirmations = new BigInteger(executionResult).intValueExact();
                     Assert.assertEquals(expectedConfirmations, numberOfConfirmations);
+                },
+                (EnvironmentBuilder.Environment environment) -> {
+                    if (!useCache) {
+                        Bridge bridge = (Bridge) environment.getContract();
+                        BridgeSupport bridgeSupport = Whitebox.getInternalState(bridge, "bridgeSupport");
+                        Repository repository = Whitebox.getInternalState(bridgeSupport, "rskRepository");
+                        BtcBlockStore diskAccessRepositoryBlockStore = new DiskAccessRepositoryBlockStore(new TestSystemProperties(), repository, PrecompiledContracts.BRIDGE_ADDR);
+                        Whitebox.setInternalState(bridgeSupport, "btcBlockStore", diskAccessRepositoryBlockStore);
+                    }
                 }
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
@@ -91,6 +91,14 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
         ));
     }
 
+    @Test
+    public void getBtcTransactionConfirmations_Hundred() {
+        BridgePerformanceTest.addStats(estimateGetBtcTransactionConfirmations(
+                "getBtcTransactionConfirmations-hundred",
+                2000, 100, 750, 3000
+        ));
+    }
+
     private ExecutionStats estimateGetBtcTransactionConfirmations(
             String caseName,
             int times, int confirmations, int  minTransactions,

--- a/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
@@ -83,6 +83,14 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
         BridgePerformanceTest.addStats(stats);
     }
 
+    @Test
+    public void getBtcTransactionConfirmations_Zero() {
+        BridgePerformanceTest.addStats(estimateGetBtcTransactionConfirmations(
+                "getBtcTransactionConfirmations-zero",
+                2000, 0, 750, 3000
+        ));
+    }
+
     private ExecutionStats estimateGetBtcTransactionConfirmations(
             String caseName,
             int times, int confirmations, int  minTransactions,

--- a/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/GetBtcTransactionConfirmationsTest.java
@@ -38,33 +38,53 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
     @Before
     public void setRskipToTrue() {
         config.setBlockchainConfig(new RegTestSecondForkConfig());
+        warmUp();
     }
 
-    @Test
-    public void getBtcTransactionConfirmations() {
-        CombinedExecutionStats stats = new CombinedExecutionStats("getBtcTransactionConfirmations");
-
+    private void warmUp() {
         // Doing an initial estimation gets some things cached and speeds up the rest,
         // so that we get even numbers at the end
         System.out.print("Doing an initial pass... ");
         setQuietMode(true);
-        estimateGetBtcTransactionConfirmations(20, 4000, 750, 1000);
+        estimateGetBtcTransactionConfirmations("foo", 20, 4000, 750, 1000);
         setQuietMode(false);
         System.out.print("Done!\n");
+    }
+
+    @Test
+    public void getBtcTransactionConfirmations_Weighed() {
+        final String CASE_NAME = "getBtcTransactionConfirmations-weighed";
+        CombinedExecutionStats stats = new CombinedExecutionStats(CASE_NAME);
 
         // We always consider the average BTC block case from https://www.blockchain.com/charts/n-transactions-per-block
 
         // One day of BTC blocks
-        stats.add(estimateGetBtcTransactionConfirmations(300, 144, 750, 3000));
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 300, 144, 750, 3000));
         // Maximum number of confirmations
-        stats.add(estimateGetBtcTransactionConfirmations(10, BridgeSupport.BTC_TRANSACTION_CONFIRMATION_MAX_DEPTH, 750, 3000));
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 10, BridgeSupport.BTC_TRANSACTION_CONFIRMATION_MAX_DEPTH, 750, 3000));
         // Single confirmation
-        stats.add(estimateGetBtcTransactionConfirmations(10, 0,750,3000));
+        stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 10, 0,750,3000));
+
+        BridgePerformanceTest.addStats(stats);
+    }
+
+    @Test
+    public void getBtcTransactionConfirmations_Even() {
+        final String CASE_NAME = "getBtcTransactionConfirmations-even";
+        CombinedExecutionStats stats = new CombinedExecutionStats(CASE_NAME);
+
+        // Up to two days of confirmations (average of 6 blocks per hour)
+        final int MAX_CONFIRMATIONS = 6*24*2;
+
+        for (int numConfirmations = 0; numConfirmations <= MAX_CONFIRMATIONS; numConfirmations++) {
+            stats.add(estimateGetBtcTransactionConfirmations(CASE_NAME, 100, numConfirmations, 750, 3000));
+        }
 
         BridgePerformanceTest.addStats(stats);
     }
 
     private ExecutionStats estimateGetBtcTransactionConfirmations(
+            String caseName,
             int times, int confirmations, int  minTransactions,
             int maxTransactions) {
 
@@ -76,7 +96,7 @@ public class GetBtcTransactionConfirmationsTest extends BridgePerformanceTestCas
                 maxTransactions
         );
 
-        String name = String.format("getBtcTransactionConfirmations-confirmations-%d", confirmations);
+        String name = String.format("%s-%d", caseName, confirmations);
         ExecutionStats stats = new ExecutionStats(name);
 
         executeAndAverage(


### PR DESCRIPTION
This PR sets the (dynamic) gas cost for the new Bridge method getBtcTransactionConfirmations. It also adds a few extra estimation tests that helped in the actual dynamic function calculation.

The cost calculation and its error handling are also unit tested.

The cost itself is based upon an interpolation of two cases (zero confirmations vs. one hundred confirmations), each averaged from 2000 random cases. Details on these tests can be seen [here](https://docs.google.com/spreadsheets/d/1c4b2vCcpCKVhZ7opEH_OlLn8LIeiGPyRdBtjL1xJSKA/edit?usp=sharing).