### PR TITLE
RSKIP123 Multiple fed keys (BTC, RSK & MST)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import com.google.common.collect.Lists;
 import org.ethereum.crypto.ECKey;
 import org.bouncycastle.util.encoders.Hex;
@@ -45,6 +46,10 @@ public class BridgeDevNetConstants extends BridgeConstants {
         List<BtcECKey> genesisFederationPublicKeys = Lists.newArrayList(
                 federator0PublicKey, federator1PublicKey, federator2PublicKey
         );
+
+        // IMPORTANT: BTC, RSK and MST keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
         
         // Currently set to:
         // Monday, November 13, 2017 9:00:00 PM GMT-03:00
@@ -53,7 +58,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
         // Expected federation address is:
         // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
         genesisFederation = new Federation(
-                genesisFederationPublicKeys,
+                federationMembers,
                 genesisFederationAddressCreatedAt,
                 1L,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -5,6 +5,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import com.google.common.collect.Lists;
 import org.ethereum.crypto.ECKey;
 import org.bouncycastle.util.encoders.Hex;
@@ -44,12 +45,16 @@ public class BridgeMainNetConstants extends BridgeConstants {
                 federator12PublicKey, federator13PublicKey, federator14PublicKey
         );
 
+        // IMPORTANT: BTC, RSK and MST keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
+
         // Currently set to:
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400l);
         
         genesisFederation = new Federation(
-                genesisFederationPublicKeys,
+                federationMembers,
                 genesisFederationAddressCreatedAt,
                 1L,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import com.google.common.collect.Lists;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -50,10 +51,14 @@ public class BridgeRegTestConstants extends BridgeConstants {
         federatorPrivateKeys = Lists.newArrayList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey);
         List<BtcECKey> federatorPublicKeys = federatorPrivateKeys.stream().map(key -> BtcECKey.fromPublicOnly(key.getPubKey())).collect(Collectors.toList());
 
+        // IMPORTANT: BTC, RSK and MST keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federatorPublicKeys);
+
         Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
         genesisFederation = new Federation(
-                federatorPublicKeys,
+                federationMembers,
                 genesisFederationCreatedAt,
                 1L,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -23,8 +23,9 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
-import org.ethereum.crypto.ECKey;
+import co.rsk.peg.FederationMember;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -44,11 +45,16 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         List<BtcECKey> genesisFederationPublicKeys = Arrays.asList(federator0PublicKey, federator1PublicKey, federator2PublicKey, federator3PublicKey);
 
+        // IMPORTANT: BTC, RSK and MST keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
+
+        // Currently set to:
         // Currently set to: Monday, October 8, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1538967600l);
 
         genesisFederation = new Federation(
-                genesisFederationPublicKeys,
+                federationMembers,
                 genesisFederationAddressCreatedAt,
                 1L,
                 getBtcParams()

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -111,6 +111,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function GET_FEDERATION_THRESHOLD = BridgeMethods.GET_FEDERATION_THRESHOLD.getFunction();
     // Returns the public key of the federator at the specified index
     public static final CallTransaction.Function GET_FEDERATOR_PUBLIC_KEY = BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction();
+    // Returns the public key of given type of the federator at the specified index
+    public static final CallTransaction.Function GET_FEDERATOR_PUBLIC_KEY_OF_TYPE = BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction();
     // Returns the creation time of the federation
     public static final CallTransaction.Function GET_FEDERATION_CREATION_TIME = BridgeMethods.GET_FEDERATION_CREATION_TIME.getFunction();
     // Returns the block number of the creation of the federation
@@ -124,6 +126,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function GET_RETIRING_FEDERATION_THRESHOLD = BridgeMethods.GET_RETIRING_FEDERATION_THRESHOLD.getFunction();
     // Returns the public key of the retiring federation's federator at the specified index
     public static final CallTransaction.Function GET_RETIRING_FEDERATOR_PUBLIC_KEY = BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction();
+    // Returns the public key of given type of the retiring federation's federator at the specified index
+    public static final CallTransaction.Function GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE = BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction();
     // Returns the creation time of the retiring federation
     public static final CallTransaction.Function GET_RETIRING_FEDERATION_CREATION_TIME = BridgeMethods.GET_RETIRING_FEDERATION_CREATION_TIME.getFunction();
     // Returns the block number of the creation of the retiring federation
@@ -144,6 +148,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function GET_PENDING_FEDERATION_SIZE = BridgeMethods.GET_PENDING_FEDERATION_SIZE.getFunction();
     // Returns the public key of the federator at the specified index for the current pending federation
     public static final CallTransaction.Function GET_PENDING_FEDERATOR_PUBLIC_KEY = BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction();
+    // Returns the public key of given type the federator at the specified index for the current pending federation
+    public static final CallTransaction.Function GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE = BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction();
 
     // Returns the lock whitelist size
     public static final CallTransaction.Function GET_LOCK_WHITELIST_SIZE = BridgeMethods.GET_LOCK_WHITELIST_SIZE.getFunction();
@@ -608,6 +614,23 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return bridgeSupport.getFederatorPublicKey(index);
     }
 
+    public byte[] getFederatorPublicKeyOfType(Object[] args)
+    {
+        logger.trace("getFederatorPublicKeyOfType");
+
+        int index = ((BigInteger) args[0]).intValue();
+
+        FederationMember.KeyType keyType;
+        try {
+            keyType = FederationMember.KeyType.byValue((String) args[1]);
+        } catch (Exception e) {
+            logger.warn("Exception in getFederatorPublicKeyOfType", e);
+            throw new RuntimeException("Exception in getFederatorPublicKeyOfType", e);
+        }
+
+        return bridgeSupport.getFederatorPublicKeyOfType(index, keyType);
+    }
+
     public Long getFederationCreationTime(Object[] args)
     {
         logger.trace("getFederationCreationTime");
@@ -655,6 +678,30 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
         int index = ((BigInteger) args[0]).intValue();
         byte[] publicKey = bridgeSupport.getRetiringFederatorPublicKey(index);
+
+        if (publicKey == null) {
+            // Empty array is returned when public key is not found or there's no retiring federation
+            return new byte[]{};
+        }
+
+        return publicKey;
+    }
+
+    public byte[] getRetiringFederatorPublicKeyOfType(Object[] args)
+    {
+        logger.trace("getRetiringFederatorPublicKeyOfType");
+
+        int index = ((BigInteger) args[0]).intValue();
+
+        FederationMember.KeyType keyType;
+        try {
+            keyType = FederationMember.KeyType.byValue((String) args[1]);
+        } catch (Exception e) {
+            logger.warn("Exception in getRetiringFederatorPublicKeyOfType", e);
+            throw new RuntimeException("Exception in getRetiringFederatorPublicKeyOfType", e);
+        }
+
+        byte[] publicKey = bridgeSupport.getRetiringFederatorPublicKeyOfType(index, keyType);
 
         if (publicKey == null) {
             // Empty array is returned when public key is not found or there's no retiring federation
@@ -767,6 +814,30 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
         int index = ((BigInteger) args[0]).intValue();
         byte[] publicKey = bridgeSupport.getPendingFederatorPublicKey(index);
+
+        if (publicKey == null) {
+            // Empty array is returned when public key is not found
+            return new byte[]{};
+        }
+
+        return publicKey;
+    }
+
+    public byte[] getPendingFederatorPublicKeyOfType(Object[] args)
+    {
+        logger.trace("getPendingFederatorPublicKeyOfType");
+
+        int index = ((BigInteger) args[0]).intValue();
+
+        FederationMember.KeyType keyType;
+        try {
+            keyType = FederationMember.KeyType.byValue((String) args[1]);
+        } catch (Exception e) {
+            logger.warn("Exception in getPendingFederatorPublicKeyOfType", e);
+            throw new RuntimeException("Exception in getPendingFederatorPublicKeyOfType", e);
+        }
+
+        byte[] publicKey = bridgeSupport.getPendingFederatorPublicKeyOfType(index, keyType);
 
         if (publicKey == null) {
             // Empty array is returned when public key is not found

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -137,6 +137,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function CREATE_FEDERATION = BridgeMethods.CREATE_FEDERATION.getFunction();
     // Adds the given key to the current pending federation
     public static final CallTransaction.Function ADD_FEDERATOR_PUBLIC_KEY = BridgeMethods.ADD_FEDERATOR_PUBLIC_KEY.getFunction();
+    // Adds the given key to the current pending federation (multiple-key version)
+    public static final CallTransaction.Function ADD_FEDERATOR_PUBLIC_KEY_MULTIKEY = BridgeMethods.ADD_FEDERATOR_PUBLIC_KEY_MULTIKEY.getFunction();
     // Commits the currently pending federation
     public static final CallTransaction.Function COMMIT_FEDERATION = BridgeMethods.COMMIT_FEDERATION.getFunction();
     // Rolls back the currently pending federation
@@ -745,17 +747,25 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     {
         logger.trace("addFederatorPublicKey");
 
-        byte[] publicKeyBytes;
-        try {
-            publicKeyBytes = (byte[]) args[0];
-        } catch (Exception e) {
-            logger.warn("Exception in addFederatorPublicKey", e);
-            return -10;
-        }
+        byte[] publicKeyBytes = (byte[]) args[0];
 
         return bridgeSupport.voteFederationChange(
                 rskTx,
                 new ABICallSpec("add", new byte[][]{ publicKeyBytes })
+        );
+    }
+
+    public Integer addFederatorPublicKeyMultikey(Object[] args)
+    {
+        logger.trace("addFederatorPublicKeyMultikey");
+
+        byte[] btcPublicKeyBytes = (byte[]) args[0];
+        byte[] rskPublicKeyBytes = (byte[]) args[1];
+        byte[] mstPublicKeyBytes = (byte[]) args[2];
+
+        return bridgeSupport.voteFederationChange(
+                rskTx,
+                new ABICallSpec("add-multi", new byte[][]{ btcPublicKeyBytes, rskPublicKeyBytes, mstPublicKeyBytes })
         );
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -747,7 +747,13 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     {
         logger.trace("addFederatorPublicKey");
 
-        byte[] publicKeyBytes = (byte[]) args[0];
+        byte[] publicKeyBytes;
+        try {
+            publicKeyBytes = (byte[]) args[0];
+        } catch (Exception e) {
+            logger.warn("Exception in addFederatorPublicKey", e);
+            return -10;
+        }
 
         return bridgeSupport.voteFederationChange(
                 rskTx,

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeBtcWallet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeBtcWallet.java
@@ -52,6 +52,6 @@ public class BridgeBtcWallet extends Wallet {
         if (!destinationFederation.isPresent()) {
             return null;
         }
-        return RedeemData.of(destinationFederation.get().getPublicKeys(), destinationFederation.get().getRedeemScript());
+        return RedeemData.of(destinationFederation.get().getBtcPublicKeys(), destinationFederation.get().getRedeemScript());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -39,6 +39,18 @@ public enum BridgeMethods {
             ),
             13000L,
             (BridgeMethodExecutorTyped) Bridge::addFederatorPublicKey,
+            blockchainConfig -> !blockchainConfig.isRskipMultipleKeyFederateMembers(),
+            false
+    ),
+    ADD_FEDERATOR_PUBLIC_KEY_MULTIKEY(
+            CallTransaction.Function.fromSignature(
+                    "addFederatorPublicKeyMultikey",
+                    new String[]{"bytes", "bytes", "bytes"},
+                    new String[]{"int256"}
+            ),
+            13000L,
+            (BridgeMethodExecutorTyped) Bridge::addFederatorPublicKeyMultikey,
+            blockchainConfig -> blockchainConfig.isRskipMultipleKeyFederateMembers(),
             false
     ),
     ADD_LOCK_WHITELIST_ADDRESS(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -39,7 +39,7 @@ public enum BridgeMethods {
             ),
             13000L,
             (BridgeMethodExecutorTyped) Bridge::addFederatorPublicKey,
-            blockchainConfig -> !blockchainConfig.isRskipMultipleKeyFederateMembers(),
+            blockchainConfig -> !blockchainConfig.isRskip123(),
             false
     ),
     ADD_FEDERATOR_PUBLIC_KEY_MULTIKEY(
@@ -50,7 +50,7 @@ public enum BridgeMethods {
             ),
             13000L,
             (BridgeMethodExecutorTyped) Bridge::addFederatorPublicKeyMultikey,
-            blockchainConfig -> blockchainConfig.isRskipMultipleKeyFederateMembers(),
+            blockchainConfig -> blockchainConfig.isRskip123(),
             false
     ),
     ADD_LOCK_WHITELIST_ADDRESS(
@@ -227,7 +227,7 @@ public enum BridgeMethods {
             ),
             10000L,
             (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKey,
-            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            blockChainConfig -> !blockChainConfig.isRskip123(),
             true
     ),
     GET_FEDERATOR_PUBLIC_KEY_OF_TYPE(
@@ -238,7 +238,7 @@ public enum BridgeMethods {
             ),
             10000L,
             (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKeyOfType,
-            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            blockChainConfig -> blockChainConfig.isRskip123(),
             true
     ),
     GET_FEE_PER_KB(
@@ -320,7 +320,7 @@ public enum BridgeMethods {
             ),
             3000L,
             (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKey,
-            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            blockChainConfig -> !blockChainConfig.isRskip123(),
             true
     ),
     GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE(
@@ -331,7 +331,7 @@ public enum BridgeMethods {
             ),
             3000L,
             (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKeyOfType,
-            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            blockChainConfig -> blockChainConfig.isRskip123(),
             true
     ),
     GET_RETIRING_FEDERATION_ADDRESS(
@@ -392,7 +392,7 @@ public enum BridgeMethods {
             ),
             3000L,
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKey,
-            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            blockChainConfig -> !blockChainConfig.isRskip123(),
             true
     ),
     GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE(
@@ -403,7 +403,7 @@ public enum BridgeMethods {
             ),
             3000L,
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKeyOfType,
-            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            blockChainConfig -> blockChainConfig.isRskip123(),
             true
     ),
     GET_STATE_FOR_BTC_RELEASE_CLIENT(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -215,6 +215,18 @@ public enum BridgeMethods {
             ),
             10000L,
             (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKey,
+            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            true
+    ),
+    GET_FEDERATOR_PUBLIC_KEY_OF_TYPE(
+            CallTransaction.Function.fromSignature(
+                    "getFederatorPublicKeyOfType",
+                    new String[]{"int256", "string"},
+                    new String[]{"bytes"}
+            ),
+            10000L,
+            (BridgeMethodExecutorTyped) Bridge::getFederatorPublicKeyOfType,
+            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
     GET_FEE_PER_KB(
@@ -296,6 +308,18 @@ public enum BridgeMethods {
             ),
             3000L,
             (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKey,
+            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            true
+    ),
+    GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE(
+            CallTransaction.Function.fromSignature(
+                    "getPendingFederatorPublicKeyOfType",
+                    new String[]{"int256", "string"},
+                    new String[]{"bytes"}
+            ),
+            3000L,
+            (BridgeMethodExecutorTyped) Bridge::getPendingFederatorPublicKeyOfType,
+            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
     GET_RETIRING_FEDERATION_ADDRESS(
@@ -356,6 +380,18 @@ public enum BridgeMethods {
             ),
             3000L,
             (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKey,
+            blockChainConfig -> !blockChainConfig.isRskipMultipleKeyFederateMembers(),
+            true
+    ),
+    GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE(
+            CallTransaction.Function.fromSignature(
+                    "getRetiringFederatorPublicKeyOfType",
+                    new String[]{"int256", "string"},
+                    new String[]{"bytes"}
+            ),
+            3000L,
+            (BridgeMethodExecutorTyped) Bridge::getRetiringFederatorPublicKeyOfType,
+            blockChainConfig -> blockChainConfig.isRskipMultipleKeyFederateMembers(),
             true
     ),
     GET_STATE_FOR_BTC_RELEASE_CLIENT(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -609,6 +609,14 @@ public class BridgeSerializationUtils {
         return new ReleaseTransactionSet(entries);
     }
 
+    public static byte[] serializeInteger(Integer value) {
+        return RLP.encodeBigInteger(BigInteger.valueOf(value));
+    }
+
+    public static Integer deserializeInteger(byte[] data) {
+        return RLP.decodeBigInteger(data, 0).intValue();
+    }
+
     // An ABI call spec is serialized as:
     // function name encoded in UTF-8
     // arg_1, ..., arg_n

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -25,6 +25,7 @@ import co.rsk.peg.whitelist.OneOffWhiteListEntry;
 import co.rsk.peg.whitelist.UnlimitedWhiteListEntry;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bouncycastle.util.BigIntegers;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
@@ -47,7 +48,13 @@ public class BridgeSerializationUtils {
     private static final int FEDERATION_RLP_LIST_SIZE = 3;
     private static final int FEDERATION_CREATION_TIME_INDEX = 0;
     private static final int FEDERATION_CREATION_BLOCK_NUMBER_INDEX = 1;
-    private static final int FEDERATION_PUB_KEYS_INDEX = 2;
+    private static final int FEDERATION_MEMBERS_INDEX = 2;
+
+    private static final int FEDERATION_MEMBER_LIST_SIZE = 3;
+    private static final int FEDERATION_MEMBER_BTC_KEY_INDEX = 0;
+    private static final int FEDERATION_MEMBER_RSK_KEY_INDEX = 1;
+    private static final int FEDERATION_MEMBER_MST_KEY_INDEX = 2;
+
 
     private BridgeSerializationUtils(){}
 
@@ -201,24 +208,42 @@ public class BridgeSerializationUtils {
         return map;
     }
 
-    // A federation is serialized as a list in the following order:
-    // creation time
-    // list of public keys -> [pubkey1, pubkey2, ..., pubkeyn], sorted
-    // using the lexicographical order of the public keys (see BtcECKey.PUBKEY_COMPARATOR).
-    public static byte[] serializeFederation(Federation federation) {
-        List<byte[]> publicKeys = federation.getBtcPublicKeys().stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(key -> RLP.encodeElement(key.getPubKey()))
+    private interface FederationMemberSerializer {
+        byte[] serialize(FederationMember federationMember);
+    }
+
+    private interface FederationMemberDesserializer {
+        FederationMember deserialize(byte[] data);
+    }
+
+    /**
+     * A federation is serialized as a list in the following order:
+     * - creation time
+     * - creation block number
+     * - list of federation members -> [member1, member2, ..., membern], sorted
+     * using the lexicographical order of the public keys of the members
+     * (see FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).
+     * Each federation member is in turn serialized using the provided FederationMemberSerializer.
+     */
+    private static byte[] serializeFederationWithSerializer(Federation federation, FederationMemberSerializer federationMemberSerializer) {
+        List<byte[]> federationMembers = federation.getMembers().stream()
+                .sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR)
+                .map(member -> RLP.encodeElement(federationMemberSerializer.serialize(member)))
                 .collect(Collectors.toList());
+
         byte[][] rlpElements = new byte[FEDERATION_RLP_LIST_SIZE][];
         rlpElements[FEDERATION_CREATION_TIME_INDEX] = RLP.encodeBigInteger(BigInteger.valueOf(federation.getCreationTime().toEpochMilli()));
         rlpElements[FEDERATION_CREATION_BLOCK_NUMBER_INDEX] = RLP.encodeBigInteger(BigInteger.valueOf(federation.getCreationBlockNumber()));
-        rlpElements[FEDERATION_PUB_KEYS_INDEX] = RLP.encodeList((byte[][])publicKeys.toArray(new byte[publicKeys.size()][]));
+        rlpElements[FEDERATION_MEMBERS_INDEX] = RLP.encodeList((byte[][])federationMembers.toArray(new byte[federationMembers.size()][]));
         return RLP.encodeList(rlpElements);
     }
 
-    // For the serialization format, see BridgeSerializationUtils::serializeFederation
-    public static Federation deserializeFederation(byte[] data, NetworkParameters networkParameters) {
+    // For the serialization format, see BridgeSerializationUtils::serializeFederationWithSerializer
+    private static Federation deserializeFederationWithDesserializer(
+        byte[] data,
+        NetworkParameters networkParameters,
+        FederationMemberDesserializer federationMemberDesserializer) {
+
         RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
 
         if (rlpList.size() != FEDERATION_RLP_LIST_SIZE) {
@@ -228,35 +253,121 @@ public class BridgeSerializationUtils {
         byte[] creationTimeBytes = rlpList.get(FEDERATION_CREATION_TIME_INDEX).getRLPData();
         Instant creationTime = Instant.ofEpochMilli(BigIntegers.fromUnsignedByteArray(creationTimeBytes).longValue());
 
-        // IMPORTANT: All BTC, RSK and MST public keys are the same.
-        // This is for compatibility with the pre <INSERT FORK NAME HERE> fork network.
-        List<FederationMember> federationMembers = ((RLPList) rlpList.get(FEDERATION_PUB_KEYS_INDEX)).stream()
-                .map(pubKeyBytes ->
-                        FederationMember.getFederationMemberFromKey(
-                                BtcECKey.fromPublicOnly(pubKeyBytes.getRLPData())
-                        )
-                ).collect(Collectors.toList());
-
         byte[] creationBlockNumberBytes = rlpList.get(FEDERATION_CREATION_BLOCK_NUMBER_INDEX).getRLPData();
         long creationBlockNumber = BigIntegers.fromUnsignedByteArray(creationBlockNumberBytes).longValue();
+
+        List<FederationMember> federationMembers = ((RLPList) rlpList.get(FEDERATION_MEMBERS_INDEX)).stream()
+                .map(memberBytes -> federationMemberDesserializer.deserialize(memberBytes.getRLPData()))
+                .collect(Collectors.toList());
 
         return new Federation(federationMembers, creationTime, creationBlockNumber, networkParameters);
     }
 
-    // A pending federation is serialized as the
-    // public keys conforming it.
-    // See BridgeSerializationUtils::serializePublicKeys
-    public static byte[] serializePendingFederation(PendingFederation pendingFederation) {
+    /**
+     * For the federation serialization format, see serializeFederationWithSerializer.
+     * For compatibility with blocks before the "secondFork" network upgrade,
+     * each federation member is serialized only as its compressed BTC public key.
+     */
+    public static byte[] serializeFederationOnlyBtcKeys(Federation federation) {
+        return serializeFederationWithSerializer(federation,
+                federationMember -> federationMember.getBtcPublicKey().getPubKeyPoint().getEncoded(true));
+    }
+
+    // For the serialization format, see BridgeSerializationUtils::serializeFederationOnlyBtcKeys
+    public static Federation deserializeFederationOnlyBtcKeys(byte[] data, NetworkParameters networkParameters) {
+        return deserializeFederationWithDesserializer(data, networkParameters,
+                (pubKeyBytes -> FederationMember.getFederationMemberFromKey(BtcECKey.fromPublicOnly(pubKeyBytes))));
+    }
+
+    /**
+     * For the federation serialization format, see serializeFederationWithSerializer.
+     * For the federation member serialization format, see serializeFederationMember.
+     */
+    public static byte[] serializeFederation(Federation federation) {
+        return serializeFederationWithSerializer(federation,
+                BridgeSerializationUtils::serializeFederationMember);
+    }
+
+    // For the serialization format, see BridgeSerializationUtils::serializeFederation
+    public static Federation deserializeFederation(byte[] data, NetworkParameters networkParameters) {
+        return deserializeFederationWithDesserializer(data, networkParameters,
+                BridgeSerializationUtils::deserializeFederationMember);
+    }
+
+    /**
+     * A FederationMember is serialized as a list in the following order:
+     * - BTC public key
+     * - RSK public key
+     * - MST public key
+     * All keys are stored in their COMPRESSED versions.
+     */
+    public static byte[] serializeFederationMember(FederationMember federationMember) {
+        byte[][] rlpElements = new byte[FEDERATION_MEMBER_LIST_SIZE][];
+        rlpElements[FEDERATION_MEMBER_BTC_KEY_INDEX] = RLP.encodeElement(
+                federationMember.getBtcPublicKey().getPubKeyPoint().getEncoded(true)
+        );
+        rlpElements[FEDERATION_MEMBER_RSK_KEY_INDEX] = RLP.encodeElement(federationMember.getRskPublicKey().getPubKey(true));
+        rlpElements[FEDERATION_MEMBER_MST_KEY_INDEX] = RLP.encodeElement(federationMember.getMstPublicKey().getPubKey(true));
+        return RLP.encodeList(rlpElements);
+    }
+
+    // For the serialization format, see BridgeSerializationUtils::serializeFederationMember
+    private static FederationMember deserializeFederationMember(byte[] data) {
+        RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
+
+        if (rlpList.size() != FEDERATION_RLP_LIST_SIZE) {
+            throw new RuntimeException(String.format("Invalid serialized FederationMember. Expected %d elements but got %d", FEDERATION_MEMBER_LIST_SIZE, rlpList.size()));
+        }
+
+        BtcECKey btcKey = BtcECKey.fromPublicOnly(rlpList.get(FEDERATION_MEMBER_BTC_KEY_INDEX).getRLPData());
+        ECKey rskKey = ECKey.fromPublicOnly(rlpList.get(FEDERATION_MEMBER_RSK_KEY_INDEX).getRLPData());
+        ECKey mstKey = ECKey.fromPublicOnly(rlpList.get(FEDERATION_MEMBER_MST_KEY_INDEX).getRLPData());
+
+        return new FederationMember(btcKey, rskKey, mstKey);
+    }
+
+    /**
+     * A pending federation is serialized as the
+     * public keys conforming it.
+     * This is a legacy format for blocks before the "secondFork"
+     * network upgrade.
+     * See BridgeSerializationUtils::serializeBtcPublicKeys
+     */
+    public static byte[] serializePendingFederationOnlyBtcKeys(PendingFederation pendingFederation) {
         return serializeBtcPublicKeys(pendingFederation.getBtcPublicKeys());
     }
 
-    // For the serialization format, see BridgeSerializationUtils::serializePendingFederation
-    // and serializePublicKeys::deserializePublicKeys
-    public static PendingFederation deserializePendingFederation(byte[] data) {
+    // For the serialization format, see BridgeSerializationUtils::serializePendingFederationOnlyBtcKeys
+    // and serializePublicKeys::deserializeBtcPublicKeys
+    public static PendingFederation deserializePendingFederationOnlyBtcKeys(byte[] data) {
         // BTC, RSK and MST keys are the same
         List<FederationMember> members = deserializeBtcPublicKeys(data).stream().map(pk ->
             FederationMember.getFederationMemberFromKey(pk)
         ).collect(Collectors.toList());
+
+        return new PendingFederation(members);
+    }
+
+    /**
+     * A pending federation is serialized as the
+     * list of its sorted members serialized.
+     * For the member serialization format, see BridgeSerializationUtils::serializeFederationMember
+     */
+    public static byte[] serializePendingFederation(PendingFederation pendingFederation) {
+        List<byte[]> encodedMembers = pendingFederation.getMembers().stream()
+                .sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR)
+                .map(BridgeSerializationUtils::serializeFederationMember)
+                .collect(Collectors.toList());
+        return RLP.encodeList(encodedMembers.toArray(new byte[0][]));
+    }
+
+    // For the serialization format, see BridgeSerializationUtils::serializePendingFederation
+    public static PendingFederation deserializePendingFederation(byte[] data) {
+        RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
+
+        List<FederationMember> members = rlpList.stream()
+                .map(memberBytes -> deserializeFederationMember(memberBytes.getRLPData()))
+                .collect(Collectors.toList());
 
         return new PendingFederation(members);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -23,9 +23,10 @@ import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.whitelist.OneOffWhiteListEntry;
 import co.rsk.peg.whitelist.UnlimitedWhiteListEntry;
+import org.apache.commons.lang3.tuple.Pair;
+import org.bouncycastle.util.BigIntegers;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
-import org.bouncycastle.util.BigIntegers;
 
 import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
@@ -37,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Created by mario on 20/04/17.
@@ -206,7 +206,7 @@ public class BridgeSerializationUtils {
     // list of public keys -> [pubkey1, pubkey2, ..., pubkeyn], sorted
     // using the lexicographical order of the public keys (see BtcECKey.PUBKEY_COMPARATOR).
     public static byte[] serializeFederation(Federation federation) {
-        List<byte[]> publicKeys = federation.getPublicKeys().stream()
+        List<byte[]> publicKeys = federation.getBtcPublicKeys().stream()
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .map(key -> RLP.encodeElement(key.getPubKey()))
                 .collect(Collectors.toList());
@@ -228,27 +228,37 @@ public class BridgeSerializationUtils {
         byte[] creationTimeBytes = rlpList.get(FEDERATION_CREATION_TIME_INDEX).getRLPData();
         Instant creationTime = Instant.ofEpochMilli(BigIntegers.fromUnsignedByteArray(creationTimeBytes).longValue());
 
-        List<BtcECKey> pubKeys = ((RLPList) rlpList.get(FEDERATION_PUB_KEYS_INDEX)).stream()
-                .map(pubKeyBytes -> BtcECKey.fromPublicOnly(pubKeyBytes.getRLPData()))
-                .collect(Collectors.toList());
+        // IMPORTANT: All BTC, RSK and MST public keys are the same.
+        // This is for compatibility with the pre <INSERT FORK NAME HERE> fork network.
+        List<FederationMember> federationMembers = ((RLPList) rlpList.get(FEDERATION_PUB_KEYS_INDEX)).stream()
+                .map(pubKeyBytes ->
+                        FederationMember.getFederationMemberFromKey(
+                                BtcECKey.fromPublicOnly(pubKeyBytes.getRLPData())
+                        )
+                ).collect(Collectors.toList());
 
         byte[] creationBlockNumberBytes = rlpList.get(FEDERATION_CREATION_BLOCK_NUMBER_INDEX).getRLPData();
         long creationBlockNumber = BigIntegers.fromUnsignedByteArray(creationBlockNumberBytes).longValue();
 
-        return new Federation(pubKeys, creationTime, creationBlockNumber, networkParameters);
+        return new Federation(federationMembers, creationTime, creationBlockNumber, networkParameters);
     }
 
     // A pending federation is serialized as the
     // public keys conforming it.
     // See BridgeSerializationUtils::serializePublicKeys
     public static byte[] serializePendingFederation(PendingFederation pendingFederation) {
-        return serializeBtcPublicKeys(pendingFederation.getPublicKeys());
+        return serializeBtcPublicKeys(pendingFederation.getBtcPublicKeys());
     }
 
     // For the serialization format, see BridgeSerializationUtils::serializePendingFederation
     // and serializePublicKeys::deserializePublicKeys
     public static PendingFederation deserializePendingFederation(byte[] data) {
-        return new PendingFederation(deserializeBtcPublicKeys(data));
+        // BTC, RSK and MST keys are the same
+        List<FederationMember> members = deserializeBtcPublicKeys(data).stream().map(pk ->
+            FederationMember.getFederationMemberFromKey(pk)
+        ).collect(Collectors.toList());
+
+        return new PendingFederation(members);
     }
 
     // An ABI call election is serialized as a list of the votes, like so:

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageConfiguration.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageConfiguration.java
@@ -21,16 +21,28 @@ import org.ethereum.config.BlockchainConfig;
 
 public class BridgeStorageConfiguration {
     private final boolean isUnlimitedWhitelistEnabled;
+    private final boolean isMultikeyFederation;
 
-    public BridgeStorageConfiguration(boolean isUnlimitedWhitelistEnabled) {
+    public BridgeStorageConfiguration(
+            boolean isUnlimitedWhitelistEnabled,
+            boolean isMultikeyFederation
+    ) {
         this.isUnlimitedWhitelistEnabled = isUnlimitedWhitelistEnabled;
+        this.isMultikeyFederation = isMultikeyFederation;
     }
 
-    public boolean getUnlimitedWhitelistEnabled() {
+    public boolean isUnlimitedWhitelistEnabled() {
         return isUnlimitedWhitelistEnabled;
     }
 
+    public boolean isMultikeyFederation() {
+        return isMultikeyFederation;
+    }
+
     public static BridgeStorageConfiguration fromBlockchainConfig(BlockchainConfig config) {
-        return new BridgeStorageConfiguration(config.isRskip87());
+        return new BridgeStorageConfiguration(
+                config.isRskip87(),
+                config.isRskipMultipleKeyFederateMembers()
+        );
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageConfiguration.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageConfiguration.java
@@ -42,7 +42,7 @@ public class BridgeStorageConfiguration {
     public static BridgeStorageConfiguration fromBlockchainConfig(BlockchainConfig config) {
         return new BridgeStorageConfiguration(
                 config.isRskip87(),
-                config.isRskipMultipleKeyFederateMembers()
+                config.isRskip123()
         );
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -220,7 +220,7 @@ public class BridgeStorageProvider {
                 data ->
                         data == null
                         ? null
-                        : BridgeSerializationUtils.deserializeFederation(data, networkParameters)
+                        : BridgeSerializationUtils.deserializeFederationOnlyBtcKeys(data, networkParameters)
         );
         return newFederation;
     }
@@ -238,7 +238,7 @@ public class BridgeStorageProvider {
             return;
         }
 
-        safeSaveToRepository(NEW_FEDERATION_KEY, newFederation, BridgeSerializationUtils::serializeFederation);
+        safeSaveToRepository(NEW_FEDERATION_KEY, newFederation, BridgeSerializationUtils::serializeFederationOnlyBtcKeys);
     }
 
     public Federation getOldFederation() {
@@ -249,7 +249,7 @@ public class BridgeStorageProvider {
         oldFederation = safeGetFromRepository(OLD_FEDERATION_KEY,
                 data -> data == null
                         ? null
-                        : BridgeSerializationUtils.deserializeFederation(data, networkParameters)
+                        : BridgeSerializationUtils.deserializeFederationOnlyBtcKeys(data, networkParameters)
         );
         return oldFederation;
     }
@@ -264,7 +264,7 @@ public class BridgeStorageProvider {
      */
     public void saveOldFederation() {
         if (shouldSaveOldFederation) {
-            safeSaveToRepository(OLD_FEDERATION_KEY, oldFederation, BridgeSerializationUtils::serializeFederation);
+            safeSaveToRepository(OLD_FEDERATION_KEY, oldFederation, BridgeSerializationUtils::serializeFederationOnlyBtcKeys);
         }
     }
 
@@ -276,7 +276,7 @@ public class BridgeStorageProvider {
         pendingFederation = safeGetFromRepository(PENDING_FEDERATION_KEY,
                 data -> data == null
                         ? null :
-                        BridgeSerializationUtils.deserializePendingFederation(data)
+                        BridgeSerializationUtils.deserializePendingFederationOnlyBtcKeys(data)
         );
         return pendingFederation;
     }
@@ -291,7 +291,7 @@ public class BridgeStorageProvider {
      */
     public void savePendingFederation() {
         if (shouldSavePendingFederation) {
-            safeSaveToRepository(PENDING_FEDERATION_KEY, pendingFederation, BridgeSerializationUtils::serializePendingFederation);
+            safeSaveToRepository(PENDING_FEDERATION_KEY, pendingFederation, BridgeSerializationUtils::serializePendingFederationOnlyBtcKeys);
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -870,7 +870,7 @@ public class BridgeSupport {
     public void addSignature(BtcECKey federatorPublicKey, List<byte[]> signatures, byte[] rskTxHash) throws Exception {
         Context.propagate(btcContext);
         Federation retiringFederation = getRetiringFederation();
-        if (!getActiveFederation().getPublicKeys().contains(federatorPublicKey) && (retiringFederation == null || !retiringFederation.getPublicKeys().contains(federatorPublicKey))) {
+        if (!getActiveFederation().getBtcPublicKeys().contains(federatorPublicKey) && (retiringFederation == null || !retiringFederation.getBtcPublicKeys().contains(federatorPublicKey))) {
             logger.warn("Supplied federator public key {} does not belong to any of the federators.", federatorPublicKey);
             return;
         }
@@ -947,10 +947,10 @@ public class BridgeSupport {
                     logger.debug("Tx input {} for tx {} signed.", i, new Keccak256(rskTxHash));
                 } catch (IllegalStateException e) {
                     Federation retiringFederation = getRetiringFederation();
-                    if (getActiveFederation().hasPublicKey(federatorPublicKey)) {
+                    if (getActiveFederation().hasBtcPublicKey(federatorPublicKey)) {
                         logger.debug("A member of the active federation is trying to sign a tx of the retiring one");
                         return;
-                    } else if (retiringFederation != null && retiringFederation.hasPublicKey(federatorPublicKey)) {
+                    } else if (retiringFederation != null && retiringFederation.hasBtcPublicKey(federatorPublicKey)) {
                         logger.debug("A member of the retiring federation is trying to sign a tx of the active one");
                         return;
                     }
@@ -1199,7 +1199,7 @@ public class BridgeSupport {
      * @return the federation size
      */
     public Integer getFederationSize() {
-        return federationSupport.getFederationSize();
+        return getActiveFederation().getBtcPublicKeys().size();
     }
 
     /**
@@ -1216,7 +1216,7 @@ public class BridgeSupport {
      * @return the federator's public key
      */
     public byte[] getFederatorPublicKey(int index) {
-        return federationSupport.getFederatorPublicKey(index);
+        return federationSupport.getFederatorBtcPublicKey(index);
     }
 
     /**
@@ -1259,7 +1259,7 @@ public class BridgeSupport {
             return -1;
         }
 
-        return retiringFederation.getPublicKeys().size();
+        return retiringFederation.getBtcPublicKeys().size();
     }
 
     /**
@@ -1286,10 +1286,10 @@ public class BridgeSupport {
             return null;
         }
 
-        List<BtcECKey> publicKeys = retiringFederation.getPublicKeys();
+        List<BtcECKey> publicKeys = retiringFederation.getBtcPublicKeys();
 
         if (index < 0 || index >= publicKeys.size()) {
-            throw new IndexOutOfBoundsException(String.format("Retiring federator index must be between 0 and {}", publicKeys.size() - 1));
+            throw new IndexOutOfBoundsException(String.format("Retiring federator index must be between 0 and %d", publicKeys.size() - 1));
         }
 
         return publicKeys.get(index).getPubKey();
@@ -1379,7 +1379,9 @@ public class BridgeSupport {
     }
 
     /**
-     * Adds the given key to the current pending federation
+     * Adds the given key to the current pending federation.
+     * IMPORTANT: for now, the given key is used for BTC, RSK and MST.
+     *
      * @param dryRun whether to just do a dry run
      * @param key the public key to add
      * @return 1 upon success, -1 if there was no pending federation, -2 if the key was already in the pending federation
@@ -1391,7 +1393,7 @@ public class BridgeSupport {
             return -1;
         }
 
-        if (currentPendingFederation.getPublicKeys().contains(key)) {
+        if (currentPendingFederation.getBtcPublicKeys().contains(key)) {
             return -2;
         }
 
@@ -1399,7 +1401,10 @@ public class BridgeSupport {
             return 1;
         }
 
-        currentPendingFederation = currentPendingFederation.addPublicKey(key);
+        // Build the new federation member using the same key for BTC, RSK and MST
+        FederationMember member = FederationMember.getFederationMemberFromKey(key);
+
+        currentPendingFederation = currentPendingFederation.addMember(member);
 
         provider.setPendingFederation(currentPendingFederation);
 
@@ -1601,7 +1606,7 @@ public class BridgeSupport {
             return -1;
         }
 
-        return currentPendingFederation.getPublicKeys().size();
+        return currentPendingFederation.getBtcPublicKeys().size();
     }
 
     /**
@@ -1616,10 +1621,10 @@ public class BridgeSupport {
             return null;
         }
 
-        List<BtcECKey> publicKeys = currentPendingFederation.getPublicKeys();
+        List<BtcECKey> publicKeys = currentPendingFederation.getBtcPublicKeys();
 
         if (index < 0 || index >= publicKeys.size()) {
-            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and {}", publicKeys.size() - 1));
+            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", publicKeys.size() - 1));
         }
 
         return publicKeys.get(index).getPubKey();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1220,6 +1220,16 @@ public class BridgeSupport {
     }
 
     /**
+     * Returns the public key of given type of the federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @return the federator's public key
+     */
+    public byte[] getFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
+        return federationSupport.getFederatorPublicKeyOfType(index, keyType);
+    }
+
+    /**
      * Returns the federation's creation time
      * @return the federation creation time
      */
@@ -1293,6 +1303,27 @@ public class BridgeSupport {
         }
 
         return publicKeys.get(index).getPubKey();
+    }
+
+    /**
+     * Returns the public key of the given type of the retiring federation's federator at the given index
+     * @param index the retiring federator's index (zero-based)
+     * @param keyType the key type
+     * @return the retiring federator's public key of the given type, null if no retiring federation exists
+     */
+    public byte[] getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
+        Federation retiringFederation = getRetiringFederation();
+        if (retiringFederation == null) {
+            return null;
+        }
+
+        List<FederationMember> members = retiringFederation.getMembers();
+
+        if (index < 0 || index >= members.size()) {
+            throw new IndexOutOfBoundsException(String.format("Retiring federator index must be between 0 and %d", members.size() - 1));
+        }
+
+        return members.get(index).getPublicKey(keyType).getPubKey(true);
     }
 
     /**
@@ -1610,7 +1641,7 @@ public class BridgeSupport {
     }
 
     /**
-     * Returns the currently pending federation threshold, or null if none exists
+     * Returns the currently pending federation federator's public key at the given index, or null if none exists
      * @param index the federator's index (zero-based)
      * @return the pending federation's federator public key
      */
@@ -1628,6 +1659,28 @@ public class BridgeSupport {
         }
 
         return publicKeys.get(index).getPubKey();
+    }
+
+    /**
+     * Returns the public key of the given type of the pending federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @return the pending federation's federator public key of given type
+     */
+    public byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
+        PendingFederation currentPendingFederation = provider.getPendingFederation();
+
+        if (currentPendingFederation == null) {
+            return null;
+        }
+
+        List<FederationMember> members = currentPendingFederation.getMembers();
+
+        if (index < 0 || index >= members.size()) {
+            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", members.size() - 1));
+        }
+
+        return members.get(index).getPublicKey(keyType).getPubKey(true);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1317,13 +1317,7 @@ public class BridgeSupport {
             return null;
         }
 
-        List<FederationMember> members = retiringFederation.getMembers();
-
-        if (index < 0 || index >= members.size()) {
-            throw new IndexOutOfBoundsException(String.format("Retiring federator index must be between 0 and %d", members.size() - 1));
-        }
-
-        return members.get(index).getPublicKey(keyType).getPubKey(true);
+        return federationSupport.getMemberPublicKeyOfType(retiringFederation.getMembers(), index, keyType, "Retiring federator");
     }
 
     /**
@@ -1674,13 +1668,7 @@ public class BridgeSupport {
             return null;
         }
 
-        List<FederationMember> members = currentPendingFederation.getMembers();
-
-        if (index < 0 || index >= members.size()) {
-            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", members.size() - 1));
-        }
-
-        return members.get(index).getPublicKey(keyType).getPubKey(true);
+        return federationSupport.getMemberPublicKeyOfType(currentPendingFederation.getMembers(), index, keyType, "Federator");
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -23,8 +23,6 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
-import org.ethereum.crypto.ECKey;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -39,9 +37,8 @@ import java.util.stream.Collectors;
  *
  * @author Ariel Mendelzon
  */
-public class Federation {
-    private final List<BtcECKey> publicKeys;
-    private final List<ECKey> rskPublicKeys;
+public final class Federation {
+    private final List<FederationMember> members;
     private final Instant creationTime;
     private final long creationBlockNumber;
     private final NetworkParameters btcParams;
@@ -50,31 +47,39 @@ public class Federation {
     private Script p2shScript;
     private Address address;
 
-    public Federation(List<BtcECKey> publicKeys, Instant creationTime, long creationBlockNumber,  NetworkParameters btcParams) {
-        // Sorting public keys ensures same order of federators for same public keys
-        // Immutability provides protection unless unwanted modification, thus making the Federation instance
+    public Federation(List<FederationMember> members, Instant creationTime, long creationBlockNumber,  NetworkParameters btcParams) {
+        // Sorting members ensures same order of federation members for same members
+        // Immutability provides protection against unwanted modification, thus making the Federation instance
         // effectively immutable
-        this.publicKeys = Collections.unmodifiableList(publicKeys.stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList()));
-        // using this.publicKeys ensures order in rskPublicKeys
-        this.rskPublicKeys = Collections.unmodifiableList(this.publicKeys.stream()
-                .map(BtcECKey::getPubKey)
-                .map(ECKey::fromPublicOnly)
-                .collect(Collectors.toList()));
+        this.members = Collections.unmodifiableList(members.stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
+
         this.creationTime = creationTime;
         this.creationBlockNumber = creationBlockNumber;
         this.btcParams = btcParams;
+
         // Calculated once on-demand
         this.redeemScript = null;
         this.p2shScript = null;
         this.address = null;
     }
 
-    public List<BtcECKey> getPublicKeys() {
-        return publicKeys;
+    public List<FederationMember> getMembers() {
+        // Safe to return members since
+        // both list and instances are immutable
+        return members;
+    }
+
+    public List<BtcECKey> getBtcPublicKeys() {
+        // Copy instances since we don't control
+        // immutability of BtcECKey instances
+        return members.stream()
+                .map(m -> m.getBtcPublicKey().getPubKey())
+                .map(BtcECKey::fromPublicOnly)
+                .collect(Collectors.toList());
     }
 
     public int getNumberOfSignaturesRequired() {
-        return publicKeys.size() / 2 + 1;
+        return members.size() / 2 + 1;
     }
 
     public Instant getCreationTime() {
@@ -91,7 +96,7 @@ public class Federation {
 
     public Script getRedeemScript() {
         if (redeemScript == null) {
-            redeemScript = ScriptBuilder.createRedeemScript(getNumberOfSignaturesRequired(), getPublicKeys());
+            redeemScript = ScriptBuilder.createRedeemScript(getNumberOfSignaturesRequired(), getBtcPublicKeys());
         }
 
         return redeemScript;
@@ -99,7 +104,7 @@ public class Federation {
 
     public Script getP2SHScript() {
         if (p2shScript == null) {
-            p2shScript = ScriptBuilder.createP2SHOutputScript(getNumberOfSignaturesRequired(), getPublicKeys());
+            p2shScript = ScriptBuilder.createP2SHOutputScript(getNumberOfSignaturesRequired(), getBtcPublicKeys());
         }
 
         return p2shScript;
@@ -114,14 +119,14 @@ public class Federation {
     }
 
     public int getSize() {
-        return publicKeys.size();
+        return members.size();
     }
 
-    public Integer getPublicKeyIndex(BtcECKey key) {
-        for (int i = 0; i < publicKeys.size(); i++) {
+    public Integer getBtcPublicKeyIndex(BtcECKey key) {
+        for (int i = 0; i < members.size(); i++) {
             // note that this comparison doesn't take into account
             // key compression
-            if (Arrays.equals(key.getPubKey(), publicKeys.get(i).getPubKey())) {
+            if (Arrays.equals(key.getPubKey(), members.get(i).getBtcPublicKey().getPubKey())) {
                 return i;
             }
         }
@@ -129,18 +134,18 @@ public class Federation {
         return null;
     }
 
-    public boolean hasPublicKey(BtcECKey key) {
-        return getPublicKeyIndex(key) != null;
+    public boolean hasBtcPublicKey(BtcECKey key) {
+        return getBtcPublicKeyIndex(key) != null;
     }
 
     public boolean hasMemberWithRskAddress(byte[] address) {
-        return rskPublicKeys.stream()
-                .anyMatch(k -> Arrays.equals(k.getAddress(), address));
+        return members.stream()
+                .anyMatch(m -> Arrays.equals(m.getRskPublicKey().getAddress(), address));
     }
 
     @Override
     public String toString() {
-        return String.format("%d of %d signatures federation", getNumberOfSignaturesRequired(), publicKeys.size());
+        return String.format("%d of %d signatures federation", getNumberOfSignaturesRequired(), members.size());
     }
 
     @Override
@@ -155,21 +160,12 @@ public class Federation {
 
         Federation otherFederation = (Federation) other;
 
-        ByteArrayWrapper[] thisPublicKeys = this.getPublicKeys().stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(k -> new ByteArrayWrapper(k.getPubKey()))
-                .toArray(ByteArrayWrapper[]::new);
-        ByteArrayWrapper[] otherPublicKeys = otherFederation.getPublicKeys().stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(k -> new ByteArrayWrapper(k.getPubKey()))
-                .toArray(ByteArrayWrapper[]::new);
-
         return this.getNumberOfSignaturesRequired() == otherFederation.getNumberOfSignaturesRequired() &&
                 this.getSize() == otherFederation.getSize() &&
                 this.getCreationTime().equals(otherFederation.getCreationTime()) &&
                 this.creationBlockNumber == otherFederation.creationBlockNumber &&
                 this.btcParams.equals(otherFederation.btcParams) &&
-                Arrays.equals(thisPublicKeys, otherPublicKeys);
+                this.members.equals(otherFederation.members);
     }
 
     @Override
@@ -180,7 +176,7 @@ public class Federation {
                 getCreationTime(),
                 this.creationBlockNumber,
                 getNumberOfSignaturesRequired(),
-                getPublicKeys()
+                getBtcPublicKeys()
         );
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -120,9 +120,10 @@ public final class FederationMember {
 
     public FederationMember(BtcECKey btcPublicKey, ECKey rskPublicKey, ECKey mstPublicKey) {
         // Copy public keys to ensure effective immutability
-        this.btcPublicKey = BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
-        this.rskPublicKey = ECKey.fromPublicOnly(rskPublicKey.getPubKey());
-        this.mstPublicKey = ECKey.fromPublicOnly(mstPublicKey.getPubKey());
+        // Make sure we always use compressed versions of public keys
+        this.btcPublicKey = BtcECKey.fromPublicOnly(btcPublicKey.getPubKeyPoint().getEncoded(true));
+        this.rskPublicKey = ECKey.fromPublicOnly(rskPublicKey.getPubKey(true));
+        this.mstPublicKey = ECKey.fromPublicOnly(mstPublicKey.getPubKey(true));
     }
 
     BtcECKey getBtcPublicKey() {

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import com.google.common.primitives.UnsignedBytes;
+import org.ethereum.crypto.ECKey;
+import org.spongycastle.util.encoders.Hex;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Immutable representation of an RSK Federation member.
+ *
+ * It's composed of three public keys: one for the RSK network, one for the
+ * BTC network and one called MST of yet undefined usage.
+ *
+ * @author Ariel Mendelzon
+ */
+public final class FederationMember {
+    private final BtcECKey btcPublicKey;
+    private final ECKey rskPublicKey;
+    private final ECKey mstPublicKey;
+
+    // To be removed when different keys per federation member feature is implemented. These are just helper
+    // methods to make it easier w.r.t. compatibility with the current approach
+
+    public static FederationMember getFederationMemberFromKey(BtcECKey pk) {
+        ECKey ethKey = ECKey.fromPublicOnly(pk.getPubKey());
+        return new FederationMember(pk, ethKey, ethKey);
+    }
+
+    public static List<FederationMember> getFederationMembersFromKeys(List<BtcECKey> pks) {
+        return pks.stream().map(pk -> getFederationMemberFromKey(pk)).collect(Collectors.toList());
+    }
+
+    /**
+     * Compares federation members based on their underlying keys.
+     *
+     * The total ordering is defined such that, for any two members M1, M2,
+     * 1) M1 < M2 iif BTC_PUB_KEY(M1) <lex BTC_PUB_KEY(M2) OR
+     *              (BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND
+     *               RSK_PUB_KEY(M1) <lex RSK_PUB_KEY(M2)) OR
+     *              (BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND
+     *               RSK_PUB_KEY(M1) ==lex RSK_PUB_KEY(M2) AND
+     *               MST_PUB_KEY(M1) <lex MST_PUB_KEY(M2))
+     * 2) M1 == M2 iff BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND
+     *                 RSK_PUB_KEY(M1) ==lex RSK_PUB_KEY(M2) AND
+     *                 MST_PUB_KEY(M1) ==lex MST_PUB_KEY(M2) AND
+     * 3) M1 > M2 otherwise
+     *
+     * where <lex and ==lex is given by negative and zero values (resp.) of the
+     * UnsignedBytes.lexicographicalComparator() comparator.
+     */
+    public static final Comparator<FederationMember> BTC_RSK_MST_PUBKEYS_COMPARATOR = new Comparator<FederationMember>() {
+        private Comparator<byte[]> comparator = UnsignedBytes.lexicographicalComparator();
+
+        @Override
+        public int compare(FederationMember m1, FederationMember m2) {
+            int btcKeysComparison = comparator.compare(m1.getBtcPublicKey().getPubKey(), m2.getBtcPublicKey().getPubKey());
+            if (btcKeysComparison == 0) {
+                int rskKeysComparison = comparator.compare(m1.getRskPublicKey().getPubKey(), m2.getRskPublicKey().getPubKey());
+                if (rskKeysComparison == 0) {
+                    return comparator.compare(m1.getMstPublicKey().getPubKey(), m2.getMstPublicKey().getPubKey());
+                }
+                return rskKeysComparison;
+            }
+            return btcKeysComparison;
+        }
+    };
+
+    public FederationMember(BtcECKey btcPublicKey, ECKey rskPublicKey, ECKey mstPublicKey) {
+        // Copy public keys to ensure effective immutability
+        this.btcPublicKey = BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
+        this.rskPublicKey = ECKey.fromPublicOnly(rskPublicKey.getPubKey());
+        this.mstPublicKey = ECKey.fromPublicOnly(mstPublicKey.getPubKey());
+    }
+
+    BtcECKey getBtcPublicKey() {
+        // Return a copy
+        return BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
+    }
+
+    ECKey getRskPublicKey() {
+        // Return a copy
+        return ECKey.fromPublicOnly(rskPublicKey.getPubKey());
+    }
+
+    ECKey getMstPublicKey() {
+        // Return a copy
+        return ECKey.fromPublicOnly(mstPublicKey.getPubKey());
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "<BTC-%s, RSK-%s, MST-%s> federation member",
+                Hex.toHexString(btcPublicKey.getPubKey()),
+                Hex.toHexString(rskPublicKey.getPubKey()),
+                Hex.toHexString(mstPublicKey.getPubKey())
+        );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || this.getClass() != other.getClass()) {
+            return false;
+        }
+
+        FederationMember otherFederationMember = (FederationMember) other;
+
+        return Arrays.equals(btcPublicKey.getPubKey(), otherFederationMember.btcPublicKey.getPubKey()) &&
+                Arrays.equals(rskPublicKey.getPubKey(), otherFederationMember.rskPublicKey.getPubKey()) &&
+                Arrays.equals(mstPublicKey.getPubKey(), otherFederationMember.mstPublicKey.getPubKey());
+    }
+
+    @Override
+    public int hashCode() {
+        // Can use java.util.Objects.hash since both BtcECKey and ECKey have
+        // well-defined hashCode(s).
+        return Objects.hash(
+                btcPublicKey,
+                rskPublicKey,
+                mstPublicKey
+        );
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -42,6 +42,35 @@ public final class FederationMember {
     private final ECKey rskPublicKey;
     private final ECKey mstPublicKey;
 
+    public enum KeyType {
+        BTC("btc"),
+        RSK("rsk"),
+        MST("mst");
+
+        private String value;
+
+        KeyType(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static KeyType byValue(String value) {
+            switch (value) {
+                case "rsk":
+                    return KeyType.RSK;
+                case "mst":
+                    return KeyType.MST;
+                case "btc":
+                    return KeyType.BTC;
+                default:
+                    throw new IllegalArgumentException(String.format("Invalid value for FederationMember.KeyType: %s", value));
+            }
+        }
+    }
+
     // To be removed when different keys per federation member feature is implemented. These are just helper
     // methods to make it easier w.r.t. compatibility with the current approach
 
@@ -58,7 +87,7 @@ public final class FederationMember {
      * Compares federation members based on their underlying keys.
      *
      * The total ordering is defined such that, for any two members M1, M2,
-     * 1) M1 < M2 iif BTC_PUB_KEY(M1) <lex BTC_PUB_KEY(M2) OR
+     * 1) M1 < M2 iff BTC_PUB_KEY(M1) <lex BTC_PUB_KEY(M2) OR
      *              (BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND
      *               RSK_PUB_KEY(M1) <lex RSK_PUB_KEY(M2)) OR
      *              (BTC_PUB_KEY(M1) ==lex BTC_PUB_KEY(M2) AND
@@ -109,6 +138,18 @@ public final class FederationMember {
     ECKey getMstPublicKey() {
         // Return a copy
         return ECKey.fromPublicOnly(mstPublicKey.getPubKey());
+    }
+
+    ECKey getPublicKey(KeyType keyType) {
+        switch (keyType) {
+            case RSK:
+                return getRskPublicKey();
+            case MST:
+                return getMstPublicKey();
+            case BTC:
+            default:
+                return ECKey.fromPublicOnly(btcPublicKey.getPubKey());
+        }
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -74,10 +74,21 @@ public class FederationSupport {
      * @return the federator's public key
      */
     public byte[] getFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
-        List<FederationMember> members = getActiveFederation().getMembers();
+        return getMemberPublicKeyOfType(getActiveFederation().getMembers(), index, keyType, "Federator");
+    }
 
+    /**
+     * Returns the compressed public key of given type of the member list at the given index
+     * Throws a custom index out of bounds exception when appropiate
+     * @param members the list of federation members
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @param errorPrefix the index out of bounds error prefix
+     * @return the federation member's public key
+     */
+    public byte[] getMemberPublicKeyOfType(List<FederationMember> members, int index, FederationMember.KeyType keyType, String errorPrefix) {
         if (index < 0 || index >= members.size()) {
-            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", members.size() - 1));
+            throw new IndexOutOfBoundsException(String.format("%s index must be between 0 and %d", errorPrefix, members.size() - 1));
         }
 
         return members.get(index).getPublicKey(keyType).getPubKey(true);

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -49,16 +49,16 @@ public class FederationSupport {
      * @return the federation size
      */
     public int getFederationSize() {
-        return getActiveFederation().getPublicKeys().size();
+        return getActiveFederation().getBtcPublicKeys().size();
     }
 
     /**
-     * Returns the public key of the federation's federator at the given index
+     * Returns the BTC public key of the federation's federator at the given index
      * @param index the federator's index (zero-based)
      * @return the federator's public key
      */
-    public byte[] getFederatorPublicKey(int index) {
-        List<BtcECKey> publicKeys = getActiveFederation().getPublicKeys();
+    public byte[] getFederatorBtcPublicKey(int index) {
+        List<BtcECKey> publicKeys = getActiveFederation().getBtcPublicKeys();
 
         if (index < 0 || index >= publicKeys.size()) {
             throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", publicKeys.size() - 1));

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -68,6 +68,22 @@ public class FederationSupport {
     }
 
     /**
+     * Returns the public key of given type of the federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @return the federator's public key
+     */
+    public byte[] getFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
+        List<FederationMember> members = getActiveFederation().getMembers();
+
+        if (index < 0 || index >= members.size()) {
+            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", members.size() - 1));
+        }
+
+        return members.get(index).getPublicKey(keyType).getPubKey(true);
+    }
+
+    /**
      * Returns the currently active federation.
      * See getActiveFederationReference() for details.
      *

--- a/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
@@ -22,10 +22,12 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.ByteArrayWrapper;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -37,34 +39,40 @@ import java.util.stream.Collectors;
  * @author Ariel Mendelzon
  */
 public final class PendingFederation {
-    private static final int MIN_FEDERATORS_REQUIRED = 2;
+    private static final int MIN_MEMBERS_REQUIRED = 2;
 
-    private List<BtcECKey> publicKeys;
+    private List<FederationMember> members;
 
-    public PendingFederation(List<BtcECKey> publicKeys) {
-        // Sorting public keys ensures same order of federators for same public keys
-        // Immutability provides protection unless unwanted modification, thus making the Pending Federation instance
+    public PendingFederation(List<FederationMember> members) {
+        // Sorting members ensures same order for members
+        // Immutability provides protection against unwanted modification, thus making the Pending Federation instance
         // effectively immutable
-        this.publicKeys = Collections.unmodifiableList(publicKeys.stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList()));
+        this.members = Collections.unmodifiableList(members.stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
     }
 
-    public List<BtcECKey> getPublicKeys() {
-        return publicKeys;
+    public List<FederationMember> getMembers() {
+        // Safe to return instance since both the list and instances are immutable
+        return members;
+    }
+
+    public List<BtcECKey> getBtcPublicKeys() {
+        // Copy keys since we don't control immutability of BtcECKey(s)
+        return members.stream().map(m -> m.getBtcPublicKey()).collect(Collectors.toList());
     }
 
     public boolean isComplete() {
-        return this.publicKeys.size() >= MIN_FEDERATORS_REQUIRED;
+        return this.members.size() >= MIN_MEMBERS_REQUIRED;
     }
 
     /**
-     * Creates a new PendingFederation with the additional specified public key
-     * @param key the new public key
-     * @return a new PendingFederation with the added public key
+     * Creates a new PendingFederation with the additional specified member
+     * @param member the new federation member
+     * @return a new PendingFederation with the added member
      */
-    public PendingFederation addPublicKey(BtcECKey key) {
-        List<BtcECKey> newKeys = new ArrayList<>(publicKeys);
-        newKeys.add(key);
-        return new PendingFederation(newKeys);
+    public PendingFederation addMember(FederationMember member) {
+        List<FederationMember> newMembers = new ArrayList<>(members);
+        newMembers.add(member);
+        return new PendingFederation(newMembers);
     }
 
     /**
@@ -79,7 +87,7 @@ public final class PendingFederation {
         }
 
         return new Federation(
-                publicKeys,
+                members,
                 creationTime,
                 blockNumber,
                 btcParams
@@ -88,7 +96,7 @@ public final class PendingFederation {
 
     @Override
     public String toString() {
-        return String.format("%d signatures pending federation (%s)", publicKeys.size(), isComplete() ? "complete" : "incomplete");
+        return String.format("%d signatures pending federation (%s)", members.size(), isComplete() ? "complete" : "incomplete");
     }
 
     @Override
@@ -101,18 +109,7 @@ public final class PendingFederation {
             return false;
         }
 
-        PendingFederation otherFederation = (PendingFederation) other;
-        ByteArrayWrapper[] thisPublicKeys = this.getPublicKeys().stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(k -> new ByteArrayWrapper(k.getPubKey()))
-                .toArray(ByteArrayWrapper[]::new);
-        ByteArrayWrapper[] otherPublicKeys = otherFederation.getPublicKeys().stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(k -> new ByteArrayWrapper(k.getPubKey()))
-                .toArray(ByteArrayWrapper[]::new);
-
-        return this.getPublicKeys().size() == otherFederation.getPublicKeys().size() &&
-                Arrays.equals(thisPublicKeys, otherPublicKeys);
+        return this.members.equals(((PendingFederation) other).members);
     }
 
     public Keccak256 getHash() {
@@ -124,6 +121,6 @@ public final class PendingFederation {
     public int hashCode() {
         // Can use java.util.Objects.hash since List<BtcECKey> has a
         // well-defined hashCode()
-        return Objects.hash(getPublicKeys());
+        return Objects.hash(getBtcPublicKeys());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PendingFederation.java
@@ -113,7 +113,7 @@ public final class PendingFederation {
     }
 
     public Keccak256 getHash() {
-        byte[] encoded = BridgeSerializationUtils.serializePendingFederation(this);
+        byte[] encoded = BridgeSerializationUtils.serializePendingFederationOnlyBtcKeys(this);
         return new Keccak256(HashUtil.keccak256(encoded));
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -80,10 +80,10 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     public void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation) {
         List<DataWord> topics = Collections.singletonList(Bridge.COMMIT_FEDERATION_TOPIC);
 
-        byte[] oldFedFlatPubKeys = flatKeysAsRlpCollection(oldFederation.getPublicKeys());
+        byte[] oldFedFlatPubKeys = flatKeysAsRlpCollection(oldFederation.getBtcPublicKeys());
         byte[] oldFedData = RLP.encodeList(RLP.encodeElement(oldFederation.getAddress().getHash160()), RLP.encodeList(oldFedFlatPubKeys));
 
-        byte[] newFedFlatPubKeys = flatKeysAsRlpCollection(newFederation.getPublicKeys());
+        byte[] newFedFlatPubKeys = flatKeysAsRlpCollection(newFederation.getBtcPublicKeys());
         byte[] newFedData = RLP.encodeList(RLP.encodeElement(newFederation.getAddress().getHash160()), RLP.encodeList(newFedFlatPubKeys));
 
         long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge();

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
@@ -57,7 +57,7 @@ public class RemascFederationProvider {
     }
 
     public RskAddress getFederatorAddress(int n) {
-        byte[] publicKey = this.federationSupport.getFederatorPublicKey(n);
+        byte[] publicKey = this.federationSupport.getFederatorBtcPublicKey(n);
         return new RskAddress(ECKey.fromPublicOnly(publicKey).getAddress());
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -62,4 +62,6 @@ public interface BlockchainConfig {
     boolean isRskip94();
 
     boolean isRskip98();
+
+    boolean isRskipMultipleKeyFederateMembers();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -63,5 +63,5 @@ public interface BlockchainConfig {
 
     boolean isRskip98();
 
-    boolean isRskipMultipleKeyFederateMembers();
+    boolean isRskip123();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
@@ -164,7 +164,7 @@ public abstract class AbstractConfig implements BlockchainConfig, BlockchainNetC
     }
 
     @Override
-    public boolean isRskipMultipleKeyFederateMembers() {
+    public boolean isRskip123() {
         return false;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
@@ -162,4 +162,9 @@ public abstract class AbstractConfig implements BlockchainConfig, BlockchainNetC
     public boolean isRskip98() {
         return false;
     }
+
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return false;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
@@ -22,7 +22,7 @@ package org.ethereum.config.blockchain.devnet;
 public class DevNetSecondForkConfig extends DevNetOrchid060Config {
 
     @Override
-    public boolean isRskipMultipleKeyFederateMembers() {
+    public boolean isRskip123() {
         return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
@@ -20,4 +20,9 @@
 package org.ethereum.config.blockchain.devnet;
 
 public class DevNetSecondForkConfig extends DevNetOrchid060Config {
+
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
@@ -20,4 +20,8 @@
 package org.ethereum.config.blockchain.mainnet;
 
 public class MainNetSecondForkConfig extends MainNetOrchid060Config {
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
@@ -21,7 +21,7 @@ package org.ethereum.config.blockchain.mainnet;
 
 public class MainNetSecondForkConfig extends MainNetOrchid060Config {
     @Override
-    public boolean isRskipMultipleKeyFederateMembers() {
+    public boolean isRskip123() {
         return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
@@ -21,7 +21,7 @@ package org.ethereum.config.blockchain.regtest;
 
 public class RegTestSecondForkConfig extends RegTestOrchidConfig {
     @Override
-    public boolean isRskipMultipleKeyFederateMembers() {
+    public boolean isRskip123() {
         return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
@@ -20,4 +20,8 @@
 package org.ethereum.config.blockchain.regtest;
 
 public class RegTestSecondForkConfig extends RegTestOrchidConfig {
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
@@ -20,4 +20,9 @@
 package org.ethereum.config.blockchain.testnet;
 
 public class TestNetSecondForkConfig extends TestNetOrchid060Config {
+
+    @Override
+    public boolean isRskipMultipleKeyFederateMembers() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
@@ -22,7 +22,7 @@ package org.ethereum.config.blockchain.testnet;
 public class TestNetSecondForkConfig extends TestNetOrchid060Config {
 
     @Override
-    public boolean isRskipMultipleKeyFederateMembers() {
+    public boolean isRskip123() {
         return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/net/AbstractNetConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/net/AbstractNetConfig.java
@@ -22,6 +22,7 @@ package org.ethereum.config.net;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.config.BridgeConstants;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.config.BlockchainConfig;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.Constants;
@@ -84,7 +85,7 @@ public class AbstractNetConfig implements BlockchainNetConfig {
             genesisFederation = bridgeConstants.getGenesisFederation();
         } else{
             genesisFederation = new Federation(
-                    configFederationPublicKeys,
+                    FederationMember.getFederationMembersFromKeys(configFederationPublicKeys),
                     bridgeConstants.getGenesisFederation().getCreationTime(),
                     1L,
                     bridgeConstants.getBtcParams()

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1000,6 +1000,18 @@ public class BridgeSerializationUtilsTest {
                 nullValue());
     }
 
+    @Test
+    public void serializeInteger() {
+        Assert.assertEquals(BigInteger.valueOf(123), RLP.decodeBigInteger(BridgeSerializationUtils.serializeInteger(123), 0));
+        Assert.assertEquals(BigInteger.valueOf(1200), RLP.decodeBigInteger(BridgeSerializationUtils.serializeInteger(1200), 0));
+    }
+
+    @Test
+    public void deserializeInteger() {
+        Assert.assertEquals(123, BridgeSerializationUtils.deserializeInteger(RLP.encodeBigInteger(BigInteger.valueOf(123))).intValue());
+        Assert.assertEquals(1200, BridgeSerializationUtils.deserializeInteger(RLP.encodeBigInteger(BigInteger.valueOf(1200))).intValue());
+    }
+
     private Address mockAddressHash160(String hash160) {
         Address result = mock(Address.class);
         when(result.getHash160()).thenReturn(Hex.decode(hash160));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -26,6 +26,7 @@ import co.rsk.peg.whitelist.OneOffWhiteListEntry;
 import com.google.common.primitives.UnsignedBytes;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
@@ -133,8 +134,9 @@ public class BridgeSerializationUtilsTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
         };
 
+        // Only actual keys serialized are BTC keys, so we don't really care about RSK or MST keys
         Federation federation = new Federation(
-            FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+            FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                     BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[2]),
@@ -237,8 +239,9 @@ public class BridgeSerializationUtilsTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
         };
 
+        // Only actual keys serialized are BTC keys, so we don't really care about RSK or MST keys
         PendingFederation pendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+                FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[2]),
@@ -625,8 +628,9 @@ public class BridgeSerializationUtilsTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
         };
 
+        // Only actual keys serialized are BTC keys, so deserialization will fill RSK and MST keys with those
         Federation federation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(
+                FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                         BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[2]),

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -45,6 +45,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
@@ -132,14 +134,14 @@ public class BridgeSerializationUtilsTest {
         };
 
         Federation federation = new Federation(
-            Arrays.asList(new BtcECKey[]{
+            FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                     BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[2]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[3]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[4]),
                     BtcECKey.fromPublicOnly(publicKeyBytes[5]),
-            }),
+            })),
             Instant.ofEpochMilli(0xabcdef), //
             42L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -149,7 +151,7 @@ public class BridgeSerializationUtilsTest {
         StringBuilder expectedBuilder = new StringBuilder();
         expectedBuilder.append("ff00abcdef"); // Creation time
         expectedBuilder.append("ff2a"); // Creation block number
-        federation.getPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
+        federation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
             expectedBuilder.append("dd");
             expectedBuilder.append(Hex.toHexString(key.getPubKey()));
         });
@@ -185,10 +187,10 @@ public class BridgeSerializationUtilsTest {
 
         Assert.assertEquals(5000, deserializedFederation.getCreationTime().toEpochMilli());
         Assert.assertEquals(4, deserializedFederation.getNumberOfSignaturesRequired());
-        Assert.assertEquals(6, deserializedFederation.getPublicKeys().size());
+        Assert.assertEquals(6, deserializedFederation.getBtcPublicKeys().size());
         Assert.assertThat(deserializedFederation.getCreationBlockNumber(), is(42L));
         for (int i = 0; i < 6; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedFederation.getPublicKeys().get(i).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedFederation.getBtcPublicKeys().get(i).getPubKey()));
         }
         Assert.assertEquals(NetworkParameters.fromID(NetworkParameters.ID_REGTEST), deserializedFederation.getBtcParams());
     }
@@ -236,19 +238,19 @@ public class BridgeSerializationUtilsTest {
         };
 
         PendingFederation pendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[2]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[3]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[4]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[5]),
-                })
+                }))
         );
 
         byte[] result = BridgeSerializationUtils.serializePendingFederation(pendingFederation);
         StringBuilder expectedBuilder = new StringBuilder();
-        pendingFederation.getPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
+        pendingFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
             expectedBuilder.append("dd");
             expectedBuilder.append(Hex.toHexString(key.getPubKey()));
         });
@@ -276,9 +278,9 @@ public class BridgeSerializationUtilsTest {
 
         PendingFederation deserializedPendingFederation = BridgeSerializationUtils.deserializePendingFederation(sample);
 
-        Assert.assertEquals(6, deserializedPendingFederation.getPublicKeys().size());
+        Assert.assertEquals(6, deserializedPendingFederation.getBtcPublicKeys().size());
         for (int i = 0; i < 6; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedPendingFederation.getPublicKeys().get(i).getPubKey()));
+            Assert.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedPendingFederation.getBtcPublicKeys().get(i).getPubKey()));
         }
     }
 
@@ -624,14 +626,14 @@ public class BridgeSerializationUtilsTest {
         };
 
         Federation federation = new Federation(
-                Arrays.asList(
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(
                         BtcECKey.fromPublicOnly(publicKeyBytes[0]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[1]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[2]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[3]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[4]),
                         BtcECKey.fromPublicOnly(publicKeyBytes[5])
-                ),
+                )),
                 Instant.ofEpochMilli(0xabcdef),
                 42L,
                 networkParms

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -55,7 +55,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -276,7 +275,7 @@ public class BridgeStorageProviderTest {
             Assert.assertEquals(DataWord.valueOf("newFederation".getBytes(StandardCharsets.UTF_8)), address);
             return new byte[]{(byte)0xaa};
         });
-        PowerMockito.when(BridgeSerializationUtils.deserializeFederation(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
+        PowerMockito.when(BridgeSerializationUtils.deserializeFederationOnlyBtcKeys(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
             calls.add(0);
             byte[] data = invocation.getArgument(0);
             NetworkParameters networkParameters = invocation.getArgument(1);
@@ -288,7 +287,7 @@ public class BridgeStorageProviderTest {
 
         Assert.assertEquals(newFederation, storageProvider.getNewFederation());
         Assert.assertEquals(newFederation, storageProvider.getNewFederation());
-        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes
+        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederationOnlyBtcKeys & getStorageBytes
     }
 
     @Test
@@ -308,7 +307,7 @@ public class BridgeStorageProviderTest {
             Assert.assertEquals(DataWord.valueOf("newFederation".getBytes(StandardCharsets.UTF_8)), address);
             return null;
         });
-        PowerMockito.when(BridgeSerializationUtils.deserializeFederation(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
+        PowerMockito.when(BridgeSerializationUtils.deserializeFederationOnlyBtcKeys(any(byte[].class), any(NetworkParameters.class))).then((InvocationOnMock invocation) -> {
             deserializeCalls.add(0);
             return null;
         });
@@ -328,7 +327,7 @@ public class BridgeStorageProviderTest {
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
 
-        PowerMockito.when(BridgeSerializationUtils.serializeFederation(any(Federation.class))).then((InvocationOnMock invocation) -> {
+        PowerMockito.when(BridgeSerializationUtils.serializeFederationOnlyBtcKeys(any(Federation.class))).then((InvocationOnMock invocation) -> {
             Federation federation = invocation.getArgument(0);
             Assert.assertEquals(newFederation, federation);
             serializeCalls.add(0);
@@ -385,7 +384,7 @@ public class BridgeStorageProviderTest {
         });
 
         Assert.assertSame(electionMock, storageProvider.getFederationElection(authorizerMock));
-        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes
+        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederationOnlyBtcKeys & getStorageBytes
     }
 
     @Test
@@ -516,7 +515,7 @@ public class BridgeStorageProviderTest {
                 });
 
         Assert.assertEquals(whitelistMock.getAll(), storageProvider.getLockWhitelist().getAll());
-        Assert.assertEquals(4, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes (we call getStorageBytes twice)
+        Assert.assertEquals(4, calls.size()); // 1 for each call to deserializeFederationOnlyBtcKeys & getStorageBytes (we call getStorageBytes twice)
     }
 
     @Test
@@ -554,7 +553,7 @@ public class BridgeStorageProviderTest {
         LockWhitelist result = storageProvider.getLockWhitelist();
         Assert.assertNotNull(result);
         Assert.assertEquals(0, result.getSize().intValue());
-        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes
+        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederationOnlyBtcKeys & getStorageBytes
     }
 
     @Test
@@ -694,7 +693,7 @@ public class BridgeStorageProviderTest {
         });
 
         Assert.assertSame(requestQueueMock, storageProvider.getReleaseRequestQueue());
-        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes
+        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederationOnlyBtcKeys & getStorageBytes
     }
 
     @Test
@@ -725,7 +724,7 @@ public class BridgeStorageProviderTest {
         });
 
         Assert.assertSame(transactionSetMock, storageProvider.getReleaseTransactionSet());
-        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederation & getStorageBytes
+        Assert.assertEquals(2, calls.size()); // 1 for each call to deserializeFederationOnlyBtcKeys & getStorageBytes
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -55,6 +55,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -261,7 +262,7 @@ public class BridgeStorageProviderTest {
     public void getNewFederation() throws IOException {
         List<Integer> calls = new ArrayList<>();
         Context contextMock = mock(Context.class);
-        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))})), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = buildMockFederation(100, 200, 300);
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
@@ -320,7 +321,7 @@ public class BridgeStorageProviderTest {
 
     @Test
     public void saveNewFederation() throws IOException {
-        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))})), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = buildMockFederation(100, 200, 300);
         List<Integer> storageBytesCalls = new ArrayList<>();
         List<Integer> serializeCalls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
@@ -807,6 +808,14 @@ public class BridgeStorageProviderTest {
 
     private Address getBtcAddress(String addr) {
         return new Address(config.getBlockchainConfig().getCommonConstants().getBridgeConstants().getBtcParams(), Hex.decode(addr));
+    }
+
+    private Federation buildMockFederation(Integer... pks) {
+        return new Federation(
+                FederationTestUtils.getFederationMembersFromPks(pks),
+                Instant.ofEpochMilli(1000),
+                0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
     }
 
     public static RepositoryImpl createRepositoryImpl(RskSystemProperties config) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -261,7 +261,7 @@ public class BridgeStorageProviderTest {
     public void getNewFederation() throws IOException {
         List<Integer> calls = new ArrayList<>();
         Context contextMock = mock(Context.class);
-        Federation newFederation = new Federation(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))})), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), config.getBlockchainConfig().getCommonConstants().getBridgeConstants(), bridgeStorageConfigurationAtHeightZero);
@@ -320,7 +320,7 @@ public class BridgeStorageProviderTest {
 
     @Test
     public void saveNewFederation() throws IOException {
-        Federation newFederation = new Federation(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))}), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{BtcECKey.fromPrivate(BigInteger.valueOf(100))})), Instant.ofEpochMilli(1000), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         List<Integer> storageBytesCalls = new ArrayList<>();
         List<Integer> serializeCalls = new ArrayList<>();
         PowerMockito.mockStatic(BridgeSerializationUtils.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -760,7 +760,7 @@ public class BridgeStorageProviderTest {
             Assert.assertEquals(DataWord.fromString("oldFederation"), address);
             Assert.assertNull(data);
             return null;
-        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
+        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any());
 
         storageProvider.saveOldFederation();
         // Shouldn't have tried to save nor serialize anything
@@ -802,7 +802,7 @@ public class BridgeStorageProviderTest {
                 Assert.assertNull(data);
             }
             return null;
-        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
+        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any());
 
         storageProvider.saveOldFederation();
         // Shouldn't have tried to save nor serialize anything
@@ -1019,7 +1019,7 @@ public class BridgeStorageProviderTest {
             Assert.assertEquals(DataWord.fromString("pendingFederation"), address);
             Assert.assertNull(data);
             return null;
-        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
+        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any());
 
         storageProvider.savePendingFederation();
         // Shouldn't have tried to save nor serialize anything
@@ -1106,7 +1106,7 @@ public class BridgeStorageProviderTest {
                 Assert.assertNull(data);
             }
             return null;
-        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
+        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any());
 
         storageProvider.savePendingFederation();
         // Shouldn't have tried to save nor serialize anything

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -2586,6 +2586,286 @@ public class BridgeSupportTest {
     }
 
     @Test
+    public void addFederatorPublicKeyMultikey_okNoKeys() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"),
+                Hex.decode("026289413837ab836eb76428406a3b4f200418d31d99c259a0532b8e435f35153b"),
+                Hex.decode("03e12efa1146037bc9325574b0f15749ba6dc0eec360b1670b05029eead511a6ff")
+        }, true);
+
+        PendingFederation pendingFederation = new PendingFederation(Collections.emptyList());
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                pendingFederation,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertEquals(0, bridgeSupport.getPendingFederationSize().intValue());
+        // Vote with no winner
+        Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
+        Assert.assertEquals(0, bridgeSupport.getPendingFederationSize().intValue());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+
+        // Vote with winner
+        mocksProvider.setWinner(mocksProvider.getSpec());
+        Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("026289413837ab836eb76428406a3b4f200418d31d99c259a0532b8e435f35153b"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("03e12efa1146037bc9325574b0f15749ba6dc0eec360b1670b05029eead511a6ff"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)));
+        verify(mocksProvider.getElection(), times(1)).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+    }
+
+    @Test
+    public void addFederatorPublicKeyMultikey_okKeys() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"),
+                Hex.decode("03f64d2c022bca70f3ff0b1e95336be2c1507daa2ad37a484e0b66cbda86cfc6c5"),
+                Hex.decode("03eed62698319f754407a31fde9a51da8b2be0ab40e9c4c695bb057757729be37f")
+        }, true);
+
+        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new FederationMember(
+                BtcECKey.fromPublicOnly(Hex.decode("02ebd9e8b2caff48b10e661e69fe107d6986d2df1ce7e377f2ef927f3194a61b99")),
+                ECKey.fromPublicOnly(Hex.decode("02a23343f50363dc9a4c29f0c0a8386780cc8bf469211f4de51d50f8c0f274e9a7")),
+                ECKey.fromPublicOnly(Hex.decode("030dd584c286275ab2ce249096d0d7e6c78853e0902db061b14f2e39df068f95bc"))
+        )));
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                pendingFederation,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        // Vote with no winner
+        Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+
+        // Vote with winner
+        mocksProvider.setWinner(mocksProvider.getSpec());
+        Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
+        Assert.assertEquals(2, bridgeSupport.getPendingFederationSize().intValue());
+        Assert.assertTrue(Arrays.equals(Hex.decode("02ebd9e8b2caff48b10e661e69fe107d6986d2df1ce7e377f2ef927f3194a61b99"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("02a23343f50363dc9a4c29f0c0a8386780cc8bf469211f4de51d50f8c0f274e9a7"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("030dd584c286275ab2ce249096d0d7e6c78853e0902db061b14f2e39df068f95bc"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)));
+
+        Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("03f64d2c022bca70f3ff0b1e95336be2c1507daa2ad37a484e0b66cbda86cfc6c5"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("03eed62698319f754407a31fde9a51da8b2be0ab40e9c4c695bb057757729be37f"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.MST)));
+
+        verify(mocksProvider.getElection(), times(1)).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+    }
+
+    @Test
+    public void addFederatorPublicKeyMultikey_noPendingFederation() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"),
+                Hex.decode("0259323a848372c51673622b29298b6e5854b28d45de297fe7cff67915ad900a59"),
+                Hex.decode("0304d9178db5e243667824188f86f7507104d0e237838bfb22bb4af592a8bca08a")
+        }, false);
+
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                null,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertNull(bridgeSupport.getPendingFederationHash());
+        Assert.assertEquals(-1, mocksProvider.execute(bridgeSupport));
+        Assert.assertNull(bridgeSupport.getPendingFederationHash());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+        verify(mocksProvider.getElection(), never()).vote(mocksProvider.getSpec(), mocksProvider.getVoter());
+    }
+
+    @Test
+    public void addFederatorPublicKeyMultikey_btcKeyExists() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"),
+                Hex.decode("02cf0dec68ca34502e4ebd35c40a0e66ff47ba520f0418bcd7388717b12ab4b053"),
+                Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")
+        }, false);
+
+        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new FederationMember(
+                BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
+                ECKey.fromPublicOnly(Hex.decode("03981d06bd7bc419612aa09f860188f08d3c3010796dcb41cdfc43a6875600efa8")),
+                ECKey.fromPublicOnly(Hex.decode("0365e45f68d6347aaa03c76f3d6f47000df6090801e49eef6d49f547f5c19de5dd"))
+        )));
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                pendingFederation,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        Assert.assertEquals(-2, mocksProvider.execute(bridgeSupport));
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+        verify(mocksProvider.getElection(), never()).vote(mocksProvider.getSpec(), mocksProvider.getVoter());
+    }
+
+    @Test
+    public void addFederatorPublicKeyMultikey_rskKeyExists() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"),
+                Hex.decode("02cf0dec68ca34502e4ebd35c40a0e66ff47ba520f0418bcd7388717b12ab4b053"),
+                Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")
+        }, false);
+
+        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new FederationMember(
+                BtcECKey.fromPublicOnly(Hex.decode("0290d68bf50a8389e541a19d47c51447b443f41a13049e0783db6a25c419d612db")),
+                ECKey.fromPublicOnly(Hex.decode("02cf0dec68ca34502e4ebd35c40a0e66ff47ba520f0418bcd7388717b12ab4b053")),
+                ECKey.fromPublicOnly(Hex.decode("0365e45f68d6347aaa03c76f3d6f47000df6090801e49eef6d49f547f5c19de5dd"))
+        )));
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                pendingFederation,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        Assert.assertEquals(-2, mocksProvider.execute(bridgeSupport));
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+        verify(mocksProvider.getElection(), never()).vote(mocksProvider.getSpec(), mocksProvider.getVoter());
+    }
+
+    @Test
+    public void addFederatorPublicKeyMultikey_mstKeyExists() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"),
+                Hex.decode("02cf0dec68ca34502e4ebd35c40a0e66ff47ba520f0418bcd7388717b12ab4b053"),
+                Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")
+        }, false);
+
+        PendingFederation pendingFederation = new PendingFederation(Arrays.asList(new FederationMember(
+                BtcECKey.fromPublicOnly(Hex.decode("0290d68bf50a8389e541a19d47c51447b443f41a13049e0783db6a25c419d612db")),
+                ECKey.fromPublicOnly(Hex.decode("033174d2fb7a3d7a0c87d43fa3e9ba43d4962014960b82bcd793706c05f68111c8")),
+                ECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
+        )));
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                pendingFederation,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        Assert.assertEquals(-2, mocksProvider.execute(bridgeSupport));
+        Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+        verify(mocksProvider.getElection(), never()).vote(mocksProvider.getSpec(), mocksProvider.getVoter());
+    }
+
+    @Test
+    public void addFederatorPublicKey_invalidBtcKey() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("aabbccdd"),
+                Hex.decode("0245db19d3d4b8c3567a47189ae60588e18e1305f3473a7fe99b6ef559bb1d1dc6"),
+                Hex.decode("029664581b2e8dc9ba7885696a03134aaebe4be834ce0049d62f80499bbe130206")
+        }, false);
+
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                null,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertNull(bridgeSupport.getPendingFederationHash());
+        Assert.assertEquals(BridgeSupport.FEDERATION_CHANGE_GENERIC_ERROR_CODE.intValue(), mocksProvider.execute(bridgeSupport));
+        Assert.assertNull(bridgeSupport.getPendingFederationHash());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+        verify(mocksProvider.getElection(), never()).vote(mocksProvider.getSpec(), mocksProvider.getVoter());
+    }
+
+    @Test
+    public void addFederatorPublicKey_invalidRskKey() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("0245db19d3d4b8c3567a47189ae60588e18e1305f3473a7fe99b6ef559bb1d1dc6"),
+                Hex.decode("aabbccdd"),
+                Hex.decode("029664581b2e8dc9ba7885696a03134aaebe4be834ce0049d62f80499bbe130206")
+        }, false);
+
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                null,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertNull(bridgeSupport.getPendingFederationHash());
+        Assert.assertEquals(BridgeSupport.FEDERATION_CHANGE_GENERIC_ERROR_CODE.intValue(), mocksProvider.execute(bridgeSupport));
+        Assert.assertNull(bridgeSupport.getPendingFederationHash());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+        verify(mocksProvider.getElection(), never()).vote(mocksProvider.getSpec(), mocksProvider.getVoter());
+    }
+
+    @Test
+    public void addFederatorPublicKey_invalidMstKey() throws IOException {
+        VotingMocksProvider mocksProvider = new VotingMocksProvider("add-multi", new byte[][]{
+                Hex.decode("0245db19d3d4b8c3567a47189ae60588e18e1305f3473a7fe99b6ef559bb1d1dc6"),
+                Hex.decode("029664581b2e8dc9ba7885696a03134aaebe4be834ce0049d62f80499bbe130206"),
+                Hex.decode("aabbccdd")
+        }, false);
+
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
+                false,
+                null,
+                null,
+                null,
+                null,
+                mocksProvider.getElection(),
+                null
+        );
+
+        Assert.assertNull(bridgeSupport.getPendingFederationHash());
+        Assert.assertEquals(BridgeSupport.FEDERATION_CHANGE_GENERIC_ERROR_CODE.intValue(), mocksProvider.execute(bridgeSupport));
+        Assert.assertNull(bridgeSupport.getPendingFederationHash());
+        verify(mocksProvider.getElection(), never()).clearWinners();
+        verify(mocksProvider.getElection(), never()).clear();
+        verify(mocksProvider.getElection(), never()).vote(mocksProvider.getSpec(), mocksProvider.getVoter());
+    }
+
+    @Test
     public void rollbackFederation_ok() throws IOException {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("rollback", new byte[][]{}, true);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -523,7 +523,7 @@ public class BridgeSupportTest {
         BridgeConstants bridgeConstants = BridgeRegTestConstants.getInstance();
         Federation oldFederation = bridgeConstants.getGenesisFederation();
         BtcECKey key = new BtcECKey(new SecureRandom());
-        FederationMember member = FederationMember.getFederationMemberFromKey(key);
+        FederationMember member = new FederationMember(key, new ECKey(), new ECKey());
         Federation newFederation = new Federation(
                 Collections.singletonList(member),
                 Instant.EPOCH,
@@ -1502,14 +1502,14 @@ public class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation activeFederation = new Federation(FederationMember.getFederationMembersFromKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
+        Federation activeFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
 
         List<BtcECKey> retiringFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fb01")),
             BtcECKey.fromPrivate(Hex.decode("fb02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation retiringFederation = new Federation(FederationMember.getFederationMembersFromKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
+        Federation retiringFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
 
         Repository repository = createRepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1592,7 +1592,7 @@ public class BridgeSupportTest {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
         Federation activeFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(activeFederationKeys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
                 Instant.ofEpochMilli(1000L), 0L, params
         );
 
@@ -1602,7 +1602,7 @@ public class BridgeSupportTest {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
         Federation retiringFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(retiringFederationKeys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
                 Instant.ofEpochMilli(2000L), 0L, params
         );
 
@@ -1679,7 +1679,7 @@ public class BridgeSupportTest {
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
+        Federation federation1 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -1688,7 +1688,7 @@ public class BridgeSupportTest {
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
+        Federation federation2 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Repository repository = createRepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1788,6 +1788,7 @@ public class BridgeSupportTest {
         Assert.assertEquals(0, provider2.getReleaseTransactionSet().getEntries().size());
         Assert.assertTrue(provider2.getRskTxsWaitingForSignatures().isEmpty());
         Assert.assertEquals(3, provider2.getBtcTxHashesAlreadyProcessed().size());
+
     }
 
     @Test
@@ -1801,7 +1802,7 @@ public class BridgeSupportTest {
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
+        Federation federation1 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -1810,7 +1811,7 @@ public class BridgeSupportTest {
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
+        Federation federation2 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Repository repository = createRepositoryImpl(config);
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1954,13 +1955,13 @@ public class BridgeSupportTest {
     @Test
     public void getFederationMethods_genesis() throws IOException {
         Federation activeFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
+                FederationTestUtils.getFederationMembers(3),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
+                FederationTestUtils.getFederationMembers(6),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1970,22 +1971,25 @@ public class BridgeSupportTest {
         Assert.assertEquals(6, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(4, bridgeSupport.getFederationThreshold().intValue());
         Assert.assertEquals(genesisFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(6);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(6);
         for (int i = 0; i < 6; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
     @Test
     public void getFederationMethods_active() throws IOException {
         Federation activeFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
+                FederationTestUtils.getFederationMembers(3),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
+                FederationTestUtils.getFederationMembers(6),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2003,22 +2007,25 @@ public class BridgeSupportTest {
         Assert.assertEquals(3, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(2, bridgeSupport.getFederationThreshold().intValue());
         Assert.assertEquals(activeFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(3);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(3);
         for (int i = 0; i < 3; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
     @Test
     public void getFederationMethods_newActivated() throws IOException {
         Federation newFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
+                FederationTestUtils.getFederationMembers(3),
                 Instant.ofEpochMilli(1000),
                 15L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation oldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
+                FederationTestUtils.getFederationMembers(6),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2040,22 +2047,25 @@ public class BridgeSupportTest {
         Assert.assertEquals(3, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(2, bridgeSupport.getFederationThreshold().intValue());
         Assert.assertEquals(newFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(3);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(3);
         for (int i = 0; i < 3; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
     @Test
     public void getFederationMethods_newNotActivated() throws IOException {
         Federation newFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(3)),
+                FederationTestUtils.getFederationMembers(3),
                 Instant.ofEpochMilli(1000),
                 15L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation oldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(6)),
+                FederationTestUtils.getFederationMembers(6),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2077,9 +2087,13 @@ public class BridgeSupportTest {
         Assert.assertEquals(6, bridgeSupport.getFederationSize().intValue());
         Assert.assertEquals(4, bridgeSupport.getFederationThreshold().intValue());
         Assert.assertEquals(oldFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(6);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(6);
         for (int i = 0; i < 6; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
+
         }
     }
 
@@ -2090,19 +2104,22 @@ public class BridgeSupportTest {
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationSize().intValue());
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationThreshold().intValue());
         Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKey(0));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
     }
 
     @Test
     public void getRetiringFederationMethods_presentNewInactive() throws IOException {
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
+                FederationTestUtils.getFederationMembers(4),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2124,19 +2141,22 @@ public class BridgeSupportTest {
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationSize().intValue());
         Assert.assertEquals(-1, bridgeSupport.getRetiringFederationThreshold().intValue());
         Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKey(0));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
+        Assert.assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
     }
 
     @Test
     public void getRetiringFederationMethods_presentNewActive() throws IOException {
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
+                FederationTestUtils.getFederationMembers(4),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2159,9 +2179,12 @@ public class BridgeSupportTest {
         Assert.assertEquals(3, bridgeSupport.getRetiringFederationThreshold().intValue());
         Assert.assertEquals(1000, bridgeSupport.getRetiringFederationCreationTime().toEpochMilli());
         Assert.assertEquals(mockedOldFederation.getAddress().toString(), bridgeSupport.getRetiringFederationAddress().toString());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(4);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(4);
         for (int i = 0; i < 4; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getRetiringFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getRetiringFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2171,19 +2194,23 @@ public class BridgeSupportTest {
 
         Assert.assertEquals(-1, bridgeSupport.getPendingFederationSize().intValue());
         Assert.assertNull(bridgeSupport.getPendingFederatorPublicKey(0));
+        Assert.assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
+        Assert.assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
+        Assert.assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
     }
 
     @Test
     public void getPendingFederationMethods_present() throws IOException {
-        PendingFederation mockedPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(5))
-        );
+        PendingFederation mockedPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembers(5));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, mockedPendingFederation, null, null);
 
         Assert.assertEquals(5, bridgeSupport.getPendingFederationSize().intValue());
-        List<BtcECKey> publicKeys = getTestFederationPublicKeys(5);
+        List<FederationMember> members = FederationTestUtils.getFederationMembers(5);
         for (int i = 0; i < 5; i++) {
-            Assert.assertTrue(Arrays.equals(publicKeys.get(i).getPubKey(), bridgeSupport.getPendingFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getPendingFederatorPublicKey(i)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
+            Assert.assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
         }
     }
 
@@ -2326,14 +2353,14 @@ public class BridgeSupportTest {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
 
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
+                FederationTestUtils.getFederationMembers(4),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2367,14 +2394,14 @@ public class BridgeSupportTest {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
 
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         Federation mockedOldFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(4)),
+                FederationTestUtils.getFederationMembers(4),
                 Instant.ofEpochMilli(1000),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -2432,6 +2459,9 @@ public class BridgeSupportTest {
         Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
         Assert.assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
         Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKey(0)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)));
         verify(mocksProvider.getElection(), times(1)).clearWinners();
         verify(mocksProvider.getElection(), never()).clear();
     }
@@ -2442,7 +2472,7 @@ public class BridgeSupportTest {
                 Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")
         }, true);
 
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
@@ -2467,7 +2497,15 @@ public class BridgeSupportTest {
         Assert.assertEquals(1, mocksProvider.execute(bridgeSupport));
         Assert.assertEquals(2, bridgeSupport.getPendingFederationSize().intValue());
         Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKey(0)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)));
+
         Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKey(1)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.BTC)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.RSK)));
+        Assert.assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.MST)));
+
         verify(mocksProvider.getElection(), times(1)).clearWinners();
         verify(mocksProvider.getElection(), never()).clear();
     }
@@ -2502,7 +2540,7 @@ public class BridgeSupportTest {
                 Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")
         }, false);
 
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
             BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })));
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
@@ -2551,7 +2589,7 @@ public class BridgeSupportTest {
     public void rollbackFederation_ok() throws IOException {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("rollback", new byte[][]{}, true);
 
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })));
@@ -2604,7 +2642,7 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_ok() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
@@ -2619,14 +2657,14 @@ public class BridgeSupportTest {
         when(executionBlock.getTimestamp()).thenReturn(15005L);
         when(executionBlock.getNumber()).thenReturn(15L);
 
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
+        Federation expectedFederation = new Federation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
                 BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49")))),
                 Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
-        Federation newFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(
+        Federation newFederation = new Federation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
                 BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
                 BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338")))),
@@ -2716,7 +2754,7 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_incompleteFederation() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })));
 
@@ -2744,7 +2782,7 @@ public class BridgeSupportTest {
 
     @Test
     public void commitFederation_hashMismatch() throws IOException {
-        PendingFederation pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12"))
         })));
@@ -2773,7 +2811,7 @@ public class BridgeSupportTest {
 
     @Test
     public void getActiveFederationWallet() throws IOException {
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
@@ -2806,13 +2844,13 @@ public class BridgeSupportTest {
     @Test
     public void getRetiringFederationWallet_nonEmpty() throws IOException {
         Federation mockedNewFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(getTestFederationPublicKeys(2)),
+                FederationTestUtils.getFederationMembers(2),
                 Instant.ofEpochMilli(2000),
                 10L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
@@ -3427,15 +3465,6 @@ public class BridgeSupportTest {
 
     private BridgeSupport getBridgeSupportWithMocksForWhitelistTests(LockWhitelist mockedWhitelist) throws IOException {
         return getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist, null);
-    }
-
-    private List<BtcECKey> getTestFederationPublicKeys(int amount) {
-        List<BtcECKey> result = new ArrayList<>();
-        for (int i = 0; i < amount; i++) {
-            result.add(BtcECKey.fromPrivate(BigInteger.valueOf((i+1) * 100)));
-        }
-        result.sort(BtcECKey.PUBKEY_COMPARATOR);
-        return result;
     }
 
     private BtcTransaction createTransaction() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -1302,7 +1302,7 @@ public class BridgeTest {
     @Test
     public void getFederatorPublicKey_beforeMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        when(mockedConfig.isRskip123()).thenReturn(false);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1334,7 +1334,7 @@ public class BridgeTest {
     @Test
     public void getFederatorPublicKey_afterMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        when(mockedConfig.isRskip123()).thenReturn(true);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1349,7 +1349,7 @@ public class BridgeTest {
     @Test
     public void getFederatorPublicKeyOfType_beforeMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        when(mockedConfig.isRskip123()).thenReturn(false);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1364,7 +1364,7 @@ public class BridgeTest {
     @Test
     public void getFederatorPublicKeyOfType_afterMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        when(mockedConfig.isRskip123()).thenReturn(true);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1441,7 +1441,7 @@ public class BridgeTest {
     @Test
     public void getRetiringFederatorPublicKey_beforeMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        when(mockedConfig.isRskip123()).thenReturn(false);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1473,7 +1473,7 @@ public class BridgeTest {
     @Test
     public void getRetiringFederatorPublicKey_afterMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        when(mockedConfig.isRskip123()).thenReturn(true);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1488,7 +1488,7 @@ public class BridgeTest {
     @Test
     public void getRetiringFederatorPublicKeyOfType_beforeMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        when(mockedConfig.isRskip123()).thenReturn(false);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1503,7 +1503,7 @@ public class BridgeTest {
     @Test
     public void getRetiringFederatorPublicKeyOfType_afterMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        when(mockedConfig.isRskip123()).thenReturn(true);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1548,7 +1548,7 @@ public class BridgeTest {
     @Test
     public void getPendingFederatorPublicKey_beforeMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        when(mockedConfig.isRskip123()).thenReturn(false);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1580,7 +1580,7 @@ public class BridgeTest {
     @Test
     public void getPendingFederatorPublicKey_afterMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        when(mockedConfig.isRskip123()).thenReturn(true);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1595,7 +1595,7 @@ public class BridgeTest {
     @Test
     public void getPendingFederatorPublicKeyOfType_beforeMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        when(mockedConfig.isRskip123()).thenReturn(false);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1610,7 +1610,7 @@ public class BridgeTest {
     @Test
     public void getPendingFederatorPublicKeyOfType_afterMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        when(mockedConfig.isRskip123()).thenReturn(true);
         config.setBlockchainConfig(mockedConfig);
 
         Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
@@ -1656,7 +1656,7 @@ public class BridgeTest {
     @Test
     public void addFederatorPublicKey_beforeMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        when(mockedConfig.isRskip123()).thenReturn(false);
         config.setBlockchainConfig(mockedConfig);
 
         Transaction txMock = mock(Transaction.class);
@@ -1677,7 +1677,7 @@ public class BridgeTest {
     @Test
     public void addFederatorPublicKey_afterMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        when(mockedConfig.isRskip123()).thenReturn(true);
         config.setBlockchainConfig(mockedConfig);
 
         Transaction txMock = mock(Transaction.class);
@@ -1696,7 +1696,7 @@ public class BridgeTest {
     @Test
     public void addFederatorPublicKeyMultikey_beforeMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        when(mockedConfig.isRskip123()).thenReturn(false);
         config.setBlockchainConfig(mockedConfig);
 
         Transaction txMock = mock(Transaction.class);
@@ -1717,7 +1717,7 @@ public class BridgeTest {
     @Test
     public void addFederatorPublicKeyMultikey_afterMultikey() throws Exception {
         GenesisConfig mockedConfig = spy(new GenesisConfig());
-        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        when(mockedConfig.isRskip123()).thenReturn(true);
         config.setBlockchainConfig(mockedConfig);
 
         Transaction txMock = mock(Transaction.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -1372,8 +1372,8 @@ public class BridgeTest {
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
-                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
-                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+                BigInteger.valueOf(invocation.getArgument(0)).toString()
+                        .concat(((FederationMember.KeyType)invocation.getArgument(1)).getValue()).getBytes()
         );
 
         Assert.assertTrue(Arrays.equals("10btc".getBytes(),
@@ -1511,8 +1511,8 @@ public class BridgeTest {
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getRetiringFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
-                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
-                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+                BigInteger.valueOf(invocation.getArgument(0)).toString()
+                        .concat(((FederationMember.KeyType)invocation.getArgument(1)).getValue()).getBytes()
         );
 
         Assert.assertTrue(Arrays.equals("10btc".getBytes(),
@@ -1618,8 +1618,8 @@ public class BridgeTest {
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getPendingFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
-                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
-                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+                BigInteger.valueOf(invocation.getArgument(0)).toString()
+                        .concat(((FederationMember.KeyType)invocation.getArgument(1)).getValue()).getBytes()
         );
 
         Assert.assertTrue(Arrays.equals("10btc".getBytes(),

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -785,7 +785,6 @@ public class BridgeTest {
         Assert.assertNull(bridge.execute(data));
     }
 
-
     @Test
     public void getFederationAddress() throws Exception {
         // Case with genesis federation
@@ -1301,17 +1300,99 @@ public class BridgeTest {
     }
 
     @Test
-    public void getFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, getGenesisBlock(), null, null, null, null);
+    public void getFederatorPublicKey_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.<Integer>getArgument(0)).toByteArray());
 
-        Assert.assertTrue(Arrays.equals(new byte[]{10}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(10)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{20}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(20)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{1, 0}, bridge.getFederatorPublicKey(new Object[]{BigInteger.valueOf(256)})));
+        Assert.assertTrue(Arrays.equals(new byte[]{10},
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                    bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{20},
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(20)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{1, 0},
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(256)}))
+                )[0]
+        ));
+    }
+
+    @Test
+    public void getFederatorPublicKey_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
+        verify(bridgeSupportMock, never()).getFederatorPublicKey(any(int.class));
+    }
+
+    @Test
+    public void getFederatorPublicKeyOfType_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"})));
+        verify(bridgeSupportMock, never()).getFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class));
+    }
+
+    @Test
+    public void getFederatorPublicKeyOfType_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+        when(bridgeSupportMock.getFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
+                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
+                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+        );
+
+        Assert.assertTrue(Arrays.equals("10btc".getBytes(),
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("200rsk".getBytes(),
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(200), "rsk"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("172mst".getBytes(),
+                (byte[]) BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(172), "mst"}))
+                )[0]
+        ));
     }
 
     @Test
@@ -1358,17 +1439,99 @@ public class BridgeTest {
     }
 
     @Test
-    public void getRetiringFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, getGenesisBlock(), null, null, null, null);
+    public void getRetiringFederatorPublicKey_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getRetiringFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.<Integer>getArgument(0)).toByteArray());
 
-        Assert.assertTrue(Arrays.equals(new byte[]{10}, bridge.getRetiringFederatorPublicKey(new Object[]{BigInteger.valueOf(10)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{20}, bridge.getRetiringFederatorPublicKey(new Object[]{BigInteger.valueOf(20)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{1, 0}, bridge.getRetiringFederatorPublicKey(new Object[]{BigInteger.valueOf(256)})));
+        Assert.assertTrue(Arrays.equals(new byte[]{10},
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{20},
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(20)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{1, 0},
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(256)}))
+                )[0]
+        ));
+    }
+
+    @Test
+    public void getRetiringFederatorPublicKey_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
+        verify(bridgeSupportMock, never()).getRetiringFederatorPublicKey(any(int.class));
+    }
+
+    @Test
+    public void getRetiringFederatorPublicKeyOfType_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"})));
+        verify(bridgeSupportMock, never()).getRetiringFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class));
+    }
+
+    @Test
+    public void getRetiringFederatorPublicKeyOfType_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+        when(bridgeSupportMock.getRetiringFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
+                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
+                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+        );
+
+        Assert.assertTrue(Arrays.equals("10btc".getBytes(),
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("105rsk".getBytes(),
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(105), "rsk"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("232mst".getBytes(),
+                (byte[]) BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(232), "mst"}))
+                )[0]
+        ));
     }
 
     @Test
@@ -1383,17 +1546,99 @@ public class BridgeTest {
     }
 
     @Test
-    public void getPendingFederatorPublicKey() throws IOException {
-        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        bridge.init(null, getGenesisBlock(), null, null, null, null);
+    public void getPendingFederatorPublicKey_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
         when(bridgeSupportMock.getPendingFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.<Integer>getArgument(0)).toByteArray());
 
-        Assert.assertTrue(Arrays.equals(new byte[]{10}, bridge.getPendingFederatorPublicKey(new Object[]{BigInteger.valueOf(10)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{20}, bridge.getPendingFederatorPublicKey(new Object[]{BigInteger.valueOf(20)})));
-        Assert.assertTrue(Arrays.equals(new byte[]{1, 0}, bridge.getPendingFederatorPublicKey(new Object[]{BigInteger.valueOf(256)})));
+        Assert.assertTrue(Arrays.equals(new byte[]{10},
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{20},
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(20)}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals(new byte[]{1, 0},
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(256)}))
+                )[0]
+        ));
+    }
+
+    @Test
+    public void getPendingFederatorPublicKey_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
+        verify(bridgeSupportMock, never()).getPendingFederatorPublicKey(any(int.class));
+    }
+
+    @Test
+    public void getPendingFederatorPublicKeyOfType_beforeMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(false);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+
+        Assert.assertNull(bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"})));
+        verify(bridgeSupportMock, never()).getPendingFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class));
+    }
+
+    @Test
+    public void getPendingFederatorPublicKeyOfType_afterMultikey() throws Exception {
+        GenesisConfig mockedConfig = spy(new GenesisConfig());
+        when(mockedConfig.isRskipMultipleKeyFederateMembers()).thenReturn(true);
+        config.setBlockchainConfig(mockedConfig);
+
+        Bridge bridge = PowerMockito.spy(new Bridge(config, PrecompiledContracts.BRIDGE_ADDR));
+        bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        PowerMockito.doReturn(bridgeSupportMock).when(bridge, "setup");
+        when(bridgeSupportMock.getPendingFederatorPublicKeyOfType(any(int.class), any(FederationMember.KeyType.class))).then((InvocationOnMock invocation) ->
+                BigInteger.valueOf(invocation.getArgumentAt(0, int.class)).toString()
+                        .concat(invocation.getArgumentAt(1, FederationMember.KeyType.class).getValue()).getBytes()
+        );
+
+        Assert.assertTrue(Arrays.equals("10btc".getBytes(),
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(10), "btc"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("82rsk".getBytes(),
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(82), "rsk"}))
+                )[0]
+        ));
+
+        Assert.assertTrue(Arrays.equals("123mst".getBytes(),
+                (byte[]) BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().decodeResult(
+                        bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY_OF_TYPE.getFunction().encode(new Object[]{BigInteger.valueOf(123), "mst"}))
+                )[0]
+        ));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -34,6 +34,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.regtest.RegTestGenesisConfig;
 import org.ethereum.core.*;
 import org.ethereum.util.RskTestFactory;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Before;
@@ -123,7 +124,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")),
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
+        Federation federation1 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -131,7 +132,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fb03")),
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
+        Federation federation2 = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Address address1 = federation1.getAddress();
         Address address2 = federation2.getAddress();
@@ -241,14 +242,14 @@ public class BridgeUtilsTest {
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation activeFederation = new Federation(FederationMember.getFederationMembersFromKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
+        Federation activeFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
 
         List<BtcECKey> retiringFederationKeys = Stream.of(
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
                 BtcECKey.fromPrivate(Hex.decode("fb02")),
                 BtcECKey.fromPrivate(Hex.decode("fb03"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation retiringFederation = new Federation(FederationMember.getFederationMembersFromKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
+        Federation retiringFederation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
 
         Address activeFederationAddress = activeFederation.getAddress();
 
@@ -365,7 +366,7 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationNoSpendWallet() {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
@@ -380,7 +381,7 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationSpendWallet() throws UTXOProviderException {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
         })), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
@@ -438,7 +439,7 @@ public class BridgeUtilsTest {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
         Federation federation1 = new Federation(
-                FederationMember.getFederationMembersFromKeys(federation1Keys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
                 Instant.ofEpochMilli(1000L), 0L, params
         );
 
@@ -448,7 +449,7 @@ public class BridgeUtilsTest {
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
         Federation federation2 = new Federation(
-                FederationMember.getFederationMembersFromKeys(federation2Keys),
+                FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
                 Instant.ofEpochMilli(2000L), 0L, params
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -30,6 +30,7 @@ import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.regtest.RegTestGenesisConfig;
 import org.ethereum.core.*;
 import org.ethereum.util.RskTestFactory;
@@ -39,7 +40,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
@@ -123,7 +123,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")),
         });
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = new Federation(federation1Keys, Instant.ofEpochMilli(1000L), 0L, parameters);
+        Federation federation1 = new Federation(FederationMember.getFederationMembersFromKeys(federation1Keys), Instant.ofEpochMilli(1000L), 0L, parameters);
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
@@ -131,7 +131,7 @@ public class BridgeUtilsTest {
                 BtcECKey.fromPrivate(Hex.decode("fb03")),
         });
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), 0L, parameters);
+        Federation federation2 = new Federation(FederationMember.getFederationMembersFromKeys(federation2Keys), Instant.ofEpochMilli(2000L), 0L, parameters);
 
         Address address1 = federation1.getAddress();
         Address address2 = federation2.getAddress();
@@ -241,14 +241,14 @@ public class BridgeUtilsTest {
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation activeFederation = new Federation(activeFederationKeys, Instant.ofEpochMilli(2000L), 2L, parameters);
+        Federation activeFederation = new Federation(FederationMember.getFederationMembersFromKeys(activeFederationKeys), Instant.ofEpochMilli(2000L), 2L, parameters);
 
         List<BtcECKey> retiringFederationKeys = Stream.of(
                 BtcECKey.fromPrivate(Hex.decode("fb01")),
                 BtcECKey.fromPrivate(Hex.decode("fb02")),
                 BtcECKey.fromPrivate(Hex.decode("fb03"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation retiringFederation = new Federation(retiringFederationKeys, Instant.ofEpochMilli(1000L), 1L, parameters);
+        Federation retiringFederation = new Federation(FederationMember.getFederationMembersFromKeys(retiringFederationKeys), Instant.ofEpochMilli(1000L), 1L, parameters);
 
         Address activeFederationAddress = activeFederation.getAddress();
 
@@ -323,7 +323,7 @@ public class BridgeUtilsTest {
 
     private Script signWithOneKey(Federation federation, List<BtcECKey> privateKeys, Script inputScript, Sha256Hash sighash, int federatorIndex, BridgeRegTestConstants bridgeConstants) {
         BtcECKey federatorPrivKey = privateKeys.get(federatorIndex);
-        BtcECKey federatorPublicKey = federation.getPublicKeys().get(federatorIndex);
+        BtcECKey federatorPublicKey = federation.getBtcPublicKeys().get(federatorIndex);
 
         BtcECKey.ECDSASignature sig = federatorPrivKey.sign(sighash);
         TransactionSignature txSig = new TransactionSignature(sig, BtcTransaction.SigHash.ALL, false);
@@ -365,10 +365,10 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationNoSpendWallet() {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
+        })), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(regTestParameters);
 
@@ -380,10 +380,10 @@ public class BridgeUtilsTest {
     @Test
     public void getFederationSpendWallet() throws UTXOProviderException {
         NetworkParameters regTestParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        Federation federation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation federation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        }), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
+        })), Instant.ofEpochMilli(5005L), 0L, regTestParameters);
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(regTestParameters);
 
@@ -437,14 +437,20 @@ public class BridgeUtilsTest {
                 .map(BtcECKey::fromPrivate)
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
-        Federation federation1 = new Federation(federation1Keys, Instant.ofEpochMilli(1000L), 0L, params);
+        Federation federation1 = new Federation(
+                FederationMember.getFederationMembersFromKeys(federation1Keys),
+                Instant.ofEpochMilli(1000L), 0L, params
+        );
 
         List<BtcECKey> federation2Keys = Stream.of("fb01", "fb02", "fb03")
                 .map(Hex::decode)
                 .map(BtcECKey::fromPrivate)
                 .sorted(BtcECKey.PUBKEY_COMPARATOR)
                 .collect(Collectors.toList());
-        Federation federation2 = new Federation(federation2Keys, Instant.ofEpochMilli(2000L), 0L, params);
+        Federation federation2 = new Federation(
+                FederationMember.getFederationMembersFromKeys(federation2Keys),
+                Instant.ofEpochMilli(2000L), 0L, params
+        );
 
         Address federation2Address = federation2.getAddress();
 

--- a/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+import org.ethereum.crypto.ECKey;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.spongycastle.util.encoders.Hex;
+
+import java.math.BigInteger;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.Matchers.any;
+
+public class FederationMemberTest {
+    private BtcECKey btcKey;
+    private ECKey rskKey;
+    private ECKey mstKey;
+    private FederationMember member;
+
+    @Before
+    public void createFederationMember() {
+        btcKey = new BtcECKey();
+        rskKey = new ECKey();
+        mstKey = new ECKey();
+        member = new FederationMember(btcKey, rskKey, mstKey);
+    }
+
+    @Test
+    public void immutable() {
+        Assert.assertNotSame(btcKey, member.getBtcPublicKey());
+        Assert.assertTrue(Arrays.equals(btcKey.getPubKey(), member.getBtcPublicKey().getPubKey()));
+        Assert.assertNotSame(rskKey, member.getRskPublicKey());
+        Assert.assertTrue(Arrays.equals(rskKey.getPubKey(), member.getRskPublicKey().getPubKey()));
+    }
+
+    @Test
+    public void testEquals_basic() {
+        Assert.assertTrue(member.equals(member));
+
+        Assert.assertFalse(member.equals(null));
+        Assert.assertFalse(member.equals(new Object()));
+        Assert.assertFalse(member.equals("something else"));
+    }
+
+    @Test
+    public void testEquals_sameKeys() {
+        FederationMember otherMember = new FederationMember(btcKey, rskKey, mstKey);
+
+        Assert.assertTrue(member.equals(otherMember));
+    }
+
+    @Test
+    public void testEquals_differentBtcKey() {
+        FederationMember otherMember = new FederationMember(new BtcECKey(), rskKey, mstKey);
+
+        Assert.assertFalse(member.equals(otherMember));
+    }
+
+    @Test
+    public void testEquals_differentRskKey() {
+        FederationMember otherMember = new FederationMember(btcKey, new ECKey(), mstKey);
+
+        Assert.assertFalse(member.equals(otherMember));
+    }
+
+    @Test
+    public void testEquals_differentMstKey() {
+        FederationMember otherMember = new FederationMember(btcKey, rskKey, new ECKey());
+
+        Assert.assertFalse(member.equals(otherMember));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationMemberTest.java
@@ -82,6 +82,24 @@ public class FederationMemberTest {
     }
 
     @Test
+    public void testEquals_sameKeysDifferentCompression() {
+        FederationMember uncompressedMember = new FederationMember(
+                BtcECKey.fromPublicOnly(btcKey.getPubKeyPoint().getEncoded(false)),
+                ECKey.fromPublicOnly(rskKey.getPubKey(false)),
+                ECKey.fromPublicOnly(mstKey.getPubKey(false))
+        );
+
+        FederationMember compressedMember = new FederationMember(
+                BtcECKey.fromPublicOnly(btcKey.getPubKeyPoint().getEncoded(true)),
+                ECKey.fromPublicOnly(rskKey.getPubKey(true)),
+                ECKey.fromPublicOnly(mstKey.getPubKey(true))
+        );
+
+        Assert.assertTrue(compressedMember.equals(uncompressedMember));
+        Assert.assertTrue(uncompressedMember.equals(compressedMember));
+    }
+
+    @Test
     public void testEquals_differentBtcKey() {
         FederationMember otherMember = new FederationMember(new BtcECKey(), rskKey, mstKey);
 
@@ -100,5 +118,20 @@ public class FederationMemberTest {
         FederationMember otherMember = new FederationMember(btcKey, rskKey, new ECKey());
 
         Assert.assertFalse(member.equals(otherMember));
+    }
+
+    @Test
+    public void keyType_byValue() {
+        Assert.assertEquals(FederationMember.KeyType.BTC, FederationMember.KeyType.byValue("btc"));
+        Assert.assertEquals(FederationMember.KeyType.RSK, FederationMember.KeyType.byValue("rsk"));
+        Assert.assertEquals(FederationMember.KeyType.MST, FederationMember.KeyType.byValue("mst"));
+    }
+
+    @Test
+    public void keyType_byValueInvalid() {
+        try {
+            FederationMember.KeyType.byValue("whatever");
+            Assert.fail();
+        } catch (IllegalArgumentException e) {}
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -17,12 +17,16 @@
  */
 package co.rsk.peg;
 
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.config.BridgeConstants;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.Constants;
 import org.ethereum.core.Block;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -53,7 +57,7 @@ public class FederationSupportTest {
 
     @Test
     public void whenNewFederationIsNullThenActiveFederationIsGenesisFederation() {
-        Federation genesisFederation = mock(Federation.class);
+        Federation genesisFederation = getNewFakeFederation(0);
         when(provider.getNewFederation())
                 .thenReturn(null);
         when(blockchainNetConfig.getGenesisFederation())
@@ -64,7 +68,7 @@ public class FederationSupportTest {
 
     @Test
     public void whenOldFederationIsNullThenActiveFederationIsNewFederation() {
-        Federation newFederation = mock(Federation.class);
+        Federation newFederation = getNewFakeFederation(100);
         when(provider.getNewFederation())
                 .thenReturn(newFederation);
         when(provider.getOldFederation())
@@ -75,8 +79,8 @@ public class FederationSupportTest {
 
     @Test
     public void whenOldAndNewFederationArePresentReturnOldFederationByActivationAge() {
-        Federation newFederation = mock(Federation.class);
-        Federation oldFederation = mock(Federation.class);
+        Federation newFederation = getNewFakeFederation(75);
+        Federation oldFederation = getNewFakeFederation(0);
         when(provider.getNewFederation())
                 .thenReturn(newFederation);
         when(provider.getOldFederation())
@@ -85,16 +89,14 @@ public class FederationSupportTest {
                 .thenReturn(80L);
         when(bridgeConstants.getFederationActivationAge())
                 .thenReturn(10L);
-        when(newFederation.getCreationBlockNumber())
-                .thenReturn(75L);
 
         assertThat(federationSupport.getActiveFederation(), is(oldFederation));
     }
 
     @Test
     public void whenOldAndNewFederationArePresentReturnNewFederationByActivationAge() {
-        Federation newFederation = mock(Federation.class);
-        Federation oldFederation = mock(Federation.class);
+        Federation newFederation = getNewFakeFederation(65);
+        Federation oldFederation = getNewFakeFederation(0);
         when(provider.getNewFederation())
                 .thenReturn(newFederation);
         when(provider.getOldFederation())
@@ -103,9 +105,14 @@ public class FederationSupportTest {
                 .thenReturn(80L);
         when(bridgeConstants.getFederationActivationAge())
                 .thenReturn(10L);
-        when(newFederation.getCreationBlockNumber())
-                .thenReturn(65L);
 
         assertThat(federationSupport.getActiveFederation(), is(newFederation));
+    }
+
+    private Federation getNewFakeFederation(long creationBlockNumber) {
+        return new Federation(
+                Collections.emptyList(), Instant.ofEpochMilli(123),
+                creationBlockNumber, NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -17,16 +17,22 @@
  */
 package co.rsk.peg;
 
+import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.config.BridgeConstants;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.config.Constants;
 import org.ethereum.core.Block;
+import org.ethereum.crypto.ECKey;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -107,6 +113,85 @@ public class FederationSupportTest {
                 .thenReturn(10L);
 
         assertThat(federationSupport.getActiveFederation(), is(newFederation));
+    }
+
+    @Test
+    public void getFederatorPublicKeys() {
+        BtcECKey btcKey0 = BtcECKey.fromPublicOnly(Hex.decode("020000000000000000001111111111111111111122222222222222222222333333"));
+        ECKey rskKey0 = new ECKey();
+        ECKey mstKey0 = new ECKey();
+
+        BtcECKey btcKey1 = BtcECKey.fromPublicOnly(Hex.decode("020000000000000000001111111111111111111122222222222222222222444444"));
+        ECKey rskKey1 = new ECKey();
+        ECKey mstKey1 = new ECKey();
+
+        Federation theFederation = new Federation(
+                Arrays.asList(
+                        new FederationMember(btcKey0, rskKey0, mstKey0),
+                        new FederationMember(btcKey1, rskKey1, mstKey1)
+                ), Instant.ofEpochMilli(123), 456,
+                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
+        when(provider.getNewFederation()).thenReturn(theFederation);
+
+        Assert.assertTrue(Arrays.equals(federationSupport.getFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC), btcKey0.getPubKey()));
+        Assert.assertTrue(Arrays.equals(federationSupport.getFederatorPublicKeyOfType(1, FederationMember.KeyType.BTC), btcKey1.getPubKey()));
+
+        Assert.assertTrue(Arrays.equals(federationSupport.getFederatorBtcPublicKey(0), btcKey0.getPubKey()));
+        Assert.assertTrue(Arrays.equals(federationSupport.getFederatorBtcPublicKey(1), btcKey1.getPubKey()));
+
+        Assert.assertTrue(Arrays.equals(federationSupport.getFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK), rskKey0.getPubKey(true)));
+        Assert.assertTrue(Arrays.equals(federationSupport.getFederatorPublicKeyOfType(1, FederationMember.KeyType.RSK), rskKey1.getPubKey(true)));
+
+        Assert.assertTrue(Arrays.equals(federationSupport.getFederatorPublicKeyOfType(0, FederationMember.KeyType.MST), mstKey0.getPubKey(true)));
+        Assert.assertTrue(Arrays.equals(federationSupport.getFederatorPublicKeyOfType(1, FederationMember.KeyType.MST), mstKey1.getPubKey(true)));
+    }
+
+    @Test
+    public void getMemberPublicKeyOfType() {
+        BtcECKey btcKey0 = new BtcECKey();
+        ECKey rskKey0 = new ECKey();
+        ECKey mstKey0 = new ECKey();
+
+        BtcECKey btcKey1 = new BtcECKey();
+        ECKey rskKey1 = new ECKey();
+        ECKey mstKey1 = new ECKey();
+
+        List<FederationMember> members = Arrays.asList(
+                new FederationMember(btcKey0, rskKey0, mstKey0),
+                new FederationMember(btcKey1, rskKey1, mstKey1)
+        );
+
+        Assert.assertTrue(Arrays.equals(federationSupport.getMemberPublicKeyOfType(members, 0, FederationMember.KeyType.BTC, "a prefix"), btcKey0.getPubKey()));
+        Assert.assertTrue(Arrays.equals(federationSupport.getMemberPublicKeyOfType(members, 1, FederationMember.KeyType.BTC, "a prefix"), btcKey1.getPubKey()));
+
+        Assert.assertTrue(Arrays.equals(federationSupport.getMemberPublicKeyOfType(members, 0, FederationMember.KeyType.RSK, "a prefix"), rskKey0.getPubKey(true)));
+        Assert.assertTrue(Arrays.equals(federationSupport.getMemberPublicKeyOfType(members, 1, FederationMember.KeyType.RSK, "a prefix"), rskKey1.getPubKey(true)));
+
+        Assert.assertTrue(Arrays.equals(federationSupport.getMemberPublicKeyOfType(members, 0, FederationMember.KeyType.MST, "a prefix"), mstKey0.getPubKey(true)));
+        Assert.assertTrue(Arrays.equals(federationSupport.getMemberPublicKeyOfType(members, 1, FederationMember.KeyType.MST, "a prefix"), mstKey1.getPubKey(true)));
+    }
+
+    @Test
+    public void getMemberPublicKeyOfType_OutOfBounds() {
+        List<FederationMember> members = Arrays.asList(
+                new FederationMember(new BtcECKey(), new ECKey(), new ECKey()),
+                new FederationMember(new BtcECKey(), new ECKey(), new ECKey())
+        );
+
+        try {
+            federationSupport.getMemberPublicKeyOfType(members,2, FederationMember.KeyType.BTC, "a prefix");
+            Assert.fail();
+        } catch (IndexOutOfBoundsException e) {
+            Assert.assertTrue(e.getMessage().startsWith("a prefix"));
+        }
+
+        try {
+            federationSupport.getMemberPublicKeyOfType(members,-1, FederationMember.KeyType.MST, "another prefix");
+            Assert.fail();
+        } catch (IndexOutOfBoundsException e) {
+            Assert.assertTrue(e.getMessage().startsWith("another prefix"));
+        }
     }
 
     private Federation getNewFakeFederation(long creationBlockNumber) {

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -36,6 +36,7 @@ import java.math.BigInteger;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -52,14 +53,14 @@ public class FederationTest {
     @Before
     public void createFederation() {
         federation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -78,10 +79,10 @@ public class FederationTest {
     }
 
     @Test
-    public void publicKeysImmutable() {
+    public void membersImmutable() {
         boolean exception = false;
         try {
-            federation.getPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
+            federation.getMembers().add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
         } catch (Exception e) {
             exception = true;
         }
@@ -89,7 +90,7 @@ public class FederationTest {
 
         exception = false;
         try {
-            federation.getPublicKeys().remove(0);
+            federation.getMembers().remove(0);
         } catch (Exception e) {
             exception = true;
         }
@@ -168,7 +169,7 @@ public class FederationTest {
     }
 
     @Test
-    public void testEquals_a() {
+    public void testEquals_basic() {
         Assert.assertTrue(federation.equals(federation));
 
         Assert.assertFalse(federation.equals(null));
@@ -177,9 +178,9 @@ public class FederationTest {
     }
 
     @Test
-    public void testEquals_differentNumberOfPublicKeys() {
+    public void testEquals_differentNumberOfMembers() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -187,7 +188,7 @@ public class FederationTest {
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -198,14 +199,14 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationTime() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -216,14 +217,14 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationBlockNumber() {
         Federation otherFederation = new Federation(
-                Arrays.asList(
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(
                     BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                     BtcECKey.fromPrivate(BigInteger.valueOf(600))
-                ),
+                )),
                 ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
                 1L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -234,14 +235,14 @@ public class FederationTest {
     @Test
     public void testEquals_differentNetworkParameters() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_TESTNET)
@@ -250,34 +251,48 @@ public class FederationTest {
     }
 
     @Test
-    public void testEquals_differentPublicKeys() {
+    public void testEquals_differentMembers() {
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
+        }));
+
+        members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(620))));
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(610)),
-                }),
+                members,
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
+
+        members.remove(members.size()-1);
+        members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(620))));
+        Federation yetOtherFederation = new Federation(
+                members,
+                ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
+                0L,
+                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
+
+        Assert.assertFalse(otherFederation.equals(yetOtherFederation));
         Assert.assertFalse(federation.equals(otherFederation));
+        Assert.assertFalse(federation.equals(yetOtherFederation));
     }
 
     @Test
     public void testEquals_same() {
         Federation otherFederation = new Federation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }),
+                })),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -286,24 +301,24 @@ public class FederationTest {
     }
 
     @Test
-    public void getPublicKeyIndex() {
-        for (int i = 0; i < federation.getPublicKeys().size(); i++) {
-            Assert.assertEquals(i, federation.getPublicKeyIndex(sortedPublicKeys.get(i)).intValue());
+    public void getBtcPublicKeyIndex() {
+        for (int i = 0; i < federation.getBtcPublicKeys().size(); i++) {
+            Assert.assertEquals(i, federation.getBtcPublicKeyIndex(sortedPublicKeys.get(i)).intValue());
         }
-        Assert.assertNull(federation.getPublicKeyIndex(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
+        Assert.assertNull(federation.getBtcPublicKeyIndex(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
     }
 
     @Test
-    public void hasPublicKey() {
-        for (int i = 0; i < federation.getPublicKeys().size(); i++) {
-            Assert.assertTrue(federation.hasPublicKey(sortedPublicKeys.get(i)));
+    public void hasBtcPublicKey() {
+        for (int i = 0; i < federation.getBtcPublicKeys().size(); i++) {
+            Assert.assertTrue(federation.hasBtcPublicKey(sortedPublicKeys.get(i)));
         }
-        Assert.assertFalse(federation.hasPublicKey(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
+        Assert.assertFalse(federation.hasBtcPublicKey(BtcECKey.fromPrivate(BigInteger.valueOf(1234))));
     }
 
     @Test
     public void hasMemberWithRskAddress() {
-        for (int i = 0; i < federation.getPublicKeys().size(); i++) {
+        for (int i = 0; i < federation.getBtcPublicKeys().size(); i++) {
             Assert.assertTrue(federation.hasMemberWithRskAddress(rskAddresses.get(i)));
         }
 

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTest.java
@@ -53,18 +53,12 @@ public class FederationTest {
     @Before
     public void createFederation() {
         federation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
+
         sortedPublicKeys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -73,8 +67,10 @@ public class FederationTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)),
         }).stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        rskAddresses = sortedPublicKeys.stream()
-                .map(FederationTest::getRskAddressFromBtcKey)
+
+        rskAddresses = Arrays.asList(101, 201, 301, 401, 501, 601)
+                .stream()
+                .map(i -> ECKey.fromPrivate(BigInteger.valueOf(i)).getAddress())
                 .collect(Collectors.toList());
     }
 
@@ -180,15 +176,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentNumberOfMembers() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600, 700),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -199,14 +187,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationTime() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -217,14 +198,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentCreationBlockNumber() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(
-                    BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                    BtcECKey.fromPrivate(BigInteger.valueOf(600))
-                )),
+                FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
                 1L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -235,14 +209,7 @@ public class FederationTest {
     @Test
     public void testEquals_differentNetworkParameters() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_TESTNET)
@@ -252,13 +219,7 @@ public class FederationTest {
 
     @Test
     public void testEquals_differentMembers() {
-        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-        }));
+        List<FederationMember> members = FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500);
 
         members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(620))));
         Federation otherFederation = new Federation(
@@ -285,14 +246,7 @@ public class FederationTest {
     @Test
     public void testEquals_same() {
         Federation otherFederation = new Federation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })),
+                FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600),
                 ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
                 0L,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -322,17 +276,12 @@ public class FederationTest {
             Assert.assertTrue(federation.hasMemberWithRskAddress(rskAddresses.get(i)));
         }
 
-        BtcECKey nonFederateKey = BtcECKey.fromPrivate(BigInteger.valueOf(1234));
-        byte[] nonFederateRskAddress = getRskAddressFromBtcKey(nonFederateKey);
+        byte[] nonFederateRskAddress = ECKey.fromPrivate(BigInteger.valueOf(1234)).getAddress();
         Assert.assertFalse(federation.hasMemberWithRskAddress(nonFederateRskAddress));
     }
 
     @Test
     public void testToString() {
         Assert.assertEquals("4 of 6 signatures federation", federation.toString());
-    }
-
-    private static byte[] getRskAddressFromBtcKey(BtcECKey btcECKey) {
-        return ECKey.fromPublicOnly(btcECKey.getPubKey()).getAddress();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import org.ethereum.crypto.ECKey;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FederationTestUtils {
+    public static List<FederationMember> getFederationMembers(int memberCount) {
+        List<FederationMember> result = new ArrayList<>();
+        for (int i = 1; i <= memberCount; i++) {
+            result.add(new FederationMember(
+                    BtcECKey.fromPrivate(BigInteger.valueOf((i) * 100)),
+                    ECKey.fromPrivate(BigInteger.valueOf((i) * 101)),
+                    ECKey.fromPrivate(BigInteger.valueOf((i) * 102))
+            ));
+        }
+        result.sort(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR);
+        return result;
+    }
+
+    public static List<FederationMember> getFederationMembersFromPks(Integer... pks) {
+        return Arrays.stream(pks).map(n -> new FederationMember(
+                BtcECKey.fromPrivate(BigInteger.valueOf(n)),
+                ECKey.fromPrivate(BigInteger.valueOf(n+1)),
+                ECKey.fromPrivate(BigInteger.valueOf(n+2))
+        )).collect(Collectors.toList());
+    }
+
+    public static List<FederationMember> getFederationMembersWithBtcKeys(List<BtcECKey> keys) {
+        return keys.stream().map(btcKey ->
+                new FederationMember(btcKey, new ECKey(), new ECKey())
+        ).collect(Collectors.toList());
+    }
+
+    public static List<FederationMember> getFederationMembersWithKeys(List<BtcECKey> pks) {
+        return pks.stream().map(pk -> getFederationMemberWithKey(pk)).collect(Collectors.toList());
+    }
+
+    public static FederationMember getFederationMemberWithKey(BtcECKey pk) {
+        ECKey ethKey = ECKey.fromPublicOnly(pk.getPubKey());
+        return new FederationMember(pk, ethKey, ethKey);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -57,13 +57,13 @@ public class PegTestUtils {
     public static Script createBaseInputScriptThatSpendsFromTheFederation(Federation federation) {
         Script scriptPubKey = federation.getP2SHScript();
         Script redeemScript = createBaseRedeemScriptThatSpendsFromTheFederation(federation);
-        RedeemData redeemData = RedeemData.of(federation.getPublicKeys(), redeemScript);
+        RedeemData redeemData = RedeemData.of(federation.getBtcPublicKeys(), redeemScript);
         Script inputScript = scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript);
         return inputScript;
     }
 
     public static Script createBaseRedeemScriptThatSpendsFromTheFederation(Federation federation) {
-        Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getPublicKeys());
+        Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getBtcPublicKeys());
         return redeemScript;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,14 +47,14 @@ public class PendingFederationTest {
     @Before
     public void createPendingFederation() {
         pendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })
+                }))
         );
         sortedPublicKeys = Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
@@ -66,10 +67,10 @@ public class PendingFederationTest {
     }
 
     @Test
-    public void publicKeysImmutable() {
+    public void membersImmutable() {
         boolean exception = false;
         try {
-            pendingFederation.getPublicKeys().add(BtcECKey.fromPrivate(BigInteger.valueOf(1000)));
+            pendingFederation.getMembers().add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
         } catch (Exception e) {
             exception = true;
         }
@@ -77,7 +78,7 @@ public class PendingFederationTest {
 
         exception = false;
         try {
-            pendingFederation.getPublicKeys().remove(0);
+            pendingFederation.getMembers().remove(0);
         } catch (Exception e) {
             exception = true;
         }
@@ -92,15 +93,15 @@ public class PendingFederationTest {
     @Test
     public void isComplete_not() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                })
+                }))
         );
         Assert.assertFalse(otherPendingFederation.isComplete());
     }
 
     @Test
-    public void testEquals_a() {
+    public void testEquals_basic() {
         Assert.assertTrue(pendingFederation.equals(pendingFederation));
 
         Assert.assertFalse(pendingFederation.equals(null));
@@ -109,9 +110,9 @@ public class PendingFederationTest {
     }
 
     @Test
-    public void testEquals_differentNumberOfPublicKeys() {
+    public void testEquals_differentNumberOfMembers() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -119,37 +120,44 @@ public class PendingFederationTest {
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                })
+                }))
         );
         Assert.assertFalse(pendingFederation.equals(otherPendingFederation));
     }
 
     @Test
-    public void testEquals_differentPublicKeys() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(610)),
-                })
-        );
+    public void testEquals_differentMembers() {
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
+                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
+                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
+        }));
+
+        members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(620))));
+        PendingFederation otherPendingFederation = new PendingFederation(members);
+
+        members.remove(members.size()-1);
+        members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(630))));
+        PendingFederation yetOtherPendingFederation = new PendingFederation(members);
+
+        Assert.assertFalse(otherPendingFederation.equals(yetOtherPendingFederation));
         Assert.assertFalse(pendingFederation.equals(otherPendingFederation));
+        Assert.assertFalse(pendingFederation.equals(yetOtherPendingFederation));
     }
 
     @Test
     public void testEquals_same() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })
+                }))
         );
         Assert.assertTrue(pendingFederation.equals(otherPendingFederation));
     }
@@ -158,9 +166,9 @@ public class PendingFederationTest {
     public void testToString() {
         Assert.assertEquals("6 signatures pending federation (complete)", pendingFederation.toString());
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                })
+                }))
         );
         Assert.assertEquals("1 signatures pending federation (incomplete)", otherPendingFederation.toString());
     }
@@ -168,24 +176,24 @@ public class PendingFederationTest {
     @Test
     public void buildFederation_ok_a() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                })
+                }))
         );
 
-        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(300)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(400)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(500)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-        }), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        })), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         Assert.assertEquals(
                 expectedFederation,
@@ -200,7 +208,7 @@ public class PendingFederationTest {
     @Test
     public void buildFederation_ok_b() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -210,10 +218,10 @@ public class PendingFederationTest {
                         BtcECKey.fromPrivate(BigInteger.valueOf(700)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(800)),
                         BtcECKey.fromPrivate(BigInteger.valueOf(900)),
-                })
+                }))
         );
 
-        Federation expectedFederation = new Federation(Arrays.asList(new BtcECKey[]{
+        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPrivate(BigInteger.valueOf(100)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(200)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(300)),
@@ -223,7 +231,7 @@ public class PendingFederationTest {
                 BtcECKey.fromPrivate(BigInteger.valueOf(700)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(800)),
                 BtcECKey.fromPrivate(BigInteger.valueOf(900)),
-        }), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        })), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         Assert.assertEquals(
                 expectedFederation,
@@ -238,9 +246,9 @@ public class PendingFederationTest {
     @Test
     public void buildFederation_incomplete() {
         PendingFederation otherPendingFederation = new PendingFederation(
-                Arrays.asList(new BtcECKey[]{
+                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
                         BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                })
+                }))
         );
 
         try {

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -33,9 +33,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.any;
 
@@ -181,7 +179,7 @@ public class PendingFederationTest {
     @Test
     public void getHash() {
         PowerMockito.mockStatic(BridgeSerializationUtils.class);
-        PowerMockito.when(BridgeSerializationUtils.serializePendingFederation(pendingFederation)).thenReturn(new byte[] { (byte) 0xaa });
+        PowerMockito.when(BridgeSerializationUtils.serializePendingFederationOnlyBtcKeys(pendingFederation)).thenReturn(new byte[] { (byte) 0xaa });
 
         Keccak256 expectedHash = new Keccak256(HashUtil.keccak256(new byte[] { (byte) 0xaa }));
 

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -42,28 +42,10 @@ import static org.mockito.Mockito.any;
 @RunWith(PowerMockRunner.class)
 public class PendingFederationTest {
     private PendingFederation pendingFederation;
-    private List<BtcECKey> sortedPublicKeys;
 
     @Before
     public void createPendingFederation() {
-        pendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }))
-        );
-        sortedPublicKeys = Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-        }).stream().sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600));
     }
 
     @Test
@@ -92,11 +74,7 @@ public class PendingFederationTest {
 
     @Test
     public void isComplete_not() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(200));
         Assert.assertFalse(otherPendingFederation.isComplete());
     }
 
@@ -111,29 +89,13 @@ public class PendingFederationTest {
 
     @Test
     public void testEquals_differentNumberOfMembers() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600, 700));
         Assert.assertFalse(pendingFederation.equals(otherPendingFederation));
     }
 
     @Test
     public void testEquals_differentMembers() {
-        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-        }));
+        List<FederationMember> members = FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500);
 
         members.add(new FederationMember(BtcECKey.fromPrivate(BigInteger.valueOf(610)), ECKey.fromPrivate(BigInteger.valueOf(600)), ECKey.fromPrivate(BigInteger.valueOf(620))));
         PendingFederation otherPendingFederation = new PendingFederation(members);
@@ -149,51 +111,26 @@ public class PendingFederationTest {
 
     @Test
     public void testEquals_same() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600));
         Assert.assertTrue(pendingFederation.equals(otherPendingFederation));
     }
 
     @Test
     public void testToString() {
         Assert.assertEquals("6 signatures pending federation (complete)", pendingFederation.toString());
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(100));
         Assert.assertEquals("1 signatures pending federation (incomplete)", otherPendingFederation.toString());
     }
 
     @Test
     public void buildFederation_ok_a() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600));
 
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-        })), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation expectedFederation = new Federation(
+                FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600),
+                Instant.ofEpochMilli(1234L),
+                0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
 
         Assert.assertEquals(
                 expectedFederation,
@@ -207,31 +144,15 @@ public class PendingFederationTest {
 
     @Test
     public void buildFederation_ok_b() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(800)),
-                        BtcECKey.fromPrivate(BigInteger.valueOf(900)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(
+                100, 200, 300, 400, 500, 600, 700, 800, 900
+        ));
 
-        Federation expectedFederation = new Federation(FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(200)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(300)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(400)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(500)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(600)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(700)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(800)),
-                BtcECKey.fromPrivate(BigInteger.valueOf(900)),
-        })), Instant.ofEpochMilli(1234L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation expectedFederation = new Federation(
+                FederationTestUtils.getFederationMembersFromPks(100, 200, 300, 400, 500, 600, 700, 800, 900),
+                Instant.ofEpochMilli(1234L), 0L,
+                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
 
         Assert.assertEquals(
                 expectedFederation,
@@ -245,11 +166,7 @@ public class PendingFederationTest {
 
     @Test
     public void buildFederation_incomplete() {
-        PendingFederation otherPendingFederation = new PendingFederation(
-                FederationMember.getFederationMembersFromKeys(Arrays.asList(new BtcECKey[]{
-                        BtcECKey.fromPrivate(BigInteger.valueOf(100)),
-                }))
-        );
+        PendingFederation otherPendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersFromPks(100));
 
         try {
             otherPendingFederation.buildFederation(Instant.ofEpochMilli(12L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -38,6 +38,14 @@ import java.util.stream.Collectors;
 
 @Ignore
 public class ActiveFederationTest extends BridgePerformanceTestCase {
+    public static List<FederationMember> getNRandomFederationMembers(int n) {
+        List<FederationMember> result = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            result.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
+        }
+        return result;
+    }
+
     private Federation federation;
 
     @Test
@@ -103,12 +111,7 @@ public class ActiveFederationTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
             if (!genesis) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
-                List<BtcECKey> federatorKeys = new ArrayList<>();
-                for (int i = 0; i < numFederators; i++) {
-                    federatorKeys.add(new BtcECKey());
-                }
-
-                List<FederationMember> members = FederationMember.getFederationMembersFromKeys(federatorKeys);
+                List<FederationMember> members = getNRandomFederationMembers(numFederators);
 
                 federation = new Federation(
                         members,
@@ -122,6 +125,4 @@ public class ActiveFederationTest extends BridgePerformanceTestCase {
             }
         };
     }
-
-
 }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -22,8 +22,10 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
+import org.ethereum.crypto.ECKey;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -32,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 @Ignore
 public class ActiveFederationTest extends BridgePerformanceTestCase {
@@ -65,7 +68,7 @@ public class ActiveFederationTest extends BridgePerformanceTestCase {
     @Test
     public void getFederatorPublicKey() throws IOException {
         ExecutionStats stats = new ExecutionStats("getFederatorPublicKey");
-        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, federation.getPublicKeys().size()-1)});
+        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, federation.getBtcPublicKeys().size()-1)});
         executeTestCaseSection(abiEncoder, "getFederatorPublicKey", true,50, stats);
         executeTestCaseSection(abiEncoder, "getFederatorPublicKey", false,500, stats);
         BridgePerformanceTest.addStats(stats);
@@ -104,8 +107,11 @@ public class ActiveFederationTest extends BridgePerformanceTestCase {
                 for (int i = 0; i < numFederators; i++) {
                     federatorKeys.add(new BtcECKey());
                 }
+
+                List<FederationMember> members = FederationMember.getFederationMembersFromKeys(federatorKeys);
+
                 federation = new Federation(
-                        federatorKeys,
+                        members,
                         Instant.ofEpochMilli(new Random().nextLong()),
                         Helper.randomInRange(1, 10),
                         networkParameters

--- a/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
@@ -192,11 +192,11 @@ public class FederationChangeTest extends BridgePerformanceTestCase {
                 final int maxKeys = 16;
                 int numKeys = Helper.randomInRange(minKeys, maxKeys);
 
-                List<BtcECKey> pendingFederationKeys = new ArrayList<>();
+                List<FederationMember> pendingFederationMembers = new ArrayList<>();
                 for (int i = 0; i < numKeys; i++) {
-                    pendingFederationKeys.add(new BtcECKey());
+                    pendingFederationMembers.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
                 }
-                pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(pendingFederationKeys));
+                pendingFederation = new PendingFederation(pendingFederationMembers);
                 provider.setPendingFederation(pendingFederation);
             }
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
@@ -196,7 +196,7 @@ public class FederationChangeTest extends BridgePerformanceTestCase {
                 for (int i = 0; i < numKeys; i++) {
                     pendingFederationKeys.add(new BtcECKey());
                 }
-                pendingFederation = new PendingFederation(pendingFederationKeys);
+                pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(pendingFederationKeys));
                 provider.setPendingFederation(pendingFederation);
             }
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
@@ -30,7 +30,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -88,17 +90,11 @@ public class PendingFederationTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
             if (present) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
-                List<BtcECKey> federatorKeys = new ArrayList<>();
-                for (int i = 0; i < numFederators; i++) {
-                    federatorKeys.add(new BtcECKey());
-                }
-                pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(federatorKeys));
+                pendingFederation = new PendingFederation(ActiveFederationTest.getNRandomFederationMembers(numFederators));
                 provider.setPendingFederation(pendingFederation);
             } else {
                 pendingFederation = null;
             }
         };
     }
-
-
 }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
@@ -21,18 +21,18 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
-import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import co.rsk.peg.PendingFederation;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
+import org.ethereum.crypto.ECKey;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
+import java.util.stream.Collectors;
 
 @Ignore
 public class PendingFederationTest extends BridgePerformanceTestCase {
@@ -52,7 +52,7 @@ public class PendingFederationTest extends BridgePerformanceTestCase {
     public void getPendingFederatorPublicKey() throws IOException {
         ExecutionStats stats = new ExecutionStats("getPendingFederatorPublicKey");
         ABIEncoder abiEncoder;
-        abiEncoder = (int executionIndex) -> Bridge.GET_PENDING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, pendingFederation.getPublicKeys().size()-1)});
+        abiEncoder = (int executionIndex) -> Bridge.GET_PENDING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, pendingFederation.getBtcPublicKeys().size()-1)});
         executeTestCaseSection(abiEncoder, "getPendingFederatorPublicKey", true,200, stats);
         abiEncoder = (int executionIndex) -> Bridge.GET_PENDING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, 10)});
         executeTestCaseSection(abiEncoder, "getPendingFederatorPublicKey", false,200, stats);
