### PR TITLE
Get rid of MutableRepository#getSnapshotTo

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -295,7 +295,7 @@ public class RskContext implements NodeBootstrapper {
 
     public RepositoryLocator getRepositoryLocator() {
         if (repositoryLocator == null) {
-            repositoryLocator = new RepositoryLocator(getRepository(), getStateRootHandler());
+            repositoryLocator = buildRepositoryLocator();
         }
 
         return repositoryLocator;
@@ -771,6 +771,10 @@ public class RskContext implements NodeBootstrapper {
         }
 
         return new MutableRepository(new MutableTrieCache(new MutableTrieImpl(new Trie(new TrieStoreImpl(ds)))));
+    }
+
+    protected RepositoryLocator buildRepositoryLocator() {
+        return new RepositoryLocator(getRepository(), getStateRootHandler());
     }
 
     protected org.ethereum.db.BlockStore buildBlockStore() {

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -608,7 +608,7 @@ public class RskContext implements NodeBootstrapper {
 
     public NetworkStateExporter getNetworkStateExporter() {
         if (networkStateExporter == null) {
-            networkStateExporter = new NetworkStateExporter(getRepository());
+            networkStateExporter = new NetworkStateExporter(getRepositoryLocator(), getBlockchain());
         }
 
         return networkStateExporter;

--- a/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
+++ b/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
@@ -19,17 +19,19 @@
 package co.rsk.core;
 
 import co.rsk.core.bc.AccountInformationProvider;
+import co.rsk.db.RepositoryLocator;
 import co.rsk.panic.PanicProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Blockchain;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -44,18 +46,18 @@ import java.util.Iterator;
 public class NetworkStateExporter {
     private static final Logger logger = LoggerFactory.getLogger(NetworkStateExporter.class);
 
-    private Repository repository;
+    private final RepositoryLocator repositoryLocator;
+    private final Blockchain blockchain;
 
     private static final PanicProcessor panicProcessor = new PanicProcessor();
 
-    public NetworkStateExporter(Repository repository) {
-        this.repository = repository;
+    public NetworkStateExporter(RepositoryLocator repositoryLocator, Blockchain blockchain) {
+        this.repositoryLocator = repositoryLocator;
+        this.blockchain = blockchain;
     }
 
     public boolean exportStatus(String outputFile) {
-        // This will only work if GlobalKeyMap.enabled = true when building the whole
-        // repository, since keys are not stored on disk.
-        Repository frozenRepository = this.repository.getSnapshotTo(this.repository.getRoot());
+        Repository frozenRepository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         File dumpFile = new File(outputFile);
 

--- a/rskj-core/src/main/java/co/rsk/db/RepositoryLocator.java
+++ b/rskj-core/src/main/java/co/rsk/db/RepositoryLocator.java
@@ -18,8 +18,10 @@
 
 package co.rsk.db;
 
+import co.rsk.crypto.Keccak256;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Repository;
+import org.ethereum.db.MutableRepository;
 
 public class RepositoryLocator {
     private final Repository repository;
@@ -33,7 +35,7 @@ public class RepositoryLocator {
     }
 
     public Repository snapshotAt(BlockHeader header) {
-        byte[] stateRoot = stateRootHandler.translate(header).getBytes();
-        return repository.getSnapshotTo(stateRoot);
+        Keccak256 stateRoot = stateRootHandler.translate(header);
+        return new MutableRepository(repository.getMutableTrie().getSnapshotTo(stateRoot));
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/Repository.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Repository.java
@@ -22,8 +22,10 @@ package org.ethereum.core;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.AccountInformationProvider;
+import co.rsk.crypto.Keccak256;
 import co.rsk.trie.MutableTrie;
 import co.rsk.trie.Trie;
+import org.ethereum.db.MutableRepository;
 import org.ethereum.vm.DataWord;
 
 import javax.annotation.Nullable;
@@ -184,7 +186,9 @@ public interface Repository extends AccountInformationProvider {
      * @deprecated a repository responsibility isn't getting snapshots to other repositories
      * @see co.rsk.db.RepositoryLocator
      */
-    Repository getSnapshotTo(byte[] root);
+    default Repository getSnapshotTo(byte[] root) {
+        return new MutableRepository(getMutableTrie().getSnapshotTo(new Keccak256(root)));
+    }
 
     void updateAccountState(RskAddress addr, AccountState accountState);
 

--- a/rskj-core/src/main/java/org/ethereum/core/Repository.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Repository.java
@@ -22,10 +22,8 @@ package org.ethereum.core;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.AccountInformationProvider;
-import co.rsk.crypto.Keccak256;
 import co.rsk.trie.MutableTrie;
 import co.rsk.trie.Trie;
-import org.ethereum.db.MutableRepository;
 import org.ethereum.vm.DataWord;
 
 import javax.annotation.Nullable;
@@ -181,14 +179,6 @@ public interface Repository extends AccountInformationProvider {
     void syncTo(Trie root);
 
     byte[] getRoot();
-
-    /**
-     * @deprecated a repository responsibility isn't getting snapshots to other repositories
-     * @see co.rsk.db.RepositoryLocator
-     */
-    default Repository getSnapshotTo(byte[] root) {
-        return new MutableRepository(getMutableTrie().getSnapshotTo(new Keccak256(root)));
-    }
 
     void updateAccountState(RskAddress addr, AccountState accountState);
 

--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -327,18 +327,6 @@ public class MutableRepository implements Repository {
         return rootHash.getBytes();
     }
 
-    // What's the difference between startTracking() and getSnapshotTo()?
-    // getSnapshotTo() does not create a new cache layer. It just gives you a view of the same Repository under another
-    // root. This means that if you save data, that data will pass through.
-
-    // A snapshot is a RepositoryTracker object but it's not a cache, because the repository created is a
-    // MutableRepository, and not a RepositoryTrack
-    @Override
-    public synchronized Repository getSnapshotTo(byte[] root) {
-        MutableTrie atrie = mutableTrie.getSnapshotTo(new Keccak256(root));
-        return new MutableRepository(atrie.getTrie());
-    }
-
     @Override
     public synchronized void updateAccountState(RskAddress addr, final AccountState accountState) {
         byte[] accountKey = trieKeyMapper.getAccountKey(addr);

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Storage.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Storage.java
@@ -229,11 +229,6 @@ public class Storage implements Repository, ProgramListenerAware {
     }
 
     @Override
-    public Repository getSnapshotTo(byte[] root) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void updateAccountState(RskAddress addr, AccountState accountState) {
         throw new UnsupportedOperationException();
     }

--- a/rskj-core/src/test/java/co/rsk/core/NetworkStateExporterTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/NetworkStateExporterTest.java
@@ -18,7 +18,10 @@
 
 package co.rsk.core;
 
+import co.rsk.crypto.Keccak256;
 import co.rsk.db.MutableTrieImpl;
+import co.rsk.db.RepositoryLocator;
+import co.rsk.trie.MutableTrie;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStoreImpl;
 import com.fasterxml.jackson.databind.JavaType;
@@ -27,13 +30,16 @@ import com.google.common.io.ByteStreams;
 import org.apache.commons.io.FileUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.AccountState;
-import org.ethereum.core.Repository;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Blockchain;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.MutableRepository;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -43,11 +49,39 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 /**
  * Created by oscar on 13/01/2017.
  */
 public class NetworkStateExporterTest {
     static String jsonFileName = "networkStateExporterTest.json";
+    private MutableRepository repository;
+    private NetworkStateExporter nse;
+    private Blockchain blockchain;
+    private Block block;
+
+    @Before
+    public void setup() {
+        MutableTrieImpl mutableTrie = new MutableTrieImpl(new Trie(new TrieStoreImpl(new HashMapDB())));
+        repository = new MutableRepository(mutableTrie);
+        blockchain = mock(Blockchain.class);
+
+        block = mock(Block.class);
+        when(blockchain.getBestBlock()).thenReturn(block);
+        BlockHeader blockHeader = mock(BlockHeader.class);
+        when(block.getHeader()).thenReturn(blockHeader);
+
+        RepositoryLocator repositoryLocator = mock(RepositoryLocator.class);
+
+        when(repositoryLocator.snapshotAt(block.getHeader())).then(a -> {
+            MutableTrie atrie = mutableTrie.getSnapshotTo(new Keccak256(repository.getRoot()));
+            return new MutableRepository(atrie.getTrie());
+        });
+
+        this.nse = new NetworkStateExporter(repositoryLocator, blockchain);
+    }
 
     @AfterClass
     public static void cleanup(){
@@ -56,18 +90,13 @@ public class NetworkStateExporterTest {
 
     @Test
     public void testEmptyRepo() throws Exception {
-        Repository repository = new MutableRepository(new MutableTrieImpl(new Trie(new TrieStoreImpl(new HashMapDB()))));
-
-        Map result = writeAndReadJson(repository);
+        Map result = writeAndReadJson();
 
         Assert.assertEquals(0, result.keySet().size());
     }
 
     @Test
     public void testNoContracts() throws Exception {
-        // This test will work on a non-secured Trie. To make it work with a secured-trie
-        // you have to do GlobalKeyMap.enabled = true first.
-        Repository repository = new MutableRepository(new MutableTrieImpl(new Trie(new TrieStoreImpl(new HashMapDB()))));
         String address1String = "1000000000000000000000000000000000000000";
         RskAddress addr1 = new RskAddress(address1String);
         repository.createAccount(addr1);
@@ -99,8 +128,7 @@ public class NetworkStateExporterTest {
         repository.addBalance(PrecompiledContracts.REMASC_ADDR, Coin.valueOf(10L));
         repository.increaseNonce(PrecompiledContracts.REMASC_ADDR);
 
-
-        Map result = writeAndReadJson(repository);
+        Map result = writeAndReadJson();
         Assert.assertEquals(3, result.keySet().size());
 
         Map address1Value = (Map) result.get(address1String);
@@ -120,7 +148,6 @@ public class NetworkStateExporterTest {
     }
     @Test
     public void testContracts() throws Exception {
-        Repository repository = new MutableRepository(new MutableTrieImpl(new Trie(new TrieStoreImpl(new HashMapDB()))));
         String address1String = "1000000000000000000000000000000000000000";
         RskAddress addr1 = new RskAddress(address1String);
         repository.createAccount(addr1);
@@ -134,7 +161,7 @@ public class NetworkStateExporterTest {
         AccountState accountState = repository.getAccountState(addr1);
         repository.updateAccountState(addr1, accountState);
 
-        Map result = writeAndReadJson(repository);
+        Map result = writeAndReadJson();
 
         Assert.assertEquals(1, result.keySet().size());
 
@@ -156,9 +183,7 @@ public class NetworkStateExporterTest {
         Assert.assertEquals("05060708", data.get(Hex.toHexString(DataWord.ONE.getData())));
     }
 
-
-    private Map writeAndReadJson(Repository repository) throws Exception {
-        NetworkStateExporter nse = new NetworkStateExporter(repository);
+    private Map writeAndReadJson() throws Exception {
         Assert.assertTrue(nse.exportStatus(jsonFileName));
 
         InputStream inputStream = new FileInputStream(jsonFileName);
@@ -169,5 +194,4 @@ public class NetworkStateExporterTest {
         Map result = new ObjectMapper().readValue(json, type);
         return result;
     }
-
 }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -130,7 +130,7 @@ public class BlockExecutorTest {
         Assert.assertNotNull(accountState);
         Assert.assertEquals(BigInteger.valueOf(30000), accountState.getBalance().asBigInteger());
 
-        Repository finalRepository = repository.getSnapshotTo(result.getFinalState().getHash().getBytes());
+        Repository finalRepository = new MutableRepository(repository.getMutableTrie().getSnapshotTo(result.getFinalState().getHash()));
 
         accountState = finalRepository.getAccountState(account);
 
@@ -187,7 +187,7 @@ public class BlockExecutorTest {
 
         // here is the papa. my commit changes stateroot while previous commit did not.
 
-        Repository finalRepository = repository.getSnapshotTo(result.getFinalState().getHash().getBytes());
+        Repository finalRepository = new MutableRepository(repository.getMutableTrie().getSnapshotTo(result.getFinalState().getHash()));
 
         accountState = finalRepository.getAccountState(account);
 
@@ -569,7 +569,7 @@ public class BlockExecutorTest {
         Assert.assertNotNull(accountState);
         Assert.assertEquals(BigInteger.valueOf(30000), accountState.getBalance().asBigInteger());
 
-        Repository finalRepository = repository.getSnapshotTo(result.getFinalState().getHash().getBytes());
+        Repository finalRepository = new MutableRepository(repository.getMutableTrie().getSnapshotTo(result.getFinalState().getHash()));
 
         accountState = finalRepository.getAccountState(account.getAddress());
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -645,7 +645,6 @@ public class BlockValidatorTest {
         BlockStore blockStore = Mockito.mock(org.ethereum.db.BlockStore.class);
         Repository repository = Mockito.mock(Repository.class);
 
-        Mockito.when(repository.getSnapshotTo(Mockito.any())).thenReturn(repository);
         Mockito.when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
 
         Block parent = new BlockBuilder().minGasPrice(BigInteger.ZERO)
@@ -673,7 +672,6 @@ public class BlockValidatorTest {
         BlockStore blockStore = Mockito.mock(org.ethereum.db.BlockStore.class);
         Repository repository = Mockito.mock(Repository.class);
 
-        Mockito.when(repository.getSnapshotTo(Mockito.any())).thenReturn(repository);
         Mockito.when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
 
         Block parent = new BlockBuilder().minGasPrice(BigInteger.ZERO)
@@ -697,7 +695,6 @@ public class BlockValidatorTest {
         BlockStore blockStore = Mockito.mock(org.ethereum.db.BlockStore.class);
         Repository repository = Mockito.mock(Repository.class);
 
-        Mockito.when(repository.getSnapshotTo(Mockito.any())).thenReturn(repository);
         Mockito.when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
 
         Block parent = new BlockBuilder().minGasPrice(BigInteger.TEN)

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryLocatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryLocatorTest.java
@@ -19,6 +19,7 @@
 package co.rsk.db;
 
 import co.rsk.crypto.Keccak256;
+import co.rsk.trie.MutableTrie;
 import org.ethereum.TestUtils;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Repository;
@@ -37,10 +38,14 @@ public class RepositoryLocatorTest {
         BlockHeader header = mock(BlockHeader.class);
         Keccak256 stateRoot = TestUtils.randomHash();
         when(stateRootHandler.translate(header)).thenReturn(stateRoot);
-        Repository expectedRepository = mock(Repository.class);
-        when(repository.getSnapshotTo(stateRoot.getBytes())).thenReturn(expectedRepository);
+
+        MutableTrie expectedMutableTrie = mock(MutableTrie.class);
+        MutableTrie mutableTrie = mock(MutableTrie.class);
+        when(mutableTrie.getSnapshotTo(stateRoot)).thenReturn(expectedMutableTrie);
+        when(repository.getMutableTrie()).thenReturn(mutableTrie);
 
         RepositoryLocator repositoryLocator = new RepositoryLocator(repository, stateRootHandler);
-        assertSame(expectedRepository, repositoryLocator.snapshotAt(header));
+        MutableTrie actualMutableTrie = repositoryLocator.snapshotAt(header).getMutableTrie();
+        assertSame(expectedMutableTrie, actualMutableTrie);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -86,6 +86,11 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
             protected Repository buildRepository() {
                 return Mockito.spy(super.buildRepository());
             }
+
+            @Override
+            protected RepositoryLocator buildRepositoryLocator() {
+                return Mockito.spy(super.buildRepositoryLocator());
+            }
         };
         blockchain = factory.getMiningMainchainView();
         repository = factory.getRepository();
@@ -113,7 +118,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
         when(track.getNonce(RemascTransaction.REMASC_ADDRESS)).thenReturn(BigInteger.ZERO);
         when(track.getBalance(tx1.getSender())).thenReturn(Coin.valueOf(4200000L));
         when(track.getBalance(RemascTransaction.REMASC_ADDRESS)).thenReturn(Coin.valueOf(4200000L));
-        Mockito.doReturn(track).when(repository).getSnapshotTo(any());
+        Mockito.doReturn(track).when(repositoryLocator).snapshotAt(any());
         Mockito.doReturn(track).when(repository).startTracking();
         Mockito.doReturn(track).when(track).startTracking();
 

--- a/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
@@ -20,6 +20,7 @@ package co.rsk.test;
 
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainStatus;
+import co.rsk.crypto.Keccak256;
 import co.rsk.test.dsl.DslParser;
 import co.rsk.test.dsl.DslProcessorException;
 import co.rsk.test.dsl.WorldDslProcessor;
@@ -28,6 +29,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
+import org.ethereum.db.MutableRepository;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.vm.DataWord;
 import org.junit.Assert;
@@ -106,10 +108,10 @@ public class DslFilesTest {
         Block top2 = world.getBlockByName("b02b");
 
         // Creates a new view of the repository, standing on top1 state
-        Repository repo1 = world.getRepository().getSnapshotTo(top1.getStateRoot());
+        Repository repo1 = new MutableRepository(world.getRepository().getMutableTrie().getSnapshotTo(new Keccak256(top1.getStateRoot())));
 
         // Creates a new view of the repository, standing on top2 state
-        Repository repo2 = world.getRepository().getSnapshotTo(top2.getStateRoot());
+        Repository repo2 = new MutableRepository(world.getRepository().getMutableTrie().getSnapshotTo(new Keccak256(top2.getStateRoot())));
         // addr1: sender's account
         RskAddress addr1 = new RskAddress("a0663f719962ec10bb57865532bef522059dfd96");
         // addr2: Parent Contract account

--- a/rskj-core/src/test/java/co/rsk/vm/BlockchainVMTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/BlockchainVMTest.java
@@ -21,6 +21,7 @@ package co.rsk.vm;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.db.RepositoryLocator;
 import co.rsk.test.World;
 import org.ethereum.config.Constants;
 import org.ethereum.core.*;
@@ -51,6 +52,7 @@ public class BlockchainVMTest {
         public Blockchain blockchain;
         public ECKey faucetKey;
         public Repository repository;
+        public RepositoryLocator repositoryLocator;
     }
     static long addrCounter =1;
 
@@ -87,7 +89,7 @@ public class BlockchainVMTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockchain.tryToConnect(block1));
 
         MinerHelper mh = new MinerHelper(
-                binfo.repository, binfo.blockchain);
+                binfo.repository, binfo.repositoryLocator, binfo.blockchain);
 
         mh.completeBlock(block2, block1);
 
@@ -116,6 +118,7 @@ public class BlockchainVMTest {
         binfo.faucetKey = createFaucetAccount(world);
         binfo.blockchain = world.getBlockChain();
         binfo.repository = world.getRepository();
+        binfo.repositoryLocator = new RepositoryLocator(world.getRepository(), world.getStateRootHandler());
         return binfo;
     }
 

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -22,6 +22,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockHashesHelper;
+import co.rsk.db.RepositoryLocator;
 import co.rsk.mine.GasLimitCalculator;
 import co.rsk.panic.PanicProcessor;
 import co.rsk.peg.BridgeSupportFactory;
@@ -48,6 +49,7 @@ public class MinerHelper {
 
     private final Blockchain blockchain;
     private final Repository repository;
+    private final RepositoryLocator repositoryLocator;
     private final GasLimitCalculator gasLimitCalculator;
     private final BlockFactory blockFactory;
 
@@ -56,8 +58,9 @@ public class MinerHelper {
     private Coin totalPaidFees = Coin.ZERO;
     private List<TransactionReceipt> txReceipts;
 
-    public MinerHelper(Repository repository , Blockchain blockchain) {
+    public MinerHelper(Repository repository, RepositoryLocator repositoryLocator, Blockchain blockchain) {
         this.repository = repository;
+        this.repositoryLocator = repositoryLocator;
         this.blockchain = blockchain;
         this.gasLimitCalculator = new GasLimitCalculator(config.getNetworkConstants());
         this.blockFactory = new BlockFactory(config.getActivationConfig());
@@ -69,10 +72,8 @@ public class MinerHelper {
         totalPaidFees = Coin.ZERO;
         txReceipts = new ArrayList<>();
 
-        //Repository originalRepo  = ((Repository) ethereum.getRepository()).getSnapshotTo(parent.getStateRoot());
-
         // This creates a snapshot WITHOUT history of the current "parent" reponsitory.
-        Repository originalRepo  = repository.getSnapshotTo(parent.getStateRoot());
+        Repository originalRepo  = repositoryLocator.snapshotAt(parent.getHeader());
 
         Repository track = originalRepo.startTracking();
 


### PR DESCRIPTION
The plan is to completely remove `Repository` from the context, and use the `RepositoryLocator` instead. This is a step towards that.

Next, we'll try to get rid of `Repository#syncToRoot`.