### PR TITLE
Support unitrie migration after Wasabi activation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -327,6 +327,10 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getLong("database.unitrie-migration.minimum-height");
     }
 
+    public long getDatabaseMigrationMaximumHeight() {
+        return configFromFiles.getLong("database.unitrie-migration.maximum-height");
+    }
+
     public URL getDatabaseMissingStorageKeysUrl() {
         String missingKeysUrl = configFromFiles.getString("database.unitrie-migration.missing-keys-url");
         try {

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -576,6 +576,24 @@ public class IndexedBlockStore implements BlockStore {
     }
 
     /**
+     * Deletes from disk storage all blocks with number strictly larger than blockNumber.
+     * Note that this doesn't clean the caches, making it unsuitable for using after initialization.
+     */
+    public void rewind(long blockNumber) {
+        long maxNumber = getMaxNumber();
+        for (long i = maxNumber; i > blockNumber; i--) {
+            List<BlockInfo> blockInfos = index.remove(i);
+            if (blockInfos == null) {
+                continue;
+            }
+
+            for (BlockInfo blockInfo : blockInfos) {
+                this.blocks.delete(blockInfo.getHash().getBytes());
+            }
+        }
+    }
+
+    /**
      * When a block is processed on remasc the contract needs to calculate all siblings that
      * that should be rewarded when fees on this block are paid
      * @param block the block is looked for siblings

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -57,6 +57,7 @@ database {
     dir = ${user.home}/.rsk/mainnet/database
     unitrie-migration {
         minimum-height: 800000
+        maximum-height: 1590999
     }
 }
 

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -112,6 +112,7 @@ database {
     reset = false
     unitrie-migration {
         minimum-height: 0
+        maximum-height: 0
         missing-keys-url: "https://github.com/rsksmart/unitrie-migration/blob/master/migration-extras?raw=true"
     }
 }


### PR DESCRIPTION
This is intended to be released in v1.0.2 to support the case where a miner keeps producing Orchid blocks after Wasabi activation.