### PR TITLE
Rework trie mutable cache to allow a newer implementation for storage keys

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/MutableTrie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/MutableTrie.java
@@ -18,11 +18,14 @@
 
 package co.rsk.trie;
 
+import co.rsk.core.RskAddress;
 import co.rsk.core.types.ints.Uint24;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.db.ByteArrayWrapper;
+import org.ethereum.vm.DataWord;
 
 import javax.annotation.Nullable;
+import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -41,13 +44,8 @@ public interface MutableTrie {
     // This method optimizes cache-to-cache transfers
     void put(ByteArrayWrapper key, byte[] value);
 
-    /////////////////////////////////////////////////////////////////////////////////
-    // The semantic of deleteRecursive() is special, and not the same of delete()
-    // When it is applied to a mutable trie which has a cache (such as MutableTrieCache)
-    // then this is DELETE ON COMMIT, which means that changes are not applied until
-    // commit() is called, and changes are applied as the last step of commit.
-    // In a normal MutableTrie or Trie, changes are applied immediately.
-    /////////////////////////////////////////////////////////////////////////////////
+    // the key has to match exactly an account key
+    // it won't work if it is used with an storage key or any other
     void deleteRecursive(byte[] key);
 
     void save();
@@ -58,6 +56,7 @@ public interface MutableTrie {
 
     void rollback();
 
+    // TODO(mc) this method is only used from tests
     Set<ByteArrayWrapper> collectKeys(int size);
 
     MutableTrie getSnapshotTo(Keccak256 hash);
@@ -70,4 +69,8 @@ public interface MutableTrie {
     // without the need to retrieve the value itself. Implementors can fallback to
     // getting the value and then returning its size.
     Uint24 getValueLength(byte[] key);
+
+    // the key has to match exactly an account key
+    // it won't work if it is used with an storage key or any other
+    Iterator<DataWord> getStorageKeys(RskAddress addr);
 }

--- a/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
+++ b/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
@@ -22,6 +22,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.util.ByteUtil;
+import org.ethereum.vm.DataWord;
 
 import java.util.Arrays;
 
@@ -59,14 +60,15 @@ public class TrieKeyMapper {
         return ByteUtil.merge(getAccountKey(addr), STORAGE_PREFIX);
     }
 
-    public byte[] getAccountStorageKey(RskAddress addr, byte[] subkey) {
+    public byte[] getAccountStorageKey(RskAddress addr, DataWord subkeyDW) {
         // TODO(SDL) should we hash the full subkey or the stripped one?
+        byte[] subkey = subkeyDW.getData();
         byte[] secureKeyPrefix = secureKeyPrefix(subkey);
         byte[] storageKey = ByteUtil.merge(secureKeyPrefix, ByteUtil.stripLeadingZeroes(subkey));
         return ByteUtil.merge(getAccountStoragePrefixKey(addr), storageKey);
     }
 
-    private byte[] secureKeyPrefix(byte[] key) {
+    public byte[] secureKeyPrefix(byte[] key) {
         return Arrays.copyOfRange(Keccak256Helper.keccak256(key), 0, SECURE_KEY_SIZE);
     }
 

--- a/rskj-core/src/test/java/co/rsk/db/MutableTrieCacheTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/MutableTrieCacheTest.java
@@ -18,17 +18,19 @@
 
 package co.rsk.db;
 
+import co.rsk.core.RskAddress;
 import co.rsk.trie.MutableTrie;
 import co.rsk.trie.Trie;
+import co.rsk.trie.TrieKeySlice;
 import org.ethereum.db.ByteArrayWrapper;
+import org.ethereum.db.MutableRepository;
 import org.ethereum.db.TrieKeyMapper;
+import org.ethereum.vm.DataWord;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Created by SerAdmin on 9/26/2018.
@@ -37,6 +39,10 @@ public class MutableTrieCacheTest {
 
     private byte[] toBytes(String x) {
         return x.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private DataWord toStorageKey(String x) {
+        return DataWord.valueOf(toBytes(x));
     }
 
     private String setToString(Set<ByteArrayWrapper> set) {
@@ -114,9 +120,6 @@ public class MutableTrieCacheTest {
         Assert.assertNotNull(mtCache.get(toBytes(accountLikeKey.toString() + "125")));
         Assert.assertNull(mtCache.get(toBytes(accountLikeKey.toString() + "123")));
         Assert.assertNull(mtCache.get(toBytes(accountLikeKey.toString())));
-
-        mtCache.put(toBytes(accountLikeKey.toString() + "123"), toBytes("HAL"));
-        Assert.assertNotNull(mtCache.get(toBytes(accountLikeKey.toString() + "123")));
     }
 
     @Test
@@ -131,24 +134,34 @@ public class MutableTrieCacheTest {
         mtCache.put(toBytes(accountLikeKey.toString() + "123"), toBytes("HAL"));
         mtCache.put(toBytes(accountLikeKey.toString() + "124"), toBytes("HAL"));
         mtCache.put(toBytes(accountLikeKey.toString() + "125"), toBytes("HAL"));
-        mtCache.deleteRecursive(toBytes(accountLikeKey.toString()));
+
+        // puts on superior levels are not reflected on lower levels before commit
+        MutableTrieCache otherCache = new MutableTrieCache(mtCache);
+        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "126")));
+        otherCache.put(toBytes(accountLikeKey.toString() + "124"), toBytes("LAH"));
+        Assert.assertArrayEquals(toBytes("LAH"), otherCache.get(toBytes(accountLikeKey.toString() + "124")));
+        Assert.assertArrayEquals(toBytes("HAL"), mtCache.get(toBytes(accountLikeKey.toString() + "124")));
+        otherCache.put(toBytes(accountLikeKey.toString() + "123"), null);
+        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "123")));
+        Assert.assertArrayEquals(toBytes("HAL"), mtCache.get(toBytes(accountLikeKey.toString() + "123")));
 
         // after commit puts on superior levels are reflected on lower levels
-        MutableTrieCache otherCache = new MutableTrieCache(mtCache);
-        otherCache.put(toBytes(accountLikeKey.toString() + "124"), toBytes("HAL"));
-        Assert.assertNotNull(otherCache.get(toBytes(accountLikeKey.toString() + "124")));
-        Assert.assertNull(mtCache.get(toBytes(accountLikeKey.toString() + "124")));
         otherCache.commit();
-        Assert.assertNotNull(otherCache.get(toBytes(accountLikeKey.toString() + "124")));
-        Assert.assertNotNull(mtCache.get(toBytes(accountLikeKey.toString() + "124")));
+        Assert.assertArrayEquals(toBytes("LAH"), otherCache.get(toBytes(accountLikeKey.toString() + "124")));
+        Assert.assertArrayEquals(toBytes("LAH"), mtCache.get(toBytes(accountLikeKey.toString() + "124")));
+        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "123")));
+        Assert.assertNull(mtCache.get(toBytes(accountLikeKey.toString() + "123")));
+        Assert.assertArrayEquals(toBytes("HAL"), mtCache.get(toBytes(accountLikeKey.toString() + "125")));
 
         mtCache.put(toBytes(accountLikeKey.toString() + "123"), toBytes("HAL"));
