### PR TITLE
Remove harcoded checkpoit test value in testInitialChainHeadWithBtcCheckpoints()

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -174,7 +174,12 @@ public class BridgeSupportTest {
         // Force instantiation of blockstore
         bridgeSupport.getBtcBlockchainBestChainHeight();
 
-        Assert.assertEquals(1229760, getBtcBlockStoreFromBridgeSupport(bridgeSupport).getChainHead().getHeight());
+        InputStream checkpointsStream = bridgeSupport.getCheckPoints();
+        CheckpointManager manager = new CheckpointManager(btcParams, checkpointsStream);
+        long time = bridgeSupport.getActiveFederation().getCreationTime().toEpochMilli();
+        StoredBlock checkpoint = manager.getCheckpointBefore(time);
+
+        Assert.assertEquals(checkpoint.getHeight(), getBtcBlockStoreFromBridgeSupport(bridgeSupport).getChainHead().getHeight());
     }
 
     @Test


### PR DESCRIPTION
Use the checkpoint itself to compare the initial height when using a Checkpoint in BridgeSupportTest.testInitialChainHeadWithBtcCheckpoints()
This way we don't have to change the test for each new checkpoint