### PR TITLE
Rskip-121 Logging an event after a successful lock operation (BTC=>RSK)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -185,6 +185,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final DataWord UPDATE_COLLECTIONS_TOPIC = DataWord.fromString("update_collections_topic");
     public static final DataWord ADD_SIGNATURE_TOPIC = DataWord.fromString("add_signature_topic");
     public static final DataWord COMMIT_FEDERATION_TOPIC = DataWord.fromString("commit_federation_topic");
+    public static final DataWord LOCK_BTC_TOPIC = DataWord.fromString("lock_btc_topic");
 
     private final BridgeConstants bridgeConstants;
 
@@ -413,7 +414,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
         byte[] pmtSerialized = (byte[]) args[2];
         try {
-            bridgeSupport.registerBtcTransaction(rskTx, btcTxSerialized, height, pmtSerialized);
+            bridgeSupport.registerBtcTransaction(rskTx, btcTxSerialized, height, pmtSerialized, blockchainConfig.isRskip121());
         } catch (IOException | BlockStoreException e) {
             logger.warn("Exception in registerBtcTransaction", e);
             throw new RuntimeException("Exception in registerBtcTransaction", e);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -272,10 +272,11 @@ public class BridgeSupport {
      * @param btcTxSerialized The raw BTC tx
      * @param height The height of the BTC block that contains the tx
      * @param pmtSerialized The raw partial Merkle tree
+     * @param logSuccessfulLock Whether to log an event if the lock succeeds
      * @throws BlockStoreException
      * @throws IOException
      */
-    public void registerBtcTransaction(Transaction rskTx, byte[] btcTxSerialized, int height, byte[] pmtSerialized) throws IOException, BlockStoreException {
+    public void registerBtcTransaction(Transaction rskTx, byte[] btcTxSerialized, int height, byte[] pmtSerialized, boolean logSuccessfulLock) throws IOException, BlockStoreException {
         Context.propagate(btcContext);
 
         Sha256Hash btcTxHash = BtcTransactionFormatUtils.calculateBtcTxHash(btcTxSerialized);
@@ -429,6 +430,10 @@ public class BridgeSupport {
 
                 // Consume this whitelisted address
                 lockWhitelist.consume(senderBtcAddress);
+
+                if (logSuccessfulLock) {
+                    eventLogger.logLockBtc(btcTx);
+                }
             }
         } else if (BridgeUtils.isReleaseTx(btcTx, getLiveFederations())) {
             logger.debug("This is a release tx {}", btcTx);

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -41,4 +41,6 @@ public interface BridgeEventLogger {
     void logReleaseBtc(BtcTransaction btcTx);
 
     void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation);
+
+    void logLockBtc(BtcTransaction btcTx);
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -93,6 +93,13 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
         this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
     }
 
+    public void logLockBtc(BtcTransaction btcTx) {
+        List<DataWord> topics = Collections.singletonList(Bridge.LOCK_BTC_TOPIC);
+        byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()), RLP.encodeElement(btcTx.bitcoinSerialize()));
+
+        this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
+    }
+
     private byte[] flatKeysAsRlpCollection(List<BtcECKey> keys) {
         List<byte[]> pubKeys = keys.stream()
                                     .map(k -> RLP.encodeElement(k.getPubKey()))

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -60,5 +60,7 @@ public interface BlockchainConfig {
 
     boolean isRskip120();
 
+    boolean isRskip121();
+
     boolean isRskip123();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/BlockchainConfigImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/BlockchainConfigImpl.java
@@ -121,6 +121,11 @@ public class BlockchainConfigImpl implements BlockchainConfig {
     }
 
     @Override
+    public boolean isRskip121() {
+        return activationConfig.isActive(RSKIP121, blockNumber);
+    }
+
+    @Override
     public boolean isRskip123() {
         return activationConfig.isActive(RSKIP123, blockNumber);
     }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -34,6 +34,7 @@ public enum ConsensusRule {
     RSKIP98("rskip98"),
     RSKIP103("rskip103"),
     RSKIP120("rskip120"),
+    RSKIP121("rskip121"),
     RSKIP123("rskip123");
 
     private String configKey;

--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -22,6 +22,7 @@ blockchain.config {
         rskip98 = orchid,
         rskip103 = orchid060,
         rskip120 = secondFork,
+        rskip121 = secondFork,
         rskip123 = secondFork
     }
 }

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -22,6 +22,7 @@ blockchain.config {
         rskip98 = orchid,
         rskip103 = orchid060,
         rskip120 = secondFork,
+        rskip121 = secondFork,
         rskip123 = secondFork
     }
 }

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -22,6 +22,7 @@ blockchain.config {
         rskip98 = orchid,
         rskip103 = orchid060,
         rskip120 = secondFork,
+        rskip121 = secondFork,
         rskip123 = secondFork
     }
 }

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -21,6 +21,7 @@ blockchain.config {
         rskip98 = genesis,
         rskip103 = orchid060,
         rskip120 = secondFork,
+        rskip121 = secondFork,
         rskip123 = secondFork
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1202,7 +1202,7 @@ public class BridgeSupportTest {
 
         BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, mock(BridgeEventLogger.class), track, null, null, null);
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 0, null);
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 0, null, false);
         bridgeSupport.save();
 
         track.commit();
