### PR TITLE
Validate Hashes size to be lower than 256 (uint8)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/MerkleBranch.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/MerkleBranch.java
@@ -30,6 +30,11 @@ public class MerkleBranch {
         this.hashes = Collections.unmodifiableList(hashes);
         this.path = path;
 
+        //We validate that the number of hashes is uint8 as described in https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki
+        if (hashes.size() > 256) {
+            throw new InvalidMerkleBranchException("The number of hashes can't be bigger than 256");
+        }
+
         // We validate here that there are no more bits in the
         // path than those needed to reduce the branch to the
         // merkle root. That is, that the number of significant
@@ -70,7 +75,7 @@ public class MerkleBranch {
      */
     public Sha256Hash reduceFrom(Sha256Hash txHash) {
         Sha256Hash current = txHash;
-        byte index = 0;
+        int index = 0;
         while (index < hashes.size()) {
             boolean currentRight = ((path >> index) & 1) == 1;
             if (currentRight) {

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/MerkleBranchTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/MerkleBranchTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class MerkleBranchTest {
+    @Test
+    public void moreHashesThanUint8() {
+        try {
+            new MerkleBranch(
+                    Collections.nCopies(257, Sha256Hash.of(Hex.decode("aa")))
+                    , 0b111);
+            Assert.fail();
+        } catch (InvalidMerkleBranchException e) {
+            Assert.assertTrue(e.getMessage().contains("number of hashes"));
+        }
+    }
+
     @Test
     public void moreSignificantBitsThanHashes() {
         try {


### PR DESCRIPTION
As described in https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki
If not throws InvalidMerkleBranchException