### PR TITLE
Support multiple addresses from Amazon checkip service

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
@@ -440,14 +441,15 @@ public abstract class SystemProperties {
 
     private String getMyPublicIpFromRemoteService(){
         try {
-            logger.info("Public IP wasn't set or resolved, using checkip.amazonaws.com to identify it...");
+            URL ipCheckService = publicIpCheckService();
+            logger.info("Public IP wasn't set or resolved, using {} to identify it...", ipCheckService);
 
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(new URL("http://checkip.amazonaws.com").openStream()))) {
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(ipCheckService.openStream()))) {
                 publicIp = in.readLine();
             }
 
             if (publicIp == null || publicIp.trim().isEmpty()) {
-                logger.warn("Unable to retrieve public IP from checkip.amazonaws.com {}.", publicIp);
+                logger.warn("Unable to retrieve public IP from {} {}.", ipCheckService, publicIp);
                 throw new IOException("Invalid address: '" + publicIp + "'");
             }
 
@@ -467,6 +469,10 @@ public abstract class SystemProperties {
         publicIp = bindAddress;
 
         return publicIp;
+    }
+
+    private URL publicIpCheckService() throws MalformedURLException {
+        return new URL(configFromFiles.getString("public.ipCheckService"));
     }
 
     public boolean isSyncEnabled() {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -123,7 +123,7 @@ public {
     # ip = google.com
 
     # The URL of a service returning our own public IP as the response body
-    ipCheckService = "http://checkip.amazonaws.com"
+    ipCheckService = "https://checkip.amazonaws.com"
 }
 
 # the number of blocks should pass before pending transaction is removed

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -117,10 +117,14 @@ database {
 # Interface to bind peer discovery and wire protocol
 bind_address = 0.0.0.0
 
-# public IP/hostname which is reported as our host during discovery
-# if not set, the service http://checkip.amazonaws.com is used.
-# bind.address is the last resort for public ip when it cannot be obtained by other ways
-# public.ip = google.com
+public {
+    # public IP/hostname which is reported as our host during discovery.
+    # if not set, the ipCheckService URL is used.
+    # ip = google.com
+
+    # The URL of a service returning our own public IP as the response body
+    ipCheckService = "http://checkip.amazonaws.com"
+}
 
 # the number of blocks should pass before pending transaction is removed
 transaction.outdated.threshold = 10

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -122,7 +122,8 @@ public {
     # if not set, the ipCheckService URL is used.
     # ip = google.com
 
-    # The URL of a service returning our own public IP as the response body
+    # The URL of a service returning our own public IP as the response body.
+    # If multiple IPs are returned separated by commas (e.g Amazon returns X-Forwarded-For values) the last one is used
     ipCheckService = "https://checkip.amazonaws.com"
 }
 


### PR DESCRIPTION
Fixes #633.

To verify the service response:

```
$ curl --header "X-Forwarded-For: 192.168.0.2" checkip.amazonaws.com                                                rskj/git/checkip_fix
192.168.0.2, <YOUR IP WILL BE HERE>
```