@@ -1233,7 +1233,7 @@ public class BridgeSupportTest {
 
         PartialMerkleTree pmt = new PartialMerkleTree(btcParams, bits, hashes, 1);
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 0, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 0, pmt.bitcoinSerialize(), false);
         bridgeSupport.save();
 
         track.commit();
@@ -1264,7 +1264,7 @@ public class BridgeSupportTest {
 
         PartialMerkleTree pmt = new PartialMerkleTree(btcParams, bits, hashes, 1);
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), -1, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), -1, pmt.bitcoinSerialize(), false);
         bridgeSupport.save();
 
         track.commit();
@@ -1295,7 +1295,7 @@ public class BridgeSupportTest {
 
         PartialMerkleTree pmt = new PartialMerkleTree(btcParams, bits, hashes, 1);
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 1, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 1, pmt.bitcoinSerialize(), false);
         bridgeSupport.save();
 
         track.commit();
@@ -1339,7 +1339,7 @@ public class BridgeSupportTest {
                 null
         );
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), noInputsTx.bitcoinSerialize(), btcTxHeight, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), noInputsTx.bitcoinSerialize(), btcTxHeight, pmt.bitcoinSerialize(), false);
     }
 
     @Test
@@ -1374,7 +1374,7 @@ public class BridgeSupportTest {
 
         btcBlockChain.add(block);
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 1, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 1, pmt.bitcoinSerialize(), false);
         bridgeSupport.save();
 
         track.commit();
@@ -1435,7 +1435,8 @@ public class BridgeSupportTest {
 
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, bridgeConstants, bridgeStorageConfigurationAtHeightZero);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, null, track, executionBlock, btcBlockStore, null);
+        BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, mockedEventLogger, track, executionBlock, btcBlockStore, null);
 
         byte[] bits = new byte[1];
         bits[0] = 0x01;
@@ -1452,7 +1453,7 @@ public class BridgeSupportTest {
         // so that the blockchain can be iterated and the block found
         mockChainOfStoredBlocks(btcBlockStore, registerHeader, 35, 30);
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 30, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), false);
         bridgeSupport.save();
 
         track.commit();
@@ -1468,6 +1469,8 @@ public class BridgeSupportTest {
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertEquals(1, provider2.getBtcTxHashesAlreadyProcessed().size());
+
+        verify(mockedEventLogger, never()).logLockBtc(any(BtcTransaction.class));
     }
 
     @Test
@@ -1529,7 +1532,9 @@ public class BridgeSupportTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(track, contractAddress, bridgeConstants, bridgeStorageConfigurationAtHeightZero);
         provider.setNewFederation(activeFederation);
         provider.setOldFederation(retiringFederation);
