### PR TITLE
Segregate the Repository reader interface

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
+++ b/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
@@ -20,6 +20,7 @@ package co.rsk.core;
 
 import co.rsk.core.bc.AccountInformationProvider;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.panic.PanicProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -27,7 +28,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Blockchain;
-import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.slf4j.Logger;
@@ -57,7 +57,7 @@ public class NetworkStateExporter {
     }
 
     public boolean exportStatus(String outputFile) {
-        Repository frozenRepository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader frozenRepository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         File dumpFile = new File(outputFile);
 

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -50,7 +50,7 @@ public class ReversibleTransactionExecutor {
             byte[] value,
             byte[] data,
             RskAddress fromAddress) {
-        Repository snapshot = repositoryLocator.snapshotAt(executionBlock.getHeader()).startTracking();
+        Repository snapshot = repositoryLocator.startTrackingAt(executionBlock.getHeader());
 
         byte[] nonce = snapshot.getNonce(fromAddress).toByteArray();
         UnsignedTransaction tx = new UnsignedTransaction(

--- a/rskj-core/src/main/java/co/rsk/core/bc/AccountInformationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/AccountInformationProvider.java
@@ -72,9 +72,14 @@ public interface AccountInformationProvider {
     /**
      * Retrieve the code associated with an account
      *
+     * This method returns null if there is no code at the address.
+     * It may return the empty array for contracts that have installed zero code on construction.
+     * (not checked)
+     *
      * @param addr of the account
      * @return code in byte-array format
      */
+    @Nullable
     byte[] getCode(RskAddress addr);
 
     /**

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -259,9 +259,8 @@ public class BlockExecutor {
         // of the repository to the state post execution, so it's necessary to get it to
         // the state prior execution again.
         Metric metric = profiler.start(Profiler.PROFILING_TYPE.BLOCK_EXECUTE);
-        Repository initialRepository = repositoryLocator.snapshotAt(parent);
 
-        Repository track = initialRepository.startTracking();
+        Repository track = repositoryLocator.startTrackingAt(parent);
 
         maintainPrecompiledContractStorageRoots(track, activationConfig.forBlock(block.getNumber()));
 
@@ -353,7 +352,7 @@ public class BlockExecutor {
                 receipts,
                 totalGasUsed,
                 totalPaidFees,
-                initialRepository.getTrie()
+                track.getTrie()
         );
         profiler.stop(metric);
         return result;

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -346,13 +346,7 @@ public class BlockExecutor {
             logger.trace("tx done");
         }
 
-        // This commitment changes the initialRepository's view of the state
-        // This does not affect the parent's (repository) view or state, but it DOES
-        // affect the storage of the parent.
-        track.commit();
-
-        // All data saved to store
-        initialRepository.save();
+        track.save();
 
         BlockResult result = new BlockResult(
                 executedTransactions,

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -353,7 +353,7 @@ public class BlockExecutor {
                 receipts,
                 totalGasUsed,
                 totalPaidFees,
-                initialRepository.getMutableTrie().getTrie()
+                initialRepository.getTrie()
         );
         profiler.stop(metric);
         return result;

--- a/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
@@ -20,7 +20,11 @@ package co.rsk.core.bc;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
-import org.ethereum.core.*;
+import co.rsk.db.RepositoryReader;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionExecutor;
+import org.ethereum.core.TransactionSet;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.slf4j.Logger;
@@ -43,7 +47,7 @@ public class PendingState implements AccountInformationProvider {
     private boolean executed = false;
 
 
-    public PendingState(Repository repository, TransactionSet pendingTransactions, TransactionExecutorFactory transactionExecutorFactory) {
+    public PendingState(RepositoryReader repository, TransactionSet pendingTransactions, TransactionExecutorFactory transactionExecutorFactory) {
         this.pendingRepository = repository.startTracking();
         this.pendingTransactions = pendingTransactions;
         this.transactionExecutorFactory = transactionExecutorFactory;

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -23,6 +23,7 @@ import co.rsk.core.Coin;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.net.TransactionValidationResult;
 import co.rsk.net.handler.TxPendingValidator;
 import com.google.common.annotations.VisibleForTesting;
@@ -132,7 +133,7 @@ public class TransactionPoolImpl implements TransactionPool {
         return getPendingState(getCurrentRepository());
     }
 
-    private PendingState getPendingState(Repository currentRepository) {
+    private PendingState getPendingState(RepositoryReader currentRepository) {
         removeObsoleteTransactions(this.getCurrentBestBlockNumber(), this.outdatedThreshold, this.outdatedTimeout);
         return new PendingState(
                 currentRepository,
@@ -148,7 +149,7 @@ public class TransactionPoolImpl implements TransactionPool {
         );
     }
 
-    private Repository getCurrentRepository() {
+    private RepositoryReader getCurrentRepository() {
         return repositoryLocator.snapshotAt(getBestBlock().getHeader());
     }
 
@@ -204,7 +205,7 @@ public class TransactionPoolImpl implements TransactionPool {
 
     @Override
     public synchronized TransactionPoolAddResult addTransaction(final Transaction tx) {
-        Repository currentRepository = getCurrentRepository();
+        RepositoryReader currentRepository = getCurrentRepository();
         TransactionValidationResult validationResult = shouldAcceptTx(tx, currentRepository);
         if (!validationResult.transactionIsValid()) {
             return TransactionPoolAddResult.withError(validationResult.getErrorMessage());
@@ -424,7 +425,7 @@ public class TransactionPoolImpl implements TransactionPool {
         );
     }
 
-    private TransactionValidationResult shouldAcceptTx(Transaction tx, Repository currentRepository) {
+    private TransactionValidationResult shouldAcceptTx(Transaction tx, RepositoryReader currentRepository) {
         AccountState state = currentRepository.getAccountState(tx.getSender());
         return validator.isValid(tx, bestBlock, state);
     }
@@ -436,7 +437,7 @@ public class TransactionPoolImpl implements TransactionPool {
      */
     private boolean senderCanPayPendingTransactionsAndNewTx(
             Transaction newTx,
-            Repository currentRepository) {
+            RepositoryReader currentRepository) {
         List<Transaction> transactions = pendingTransactions.getTransactionsWithSender(newTx.getSender());
 
         Coin accumTxCost = Coin.ZERO;

--- a/rskj-core/src/main/java/co/rsk/db/RepositoryLocator.java
+++ b/rskj-core/src/main/java/co/rsk/db/RepositoryLocator.java
@@ -36,6 +36,6 @@ public class RepositoryLocator {
 
     public Repository snapshotAt(BlockHeader header) {
         Keccak256 stateRoot = stateRootHandler.translate(header);
-        return new MutableRepository(repository.getMutableTrie().getSnapshotTo(stateRoot));
+        return new MutableRepository(repository.getTrie().getSnapshotTo(stateRoot));
     }
 }

--- a/rskj-core/src/main/java/co/rsk/db/RepositoryLocator.java
+++ b/rskj-core/src/main/java/co/rsk/db/RepositoryLocator.java
@@ -19,6 +19,7 @@
 package co.rsk.db;
 
 import co.rsk.crypto.Keccak256;
+import co.rsk.trie.MutableTrie;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Repository;
 import org.ethereum.db.MutableRepository;
@@ -34,8 +35,16 @@ public class RepositoryLocator {
         this.stateRootHandler = stateRootHandler;
     }
 
-    public Repository snapshotAt(BlockHeader header) {
+    public RepositoryReader snapshotAt(BlockHeader header) {
+        return new MutableRepository(mutableTrieSnapshotAt(header));
+    }
+
+    public Repository startTrackingAt(BlockHeader header) {
+        return new MutableRepository(new MutableTrieCache(mutableTrieSnapshotAt(header)));
+    }
+
+    private MutableTrie mutableTrieSnapshotAt(BlockHeader header) {
         Keccak256 stateRoot = stateRootHandler.translate(header);
-        return new MutableRepository(repository.getTrie().getSnapshotTo(stateRoot));
+        return new MutableTrieImpl(repository.getTrie().getSnapshotTo(stateRoot));
     }
 }

--- a/rskj-core/src/main/java/co/rsk/db/RepositoryReader.java
+++ b/rskj-core/src/main/java/co/rsk/db/RepositoryReader.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.db;
+
+import co.rsk.core.RskAddress;
+import co.rsk.core.bc.AccountInformationProvider;
+import org.ethereum.core.AccountState;
+import org.ethereum.core.Repository;
+
+import java.util.Set;
+
+/**
+ * The readonly methods of a Repository.
+ * This interface DOES NOT represent an immutable value, since we have startTracking/commit to apply changes.
+ */
+public interface RepositoryReader extends AccountInformationProvider {
+    /**
+     * @return the storage root of this repository
+     */
+    byte[] getRoot();
+
+    /**
+     * @return set of all the account addresses
+     */
+    Set<RskAddress> getAccountsKeys();
+
+    /**
+     * This method can retrieve the code size without actually retrieving the code
+     * in some cases.
+     */
+    int getCodeLength(RskAddress addr);
+
+    /**
+     * @param addr - account to check
+     * @return - true if account exist,
+     *           false otherwise
+     */
+    boolean isExist(RskAddress addr);
+
+    /**
+     * Retrieve an account
+     *
+     * @param addr of the account
+     * @return account state as stored in the database
+     */
+    AccountState getAccountState(RskAddress addr);
+
+    /**
+     * This method creates a new child repository for change tracking purposes.
+     * Changes will be applied to this repository after calling commit on the child. This means that this interface does
+     * NOT represent an immutable value.
+     */
+    Repository startTracking();
+}

--- a/rskj-core/src/main/java/co/rsk/db/migration/OrchidToUnitrieMigrator.java
+++ b/rskj-core/src/main/java/co/rsk/db/migration/OrchidToUnitrieMigrator.java
@@ -180,7 +180,7 @@ public class OrchidToUnitrieMigrator {
         }
 
         byte[] lastStateRoot = unitrieRepository.getRoot();
-        byte[] orchidMigratedStateRoot = trieConverter.getOrchidAccountTrieRoot(unitrieRepository.getMutableTrie().getTrie());
+        byte[] orchidMigratedStateRoot = trieConverter.getOrchidAccountTrieRoot(unitrieRepository.getTrie());
         if (!Arrays.equals(orchidStateRoot, orchidMigratedStateRoot)) {
             logger.error("State root after migration doesn't match");
             logger.error("Orchid state root: {}", Hex.toHexString(orchidStateRoot));
@@ -192,7 +192,7 @@ public class OrchidToUnitrieMigrator {
             logger.info("State root: {}", Hex.toHexString(lastStateRoot));
         }
 
-        return unitrieRepository.getMutableTrie().getTrie();
+        return unitrieRepository.getTrie();
     }
 
     private void buildPartialUnitrie(Trie orchidAccountsTrie, Repository repository) throws MissingContractStorageKeysException {

--- a/rskj-core/src/main/java/co/rsk/mine/BlockToMineBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/mine/BlockToMineBuilder.java
@@ -26,6 +26,7 @@ import co.rsk.core.bc.BlockExecutor;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.core.bc.FamilyUtils;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.panic.PanicProcessor;
 import co.rsk.remasc.RemascTransaction;
 import co.rsk.validators.BlockValidationRule;
@@ -140,7 +141,7 @@ public class BlockToMineBuilder {
 
         Map<RskAddress, BigInteger> accountNonces = new HashMap<>();
 
-        Repository originalRepo = repositoryLocator.snapshotAt(parentHeader);
+        RepositoryReader originalRepo = repositoryLocator.snapshotAt(parentHeader);
 
         return minerUtils.filterTransactions(txsToRemove, txs, accountNonces, originalRepo, minGasPrice);
     }

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -25,22 +25,25 @@ import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.PendingState;
 import co.rsk.crypto.Keccak256;
+import co.rsk.db.RepositoryReader;
 import co.rsk.remasc.RemascTransaction;
+import org.bouncycastle.util.Arrays;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.core.TransactionPool;
-import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionPool;
 import org.ethereum.rpc.TypeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.Arrays;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 public class MinerUtils {
@@ -156,7 +159,7 @@ public class MinerUtils {
         return PendingState.sortByPriceTakingIntoAccountSenderAndNonce(txs);
     }
 
-    public List<org.ethereum.core.Transaction> filterTransactions(List<Transaction> txsToRemove, List<Transaction> txs, Map<RskAddress, BigInteger> accountNonces, Repository originalRepo, Coin minGasPrice) {
+    public List<org.ethereum.core.Transaction> filterTransactions(List<Transaction> txsToRemove, List<Transaction> txs, Map<RskAddress, BigInteger> accountNonces, RepositoryReader originalRepo, Coin minGasPrice) {
         List<org.ethereum.core.Transaction> txsResult = new ArrayList<>();
         for (org.ethereum.core.Transaction tx : txs) {
             try {

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -18,8 +18,6 @@
 
 package co.rsk.rpc.modules.eth;
 
-import static org.ethereum.rpc.TypeConverter.toJsonHex;
-
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.config.BridgeConstants;
 import co.rsk.core.ReversibleTransactionExecutor;
@@ -28,8 +26,6 @@ import co.rsk.peg.BridgeState;
 import co.rsk.peg.BridgeSupport;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.rpc.ExecutionBlockRetriever;
-import java.io.IOException;
-import java.util.Map;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Repository;
@@ -41,6 +37,11 @@ import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.ethereum.rpc.TypeConverter.toJsonHex;
 
 // TODO add all RPC methods
 public class EthModule
@@ -86,7 +87,7 @@ public class EthModule
 
     public Map<String, Object> bridgeState() throws IOException, BlockStoreException {
         Block bestBlock = blockchain.getBestBlock();
-        Repository repository = repositoryLocator.snapshotAt(bestBlock.getHeader()).startTracking();
+        Repository repository = repositoryLocator.startTrackingAt(bestBlock.getHeader());
 
         BridgeSupport bridgeSupport = bridgeSupportFactory.newInstance(
                 repository, bestBlock, PrecompiledContracts.BRIDGE_ADDR, null);

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
@@ -20,9 +20,9 @@ package co.rsk.validators;
 
 import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.panic.PanicProcessor;
 import org.ethereum.core.Block;
-import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +65,7 @@ public class BlockTxsValidationRule implements BlockParentDependantValidationRul
             return true;
         }
 
-        Repository parentRepo = repositoryLocator.snapshotAt(parent.getHeader());
+        RepositoryReader parentRepo = repositoryLocator.snapshotAt(parent.getHeader());
 
         Map<RskAddress, BigInteger> curNonce = new HashMap<>();
 

--- a/rskj-core/src/main/java/org/ethereum/core/Repository.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Repository.java
@@ -21,15 +21,13 @@ package org.ethereum.core;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
-import co.rsk.core.bc.AccountInformationProvider;
+import co.rsk.db.RepositoryReader;
 import co.rsk.trie.Trie;
 import org.ethereum.vm.DataWord;
 
-import javax.annotation.Nullable;
 import java.math.BigInteger;
-import java.util.Set;
 
-public interface Repository extends AccountInformationProvider {
+public interface Repository extends RepositoryReader {
     Trie getTrie();
 
     /**
@@ -50,21 +48,6 @@ public interface Repository extends AccountInformationProvider {
     AccountState createAccount(RskAddress addr);
 
     void setupContract(RskAddress addr);
-
-    /**
-     * @param addr - account to check
-     * @return - true if account exist,
-     *           false otherwise
-     */
-    boolean isExist(RskAddress addr);
-
-    /**
-     * Retrieve an account
-     *
-     * @param addr of the account
-     * @return account state as stored in the database
-     */
-    AccountState getAccountState(RskAddress addr);
 
     /**
      * Deletes the account. This is recursive: all storage keys are deleted
@@ -99,21 +82,6 @@ public interface Repository extends AccountInformationProvider {
     void saveCode(RskAddress addr, byte[] code);
 
     /**
-     * get the code associated with an account
-     *
-     * This method returns null if there is no code at the address.
-     * It may return the empty array for contracts that have installed zero code on construction.
-     * (not checked)
-    */
-    @Override
-    @Nullable
-    byte[] getCode(RskAddress addr);
-
-     // This method can retrieve the code size without actually retrieving the code
-    // in some cases.
-    int getCodeLength(RskAddress addr);
-
-    /**
      * Put a value in storage of an account at a given key
      *
      * @param addr of the account
@@ -124,9 +92,6 @@ public interface Repository extends AccountInformationProvider {
 
     void addStorageBytes(RskAddress addr, DataWord key, byte[] value);
 
-    @Override
-    byte[] getStorageBytes(RskAddress addr, DataWord key);
-
     /**
      * Add value to the balance of an account
      *
@@ -135,18 +100,6 @@ public interface Repository extends AccountInformationProvider {
      * @return new balance of the account
      */
     Coin addBalance(RskAddress addr, Coin value);
-
-    /**
-     * @return Returns set of all the account addresses
-     */
-    Set<RskAddress> getAccountsKeys();
-
-    /**
-     * Save a snapshot and start tracking future changes
-     *
-     * @return the tracker repository
-     */
-    Repository startTracking();
 
     void flush();
 
@@ -165,8 +118,6 @@ public interface Repository extends AccountInformationProvider {
     void rollback();
 
     void save();
-
-    byte[] getRoot();
 
     void updateAccountState(RskAddress addr, AccountState accountState);
 

--- a/rskj-core/src/main/java/org/ethereum/core/Repository.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Repository.java
@@ -22,7 +22,7 @@ package org.ethereum.core;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.AccountInformationProvider;
-import co.rsk.trie.MutableTrie;
+import co.rsk.trie.Trie;
 import org.ethereum.vm.DataWord;
 
 import javax.annotation.Nullable;
@@ -30,8 +30,7 @@ import java.math.BigInteger;
 import java.util.Set;
 
 public interface Repository extends AccountInformationProvider {
-
-    MutableTrie getMutableTrie();
+    Trie getTrie();
 
     /**
      * Create a new account in the database

--- a/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
@@ -134,9 +134,9 @@ public class BlockChainLoader {
     }
 
     private void updateGenesis(Repository repository) {
-        genesis.setStateRoot(stateRootHandler.convert(genesis.getHeader(), repository.getMutableTrie().getTrie()).getBytes());
+        genesis.setStateRoot(stateRootHandler.convert(genesis.getHeader(), repository.getTrie()).getBytes());
         genesis.flushRLP();
-        stateRootHandler.register(genesis.getHeader(), repository.getMutableTrie().getTrie());
+        stateRootHandler.register(genesis.getHeader(), repository.getTrie());
     }
 
     private void loadRepository(Repository repository) {

--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -57,8 +57,8 @@ public class MutableRepository implements Repository {
     }
 
     @Override
-    public MutableTrie getMutableTrie() {
-        return mutableTrie;
+    public Trie getTrie() {
+        return mutableTrie.getTrie();
     }
 
     @Override
@@ -277,7 +277,7 @@ public class MutableRepository implements Repository {
     // To start tracking, a new repository is created, with a MutableTrieCache in the middle
     @Override
     public synchronized Repository startTracking() {
-        return new MutableRepository(new MutableTrieCache(this.getMutableTrie()));
+        return new MutableRepository(new MutableTrieCache(mutableTrie));
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Storage.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Storage.java
@@ -21,7 +21,7 @@ package org.ethereum.vm.program;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
-import co.rsk.trie.MutableTrie;
+import co.rsk.trie.Trie;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
@@ -55,8 +55,8 @@ public class Storage implements Repository, ProgramListenerAware {
     }
 
     @Override
-    public MutableTrie getMutableTrie() {
-        return repository.getMutableTrie();
+    public Trie getTrie() {
+        return repository.getTrie();
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
@@ -66,8 +66,7 @@ public class CallContractTest {
         Block bestBlock = world.getBlockChain().getBestBlock();
 
         Repository repository = world.getRepositoryLocator()
-                .snapshotAt(world.getBlockChain().getBestBlock().getHeader())
-                .startTracking();
+                .startTrackingAt(world.getBlockChain().getBestBlock().getHeader());
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(
                 config.getNetworkConstants().getBridgeConstants().getBtcParams());
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -130,7 +130,7 @@ public class BlockExecutorTest {
         Assert.assertNotNull(accountState);
         Assert.assertEquals(BigInteger.valueOf(30000), accountState.getBalance().asBigInteger());
 
-        Repository finalRepository = new MutableRepository(repository.getMutableTrie().getSnapshotTo(result.getFinalState().getHash()));
+        Repository finalRepository = new MutableRepository(repository.getTrie().getSnapshotTo(result.getFinalState().getHash()));
 
         accountState = finalRepository.getAccountState(account);
 
@@ -187,7 +187,7 @@ public class BlockExecutorTest {
 
         // here is the papa. my commit changes stateroot while previous commit did not.
 
-        Repository finalRepository = new MutableRepository(repository.getMutableTrie().getSnapshotTo(result.getFinalState().getHash()));
+        Repository finalRepository = new MutableRepository(repository.getTrie().getSnapshotTo(result.getFinalState().getHash()));
 
         accountState = finalRepository.getAccountState(account);
 
@@ -569,7 +569,7 @@ public class BlockExecutorTest {
         Assert.assertNotNull(accountState);
         Assert.assertEquals(BigInteger.valueOf(30000), accountState.getBalance().asBigInteger());
 
-        Repository finalRepository = new MutableRepository(repository.getMutableTrie().getSnapshotTo(result.getFinalState().getHash()));
+        Repository finalRepository = new MutableRepository(repository.getTrie().getSnapshotTo(result.getFinalState().getHash()));
 
         accountState = finalRepository.getAccountState(account.getAddress());
 

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryLocatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryLocatorTest.java
@@ -25,27 +25,27 @@ import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Repository;
 import org.junit.Test;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class RepositoryLocatorTest {
     @Test
     public void getsSnapshotFromTranslatedStateRoot() {
-        Repository repository = mock(Repository.class);
-        StateRootHandler stateRootHandler = mock(StateRootHandler.class);
-
         BlockHeader header = mock(BlockHeader.class);
         Keccak256 stateRoot = TestUtils.randomHash();
+        StateRootHandler stateRootHandler = mock(StateRootHandler.class);
         when(stateRootHandler.translate(header)).thenReturn(stateRoot);
 
-        Trie expectedTrie = mock(Trie.class);
+        Trie underlyingTrie = mock(Trie.class);
+        when(underlyingTrie.getHash()).thenReturn(TestUtils.randomHash());
         Trie trie = mock(Trie.class);
-        when(trie.getSnapshotTo(stateRoot)).thenReturn(expectedTrie);
+        when(trie.getSnapshotTo(stateRoot)).thenReturn(underlyingTrie);
+        Repository repository = mock(Repository.class);
         when(repository.getTrie()).thenReturn(trie);
 
         RepositoryLocator repositoryLocator = new RepositoryLocator(repository, stateRootHandler);
-        Trie actualTrie = repositoryLocator.snapshotAt(header).getTrie();
-        assertSame(expectedTrie, actualTrie);
+        RepositoryReader actualRepository = repositoryLocator.snapshotAt(header);
+        assertEquals(underlyingTrie.getHash(), new Keccak256(actualRepository.getRoot()));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryLocatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryLocatorTest.java
@@ -19,7 +19,7 @@
 package co.rsk.db;
 
 import co.rsk.crypto.Keccak256;
-import co.rsk.trie.MutableTrie;
+import co.rsk.trie.Trie;
 import org.ethereum.TestUtils;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Repository;
@@ -39,13 +39,13 @@ public class RepositoryLocatorTest {
         Keccak256 stateRoot = TestUtils.randomHash();
         when(stateRootHandler.translate(header)).thenReturn(stateRoot);
 
-        MutableTrie expectedMutableTrie = mock(MutableTrie.class);
-        MutableTrie mutableTrie = mock(MutableTrie.class);
-        when(mutableTrie.getSnapshotTo(stateRoot)).thenReturn(expectedMutableTrie);
-        when(repository.getMutableTrie()).thenReturn(mutableTrie);
+        Trie expectedTrie = mock(Trie.class);
+        Trie trie = mock(Trie.class);
+        when(trie.getSnapshotTo(stateRoot)).thenReturn(expectedTrie);
+        when(repository.getTrie()).thenReturn(trie);
 
         RepositoryLocator repositoryLocator = new RepositoryLocator(repository, stateRootHandler);
-        MutableTrie actualMutableTrie = repositoryLocator.snapshotAt(header).getMutableTrie();
-        assertSame(expectedMutableTrie, actualMutableTrie);
+        Trie actualTrie = repositoryLocator.snapshotAt(header).getTrie();
+        assertSame(expectedTrie, actualTrie);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryMigrationTest.java
@@ -34,7 +34,7 @@ public class RepositoryMigrationTest {
         Assert.assertThat(repository.getAccountState(COW).getNonce(), is(accountNonce));
 
         TrieConverter converter = new TrieConverter();
-        byte[] oldRoot = converter.getOrchidAccountTrieRoot(repository.getMutableTrie().getTrie());
+        byte[] oldRoot = converter.getOrchidAccountTrieRoot(repository.getTrie());
         // expected ab158b4a1d2411492194768fbd2669c069b60e5d0bcc859e51fe477855829ae7
         System.out.println(Hex.toHexString(oldRoot));
     }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackWithBenchmarking.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackWithBenchmarking.java
@@ -28,7 +28,7 @@ public class RepositoryTrackWithBenchmarking extends MutableRepository implement
     protected final Statistics statistics;
 
     public RepositoryTrackWithBenchmarking(Repository repository) {
-        super(new MutableTrieCache(repository.getMutableTrie()));
+        super(new MutableTrieCache(new MutableTrieImpl(repository.getTrie())));
         statistics = new Statistics();
     }
 

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryUpdateTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryUpdateTest.java
@@ -51,8 +51,9 @@ public class RepositoryUpdateTest {
 
         Repository repo = new MutableRepository(new MutableTrieCache(new MutableTrieImpl(new Trie())));
         updateContractDetails(repo, address, details);
+        repo.commit();
 
-        byte[] value = repo.getMutableTrie().get(DataWord.ONE.getData());
+        byte[] value = repo.getTrie().get(DataWord.ONE.getData());
 
         Assert.assertNull(value);
         Assert.assertEquals(0, details.getStorageSize());
@@ -66,8 +67,9 @@ public class RepositoryUpdateTest {
 
         Repository repo = new MutableRepository(new MutableTrieCache(new MutableTrieImpl(new Trie())));
         updateContractDetails(repo, address, details);
+        repo.commit();
 
-        byte[] value = repo.getMutableTrie().get(DataWord.ONE.getData());
+        byte[] value = repo.getTrie().get(DataWord.ONE.getData());
 
         Assert.assertNull(value);
         Assert.assertEquals(0, details.getStorageSize());
@@ -83,7 +85,7 @@ public class RepositoryUpdateTest {
         Repository repo = new MutableRepository(new MutableTrieImpl(new Trie()));
         updateContractDetails(repo, address, details);
 
-        Assert.assertNotNull(repo.getMutableTrie().getHash().getBytes());
+        Assert.assertNotNull(repo.getTrie().getHash().getBytes());
     }
 
     private static void updateContractDetails(Repository repository, RskAddress addr, ContractDetailsImpl contractDetails) {

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -113,7 +113,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         Repository track = mock(Repository.class);
         Mockito.doReturn(repository.getRoot()).when(track).getRoot();
-        Mockito.doReturn(repository.getMutableTrie()).when(track).getMutableTrie();
+        Mockito.doReturn(repository.getTrie()).when(track).getTrie();
         when(track.getNonce(tx1.getSender())).thenReturn(BigInteger.ZERO);
         when(track.getNonce(RemascTransaction.REMASC_ADDRESS)).thenReturn(BigInteger.ZERO);
         when(track.getBalance(tx1.getSender())).thenReturn(Coin.valueOf(4200000L));

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -118,8 +118,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
         when(track.getNonce(RemascTransaction.REMASC_ADDRESS)).thenReturn(BigInteger.ZERO);
         when(track.getBalance(tx1.getSender())).thenReturn(Coin.valueOf(4200000L));
         when(track.getBalance(RemascTransaction.REMASC_ADDRESS)).thenReturn(Coin.valueOf(4200000L));
-        Mockito.doReturn(track).when(repositoryLocator).snapshotAt(any());
-        Mockito.doReturn(track).when(repository).startTracking();
+        Mockito.doReturn(track).when(repositoryLocator).startTrackingAt(any());
         Mockito.doReturn(track).when(track).startTracking();
 
         List<Transaction> txs = new ArrayList<>(Collections.singletonList(tx1));

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -24,6 +24,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.*;
 import co.rsk.core.bc.*;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.db.StateRootHandler;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
@@ -239,14 +240,14 @@ public class TransactionModuleTest {
         return txInBlock;
     }
 
-    private String sendTransaction(Web3Impl web3, Repository repository) {
+    private String sendTransaction(Web3Impl web3, RepositoryReader repository) {
 
         Web3.CallArguments args = getTransactionParameters(web3, repository);
 
         return web3.eth_sendTransaction(args);
     }
 
-    private Web3.CallArguments getTransactionParameters(Web3Impl web3, Repository repository) {
+    private Web3.CallArguments getTransactionParameters(Web3Impl web3, RepositoryReader repository) {
         RskAddress addr1 = new RskAddress(ECKey.fromPrivate(Keccak256Helper.keccak256("cow".getBytes())).getAddress());
         String addr2 = web3.personal_newAccountWithSeed("addr2");
         BigInteger value = BigInteger.valueOf(7);

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -90,18 +90,18 @@ public class RskForksBridgeTest {
         Transaction releaseTx = buildReleaseTx();
         Block blockB1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB1));
-        repository = repositoryLocator.snapshotAt(blockB1.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB1.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB2 = buildBlock(blockB1);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB2));
-        repository = repositoryLocator.snapshotAt(blockB2.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
@@ -115,7 +115,7 @@ public class RskForksBridgeTest {
 
         Block blockA2 = buildBlock(blockA1, 6l, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA2));
-        repository = repositoryLocator.snapshotAt(blockA2.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockA2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB1 = buildBlock(blockBase, 1l, releaseTx);
@@ -129,7 +129,7 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, 10l, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
@@ -140,12 +140,12 @@ public class RskForksBridgeTest {
 
         Block blockB1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB1));
-        repository = repositoryLocator.snapshotAt(blockB1.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB1.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB2 = buildBlock(blockB1,6l);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB2));
-        repository = repositoryLocator.snapshotAt(blockB2.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockA1 = buildBlock(blockBase,1);
@@ -159,7 +159,7 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2,12, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 
@@ -169,12 +169,12 @@ public class RskForksBridgeTest {
 
         Block blockA1 = buildBlock(blockBase, releaseTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA1));
-        repository = repositoryLocator.snapshotAt(blockA1.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockA1.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockA2 = buildBlock(blockA1,3);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA2));
-        repository = repositoryLocator.snapshotAt(blockA2.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockA2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_SELECTION);
 
         Block blockB1 = buildBlock(blockBase,2);
@@ -188,7 +188,7 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2,6l, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.NO_TX);
     }
 
@@ -198,12 +198,12 @@ public class RskForksBridgeTest {
 
         Block blockA1 = buildBlock(blockBase, 4l);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA1));
-        repository = repositoryLocator.snapshotAt(blockA1.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockA1.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.NO_TX);
 
         Block blockA2 = buildBlock(blockA1, 5l);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockA2));
-        repository = repositoryLocator.snapshotAt(blockA2.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockA2.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.NO_TX);
 
         Block blockB1 = buildBlock(blockBase, 1l, releaseTx);
@@ -217,7 +217,7 @@ public class RskForksBridgeTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTx();
         Block blockB3 = buildBlock(blockB2, 10l, updateCollectionsTx);
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(blockB3));
-        repository = repositoryLocator.snapshotAt(blockB3.getHeader());
+        repository = repositoryLocator.startTrackingAt(blockB3.getHeader());
         assertReleaseTransactionState(ReleaseTransactionState.WAITING_FOR_CONFIRMATIONS);
     }
 

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -29,6 +29,7 @@ import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.db.StateRootHandler;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.PegTestUtils;
@@ -52,9 +53,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -117,7 +116,7 @@ public class RemascProcessMinerFeesTest {
         Blockchain blockchain = blockchainBuilder.setBlocks(blocks).build();
         RepositoryLocator repositoryLocator = blockchainBuilder.getRepositoryLocator();
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         assertNull(repository.getAccountState(coinbaseA));
     }
@@ -136,7 +135,7 @@ public class RemascProcessMinerFeesTest {
 
         executeBlocks(blockchain, blocks, blockExecutor);
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         assertEquals(cowInitialBalance.subtract(Coin.valueOf(minerFee+txValue)), repository.getAccountState(new RskAddress(cowAddress)).getBalance());
 
@@ -175,7 +174,7 @@ public class RemascProcessMinerFeesTest {
 
         executeBlocks(blockchain, blocks, blockExecutor);
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         assertEquals(cowInitialBalance.subtract(Coin.valueOf(minerFee+txValue)), repository.getAccountState(new RskAddress(cowAddress)).getBalance());
         assertEquals(Coin.valueOf(minerFee), repository.getAccountState(PrecompiledContracts.REMASC_ADDR).getBalance());
@@ -227,7 +226,7 @@ public class RemascProcessMinerFeesTest {
 
         executeBlocks(blockchain, blocks, blockExecutor);
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         assertEquals(cowInitialBalance.subtract(Coin.valueOf(minerFee+txValue)), repository.getAccountState(new RskAddress(cowAddress)).getBalance());
         assertEquals(Coin.valueOf(minerFee), repository.getAccountState(PrecompiledContracts.REMASC_ADDR).getBalance());
@@ -321,7 +320,7 @@ public class RemascProcessMinerFeesTest {
 
         executeBlocks(blockchain, blocks, blockExecutor);
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         // validate that the blockchain's and REMASC's initial states are correct
         Coin cowRemainingBalance = cowInitialBalance.subtract(Coin.valueOf(
@@ -447,7 +446,7 @@ public class RemascProcessMinerFeesTest {
 
         executeBlocks(blockchain, blocks, blockExecutor);
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         // validate that the blockchain's and REMASC's initial states are correct
         Coin cowRemainingBalance = cowInitialBalance.subtract(Coin.valueOf(minerFee * NUMBER_OF_TXS_WITH_FEES + txValue * NUMBER_OF_TXS_WITH_FEES));
@@ -525,7 +524,7 @@ public class RemascProcessMinerFeesTest {
         boolean isSuccessful = executeBlocks(blockchain, blocks, blockExecutor);
         assertTrue(isSuccessful);
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         // validate that the blockchain's and REMASC's initial states are correct
         Coin cowRemainingBalance = cowInitialBalance.subtract(Coin.valueOf(minerFee * NUMBER_OF_TXS_WITH_FEES + txValue * NUMBER_OF_TXS_WITH_FEES));
@@ -611,7 +610,7 @@ public class RemascProcessMinerFeesTest {
 
         executeBlocks(blockchain, blocks, blockExecutor);
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         assertEquals(cowInitialBalance.subtract(Coin.valueOf(minerFee+txValue)), repository.getAccountState(new RskAddress(cowAddress)).getBalance());
         assertEquals(Coin.valueOf(minerFee), repository.getAccountState(PrecompiledContracts.REMASC_ADDR).getBalance());
@@ -675,7 +674,7 @@ public class RemascProcessMinerFeesTest {
             blockchain.tryToConnect(b);
         }
 
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         assertEquals(cowInitialBalance.subtract(Coin.valueOf(minerFee+txValue)), repository.getAccountState(new RskAddress(cowAddress)).getBalance());
         assertEquals(Coin.valueOf(minerFee), repository.getAccountState(PrecompiledContracts.REMASC_ADDR).getBalance());
@@ -760,7 +759,7 @@ public class RemascProcessMinerFeesTest {
 
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         Block blockAtHeightSeven = blockchain.getBlockByNumber(8);
         assertEquals(Coin.valueOf(1680L - 17L), testRunner.getAccountBalance(blockAtHeightSeven.getCoinbase()));
@@ -790,7 +789,7 @@ public class RemascProcessMinerFeesTest {
 
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         Block blockAtHeightSix = blockchain.getBlockByNumber(7);
         assertEquals(Coin.valueOf(840L - 9L), testRunner.getAccountBalance(blockAtHeightSix.getCoinbase()));
@@ -826,7 +825,7 @@ public class RemascProcessMinerFeesTest {
 
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         Block blockAtHeightTwelve = blockchain.getBlockByNumber(13);
         assertEquals(Coin.valueOf(1680L - 17), testRunner.getAccountBalance(blockAtHeightTwelve.getCoinbase()));
@@ -865,7 +864,7 @@ public class RemascProcessMinerFeesTest {
 
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         Block blockAtHeightSix = blockchain.getBlockByNumber(7);
         // TODO Review value 18
@@ -909,7 +908,7 @@ public class RemascProcessMinerFeesTest {
 
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
         Block blockAtHeightSix = blockchain.getBlockByNumber(7);
         // TODO review value -20
@@ -953,8 +952,8 @@ public class RemascProcessMinerFeesTest {
         return accountsWithExpectedBalance;
     }
 
-    private void validateFederatorsBalanceIsCorrect(Repository repository, long federationReward, Block executionBlock) {
-        RemascFederationProvider provider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository, executionBlock);
+    private void validateFederatorsBalanceIsCorrect(RepositoryReader repository, long federationReward, Block executionBlock) {
+        RemascFederationProvider provider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), executionBlock);
 
         int nfederators = provider.getFederationSize();
 
@@ -965,7 +964,7 @@ public class RemascProcessMinerFeesTest {
         }
     }
 
-    private void validateAccountsCurrentBalanceIsCorrect(Repository repository, Coin cowBalance,
+    private void validateAccountsCurrentBalanceIsCorrect(RepositoryReader repository, Coin cowBalance,
                                                          Long remascBalance, Long rskBalance,
                                                          HashMap<byte[], Coin> otherAccountsBalance) {
 
@@ -989,8 +988,8 @@ public class RemascProcessMinerFeesTest {
         assertEquals(expectedBurnedBalance, provider.getBurnedBalance());
     }
 
-    private RemascStorageProvider getRemascStorageProvider(Repository repository) {
-        return new RemascStorageProvider(repository, PrecompiledContracts.REMASC_ADDR);
+    private RemascStorageProvider getRemascStorageProvider(RepositoryReader repository) {
+        return new RemascStorageProvider(repository.startTracking(), PrecompiledContracts.REMASC_ADDR);
     }
 
     private BlockExecutor buildBlockExecutor(Blockchain blockchain, RepositoryLocator repositoryLocator) {

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -25,10 +25,7 @@ import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockExecutor;
-import co.rsk.db.MutableTrieCache;
-import co.rsk.db.MutableTrieImpl;
-import co.rsk.db.RepositoryLocator;
-import co.rsk.db.StateRootHandler;
+import co.rsk.db.*;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.PegTestUtils;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
@@ -73,8 +70,8 @@ public class RemascStorageProviderTest {
         assertEquals(expectedBurnedBalance, provider.getBurnedBalance());
     }
 
-    private RemascStorageProvider getRemascStorageProvider(Repository repository) {
-        return new RemascStorageProvider(repository, PrecompiledContracts.REMASC_ADDR);
+    private RemascStorageProvider getRemascStorageProvider(RepositoryReader repository) {
+        return new RemascStorageProvider(repository.startTracking(), PrecompiledContracts.REMASC_ADDR);
     }
 
     private List<Block> createSimpleBlocks(Block parent, int size, RskAddress coinbase) {
@@ -230,7 +227,7 @@ public class RemascStorageProviderTest {
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(repository), Coin.valueOf(0), Coin.valueOf(0L), 1L);
     }
 
@@ -277,7 +274,7 @@ public class RemascStorageProviderTest {
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(repository), Coin.valueOf(84000), Coin.valueOf(0L), 0L);
     }
 
@@ -299,8 +296,8 @@ public class RemascStorageProviderTest {
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository, testRunner.getBlockChain().getBestBlock());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
         assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(repository).getFederationBalance());
         long federatorBalance = (168 / federationProvider.getFederationSize()) * 2;
         assertEquals(Coin.valueOf(federatorBalance), RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
@@ -326,8 +323,8 @@ public class RemascStorageProviderTest {
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository, testRunner.getBlockChain().getBestBlock());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
         assertEquals(Coin.valueOf(336), this.getRemascStorageProvider(repository).getFederationBalance());
         assertEquals(null, RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
     }
@@ -351,7 +348,7 @@ public class RemascStorageProviderTest {
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(repository), Coin.valueOf(126000), Coin.valueOf(0L), 0L);
     }
 
@@ -376,8 +373,8 @@ public class RemascStorageProviderTest {
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository, testRunner.getBlockChain().getBestBlock());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
         long federatorBalance = (1680 / federationProvider.getFederationSize()) * 2;
         assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(repository).getFederationBalance());
         assertEquals(Coin.valueOf(federatorBalance), RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
@@ -404,7 +401,7 @@ public class RemascStorageProviderTest {
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         this.validateRemascsStorageIsCorrect(this.getRemascStorageProvider(repository), Coin.valueOf(840000L), Coin.valueOf(0L), 0L);
     }
 
@@ -431,7 +428,6 @@ public class RemascStorageProviderTest {
         testRunner.start();
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         List<Block> blocks = new ArrayList<>();
         blocks.add(RemascTestRunner.createBlock(genesisBlock, blockchain.getBestBlock(), PegTestUtils.createHash3(),
                 coinbase, Collections.emptyList(), gasLimit, gasPrice, 14, txValue, cowKey, null));
@@ -469,7 +465,7 @@ public class RemascStorageProviderTest {
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock().getHeader());
             Assert.assertEquals(ImportResult.IMPORTED_BEST, blockchain.tryToConnect(b));
-            repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+            RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
             long blockNumber = blockchain.getBestBlock().getNumber();
             if (blockNumber == 24){ // before first special block

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -26,6 +26,7 @@ import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.crypto.Keccak256;
+import co.rsk.db.RepositoryReader;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.PegTestUtils;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
@@ -196,15 +197,15 @@ class RemascTestRunner {
     }
 
     public Coin getAccountBalance(RskAddress addr) {
-        Repository repository = builder.getRepositoryLocator().snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = builder.getRepositoryLocator().snapshotAt(blockchain.getBestBlock().getHeader());
         return getAccountBalance(repository, addr);
     }
 
-    public static Coin getAccountBalance(Repository repository, byte[] address) {
+    public static Coin getAccountBalance(RepositoryReader repository, byte[] address) {
         return getAccountBalance(repository, new RskAddress(address));
     }
 
-    public static Coin getAccountBalance(Repository repository, RskAddress addr) {
+    public static Coin getAccountBalance(RepositoryReader repository, RskAddress addr) {
         AccountState accountState = repository.getAccountState(addr);
 
         return accountState == null ? null : repository.getAccountState(addr).getBalance();

--- a/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
@@ -108,10 +108,10 @@ public class DslFilesTest {
         Block top2 = world.getBlockByName("b02b");
 
         // Creates a new view of the repository, standing on top1 state
-        Repository repo1 = new MutableRepository(world.getRepository().getMutableTrie().getSnapshotTo(new Keccak256(top1.getStateRoot())));
+        Repository repo1 = new MutableRepository(world.getRepository().getTrie().getSnapshotTo(new Keccak256(top1.getStateRoot())));
 
         // Creates a new view of the repository, standing on top2 state
-        Repository repo2 = new MutableRepository(world.getRepository().getMutableTrie().getSnapshotTo(new Keccak256(top2.getStateRoot())));
+        Repository repo2 = new MutableRepository(world.getRepository().getTrie().getSnapshotTo(new Keccak256(top2.getStateRoot())));
         // addr1: sender's account
         RskAddress addr1 = new RskAddress("a0663f719962ec10bb57865532bef522059dfd96");
         // addr2: Parent Contract account

--- a/rskj-core/src/test/java/co/rsk/test/builders/AccountBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/AccountBuilder.java
@@ -21,6 +21,7 @@ package co.rsk.test.builders;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.test.World;
 import org.ethereum.core.Account;
 import org.ethereum.core.Block;
@@ -74,7 +75,7 @@ public class AccountBuilder {
         if (blockChain != null) {
             Block best = blockChain.getStatus().getBestBlock();
             BlockDifficulty td = blockChain.getStatus().getTotalDifficulty();
-            Repository repository = repositoryLocator.snapshotAt(blockChain.getBestBlock().getHeader());
+            RepositoryReader repository = repositoryLocator.snapshotAt(blockChain.getBestBlock().getHeader());
 
             Repository track = repository.startTracking();
 

--- a/rskj-core/src/test/java/co/rsk/test/builderstest/AccountBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/builderstest/AccountBuilderTest.java
@@ -19,10 +19,10 @@
 package co.rsk.test.builderstest;
 
 import co.rsk.core.Coin;
+import co.rsk.db.RepositoryReader;
 import co.rsk.test.World;
 import co.rsk.test.builders.AccountBuilder;
 import org.ethereum.core.Account;
-import org.ethereum.core.Repository;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -52,7 +52,7 @@ public class AccountBuilderTest {
 
         Assert.assertNotNull(account);
         Assert.assertTrue(account.getEcKey().hasPrivKey());
-        Repository repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        RepositoryReader repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
         Assert.assertEquals(balance, repository.getBalance(account.getAddress()));
         Assert.assertArrayEquals(code, repository.getCode(account.getAddress()));
     }

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -25,6 +25,7 @@ import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.db.StateRootHandler;
 import co.rsk.net.NodeBlockProcessor;
 import co.rsk.test.World;
@@ -137,7 +138,7 @@ public class WorldDslProcessor {
         }
 
         BlockHeader bestBlock = world.getBlockChain().getBestBlock().getHeader();
-        Repository repository = world.getRepositoryLocator().snapshotAt(bestBlock);
+        RepositoryReader repository = world.getRepositoryLocator().snapshotAt(bestBlock);
         Coin accountBalance = repository.getBalance(accountAddress);
         if (expected.equals(accountBalance))
             return;

--- a/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
@@ -18,13 +18,13 @@
 
 package co.rsk.test.dsltest;
 
+import co.rsk.db.RepositoryReader;
 import co.rsk.test.World;
 import co.rsk.test.dsl.DslParser;
 import co.rsk.test.dsl.DslProcessorException;
 import co.rsk.test.dsl.WorldDslProcessor;
 import org.ethereum.core.Account;
 import org.ethereum.core.Block;
-import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.junit.Assert;
 import org.junit.Test;
@@ -269,7 +269,7 @@ public class WorldDslProcessorTest {
         Account account = world.getAccountByName("acc1");
 
         Assert.assertNotNull(account);
-        Repository repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        RepositoryReader repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
         Assert.assertEquals(new BigInteger("1000000"), repository.getBalance(account.getAddress()).asBigInteger());
     }
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieConverterTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieConverterTest.java
@@ -247,7 +247,7 @@ public class TrieConverterTest {
 
         track.commit();
         TrieConverter tc = new TrieConverter();
-        byte[] oldRoot = tc.getOrchidAccountTrieRoot(repository.getMutableTrie().getTrie());
+        byte[] oldRoot = tc.getOrchidAccountTrieRoot(repository.getTrie());
         Trie atrie = deserialize(SERIALIZED_ORCHID_TRIESTORE_WITH_LEADING_ZEROES_STORAGE_KEYS);
 
         Assert.assertThat(Hex.toHexString(oldRoot), is(atrie.getHashOrchid(true).toHexString()));
@@ -284,7 +284,7 @@ public class TrieConverterTest {
 
         track.commit();
         TrieConverter tc = new TrieConverter();
-        byte[] oldRoot = tc.getOrchidAccountTrieRoot(repository.getMutableTrie().getTrie());
+        byte[] oldRoot = tc.getOrchidAccountTrieRoot(repository.getTrie());
         Trie atrie = deserialize(SERIALIZED_ORCHID_TRIESTORE_SIMPLE);
 
         Assert.assertThat(Hex.toHexString(oldRoot), is(atrie.getHashOrchid(true).toHexString()));

--- a/rskj-core/src/test/java/co/rsk/vm/BlockchainVMTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/BlockchainVMTest.java
@@ -22,6 +22,7 @@ import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.test.World;
 import org.ethereum.config.Constants;
 import org.ethereum.core.*;
@@ -94,7 +95,7 @@ public class BlockchainVMTest {
         mh.completeBlock(block2, block1);
 
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockchain.tryToConnect(block2));
-        Repository repository = binfo.repositoryLocator.snapshotAt(block2.getHeader());
+        RepositoryReader repository = binfo.repositoryLocator.snapshotAt(block2.getHeader());
 
         Assert.assertEquals(blockchain.getBestBlock(), block2);
         Assert.assertEquals(2, block2.getNumber());

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -72,15 +72,10 @@ public class MinerHelper {
         totalPaidFees = Coin.ZERO;
         txReceipts = new ArrayList<>();
 
-        // This creates a snapshot WITHOUT history of the current "parent" reponsitory.
-        Repository originalRepo  = repositoryLocator.snapshotAt(parent.getHeader());
-
-        Repository track = originalRepo.startTracking();
-
-        // Repository track = new RepositoryTrack((Repository)ethereum.getRepository());
+        Repository track = repositoryLocator.startTrackingAt(parent.getHeader());
 
         // this variable is set before iterating transactions in case list is empty
-        latestStateRootHash = originalRepo.getRoot();
+        latestStateRootHash = track.getRoot();
 
         // RSK test, remove
         String stateHash1 = Hex.toHexString(blockchain.getBestBlock().getStateRoot());
@@ -123,7 +118,7 @@ public class MinerHelper {
             TransactionReceipt receipt = new TransactionReceipt();
             receipt.setGasUsed(gasUsed);
             receipt.setCumulativeGas(totalGasUsed);
-            latestStateRootHash = originalRepo.getRoot();
+            latestStateRootHash = track.getRoot();
             receipt.setPostTxState(latestStateRootHash);
             receipt.setTxStatus(executor.getReceipt().isSuccessful());
             receipt.setStatus(executor.getReceipt().getStatus());

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -4,6 +4,7 @@ import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositoryReader;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.TransactionBuilder;
@@ -64,20 +65,20 @@ public class ContractRunner {
         return createContract(bytecode, repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader()));
     }
 
-    private ProgramResult createContract(byte[] bytecode, Repository repository) {
+    private ProgramResult createContract(byte[] bytecode, RepositoryReader repository) {
         Transaction creationTx = contractCreateTx(bytecode, repository);
         return executeTransaction(creationTx, repository).getResult();
     }
 
     public ProgramResult createAndRunContract(byte[] bytecode, byte[] encodedCall, BigInteger value, boolean localCall) {
-        Repository repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
+        RepositoryReader repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
         createContract(bytecode, repository);
         Transaction creationTx = contractCreateTx(bytecode, repository);
         executeTransaction(creationTx, repository);
         return runContract(creationTx.getContractAddress().getBytes(), encodedCall, value, localCall, repository);
     }
 
-    private Transaction contractCreateTx(byte[] bytecode, Repository repository) {
+    private Transaction contractCreateTx(byte[] bytecode, RepositoryReader repository) {
         BigInteger nonceCreate = repository.getNonce(sender.getAddress());
         return new TransactionBuilder()
                 .gasLimit(BigInteger.valueOf(10_000_000))
@@ -87,7 +88,7 @@ public class ContractRunner {
                 .build();
     }
 
-    private ProgramResult runContract(byte[] contractAddress, byte[] encodedCall, BigInteger value, boolean localCall, Repository repository) {
+    private ProgramResult runContract(byte[] contractAddress, byte[] encodedCall, BigInteger value, boolean localCall, RepositoryReader repository) {
         BigInteger nonceExecute = repository.getNonce(sender.getAddress());
         Transaction transaction = new TransactionBuilder()
                 // a large gas limit will allow running any contract
@@ -102,10 +103,10 @@ public class ContractRunner {
         return executeTransaction(transaction, repository).getResult();
     }
 
-    private TransactionExecutor executeTransaction(Transaction transaction, Repository repository) {
+    private TransactionExecutor executeTransaction(Transaction transaction, RepositoryReader repository) {
         Repository track = repository.startTracking();
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(transaction, 0, RskAddress.nullAddress(), repository, blockchain.getBestBlock(), 0);
+                .newInstance(transaction, 0, RskAddress.nullAddress(), track, blockchain.getBestBlock(), 0);
         executor.init();
         executor.execute();
         executor.go();


### PR DESCRIPTION
Introduce `RepositoryReader` and use it everywhere possible (mostly through `RepositoryLocator#snapshotAt`)