### PR TITLE
Remove Repository#syncToRoot

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -280,7 +280,7 @@ public class RskContext implements NodeBootstrapper {
             RskSystemProperties rskSystemProperties = getRskSystemProperties();
             transactionPool = new TransactionPoolImpl(
                     rskSystemProperties,
-                    getRepository(),
+                    getRepositoryLocator(),
                     getBlockStore(),
                     getBlockFactory(),
                     getCompositeEthereumListener(),

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
@@ -354,7 +354,6 @@ public class BlockChainImpl implements Blockchain {
         synchronized (accessLock) {
             status = new BlockChainStatus(block, totalDifficulty);
             blockStore.saveBlock(block, totalDifficulty, true);
-            repository.syncToRoot(stateRootHandler.translate(block.getHeader()).getBytes());
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
@@ -479,7 +479,8 @@ public class BlockChainImpl implements Blockchain {
     }
 
     private void processBest(final Block block) {
-        EventDispatchThread.invokeLater(() -> transactionPool.processBest(block));
+        // this has to happen in the same thread so the TransactionPool is immediately aware of the new best block
+        transactionPool.processBest(block);
     }
 
     private void onBlock(Block block, BlockResult result) {

--- a/rskj-core/src/main/java/org/ethereum/core/Repository.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Repository.java
@@ -23,7 +23,6 @@ import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.AccountInformationProvider;
 import co.rsk.trie.MutableTrie;
-import co.rsk.trie.Trie;
 import org.ethereum.vm.DataWord;
 
 import javax.annotation.Nullable;
@@ -175,8 +174,6 @@ public interface Repository extends AccountInformationProvider {
      * @param root - new root
      */
     void syncToRoot(byte[] root);
-
-    void syncTo(Trie root);
 
     byte[] getRoot();
 

--- a/rskj-core/src/main/java/org/ethereum/core/Repository.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Repository.java
@@ -167,14 +167,6 @@ public interface Repository extends AccountInformationProvider {
 
     void save();
 
-    /**
-     * Return to one of the previous snapshots
-     * by moving the root.
-     *
-     * @param root - new root
-     */
-    void syncToRoot(byte[] root);
-
     byte[] getRoot();
 
     void updateAccountState(RskAddress addr, AccountState accountState);

--- a/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
@@ -127,10 +127,7 @@ public class BlockChainLoader {
 
         String rootHash = config.rootHashStart();
         if (rootHash != null && !"".equals(rootHash.trim())) {
-            // update world state by dummy hash
-            byte[] rootHashArray = Hex.decode(rootHash);
             logger.info("Loading root hash from property file: [{}]", rootHash);
-            this.repository.syncToRoot(rootHashArray);
         }
 
         return blockchain;

--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -312,11 +312,6 @@ public class MutableRepository implements Repository {
     }
 
     @Override
-    public void syncTo(Trie root) {
-        mutableTrie = new MutableTrieImpl(root);
-    }
-
-    @Override
     public synchronized byte[] getRoot() {
         if (mutableTrie.hasStore()) {
             mutableTrie.save();

--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -45,7 +45,7 @@ public class MutableRepository implements Repository {
     private static final byte[] ONE_BYTE_ARRAY = new byte[] { 0x01 };
 
     private final TrieKeyMapper trieKeyMapper;
-    private MutableTrie mutableTrie;
+    private final MutableTrie mutableTrie;
 
     public MutableRepository(Trie atrie) {
         this(new MutableTrieImpl(atrie));
@@ -304,11 +304,6 @@ public class MutableRepository implements Repository {
     @Override
     public synchronized void rollback() {
         mutableTrie.rollback();
-    }
-
-    @Override
-    public synchronized void syncToRoot(byte[] root) {
-        mutableTrie = mutableTrie.getSnapshotTo(new Keccak256(root));
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Storage.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Storage.java
@@ -213,11 +213,6 @@ public class Storage implements Repository, ProgramListenerAware {
     }
 
     @Override
-    public void syncToRoot(byte[] root) {
-        repository.syncToRoot(root);
-    }
-
-    @Override
     public byte[] getRoot() {
         return repository.getRoot();
     }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Storage.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Storage.java
@@ -22,7 +22,6 @@ package org.ethereum.vm.program;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.trie.MutableTrie;
-import co.rsk.trie.Trie;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
@@ -216,11 +215,6 @@ public class Storage implements Repository, ProgramListenerAware {
     @Override
     public void syncToRoot(byte[] root) {
         repository.syncToRoot(root);
-    }
-
-    @Override
-    public void syncTo(Trie root) {
-        repository.syncTo(root);
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
@@ -65,7 +65,9 @@ public class CallContractTest {
 
         Block bestBlock = world.getBlockChain().getBestBlock();
 
-        Repository repository = world.getRepository().startTracking();
+        Repository repository = world.getRepositoryLocator()
+                .snapshotAt(world.getBlockChain().getBestBlock().getHeader())
+                .startTracking();
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(
                 config.getNetworkConstants().getBridgeConstants().getBtcParams());
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(

--- a/rskj-core/src/test/java/co/rsk/core/SnapshotManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/SnapshotManagerTest.java
@@ -18,19 +18,18 @@
 
 package co.rsk.core;
 
-import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.bc.BlockChainStatus;
+import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import org.ethereum.core.*;
-import org.ethereum.util.RskTestFactory;
+import org.ethereum.util.RskTestContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigInteger;
-import java.util.List;
 
 import static org.mockito.Mockito.mock;
 
@@ -40,15 +39,17 @@ import static org.mockito.Mockito.mock;
 public class SnapshotManagerTest {
 
     private Blockchain blockchain;
-    private Repository repository;
     private TransactionPool transactionPool;
     private SnapshotManager manager;
+    private MinerServer minerServer;
+    private MinerClient minerClient;
 
     @Before
     public void setUp() {
-        RskTestFactory factory = new RskTestFactory();
+        RskTestContext factory = new RskTestContext(new String[]{"--regtest"});
         blockchain = factory.getBlockchain();
-        repository = factory.getRepository();
+        minerServer = factory.getMinerServer();
+        minerClient = factory.getMinerClient();
         transactionPool = factory.getTransactionPool();
         // don't call start to avoid creating threads
         transactionPool.processBest(blockchain.getBestBlock());
@@ -75,7 +76,7 @@ public class SnapshotManagerTest {
 
     @Test
     public void takeSnapshotOnManyBlocks() {
-        addBlocks(blockchain, 10);
+        addBlocks(10);
 
         int result = manager.takeSnapshot();
 
@@ -89,13 +90,13 @@ public class SnapshotManagerTest {
 
     @Test
     public void takeTwoSnapshots() {
-        addBlocks(blockchain, 10);
+        addBlocks(10);
 
         int result1 = manager.takeSnapshot();
 
         Assert.assertEquals(1, result1);
 
-        addBlocks(blockchain, 10);
+        addBlocks(10);
 
         int result2 = manager.takeSnapshot();
 
@@ -122,13 +123,13 @@ public class SnapshotManagerTest {
 
     @Test
     public void revertToSnapshot() {
-        addBlocks(blockchain, 10);
+        addBlocks(10);
 
         BlockChainStatus status = blockchain.getStatus();
 
         int snapshotId = manager.takeSnapshot();
 
-        addBlocks(blockchain, 20);
+        addBlocks(20);
 
         Assert.assertEquals(30, blockchain.getStatus().getBestBlockNumber());
 
@@ -146,13 +147,13 @@ public class SnapshotManagerTest {
 
     @Test
     public void revertToSnapshotClearingTransactionPool() {
-        addBlocks(blockchain, 10);
+        addBlocks(10);
 
         BlockChainStatus status = blockchain.getStatus();
 
         int snapshotId = manager.takeSnapshot();
 
-        addBlocks(blockchain, 20);
+        addBlocks(20);
 
         manager.takeSnapshot();
 
@@ -160,8 +161,6 @@ public class SnapshotManagerTest {
 
         Assert.assertNotNull(transactionPool);
 
-        setUpSampleAccounts();
-        repository.commit();
         transactionPool.addTransaction(createSampleTransaction());
         Assert.assertFalse(transactionPool.getPendingTransactions().isEmpty());
         Assert.assertFalse(transactionPool.getPendingTransactions().isEmpty());
@@ -189,16 +188,12 @@ public class SnapshotManagerTest {
         Block genesis = blockchain.getBestBlock();
         BlockDifficulty genesisDifficulty = blockchain.getStatus().getTotalDifficulty();
 
-        addBlocks(blockchain, 10);
+        addBlocks(10);
 
         BlockChainStatus status = blockchain.getStatus();
 
         Assert.assertEquals(10, status.getBestBlockNumber());
 
-        setUpSampleAccounts();
-        // Now the repository has uncommited changes. Before taking a snapshot,
-        // it should commit them upstream.
-        repository.commit();
         transactionPool.addTransaction(createSampleTransaction());
         Assert.assertFalse(transactionPool.getPendingTransactions().isEmpty());
         Assert.assertFalse(transactionPool.getPendingTransactions().isEmpty());
@@ -224,27 +219,15 @@ public class SnapshotManagerTest {
             Assert.assertTrue(blockchain.getBlocksByNumber(k).isEmpty());
     }
 
-    private static void addBlocks(Blockchain blockchain, int size) {
-        List<Block> blocks = new BlockGenerator().getBlockChain(blockchain.getBestBlock(), size);
-
-        for (Block block : blocks)
-            blockchain.tryToConnect(block);
-    }
-
-    private void setUpSampleAccounts() {
-        Repository track = repository.startTracking();
-
-        for (String name : new String[]{"sender", "receiver"}) {
-            Account account = new AccountBuilder().name(name).build();
-            track.createAccount(account.getAddress());
-            track.addBalance(account.getAddress(), Coin.valueOf(5000000));
+    private void addBlocks(int size) {
+        for (int i = 0; i < size; i++) {
+            minerServer.buildBlockToMine(blockchain.getBestBlock(), false);
+            Assert.assertTrue(minerClient.mineBlock());
         }
-
-        track.commit();
     }
 
-    private static Transaction createSampleTransaction() {
-        Account sender = new AccountBuilder().name("sender").build();
+    private Transaction createSampleTransaction() {
+        Account sender = new AccountBuilder().name("cow").build();
         Account receiver = new AccountBuilder().name("receiver").build();
 
         Transaction tx = new TransactionBuilder()

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplTest.java
@@ -76,32 +76,6 @@ public class RepositoryImplTest {
     }
 
     @Test
-    public void syncToRootAfterCreatingAnAccount() {
-        TrieStore store = new TrieStoreImpl(new HashMapDB());
-        Repository repository = new MutableRepository(new MutableTrieImpl(new Trie(store)));
-
-        repository.flush();
-
-        RskAddress accAddress = randomAccountAddress();
-        byte[] initialRoot = repository.getRoot();
-
-        repository.createAccount(accAddress);
-        repository.flush();
-
-        byte[] newRoot = repository.getRoot();
-
-        Assert.assertTrue(repository.isExist(accAddress));
-
-        repository.syncToRoot(initialRoot);
-
-        Assert.assertFalse(repository.isExist(accAddress));
-
-        repository.syncToRoot(newRoot);
-
-        Assert.assertTrue(repository.isExist(accAddress));
-    }
-
-    @Test
     public void updateAccountState() {
         RskAddress accAddress = randomAccountAddress();
 
@@ -438,31 +412,6 @@ public class RepositoryImplTest {
         Assert.assertEquals(2, keys.size());
         Assert.assertTrue(keys.contains(accAddress1));
         Assert.assertTrue(keys.contains(accAddress2));
-    }
-
-    @Test
-    public void getAccountsKeysOnSnapshot()
-    {
-        RskAddress accAddress1 = randomAccountAddress();
-        RskAddress accAddress2 = randomAccountAddress();
-
-        TrieStore store = new TrieStoreImpl(new HashMapDB());
-        Repository repository = new MutableRepository(new MutableTrieImpl(new Trie(store)));
-
-        repository.createAccount(accAddress1);
-        repository.flush();
-
-        byte[] root = repository.getRoot();
-
-        repository.createAccount(accAddress2);
-
-        repository.syncToRoot(root);
-
-        Set<RskAddress> keys = repository.getAccountsKeys();
-
-        Assert.assertNotNull(keys);
-        Assert.assertFalse(keys.isEmpty());
-        Assert.assertEquals(1, keys.size());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -25,6 +25,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
+import co.rsk.db.RepositoryLocator;
 import co.rsk.test.World;
 import co.rsk.test.builders.BlockBuilder;
 import org.bouncycastle.util.encoders.Hex;
@@ -49,6 +50,7 @@ public class RskForksBridgeTest {
             BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS.get(0).getPrivKey()
     );
 
+    private RepositoryLocator repositoryLocator;
     private Repository repository;
     //private ECKey keyHoldingRSKs;
     private ECKey whitelistManipulationKey;
@@ -61,6 +63,7 @@ public class RskForksBridgeTest {
     public void before() throws IOException, ClassNotFoundException {
         world = new World();
         blockChain = world.getBlockChain();
+        repositoryLocator = world.getRepositoryLocator();
         repository = blockChain.getRepository();
 
         whitelistManipulationKey = ECKey.fromPrivate(Hex.decode("3890187a3071327cee08467ba1b44ed4c13adb2da0d5ffcc0563c371fa88259c"));
@@ -87,18 +90,18 @@ public class RskForksBridgeTest {
         Transaction releaseTx = buildReleaseTx();
         Block blockB1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB1));
-        blockChain.getRepository().syncToRoot(blockB1.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB1.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB2 = buildBlock(blockB1);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB2));
-        blockChain.getRepository().syncToRoot(blockB2.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        blockChain.getRepository().syncToRoot(blockB3.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
@@ -112,7 +115,7 @@ public class RskForksBridgeTest {
 
         Block blockA2 = buildBlock(blockA1, 6l, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA2));
-        blockChain.getRepository().syncToRoot(blockA2.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockA2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB1 = buildBlock(blockBase, 1l, releaseTx);
@@ -126,7 +129,7 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, 10l, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        blockChain.getRepository().syncToRoot(blockB3.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
@@ -137,12 +140,12 @@ public class RskForksBridgeTest {
 
         Block blockB1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB1));
-        blockChain.getRepository().syncToRoot(blockB1.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB1.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB2 = buildBlock(blockB1,6l);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB2));
-        blockChain.getRepository().syncToRoot(blockB2.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockA1 = buildBlock(blockBase,1);
@@ -156,7 +159,7 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2,12, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        blockChain.getRepository().syncToRoot(blockB3.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
@@ -166,12 +169,12 @@ public class RskForksBridgeTest {
 
         Block blockA1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA1));
-        blockChain.getRepository().syncToRoot(blockA1.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockA1.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockA2 = buildBlock(blockA1,3);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA2));
-        blockChain.getRepository().syncToRoot(blockA2.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockA2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB1 = buildBlock(blockBase,2);
@@ -185,7 +188,7 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2,6l, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        blockChain.getRepository().syncToRoot(blockB3.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.NO_TX);
     }
 
@@ -195,12 +198,12 @@ public class RskForksBridgeTest {
 
         Block blockA1 = buildBlock(blockBase, 4l);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA1));
-        blockChain.getRepository().syncToRoot(blockA1.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockA1.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.NO_TX);
 
         Block blockA2 = buildBlock(blockA1, 5l);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA2));
-        blockChain.getRepository().syncToRoot(blockA2.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockA2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.NO_TX);
 
         Block blockB1 = buildBlock(blockBase, 1l, releaseTx);
@@ -214,12 +217,12 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, 10l, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        blockChain.getRepository().syncToRoot(blockB3.getStateRoot());
+        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
     private Block buildBlock(Block parent, long difficulty) {
-        World world = new World(blockChain, genesis);
+        World world = new World(blockChain, null, null, genesis);
         BlockBuilder blockBuilder = new BlockBuilder(world).difficulty(difficulty).parent(parent);
         return blockBuilder.build();
     }
@@ -230,7 +233,7 @@ public class RskForksBridgeTest {
 
     private Block buildBlock(Block parent, long difficulty, Transaction ... txs) {
         List<Transaction> txList = Arrays.asList(txs);
-        World world = new World(blockChain, genesis);
+        World world = new World(blockChain, null, null, genesis);
         BlockBuilder blockBuilder = new BlockBuilder(world).difficulty(difficulty).parent(parent).transactions(txList).uncles(new ArrayList<>());
         return blockBuilder.build();
     }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -73,8 +73,8 @@ public class RemascStorageProviderTest {
         assertEquals(expectedBurnedBalance, provider.getBurnedBalance());
     }
 
-    private RemascStorageProvider getRemascStorageProvider(Blockchain blockchain) throws IOException {
-        return new RemascStorageProvider(blockchain.getRepository(), PrecompiledContracts.REMASC_ADDR);
+    private RemascStorageProvider getRemascStorageProvider(Repository repository) {
+        return new RemascStorageProvider(repository, PrecompiledContracts.REMASC_ADDR);
     }
 
     private List<Block> createSimpleBlocks(Block parent, int size, RskAddress coinbase) {
@@ -228,7 +228,10 @@ public class RemascStorageProviderTest {
                 .initialHeight(15).siblingElements(siblings).txSigningKey(this.cowKey);
 
         testRunner.start();
-        this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(testRunner.getBlockChain()), Coin.valueOf(0), Coin.valueOf(0L), 1L);
+        Blockchain blockchain = testRunner.getBlockChain();
+        RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(repository), Coin.valueOf(0), Coin.valueOf(0L), 1L);
     }
 
     @Test
@@ -249,7 +252,7 @@ public class RemascStorageProviderTest {
 
         testRunner.start();
         this.validateRemascsStorageIsCorrect(
-                this.getRemascStorageProvider(testRunner.getBlockChain()),
+                this.getRemascStorageProvider(testRunner.getBlockChain().getRepository()),
                 Coin.valueOf(0L),
                 Coin.valueOf(0L),
                 0L
@@ -272,7 +275,10 @@ public class RemascStorageProviderTest {
                 .initialHeight(15).siblingElements(new ArrayList<>()).txSigningKey(this.cowKey).gasPrice(gasPrice);
 
         testRunner.start();
-        this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(testRunner.getBlockChain()), Coin.valueOf(84000), Coin.valueOf(0L), 0L);
+        Blockchain blockchain = testRunner.getBlockChain();
+        RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(repository), Coin.valueOf(84000), Coin.valueOf(0L), 0L);
     }
 
     @Test
@@ -291,9 +297,11 @@ public class RemascStorageProviderTest {
                 .initialHeight(15).siblingElements(new ArrayList<>()).txSigningKey(this.cowKey).gasPrice(gasPrice);
 
         testRunner.start();
-        Repository repository = testRunner.getBlockChain().getRepository();
+        Blockchain blockchain = testRunner.getBlockChain();
+        RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository, testRunner.getBlockChain().getBestBlock());
-        assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(testRunner.getBlockChain()).getFederationBalance());
+        assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(repository).getFederationBalance());
         long federatorBalance = (168 / federationProvider.getFederationSize()) * 2;
         assertEquals(Coin.valueOf(federatorBalance), RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
     }
@@ -316,9 +324,11 @@ public class RemascStorageProviderTest {
                 .initialHeight(15).siblingElements(new ArrayList<>()).txSigningKey(this.cowKey).gasPrice(gasPrice);
 
         testRunner.start();
-        Repository repository = testRunner.getBlockChain().getRepository();
+        Blockchain blockchain = testRunner.getBlockChain();
+        RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository, testRunner.getBlockChain().getBestBlock());
-        assertEquals(Coin.valueOf(336), this.getRemascStorageProvider(testRunner.getBlockChain()).getFederationBalance());
+        assertEquals(Coin.valueOf(336), this.getRemascStorageProvider(repository).getFederationBalance());
         assertEquals(null, RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
     }
 
@@ -339,7 +349,10 @@ public class RemascStorageProviderTest {
                 .initialHeight(15).siblingElements(new ArrayList<>()).txSigningKey(this.cowKey).gasPrice(gasPrice);
 
         testRunner.start();
-        this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(testRunner.getBlockChain()), Coin.valueOf(126000), Coin.valueOf(0L), 0L);
+        Blockchain blockchain = testRunner.getBlockChain();
+        RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(repository), Coin.valueOf(126000), Coin.valueOf(0L), 0L);
     }
 
     @Test
@@ -361,10 +374,12 @@ public class RemascStorageProviderTest {
                 .initialHeight(15).siblingElements(new ArrayList<>()).txSigningKey(this.cowKey).gasPrice(gasPrice);
 
         testRunner.start();
-        Repository repository = testRunner.getBlockChain().getRepository();
+        Blockchain blockchain = testRunner.getBlockChain();
+        RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository, testRunner.getBlockChain().getBestBlock());
         long federatorBalance = (1680 / federationProvider.getFederationSize()) * 2;
-        assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(testRunner.getBlockChain()).getFederationBalance());
+        assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(repository).getFederationBalance());
         assertEquals(Coin.valueOf(federatorBalance), RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
     }
 
@@ -387,7 +402,10 @@ public class RemascStorageProviderTest {
                 .initialHeight(15).siblingElements(new ArrayList<>()).txSigningKey(this.cowKey).gasPrice(gasPrice);
 
         testRunner.start();
-        this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(testRunner.getBlockChain()), Coin.valueOf(840000L), Coin.valueOf(0L), 0L);
+        Blockchain blockchain = testRunner.getBlockChain();
+        RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(repository), Coin.valueOf(840000L), Coin.valueOf(0L), 0L);
     }
 
     @Test
@@ -412,6 +430,8 @@ public class RemascStorageProviderTest {
         testRunner.setFixedCoinbase(coinbase);
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
+        RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         List<Block> blocks = new ArrayList<>();
         blocks.add(RemascTestRunner.createBlock(genesisBlock, blockchain.getBestBlock(), PegTestUtils.createHash3(),
                 coinbase, Collections.emptyList(), gasLimit, gasPrice, 14, txValue, cowKey, null));
@@ -434,7 +454,7 @@ public class RemascStorageProviderTest {
 
         BlockExecutor blockExecutor = new BlockExecutor(
                 config.getActivationConfig(),
-                new RepositoryLocator(blockchain.getRepository(), stateRootHandler),
+                repositoryLocator,
                 stateRootHandler,
                 new TransactionExecutorFactory(
                         config,
@@ -449,15 +469,15 @@ public class RemascStorageProviderTest {
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock().getHeader());
             Assert.assertEquals(ImportResult.IMPORTED_BEST, blockchain.tryToConnect(b));
-            blockchain.getRepository().syncToRoot(builder.getStateRootHandler().translate(b.getHeader()).getBytes());
+            repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
             long blockNumber = blockchain.getBestBlock().getNumber();
             if (blockNumber == 24){ // before first special block
-                assertEquals(Coin.valueOf(1663200L), RemascTestRunner.getAccountBalance(blockchain.getRepository(), coinbase));
+                assertEquals(Coin.valueOf(1663200L), RemascTestRunner.getAccountBalance(repository, coinbase));
             } else if (blockNumber == 25 || blockNumber == 26){ // after first and second special block
-                assertEquals(Coin.valueOf(1829520L), RemascTestRunner.getAccountBalance(blockchain.getRepository(), coinbase));
+                assertEquals(Coin.valueOf(1829520L), RemascTestRunner.getAccountBalance(repository, coinbase));
             } else if (blockNumber == 27 || blockNumber == 28){ // after third and fourth special block
-                assertEquals(Coin.valueOf(1999167L), RemascTestRunner.getAccountBalance(blockchain.getRepository(), coinbase));
+                assertEquals(Coin.valueOf(1999167L), RemascTestRunner.getAccountBalance(repository, coinbase));
             }
         }
     }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -26,7 +26,6 @@ import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.crypto.Keccak256;
-import co.rsk.db.RepositoryLocator;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.PegTestUtils;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
@@ -137,7 +136,7 @@ class RemascTestRunner {
         PrecompiledContracts precompiledContracts = new PrecompiledContracts(builder.getConfig(), bridgeSupportFactory);
         BlockExecutor blockExecutor = new BlockExecutor(
                 builder.getConfig().getActivationConfig(),
-                new RepositoryLocator(blockchain.getRepository(), builder.getStateRootHandler()),
+                builder.getRepositoryLocator(),
                 builder.getStateRootHandler(),
                 new TransactionExecutorFactory(
                         builder.getConfig(),
@@ -190,10 +189,6 @@ class RemascTestRunner {
 
             System.out.println(result);
         }
-
-        this.blockchain.getRepository().syncToRoot(
-                builder.getStateRootHandler().translate(blockchain.getBestBlock().getHeader()).getBytes()
-        );
     }
 
     public Blockchain getBlockChain() {
@@ -201,7 +196,8 @@ class RemascTestRunner {
     }
 
     public Coin getAccountBalance(RskAddress addr) {
-        return getAccountBalance(this.blockchain.getRepository(), addr);
+        Repository repository = builder.getRepositoryLocator().snapshotAt(blockchain.getBestBlock().getHeader());
+        return getAccountBalance(repository, addr);
     }
 
     public static Coin getAccountBalance(Repository repository, byte[] address) {

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -56,26 +56,30 @@ public class World {
     private Map<String, Account> accounts = new HashMap<>();
     private Map<String, Transaction> transactions = new HashMap<>();
     private StateRootHandler stateRootHandler;
+    private Repository repository;
+    private TransactionPool transactionPool;
     private BridgeSupportFactory bridgeSupportFactory;
 
     public World() {
-        this(new BlockChainBuilder().build());
+        this(new BlockChainBuilder());
     }
 
     public World(Repository repository) {
-        this(new BlockChainBuilder().setRepository(repository).build());
+        this(new BlockChainBuilder().setRepository(repository));
     }
 
     public World(ReceiptStore receiptStore) {
-        this(new BlockChainBuilder().setReceiptStore(receiptStore).build());
+        this(new BlockChainBuilder().setReceiptStore(receiptStore));
     }
 
-    public World(BlockChainImpl blockChain) {
-        this(blockChain, null);
+    private World(BlockChainBuilder blockChainBuilder) {
+        this(blockChainBuilder.build(), blockChainBuilder.getRepository(), blockChainBuilder.getTransactionPool(), null);
     }
 
-    public World(BlockChainImpl blockChain, Genesis genesis) {
+    public World(BlockChainImpl blockChain, Repository repository, TransactionPool transactionPool, Genesis genesis) {
         this.blockChain = blockChain;
+        this.repository = repository;
+        this.transactionPool = transactionPool;
 
         if (genesis == null) {
             genesis = (Genesis) BlockChainImplTest.getGenesisBlock(blockChain);
@@ -162,7 +166,15 @@ public class World {
     public void saveTransaction(String name, Transaction transaction) { transactions.put(name, transaction); }
 
     public Repository getRepository() {
-        return this.blockChain.getRepository();
+        return repository;
+    }
+
+    public RepositoryLocator getRepositoryLocator() {
+        return new RepositoryLocator(getRepository(), getStateRootHandler());
+    }
+
+    public TransactionPool getTransactionPool() {
+        return transactionPool;
     }
 
     public BridgeSupportFactory getBridgeSupportFactory() {

--- a/rskj-core/src/test/java/co/rsk/test/builders/AccountBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/AccountBuilder.java
@@ -20,6 +20,7 @@ package co.rsk.test.builders;
 
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
+import co.rsk.db.RepositoryLocator;
 import co.rsk.test.World;
 import org.ethereum.core.Account;
 import org.ethereum.core.Block;
@@ -36,16 +37,18 @@ public class AccountBuilder {
     private Coin balance;
     private byte[] code;
     private Blockchain blockChain;
+    private RepositoryLocator repositoryLocator;
 
     public AccountBuilder() {
     }
 
     public AccountBuilder(World world) {
-        this(world.getBlockChain());
+        this(world.getBlockChain(), world.getRepositoryLocator());
     }
 
-    public AccountBuilder(Blockchain blockChain) {
+    public AccountBuilder(Blockchain blockChain, RepositoryLocator repositoryLocator) {
         this.blockChain = blockChain;
+        this.repositoryLocator = repositoryLocator;
     }
 
     public AccountBuilder name(String name) {
@@ -71,7 +74,7 @@ public class AccountBuilder {
         if (blockChain != null) {
             Block best = blockChain.getStatus().getBestBlock();
             BlockDifficulty td = blockChain.getStatus().getTotalDifficulty();
-            Repository repository = blockChain.getRepository();
+            Repository repository = repositoryLocator.snapshotAt(blockChain.getBestBlock().getHeader());
 
             Repository track = repository.startTracking();
 

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -66,6 +66,8 @@ public class BlockChainBuilder {
     private EthereumListener listener;
     private StateRootHandler stateRootHandler;
     private BridgeSupportFactory bridgeSupportFactory;
+    private TransactionPoolImpl transactionPool;
+    private RepositoryLocator repositoryLocator;
 
     public BlockChainBuilder setTesting(boolean value) {
         this.testing = value;
@@ -129,6 +131,18 @@ public class BlockChainBuilder {
         return this.stateRootHandler;
     }
 
+    public Repository getRepository() {
+        return repository;
+    }
+
+    public RepositoryLocator getRepositoryLocator() {
+        return repositoryLocator;
+    }
+
+    public TransactionPoolImpl getTransactionPool() {
+        return transactionPool;
+    }
+
     public BlockChainImpl build() {
         if (config == null){
             config = new TestSystemProperties();
@@ -188,8 +202,9 @@ public class BlockChainBuilder {
                 new ProgramInvokeFactoryImpl(),
                 new PrecompiledContracts(config, bridgeSupportFactory)
         );
-        TransactionPoolImpl transactionPool = new TransactionPoolImpl(
-                config, this.repository, this.blockStore, blockFactory, new TestCompositeEthereumListener(),
+        repositoryLocator = new RepositoryLocator(repository, stateRootHandler);
+        transactionPool = new TransactionPoolImpl(
+                config, repositoryLocator, this.blockStore, blockFactory, new TestCompositeEthereumListener(),
                 transactionExecutorFactory, 10, 100
         );
         BlockExecutor blockExecutor = new BlockExecutor(

--- a/rskj-core/src/test/java/co/rsk/test/builderstest/AccountBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/builderstest/AccountBuilderTest.java
@@ -22,6 +22,7 @@ import co.rsk.core.Coin;
 import co.rsk.test.World;
 import co.rsk.test.builders.AccountBuilder;
 import org.ethereum.core.Account;
+import org.ethereum.core.Repository;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,7 +52,8 @@ public class AccountBuilderTest {
 
         Assert.assertNotNull(account);
         Assert.assertTrue(account.getEcKey().hasPrivKey());
-        Assert.assertEquals(balance, world.getRepository().getBalance(account.getAddress()));
-        Assert.assertArrayEquals(code, world.getRepository().getCode(account.getAddress()));
+        Repository repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        Assert.assertEquals(balance, repository.getBalance(account.getAddress()));
+        Assert.assertArrayEquals(code, repository.getCode(account.getAddress()));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -136,7 +136,9 @@ public class WorldDslProcessor {
                 accountAddress = new RskAddress(accountName);
         }
 
-        Coin accountBalance = world.getRepository().getBalance(accountAddress);
+        BlockHeader bestBlock = world.getBlockChain().getBestBlock().getHeader();
+        Repository repository = world.getRepositoryLocator().snapshotAt(bestBlock);
+        Coin accountBalance = repository.getBalance(accountAddress);
         if (expected.equals(accountBalance))
             return;
 
@@ -205,7 +207,6 @@ public class WorldDslProcessor {
             block.seal();
 
             latestImportResult = blockChain.tryToConnect(block);
-            blockChain.getRepository().syncToRoot(block.getStateRoot());
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
@@ -24,6 +24,7 @@ import co.rsk.test.dsl.DslProcessorException;
 import co.rsk.test.dsl.WorldDslProcessor;
 import org.ethereum.core.Account;
 import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.junit.Assert;
 import org.junit.Test;
@@ -268,7 +269,8 @@ public class WorldDslProcessorTest {
         Account account = world.getAccountByName("acc1");
 
         Assert.assertNotNull(account);
-        Assert.assertEquals(new BigInteger("1000000"), world.getRepository().getBalance(account.getAddress()).asBigInteger());
+        Repository repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        Assert.assertEquals(new BigInteger("1000000"), repository.getBalance(account.getAddress()).asBigInteger());
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -70,9 +70,11 @@ public class ImportLightTest {
                 new ProgramInvokeFactoryImpl(),
 
                 null);
-        TransactionPoolImpl transactionPool = new TransactionPoolImpl(config, repository, null, blockFactory, listener, transactionExecutorFactory, 10, 100);
-
         StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
+        RepositoryLocator repositoryLocator = new RepositoryLocator(repository, stateRootHandler);
+
+        TransactionPoolImpl transactionPool = new TransactionPoolImpl(config, repositoryLocator, null, blockFactory, listener, transactionExecutorFactory, 10, 100);
+
         BlockChainImpl blockchain = new BlockChainImpl(
                 repository,
                 blockStore,

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -148,9 +148,11 @@ public class TestRunner {
                 blockFactory,
                 new ProgramInvokeFactoryImpl(),
                 null);
-        TransactionPoolImpl transactionPool = new TransactionPoolImpl(config, repository, null, blockFactory, listener, transactionExecutorFactory, 10, 100);
-
         StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
+        RepositoryLocator repositoryLocator = new RepositoryLocator(repository, stateRootHandler);
+
+        TransactionPoolImpl transactionPool = new TransactionPoolImpl(config, repositoryLocator, null, blockFactory, listener, transactionExecutorFactory, 10, 100);
+
         BlockChainImpl blockchain = new BlockChainImpl(
                 repository,
                 blockStore,

--- a/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
@@ -20,6 +20,7 @@ package org.ethereum.rpc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.RskAddress;
+import co.rsk.db.RepositoryLocator;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
 import org.ethereum.util.RskTestFactory;
@@ -56,8 +57,10 @@ public class LogFilterTest {
 
     @Test
     public void eventAfterBlockWithEvent() {
-        Blockchain blockchain = new RskTestFactory().getBlockchain();
-        Web3ImplLogsTest.addEmptyBlockToBlockchain(blockchain);
+        RskTestFactory factory = new RskTestFactory();
+        Blockchain blockchain = factory.getBlockchain();
+        RepositoryLocator repositoryLocator = factory.getRepositoryLocator();
+        Web3ImplLogsTest.addEmptyBlockToBlockchain(blockchain, repositoryLocator);
         Block block = blockchain.getBestBlock();
 
         AddressesTopicsFilter atfilter = new AddressesTopicsFilter(new RskAddress[0], null);
@@ -74,8 +77,10 @@ public class LogFilterTest {
 
     @Test
     public void twoEventsAfterTwoBlocksWithEventAndToLatestBlock() {
-        Blockchain blockchain = new RskTestFactory().getBlockchain();
-        Web3ImplLogsTest.addEmptyBlockToBlockchain(blockchain);
+        RskTestFactory factory = new RskTestFactory();
+        Blockchain blockchain = factory.getBlockchain();
+        RepositoryLocator repositoryLocator = factory.getRepositoryLocator();
+        Web3ImplLogsTest.addEmptyBlockToBlockchain(blockchain, repositoryLocator);
         Block block = blockchain.getBestBlock();
 
         AddressesTopicsFilter atfilter = new AddressesTopicsFilter(new RskAddress[0], null);
@@ -93,8 +98,10 @@ public class LogFilterTest {
 
     @Test
     public void onlyOneEventAfterTwoBlocksWithEventAndFromLatestBlock() {
-        Blockchain blockchain = new RskTestFactory().getBlockchain();
-        Web3ImplLogsTest.addEmptyBlockToBlockchain(blockchain);
+        RskTestFactory factory = new RskTestFactory();
+        Blockchain blockchain = factory.getBlockchain();
+        RepositoryLocator repositoryLocator = factory.getRepositoryLocator();
+        Web3ImplLogsTest.addEmptyBlockToBlockchain(blockchain, repositoryLocator);
         Block block = blockchain.getBestBlock();
 
         AddressesTopicsFilter atfilter = new AddressesTopicsFilter(new RskAddress[0], null);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -135,7 +135,7 @@ public class Web3ImplLogsTest {
 
     @Test
     public void newFilterGetLogsAfterBlock() throws Exception {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
         web3.personal_newAccountWithSeed("notDefault");
 
         Web3.FilterRequest fr = new Web3.FilterRequest();
@@ -162,7 +162,7 @@ public class Web3ImplLogsTest {
 
     @Test
     public void newFilterWithAccountAndTopicsCreatedAfterBlockAndGetLogs() throws Exception {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
 
         web3.personal_newAccountWithSeed("notDefault");
 
@@ -191,7 +191,7 @@ public class Web3ImplLogsTest {
 
     @Test
     public void newFilterGetLogsTwiceAfterBlock() throws Exception {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
 
         web3.personal_newAccountWithSeed("notDefault");
 
@@ -232,7 +232,7 @@ public class Web3ImplLogsTest {
 
     @Test
     public void newFilterGetChangesAfterBlock() throws Exception {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
 
         web3.personal_newAccountWithSeed("notDefault");
 
@@ -790,7 +790,7 @@ public class Web3ImplLogsTest {
 
     @Test
     public void createMainContractWithoutEvents() throws Exception {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
         web3.personal_newAccountWithSeed("notDefault");
 
         Web3.FilterRequest fr = new Web3.FilterRequest();
@@ -815,7 +815,7 @@ public class Web3ImplLogsTest {
 
     @Test
     public void createCallerContractWithEvents() throws Exception {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
         web3.personal_newAccountWithSeed("notDefault");
 
         Web3.FilterRequest fr = new Web3.FilterRequest();
@@ -854,7 +854,7 @@ public class Web3ImplLogsTest {
 
     @Test
     public void createCallerContractWithEventsOnInvoke() throws Exception {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
         web3.personal_newAccountWithSeed("notDefault");
 
         Web3.FilterRequest fr = new Web3.FilterRequest();
@@ -902,7 +902,7 @@ public class Web3ImplLogsTest {
 
     @Test
     public void createCallerContractWithEventsOnInvokeUsingGetFilterLogs() throws Exception {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
         web3.personal_newAccountWithSeed("notDefault");
 
         Block genesis = blockChain.getBlockByNumber(0);
@@ -997,7 +997,7 @@ public class Web3ImplLogsTest {
     private String compiledGreeter = "60606040525b33600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff02191690836c010000000000000000000000009081020402179055505b610181806100516000396000f360606040526000357c010000000000000000000000000000000000000000000000000000000090048063ead710c41461003c57610037565b610002565b34610002576100956004808035906020019082018035906020019191908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050909091905050610103565b60405180806020018281038252838181518152602001915080519060200190808383829060006004602084601f0104600302600f01f150905090810190601f1680156100f55780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6020604051908101604052806000815260200150600060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614151561017357610002565b81905061017b565b5b91905056";
 
     private void addContractCreationWithoutEvents() {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
 
         Block genesis = blockChain.getBlockByNumber(0);
 
@@ -1030,13 +1030,13 @@ public class Web3ImplLogsTest {
     }
 
     private void addEventInContractCreation() {
-        addEmptyBlockToBlockchain(blockChain);
+        addEmptyBlockToBlockchain(blockChain, repositoryLocator);
 
         web3.personal_newAccountWithSeed("notDefault");
     }
 
-    public static void addEmptyBlockToBlockchain(Blockchain blockChain) {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+    public static void addEmptyBlockToBlockchain(Blockchain blockChain, RepositoryLocator repositoryLocator) {
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
 
         Block genesis = blockChain.getBlockByNumber(0);
         Transaction tx;
@@ -1049,7 +1049,7 @@ public class Web3ImplLogsTest {
     }
 
     private void addContractInvoke() {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
 
         Block genesis = blockChain.getBlockByNumber(0);
         Transaction tx;
@@ -1073,7 +1073,7 @@ public class Web3ImplLogsTest {
     }
 
     private void addContractCall() {
-        Account acc1 = new AccountBuilder(blockChain).name("notDefault").balance(Coin.valueOf(10000000)).build();
+        Account acc1 = new AccountBuilder(blockChain, repositoryLocator).name("notDefault").balance(Coin.valueOf(10000000)).build();
         // acc1 Account created address should be 661b05ca9eb621164906671efd2731ce0d7dd8b4
 
         Block genesis = blockChain.getBlockByNumber(0);

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -1,21 +1,15 @@
 package org.ethereum.util;
 
-import co.rsk.config.RskSystemProperties;
-import co.rsk.config.TestSystemProperties;
-import co.rsk.core.*;
-import co.rsk.peg.BridgeSupportFactory;
-import co.rsk.peg.BtcBlockStoreWithCache;
-import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.core.TransactionExecutorFactory;
+import co.rsk.db.RepositoryLocator;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import org.ethereum.core.*;
-import org.ethereum.db.BlockStore;
-import org.ethereum.db.ReceiptStore;
 import org.ethereum.rpc.TypeConverter;
-import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
-import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 
 import java.math.BigInteger;
 
@@ -23,10 +17,9 @@ import java.math.BigInteger;
  * Helper methods to easily run contracts.
  */
 public class ContractRunner {
-    private final Repository repository;
+    private final RepositoryLocator repositoryLocator;
     private final Blockchain blockchain;
-    private final BlockStore blockStore;
-    private final ReceiptStore receiptStore;
+    private final TransactionExecutorFactory transactionExecutorFactory;
 
     public final Account sender;
 
@@ -35,17 +28,15 @@ public class ContractRunner {
     }
 
     public ContractRunner(RskTestFactory factory) {
-        this(factory.getRepository(), factory.getBlockchain(), factory.getBlockStore(), factory.getReceiptStore());
+        this(factory.getRepositoryLocator(), factory.getBlockchain(), factory.getTransactionExecutorFactory());
     }
 
-    private ContractRunner(Repository repository,
+    private ContractRunner(RepositoryLocator repositoryLocator,
                            Blockchain blockchain,
-                           BlockStore blockStore,
-                           ReceiptStore receiptStore) {
+                           TransactionExecutorFactory transactionExecutorFactory) {
         this.blockchain = blockchain;
-        this.repository = repository;
-        this.blockStore = blockStore;
-        this.receiptStore = receiptStore;
+        this.repositoryLocator = repositoryLocator;
+        this.transactionExecutorFactory = transactionExecutorFactory;
 
         // we build a new block with high gas limit because Genesis' is too low
         Block block = new BlockBuilder(blockchain)
@@ -53,14 +44,14 @@ public class ContractRunner {
                 .build();
         blockchain.setStatus(block, block.getCumulativeDifficulty());
         // create a test sender account with a large balance for running any contract
-        this.sender = new AccountBuilder(blockchain)
+        this.sender = new AccountBuilder(blockchain, repositoryLocator)
                 .name("sender")
                 .balance(Coin.valueOf(1_000_000_000_000L))
                 .build();
     }
 
     public RskAddress addContract(String runtimeBytecode) {
-        Account contractAccount = new AccountBuilder(blockchain)
+        Account contractAccount = new AccountBuilder(blockchain, repositoryLocator)
                         .name(runtimeBytecode)
                         .balance(Coin.valueOf(10))
                         .code(TypeConverter.stringHexToByteArray(runtimeBytecode))
@@ -70,18 +61,23 @@ public class ContractRunner {
     }
 
     public ProgramResult createContract(byte[] bytecode) {
-        Transaction creationTx = contractCreateTx(bytecode);
-        return executeTransaction(creationTx).getResult();
+        return createContract(bytecode, repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader()));
+    }
+
+    private ProgramResult createContract(byte[] bytecode, Repository repository) {
+        Transaction creationTx = contractCreateTx(bytecode, repository);
+        return executeTransaction(creationTx, repository).getResult();
     }
 
     public ProgramResult createAndRunContract(byte[] bytecode, byte[] encodedCall, BigInteger value, boolean localCall) {
-        createContract(bytecode);
-        Transaction creationTx = contractCreateTx(bytecode);
-        executeTransaction(creationTx);
-        return runContract(creationTx.getContractAddress().getBytes(), encodedCall, value, localCall);
+        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        createContract(bytecode, repository);
+        Transaction creationTx = contractCreateTx(bytecode, repository);
+        executeTransaction(creationTx, repository);
+        return runContract(creationTx.getContractAddress().getBytes(), encodedCall, value, localCall, repository);
     }
 
-    private Transaction contractCreateTx(byte[] bytecode) {
+    private Transaction contractCreateTx(byte[] bytecode, Repository repository) {
         BigInteger nonceCreate = repository.getNonce(sender.getAddress());
         return new TransactionBuilder()
                 .gasLimit(BigInteger.valueOf(10_000_000))
@@ -91,7 +87,7 @@ public class ContractRunner {
                 .build();
     }
 
-    private ProgramResult runContract(byte[] contractAddress, byte[] encodedCall, BigInteger value, boolean localCall) {
+    private ProgramResult runContract(byte[] contractAddress, byte[] encodedCall, BigInteger value, boolean localCall, Repository repository) {
         BigInteger nonceExecute = repository.getNonce(sender.getAddress());
         Transaction transaction = new TransactionBuilder()
                 // a large gas limit will allow running any contract
@@ -103,25 +99,11 @@ public class ContractRunner {
                 .value(value)
                 .build();
         transaction.setLocalCallTransaction(localCall);
-        return executeTransaction(transaction).getResult();
+        return executeTransaction(transaction, repository).getResult();
     }
 
-    private TransactionExecutor executeTransaction(Transaction transaction) {
+    private TransactionExecutor executeTransaction(Transaction transaction, Repository repository) {
         Repository track = repository.startTracking();
-        RskSystemProperties config = new TestSystemProperties();
-        BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(
-                        config.getNetworkConstants().getBridgeConstants().getBtcParams()),
-                config.getNetworkConstants().getBridgeConstants(),
-                config.getActivationConfig());
-        TransactionExecutorFactory transactionExecutorFactory = new TransactionExecutorFactory(
-                config,
-                blockStore,
-                receiptStore,
-                new BlockFactory(config.getActivationConfig()),
-                new ProgramInvokeFactoryImpl(),
-                new PrecompiledContracts(config, bridgeSupportFactory)
-        );
         TransactionExecutor executor = transactionExecutorFactory
                 .newInstance(transaction, 0, RskAddress.nullAddress(), repository, blockchain.getBestBlock(), 0);
         executor.init();


### PR DESCRIPTION
Remove  `Repository#syncToRoot` and use `RepositoryLocator#snapshotAt` instead. This forces the user of the repository to think about the `state root` on which to work, and gets us closer to removing `Repository` from the DI context.

*fed:repository_synctoroot*