-        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, null, track, executionBlock, btcBlockStore, null);
+
+        BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, mockedEventLogger, track, executionBlock, btcBlockStore, null);
 
         byte[] bits = new byte[1];
         bits[0] = 0x3f;
@@ -1546,7 +1551,7 @@ public class BridgeSupportTest {
         // so that the blockchain can be iterated and the block found
         mockChainOfStoredBlocks(btcBlockStore, registerHeader, 35, 30);
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 30, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), false);
         bridgeSupport.save();
 
         track.commit();
@@ -1555,6 +1560,8 @@ public class BridgeSupportTest {
         List<Coin> activeFederationBtcCoins = activeFederationBtcUTXOs.stream().map(UTXO::getValue).collect(Collectors.toList());
         assertThat(activeFederationBtcUTXOs, hasSize(1));
         assertThat(activeFederationBtcCoins, hasItem(Coin.COIN));
+
+        verify(mockedEventLogger, never()).logLockBtc(any(BtcTransaction.class));
     }
 
     @Test
@@ -1617,10 +1624,12 @@ public class BridgeSupportTest {
         PowerMockito.doReturn(false).when(BridgeUtils.class, "isLockTx", any(BtcTransaction.class), anyList(), any(Context.class), any(BridgeConstants.class));
         PowerMockito.doReturn(true).when(BridgeUtils.class, "isReleaseTx", any(BtcTransaction.class), anyList());
 
+        BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+
         BridgeSupport bridgeSupport = new BridgeSupport(
                 bridgeConstants,
                 mockBridgeStorageProvider,
-                mock(BridgeEventLogger.class),
+                mockedEventLogger,
                 mock(Repository.class),
                 mock(Block.class),
                 btcContext,
@@ -1629,7 +1638,7 @@ public class BridgeSupportTest {
                 mock(BtcBlockChain.class)
         );
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), releaseWithChangeTx.bitcoinSerialize(), 1, partialMerkleTree.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), releaseWithChangeTx.bitcoinSerialize(), 1, partialMerkleTree.bitcoinSerialize(), false);
 
         assertThat(retiringFederationUtxos, hasSize(1));
         UTXO changeUtxo = retiringFederationUtxos.get(0);
@@ -1643,6 +1652,8 @@ public class BridgeSupportTest {
 
         assertThat(releasedBtcTxCaptor.getValue(), is(releaseWithChangeTx));
         assertThat(fedListCaptor.getValue(), IsIterableContainingInOrder.contains(activeFederation, retiringFederation));
+
+        verify(mockedEventLogger, never()).logLockBtc(any(BtcTransaction.class));
     }
 
     @Test
@@ -1706,7 +1717,9 @@ public class BridgeSupportTest {
         whitelist.put(address2, new OneOffWhiteListEntry(address2, Coin.COIN.multiply(10)));
         whitelist.put(address3, new OneOffWhiteListEntry(address3, Coin.COIN.multiply(2).add(Coin.COIN.multiply(3))));
 
-        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, null, track, executionBlock, btcBlockStore, null);
+        BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, mockedEventLogger, track, executionBlock, btcBlockStore, null);
+
         byte[] bits = new byte[1];
         bits[0] = 0x3f;
 
@@ -1724,9 +1737,9 @@ public class BridgeSupportTest {
         // so that the blockchain can be iterated and the block found
         mockChainOfStoredBlocks(btcBlockStore, registerHeader, 35, 30);
 
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx1.bitcoinSerialize(), 30, pmt.bitcoinSerialize());
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx2.bitcoinSerialize(), 30, pmt.bitcoinSerialize());
-        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx3.bitcoinSerialize(), 30, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx1.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), false);
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx2.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), false);
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx3.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), false);
         bridgeSupport.save();
 
         track.commit();
