### PR TITLE
Use Gradle's SonarQube

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,36 @@ jobs:
       - image: openjdk:8-jdk
     environment:
       _JAVA_OPTIONS: "-Xmx3G -Xms2G"
-      SONAR_VERSION: "3.0.3.778"
     resource_class: medium+
     steps:
       - checkout
       - run: apt update -y && apt install -y gnupg2
       - run: curl -sSL https://secchannel.rsk.co/release.asc | gpg2 --import -
       - run: gpg2 --verify SHA256SUMS.asc && sha256sum --check SHA256SUMS.asc
-      - run: curl -OJL http://central.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/$SONAR_VERSION/sonar-scanner-cli-$SONAR_VERSION.jar
       - run: ./configure.sh
       - run: ./gradlew --no-daemon dependencies
       - run: ./gradlew --no-daemon --stacktrace build
+      - run:
+          name: Run SonarQube analysis
+          # https://community.sonarsource.com/t/no-code-or-issue-found-in-pull-request-decorations-github-circleci/8496
+          command: |
+            git branch -f master origin/master
+            if [ ! -z $CIRCLE_PULL_REQUEST ]; then
+              PULL_REQUEST=$(echo $CIRCLE_PULL_REQUEST | awk '{print substr($1,39)}')
+              ./gradlew sonarqube --no-daemon -x build -x test \
+                -Dsonar.pullrequest.base=master \
+                -Dsonar.pullrequest.branch=$CIRCLE_BRANCH \
+                -Dsonar.pullrequest.key=$PULL_REQUEST \
+                -Dsonar.organization=rsksmart \
+                -Dsonar.host.url=$SONAR_URL \
+                -Dsonar.login=$SONAR_TOKEN
+            else
+              ./gradlew sonarqube --no-daemon -x build -x test \
+                -Dsonar.branch.name=master \
+                -Dsonar.organization=rsksmart \
+                -Dsonar.host.url=$SONAR_URL \
+                -Dsonar.login=$SONAR_TOKEN
+            fi
       - run:
           name: Save test results
           command: |
@@ -27,5 +46,3 @@ jobs:
           path: ~/junit
       - store_artifacts:
           path: ~/junit
-      - run: if [ ! -z $CI_PULL_REQUEST ]; then export PULL_REQUEST=$(echo $CI_PULL_REQUEST | awk '{print substr($1,39)}') && java -jar ./sonar-scanner-cli-$SONAR_VERSION.jar -Dsonar.pullrequest.provider=github -Dsonar.pullrequest.base=master -Dsonar.pullrequest.branch=$CIRCLE_BRANCH -Dsonar.pullrequest.key=$PULL_REQUEST -Dsonar.projectKey=rsksmart_rskj -Dsonar.organization=rsksmart -Dsonar.host.url=$SONAR_URL -Dsonar.login=$SONAR_TOKEN -Dsonar.sources="rskj-core/src/main/java,rskj-core/src/main/resources" -Dsonar.java.binaries="rskj-core/build/classes/java/main" -Dsonar.java.libraries="/root/.gradle/caches/modules-2/files-2.1/*"; else java -jar ./sonar-scanner-cli-$SONAR_VERSION.jar -Dsonar.branch.name=master -Dsonar.projectKey=rsksmart_rskj -Dsonar.organization=rsksmart -Dsonar.host.url=$SONAR_URL -Dsonar.login=$SONAR_TOKEN -Dsonar.sources="rskj-core/src/main/java,rskj-core/src/main/resources" -Dsonar.java.binaries="rskj-core/build/classes/java/main" -Dsonar.java.libraries="/root/.gradle/caches/modules-2/files-2.1/*"; fi
-      

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to RskJ
 [![CircleCI](https://circleci.com/gh/rsksmart/rskj/tree/master.svg?style=svg)](https://circleci.com/gh/rsksmart/rskj/tree/master)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rsksmart_rskj&metric=alert_status)](https://sonarcloud.io/dashboard?id=rsksmart_rskj)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rskj&metric=alert_status)](https://sonarcloud.io/dashboard?id=rskj)
 
 
 # About

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id "org.sonarqube" version "2.7.1"
+}
 
 subprojects {
     def config = new ConfigSlurper().parse(new File("$projectDir/src/main/resources/version.properties").toURI().toURL())


### PR DESCRIPTION
1. Use Gradle's SonarQube plugin so project settings are picked up automatically
2. Apply workaround that prevented analysis from running correctly on CircleCI: https://community.sonarsource.com/t/no-code-or-issue-found-in-pull-request-decorations-github-circleci/8496