### PR TITLE
Extend existing eth_getBlock methods to include merge mining fields

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -20,6 +20,7 @@ package co.rsk.rpc;
 
 import co.rsk.rpc.modules.eth.EthModule;
 import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.dto.BlockResultDTO;
 import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
@@ -100,9 +101,9 @@ public interface Web3EthModule {
         return getEthModule().sendTransaction(args);
     }
 
-    Web3.BlockResult eth_getBlockByHash(String blockHash, Boolean fullTransactionObjects) throws Exception;
+    BlockResultDTO eth_getBlockByHash(String blockHash, Boolean fullTransactionObjects) throws Exception;
 
-    Web3.BlockResult eth_getBlockByNumber(String bnOrId, Boolean fullTransactionObjects) throws Exception;
+    BlockResultDTO eth_getBlockByNumber(String bnOrId, Boolean fullTransactionObjects) throws Exception;
 
     TransactionResultDTO eth_getTransactionByHash(String transactionHash) throws Exception;
 
@@ -112,9 +113,9 @@ public interface Web3EthModule {
 
     TransactionReceiptDTO eth_getTransactionReceipt(String transactionHash) throws Exception;
 
-    Web3.BlockResult eth_getUncleByBlockHashAndIndex(String blockHash, String uncleIdx) throws Exception;
+    BlockResultDTO eth_getUncleByBlockHashAndIndex(String blockHash, String uncleIdx) throws Exception;
 
-    Web3.BlockResult eth_getUncleByBlockNumberAndIndex(String blockId, String uncleIdx) throws Exception;
+    BlockResultDTO eth_getUncleByBlockNumberAndIndex(String blockId, String uncleIdx) throws Exception;
 
     String[] eth_getCompilers();
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -60,53 +60,6 @@ public interface Web3 extends Web3TxPoolModule, Web3EthModule, Web3EvmModule, We
         public boolean inMainChain;
     }
 
