### PR TITLE
Increase block's timestamp when Automine=false

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerClock.java
@@ -22,19 +22,19 @@ import org.ethereum.core.Block;
 import java.time.Clock;
 
 public class MinerClock {
-    private final boolean isRegtest;
+    private final boolean isFixedClock;
     private final Clock clock;
 
     private long timeAdjustment;
 
-    public MinerClock(boolean isRegtest, Clock clock) {
-        this.isRegtest = isRegtest;
+    public MinerClock(boolean isFixedClock, Clock clock) {
+        this.isFixedClock = isFixedClock;
         this.clock = clock;
     }
 
     public long calculateTimestampForChild(Block parent) {
         long previousTimestamp = parent.getTimestamp();
-        if (isRegtest) {
+        if (isFixedClock) {
             return previousTimestamp + timeAdjustment;
         }
 

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -50,10 +50,7 @@ peer {
 }
 
 miner {
-    server {
-        enabled = true
-        isFixedClock = true
-    }
+    server.enabled = true
 
     client {
         enabled = true


### PR DESCRIPTION
**This PR has last master changes.** 

Now when Regtest is enabled and Automine is disabled, block timestamp will increase as used to.
Also timeAjustment won't be compute when Regtest is disabled