@@ -92,7 +92,7 @@ public class PendingFederationTest extends BridgePerformanceTestCase {
                 for (int i = 0; i < numFederators; i++) {
                     federatorKeys.add(new BtcECKey());
                 }
-                pendingFederation = new PendingFederation(federatorKeys);
+                pendingFederation = new PendingFederation(FederationMember.getFederationMembersFromKeys(federatorKeys));
                 provider.setPendingFederation(pendingFederation);
             } else {
                 pendingFederation = null;

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -105,12 +105,8 @@ public class RetiringFederationTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex) -> {
             if (present) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
-                List<BtcECKey> federatorKeys = new ArrayList<>();
-                for (int i = 0; i < numFederators; i++) {
-                    federatorKeys.add(new BtcECKey());
-                }
                 retiringFederation = new Federation(
-                        FederationMember.getFederationMembersFromKeys(federatorKeys),
+                        ActiveFederationTest.getNRandomFederationMembers(numFederators),
                         Instant.ofEpochMilli(new Random().nextLong()),
                         Helper.randomInRange(1, 10),
                         networkParameters

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -22,8 +22,10 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
+import org.ethereum.crypto.ECKey;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -32,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 @Ignore
 public class RetiringFederationTest extends BridgePerformanceTestCase {
@@ -66,7 +69,7 @@ public class RetiringFederationTest extends BridgePerformanceTestCase {
     public void getRetiringFederatorPublicKey() throws IOException {
         ExecutionStats stats = new ExecutionStats("getRetiringFederatorPublicKey");
         ABIEncoder abiEncoder;
-        abiEncoder = (int executionIndex) -> Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, retiringFederation.getPublicKeys().size()-1)});
+        abiEncoder = (int executionIndex) -> Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, retiringFederation.getBtcPublicKeys().size()-1)});
         executeTestCaseSection(abiEncoder, "getRetiringFederatorPublicKey", true,50, stats);
         abiEncoder = (int executionIndex) -> Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY.encode(new Object[]{Helper.randomInRange(0, 10)});
         executeTestCaseSection(abiEncoder, "getRetiringFederatorPublicKey", false,500, stats);