@@ -1763,6 +1776,62 @@ public class BridgeSupportTest {
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertEquals(3, provider2.getBtcTxHashesAlreadyProcessed().size());
 
+        verify(mockedEventLogger, never()).logLockBtc(any(BtcTransaction.class));
+    }
+
+    @Test
+    public void registerBtcTransactionLockTxLogsLock() throws Exception {
+        List<BtcECKey> federation1Keys = Arrays.asList(new BtcECKey[]{
+                BtcECKey.fromPrivate(Hex.decode("fa01")),
+                BtcECKey.fromPrivate(Hex.decode("fa02")),
+        });
+        federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
+        Federation federation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, btcParams);
+
+        Repository repository = createRepositoryImpl();
+        repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
+        Block executionBlock = Mockito.mock(Block.class);
+        Mockito.when(executionBlock.getNumber()).thenReturn(10L);
+
+        Repository track = repository.startTracking();
+
+        BtcTransaction tx1 = new BtcTransaction(this.btcParams);
+        tx1.addOutput(Coin.COIN.multiply(5), federation.getAddress());
+        BtcECKey srcKey1 = new BtcECKey();
+        tx1.addInput(PegTestUtils.createHash(), 0, ScriptBuilder.createInputScript(null, srcKey1));
+
+        BtcBlockstoreWithCache btcBlockStore = mock(BtcBlockstoreWithCache.class);
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, bridgeStorageConfigurationAtHeightZero);
+        provider.setNewFederation(federation);
+
+        // Whitelist the addresses
+        LockWhitelist whitelist = provider.getLockWhitelist();
+        Address address1 = srcKey1.toAddress(btcParams);
+        whitelist.put(address1, new OneOffWhiteListEntry(address1, Coin.COIN.multiply(5)));
+
+        BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, mockedEventLogger, track, executionBlock, btcBlockStore, null);
+        byte[] bits = new byte[1];
+        bits[0] = 0x3f;
+
+        List<Sha256Hash> hashes = new ArrayList<>();
+        hashes.add(tx1.getHash());
+        PartialMerkleTree pmt = new PartialMerkleTree(btcParams, bits, hashes, 1);
+        List<Sha256Hash> hashlist = new ArrayList<>();
+        Sha256Hash merkleRoot = pmt.getTxnHashAndMerkleRoot(hashlist);
+
+        co.rsk.bitcoinj.core.BtcBlock registerHeader = new co.rsk.bitcoinj.core.BtcBlock(btcParams, 1, PegTestUtils.createHash(), merkleRoot, 1, 1, 1, new ArrayList<BtcTransaction>());
+
+        // Simulate that the block is in there but that there is a chain of blocks on top of it,
+        // so that the blockchain can be iterated and the block found
+        mockChainOfStoredBlocks(btcBlockStore, registerHeader, 35, 30);
+        bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx1.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), true);
+        bridgeSupport.save();
+
+        track.commit();
+
+        verify(mockedEventLogger, times(1)).logLockBtc(tx1);
     }
 
     @Test
@@ -1817,7 +1886,8 @@ public class BridgeSupportTest {
         provider.setNewFederation(federation1);
         provider.setOldFederation(federation2);
 
-        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, null, track, executionBlock, btcBlockStore, null);
+        BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        BridgeSupport bridgeSupport = new BridgeSupport(bridgeConstants, provider, mockedEventLogger, track, executionBlock, btcBlockStore, null);
         byte[] bits = new byte[1];
         bits[0] = 0x3f;
 
