### PR TITLE
Added method isMember on Federation class and unit tests for it.

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
  *
  * @author Ariel Mendelzon
  */
+
 public final class Federation {
     private final List<FederationMember> members;
     private final Instant creationTime;
@@ -141,6 +142,10 @@ public final class Federation {
     public boolean hasMemberWithRskAddress(byte[] address) {
         return members.stream()
                 .anyMatch(m -> Arrays.equals(m.getRskPublicKey().getAddress(), address));
+    }
+
+    public boolean isMember(FederationMember federationMember){
+        return this.members.contains(federationMember);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -126,22 +126,22 @@ public final class FederationMember {
         this.mstPublicKey = ECKey.fromPublicOnly(mstPublicKey.getPubKey(true));
     }
 
-    BtcECKey getBtcPublicKey() {
+    public BtcECKey getBtcPublicKey() {
         // Return a copy
         return BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
     }
 
-    ECKey getRskPublicKey() {
+    public ECKey getRskPublicKey() {
         // Return a copy
         return ECKey.fromPublicOnly(rskPublicKey.getPubKey());
     }
 
-    ECKey getMstPublicKey() {
+    public ECKey getMstPublicKey() {
         // Return a copy
         return ECKey.fromPublicOnly(mstPublicKey.getPubKey());
     }
 
-    ECKey getPublicKey(KeyType keyType) {
+    public ECKey getPublicKey(KeyType keyType) {
         switch (keyType) {
             case RSK:
                 return getRskPublicKey();


### PR DESCRIPTION
Previously we used to check only for btcPublicKeys. Now that we have multiple keys, we are checking also rskPubKeys.

*fed:added-ismember*