-    class BlockResult {
-        public String number; // QUANTITY - the block number. null when its pending block.
-        public String hash; // DATA, 32 Bytes - hash of the block. null when its pending block.
-        public String parentHash; // DATA, 32 Bytes - hash of the parent block.
-        public String sha3Uncles; // DATA, 32 Bytes - SHA3 of the uncles data in the block.
-        public String logsBloom; // DATA, 256 Bytes - the bloom filter for the logs of the block. null when its pending block.
-        public String transactionsRoot; // DATA, 32 Bytes - the root of the transaction trie of the block.
-        public String stateRoot; // DATA, 32 Bytes - the root of the final state trie of the block.
-        public String receiptsRoot; // DATA, 32 Bytes - the root of the receipts trie of the block.
-        public String miner; // DATA, 20 Bytes - the address of the beneficiary to whom the mining rewards were given.
-        public String difficulty; // QUANTITY - integer of the difficulty for this block.
-        public String totalDifficulty; // QUANTITY - integer of the total difficulty of the chain until this block.
-        public String extraData; // DATA - the "extra data" field of this block
-        public String size;//QUANTITY - integer the size of this block in bytes.
-        public String gasLimit;//: QUANTITY - the maximum gas allowed in this block.
-        public String gasUsed; // QUANTITY - the total used gas by all transactions in this block.
-        public String timestamp; //: QUANTITY - the unix timestamp for when the block was collated.
-        public Object[] transactions; //: Array - Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
-        public String[] uncles; //: Array - Array of uncle hashes.
-        public String minimumGasPrice;
-
-        @Override
-        public String toString() {
-            return "BlockResult{" +
-                    "number='" + number + '\'' +
-                    ", hash='" + hash + '\'' +
-                    ", parentHash='" + parentHash + '\'' +
-                    ", sha3Uncles='" + sha3Uncles + '\'' +
-                    ", logsBloom='" + logsBloom + '\'' +
-                    ", transactionsRoot='" + transactionsRoot + '\'' +
-                    ", stateRoot='" + stateRoot + '\'' +
-                    ", receiptsRoot='" + receiptsRoot + '\'' +
-                    ", miner='" + miner + '\'' +
-                    ", difficulty='" + difficulty + '\'' +
-                    ", totalDifficulty='" + totalDifficulty + '\'' +
-                    ", extraData='" + extraData + '\'' +
-                    ", size='" + size + '\'' +
-                    ", gasLimit='" + gasLimit + '\'' +
-                    ", minimumGasPrice='" + minimumGasPrice + '\'' +
-                    ", gasUsed='" + gasUsed + '\'' +
-                    ", timestamp='" + timestamp + '\'' +
-                    ", transactions=" + Arrays.toString(transactions) +
-                    ", uncles=" + Arrays.toString(uncles) +
-                    '}';
-        }
-    }
-
     class FilterRequest {
         public String fromBlock;
         public String toBlock;

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
@@ -1,0 +1,226 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.rpc.dto;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Transaction;
+import org.ethereum.db.BlockStore;
+import org.ethereum.rpc.TypeConverter;
+
+import java.util.*;
+
+import static org.ethereum.rpc.TypeConverter.toJsonHex;
+
+public class BlockResultDTO {
+    private final String number; // QUANTITY - the block number. null when its pending block.
+    private final String hash; // DATA, 32 Bytes - hash of the block. null when its pending block.
+    private final String parentHash; // DATA, 32 Bytes - hash of the parent block.
+    private final String sha3Uncles; // DATA, 32 Bytes - SHA3 of the uncles data in the block.
+    private final String logsBloom; // DATA, 256 Bytes - the bloom filter for the logs of the block. null when its pending block.
+    private final String transactionsRoot; // DATA, 32 Bytes - the root of the transaction trie of the block.
+    private final String stateRoot; // DATA, 32 Bytes - the root of the final state trie of the block.
+    private final String receiptsRoot; // DATA, 32 Bytes - the root of the receipts trie of the block.
+    private final String miner; // DATA, 20 Bytes - the address of the beneficiary to whom the mining rewards were given.
+    private final String difficulty; // QUANTITY - integer of the difficulty for this block.
+    private final String totalDifficulty; // QUANTITY - integer of the total difficulty of the chain until this block.
+    private final String extraData; // DATA - the "extra data" field of this block
+    private final String size;//QUANTITY - integer the size of this block in bytes.
+    private final String gasLimit;//: QUANTITY - the maximum gas allowed in this block.
+    private final String gasUsed; // QUANTITY - the total used gas by all transactions in this block.
+    private final String timestamp; //: QUANTITY - the unix timestamp for when the block was collated.
+    private final List<Object> transactions; //: Array - Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
+    private final List<String> uncles; //: Array - Array of uncle hashes.
+    private final String minimumGasPrice;
+
+    public BlockResultDTO(
+            Long number,
+            Keccak256 hash,
+            Keccak256 parentHash,
+            byte[] sha3Uncles,
+            byte[] logsBloom,
+            byte[] transactionsRoot,
+            byte[] stateRoot,
+            byte[] receiptsRoot,
+            RskAddress miner,
+            BlockDifficulty difficulty,
+            BlockDifficulty totalDifficulty,
+            byte[] extraData,
+            int size,
+            byte[] gasLimit,
+            long gasUsed,
+            long timestamp,
+            Object[] transactions,
+            String[] uncles,
+            Coin minimumGasPrice) {
+        this.number = number != null ? TypeConverter.toJsonHex(number) : null;
+        this.hash = hash != null ? TypeConverter.toJsonHex(hash.getBytes()) : null;
+        this.parentHash = TypeConverter.toJsonHex(parentHash.getBytes());
+        this.sha3Uncles = TypeConverter.toJsonHex(sha3Uncles);
+        this.logsBloom = logsBloom != null ? TypeConverter.toJsonHex(logsBloom) : null;
+        this.transactionsRoot = TypeConverter.toJsonHex(transactionsRoot);
+        this.stateRoot = TypeConverter.toJsonHex(stateRoot);
+        this.receiptsRoot = TypeConverter.toJsonHex(receiptsRoot);
+        this.miner = miner != null ? TypeConverter.toJsonHex(miner.getBytes()) : null;
+        this.difficulty = TypeConverter.toJsonHex(difficulty.getBytes());
+
+        this.totalDifficulty = TypeConverter.toJsonHex(totalDifficulty.getBytes());
+        this.extraData = TypeConverter.toJsonHex(extraData);
+        this.size = TypeConverter.toJsonHex(size);
+        this.gasLimit = TypeConverter.toJsonHex(gasLimit);
+        this.gasUsed = TypeConverter.toJsonHex(gasUsed);
+        this.timestamp = TypeConverter.toJsonHex(timestamp);
+
+        this.transactions = Arrays.asList(transactions);
+        this.uncles = Arrays.asList(uncles);
+
+        this.minimumGasPrice = minimumGasPrice != null ? TypeConverter.toJsonHex(minimumGasPrice.getBytes()) : null;
+    }
+
+    public static BlockResultDTO fromBlock(Block b, boolean fullTx, BlockStore blockStore) {
+        if (b == null) {
+            return null;
+        }
+
+        byte[] mergeHeader = b.getBitcoinMergedMiningHeader();
+        boolean isPending = (mergeHeader == null || mergeHeader.length == 0) && !b.isGenesis();
+
+        Coin mgp = b.getMinimumGasPrice();
+
+        List<Object> transactions = new ArrayList<>();
+
+        if (fullTx) {
+            for (int i = 0; i < b.getTransactionsList().size(); i++) {
+                transactions.add(new TransactionResultDTO(b, i, b.getTransactionsList().get(i)));
+            }
+        } else {
+            for (Transaction tx : b.getTransactionsList()) {
+                transactions.add(tx.getHash().toJsonString());
+            }
+        }
+
+        List<String> uncles = new ArrayList<>();
+
+        for (BlockHeader header : b.getUncleList()) {
+            uncles.add(toJsonHex(header.getHash().getBytes()));
+        }
+
+        return new BlockResultDTO(
+                isPending ? null : b.getNumber(),
+                isPending ? null : b.getHash(),
+                b.getParentHash(),
+                b.getUnclesHash(),
+                isPending ? null : b.getLogBloom(),
+                b.getTxTrieRoot(),
+                b.getStateRoot(),
+                b.getReceiptsRoot(),
+                isPending ? null : b.getCoinbase(),
+                b.getDifficulty(),
+                blockStore.getTotalDifficultyForHash(b.getHash().getBytes()),
+                b.getExtraData(),
+                b.getEncoded().length,
+                b.getGasLimit(),
+                b.getGasUsed(),
+                b.getTimestamp(),
+                transactions.toArray(),
+                uncles.toArray(new String[uncles.size()]),
+                mgp == null ? null : mgp
+        );
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public String getParentHash() {
+        return parentHash;
+    }
+
+    public String getSha3Uncles() {
+        return sha3Uncles;
+    }
+
+    public String getLogsBloom() {
+        return logsBloom;
+    }
+
+    public String getTransactionsRoot() {
+        return transactionsRoot;
+    }
+
+    public String getStateRoot() {
+        return stateRoot;
+    }
+
+    public String getReceiptsRoot() {
+        return receiptsRoot;
+    }
+
+    public String getMiner() {
+        return miner;
+    }
+
+    public String getDifficulty() {
+        return difficulty;
+    }
+
+    public String getTotalDifficulty() {
+        return totalDifficulty;
+    }
+
+    public String getExtraData() {
+        return extraData;
+    }
+
+    public String getSize() {
+        return size;
+    }
+
+    public String getGasLimit() {
+        return gasLimit;
+    }
+
+    public String getGasUsed() {
+        return gasUsed;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public Object[] getTransactions() {
+        return transactions.toArray();
+    }
+
+    public String[] getUncles() {
+        return uncles.toArray(new String[uncles.size()]);
+    }
+
+    public String getMinimumGasPrice() {
+        return minimumGasPrice;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -44,6 +44,7 @@ import org.ethereum.db.BlockStore;
 import org.ethereum.rpc.LogFilterElement;
 import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.Web3Mocks;
+import org.ethereum.rpc.dto.BlockResultDTO;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.junit.Assert;
@@ -52,6 +53,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalLong;
 
 public class Web3RskImplTest {
 
@@ -152,33 +154,6 @@ public class Web3RskImplTest {
         callArguments.nonce = "0";
 
         Assert.assertEquals(callArguments.toString(), "CallArguments{from='0x1', to='0x2', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0'}");
-    }
-
-    @Test
-    public void web3_BlockResult_toString() {
-        Web3.BlockResult blockResult = new Web3.BlockResult();
-
-        blockResult.number = "number";
-        blockResult.hash = "hash";
-        blockResult.parentHash = "parentHash";
-        blockResult.sha3Uncles = "sha3Uncles";
-        blockResult.logsBloom = "logsBloom";
-        blockResult.transactionsRoot = "transactionsRoot";
-        blockResult.stateRoot = "stateRoot";
-        blockResult.receiptsRoot = "receiptsRoot";
-        blockResult.miner = "miner";
-        blockResult.difficulty = "difficulty";
-        blockResult.totalDifficulty = "totalDifficulty";
-        blockResult.extraData = "extraData";
-        blockResult.size = "size";
-        blockResult.gasLimit = "gasLimit";
-        blockResult.gasUsed = "gasUsed";
-        blockResult.timestamp = "timestamp";
-        blockResult.transactions = new Object[] {"tx1", "tx2"};
-        blockResult.uncles = new String[] {"uncle1", "uncle2"};
-        blockResult.minimumGasPrice = "minimumGasPrice";
-
-        Assert.assertEquals(blockResult.toString(), "BlockResult{number='number', hash='hash', parentHash='parentHash', sha3Uncles='sha3Uncles', logsBloom='logsBloom', transactionsRoot='transactionsRoot', stateRoot='stateRoot', receiptsRoot='receiptsRoot', miner='miner', difficulty='difficulty', totalDifficulty='totalDifficulty', extraData='extraData', size='size', gasLimit='gasLimit', minimumGasPrice='minimumGasPrice', gasUsed='gasUsed', timestamp='timestamp', transactions=[tx1, tx2], uncles=[uncle1, uncle2]}");
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -57,6 +57,7 @@ import org.ethereum.net.client.ConfigCapabilities;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.Simples.*;
+import org.ethereum.rpc.dto.BlockResultDTO;
 import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
@@ -607,19 +608,19 @@ public class Web3ImplTest {
         org.junit.Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, world.getBlockChain().tryToConnect(block1b));
         org.junit.Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block2b));
 
-        Web3.BlockResult bresult = web3.eth_getBlockByNumber("0x1", false);
+        BlockResultDTO bresult = web3.eth_getBlockByNumber("0x1", false);
 
         Assert.assertNotNull(bresult);
 
         String blockHash = "0x" + block1b.getHash();
-        org.junit.Assert.assertEquals(blockHash, bresult.hash);
+        org.junit.Assert.assertEquals(blockHash, bresult.getHash());
 
         bresult = web3.eth_getBlockByNumber("0x2", true);
 
         Assert.assertNotNull(bresult);
 
         blockHash = "0x" + block2b.getHash();
-        org.junit.Assert.assertEquals(blockHash, bresult.hash);
+        org.junit.Assert.assertEquals(blockHash, bresult.getHash());
     }
 
     @Test
@@ -663,11 +664,11 @@ public class Web3ImplTest {
         block1.setBitcoinMergedMiningHeader(new byte[] { 0x01 });
         org.junit.Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
 
-        Web3.BlockResult blockResult = web3.eth_getBlockByNumber("latest", false);
+        BlockResultDTO blockResult = web3.eth_getBlockByNumber("latest", false);
 
         Assert.assertNotNull(blockResult);
         String blockHash = TypeConverter.toJsonHex(block1.getHash().toString());
-        org.junit.Assert.assertEquals(blockHash, blockResult.hash);
+        org.junit.Assert.assertEquals(blockHash, blockResult.getHash());
     }
 
     @Test
@@ -682,11 +683,11 @@ public class Web3ImplTest {
                                         world.getBlockStore()).trieStore(world.getTrieStore()).parent(genesis).build();
         org.junit.Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
 
-        Web3.BlockResult blockResult = web3.eth_getBlockByNumber("earliest", false);
+        BlockResultDTO blockResult = web3.eth_getBlockByNumber("earliest", false);
 
         Assert.assertNotNull(blockResult);
         String blockHash = genesis.getHashJsonString();
-        org.junit.Assert.assertEquals(blockHash, blockResult.hash);
+        org.junit.Assert.assertEquals(blockHash, blockResult.getHash());
     }
 
     @Test
@@ -695,7 +696,7 @@ public class Web3ImplTest {
 
         Web3Impl web3 = createWeb3(world);
 
-        Web3.BlockResult blockResult = web3.eth_getBlockByNumber("0x1234", false);
+        BlockResultDTO blockResult = web3.eth_getBlockByNumber("0x1234", false);
 
         Assert.assertNull(blockResult);
     }
@@ -724,23 +725,23 @@ public class Web3ImplTest {
         String block1bHashString = "0x" + block1b.getHash();
         String block2bHashString = "0x" + block2b.getHash();
 
-        Web3.BlockResult bresult = web3.eth_getBlockByHash(block1HashString, false);
+        BlockResultDTO bresult = web3.eth_getBlockByHash(block1HashString, false);
 
         Assert.assertNotNull(bresult);
-        org.junit.Assert.assertEquals(block1HashString, bresult.hash);
-        org.junit.Assert.assertEquals("0x00", bresult.extraData);
-        org.junit.Assert.assertEquals(0, bresult.transactions.length);
-        org.junit.Assert.assertEquals(0, bresult.uncles.length);
+        org.junit.Assert.assertEquals(block1HashString, bresult.getHash());
+        org.junit.Assert.assertEquals("0x00", bresult.getExtraData());
+        org.junit.Assert.assertEquals(0, bresult.getTransactions().length);
+        org.junit.Assert.assertEquals(0, bresult.getUncles().length);
 
         bresult = web3.eth_getBlockByHash(block1bHashString, true);
 
         Assert.assertNotNull(bresult);
-        org.junit.Assert.assertEquals(block1bHashString, bresult.hash);
+        org.junit.Assert.assertEquals(block1bHashString, bresult.getHash());
 
         bresult = web3.eth_getBlockByHash(block2bHashString, true);
 
         Assert.assertNotNull(bresult);
-        org.junit.Assert.assertEquals(block2bHashString, bresult.hash);
+        org.junit.Assert.assertEquals(block2bHashString, bresult.getHash());
     }
 
     @Test
@@ -763,13 +764,13 @@ public class Web3ImplTest {
 
         String block1HashString = block1.getHashJsonString();
 
-        Web3.BlockResult bresult = web3.eth_getBlockByHash(block1HashString, true);
+        BlockResultDTO bresult = web3.eth_getBlockByHash(block1HashString, true);
 
         Assert.assertNotNull(bresult);
-        org.junit.Assert.assertEquals(block1HashString, bresult.hash);
-        org.junit.Assert.assertEquals(1, bresult.transactions.length);
-        org.junit.Assert.assertEquals(block1HashString, ((TransactionResultDTO) bresult.transactions[0]).blockHash);
-        org.junit.Assert.assertEquals(0, bresult.uncles.length);
+        org.junit.Assert.assertEquals(block1HashString, bresult.getHash());
+        org.junit.Assert.assertEquals(1, bresult.getTransactions().length);
+        org.junit.Assert.assertEquals(block1HashString, ((TransactionResultDTO) bresult.getTransactions()[0]).blockHash);
+        org.junit.Assert.assertEquals(0, bresult.getUncles().length);
     }
 
     @Test
@@ -792,13 +793,13 @@ public class Web3ImplTest {
 
         String block1HashString = block1.getHashJsonString();
 
-        Web3.BlockResult bresult = web3.eth_getBlockByHash(block1HashString, false);
+        BlockResultDTO bresult = web3.eth_getBlockByHash(block1HashString, false);
 
         Assert.assertNotNull(bresult);
-        org.junit.Assert.assertEquals(block1HashString, bresult.hash);
-        org.junit.Assert.assertEquals(1, bresult.transactions.length);
-        org.junit.Assert.assertEquals(tx.getHash().toJsonString(), bresult.transactions[0]);
-        org.junit.Assert.assertEquals(0, bresult.uncles.length );
+        org.junit.Assert.assertEquals(block1HashString, bresult.getHash());
+        org.junit.Assert.assertEquals(1, bresult.getTransactions().length);
+        org.junit.Assert.assertEquals(tx.getHash().toJsonString(), bresult.getTransactions()[0]);
+        org.junit.Assert.assertEquals(0, bresult.getUncles().length);
     }
 
     @Test
@@ -807,7 +808,7 @@ public class Web3ImplTest {
 
         Web3Impl web3 = createWeb3(world);
 
-        Web3.BlockResult blockResult = web3.eth_getBlockByHash("0x1234000000000000000000000000000000000000000000000000000000000000", false);
+        BlockResultDTO blockResult = web3.eth_getBlockByHash("0x1234000000000000000000000000000000000000000000000000000000000000", false);
 
         Assert.assertNull(blockResult);
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -21,7 +21,10 @@ package org.ethereum.rpc;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.*;
-import co.rsk.core.bc.*;
+import co.rsk.core.bc.BlockChainImpl;
+import co.rsk.core.bc.MiningMainchainView;
+import co.rsk.core.bc.MiningMainchainViewImpl;
+import co.rsk.core.bc.TransactionPoolImpl;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
@@ -644,11 +647,14 @@ public class Web3ImplTest {
 
         Web3.BlockInformationResult[] bresult = web3.eth_getBlocksByNumber("0x1");
 
+        String hashBlock1String = block1.getHashJsonString();
+        String hashBlock1bString = block1b.getHashJsonString();
+
         Assert.assertNotNull(bresult);
 
         org.junit.Assert.assertEquals(2, bresult.length);
-        org.junit.Assert.assertEquals(block1.getHashJsonString(), bresult[0].hash);
-        org.junit.Assert.assertEquals(block1b.getHashJsonString(), bresult[1].hash);
+        org.junit.Assert.assertEquals(hashBlock1String, bresult[0].hash);
+        org.junit.Assert.assertEquals(hashBlock1bString, bresult[1].hash);
     }
 
     @Test
@@ -686,6 +692,7 @@ public class Web3ImplTest {
         BlockResultDTO blockResult = web3.eth_getBlockByNumber("earliest", false);
 
         Assert.assertNotNull(blockResult);
+
         String blockHash = genesis.getHashJsonString();
         org.junit.Assert.assertEquals(blockHash, blockResult.getHash());
     }
@@ -730,8 +737,8 @@ public class Web3ImplTest {
         Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block1HashString, bresult.getHash());
         org.junit.Assert.assertEquals("0x00", bresult.getExtraData());
-        org.junit.Assert.assertEquals(0, bresult.getTransactions().length);
-        org.junit.Assert.assertEquals(0, bresult.getUncles().length);
+        org.junit.Assert.assertEquals(0, bresult.getTransactions().size());
+        org.junit.Assert.assertEquals(0, bresult.getUncles().size());
 
         bresult = web3.eth_getBlockByHash(block1bHashString, true);
 
@@ -768,9 +775,9 @@ public class Web3ImplTest {
 
         Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block1HashString, bresult.getHash());
-        org.junit.Assert.assertEquals(1, bresult.getTransactions().length);
-        org.junit.Assert.assertEquals(block1HashString, ((TransactionResultDTO) bresult.getTransactions()[0]).blockHash);
-        org.junit.Assert.assertEquals(0, bresult.getUncles().length);
+        org.junit.Assert.assertEquals(1, bresult.getTransactions().size());
+        org.junit.Assert.assertEquals(block1HashString, ((TransactionResultDTO) bresult.getTransactions().get(0)).blockHash);
+        org.junit.Assert.assertEquals(0, bresult.getUncles().size());
     }
 
     @Test
@@ -797,9 +804,9 @@ public class Web3ImplTest {
 
         Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block1HashString, bresult.getHash());
-        org.junit.Assert.assertEquals(1, bresult.getTransactions().length);
-        org.junit.Assert.assertEquals(tx.getHash().toJsonString(), bresult.getTransactions()[0]);
-        org.junit.Assert.assertEquals(0, bresult.getUncles().length);
+        org.junit.Assert.assertEquals(1, bresult.getTransactions().size());
+        org.junit.Assert.assertEquals(tx.getHash().toJsonString(), bresult.getTransactions().get(0));
+        org.junit.Assert.assertEquals(0, bresult.getUncles().size());
     }
 
     @Test


### PR DESCRIPTION
This PR aims to include the merge mining related fields to the responses from rpc methods such as `eth_getBlockByHash` or `eth_getBlockByNumber`.

Said fields are:
 * `bitcoinMergeMiningHeader`: the bitcoin header which serves as proof of work for the rsk block
 * `bitcoinMergedMiningCoinbaseTransaction`: the bitcoin block coinbase transaction which links the btc block with the rsk block
 * `bitcoinMergedMiningMerkleProof`: the bitcoin block coinbase's SPV
 * `hashForMergedMining`: the rsk mining hash used to link the btc and rsk blocks through the coinbase

For more information about these fields refer to the [wiki](https://github.com/rsksmart/rskj/wiki/Merged-Mining) 