### PR TITLE
Add LGTM.com configuration

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  java:
+    before_index:
+      - ./configure.sh


### PR DESCRIPTION
This configuration file allows the Java analysis on LGTM.com to succeed: https://lgtm.com/projects/g/rsksmart/rskj/logs/languages/lang:java