### PR TITLE
Fix uncle count alculation in ForkDetectionData

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/ForkDetectionDataCalculator.java
+++ b/rskj-core/src/main/java/co/rsk/mine/ForkDetectionDataCalculator.java
@@ -100,11 +100,16 @@ public class ForkDetectionDataCalculator {
     }
 
     private Uint8 getNumberOfUncles(List<BlockHeader> mainchainBlocks) {
-        // int to Uint8 is a safe creation since number of uncles is max 7 and blocks evaluated are at most 32.
-        // Hence, 7 * 32 = 224 and 224 < 255 (max number that fits on a short type variable)
-        return new Uint8(IntStream
+        int sum = IntStream
                 .range(0, NUMBER_OF_UNCLES)
-                .map(i -> mainchainBlocks.get(i).getUncleCount()).sum());
+                .map(i -> mainchainBlocks.get(i).getUncleCount()).sum();
+
+        final int maxUint = Uint8.MAX_VALUE.intValue();
+        if (sum > maxUint) {
+            return new Uint8(maxUint);
+        }
+
+        return new Uint8(sum);
     }
 
     private byte[] getBlockBeingMinedHeight(List<BlockHeader> mainchainBlocks) {

--- a/rskj-core/src/test/java/co/rsk/mine/ForkDataDetectionCalculatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/ForkDataDetectionCalculatorTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.when;
 
 
 public class ForkDataDetectionCalculatorTest {
+    private static final int MAX_UNCLES = 10;
 
     private static MessageSerializer serializer;
 
@@ -156,7 +157,7 @@ public class ForkDataDetectionCalculatorTest {
         assertThat(forkDetectionData[6],
                 is(getBtcBlockHashLeastSignificantByte(trimmedBlocks.get(446).getBitcoinMergedMiningHeader())));
 
-        assertThat(forkDetectionData[7], is((byte)90));
+        assertThat(forkDetectionData[7], is((byte)-120));
 
         assertThat(forkDetectionData[8], is((byte)0));
         assertThat(forkDetectionData[9], is((byte)0));
@@ -190,7 +191,7 @@ public class ForkDataDetectionCalculatorTest {
         assertThat(forkDetectionData[6],
                 is(getBtcBlockHashLeastSignificantByte(trimmedBlocks.get(436).getBitcoinMergedMiningHeader())));
 
-        assertThat(forkDetectionData[7], is((byte)224));
+        assertThat(forkDetectionData[7], is((byte)-1));
 
         assertThat(forkDetectionData[8], is((byte)0));
         assertThat(forkDetectionData[9], is((byte)0));
@@ -206,7 +207,7 @@ public class ForkDataDetectionCalculatorTest {
         List<Block> blocksUncles = createBlockchainAsList(height);
         int i = 0;
         for(Block block : blocksUncles) {
-            when(block.getHeader().getUncleCount()).thenReturn(maxUncles ? 7 : i % 7);
+            when(block.getHeader().getUncleCount()).thenReturn(maxUncles ? MAX_UNCLES : i % MAX_UNCLES);
             i++;
         }
 


### PR DESCRIPTION
The max uncle possible for a block was mistakingly assumed to be 7, when instead it was 10.

This PR addresses the issue by capping the total uncle count to 255 