@@ -1839,9 +1909,9 @@ public class BridgeSupportTest {
         Transaction rskTx2 = getMockedRskTxWithHash("bb");
         Transaction rskTx3 = getMockedRskTxWithHash("cc");
 
-        bridgeSupport.registerBtcTransaction(rskTx1, tx1.bitcoinSerialize(), 30, pmt.bitcoinSerialize());
-        bridgeSupport.registerBtcTransaction(rskTx2, tx2.bitcoinSerialize(), 30, pmt.bitcoinSerialize());
-        bridgeSupport.registerBtcTransaction(rskTx3, tx3.bitcoinSerialize(), 30, pmt.bitcoinSerialize());
+        bridgeSupport.registerBtcTransaction(rskTx1, tx1.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), false);
+        bridgeSupport.registerBtcTransaction(rskTx2, tx2.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), false);
+        bridgeSupport.registerBtcTransaction(rskTx3, tx3.bitcoinSerialize(), 30, pmt.bitcoinSerialize(), false);
         bridgeSupport.save();
 
         track.commit();
@@ -1901,6 +1971,8 @@ public class BridgeSupportTest {
 
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertEquals(3, provider2.getBtcTxHashesAlreadyProcessed().size());
+
+        verify(mockedEventLogger, never()).logLockBtc(any(BtcTransaction.class));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -19,9 +19,11 @@
 package co.rsk.peg.utils;
 
 import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.core.RskAddress;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.Federation;
 import co.rsk.peg.FederationMember;
@@ -54,7 +56,6 @@ import static org.mockito.Mockito.when;
  * @author martin.medina
  */
 public class BridgeEventLoggerImplTest {
-
     @Test
     public void logCommitFederation() {
         // Setup event logger
@@ -136,5 +137,31 @@ public class BridgeEventLoggerImplTest {
 
         // Assert new federation activation block number
         Assert.assertEquals(15L + BridgeRegTestConstants.getInstance().getFederationActivationAge(), Long.valueOf(new String(dataList.get(2).getRLPData(), StandardCharsets.UTF_8)).longValue());
+    }
+
+    @Test
+    public void logLockBtc() {
+        // Setup event logger
+        List<LogInfo> eventLogs = new LinkedList<>();
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(null, eventLogs);
+
+        // Mock btc transaction
+        BtcTransaction mockedTx = mock(BtcTransaction.class);
+        when(mockedTx.getHashAsString()).thenReturn("a-tx-hash");
+        when(mockedTx.bitcoinSerialize()).thenReturn(Hex.decode("1122334455"));
+
+        eventLogger.logLockBtc(mockedTx);
+
+        Assert.assertEquals(1, eventLogs.size());
+        LogInfo entry = eventLogs.get(0);
+
+        Assert.assertEquals(PrecompiledContracts.BRIDGE_ADDR, new RskAddress(entry.getAddress()));
+
+        Assert.assertEquals(1, entry.getTopics().size());
+        Assert.assertEquals(Bridge.LOCK_BTC_TOPIC, entry.getTopics().get(0));
+
+        byte[] data = entry.getData();
+        byte[] expectedData = RLP.encodeList(RLP.encodeString("a-tx-hash"), RLP.encodeElement(Hex.decode("1122334455")));
+        Assert.assertTrue(Arrays.equals(data, expectedData));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -51,6 +51,7 @@ public class ActivationConfigTest {
             "    rskip98: orchid,",
             "    rskip103: orchid060,",
             "    rskip120: secondFork,",
+            "    rskip121: secondFork,",
             "    rskip123: secondFork",
             "}"
     ));


### PR DESCRIPTION
Currently the lock operation needs confirmations equivalent to a full day on MainNet.
The comunity wants to check if the lock operation was successful or not as soon as posible, this is the reason this event log was added.
Event Specification:
- Topic: "lock_btc_topic"
- Data: [ BTC Tx Hash, Serialized BTC Tx]

Changes made:
- Added isRskip121 flag, only active after "secondFork" fork
- Added LOCK_BTC_TOPIC to the Bridge
- BridgeSupport.registerBtcTransaction receives extra parameter that indicates whether to log, implemented logging
- Added and implemented BridgeEventLogger.logLockBtc
- Added Unit test for BridgeEventLoggerImpl.logLockBtc
- Added Testing log parameter call pre and post RSKIP-121 on the Bridge to BridgeSupport call