### PR TITLE
New precompiled contract BTO utils

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -66,7 +66,7 @@ ext {
     powermockitoVersion = '1.7.4'
     rskLllVersion = '0.0.2'
     logbackVersion = '1.2.2'
-    bitcoinjVersion = '0.14.4-rsk-5'
+    bitcoinjVersion = '0.14.4-rsk-6'
     nettyVersion = '4.0.56.Final'
 }
 
@@ -105,7 +105,7 @@ dependencyVerification {
     verify = [
         'ch.qos.logback:logback-classic:48ade385bbae0222b2934b65738892117d8cb8366b3a3df442d3826c11cedff1',
         'ch.qos.logback:logback-core:280be7a9327e7434d214d6b9eb881c083c3e057a22d0ed7663a7ce81a718a494',
-        'co.rsk.bitcoinj:bitcoinj-thin:dd2cc70c2b37c2d76467bbc2bc69c926df388181ccb9aa333ec2b6b433ea1490',
+        'co.rsk.bitcoinj:bitcoinj-thin:0855ffa3254a8fb98143cd22e9b8d3a0c50346a3d08894b20dfbc4323750586f',
         'co.rsk:lll-compiler:a645fdb272f56721761f65dd32caa952453efc07d98d292259d99353b6f647d0',
         'com.fasterxml.jackson.core:jackson-annotations:4caf3936315439b509b8c3ef494d4e47eaa6d25c3b5299aadb0eafb3944ed32f',
         'com.fasterxml.jackson.core:jackson-core:256ff34118ab292d1b4f3ee4d2c3e5e5f0f609d8e07c57e8ad1f51c46d4fbb46',

--- a/rskj-core/src/main/java/co/rsk/pcc/ExecutionEnvironment.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/ExecutionEnvironment.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc;
+
+import org.ethereum.config.BlockchainConfig;
+import org.ethereum.config.BlockchainNetConfig;
+import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.vm.LogInfo;
+
+import java.util.List;
+
+/**
+ * Represents the execution environment of a particular native contract's method execution.
+ * Things as block-dependent configuration, execution block and repository are kept here.
+ *
+ * @author Ariel Mendelzon
+ */
+public class ExecutionEnvironment {
+    private Transaction transaction;
+    private Block block;
+    private Repository repository;
+    private BlockStore blockStore;
+    private ReceiptStore receiptStore;
+    private List<LogInfo> logs;
+    private BlockchainNetConfig config;
+    private BlockchainConfig blockConfig;
+
+    public ExecutionEnvironment(
+            BlockchainNetConfig config,
+            Transaction transaction,
+            Block block,
+            Repository repository,
+            BlockStore blockStore,
+            ReceiptStore receiptStore,
+            List<LogInfo> logs) {
+        this.config = config;
+        this.blockConfig = config.getConfigForBlock(block.getNumber());
+        this.transaction = transaction;
+        this.block = block;
+        this.repository = repository;
+        this.blockStore = blockStore;
+        this.receiptStore = receiptStore;
+        this.logs = logs;
+    }
+
+    public BlockchainNetConfig getConfig() {
+        return config;
+    }
+
+    public BlockchainConfig getBlockConfig() {
+        return blockConfig;
+    }
+
+    public Transaction getTransaction() {
+        return transaction;
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+
+    public Repository getRepository() {
+        return repository;
+    }
+
+    public BlockStore getBlockStore() {
+        return blockStore;
+    }
+
+    public ReceiptStore getReceiptStore() {
+        return receiptStore;
+    }
+
+    public List<LogInfo> getLogs() {
+        return logs;
+    }
+
+    public boolean isLocalCall() {
+        return transaction.isLocalCallTransaction();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/NativeContract.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/NativeContract.java
@@ -1,0 +1,220 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.panic.PanicProcessor;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This class contains common behavior for a RSK native contract.
+ *
+ * @author Ariel Mendelzon
+ */
+public abstract class NativeContract extends PrecompiledContracts.PrecompiledContract {
+    private static final Logger logger = LoggerFactory.getLogger(NativeContract.class);
+    private static final PanicProcessor panicProcessor = new PanicProcessor();
+
+    private final RskSystemProperties config;
+
+    private ExecutionEnvironment executionEnvironment;
+
+    public NativeContract(RskSystemProperties config, RskAddress contractAddress) {
+        this.contractAddress = contractAddress;
+        this.config = config;
+    }
+
+    public ExecutionEnvironment getExecutionEnvironment() {
+        return executionEnvironment;
+    }
+
+    public abstract List<NativeMethod> getMethods();
+
+    public abstract Optional<NativeMethod> getDefaultMethod();
+
+    public void before() {
+        // Can be overriden to provide logic that executes right before each method execution
+    }
+
+    public void after() {
+        // Can be overriden to provide logic that executes right after each method execution
+    }
+
+    @Override
+    public void init(Transaction tx, Block executionBlock, Repository repository, BlockStore blockStore, ReceiptStore receiptStore, List<LogInfo> logs) {
+        super.init(tx, executionBlock, repository, blockStore, receiptStore, logs);
+
+        executionEnvironment = new ExecutionEnvironment(
+                config.getBlockchainConfig(),
+                tx,
+                executionBlock,
+                repository,
+                blockStore,
+                receiptStore,
+                logs
+        );
+    }
+
+    @Override
+    public long getGasForData(byte[] data) {
+        // Preliminary validation: we need an execution environment
+        if (executionEnvironment == null) {
+            throw new RuntimeException("Execution environment is null");
+        }
+
+        Optional<NativeMethod.WithArguments> methodWithArguments = parseData(data);
+
+        if (!methodWithArguments.isPresent()) {
+            // TODO: Define whether we should log or even do something different in this case.
+            // TODO: I reckon this is fine since execution doesn't actually go ahead and
+            // TODO: inexistent method logging happens within parseData anyway.
+            return 0L;
+        }
+
+        return methodWithArguments.get().getGas();
+    }
+
+    @Override
+    public byte[] execute(byte[] data) {
+        try
+        {
+            // Preliminary validation: we need an execution environment
+            if (executionEnvironment == null) {
+                throw new RuntimeException("Execution environment is null");
+            }
+
+            // Preliminary validation: the transaction on which we execute cannot be null
+            if (executionEnvironment.getTransaction() == null) {
+                throw new RuntimeException("RSK Transaction is null");
+            }
+
+            Optional<NativeMethod.WithArguments> methodWithArguments = parseData(data);
+
+            // No function found with the given data? => halt!
+            if (!methodWithArguments.isPresent()) {
+                String errorMessage = String.format("Invalid data given: %s.", Hex.toHexString(data));
+                logger.info(errorMessage);
+                throw new NativeContractIllegalArgumentException(errorMessage);
+            }
+
+            NativeMethod method = methodWithArguments.get().getMethod();
+
+            // If this is not a local call, then first check whether the function
+            // allows for non-local calls
+
+            if (!executionEnvironment.isLocalCall() && method.onlyAllowsLocalCalls()) {
+                String errorMessage = String.format("Non-local-call to %s. Returning without execution.", method.getName());
+                logger.info(errorMessage);
+                throw new NativeContractIllegalArgumentException(errorMessage);
+            }
+
+            before();
+
+            Object result;
+            try {
+                result = methodWithArguments.get().execute();
+            } catch (NativeContractIllegalArgumentException ex) {
+                String errorMessage = String.format("Error executing: %s", method.getName());
+                logger.warn(errorMessage, ex);
+                throw new NativeContractIllegalArgumentException(errorMessage, ex);
+            }
+
+            after();
+
+            // Special cases:
+            // - null => null
+            // - empty Optional<?> => null
+            // - nonempty Optional<?> => encoded ?
+            // Note: this is hacky, but ultimately very short and to the point.
+            if (result == null) {
+                return null;
+            } else if (result.getClass() == Optional.class) {
+                Optional<?> optionalResult = (Optional<?>) result;
+                if (!optionalResult.isPresent()) {
+                    return null;
+                } else {
+                    result = optionalResult.get();
+                }
+            }
+
+            return method.getFunction().encodeOutputs(result);
+        } catch (Exception ex) {
+            logger.error(ex.getMessage(), ex);
+            panicProcessor.panic("nativecontractexecute", ex.getMessage());
+            throw new RuntimeException(String.format("Exception executing native contract: %s", ex.getMessage()), ex);
+        }
+    }
+
+    private Optional<NativeMethod.WithArguments> parseData(byte[] data) {
+        if (data != null && (data.length >= 1 && data.length <= 3)) {
+            logger.warn("Invalid function signature {}.", Hex.toHexString(data));
+            return Optional.empty();
+        }
+
+        if (data == null || data.length == 0) {
+            if (getDefaultMethod().isPresent()) {
+                return Optional.of(this.getDefaultMethod().get().new WithArguments(new Object[]{}, data));
+            }
+            return Optional.empty();
+        } else {
+            byte[] encodedSignature = Arrays.copyOfRange(data, 0, 4);
+            Optional<NativeMethod> maybeMethod = getMethods().stream()
+                    .filter(m ->
+                            Arrays.equals(
+                                    encodedSignature,
+                                    m.getFunction().encodeSignature()
+                            )
+                    ).findFirst();
+
+            if (!maybeMethod.isPresent()) {
+                logger.warn("Invalid function signature {}.", Hex.toHexString(encodedSignature));
+                return Optional.empty();
+            }
+
+            NativeMethod method = maybeMethod.get();
+
+            if (!method.isEnabled()) {
+                logger.warn("'{}' is not enabled", method.getName());
+                return Optional.empty();
+            }
+
+            try {
+                Object[] arguments = method.getFunction().decode(data);
+                return Optional.of(method.new WithArguments(arguments, data));
+            } catch (Exception e) {
+                logger.warn(String.format("Invalid arguments %s for function %s.", Hex.toHexString(data), Hex.toHexString(encodedSignature)), e);
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/NativeContractIllegalArgumentException.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/NativeContractIllegalArgumentException.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc;
+
+/**
+ * Any native contract illegal argument exceptions should be an instance of this class.
+ *
+ * @author Ariel Mendelzon
+ */
+public class NativeContractIllegalArgumentException extends IllegalArgumentException {
+    public NativeContractIllegalArgumentException(String s) {
+        super(s);
+    }
+
+    public NativeContractIllegalArgumentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/NativeMethod.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/NativeMethod.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc;
+
+import org.ethereum.core.CallTransaction;
+
+/**
+ * This class contains common behavior for a single RSK native contract's method.
+ *
+ * @author Ariel Mendelzon
+ */
+public abstract class NativeMethod {
+    public final class WithArguments {
+        private final Object[] arguments;
+        private final byte[] originalData;
+
+        public WithArguments(Object[] arguments, byte[] originalData) {
+            this.arguments = arguments;
+            this.originalData = originalData;
+        }
+
+        public NativeMethod getMethod() {
+            return NativeMethod.this;
+        }
+
+        public long getGas() {
+            return NativeMethod.this.getGas(arguments, originalData);
+        }
+
+        public Object[] getArguments() {
+            return arguments;
+        }
+
+        public byte[] getOriginalData() {
+            return originalData;
+        }
+
+        public Object execute() {
+            return NativeMethod.this.execute(arguments);
+        }
+    }
+
+    private ExecutionEnvironment executionEnvironment;
+
+    public NativeMethod(ExecutionEnvironment executionEnvironment) {
+        this.executionEnvironment = executionEnvironment;
+    }
+
+    public ExecutionEnvironment getExecutionEnvironment() {
+        return executionEnvironment;
+    }
+
+    public abstract CallTransaction.Function getFunction();
+
+    public abstract Object execute(Object[] arguments);
+
+    public long getGas(Object[] parsedArguments, byte[] originalData) {
+        // By default, gas is twice the length of the original data passed in
+        // This can (AND SHOULD) be overriden in implementing methods, although
+        // the default can always be used on top.
+        // (e.g., "return 23000L + super(parsedArguments, originalData);")
+
+        return originalData == null ? 0 : originalData.length * 2;
+    }
+
+    public abstract boolean isEnabled();
+
+    public abstract boolean onlyAllowsLocalCalls();
+
+    public String getName() {
+        // Can be overriden to provide a more specific name
+        return getFunction().name;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/BTOUtils.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/BTOUtils.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.pcc.NativeContract;
+import co.rsk.pcc.NativeMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Precompiled contract that provides certain BTO (Bitcoin Token Offering)
+ * related utility functions.
+ *
+ * @author Ariel Mendelzon
+ */
+public class BTOUtils extends NativeContract {
+    private final BTOUtilsHelper helper;
+
+    public BTOUtils(RskSystemProperties config, RskAddress contractAddress) {
+        super(config, contractAddress);
+        this.helper = new BTOUtilsHelper();
+    }
+
+    @Override
+    public List<NativeMethod> getMethods() {
+        return Arrays.asList(
+            new ToBase58Check(getExecutionEnvironment()),
+            new DeriveExtendedPublicKey(getExecutionEnvironment(), helper),
+            new ExtractPublicKeyFromExtendedPublicKey(getExecutionEnvironment(), helper),
+            new GetMultisigScriptHash(getExecutionEnvironment())
+        );
+    }
+
+    @Override
+    public Optional<NativeMethod> getDefaultMethod() {
+        return Optional.empty();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/BTOUtilsHelper.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/BTOUtilsHelper.java
@@ -1,0 +1,18 @@
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+
+public class BTOUtilsHelper {
+    public NetworkParameters validateAndExtractNetworkFromExtendedPublicKey(String xpub) {
+        // Network determination is done by starting character
+        // Extended public key must start with a "xpub" (mainnet) or "tpub" (testnet)
+        if (xpub.startsWith("xpub")) {
+            return NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+        } else if (xpub.startsWith("tpub")) {
+            return NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
+        } else {
+            throw new NativeContractIllegalArgumentException(String.format("Invalid extended public key '%s'", xpub));
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/DeriveExtendedPublicKey.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/DeriveExtendedPublicKey.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.crypto.ChildNumber;
+import co.rsk.bitcoinj.crypto.DeterministicKey;
+import co.rsk.bitcoinj.crypto.HDKeyDerivation;
+import co.rsk.bitcoinj.crypto.HDUtils;
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import co.rsk.pcc.NativeMethod;
+import org.ethereum.core.CallTransaction;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This implements the "deriveExtendedPublicKey" method
+ * that belongs to the BTOUtils native contract.
+ *
+ * @author Ariel Mendelzon
+ */
+public class DeriveExtendedPublicKey extends NativeMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "deriveExtendedPublicKey",
+            new String[]{"string", "string"},
+            new String[]{"string"}
+    );
+
+    private final BTOUtilsHelper helper;
+
+    public DeriveExtendedPublicKey(ExecutionEnvironment executionEnvironment, BTOUtilsHelper helper) {
+        super(executionEnvironment);
+        this.helper = helper;
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    public Object execute(Object[] arguments) {
+        String xpub = (String) arguments[0];
+        String path = (String) arguments[1];
+
+        NetworkParameters params = helper.validateAndExtractNetworkFromExtendedPublicKey(xpub);
+        DeterministicKey key;
+        try {
+            key = DeterministicKey.deserializeB58(xpub, params);
+        } catch (IllegalArgumentException e) {
+            throw new NativeContractIllegalArgumentException(String.format("Invalid extended public key '%s", xpub), e);
+        }
+
+        // Path must be of the form S, with S ::= n || n/S with n an unsigned integer
+
+        // Covering special case: upon splitting a string, if the string ends with the delimiter, then
+        // there is no empty string as a last element. Make sure that the whole path starts and ends with a digit
+        // just in case.
+        if (path.length() == 0 || !isDecimal(path.charAt(0)) || !isDecimal(path.charAt(path.length()-1))) {
+            throwInvalidPath(path);
+        }
+
+        String[] pathChunks = path.split("/");
+
+        if (Arrays.stream(pathChunks).anyMatch(s -> !isDecimal(s))) {
+            throwInvalidPath(path);
+        }
+
+        List<ChildNumber> pathList;
+        try {
+            pathList = HDUtils.parsePath(path);
+        } catch (NumberFormatException ex) {
+            throw new NativeContractIllegalArgumentException(getInvalidPathErrorMessage(path), ex);
+        }
+
+        DeterministicKey derived = key;
+        for (int i = 0; i < pathList.size(); i++) {
+            derived = HDKeyDerivation.deriveChildKey(derived, pathList.get(i).getI());
+        }
+
+        return derived.serializePubB58(params);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean onlyAllowsLocalCalls() {
+        return false;
+    }
+
+    private void throwInvalidPath(String path) {
+        throw new NativeContractIllegalArgumentException(getInvalidPathErrorMessage(path));
+    }
+
+    private String getInvalidPathErrorMessage(String path) {
+        return String.format("Invalid path '%s'", path);
+    }
+
+    private boolean isDecimal(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private boolean isDecimal(String s) {
+        return s.chars().mapToObj(c -> (char) c).allMatch(c -> isDecimal(c));
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKey.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKey.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.crypto.DeterministicKey;
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import co.rsk.pcc.NativeMethod;
+import org.ethereum.core.CallTransaction;
+
+/**
+ * This implements the "extractPublicKeyFromExtendedPublicKey" method
+ * that belongs to the BTOUtils native contract.
+ *
+ * @author Ariel Mendelzon
+ */
+public class ExtractPublicKeyFromExtendedPublicKey extends NativeMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "extractPublicKeyFromExtendedPublicKey",
+            new String[]{"string"},
+            new String[]{"bytes"}
+    );
+
+    private final BTOUtilsHelper helper;
+
+    public ExtractPublicKeyFromExtendedPublicKey(ExecutionEnvironment executionEnvironment, BTOUtilsHelper helper) {
+        super(executionEnvironment);
+        this.helper = helper;
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    public Object execute(Object[] arguments) {
+        String xpub = (String) arguments[0];
+
+        NetworkParameters params = helper.validateAndExtractNetworkFromExtendedPublicKey(xpub);
+        DeterministicKey key;
+        try {
+            key = DeterministicKey.deserializeB58(xpub, params);
+        } catch (IllegalArgumentException e) {
+            throw new NativeContractIllegalArgumentException(String.format("Invalid extended public key '%s", xpub), e);
+        }
+
+        return key.getPubKeyPoint().getEncoded(true);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean onlyAllowsLocalCalls() {
+        return false;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import co.rsk.pcc.NativeMethod;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.CallTransaction;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This implements the "getMultisigScriptHash" method
+ * that belongs to the BTOUtils native contract.
+ *
+ * @author Ariel Mendelzon
+ */
+public class GetMultisigScriptHash extends NativeMethod {
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "getMultisigScriptHash",
+            new String[]{"int256", "bytes[]"},
+            new String[]{"bytes"}
+    );
+
+    private final static int COMPRESSED_PUBLIC_KEY_LENGTH = 33;
+    private final static int UNCOMPRESSED_PUBLIC_KEY_LENGTH = 65;
+
+    // Enforced by the 520-byte size limit of the redeem script
+    // (see https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#520byte_limitation_on_serialized_script_size)
+    private final static int MAXIMUM_ALLOWED_SIGNATURES = 15;
+
+    public GetMultisigScriptHash(ExecutionEnvironment executionEnvironment) {
+        super(executionEnvironment);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    public Object execute(Object[] arguments) {
+        int minimumSignatures = ((BigInteger) arguments[0]).intValueExact();
+        Object[] publicKeys = (Object[]) arguments[1];
+
+        if (minimumSignatures == 0) {
+            throw new NativeContractIllegalArgumentException("Minimum required signatures must be greater than zero");
+        }
+
+        if (publicKeys.length == 0) {
+            throw new NativeContractIllegalArgumentException("At least one public key is required");
+        }
+
+        if (publicKeys.length < minimumSignatures) {
+            throw new NativeContractIllegalArgumentException(String.format(
+                    "Given public keys (%d) are less than the minimum required signatures (%d)",
+                    publicKeys.length, minimumSignatures
+            ));
+        }
+
+        if (publicKeys.length > MAXIMUM_ALLOWED_SIGNATURES) {
+            throw new NativeContractIllegalArgumentException(String.format(
+                    "Given public keys (%d) are more than the maximum allowed signatures (%d)",
+                    publicKeys.length, MAXIMUM_ALLOWED_SIGNATURES
+            ));
+        }
+
+        List<BtcECKey> btcPublicKeys = new ArrayList<>();
+        Arrays.stream(publicKeys).forEach(o -> {
+            byte[] publicKey = (byte[]) o;
+            if (publicKey.length != COMPRESSED_PUBLIC_KEY_LENGTH && publicKey.length != UNCOMPRESSED_PUBLIC_KEY_LENGTH) {
+                throw new NativeContractIllegalArgumentException(String.format(
+                        "Invalid public key length: %d", publicKey.length
+                ));
+            }
+
+            // Avoid extra work by not recalculating compressed keys on already compressed keys
+            try {
+                BtcECKey btcPublicKey = BtcECKey.fromPublicOnly(publicKey);
+                if (publicKey.length == UNCOMPRESSED_PUBLIC_KEY_LENGTH) {
+                    btcPublicKey = BtcECKey.fromPublicOnly(btcPublicKey.getPubKeyPoint().getEncoded(true));
+                }
+                btcPublicKeys.add(btcPublicKey);
+            } catch (IllegalArgumentException e) {
+                throw new NativeContractIllegalArgumentException(String.format(
+                        "Invalid public key format: %s", Hex.toHexString(publicKey)
+                ), e);
+            }
+        });
+
+        Script multisigScript = ScriptBuilder.createP2SHOutputScript(minimumSignatures, btcPublicKeys);
+
+        return multisigScript.getPubKeyHash();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean onlyAllowsLocalCalls() {
+        return false;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/ToBase58Check.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/ToBase58Check.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import co.rsk.pcc.NativeMethod;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.CallTransaction;
+
+import java.math.BigInteger;
+
+/**
+ * This implements the "toBase58Check" method
+ * that belongs to the BTOUtils native contract.
+ *
+ * @author Ariel Mendelzon
+ */
+public class ToBase58Check extends NativeMethod {
+    /**
+     * This is here since the bitcoinj Address class performs version
+     * validation depending on the actual network passed in,
+     * and the given constructor within VersionedChecksummedBytes is protected.
+     */
+    private static class VersionedChecksummedBytes extends co.rsk.bitcoinj.core.VersionedChecksummedBytes {
+        public VersionedChecksummedBytes(int version, byte[] bytes) {
+            super(version, bytes);
+        }
+    }
+
+    private final CallTransaction.Function function = CallTransaction.Function.fromSignature(
+            "toBase58Check",
+            new String[]{"bytes", "int256"},
+            new String[]{"string"}
+    );
+
+    public ToBase58Check(ExecutionEnvironment executionEnvironment) {
+        super(executionEnvironment);
+    }
+
+    @Override
+    public CallTransaction.Function getFunction() {
+        return function;
+    }
+
+    @Override
+    public Object execute(Object[] arguments) {
+        byte[] hash = (byte[]) arguments[0];
+        if (hash.length != 20) {
+            throw new NativeContractIllegalArgumentException(String.format(
+                    "Invalid hash160 '%s' (should be 20 bytes and is %d bytes)",
+                    Hex.toHexString(hash), hash.length
+            ));
+        }
+
+        int version = ((BigInteger) arguments[1]).intValueExact();
+
+        return new VersionedChecksummedBytes(version, hash).toBase58();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean onlyAllowsLocalCalls() {
+        return false;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/BlockchainConfig.java
@@ -64,4 +64,6 @@ public interface BlockchainConfig {
     boolean isRskip98();
 
     boolean isRskip123();
+
+    boolean isRskip106();
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/AbstractConfig.java
@@ -164,7 +164,8 @@ public abstract class AbstractConfig implements BlockchainConfig, BlockchainNetC
     }
 
     @Override
-    public boolean isRskip123() {
-        return false;
-    }
+    public boolean isRskip123() { return false; }
+
+    @Override
+    public boolean isRskip106() { return false; }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/devnet/DevNetSecondForkConfig.java
@@ -25,4 +25,9 @@ public class DevNetSecondForkConfig extends DevNetOrchid060Config {
     public boolean isRskip123() {
         return true;
     }
+
+    @Override
+    public boolean isRskip106() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/mainnet/MainNetSecondForkConfig.java
@@ -20,8 +20,14 @@
 package org.ethereum.config.blockchain.mainnet;
 
 public class MainNetSecondForkConfig extends MainNetOrchid060Config {
+
     @Override
     public boolean isRskip123() {
+        return true;
+    }
+
+    @Override
+    public boolean isRskip106() {
         return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/regtest/RegTestSecondForkConfig.java
@@ -20,8 +20,14 @@
 package org.ethereum.config.blockchain.regtest;
 
 public class RegTestSecondForkConfig extends RegTestOrchidConfig {
+
     @Override
     public boolean isRskip123() {
+        return true;
+    }
+
+    @Override
+    public boolean isRskip106() {
         return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/testnet/TestNetSecondForkConfig.java
@@ -25,4 +25,9 @@ public class TestNetSecondForkConfig extends TestNetOrchid060Config {
     public boolean isRskip123() {
         return true;
     }
+
+    @Override
+    public boolean isRskip106() {
+        return true;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
@@ -22,6 +22,7 @@ package org.ethereum.vm;
 import co.rsk.config.RemascConfigFactory;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.pcc.bto.BTOUtils;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.SamplePrecompiledContract;
 import co.rsk.remasc.RemascContract;
@@ -57,11 +58,14 @@ public class PrecompiledContracts {
     public static final String SAMPLE_ADDR_STR = "0000000000000000000000000000000001000005";
     public static final String BRIDGE_ADDR_STR = "0000000000000000000000000000000001000006";
     public static final String REMASC_ADDR_STR = "0000000000000000000000000000000001000008";
+    public static final String BTOUTILS_ADDR_STR = "0000000000000000000000000000000001000009";
 
     public static final RskAddress BRIDGE_ADDR = new RskAddress(BRIDGE_ADDR_STR);
     public static final RskAddress IDENTITY_ADDR = new RskAddress(IDENTITY_ADDR_STR);
     public static final RskAddress REMASC_ADDR = new RskAddress(REMASC_ADDR_STR);
     public static final RskAddress SAMPLE_ADDR = new RskAddress(SAMPLE_ADDR_STR);
+    public static final RskAddress BTOUTILS_ADDR = new RskAddress(BTOUTILS_ADDR_STR);
+
 
     public static final DataWord BRIDGE_ADDR_DW = DataWord.valueOf(BRIDGE_ADDR.getBytes());
     public static final DataWord IDENTITY_ADDR_DW = DataWord.valueOf(IDENTITY_ADDR.getBytes());
@@ -71,6 +75,7 @@ public class PrecompiledContracts {
     public static final DataWord RIPEMPD160_ADDR_DW = DataWord.valueFromHex(RIPEMPD160_ADDR);
     public static final DataWord BIG_INT_MODEXP_ADDR_DW = DataWord.valueFromHex(BIG_INT_MODEXP_ADDR);
     public static final DataWord SHA256_ADDR_DW = DataWord.valueFromHex(SHA256_ADDR);
+    public static final DataWord BTOUTILS_ADDR_DW = DataWord.valueOf(BTOUTILS_ADDR.getBytes());
 
     private static ECRecover ecRecover = new ECRecover();
     private static Sha256 sha256 = new Sha256();
@@ -115,6 +120,9 @@ public class PrecompiledContracts {
         }
         if (address.equals(REMASC_ADDR_DW)) {
             return new RemascContract(config, new RemascConfigFactory(RemascContract.REMASC_CONFIG).createRemascConfig(config.netName()), REMASC_ADDR);
+        }
+        if (blockchainConfig.isRskip106() && address.equals(BTOUTILS_ADDR_DW)) {
+            return new BTOUtils(config, BTOUTILS_ADDR);
         }
 
         return null;

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -22,6 +22,7 @@ package org.ethereum.vm.program;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.pcc.NativeContract;
 import co.rsk.peg.Bridge;
 import co.rsk.remasc.RemascContract;
 import co.rsk.vm.BitSet;
@@ -260,11 +261,11 @@ public class Program {
 
 
     public DataWord sweepGetDataWord(int n) {
-          if (pc + n > ops.length) {
-              stop();
-              // In this case partial data is copied. At least Ethereumj does this
-              // Asummes LSBs are zero. assignDataRange undestands this semantics.
-          }
+        if (pc + n > ops.length) {
+            stop();
+            // In this case partial data is copied. At least Ethereumj does this
+            // Asummes LSBs are zero. assignDataRange undestands this semantics.
+        }
 
         DataWord dw = DataWord.valueOf(ops, pc, n);
         pc += n;
@@ -486,8 +487,8 @@ public class Program {
         if (programResult.getException() != null || programResult.isRevert()) {
             if (isLogEnabled) {
                 logger.debug("contract run halted by Exception: contract: [{}], exception: [{}]",
-                      newAddress,
-                      programResult.getException());
+                        newAddress,
+                        programResult.getException());
             }
 
             if (internalTx == null) {
@@ -655,7 +656,7 @@ public class Program {
         if (byTestingSuite()) {
             // This keeps track of the calls created for a test
             getResult().addCallCreate(data, contextAddress.getBytes(),
-                        msg.getGas().longValueSafe(),
+                    msg.getGas().longValueSafe(),
                     msg.getEndowment().getNoLeadZeroesData());
             return;
         }
@@ -718,8 +719,8 @@ public class Program {
         if (childResult.getException() != null || childResult.isRevert()) {
             if (isGasLogEnabled) {
                 gasLogger.debug("contract run halted by Exception: contract: [{}], exception: [{}]",
-                    contextAddress,
-                    childResult .getException());
+                        contextAddress,
+                        childResult .getException());
             }
 
             internalTx.reject();
@@ -859,7 +860,7 @@ public class Program {
     }
 
     public DataWord getBlockHash(long index) {
-       long bn = this.getNumber().longValue();
+        long bn = this.getNumber().longValue();
         if ((index <  bn) && (index >= Math.max(0, bn - 256))) {
             return DataWord.valueOf(this.invoke.getBlockStore().getBlockHashByNumber(index, getPrevHash().getData()));
         } else {
@@ -889,7 +890,7 @@ public class Program {
     }
 
     public DataWord getCallValue() {
-            return invoke.getCallValue();
+        return invoke.getCallValue();
     }
 
     public DataWord getDataSize() {
@@ -1228,8 +1229,8 @@ public class Program {
             return;
         }
 
-        // Special initialization for Bridge and Remasc contracts
-        if (contract instanceof Bridge || contract instanceof RemascContract) {
+        // Special initialization for Bridge, Remasc and NativeContract contracts
+        if (contract instanceof Bridge || contract instanceof RemascContract || contract instanceof NativeContract) {
             // CREATE CALL INTERNAL TRANSACTION
             InternalTransaction internalTx = addInternalTx(null, getGasLimit(), senderAddress, contextAddress, endowment, EMPTY_BYTE_ARRAY, "call");
 

--- a/rskj-core/src/test/java/co/rsk/db/BenchmarkedRepository.java
+++ b/rskj-core/src/test/java/co/rsk/db/BenchmarkedRepository.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.db;
+
+public interface BenchmarkedRepository {
+    class Statistics {
+        private final int SLOT_SIZE_BYTES = 32;
+        private int slotsWritten;
+        private int slotsCleared;
+
+        public Statistics() {
+            clear();
+        }
+
+        public void clear() {
+            slotsWritten = 0;
+            slotsCleared = 0;
+        }
+
+        public void recordWrite(byte[] oldValue, byte[] newValue) {
+            int oldValueLength = oldValue == null ? 0 : oldValue.length;
+            int newValueLength = newValue == null ? 0 : newValue.length;
+            int delta = newValueLength - oldValueLength;
+            int slots = (int) Math.ceil((double)Math.abs(delta) / (double)SLOT_SIZE_BYTES);
+            if (delta > 0) {
+                slotsWritten += slots;
+            } else {
+                slotsCleared += slots;
+            }
+        }
+
+        public int getSlotsWritten() {
+            return slotsWritten;
+        }
+
+        public int getSlotsCleared() {
+            return slotsCleared;
+        }
+    }
+
+    Statistics getStatistics();
+}

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackWithBenchmarking.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackWithBenchmarking.java
@@ -25,43 +25,8 @@ import org.ethereum.core.Repository;
 import org.ethereum.db.RepositoryTrack;
 import org.ethereum.vm.DataWord;
 
-public class RepositoryTrackWithBenchmarking extends RepositoryTrack {
-    public class Statistics {
-        private final int SLOT_SIZE_BYTES = 32;
-        private int slotsWritten;
-        private int slotsCleared;
-
-        public Statistics() {
-            clear();
-        }
-
-        public void clear() {
-            slotsWritten = 0;
-            slotsCleared = 0;
-        }
-
-        public void recordWrite(byte[] oldValue, byte[] newValue) {
-            int oldValueLength = oldValue == null ? 0 : oldValue.length;
-            int newValueLength = newValue == null ? 0 : newValue.length;
-            int delta = newValueLength - oldValueLength;
-            int slots = (int) Math.ceil((double)Math.abs(delta) / (double)SLOT_SIZE_BYTES);
-            if (delta > 0) {
-                slotsWritten += slots;
-            } else {
-                slotsCleared += slots;
-            }
-        }
-
-        public int getSlotsWritten() {
-            return slotsWritten;
-        }
-
-        public int getSlotsCleared() {
-            return slotsCleared;
-        }
-    }
-
-    private final Statistics statistics;
+public class RepositoryTrackWithBenchmarking extends RepositoryTrack implements BenchmarkedRepository {
+    protected final Statistics statistics;
 
     public RepositoryTrackWithBenchmarking(Repository repository) {
         super(repository);

--- a/rskj-core/src/test/java/co/rsk/pcc/NativeContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/NativeContractTest.java
@@ -1,0 +1,459 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Block;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.vm.LogInfo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class NativeContractTest {
+    private interface MethodListProvider {
+        List<NativeMethod> get();
+    }
+
+    private interface OptionalMethodProvider {
+        Optional<NativeMethod> get();
+    }
+
+    private TestSystemProperties config;
+    private NativeContract contract;
+    private OptionalMethodProvider defaultMethodProvider;
+    private Transaction tx;
+    private Block block;
+    private Repository repository;
+    private BlockStore blockStore;
+    private ReceiptStore receiptStore;
+    private List<LogInfo> logs;
+    private boolean beforeRan;
+    private boolean afterRan;
+
+    @Before
+    public void beforeTests() {
+        config = new TestSystemProperties();
+        defaultMethodProvider = () -> Optional.empty();
+        contract = spy(new EmptyNativeContract(config));
+    }
+
+    @Test
+    public void createsExecutionEnvironmentUponInit() {
+        Assert.assertNull(contract.getExecutionEnvironment());
+
+        doInit();
+
+        ExecutionEnvironment executionEnvironment = contract.getExecutionEnvironment();
+        Assert.assertNotNull(executionEnvironment);
+        Assert.assertEquals(tx, executionEnvironment.getTransaction());
+        Assert.assertEquals(block, executionEnvironment.getBlock());
+        Assert.assertEquals(repository, executionEnvironment.getRepository());
+        Assert.assertEquals(blockStore, executionEnvironment.getBlockStore());
+        Assert.assertEquals(receiptStore, executionEnvironment.getReceiptStore());
+        Assert.assertEquals(logs, executionEnvironment.getLogs());
+    }
+
+    @Test
+    public void getGasForDataFailsWhenNoInit() {
+        assertFails(() -> contract.getGasForData(Hex.decode("aabb")));
+    }
+
+    @Test
+    public void getGasForDataZeroWhenNullData() {
+        doInit();
+        Assert.assertEquals(0L, contract.getGasForData(null));
+    }
+
+    @Test
+    public void getGasForDataZeroWhenEmptyData() {
+        contract = new EmptyNativeContract(config);
+        doInit();
+        Assert.assertEquals(0L, contract.getGasForData(null));
+    }
+
+    @Test
+    public void getGasForNullDataAndDefaultMethod() {
+        NativeMethod method = mock(NativeMethod.class);
+        when(method.getGas(any(), any())).thenReturn(10L);
+        contract = new EmptyNativeContract(config) {
+            @Override
+            public Optional<NativeMethod> getDefaultMethod() {
+                return Optional.of(method);
+            }
+        };
+        doInit();
+        Assert.assertEquals(10L, contract.getGasForData(null));
+    }
+
+    @Test
+    public void getGasForEmptyDataAndDefaultMethod() {
+        contract = new EmptyNativeContract(config);
+        NativeMethod method = mock(NativeMethod.class);
+        when(method.getGas(any(), any())).thenReturn(10L);
+        contract = new EmptyNativeContract(config) {
+            @Override
+            public Optional<NativeMethod> getDefaultMethod() {
+                return Optional.of(method);
+            }
+        };
+        doInit();
+        Assert.assertEquals(10L, contract.getGasForData(new byte[]{}));
+    }
+
+    @Test
+    public void getGasForDataZeroWhenInvalidSignature() {
+        doInit();
+        Assert.assertEquals(0L, contract.getGasForData(Hex.decode("aabb")));
+    }
+
+    @Test
+    public void getGasForDataZeroWhenNoMappedMethod() {
+        doInit();
+        Assert.assertEquals(0L, contract.getGasForData(Hex.decode("aabbccdd")));
+    }
+
+    @Test
+    public void getGasForDataZeroWhenMethodDisabled() {
+        doInit();
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(method.getFunction()).thenReturn(fn);
+        when(method.getGas(any(), any())).thenReturn(123L);
+        when(method.isEnabled()).thenReturn(false);
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+        Assert.assertEquals(0L, contract.getGasForData(Hex.decode("00112233")));
+    }
+
+    @Test
+    public void getGasForDataNonZeroWhenMethodMatches() {
+        doInit();
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(method.getFunction()).thenReturn(fn);
+        when(method.getGas(any(), any())).thenReturn(123L);
+        when(method.isEnabled()).thenReturn(true);
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+        Assert.assertEquals(123L, contract.getGasForData(Hex.decode("00112233")));
+    }
+
+    @Test
+    public void getGasForDataNonZeroWhenMethodMatchesMoreThanOne() {
+        doInit();
+
+        NativeMethod method1 = mock(NativeMethod.class);
+        CallTransaction.Function fn1 = mock(CallTransaction.Function.class);
+        when(fn1.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(method1.getFunction()).thenReturn(fn1);
+        when(method1.getGas(any(), any())).thenReturn(123L);
+        when(method1.isEnabled()).thenReturn(true);
+
+        NativeMethod method2 = mock(NativeMethod.class);
+        CallTransaction.Function fn2 = mock(CallTransaction.Function.class);
+        when(fn2.encodeSignature()).thenReturn(Hex.decode("44556677"));
+        when(method2.getFunction()).thenReturn(fn2);
+        when(method2.getGas(any(), any())).thenReturn(456L);
+        when(method2.isEnabled()).thenReturn(true);
+        when(contract.getMethods()).thenReturn(Arrays.asList(method1, method2));
+        Assert.assertEquals(123L, contract.getGasForData(Hex.decode("00112233")));
+        Assert.assertEquals(456L, contract.getGasForData(Hex.decode("44556677")));
+    }
+
+    @Test
+    public void executeThrowsWhenNoInit() {
+        assertContractExecutionFails("aabbccdd");
+        verify(contract, never()).before();
+        verify(contract, never()).after();
+        Assert.assertFalse(beforeRan);
+        Assert.assertFalse(afterRan);
+    }
+
+    @Test
+    public void executeThrowsWhenNoTransaction() {
+        doInit();
+        Whitebox.setInternalState(contract.getExecutionEnvironment(), "transaction", (Transaction) null);
+        assertContractExecutionFails("aabbccdd");
+        Assert.assertFalse(beforeRan);
+        Assert.assertFalse(afterRan);
+    }
+
+    @Test
+    public void executeThrowsWhenInvalidSignature() {
+        doInit();
+        assertContractExecutionFails("aa");
+        Assert.assertFalse(beforeRan);
+        Assert.assertFalse(afterRan);
+    }
+
+    @Test
+    public void executeThrowsWhenMethodDisabled() {
+        doInit();
+
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(method.getFunction()).thenReturn(fn);
+        when(method.isEnabled()).thenReturn(false);
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+
+        assertContractExecutionFails("00112233");
+        Assert.assertFalse(beforeRan);
+        Assert.assertFalse(afterRan);
+    }
+
+    @Test
+    public void executeThrowsWhenMethodMatchesButArgumentsInvalid() {
+        doInit();
+
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(fn.decode(Hex.decode("00112233"))).thenThrow(new RuntimeException("invalid arguments"));
+        when(method.getFunction()).thenReturn(fn);
+        when(method.isEnabled()).thenReturn(true);
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+
+        assertContractExecutionFails("00112233");
+        Assert.assertFalse(beforeRan);
+        Assert.assertFalse(afterRan);
+    }
+
+    @Test
+    public void executeThrowsWhenMethodMatchesButNoLocalCallsAllowed() {
+        doInit();
+
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(method.getFunction()).thenReturn(fn);
+        when(method.isEnabled()).thenReturn(true);
+        when(method.onlyAllowsLocalCalls()).thenReturn(true);
+        when(tx.isLocalCallTransaction()).thenReturn(false);
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+
+        assertContractExecutionFails("00112233");
+        Assert.assertFalse(beforeRan);
+        Assert.assertFalse(afterRan);
+    }
+
+    @Test
+    public void executeRunsWhenMethodMatchesAndArgumentsValid() {
+        doInit();
+
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(fn.decode(Hex.decode("00112233"))).thenReturn(new Object[]{ "arg1", "arg2" });
+        when(fn.encodeOutputs("execution-result")).thenReturn(Hex.decode("aabbccddeeff112233"));
+        when(method.getFunction()).thenReturn(fn);
+        when(method.isEnabled()).thenReturn(true);
+        when(method.execute(any())).thenAnswer((InvocationOnMock m) -> {
+            Object[] arguments = m.getArgument(0);
+            Assert.assertEquals(2, arguments.length);
+            Assert.assertEquals("arg1", arguments[0]);
+            Assert.assertEquals("arg2", arguments[1]);
+            return "execution-result";
+        });
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+
+        Assert.assertEquals("aabbccddeeff112233", Hex.toHexString(contract.execute(Hex.decode("00112233"))));
+        verify(method, times(1)).execute(any());
+        verify(contract, times(1)).before();
+        verify(contract, times(1)).after();
+    }
+
+    @Test
+    public void executeRunsWhenMethodMatchesAndArgumentsValidExecutionThrows() {
+        doInit();
+
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(fn.decode(Hex.decode("00112233"))).thenReturn(new Object[]{ "arg1", "arg2" });
+        when(fn.encodeOutputs("execution-result")).thenReturn(Hex.decode("aabbccddeeff112233"));
+        when(method.getFunction()).thenReturn(fn);
+        when(method.getGas(any(), any())).thenReturn(123L);
+        when(method.isEnabled()).thenReturn(true);
+        when(method.execute(any())).thenAnswer((InvocationOnMock m) -> {
+            Object[] arguments = m.getArgument(0);
+            Assert.assertEquals(2, arguments.length);
+            Assert.assertEquals("arg1", arguments[0]);
+            Assert.assertEquals("arg2", arguments[1]);
+            throw new Exception("something hapened");
+        });
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+
+        assertContractExecutionFails("00112233");
+        verify(method, times(1)).execute(any());
+        verify(contract, times(1)).before();
+        verify(contract, never()).after();
+    }
+
+    @Test
+    public void executeWithNullResult() {
+        doInit();
+
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(fn.decode(Hex.decode("00112233"))).thenReturn(new Object[]{ "arg1", "arg2" });
+        when(method.getFunction()).thenReturn(fn);
+        when(method.isEnabled()).thenReturn(true);
+        when(method.execute(any())).thenAnswer((InvocationOnMock m) -> {
+            Object[] arguments = m.getArgument(0);
+            Assert.assertEquals(2, arguments.length);
+            Assert.assertEquals("arg1", arguments[0]);
+            Assert.assertEquals("arg2", arguments[1]);
+            return null;
+        });
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+
+        Assert.assertNull(contract.execute(Hex.decode("00112233")));
+        verify(method, times(1)).execute(any());
+        verify(fn, never()).encodeOutputs(any());
+        verify(contract, times(1)).before();
+        verify(contract, times(1)).after();
+    }
+
+    @Test
+    public void executeWithEmptyOptionalResult() {
+        doInit();
+
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(fn.decode(Hex.decode("00112233"))).thenReturn(new Object[]{ "arg1", "arg2" });
+        when(method.getFunction()).thenReturn(fn);
+        when(method.isEnabled()).thenReturn(true);
+        when(method.execute(any())).thenAnswer((InvocationOnMock m) -> {
+            Object[] arguments = m.getArgument(0);
+            Assert.assertEquals(2, arguments.length);
+            Assert.assertEquals("arg1", arguments[0]);
+            Assert.assertEquals("arg2", arguments[1]);
+            return Optional.empty();
+        });
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+
+        Assert.assertNull(contract.execute(Hex.decode("00112233")));
+        verify(method, times(1)).execute(any());
+        verify(fn, never()).encodeOutputs(any());
+        verify(contract, times(1)).before();
+        verify(contract, times(1)).after();
+    }
+
+    @Test
+    public void executeWithNonEmptyOptionalResult() {
+        doInit();
+
+        NativeMethod method = mock(NativeMethod.class);
+        CallTransaction.Function fn = mock(CallTransaction.Function.class);
+        when(fn.encodeSignature()).thenReturn(Hex.decode("00112233"));
+        when(fn.decode(Hex.decode("00112233"))).thenReturn(new Object[]{ "arg1", "arg2" });
+        when(fn.encodeOutputs("another-result")).thenReturn(Hex.decode("ffeeddccbb"));
+        when(method.getFunction()).thenReturn(fn);
+        when(method.isEnabled()).thenReturn(true);
+        when(method.execute(any())).thenAnswer((InvocationOnMock m) -> {
+            Object[] arguments = m.getArgument(0);
+            Assert.assertEquals(2, arguments.length);
+            Assert.assertEquals("arg1", arguments[0]);
+            Assert.assertEquals("arg2", arguments[1]);
+            return Optional.of("another-result");
+        });
+        when(contract.getMethods()).thenReturn(Arrays.asList(method));
+
+        Assert.assertEquals("ffeeddccbb", Hex.toHexString(contract.execute(Hex.decode("00112233"))));
+        verify(method, times(1)).execute(any());
+        verify(contract, times(1)).before();
+        verify(contract, times(1)).after();
+    }
+
+    private void doInit() {
+        tx = mock(Transaction.class);
+        block = mock(Block.class);
+        repository = mock(Repository.class);
+        blockStore = mock(BlockStore.class);
+        receiptStore = mock(ReceiptStore.class);
+        logs = Collections.emptyList();
+        contract.init(tx, block, repository, blockStore, receiptStore, logs);
+    }
+
+    private void assertFails(Runnable statement) {
+        boolean failed = false;
+        try {
+            statement.run();
+        } catch (RuntimeException e) {
+            failed = true;
+        }
+        Assert.assertTrue(failed);
+    }
+
+    private void assertContractExecutionFails(String hexData) {
+        assertFails(() -> contract.execute(Hex.decode(hexData)));
+    }
+
+    static class EmptyNativeContract extends NativeContract {
+
+        boolean beforeRan = false;
+        boolean afterRan = false;
+
+        EmptyNativeContract(RskSystemProperties config){
+            super(config, new RskAddress("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        }
+
+        @Override
+        public List<NativeMethod> getMethods() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Optional<NativeMethod> getDefaultMethod() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void before() {
+            beforeRan = true;
+        }
+
+        @Override
+        public void after() {
+            afterRan = true;
+        }
+    };
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/NativeMethodTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/NativeMethodTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.CallTransaction;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class NativeMethodTest {
+    private ExecutionEnvironment executionEnvironment;
+    private CallTransaction.Function function;
+    private NativeMethod method;
+    private NativeMethod.WithArguments withArguments;
+
+    @Before
+    public void createMethodAndArguments() {
+        executionEnvironment = mock(ExecutionEnvironment.class);
+        function = mock(CallTransaction.Function.class);
+        method = new NativeMethod(executionEnvironment) {
+            @Override
+            public CallTransaction.Function getFunction() {
+                return function;
+            }
+
+            @Override
+            public Object execute(Object[] arguments) {
+                return "execution-result";
+            }
+
+            @Override
+            public boolean isEnabled() {
+                return false;
+            }
+
+            @Override
+            public boolean onlyAllowsLocalCalls() {
+                return false;
+            }
+        };
+        withArguments = method.new WithArguments(new Object[]{ "arg1", "arg2" }, Hex.decode("aabbcc"));
+    }
+
+    @Test
+    public void executionEnvironmentGetter() {
+        Assert.assertEquals(executionEnvironment, method.getExecutionEnvironment());
+    }
+
+    @Test
+    public void getGasWithNullData() {
+        Assert.assertEquals(0L, method.getGas(null, null));
+    }
+
+    @Test
+    public void getGasWithNonNullData() {
+        Assert.assertEquals(6L, method.getGas(null, Hex.decode("aabbcc")));
+        Assert.assertEquals(10L, method.getGas(null, Hex.decode("aabbccddee")));
+    }
+
+    @Test
+    public void getName() {
+        function.name = "a-method-name";
+        Assert.assertEquals("a-method-name", method.getName());
+    }
+
+    @Test
+    public void withArgumentsGetsMethod() {
+        Assert.assertEquals(method, withArguments.getMethod());
+    }
+
+    @Test
+    public void withArgumentsGetsGas() {
+        Assert.assertEquals(6L, withArguments.getGas());
+    }
+
+    @Test
+    public void withArgumentsExecutesMethod() {
+        Assert.assertEquals("execution-result", withArguments.execute());
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/BTOUtilsHelperTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/BTOUtilsHelperTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BTOUtilsHelperTest {
+    private BTOUtilsHelper helper;
+
+    @Before
+    public void createHelper() {
+        helper = new BTOUtilsHelper();
+    }
+
+    @Test
+    public void validateAndExtractNetworkFromExtendedPublicKeyMainnet() {
+        Assert.assertEquals(
+                NetworkParameters.fromID(NetworkParameters.ID_MAINNET),
+                helper.validateAndExtractNetworkFromExtendedPublicKey("xpubSomethingSomething")
+        );
+    }
+
+    @Test
+    public void validateAndExtractNetworkFromExtendedPublicKeyTestnet() {
+        Assert.assertEquals(
+                NetworkParameters.fromID(NetworkParameters.ID_TESTNET),
+                helper.validateAndExtractNetworkFromExtendedPublicKey("tpubSomethingSomething")
+        );
+    }
+
+    @Test(expected = NativeContractIllegalArgumentException.class)
+    public void validateAndExtractNetworkFromExtendedPublicKeyInvalid() {
+        helper.validateAndExtractNetworkFromExtendedPublicKey("completelyInvalidStuff");
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/BTOUtilsPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/BTOUtilsPerformanceTest.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.peg.performance.PrecompiledContractPerformanceTest;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        ToBase58CheckPerformanceTestCase.class,
+        DeriveExtendedPublicKeyPerformanceTestCase.class,
+        ExtractPublicKeyFromExtendedPublicKeyPerformanceTestCase.class,
+        GetMultisigScriptHashPerformanceTestCase.class
+})
+@Ignore
+public class BTOUtilsPerformanceTest extends PrecompiledContractPerformanceTest {
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/BTOUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/BTOUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeMethod;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+
+public class BTOUtilsTest {
+    private RskSystemProperties config;
+    private ExecutionEnvironment executionEnvironment;
+    private BTOUtils contract;
+
+    @Before
+    public void createContract() {
+        config = new TestSystemProperties();
+        executionEnvironment = mock(ExecutionEnvironment.class);
+        contract = new BTOUtils(config, new RskAddress("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        Whitebox.setInternalState(contract, "executionEnvironment", executionEnvironment);
+    }
+
+    @Test
+    public void hasNoDefaultMethod() {
+        Assert.assertFalse(contract.getDefaultMethod().isPresent());
+    }
+
+    @Test
+    public void hasFourMethods() {
+        Assert.assertEquals(4, contract.getMethods().size());
+    }
+
+    @Test
+    public void hasToBase58Check() {
+        assertHasMethod(ToBase58Check.class, false);
+    }
+
+    @Test
+    public void hasDeriveExtendedPublicKey() {
+        assertHasMethod(DeriveExtendedPublicKey.class, true);
+    }
+
+    @Test
+    public void hasExtractPublicKeyFromExtendedPublicKey() {
+        assertHasMethod(ExtractPublicKeyFromExtendedPublicKey.class, true);
+    }
+
+    @Test
+    public void hasGetMultisigScriptHash() {
+        assertHasMethod(GetMultisigScriptHash.class, false);
+    }
+
+    private void assertHasMethod(Class clazz, boolean withHelper) {
+        Optional<NativeMethod> method = contract.getMethods().stream()
+                .filter(m -> m.getClass() == clazz).findFirst();
+        Assert.assertTrue(method.isPresent());
+        Assert.assertEquals(executionEnvironment, method.get().getExecutionEnvironment());
+        if (withHelper) {
+            Object helper = Whitebox.getInternalState(method.get(), "helper");
+            Assert.assertNotNull(helper);
+            Assert.assertEquals(BTOUtilsHelper.class, helper.getClass());
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/DeriveExtendedPublicKeyPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/DeriveExtendedPublicKeyPerformanceTestCase.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.crypto.DeterministicKey;
+import co.rsk.bitcoinj.crypto.HDKeyDerivation;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.db.BenchmarkedRepository;
+import co.rsk.peg.performance.CombinedExecutionStats;
+import co.rsk.peg.performance.ExecutionStats;
+import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+@Ignore
+public class DeriveExtendedPublicKeyPerformanceTestCase extends PrecompiledContractPerformanceTestCase {
+    private static final int MAX_CHILD = (2 << 30) - 1;
+
+    private CallTransaction.Function function;
+
+    @Test
+    public void deriveExtendedPublicKey() throws IOException {
+        function = new DeriveExtendedPublicKey(null, null).getFunction();
+
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
+            @Override
+            public Environment initialize(int executionIndex, TxBuilder txBuilder, int height) {
+                BTOUtils contract = new BTOUtils(new TestSystemProperties(), PrecompiledContracts.BTOUTILS_ADDR);
+                contract.init(txBuilder.build(executionIndex), Helper.getMockBlock(1), null, null, null, null);
+
+                return new Environment(
+                        contract,
+                        () -> new BenchmarkedRepository.Statistics()
+                );
+            }
+
+            @Override
+            public void teardown() {
+            }
+        };
+
+        // Get rid of outliers by executing some cases beforehand
+        setQuietMode(true);
+        System.out.print("Doing an initial pass... ");
+        estimateDeriveExtendedPublicKey(100, 1, environmentBuilder);
+        System.out.print("Done!\n");
+        setQuietMode(false);
+
+        CombinedExecutionStats stats = new CombinedExecutionStats(function.name);
+
+        stats.add(estimateDeriveExtendedPublicKey(500, 1, environmentBuilder));
+        stats.add(estimateDeriveExtendedPublicKey(2000, 2, environmentBuilder));
+        stats.add(estimateDeriveExtendedPublicKey(500, 4, environmentBuilder));
+
+        BTOUtilsPerformanceTest.addStats(stats);
+    }
+
+    private ExecutionStats estimateDeriveExtendedPublicKey(int times, int pathLength, EnvironmentBuilder environmentBuilder) {
+        String name = String.format("%s-%d", function.name, pathLength);
+        ExecutionStats stats = new ExecutionStats(name);
+        Random rnd = new Random();
+        byte[] chainCode = new byte[32];
+        NetworkParameters networkParameters = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+
+        ABIEncoder abiEncoder = (int executionIndex) -> {
+            rnd.nextBytes(chainCode);
+            DeterministicKey key = HDKeyDerivation.createMasterPubKeyFromBytes(
+                    new ECKey().getPubKey(true),
+                    chainCode
+            );
+            int[] pathParts = new int[pathLength];
+            for (int i = 0; i < pathLength; i++) {
+                pathParts[i] = rnd.nextInt(MAX_CHILD);
+            }
+            String path = String.join("/", Arrays.stream(pathParts)
+                    .mapToObj(i -> String.format("%d", i)).collect(Collectors.toList()));
+
+            return function.encode(new Object[] {
+                    key.serializePubB58(networkParameters), path
+            });
+        };
+
+        executeAndAverage(
+                name,
+                times,
+                environmentBuilder,
+                abiEncoder,
+                Helper.getZeroValueTxBuilder(new ECKey()),
+                Helper.getRandomHeightProvider(10),
+                stats,
+                (byte[] result) -> {
+                    Object[] decodedResult = function.decodeResult(result);
+                    Assert.assertEquals(String.class, decodedResult[0].getClass());
+                    String address = (String) decodedResult[0];
+                    Assert.assertTrue(address.startsWith("xpub"));
+                }
+        );
+
+        return stats;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/DeriveExtendedPublicKeyTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/DeriveExtendedPublicKeyTest.java
@@ -1,0 +1,191 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.solidity.SolidityType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class DeriveExtendedPublicKeyTest {
+    private ExecutionEnvironment executionEnvironment;
+    private BTOUtilsHelper helper;
+    private DeriveExtendedPublicKey method;
+
+    @Before
+    public void createMethod() {
+        executionEnvironment = mock(ExecutionEnvironment.class);
+        helper = new BTOUtilsHelper();
+        method = new DeriveExtendedPublicKey(executionEnvironment, helper);
+    }
+
+    @Test
+    public void functionSignatureOk() {
+        CallTransaction.Function fn = method.getFunction();
+        Assert.assertEquals("deriveExtendedPublicKey", fn.name);
+
+        Assert.assertEquals(2, fn.inputs.length);
+        Assert.assertEquals(SolidityType.getType("string").getName(), fn.inputs[0].type.getName());
+        Assert.assertEquals(SolidityType.getType("string").getName(), fn.inputs[1].type.getName());
+
+        Assert.assertEquals(1, fn.outputs.length);
+        Assert.assertEquals(SolidityType.getType("string").getName(), fn.outputs[0].type.getName());
+    }
+
+    @Test
+    public void shouldBeEnabled() {
+        Assert.assertTrue(method.isEnabled());
+    }
+
+    @Test
+    public void shouldAllowAnyTypeOfCall() {
+        Assert.assertFalse(method.onlyAllowsLocalCalls());
+    }
+
+    @Test
+    public void executes() {
+        Assert.assertEquals(
+                "tpubDCGMkPKredy7oh6zw8f4ExWFdTgQCrAHToF1ytny3gbVy9GkUNK2Nqh7NbKbh8dkd5VtjUiLJPkbEkeg29NVHwxYwzHJFt9SazGLZrrU4Y4",
+                method.execute(new Object[]{
+                        "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                        "2/3/4"
+                }));
+
+        Assert.assertEquals(
+                "tpubDJ28nwFGUypUD6i8eGCQfMkwNGxzzabA5Mh7AcUdwm6ziFxCSWjy4HyhPXH5uU2ovdMMYLT9W3g3MrGo52TrprMvX8o1dzT2ZGz1pwCPTNv",
+                method.execute(new Object[]{
+                        "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                        "0/0/0/0/0/0"
+                }));
+
+        Assert.assertEquals(
+                "tpubD8fY35uPCY1rUjMUZwhkGUFi33pwkffMEBaCsTSw1he2AbM6DMbPaRR2guvk5qTWDfE9ubFB5pzuUNnMtsqbCeKAAjfepSvEWyetyF9Q4fG",
+                method.execute(new Object[]{
+                        "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                        "2147483647"
+                }));
+    }
+
+    @Test
+    public void validatesExtendedPublicKeyFormat() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "this-is-not-an-xpub",
+                    "this-doesnt-matter"
+            });
+        }, "Invalid extended public key");
+    }
+
+    @Test
+    public void pathCannotBeAnything() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                    "this-is-not-a-path"
+            });
+        }, "Invalid path");
+    }
+
+    @Test
+    public void pathCannotBeEmpty() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                    ""
+            });
+        }, "Invalid path");
+    }
+
+    @Test
+    public void pathCannotContainALeadingM() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                    "M/0/1/2"
+            });
+        }, "Invalid path");
+    }
+
+    @Test
+    public void pathCannotContainALeadingSlash() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                    "/0"
+            });
+        }, "Invalid path");
+    }
+
+    @Test
+    public void pathCannotContainATrailingSlash() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                    "0/"
+            });
+        }, "Invalid path");
+    }
+
+    @Test
+    public void pathCannotContainHardening() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                    "M/4'/5"
+            });
+        }, "Invalid path");
+    }
+
+    @Test
+    public void pathCannotContainNegativeNumbers() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                    "M/0/-1"
+            });
+        }, "Invalid path");
+    }
+
+    @Test
+    public void pathCannotContainPartsBiggerOrEqualThan2Pwr31() {
+        assertFailsWithMessage(() -> {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1r",
+                    "M/0/1/2/2147483648"
+            });
+        }, "Invalid path");
+    }
+
+    private void assertFailsWithMessage(Runnable statement, String message) {
+        boolean failed = false;
+        try {
+            statement.run();
+        } catch (NativeContractIllegalArgumentException e) {
+            failed = true;
+            Assert.assertTrue(e.getMessage().contains(message));
+        }
+        Assert.assertTrue(failed);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKeyPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKeyPerformanceTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.crypto.DeterministicKey;
+import co.rsk.bitcoinj.crypto.HDKeyDerivation;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.db.BenchmarkedRepository;
+import co.rsk.peg.performance.ExecutionStats;
+import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.io.IOException;
+import java.util.Random;
+
+@Ignore
+public class ExtractPublicKeyFromExtendedPublicKeyPerformanceTestCase extends PrecompiledContractPerformanceTestCase {
+    private CallTransaction.Function function;
+
+    @Test
+    public void extractPublicKeyFromExtendedPublicKey() throws IOException {
+        function = new ExtractPublicKeyFromExtendedPublicKey(null, null).getFunction();
+
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
+            @Override
+            public Environment initialize(int executionIndex, TxBuilder txBuilder, int height) {
+                BTOUtils contract = new BTOUtils(new TestSystemProperties(), PrecompiledContracts.BTOUTILS_ADDR);
+                contract.init(txBuilder.build(executionIndex), Helper.getMockBlock(1), null, null, null, null);
+
+                return new Environment(
+                        contract,
+                        () -> new BenchmarkedRepository.Statistics()
+                );
+            }
+
+            @Override
+            public void teardown() {
+            }
+        };
+
+        BTOUtilsPerformanceTest.addStats(estimateExtractPublicKeyFromExtendedPublicKey(500, environmentBuilder));
+    }
+
+    private ExecutionStats estimateExtractPublicKeyFromExtendedPublicKey(int times, EnvironmentBuilder environmentBuilder) {
+        ExecutionStats stats = new ExecutionStats(function.name);
+        Random rnd = new Random();
+        byte[] chainCode = new byte[32];
+        NetworkParameters networkParameters = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+
+        byte[] publicKey = new ECKey().getPubKey(true);
+        String expectedHexPublicKey = Hex.toHexString(publicKey);
+
+        ABIEncoder abiEncoder = (int executionIndex) -> {
+            rnd.nextBytes(chainCode);
+            DeterministicKey key = HDKeyDerivation.createMasterPubKeyFromBytes(
+                    publicKey,
+                    chainCode
+            );
+
+            return function.encode(new Object[] {
+                    key.serializePubB58(networkParameters)
+            });
+        };
+
+        executeAndAverage(
+                function.name,
+                times,
+                environmentBuilder,
+                abiEncoder,
+                Helper.getZeroValueTxBuilder(new ECKey()),
+                Helper.getRandomHeightProvider(10),
+                stats,
+                (byte[] result) -> {
+                    Object[] decodedResult = function.decodeResult(result);
+                    Assert.assertEquals(byte[].class, decodedResult[0].getClass());
+                    String hexPublicKey = Hex.toHexString((byte[]) decodedResult[0]);
+                    Assert.assertEquals(expectedHexPublicKey, hexPublicKey);
+                }
+        );
+
+        return stats;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKeyTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKeyTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.solidity.SolidityType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class ExtractPublicKeyFromExtendedPublicKeyTest {
+    private ExecutionEnvironment executionEnvironment;
+    private BTOUtilsHelper helper;
+    private ExtractPublicKeyFromExtendedPublicKey method;
+
+    @Before
+    public void createMethod() {
+        executionEnvironment = mock(ExecutionEnvironment.class);
+        helper = new BTOUtilsHelper();
+        method = new ExtractPublicKeyFromExtendedPublicKey(executionEnvironment, helper);
+    }
+
+    @Test
+    public void functionSignatureOk() {
+        CallTransaction.Function fn = method.getFunction();
+        Assert.assertEquals("extractPublicKeyFromExtendedPublicKey", fn.name);
+
+        Assert.assertEquals(1, fn.inputs.length);
+        Assert.assertEquals(SolidityType.getType("string").getName(), fn.inputs[0].type.getName());
+
+        Assert.assertEquals(1, fn.outputs.length);
+        Assert.assertEquals(SolidityType.getType("bytes").getName(), fn.outputs[0].type.getName());
+    }
+
+    @Test
+    public void shouldBeEnabled() {
+        Assert.assertTrue(method.isEnabled());
+    }
+
+    @Test
+    public void shouldAllowAnyTypeOfCall() {
+        Assert.assertFalse(method.onlyAllowsLocalCalls());
+    }
+
+    @Test
+    public void executes() {
+        Assert.assertEquals(
+                "02be517550b9e3be7fe42c80932d51e88e698663b4926e598b269d050e87e34d8c",
+                Hex.toHexString((byte[]) method.execute(new Object[]{
+                    "xpub661MyMwAqRbcFMGNG2YcHvj3x63bAZN9U5cKikaiQ4zu2D1cvpnZYyXNR9nH62sGp4RR39Ui7SVQSq1PY4JbPuEuu5prVJJC3d5Pogft712",
+                })));
+    }
+
+    @Test
+    public void validatesExtendedPublicKeyFormat() {
+        boolean failed = false;
+        try {
+            method.execute(new Object[]{
+                    "this-is-not-an-xpub",
+            });
+        } catch (NativeContractIllegalArgumentException e) {
+            failed = true;
+            Assert.assertTrue(e.getMessage().contains("Invalid extended public key"));
+        }
+        Assert.assertTrue(failed);
+    }
+
+    @Test
+    public void failsUponInvalidPublicKey() {
+        boolean failed = false;
+        try {
+            method.execute(new Object[]{
+                    "tpubD6NzVbkrYhZ4YHQqwWz3Tm1ESZ9AidobeyLG4mEezB6hN8gFFWrcjczyF77Lw3HEs6Rjd2R11BEJ8Y9ptfxx9DFknkdujp58mFMx9H5dc1s",
+            });
+        } catch (NativeContractIllegalArgumentException e) {
+            failed = true;
+            Assert.assertTrue(e.getMessage().contains("Invalid extended public key"));
+        }
+        Assert.assertTrue(failed);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashPerformanceTestCase.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.crypto.DeterministicKey;
+import co.rsk.bitcoinj.crypto.HDKeyDerivation;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.db.BenchmarkedRepository;
+import co.rsk.peg.performance.CombinedExecutionStats;
+import co.rsk.peg.performance.ExecutionStats;
+import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+@Ignore
+public class GetMultisigScriptHashPerformanceTestCase extends PrecompiledContractPerformanceTestCase {
+    private CallTransaction.Function function;
+
+    @Test
+    public void getMultisigScriptHash() throws IOException {
+        function = new GetMultisigScriptHash(null).getFunction();
+
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
+            @Override
+            public Environment initialize(int executionIndex, TxBuilder txBuilder, int height) {
+                BTOUtils contract = new BTOUtils(new TestSystemProperties(), PrecompiledContracts.BTOUTILS_ADDR);
+                contract.init(txBuilder.build(executionIndex), Helper.getMockBlock(1), null, null, null, null);
+
+                return new Environment(
+                        contract,
+                        () -> new BenchmarkedRepository.Statistics()
+                );
+            }
+
+            @Override
+            public void teardown() {
+            }
+        };
+
+        // Get rid of outliers by executing some cases beforehand
+        setQuietMode(true);
+        System.out.print("Doing an initial pass... ");
+        estimateGetMultisigScriptHash(100, 15, environmentBuilder);
+        System.out.print("Done!\n");
+        setQuietMode(false);
+
+        CombinedExecutionStats stats = new CombinedExecutionStats(function.name);
+
+        stats.add(estimateGetMultisigScriptHash(500, 2, environmentBuilder));
+        stats.add(estimateGetMultisigScriptHash(2000, 8, environmentBuilder));
+        stats.add(estimateGetMultisigScriptHash(1000, 15, environmentBuilder));
+
+        BTOUtilsPerformanceTest.addStats(stats);
+    }
+
+    private ExecutionStats estimateGetMultisigScriptHash(int times, int numberOfKeys, EnvironmentBuilder environmentBuilder) {
+        String name = String.format("%s-%d", function.name, numberOfKeys);
+        ExecutionStats stats = new ExecutionStats(name);
+        Random rnd = new Random();
+
+        int minimumSignatures = rnd.nextInt(numberOfKeys) + 1;
+        byte[][] publicKeys = new byte[numberOfKeys][];
+        for (int i = 0; i < numberOfKeys; i++) {
+            publicKeys[i] = new ECKey().getPubKey(true);
+        }
+
+        String expectedHashHex = Hex.toHexString(ScriptBuilder.createP2SHOutputScript(
+                minimumSignatures,
+                Arrays.stream(publicKeys).map(pk -> BtcECKey.fromPublicOnly(pk)).collect(Collectors.toList())
+        ).getPubKeyHash());
+
+        ABIEncoder abiEncoder = (int executionIndex) -> function.encode(new Object[]{
+                minimumSignatures, publicKeys
+        });
+
+        executeAndAverage(
+                name,
+                times,
+                environmentBuilder,
+                abiEncoder,
+                Helper.getZeroValueTxBuilder(new ECKey()),
+                Helper.getRandomHeightProvider(10),
+                stats,
+                (byte[] result) -> {
+                    Object[] decodedResult = function.decodeResult(result);
+                    Assert.assertEquals(byte[].class, decodedResult[0].getClass());
+                    String hexHash = Hex.toHexString((byte[]) decodedResult[0]);
+                    Assert.assertEquals(expectedHashHex, hexHash);
+                }
+        );
+
+        return stats;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
@@ -1,0 +1,218 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.solidity.SolidityType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.function.Consumer;
+
+import static org.mockito.Mockito.mock;
+
+public class GetMultisigScriptHashTest {
+    private ExecutionEnvironment executionEnvironment;
+    private GetMultisigScriptHash method;
+
+    @Before
+    public void createMethod() {
+        executionEnvironment = mock(ExecutionEnvironment.class);
+        method = new GetMultisigScriptHash(executionEnvironment);
+    }
+
+    @Test
+    public void functionSignatureOk() {
+        CallTransaction.Function fn = method.getFunction();
+        Assert.assertEquals("getMultisigScriptHash", fn.name);
+
+        Assert.assertEquals(2, fn.inputs.length);
+        Assert.assertEquals(SolidityType.getType("int256").getName(), fn.inputs[0].type.getName());
+        Assert.assertEquals(SolidityType.getType("bytes[]").getName(), fn.inputs[1].type.getName());
+
+        Assert.assertEquals(1, fn.outputs.length);
+        Assert.assertEquals(SolidityType.getType("bytes").getName(), fn.outputs[0].type.getName());
+    }
+
+    @Test
+    public void shouldBeEnabled() {
+        Assert.assertTrue(method.isEnabled());
+    }
+
+    @Test
+    public void shouldAllowAnyTypeOfCall() {
+        Assert.assertFalse(method.onlyAllowsLocalCalls());
+    }
+
+    @Test
+    public void executesWithAllCompressed() {
+        Assert.assertEquals(
+                "51f103320b435b5fe417b3f3e0f18972ccc710a0",
+                Hex.toHexString((byte[]) method.execute(new Object[]{
+                        BigInteger.valueOf(8L),
+                        new byte[][] {
+                                Hex.decode("03b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2"),
+                                Hex.decode("027319afb15481dbeb3c426bcc37f9a30e7f51ceff586936d85548d9395bcc2344"),
+                                Hex.decode("0355a2e9bf100c00fc0a214afd1bf272647c7824eb9cb055480962f0c382596a70"),
+                                Hex.decode("02566d5ded7c7db1aa7ee4ef6f76989fb42527fcfdcddcd447d6793b7d869e46f7"),
+                                Hex.decode("0294c817150f78607566e961b3c71df53a22022a80acbb982f83c0c8baac040adc"),
+                                Hex.decode("0372cd46831f3b6afd4c044d160b7667e8ebf659d6cb51a825a3104df6ee0638c6"),
+                                Hex.decode("0340df69f28d69eef60845da7d81ff60a9060d4da35c767f017b0dd4e20448fb44"),
+                                Hex.decode("02ac1901b6fba2c1dbd47d894d2bd76c8ba1d296d65f6ab47f1c6b22afb53e73eb"),
+                                Hex.decode("031aabbeb9b27258f98c2bf21f36677ae7bae09eb2d8c958ef41a20a6e88626d26"),
+                                Hex.decode("0245ef34f5ee218005c9c21227133e8568a4f3f11aeab919c66ff7b816ae1ffeea"),
+                                Hex.decode("02550cc87fa9061162b1dd395a16662529c9d8094c0feca17905a3244713d65fe8"),
+                                Hex.decode("02481f02b7140acbf3fcdd9f72cf9a7d9484d8125e6df7c9451cfa55ba3b077265"),
+                                Hex.decode("03f909ae15558c70cc751aff9b1f495199c325b13a9e5b934fd6299cd30ec50be8"),
+                                Hex.decode("02c6018fcbd3e89f3cf9c7f48b3232ea3638eb8bf217e59ee290f5f0cfb2fb9259"),
+                                Hex.decode("03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6")
+                        }
+                })));
+    }
+
+    @Test
+    public void executesWithMixed() {
+        Assert.assertEquals(
+                "51f103320b435b5fe417b3f3e0f18972ccc710a0",
+                Hex.toHexString((byte[]) method.execute(new Object[]{
+                        BigInteger.valueOf(8L),
+                        new byte[][] {
+                                Hex.decode("04b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2aafaaa2611606699ec4f82777a268b708dab346de4880cd223969f7bbe5422bf"),
+                                Hex.decode("027319afb15481dbeb3c426bcc37f9a30e7f51ceff586936d85548d9395bcc2344"),
+                                Hex.decode("0355a2e9bf100c00fc0a214afd1bf272647c7824eb9cb055480962f0c382596a70"),
+                                Hex.decode("02566d5ded7c7db1aa7ee4ef6f76989fb42527fcfdcddcd447d6793b7d869e46f7"),
+                                Hex.decode("0494c817150f78607566e961b3c71df53a22022a80acbb982f83c0c8baac040adcb17171aa9ec8d8587098e0771f686ee61ac35279f9e5aadf9b06b738aa6d3720"),
+                                Hex.decode("0372cd46831f3b6afd4c044d160b7667e8ebf659d6cb51a825a3104df6ee0638c6"),
+                                Hex.decode("0440df69f28d69eef60845da7d81ff60a9060d4da35c767f017b0dd4e20448fb44e1abebaea4c3c57c6e9e39e205b4df046f7110a8d3477c0d8e26a28be9692c29"),
+                                Hex.decode("02ac1901b6fba2c1dbd47d894d2bd76c8ba1d296d65f6ab47f1c6b22afb53e73eb"),
+                                Hex.decode("031aabbeb9b27258f98c2bf21f36677ae7bae09eb2d8c958ef41a20a6e88626d26"),
+                                Hex.decode("0445ef34f5ee218005c9c21227133e8568a4f3f11aeab919c66ff7b816ae1ffeeae024d50312de76a7950f8c6268fbf454335cf252f961a67c47e67dc06fa590ba"),
+                                Hex.decode("02550cc87fa9061162b1dd395a16662529c9d8094c0feca17905a3244713d65fe8"),
+                                Hex.decode("02481f02b7140acbf3fcdd9f72cf9a7d9484d8125e6df7c9451cfa55ba3b077265"),
+                                Hex.decode("03f909ae15558c70cc751aff9b1f495199c325b13a9e5b934fd6299cd30ec50be8"),
+                                Hex.decode("02c6018fcbd3e89f3cf9c7f48b3232ea3638eb8bf217e59ee290f5f0cfb2fb9259"),
+                                Hex.decode("03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6")
+                        }
+                })));
+    }
+
+    @Test
+    public void minimumSignaturesMustBeGreaterThanZero() {
+        assertFails(
+                () -> method.execute(new Object[]{
+                        BigInteger.ZERO,
+                        new Object[]{}
+                }),
+                "Minimum required signatures"
+        );
+    }
+
+    @Test
+    public void mustProvideAtLeastOnePublicKey() {
+        assertFails(
+                () -> method.execute(new Object[]{
+                        BigInteger.ONE,
+                        new Object[]{}
+                }),
+                "At least one public key"
+        );
+    }
+
+    @Test
+    public void atLeastAsManyPublicKeyAsMinimumSignatures() {
+        assertFails(
+                () -> method.execute(new Object[]{
+                        BigInteger.valueOf(3L),
+                        new Object[]{
+                                Hex.decode("03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6"),
+                                Hex.decode("02566d5ded7c7db1aa7ee4ef6f76989fb42527fcfdcddcd447d6793b7d869e46f7"),
+                        }
+                }),
+                "are less than the minimum required signatures"
+        );
+    }
+
+    @Test
+    public void atMostFifteenPublicKeys() {
+        byte[][] keys = new byte[16][];
+        for (int i = 0; i < 16; i++)
+            keys[i] = new BtcECKey().getPubKeyPoint().getEncoded(true);
+
+        assertFails(
+                () -> method.execute(new Object[]{
+                        BigInteger.valueOf(3L),
+                        keys
+                }),
+                "are more than the maximum allowed signatures"
+        );
+    }
+
+    @Test
+    public void keyLengthIsValidated() {
+        assertFails(
+                () -> method.execute(new Object[]{
+                        BigInteger.valueOf(1L),
+                        new Object[]{
+                                Hex.decode("02566d5ded7c7db1aa7ee4ef6f76989fb42527fcfdcddcd447d6793b7d869e46f7"),
+                                Hex.decode("aabbcc"),
+                        }
+                }),
+                "Invalid public key length"
+        );
+    }
+
+    @Test
+    public void keyFormatIsValidated() {
+        assertFails(
+                () -> method.execute(new Object[]{
+                        BigInteger.valueOf(1L),
+                        new Object[]{
+                                Hex.decode("03566d5ded7c7db1aa7ee4ef6f76989fb42527fcfdcddcd447d6793b7d869e46f7"),
+                                Hex.decode("08566d5ded7c7db1aa7ee4ef6f76989fb42527fcfdcddcd447d6793b7d869e46f7"),
+                        }
+                }),
+                "Invalid public key format"
+        );
+    }
+
+    private void assertFails(Runnable runnable, Consumer<Exception> exceptionHandler) {
+        boolean failed = false;
+        try {
+            runnable.run();
+        } catch (Exception ex) {
+            failed = true;
+            exceptionHandler.accept(ex);
+        }
+        Assert.assertTrue(failed);
+    }
+
+    private void assertFails(Runnable runnable, String expectedMessage) {
+        assertFails(runnable, (ex) -> {
+            Assert.assertEquals(NativeContractIllegalArgumentException.class, ex.getClass());
+            Assert.assertTrue(ex.getMessage().contains(expectedMessage));
+        });
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/ToBase58CheckPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/ToBase58CheckPerformanceTestCase.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.config.TestSystemProperties;
+import co.rsk.db.BenchmarkedRepository;
+import co.rsk.peg.performance.ExecutionStats;
+import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Random;
+
+@Ignore
+public class ToBase58CheckPerformanceTestCase extends PrecompiledContractPerformanceTestCase {
+    private static final int MIN_ADDRESS_LENGTH = 26;
+    private static final int MAX_ADDRESS_LENGTH = 35;
+
+    private CallTransaction.Function function;
+
+    @Test
+    public void toBase58Check() throws IOException {
+        function = new ToBase58Check(null).getFunction();
+
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
+            @Override
+            public Environment initialize(int executionIndex, TxBuilder txBuilder, int height) {
+                BTOUtils contract = new BTOUtils(new TestSystemProperties(), PrecompiledContracts.BTOUTILS_ADDR);
+                contract.init(txBuilder.build(executionIndex), Helper.getMockBlock(1), null, null, null, null);
+
+                return new Environment(
+                        contract,
+                        () -> new BenchmarkedRepository.Statistics()
+                );
+            }
+
+            @Override
+            public void teardown() {
+            }
+        };
+
+        BTOUtilsPerformanceTest.addStats(estimateToBase58Check(2000, environmentBuilder));
+    }
+
+    private ExecutionStats estimateToBase58Check(int times, EnvironmentBuilder environmentBuilder) {
+        String name = function.name;
+        ExecutionStats stats = new ExecutionStats(name);
+        Random rnd = new Random();
+        int[] versions = new int[] {
+                // Testnet and mainnet pubkey hash and script hash only
+                // See https://en.bitcoin.it/wiki/Base58Check_encoding for details
+                0, 5, 111, 196
+        };
+        byte[] hash = new byte[20];
+
+        ABIEncoder abiEncoder = (int executionIndex) -> {
+            rnd.nextBytes(hash);
+            int version = versions[rnd.nextInt(versions.length)];
+
+            return function.encode(new Object[] { hash, version });
+        };
+
+        executeAndAverage(
+                name,
+                times,
+                environmentBuilder,
+                abiEncoder,
+                Helper.getZeroValueTxBuilder(new ECKey()),
+                Helper.getRandomHeightProvider(10),
+                stats,
+                (byte[] result) -> {
+                    Object[] decodedResult = function.decodeResult(result);
+                    Assert.assertEquals(String.class, decodedResult[0].getClass());
+                    String address = (String) decodedResult[0];
+                    Assert.assertTrue(MIN_ADDRESS_LENGTH <= address.length());
+                    Assert.assertTrue(MAX_ADDRESS_LENGTH >= address.length());
+                }
+        );
+
+        return stats;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/ToBase58CheckTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/ToBase58CheckTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.pcc.bto;
+
+import co.rsk.pcc.ExecutionEnvironment;
+import co.rsk.pcc.NativeContractIllegalArgumentException;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.solidity.SolidityType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+import static org.mockito.Mockito.mock;
+
+public class ToBase58CheckTest {
+    private ExecutionEnvironment executionEnvironment;
+    private ToBase58Check method;
+
+    @Before
+    public void createMethod() {
+        executionEnvironment = mock(ExecutionEnvironment.class);
+        method = new ToBase58Check(executionEnvironment);
+    }
+
+    @Test
+    public void functionSignatureOk() {
+        CallTransaction.Function fn = method.getFunction();
+        Assert.assertEquals("toBase58Check", fn.name);
+
+        Assert.assertEquals(2, fn.inputs.length);
+        Assert.assertEquals(SolidityType.getType("bytes").getName(), fn.inputs[0].type.getName());
+        Assert.assertEquals(SolidityType.getType("int256").getName(), fn.inputs[1].type.getName());
+
+        Assert.assertEquals(1, fn.outputs.length);
+        Assert.assertEquals(SolidityType.getType("string").getName(), fn.outputs[0].type.getName());
+    }
+
+    @Test
+    public void shouldBeEnabled() {
+        Assert.assertTrue(method.isEnabled());
+    }
+
+    @Test
+    public void shouldAllowAnyTypeOfCall() {
+        Assert.assertFalse(method.onlyAllowsLocalCalls());
+    }
+
+    @Test
+    public void executes() {
+        Assert.assertEquals(
+                "mgivuh9jErcGdRr81cJ3A7YfgbJV7WNyZV",
+                method.execute(new Object[]{
+                        Hex.decode("0d3bf5f30dda7584645546079318e97f0e1d044f"),
+                        BigInteger.valueOf(111L)
+                }));
+    }
+
+    @Test
+    public void validatesHashLength() {
+        boolean failed = false;
+        try {
+            method.execute(new Object[]{
+                    Hex.decode("aabbcc"),
+                    BigInteger.valueOf(111L)
+            });
+        } catch (NativeContractIllegalArgumentException e) {
+            failed = true;
+            Assert.assertTrue(e.getMessage().contains("Invalid hash160"));
+        }
+        Assert.assertTrue(failed);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -58,9 +58,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class BridgeUtilsTest {
-
-    private static final Logger logger = LoggerFactory.getLogger("test");
-
     private static final String TO_ADDRESS = "0000000000000000000000000000000000000006";
     private static final BigInteger AMOUNT = new BigInteger("1");
     private static final BigInteger NONCE = new BigInteger("0");

--- a/rskj-core/src/test/java/co/rsk/peg/performance/AddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/AddSignatureTest.java
@@ -65,7 +65,7 @@ public class AddSignatureTest extends BridgePerformanceTestCase {
                 times,
                 getABIEncoder(),
                 getInitializerFor(0),
-                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
+                Helper.getZeroValueValueTxBuilderFromFedMember(),
                 Helper.getRandomHeightProvider(10),
                 stats
         );
@@ -77,7 +77,7 @@ public class AddSignatureTest extends BridgePerformanceTestCase {
                 times,
                 getABIEncoder(),
                 getInitializerFor(bridgeConstants.getGenesisFederation().getNumberOfSignaturesRequired()-1),
-                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
+                Helper.getZeroValueValueTxBuilderFromFedMember(),
                 Helper.getRandomHeightProvider(10),
                 stats
         );

--- a/rskj-core/src/test/java/co/rsk/peg/performance/AddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/AddSignatureTest.java
@@ -65,7 +65,7 @@ public class AddSignatureTest extends BridgePerformanceTestCase {
                 times,
                 getABIEncoder(),
                 getInitializerFor(0),
-                Helper.getZeroValueRandomSenderTxBuilder(),
+                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
                 Helper.getRandomHeightProvider(10),
                 stats
         );
@@ -77,7 +77,7 @@ public class AddSignatureTest extends BridgePerformanceTestCase {
                 times,
                 getABIEncoder(),
                 getInitializerFor(bridgeConstants.getGenesisFederation().getNumberOfSignaturesRequired()-1),
-                Helper.getZeroValueRandomSenderTxBuilder(),
+                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
                 Helper.getRandomHeightProvider(10),
                 stats
         );

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
@@ -21,160 +21,53 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.RskSystemProperties;
-import co.rsk.config.TestSystemProperties;
 import co.rsk.db.RepositoryImpl;
 import co.rsk.db.RepositoryTrackWithBenchmarking;
+import co.rsk.trie.Trie;
+import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.TrieStorePoolOnMemory;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageConfiguration;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.test.builders.BlockChainBuilder;
-import co.rsk.trie.Trie;
-import co.rsk.vm.VMPerformanceTest;
-import org.ethereum.config.blockchain.regtest.RegTestGenesisConfig;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.datasource.HashMapDB;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.bouncycastle.util.encoders.Hex;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadMXBean;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
 
-public abstract class BridgePerformanceTestCase {
+public abstract class BridgePerformanceTestCase extends PrecompiledContractPerformanceTestCase {
     protected static NetworkParameters networkParameters;
     protected static BridgeConstants bridgeConstants;
-    private static TestSystemProperties config;
-
-    private boolean oldCpuTimeEnabled;
-    private ThreadMXBean thread;
-
-    protected class ExecutionTracker {
-        private static final long MILLION = 1_000_000;
-
-        private final ThreadMXBean thread;
-        private long startTime, endTime;
-        private long startRealTime, endRealTime;
-        private RepositoryTrackWithBenchmarking.Statistics repositoryStatistics;
-
-        public ExecutionTracker(ThreadMXBean thread) {
-            this.thread = thread;
-        }
-
-        public void startTimer() {
-            startTime = thread.getCurrentThreadCpuTime();
-            startRealTime = System.currentTimeMillis() * MILLION;
-        }
-
-        public void endTimer() {
-            endTime = thread.getCurrentThreadCpuTime();
-            endRealTime = System.currentTimeMillis() * MILLION;
-        }
-
-        public void setRepositoryStatistics(RepositoryTrackWithBenchmarking.Statistics statistics) {
-            this.repositoryStatistics = statistics;
-        }
-
-        public RepositoryTrackWithBenchmarking.Statistics getRepositoryStatistics() {
-            return this.repositoryStatistics;
-        }
-
-        public long getExecutionTime() {
-            return endTime - startTime;
-        }
-
-        public long getRealExecutionTime() {
-            return endRealTime - startRealTime;
-        }
-    }
 
     @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        config = new TestSystemProperties();
-        config.setBlockchainConfig(new RegTestGenesisConfig());
+    public static void setupB() throws Exception {
         bridgeConstants = config.getBlockchainConfig().getCommonConstants().getBridgeConstants();
         networkParameters = bridgeConstants.getBtcParams();
     }
 
-    @AfterClass
-    public static void printStatsIfNotInSuite() throws Exception {
-        if (!BridgePerformanceTest.isRunning()) {
-            BridgePerformanceTest.printStats();
-        }
-    }
+    protected static class Helper extends PrecompiledContractPerformanceTestCase.Helper {
+        // Federates for bridge regtest constants
+        public static final List<ECKey> FEDERATOR_ECKEYS = Arrays.stream(new String[]{
+                "federator1",
+                "federator2",
+                "federator3"
+        }).map(generator -> ECKey.fromPrivate(HashUtil.keccak256(generator.getBytes(StandardCharsets.UTF_8)))).collect(Collectors.toList());
 
-    @Before
-    public void setupCpuTime() {
-        thread = ManagementFactory.getThreadMXBean();
-        if (!thread.isThreadCpuTimeSupported()) {
-            throw new RuntimeException("Thread CPU time not supported");
-        };
-
-        oldCpuTimeEnabled = thread.isThreadCpuTimeEnabled();
-        thread.setThreadCpuTimeEnabled(true);
-    }
-
-    @After
-    public void teardownCpuTime() {
-        thread.setThreadCpuTimeEnabled(oldCpuTimeEnabled);
-    }
-
-    @After
-    public void forceGC() {
-        long sm = Runtime.getRuntime().freeMemory();
-        VMPerformanceTest.forceGc();
-        long em = Runtime.getRuntime().freeMemory();
-        System.out.println(String.format("GC - free mem before: %d, after: %d", sm, em));
-    }
-
-    protected static class Helper {
-        public static Transaction buildTx(ECKey sender) {
-            return buildSendValueTx(sender, BigInteger.ZERO);
-        }
-
-        public static Transaction buildSendValueTx(ECKey sender, BigInteger value) {
-            byte[] gasPrice = Hex.decode("00");
-            byte[] gasLimit = Hex.decode("00");
-
-            Transaction tx = new Transaction(
-                    null,
-                    gasPrice,
-                    gasLimit,
-                    sender.getAddress(),
-                    value.toByteArray(),
-                    null);
-            tx.sign(sender.getPrivKeyBytes());
-
-            return tx;
-        }
-
-        public static int randomInRange(int min, int max) {
-            return new Random().nextInt(max - min + 1) + min;
+        public static ECKey getRandomFederatorECKey() {
+            return Helper.FEDERATOR_ECKEYS.get(Helper.randomInRange(0, Helper.FEDERATOR_ECKEYS.size()-1));
         }
 
         public static Coin randomCoin(Coin base, int min, int max) {
             return base.multiply(randomInRange(min, max));
-        }
-
-        public static HeightProvider getRandomHeightProvider(int max) {
-            return (int executionIndex) -> new Random().nextInt(max);
-        }
-
-        public static HeightProvider getRandomHeightProvider(int min, int max) {
-            return (int executionIndex) -> randomInRange(min, max);
         }
 
         public static BtcBlock generateAndAddBlocks(BtcBlockChain btcBlockChain, int blocksToGenerate) {
@@ -221,7 +114,7 @@ public abstract class BridgePerformanceTestCase {
         }
 
         public static TxBuilder getZeroValueRandomSenderTxBuilder() {
-            return (int executionIndex) -> Helper.buildSendValueTx(new ECKey(), BigInteger.ZERO);
+            return (int executionIndex) -> Helper.buildTx(new ECKey());
         }
 
         public static BridgeStorageProviderInitializer buildNoopInitializer() {
@@ -233,99 +126,91 @@ public abstract class BridgePerformanceTestCase {
         void initialize(BridgeStorageProvider provider, Repository repository, int executionIndex);
     }
 
-    protected interface TxBuilder {
-        Transaction build(int executionIndex);
-    }
-
-    protected interface ABIEncoder {
-        byte[] encode(int executionIndex);
-    }
-
-    protected interface HeightProvider {
-        int getHeight(int executionIndex);
-    }
-
-    private ExecutionTracker execute(
+    protected ExecutionStats executeAndAverage(
+            String name,
+            int times,
             ABIEncoder abiEncoder,
             BridgeStorageProviderInitializer storageInitializer,
-            TxBuilder txBuilder, HeightProvider heightProvider, int executionIndex) {
-
-        ExecutionTracker executionInfo = new ExecutionTracker(thread);
-
-        RepositoryImpl repository = createRepositoryImpl(config);
-        Repository track = repository.startTracking();
-        BridgeStorageConfiguration bridgeStorageConfigurationAtThisHeight = BridgeStorageConfiguration.fromBlockchainConfig(config.getBlockchainConfig().getConfigForBlock(executionIndex));
-        BridgeStorageProvider storageProvider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants,bridgeStorageConfigurationAtThisHeight);
-
-        storageInitializer.initialize(storageProvider, track, executionIndex);
-
-        try {
-            storageProvider.save();
-        } catch (Exception e) {
-            throw new RuntimeException("Error trying to save the storage after initialization", e);
-        }
-        track.commit();
-
-        Transaction tx = txBuilder.build(executionIndex);
-
-        List<LogInfo> logs = new ArrayList<>();
-
-        RepositoryTrackWithBenchmarking benchmarkerTrack = new RepositoryTrackWithBenchmarking(repository);
-
-        Bridge bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
-        Blockchain blockchain = BlockChainBuilder.ofSize(heightProvider.getHeight(executionIndex));
-        bridge.init(
-                tx,
-                blockchain.getBestBlock(),
-                benchmarkerTrack,
-                blockchain.getBlockStore(),
-                null,
-                logs
+            TxBuilder txBuilder,
+            HeightProvider heightProvider,
+            ExecutionStats stats) {
+        return executeAndAverage(
+                name, times, abiEncoder, storageInitializer,
+                txBuilder, heightProvider, stats, null
         );
-
-        // Execute a random method so that bridge support initialization
-        // does its initial writes to the repo for e.g. genesis block,
-        // federation, etc, etc. and we don't get
-        // those recorded in the actual execution.
-        bridge.execute(Bridge.GET_FEDERATION_SIZE.encode());
-        benchmarkerTrack.getStatistics().clear();
-
-        executionInfo.startTimer();
-        bridge.execute(abiEncoder.encode(executionIndex));
-        executionInfo.endTimer();
-
-        benchmarkerTrack.commit();
-
-        executionInfo.setRepositoryStatistics(benchmarkerTrack.getStatistics());
-
-        return executionInfo;
     }
 
-    protected ExecutionStats executeAndAverage(String name,
-             int times,
-             ABIEncoder abiEncoder,
-             BridgeStorageProviderInitializer storageInitializer,
-             TxBuilder txBuilder,
-             HeightProvider heightProvider,
-             ExecutionStats stats) {
+    protected ExecutionStats executeAndAverage(
+            String name,
+            int times,
+            ABIEncoder abiEncoder,
+            BridgeStorageProviderInitializer storageInitializer,
+            TxBuilder txBuilder,
+            HeightProvider heightProvider,
+            ExecutionStats stats,
+            ResultCallback resultCallback) {
 
-        long sm = Runtime.getRuntime().freeMemory();
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
+            private Bridge bridge;
+            private RepositoryTrackWithBenchmarking benchmarkerTrack;
 
-        for (int i = 0; i < times; i++) {
-            System.out.println(String.format("%s %d/%d", name, i+1, times));
+            private RepositoryImpl createRepositoryImpl(RskSystemProperties config) {
+                return new RepositoryImpl(new Trie(null, true), new HashMapDB(), new TrieStorePoolOnMemory());
+            }
 
-            ExecutionTracker tracker = execute(abiEncoder, storageInitializer, txBuilder, heightProvider, i);
+            @Override
+            public Environment initialize(int executionIndex, Transaction tx, int height) {
+                RepositoryImpl repository = createRepositoryImpl(config);
+                Repository track = repository.startTracking();
+                BridgeStorageConfiguration bridgeStorageConfigurationAtThisHeight = BridgeStorageConfiguration.fromBlockchainConfig(config.getBlockchainConfig().getConfigForBlock(executionIndex));
+                BridgeStorageProvider storageProvider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants,bridgeStorageConfigurationAtThisHeight);
 
-            stats.executionTimes.add(tracker.getExecutionTime());
-            stats.realExecutionTimes.add(tracker.getRealExecutionTime());
-            stats.slotsWritten.add(tracker.getRepositoryStatistics().getSlotsWritten());
-            stats.slotsCleared.add(tracker.getRepositoryStatistics().getSlotsCleared());
-        }
+                storageInitializer.initialize(storageProvider, track, executionIndex);
 
-        return stats;
-    }
+                try {
+                    storageProvider.save();
+                } catch (Exception e) {
+                    throw new RuntimeException("Error trying to save the storage after initialization", e);
+                }
+                track.commit();
 
-    public static RepositoryImpl createRepositoryImpl(RskSystemProperties config) {
-        return new RepositoryImpl(new Trie(null, true), new HashMapDB(), new TrieStorePoolOnMemory());
+                List<LogInfo> logs = new ArrayList<>();
+
+                benchmarkerTrack = new RepositoryTrackWithBenchmarking(repository);
+
+                bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
+                Blockchain blockchain = BlockChainBuilder.ofSize(height);
+                bridge.init(
+                        tx,
+                        blockchain.getBestBlock(),
+                        benchmarkerTrack,
+                        blockchain.getBlockStore(),
+                        null,
+                        logs
+                );
+
+                // Execute a random method so that bridge support initialization
+                // does its initial writes to the repo for e.g. genesis block,
+                // federation, etc, etc. and we don't get
+                // those recorded in the actual execution.
+                boolean oldLocalCall = tx.isLocalCallTransaction();
+                tx.setLocalCallTransaction(true);
+                bridge.execute(Bridge.GET_FEDERATION_SIZE.encode());
+                tx.setLocalCallTransaction(oldLocalCall);
+                benchmarkerTrack.getStatistics().clear();
+
+                return new Environment(
+                        bridge,
+                        benchmarkerTrack
+                );
+            }
+
+            @Override
+            public void teardown() {
+                benchmarkerTrack.commit();
+            }
+        };
+
+        return super.executeAndAverage(name, times, environmentBuilder, abiEncoder, txBuilder, heightProvider, stats, resultCallback);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
@@ -70,6 +70,10 @@ public abstract class BridgePerformanceTestCase extends PrecompiledContractPerfo
             return base.multiply(randomInRange(min, max));
         }
 
+        public static TxBuilder getZeroValueValueTxBuilderFromFedMember() {
+            return Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey());
+        }
+
         public static BtcBlock generateAndAddBlocks(BtcBlockChain btcBlockChain, int blocksToGenerate) {
             BtcBlock block = btcBlockChain.getChainHead().getHeader();
             int initialHeight = btcBlockChain.getBestChainHeight();

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
@@ -159,7 +159,7 @@ public abstract class BridgePerformanceTestCase extends PrecompiledContractPerfo
             }
 
             @Override
-            public Environment initialize(int executionIndex, Transaction tx, int height) {
+            public Environment initialize(int executionIndex, TxBuilder txBuilder, int height) {
                 RepositoryImpl repository = createRepositoryImpl(config);
                 Repository track = repository.startTracking();
                 BridgeStorageConfiguration bridgeStorageConfigurationAtThisHeight = BridgeStorageConfiguration.fromBlockchainConfig(config.getBlockchainConfig().getConfigForBlock(executionIndex));
@@ -180,6 +180,7 @@ public abstract class BridgePerformanceTestCase extends PrecompiledContractPerfo
 
                 bridge = new Bridge(config, PrecompiledContracts.BRIDGE_ADDR);
                 Blockchain blockchain = BlockChainBuilder.ofSize(height);
+                Transaction tx = txBuilder.build(executionIndex);
                 bridge.init(
                         tx,
                         blockchain.getBestBlock(),

--- a/rskj-core/src/test/java/co/rsk/peg/performance/CombinedExecutionStats.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/CombinedExecutionStats.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg.performance;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CombinedExecutionStats extends ExecutionStats {
+    private List<ExecutionStats> statsList;
+
+    public CombinedExecutionStats(String name, List<ExecutionStats> statsList) {
+        super(name);
+        this.statsList = new ArrayList<>();
+        statsList.stream().forEach(stats -> this.add(stats));
+    }
+
+    public CombinedExecutionStats(String name) {
+        this(name, Collections.emptyList());
+    }
+
+    public void add(ExecutionStats stats) {
+        // Note that this yields weighted stats, as opposed
+        // to the mean of the stats
+        this.statsList.add(stats);
+        this.executionTimes.addFrom(stats.executionTimes);
+        this.realExecutionTimes.addFrom(stats.realExecutionTimes);
+        this.slotsWritten.addFrom(stats.slotsWritten);
+        this.slotsCleared.addFrom(stats.executionTimes);
+    }
+
+    public String getPrintable() {
+        StringBuilder result = new StringBuilder();
+
+        result.append(String.format("%s\n", super.getPrintable()));
+        statsList.stream().forEach(stats ->
+                result.append(String.format("\t\t%s\n", stats.getPrintable()))
+        );
+
+        // Get rid of the last return of carriage
+        String printable = result.toString();
+        return printable.substring(0, printable.length()-1);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ExecutionStats.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ExecutionStats.java
@@ -18,6 +18,8 @@
 
 package co.rsk.peg.performance;
 
+import java.util.Optional;
+
 public class ExecutionStats {
     public String name;
     public Mean executionTimes;
@@ -25,7 +27,7 @@ public class ExecutionStats {
     public Mean slotsWritten;
     public Mean slotsCleared;
 
-    public static long gasPerMicrosecond = 0;
+    public static long nanosecondsPerGasUnit = 0;
 
     public ExecutionStats(String name) {
         this.name = name;
@@ -35,15 +37,19 @@ public class ExecutionStats {
         this.slotsCleared = new Mean();
     }
 
-    public long getEstimatedGas() {
-        return (executionTimes.getMean() / 1000) * gasPerMicrosecond;
+    public Optional<Long> getEstimatedGas() {
+        if (nanosecondsPerGasUnit == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(executionTimes.getMean() / nanosecondsPerGasUnit);
     }
 
     public String getPrintable() {
         return String.format(
-                "%-45s\tgas: %d\t\tcpu(us): %d\t\treal(us): %d\t\twrt(slots): %d\t\tclr(slots): %d",
+                "%-45s\tgas: %s\t\tcpu(us): %d\t\treal(us): %d\t\twrt(slots): %d\t\tclr(slots): %d",
                 name,
-                getEstimatedGas(),
+                getEstimatedGas().map(Object::toString).orElse("N/A"),
                 executionTimes.getMean() / 1000,
                 realExecutionTimes.getMean() / 1000,
                 slotsWritten.getMean(),

--- a/rskj-core/src/test/java/co/rsk/peg/performance/IdentityPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/IdentityPerformanceTest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of RskJ
- * Copyright (C) 2017 RSK Labs Ltd.
+ * Copyright (C) 2019 RSK Labs Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -24,22 +24,8 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-        ReleaseBtcTest.class,
-        UpdateCollectionsTest.class,
-        ReceiveHeadersTest.class,
-        RegisterBtcTransactionTest.class,
-        AddSignatureTest.class,
-        BtcBlockchainTest.class,
-        LockTest.class,
-        ActiveFederationTest.class,
-        RetiringFederationTest.class,
-        PendingFederationTest.class,
-        FederationChangeTest.class,
-        VoteFeePerKbChangeTest.class,
-        GetFeePerKbTest.class,
-        LockWhitelistTest.class,
-        StateForBtcReleaseClientTest.class
+        IdentityPerformanceTestCase.class,
 })
 @Ignore
-public class BridgePerformanceTest extends PrecompiledContractPerformanceTest {
+public class IdentityPerformanceTest extends PrecompiledContractPerformanceTest {
 }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/IdentityPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/IdentityPerformanceTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg.performance;
+
+import co.rsk.db.BenchmarkedRepository;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+
+@Ignore
+public class IdentityPerformanceTestCase extends PrecompiledContractPerformanceTestCase {
+    @Test
+    public void identity() throws IOException {
+        ExecutionStats stats = new ExecutionStats("identity");
+
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
+            @Override
+            public Environment initialize(int executionIndex, Transaction tx, int height) {
+                return new Environment(
+                        new PrecompiledContracts.Identity(),
+                        () -> new BenchmarkedRepository.Statistics()
+                );
+            }
+
+            @Override
+            public void teardown() {
+            }
+        };
+
+        doIdentity(environmentBuilder, stats, 2000);
+
+        IdentityPerformanceTest.addStats(stats);
+    }
+
+    private void doIdentity(EnvironmentBuilder environmentBuilder, ExecutionStats stats, int numCases) throws IOException {
+        ABIEncoder abiEncoder = (int executionIndex) -> new byte[]{};
+
+        executeAndAverage(
+                "identity",
+                numCases,
+                environmentBuilder,
+                abiEncoder,
+                Helper.getZeroValueTxBuilder(new ECKey()),
+                Helper.getRandomHeightProvider(10),
+                stats,
+                null
+        );
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/performance/IdentityPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/IdentityPerformanceTestCase.java
@@ -35,7 +35,7 @@ public class IdentityPerformanceTestCase extends PrecompiledContractPerformanceT
 
         EnvironmentBuilder environmentBuilder = new EnvironmentBuilder() {
             @Override
-            public Environment initialize(int executionIndex, Transaction tx, int height) {
+            public Environment initialize(int executionIndex, TxBuilder txBuilder, int height) {
                 return new Environment(
                         new PrecompiledContracts.Identity(),
                         () -> new BenchmarkedRepository.Statistics()

--- a/rskj-core/src/test/java/co/rsk/peg/performance/Mean.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/Mean.java
@@ -21,13 +21,36 @@ package co.rsk.peg.performance;
 public class Mean {
     private long total = 0;
     private int samples = 0;
+    private long min;
+    private long max;
 
     public void add(long value) {
+        if (samples == 0 || value < min)
+            min = value;
+        if (samples == 0 || value > max)
+            max = value;
         total += value;
         samples++;
     }
 
+    public void addFrom(Mean otherMean) {
+        // Note that this would yield a weighted mean, as
+        // opposed to a mean of means
+        this.total += otherMean.total;
+        this.samples += otherMean.samples;
+        this.max = Math.max(this.max, otherMean.max);
+        this.min = Math.max(this.min, otherMean.min);
+    }
+
     public long getMean() {
         return total / samples;
+    }
+
+    public long getMin() {
+        return min;
+    }
+
+    public long getMax() {
+        return max;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PrecompiledContractPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PrecompiledContractPerformanceTest.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg.performance;
+
+import co.rsk.vm.VMPerformanceTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PrecompiledContractPerformanceTest {
+    private static List<ExecutionStats> statsList;
+    private static boolean running = false;
+    private static Mean averageNanosecondsPerGasUnit;
+
+    @BeforeClass
+    public static void setRunning() {
+        running = true;
+    }
+
+    @BeforeClass
+    public static void estimateReferenceCost() {
+        // Run VM tests and average
+        averageNanosecondsPerGasUnit = new Mean();
+        VMPerformanceTest.ResultLogger resultLogger = (String name, VMPerformanceTest.PerfRes result) -> {
+            long nanosecondsPerGasUnit = result.deltaTime_nS / result.gas;
+            averageNanosecondsPerGasUnit.add(nanosecondsPerGasUnit);
+        };
+        VMPerformanceTest.runWithLogging(resultLogger);
+        // Set reference cost on stats (getMax(), getMean() or getMin() can be used depending on the desired
+        // reference value).
+        ExecutionStats.nanosecondsPerGasUnit = averageNanosecondsPerGasUnit.getMean();
+        System.out.println(String.format(
+                "Reference cost: %d ns/gas (min: %d ns/gas, max: %d ns/gas)",
+                ExecutionStats.nanosecondsPerGasUnit,
+                averageNanosecondsPerGasUnit.getMin(),
+                averageNanosecondsPerGasUnit.getMax()
+        ));
+    }
+
+    @AfterClass
+    public static void printStats() {
+        for (ExecutionStats stats : statsList) {
+            System.out.println(stats.getPrintable());
+        }
+    }
+
+    public static boolean isRunning() {
+        return running;
+    }
+
+    public static void addStats(ExecutionStats stats) {
+        ensureStatsCreated();
+        statsList.add(stats);
+    }
+
+    private static void ensureStatsCreated() {
+        if (statsList == null) {
+            statsList = new ArrayList<>();
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PrecompiledContractPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PrecompiledContractPerformanceTestCase.java
@@ -1,0 +1,275 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg.performance;
+
+import co.rsk.config.TestSystemProperties;
+import co.rsk.db.BenchmarkedRepository;
+import co.rsk.db.RepositoryTrackWithBenchmarking;
+import co.rsk.vm.VMPerformanceTest;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.config.blockchain.regtest.RegTestGenesisConfig;
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.math.BigInteger;
+import java.util.Random;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public abstract class PrecompiledContractPerformanceTestCase {
+    protected static TestSystemProperties config;
+
+    private boolean oldCpuTimeEnabled;
+    private ThreadMXBean thread;
+    private boolean quiet;
+
+    protected void setQuietMode(boolean quiet) {
+        this.quiet = quiet;
+    }
+
+    protected boolean isInQuietMode() {
+        return quiet;
+    }
+
+    private void printLine(String line) {
+        if (!this.isInQuietMode()) {
+            System.out.println(line);
+        }
+    }
+
+    protected class ExecutionTracker {
+        private static final long MILLION = 1_000_000;
+
+        private final ThreadMXBean thread;
+        private long startTime, endTime;
+        private long startRealTime, endRealTime;
+        private RepositoryTrackWithBenchmarking.Statistics repositoryStatistics;
+
+        public ExecutionTracker(ThreadMXBean thread) {
+            this.thread = thread;
+        }
+
+        public void startTimer() {
+            // Everything is expressed in nanoseconds
+            startTime = thread.getCurrentThreadCpuTime();
+            startRealTime = System.currentTimeMillis() * MILLION;
+        }
+
+        public void endTimer() {
+            endTime = thread.getCurrentThreadCpuTime();
+            endRealTime = System.currentTimeMillis() * MILLION;
+        }
+
+        public void setRepositoryStatistics(RepositoryTrackWithBenchmarking.Statistics statistics) {
+            this.repositoryStatistics = statistics;
+        }
+
+        public RepositoryTrackWithBenchmarking.Statistics getRepositoryStatistics() {
+            return this.repositoryStatistics;
+        }
+
+        public long getExecutionTime() {
+            return endTime - startTime;
+        }
+
+        public long getRealExecutionTime() {
+            return endRealTime - startRealTime;
+        }
+    }
+
+    @BeforeClass
+    public static void setupA() throws Exception {
+        config = new TestSystemProperties();
+        config.setBlockchainConfig(new RegTestGenesisConfig());
+    }
+
+    @AfterClass
+    public static void printStatsIfNotInSuite() throws Exception {
+        if (!PrecompiledContractPerformanceTest.isRunning()) {
+            PrecompiledContractPerformanceTest.printStats();
+        }
+    }
+
+    @Before
+    public void setupCpuTime() {
+        thread = ManagementFactory.getThreadMXBean();
+        if (!thread.isThreadCpuTimeSupported()) {
+            throw new RuntimeException("Thread CPU time not supported");
+        };
+
+        oldCpuTimeEnabled = thread.isThreadCpuTimeEnabled();
+        thread.setThreadCpuTimeEnabled(true);
+    }
+
+    @After
+    public void teardownCpuTime() {
+        thread.setThreadCpuTimeEnabled(oldCpuTimeEnabled);
+    }
+
+    @After
+    public void forceGC() {
+        long sm = Runtime.getRuntime().freeMemory();
+        VMPerformanceTest.forceGc();
+        long em = Runtime.getRuntime().freeMemory();
+        printLine(String.format("GC - free mem before: %d, after: %d", sm, em));
+    }
+
+    protected static class Helper {
+        public static int randomInRange(int min, int max) {
+            return new Random().nextInt(max - min + 1) + min;
+        }
+
+        public static Transaction buildTx(ECKey sender) {
+            return buildSendValueTx(sender, BigInteger.ZERO);
+        }
+
+        public static Transaction buildSendValueTx(ECKey sender, BigInteger value) {
+            byte[] gasPrice = Hex.decode("00");
+            byte[] gasLimit = Hex.decode("00");
+
+            Transaction tx = new Transaction(
+                    null,
+                    gasPrice,
+                    gasLimit,
+                    sender.getAddress(),
+                    value.toByteArray(),
+                    null);
+            tx.sign(sender.getPrivKeyBytes());
+
+            return tx;
+        }
+
+        public static TxBuilder getZeroValueTxBuilder(ECKey sender) {
+            return (int executionIndex) -> buildTx(sender);
+        }
+
+        public static HeightProvider getRandomHeightProvider(int max) {
+            return (int executionIndex) -> new Random().nextInt(max);
+        }
+
+        public static HeightProvider getRandomHeightProvider(int min, int max) {
+            return (int executionIndex) -> randomInRange(min, max);
+        }
+
+        public static Block getMockBlock(long blockNumber) {
+            Block block = mock(Block.class);
+            when(block.getNumber()).thenReturn(blockNumber);
+            return block;
+        }
+    }
+
+    protected interface TxBuilder {
+        Transaction build(int executionIndex);
+    }
+
+    protected interface ABIEncoder {
+        byte[] encode(int executionIndex);
+    }
+
+    protected interface HeightProvider {
+        int getHeight(int executionIndex);
+    }
+
+    protected interface EnvironmentBuilder {
+        class Environment {
+            PrecompiledContracts.PrecompiledContract contract;
+            BenchmarkedRepository benchmarkedRepository;
+
+            public Environment(
+                    PrecompiledContracts.PrecompiledContract contract,
+                    BenchmarkedRepository benchmarkedRepository) {
+
+                this.contract = contract;
+                this.benchmarkedRepository = benchmarkedRepository;
+            }
+        }
+
+        Environment initialize(int executionIndex, Transaction tx, int height);
+        void teardown();
+    }
+
+    protected interface ResultCallback {
+        void callback(byte[] callResult);
+    }
+
+    private ExecutionTracker execute(
+            EnvironmentBuilder testEnvironment,
+            ABIEncoder abiEncoder,
+            TxBuilder txBuilder,
+            HeightProvider heightProvider,
+            int executionIndex,
+            ResultCallback resultCallback) {
+
+        ExecutionTracker executionInfo = new ExecutionTracker(thread);
+
+        // Initialize the environment, obtaining a fresh contract ready for execution
+        EnvironmentBuilder.Environment environment = testEnvironment.initialize(
+                executionIndex,
+                txBuilder.build(executionIndex),
+                heightProvider.getHeight(executionIndex)
+        );
+
+        executionInfo.startTimer();
+        byte[] executionResult = environment.contract.execute(abiEncoder.encode(executionIndex));
+        executionInfo.endTimer();
+
+        if (resultCallback != null) {
+            resultCallback.callback(executionResult);
+        }
+
+        testEnvironment.teardown();
+
+        executionInfo.setRepositoryStatistics(environment.benchmarkedRepository.getStatistics());
+
+        return executionInfo;
+    }
+
+    protected ExecutionStats executeAndAverage(
+            String name,
+            int times,
+            EnvironmentBuilder environmentBuilder,
+            ABIEncoder abiEncoder,
+            TxBuilder txBuilder,
+            HeightProvider heightProvider,
+            ExecutionStats stats,
+            ResultCallback resultCallback) {
+
+        for (int i = 0; i < times; i++) {
+            printLine(String.format("%s %d/%d", name, i + 1, times));
+
+            ExecutionTracker tracker = execute(environmentBuilder, abiEncoder, txBuilder, heightProvider, i, resultCallback);
+
+            stats.executionTimes.add(tracker.getExecutionTime());
+            stats.realExecutionTimes.add(tracker.getRealExecutionTime());
+            stats.slotsWritten.add(tracker.getRepositoryStatistics().getSlotsWritten());
+            stats.slotsCleared.add(tracker.getRepositoryStatistics().getSlotsCleared());
+        }
+
+        return stats;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PrecompiledContractPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PrecompiledContractPerformanceTestCase.java
@@ -209,7 +209,7 @@ public abstract class PrecompiledContractPerformanceTestCase {
             }
         }
 
-        Environment initialize(int executionIndex, Transaction tx, int height);
+        Environment initialize(int executionIndex, TxBuilder txBuilder, int height);
         void teardown();
     }
 
@@ -230,7 +230,7 @@ public abstract class PrecompiledContractPerformanceTestCase {
         // Initialize the environment, obtaining a fresh contract ready for execution
         EnvironmentBuilder.Environment environment = testEnvironment.initialize(
                 executionIndex,
-                txBuilder.build(executionIndex),
+                txBuilder,
                 heightProvider.getHeight(executionIndex)
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
@@ -72,7 +72,7 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
         };
 
         ExecutionStats stats = new ExecutionStats("receiveHeaders");
-        executeAndAverage("receiveHeaders", 200, abiEncoder, storageInitializer, Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
+        executeAndAverage("receiveHeaders", 200, abiEncoder, storageInitializer, Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()), Helper.getRandomHeightProvider(10), stats);
 
         BridgePerformanceTest.addStats(stats);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ReceiveHeadersTest.java
@@ -72,7 +72,7 @@ public class ReceiveHeadersTest extends BridgePerformanceTestCase {
         };
 
         ExecutionStats stats = new ExecutionStats("receiveHeaders");
-        executeAndAverage("receiveHeaders", 200, abiEncoder, storageInitializer, Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()), Helper.getRandomHeightProvider(10), stats);
+        executeAndAverage("receiveHeaders", 200, abiEncoder, storageInitializer, Helper.getZeroValueValueTxBuilderFromFedMember(), Helper.getRandomHeightProvider(10), stats);
 
         BridgePerformanceTest.addStats(stats);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
@@ -61,7 +61,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
                 false
         );
 
-        executeAndAverage("registerBtcTransaction-lockSuccess", times, getABIEncoder(), storageInitializer, Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
+        executeAndAverage("registerBtcTransaction-lockSuccess", times, getABIEncoder(), storageInitializer, Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()), Helper.getRandomHeightProvider(10), stats);
 
     }
 
@@ -73,7 +73,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
                 true
         );
 
-        executeAndAverage("registerBtcTransaction-alreadyProcessed", times, getABIEncoder(), storageInitializer, Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
+        executeAndAverage("registerBtcTransaction-alreadyProcessed", times, getABIEncoder(), storageInitializer, Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()), Helper.getRandomHeightProvider(10), stats);
     }
 
     private void registerBtcTransaction_notEnoughConfirmations(int times, ExecutionStats stats) {
@@ -84,7 +84,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
                 false
         );
 
-        executeAndAverage("registerBtcTransaction-notEnoughConfirmations", times, getABIEncoder(), storageInitializer, Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
+        executeAndAverage("registerBtcTransaction-notEnoughConfirmations", times, getABIEncoder(), storageInitializer, Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()), Helper.getRandomHeightProvider(10), stats);
     }
 
     private ABIEncoder getABIEncoder() {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
@@ -61,7 +61,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
                 false
         );
 
-        executeAndAverage("registerBtcTransaction-lockSuccess", times, getABIEncoder(), storageInitializer, Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()), Helper.getRandomHeightProvider(10), stats);
+        executeAndAverage("registerBtcTransaction-lockSuccess", times, getABIEncoder(), storageInitializer, Helper.getZeroValueValueTxBuilderFromFedMember(), Helper.getRandomHeightProvider(10), stats);
 
     }
 
@@ -73,7 +73,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
                 true
         );
 
-        executeAndAverage("registerBtcTransaction-alreadyProcessed", times, getABIEncoder(), storageInitializer, Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()), Helper.getRandomHeightProvider(10), stats);
+        executeAndAverage("registerBtcTransaction-alreadyProcessed", times, getABIEncoder(), storageInitializer, Helper.getZeroValueValueTxBuilderFromFedMember(), Helper.getRandomHeightProvider(10), stats);
     }
 
     private void registerBtcTransaction_notEnoughConfirmations(int times, ExecutionStats stats) {
@@ -84,7 +84,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
                 false
         );
 
-        executeAndAverage("registerBtcTransaction-notEnoughConfirmations", times, getABIEncoder(), storageInitializer, Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()), Helper.getRandomHeightProvider(10), stats);
+        executeAndAverage("registerBtcTransaction-notEnoughConfirmations", times, getABIEncoder(), storageInitializer, Helper.getZeroValueValueTxBuilderFromFedMember(), Helper.getRandomHeightProvider(10), stats);
     }
 
     private ABIEncoder getABIEncoder() {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/UpdateCollectionsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/UpdateCollectionsTest.java
@@ -61,7 +61,7 @@ public class UpdateCollectionsTest extends BridgePerformanceTestCase {
                 numCases,
                 abiEncoder,
                 storageInitializer,
-                Helper.getZeroValueRandomSenderTxBuilder(),
+                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
                 Helper.getRandomHeightProvider(10), stats
         );
     }
@@ -120,7 +120,7 @@ public class UpdateCollectionsTest extends BridgePerformanceTestCase {
                 numCases,
                 abiEncoder,
                 storageInitializer,
-                Helper.getZeroValueRandomSenderTxBuilder(),
+                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
                 Helper.getRandomHeightProvider(10),
                 stats
         );
@@ -187,7 +187,7 @@ public class UpdateCollectionsTest extends BridgePerformanceTestCase {
                 numCases,
                 abiEncoder,
                 storageInitializer,
-                Helper.getZeroValueRandomSenderTxBuilder(),
+                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
                 heightProvider,
                 stats
         );

--- a/rskj-core/src/test/java/co/rsk/peg/performance/UpdateCollectionsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/UpdateCollectionsTest.java
@@ -61,7 +61,7 @@ public class UpdateCollectionsTest extends BridgePerformanceTestCase {
                 numCases,
                 abiEncoder,
                 storageInitializer,
-                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
+                Helper.getZeroValueValueTxBuilderFromFedMember(),
                 Helper.getRandomHeightProvider(10), stats
         );
     }
@@ -120,7 +120,7 @@ public class UpdateCollectionsTest extends BridgePerformanceTestCase {
                 numCases,
                 abiEncoder,
                 storageInitializer,
-                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
+                Helper.getZeroValueValueTxBuilderFromFedMember(),
                 Helper.getRandomHeightProvider(10),
                 stats
         );
@@ -187,7 +187,7 @@ public class UpdateCollectionsTest extends BridgePerformanceTestCase {
                 numCases,
                 abiEncoder,
                 storageInitializer,
-                Helper.getZeroValueTxBuilder(Helper.getRandomFederatorECKey()),
+                Helper.getZeroValueValueTxBuilderFromFedMember(),
                 heightProvider,
                 stats
         );

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractAddressTests.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractAddressTests.java
@@ -20,10 +20,15 @@ package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import org.ethereum.config.BlockchainConfig;
+import org.ethereum.core.Blockchain;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by Sergio Demian Lerner on 12/10/2018.
@@ -38,6 +43,7 @@ public class PrecompiledContractAddressTests {
     public static final String SAMPLE_ADDR_STR = "0000000000000000000000000000000001000005";
     public static final String BRIDGE_ADDR_STR = "0000000000000000000000000000000001000006";
     public static final String REMASC_ADDR_STR = "0000000000000000000000000000000001000008";
+    public static final String BTOUTILS_ADDR_STR = "0000000000000000000000000000000001000009";
 
     private final TestSystemProperties config = new TestSystemProperties();
 
@@ -52,12 +58,18 @@ public class PrecompiledContractAddressTests {
         //checkAddr(pcList,SAMPLE_ADDR_STR ,"SamplePrecompiledContract");
         checkAddr(pcList,BRIDGE_ADDR_STR ,"Bridge");
         checkAddr(pcList,REMASC_ADDR_STR ,"RemascContract");
+        checkAddr(pcList,BTOUTILS_ADDR_STR,"BTOUtils");
     }
 
     void checkAddr(PrecompiledContracts pcList,String addr,String className) {
+        BlockchainConfig afterRskip106 = mock(BlockchainConfig.class);
+
+        // Enabling necessary RSKIPs for every precompiled contract to be available
+        when(afterRskip106.isRskip106()).thenReturn(true);
+
         RskAddress a;
         a = new RskAddress(addr);
-        PrecompiledContracts.PrecompiledContract pc = pcList.getContractForAddress(null, DataWord.valueOf(a.getBytes()));
+        PrecompiledContracts.PrecompiledContract pc = pcList.getContractForAddress(afterRskip106, DataWord.valueOf(a.getBytes()));
         Assert.assertEquals(className,pc.getClass().getSimpleName());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
@@ -19,12 +19,18 @@
 package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.pcc.bto.BTOUtils;
 import co.rsk.peg.Bridge;
+import org.ethereum.config.BlockchainConfig;
+import org.ethereum.config.BlockchainNetConfig;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.PrecompiledContracts.PrecompiledContract;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PrecompiledContractTest {
 
@@ -49,5 +55,30 @@ public class PrecompiledContractTest {
         Assert.assertNotNull(bridge1);
         Assert.assertNotNull(bridge2);
         Assert.assertNotSame(bridge1, bridge2);
+    }
+
+    @Test
+    public void getBtoUtilsBeforeRskip106() {
+        BlockchainConfig afterRskip106 = mock(BlockchainConfig.class);
+        when(afterRskip106.isRskip106()).thenReturn(false);
+        DataWord btoUtilsAddress = DataWord.valueOf(PrecompiledContracts.BTOUTILS_ADDR.getBytes());
+        PrecompiledContract btoUtils = precompiledContracts.getContractForAddress(afterRskip106, btoUtilsAddress);
+
+        Assert.assertNull(btoUtils);
+    }
+
+    @Test
+    public void getBtoUtilsAfterRskip106() {
+        BlockchainConfig afterRskip106 = mock(BlockchainConfig.class);
+        when(afterRskip106.isRskip106()).thenReturn(true);
+        DataWord btoUtilsAddress = DataWord.valueOf(PrecompiledContracts.BTOUTILS_ADDR.getBytes());
+        PrecompiledContract btoUtils1 = precompiledContracts.getContractForAddress(afterRskip106, btoUtilsAddress);
+        PrecompiledContract btoUtils2 = precompiledContracts.getContractForAddress(afterRskip106, btoUtilsAddress);
+
+        Assert.assertNotNull(btoUtils1);
+        Assert.assertNotNull(btoUtils2);
+        Assert.assertEquals(BTOUtils.class, btoUtils1.getClass());
+        Assert.assertEquals(BTOUtils.class, btoUtils2.getClass());
+        Assert.assertNotSame(btoUtils1, btoUtils2);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -240,7 +240,6 @@ public class VMPerformanceTest {
         // Delta time is de difference in thread time
         public long deltaTime_nS; // in nanoseconds.
         public long gas;
-
     }
 
     public interface ResultLogger {
@@ -281,6 +280,7 @@ public class VMPerformanceTest {
             // Al parecer el gc puede interrumpir en cualquier momento y hacer estragos
             // Mejor que repetir y tomar el promedio es ejecutar muchas veces y quedarse con
             // el menor tiempo logrado
+
             for (int loops = 0; loops < myLoops; loops++) {
                 vm.steps(program, insCount);
 
@@ -297,7 +297,6 @@ public class VMPerformanceTest {
 
             }
 
-
             long endTime = thread.getCurrentThreadCpuTime();
             long endRealTime = System.currentTimeMillis();
             long endGCTime = getGarbageCollectorTimeMillis();
@@ -309,7 +308,6 @@ public class VMPerformanceTest {
             pr.deltaGCTimeMillis = (endGCTime- startGCTime)*1000*1000/ maxLoops / divisor; // nanos
 
             long endUsedMemory = (rt.totalMemory() - rt.freeMemory());
-
 
             pr.deltaUsedMemory = endUsedMemory - startUsedMemory;
             if ((best == null) || (pr.deltaTime_nS < best.deltaTime_nS)) {


### PR DESCRIPTION
This pull request creates a new native contract BTOUtils making use of the newly created framework for native contracts.

For details about the actual contract please refer to [this RSKIP](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP106.md).

:robot: **build using** *fed:bitcoinj-thin-0.14.4-rsk-6*