-        mtCache.put(toBytes(accountLikeKey.toString() + "125"), toBytes("HAL"));
+        mtCache.put(toBytes(accountLikeKey.toString() + "124"), toBytes("HAL"));
         otherCache.deleteRecursive(toBytes(accountLikeKey.toString()));
+        otherCache.put(toBytes(accountLikeKey.toString() + "125"), toBytes("HAL"));
         Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "123")));
         Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "124")));
-        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "125")));
+        Assert.assertNotNull(otherCache.get(toBytes(accountLikeKey.toString() + "125")));
         Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString())));
+        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "126")));
 
         // before commit lower level cache is not affected
         Assert.assertNotNull(mtCache.get(toBytes(accountLikeKey.toString() + "123")));
@@ -157,9 +170,158 @@ public class MutableTrieCacheTest {
         Assert.assertNull(mtCache.get(toBytes(accountLikeKey.toString())));
 
         otherCache.commit();
-        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "123")));
-        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "124")));
-        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString() + "125")));
-        Assert.assertNull(otherCache.get(toBytes(accountLikeKey.toString())));
+        Assert.assertNull(mtCache.get(toBytes(accountLikeKey.toString() + "123")));
+        Assert.assertNull(mtCache.get(toBytes(accountLikeKey.toString() + "124")));
+        Assert.assertNotNull(mtCache.get(toBytes(accountLikeKey.toString() + "125")));
+        Assert.assertNull(mtCache.get(toBytes(accountLikeKey.toString())));
+    }
+
+    @Test
+    public void testStorageKeysMixOneLevel() {
+        // SUTs
+        MutableTrieImpl baseMutableTrie = new MutableTrieImpl(new Trie());
+        MutableTrieCache mtCache = new MutableTrieCache(baseMutableTrie);
+        MutableTrieCache otherCache = new MutableTrieCache(mtCache);
+
+        // setup
+
+        // helpers for interacting with the SUTs
+        MutableRepository baseRepository = new MutableRepository(baseMutableTrie);
+        MutableRepository cacheRepository = new MutableRepository(mtCache);
+        MutableRepository otherCacheRepository = new MutableRepository(otherCache);
+
+        RskAddress addr = new RskAddress("b86ca7db8c7ae687ac8d098789987eee12333fc7");
+
+        baseRepository.createAccount(addr);
+        baseRepository.setupContract(addr);
+
+        DataWord sk120 = toStorageKey("120");
+        DataWord sk121 = toStorageKey("121");
+        DataWord sk122 = toStorageKey("122");
+        DataWord sk123 = toStorageKey("123");
+        DataWord sk124 = toStorageKey("124");
+
+        baseRepository.addStorageBytes(addr, sk120, toBytes("HAL"));
+        baseRepository.addStorageBytes(addr, sk121, toBytes("HAL"));
+        baseRepository.addStorageBytes(addr, sk122, toBytes("HAL"));
+        cacheRepository.addStorageBytes(addr, sk120, null);
+        cacheRepository.addStorageBytes(addr, sk121, toBytes("LAH"));
+        cacheRepository.addStorageBytes(addr, sk123, toBytes("LAH"));
+        otherCacheRepository.addStorageBytes(addr, sk124, toBytes("HAL"));
+
+        // assertions
+
+        Iterator<DataWord> storageKeys = mtCache.getStorageKeys(addr);
+        Set<DataWord> keys = new HashSet<>();
+        storageKeys.forEachRemaining(keys::add);
+        Assert.assertFalse(keys.contains(sk120));
+        Assert.assertTrue(keys.contains(sk121));
+        Assert.assertTrue(keys.contains(sk122));
+        Assert.assertTrue(keys.contains(sk123));
+        Assert.assertFalse(keys.contains(sk124));
+        Assert.assertEquals(3, keys.size());
+
+        storageKeys = otherCache.getStorageKeys(addr);
+        keys = new HashSet<>();
+        storageKeys.forEachRemaining(keys::add);
+        Assert.assertFalse(keys.contains(sk120));
+        Assert.assertTrue(keys.contains(sk121));
+        Assert.assertTrue(keys.contains(sk122));
+        Assert.assertTrue(keys.contains(sk123));
+        Assert.assertTrue(keys.contains(sk124));
+        Assert.assertEquals(4, keys.size());
+    }
+
+    @Test
+    public void testStorageKeysNoCache() {
+        // SUTs
+        MutableTrieImpl baseMutableTrie = new MutableTrieImpl(new Trie());
+        MutableTrieCache mtCache = new MutableTrieCache(baseMutableTrie);
+
+        // setup
+
+        // helpers for interacting with the SUTs
+        MutableRepository baseRepository = new MutableRepository(baseMutableTrie);
+
+        RskAddress addr = new RskAddress("b86ca7db8c7ae687ac8d098789987eee12333fc7");
+
+        DataWord sk120 = toStorageKey("120");
+        DataWord sk121 = toStorageKey("121");
+
+        baseRepository.addStorageBytes(addr, sk120, toBytes("HAL"));
+        baseRepository.addStorageBytes(addr, sk121, toBytes("HAL"));
+
+        Iterator<DataWord> storageKeys = mtCache.getStorageKeys(addr);
+        Set<DataWord> keys = new HashSet<>();
+        storageKeys.forEachRemaining(keys::add);
+        Assert.assertTrue(keys.contains(sk120));
+        Assert.assertTrue(keys.contains(sk121));
+        Assert.assertEquals(2, keys.size());
+    }
+
+    @Test
+    public void testStorageKeysNoTrie() {
+        // SUTs
+        MutableTrieImpl baseMutableTrie = new MutableTrieImpl(new Trie());
+        MutableTrieCache mtCache = new MutableTrieCache(baseMutableTrie);
+
+        // setup
+
+        // helpers for interacting with the SUTs
+        MutableRepository cacheRepository = new MutableRepository(mtCache);
+
+        RskAddress addr = new RskAddress("b86ca7db8c7ae687ac8d098789987eee12333fc7");
+
+        DataWord skzero = DataWord.ZERO;
+        DataWord sk120 = toStorageKey("120");
+        DataWord sk121 = toStorageKey("121");
+
+        cacheRepository.addStorageBytes(addr, sk120, toBytes("HAL"));
+        cacheRepository.addStorageBytes(addr, sk121, toBytes("HAL"));
+        cacheRepository.addStorageBytes(addr, skzero, toBytes("HAL"));
+
+        Iterator<DataWord> storageKeys = mtCache.getStorageKeys(addr);
+        Set<DataWord> keys = new HashSet<>();
+        storageKeys.forEachRemaining(keys::add);
+        Assert.assertTrue(keys.contains(sk120));
+        Assert.assertTrue(keys.contains(sk121));
+        Assert.assertTrue(keys.contains(skzero));
+        Assert.assertEquals(3, keys.size());
+    }
+
+    @Test
+    public void testStorageKeysDeletedAccount() {
+        // SUTs
+        MutableTrieImpl baseMutableTrie = new MutableTrieImpl(new Trie());
+        MutableTrieCache mtCache = new MutableTrieCache(baseMutableTrie);
+
+        // setup
+
+        // helpers for interacting with the SUTs
+        MutableRepository cacheRepository = new MutableRepository(mtCache);
+        MutableRepository baseRepository = new MutableRepository(baseMutableTrie);
+        RskAddress addr = new RskAddress("b86ca7db8c7ae687ac8d098789987eee12333fc7");
+
+        DataWord sk120 = toStorageKey("120");
+        DataWord sk121 = toStorageKey("121");
+
+        baseRepository.addStorageBytes(addr, sk120, toBytes("HAL"));
+        cacheRepository.delete(addr);
+
+        Iterator<DataWord> storageKeys = mtCache.getStorageKeys(addr);
+        Set<DataWord> keys = new HashSet<>();
+        storageKeys.forEachRemaining(keys::add);
+        Assert.assertFalse(keys.contains(sk120));
+        Assert.assertFalse(keys.contains(sk121));
+        Assert.assertEquals(0, keys.size());
+
+        cacheRepository.addStorageBytes(addr, sk121, toBytes("HAL"));
+
+        storageKeys = mtCache.getStorageKeys(addr);
+        keys = new HashSet<>();
+        storageKeys.forEachRemaining(keys::add);
+        Assert.assertFalse(keys.contains(sk120));
+        Assert.assertTrue(keys.contains(sk121));
+        Assert.assertEquals(1, keys.size());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
@@ -872,6 +872,6 @@ public class RepositoryImplOriginalTest {
     }
 
     private static Repository createRepository() {
-        return new MutableRepository(new MutableTrieCache(new MutableTrieImpl(new Trie())));
+        return new MutableRepository(new MutableTrieImpl(new Trie()));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryUpdateTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryUpdateTest.java
@@ -80,7 +80,7 @@ public class RepositoryUpdateTest {
         details.put(DataWord.ONE, DataWord.valueOf(42));
         details.put(DataWord.ZERO, DataWord.valueOf(1));
 
-        Repository repo = new MutableRepository(new MutableTrieCache(new MutableTrieImpl(new Trie())));
+        Repository repo = new MutableRepository(new MutableTrieImpl(new Trie()));
         updateContractDetails(repo, address, details);
 
         Assert.assertNotNull(repo.getMutableTrie().getHash().getBytes());


### PR DESCRIPTION
MutableTrieCache changes the internal structure for a more simpler one where order of operations is not needed anymore. Deletions are marked and all this data can be committed to lower levels including Trie.

With this change introduced the implementation for storageKeys can be calculated merging the information from the trie and the current level of cache

