### PR TITLE
RFS-334 - BTOUtils datatype changes

### DIFF
--- a/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
@@ -41,7 +41,7 @@ import java.util.List;
 public class GetMultisigScriptHash extends NativeMethod {
     private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
             "getMultisigScriptHash",
-            new String[]{"uint8", "bytes[]"},
+            new String[]{"int256", "bytes[]"},
             new String[]{"bytes"}
     );
 

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/ToBase58Check.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/ToBase58Check.java
@@ -46,7 +46,7 @@ public class ToBase58Check extends NativeMethod {
 
     private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
             "toBase58Check",
-            new String[]{"bytes", "uint8"},
+            new String[]{"bytes", "int256"},
             new String[]{"string"}
     );
 

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
@@ -50,7 +50,7 @@ public class GetMultisigScriptHashTest {
         Assert.assertEquals("getMultisigScriptHash", fn.name);
 
         Assert.assertEquals(2, fn.inputs.length);
-        Assert.assertEquals(SolidityType.getType("uint8").getName(), fn.inputs[0].type.getName());
+        Assert.assertEquals(SolidityType.getType("int256").getName(), fn.inputs[0].type.getName());
         Assert.assertEquals(SolidityType.getType("bytes[]").getName(), fn.inputs[1].type.getName());
 
         Assert.assertEquals(1, fn.outputs.length);

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/ToBase58CheckTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/ToBase58CheckTest.java
@@ -49,7 +49,7 @@ public class ToBase58CheckTest {
 
         Assert.assertEquals(2, fn.inputs.length);
         Assert.assertEquals(SolidityType.getType("bytes").getName(), fn.inputs[0].type.getName());
-        Assert.assertEquals(SolidityType.getType("uint8").getName(), fn.inputs[1].type.getName());
+        Assert.assertEquals(SolidityType.getType("int256").getName(), fn.inputs[1].type.getName());
 
         Assert.assertEquals(1, fn.outputs.length);
         Assert.assertEquals(SolidityType.getType("string").getName(), fn.outputs[0].type.getName());


### PR DESCRIPTION
All numeric datatypes have been changed to `int256`.