### PR TITLE
Address issue where eth_call with 'pending' parameter would fail due to relying on an unupdated component

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
@@ -70,6 +70,15 @@ public class ExecutionBlockRetriever {
 
             Block bestBlock = blockchain.getBestBlock();
             if (cachedBlock == null || !bestBlock.isParentOf(cachedBlock)) {
+
+                // If the miner server is not running there is no one to update the mining mainchain view,
+                // thus breaking eth_call with 'pending' parameter
+                //
+                // This is just a provisional fix not intended to remain in the long run
+                if (!minerServer.isRunning()) {
+                    miningMainchainView.addBest(bestBlock.getHeader());
+                }
+
                 List<BlockHeader> mainchainHeaders = miningMainchainView.get();
                 cachedBlock = builder.build(mainchainHeaders, null);
             }


### PR DESCRIPTION
As of now, said component relies on the miner server to be updated. When the miner server is
disabled the component is not updated on new blocks which causes that when queried it returns
incomplete or inconsistent data.