### PR TITLE
Mock the getParentHashJsonString() method as it should be @Notnull

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -156,8 +156,10 @@ public class MinerServerImpl implements MinerServer {
         synchronized (lock) {
             started = false;
             ethereum.removeListener(blockListener);
-            refreshWorkTimer.cancel();
-            refreshWorkTimer = null;
+            if (refreshWorkTimer != null) {
+                refreshWorkTimer.cancel();
+                refreshWorkTimer = null;
+            }
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -673,12 +673,14 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
         when(block1.getHashForMergedMining()).thenReturn(TestUtils.randomHash().getBytes());
         when(block1.getHash()).thenReturn(TestUtils.randomHash());
         when(block1.getDifficulty()).thenReturn(BlockDifficulty.ZERO);
+        when(block1.getParentHashJsonString()).thenReturn(TestUtils.randomHash().toJsonString());
 
         Block block2 = mock(Block.class);
         when(block2.getFeesPaidToMiner()).thenReturn(new Coin(BigInteger.valueOf(24)));
         when(block2.getHashForMergedMining()).thenReturn(TestUtils.randomHash().getBytes());
         when(block2.getHash()).thenReturn(TestUtils.randomHash());
         when(block2.getDifficulty()).thenReturn(BlockDifficulty.ZERO);
+        when(block2.getParentHashJsonString()).thenReturn(TestUtils.randomHash().toJsonString());
 
         BlockToMineBuilder builder = mock(BlockToMineBuilder.class);
         BlockResult blockResult = mock(BlockResult.class);


### PR DESCRIPTION
Check if refreshWorkTimer is null at stop() to avoid a NPE

Mock the getParentHashJsonString() method as it should be @Notnull (test failing in some versions of intellij for this)