@@ -107,7 +110,7 @@ public class RetiringFederationTest extends BridgePerformanceTestCase {
                     federatorKeys.add(new BtcECKey());
                 }
                 retiringFederation = new Federation(
-                        federatorKeys,
+                        FederationMember.getFederationMembersFromKeys(federatorKeys),
                         Instant.ofEpochMilli(new Random().nextLong()),
                         Helper.randomInRange(1, 10),
                         networkParameters

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -25,6 +25,7 @@ import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.Federation;
 import co.rsk.peg.FederationMember;
+import co.rsk.peg.FederationTestUtils;
 import org.ethereum.core.Block;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
@@ -74,7 +75,7 @@ public class BridgeEventLoggerImplTest {
                 BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))
         );
 
-        List<FederationMember> oldFederationMembers = FederationMember.getFederationMembersFromKeys(oldFederationKeys);
+        List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
 
         Federation oldFederation = new Federation(oldFederationMembers,
                 Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
@@ -85,7 +86,7 @@ public class BridgeEventLoggerImplTest {
                 BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
         );
 
-        List<FederationMember> newFederationMembers = FederationMember.getFederationMembersFromKeys(newFederationKeys);
+        List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
 
         Federation newFederation = new Federation(newFederationMembers,
                 Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -24,7 +24,9 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.core.Block;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
@@ -39,6 +41,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -64,17 +67,27 @@ public class BridgeEventLoggerImplTest {
         when(executionBlock.getTimestamp()).thenReturn(15005L);
         when(executionBlock.getNumber()).thenReturn(15L);
 
-        Federation oldFederation = new Federation(Arrays.asList(
+        List<BtcECKey> oldFederationKeys = Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
                 BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
-                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))),
+                BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))
+        );
+
+        List<FederationMember> oldFederationMembers = FederationMember.getFederationMembersFromKeys(oldFederationKeys);
+
+        Federation oldFederation = new Federation(oldFederationMembers,
                 Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
-        Federation newFederation = new Federation(Arrays.asList(
+        List<BtcECKey> newFederationKeys = Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
                 BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
-                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))),
+                BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
+        );
+
+        List<FederationMember> newFederationMembers = FederationMember.getFederationMembersFromKeys(newFederationKeys);
+
+        Federation newFederation = new Federation(newFederationMembers,
                 Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
 
         // Do method call
@@ -106,7 +119,7 @@ public class BridgeEventLoggerImplTest {
         RLPList oldFedPubKeys = (RLPList) oldFedData.get(1);
         Assert.assertEquals(4, oldFedPubKeys.size());
         for(int i = 0; i < 4; i++) {
-            Assert.assertEquals(oldFederation.getPublicKeys().get(i), BtcECKey.fromPublicOnly(oldFedPubKeys.get(i).getRLPData()));
+            Assert.assertEquals(oldFederation.getBtcPublicKeys().get(i), BtcECKey.fromPublicOnly(oldFedPubKeys.get(i).getRLPData()));
         }
 
         // Assert new federation data
@@ -117,7 +130,7 @@ public class BridgeEventLoggerImplTest {
         RLPList newFedPubKeys = (RLPList) newFedData.get(1);
         Assert.assertEquals(3, newFedPubKeys.size());
         for(int i = 0; i < 3; i++) {
-            Assert.assertEquals(newFederation.getPublicKeys().get(i), BtcECKey.fromPublicOnly(newFedPubKeys.get(i).getRLPData()));
+            Assert.assertEquals(newFederation.getBtcPublicKeys().get(i), BtcECKey.fromPublicOnly(newFedPubKeys.get(i).getRLPData()));
         }
 
         // Assert new federation activation block number


### PR DESCRIPTION
Federators now has 3 keys: 
- BTC: This is to sign BTC Tx
- RSK: This is to sign RSK Tx
- MST: This is a master key that will be used to sign other keys in the future

The purpose of this change is to improve security and open the possibility to  have more keys for specific purpose in the future.

This include changes in the Brdige methods to interact with the Federation, BridgeSerialization and BridgeStorage and the new class FederationMember.

Related branches: 
- *fed:multiple-fed-keys* 
- *utils:multiple-fed-keys*