### PR TITLE
Add support for non genesis starting block index

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -24,6 +24,7 @@ import co.rsk.config.*;
 import co.rsk.core.*;
 import co.rsk.core.bc.*;
 import co.rsk.crypto.Keccak256;
+import co.rsk.db.MapDBBlocksIndex;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.StateRootHandler;
 import co.rsk.logfilter.BlocksBloomStore;
@@ -101,7 +102,6 @@ import org.ethereum.vm.program.invoke.ProgramInvokeFactory;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
-import org.mapdb.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,11 +112,7 @@ import java.nio.file.Path;
 import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
-
-import static org.ethereum.db.IndexedBlockStore.BLOCK_INFO_SERIALIZER;
-
 
 /**
  * Creates the initial object graph without a DI framework.
@@ -1462,15 +1458,9 @@ public class RskContext implements NodeBootstrapper {
                 .closeOnJvmShutdown()
                 .make();
 
-        Map<Long, List<IndexedBlockStore.BlockInfo>> indexMap = indexDB.hashMapCreate("index")
-                .keySerializer(Serializer.LONG)
-                .valueSerializer(BLOCK_INFO_SERIALIZER)
-                .counterEnable()
-                .makeOrGet();
-
         KeyValueDataSource blocksDB = makeDataSource("blocks", databaseDir);
 
-        return new IndexedBlockStore(getBlockFactory(), indexMap, blocksDB, indexDB);
+        return new IndexedBlockStore(getBlockFactory(), blocksDB, new MapDBBlocksIndex(indexDB));
     }
 
     public static KeyValueDataSource makeDataSource(String name, String databaseDir) {

--- a/rskj-core/src/main/java/co/rsk/db/BlocksIndex.java
+++ b/rskj-core/src/main/java/co/rsk/db/BlocksIndex.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.db;
+
+import org.ethereum.db.IndexedBlockStore;
+
+import java.util.List;
+
+/**
+ * BlocksIndex handles block accesses by their block number.
+ * <p>
+ * Many different blocks might contain the same block number but only one of the belongs to the main chain.
+ * (The one with the most difficulty)
+ * <p>
+ * The blocks themselves are not stored, only the smallest information required to access them by hash.
+ */
+public interface BlocksIndex {
+    /**
+     * Retrieves the max block number stored in the index. It might not belong to the main chain.
+     *
+     * @return The max block number if it exists, -1 if not.
+     */
+    long getMaxNumber();
+
+    /**
+     * Checks if a block number was stored previously.
+     *
+     * @return True iif there's at least one block stored with that number.
+     */
+    boolean contains(long blockNumber);
+
+    /**
+     * Retrieves a list in no particular order of the stored blocks that go by that number.
+     *
+     * @return A list containing the found blocks.
+     */
+    List<IndexedBlockStore.BlockInfo> getBlocksByNumber(long blockNumber);
+
+    /**
+     * Stores a list of blocks by their number, overwriting the previous existing ones.
+     *
+     * @param blocks A non null, non empty list of blocks.
+     */
+    void putBlocks(long blockNumber, List<IndexedBlockStore.BlockInfo> blocks);
+
+    /**
+     * Removes the blocks from the storage.
+     *
+     * @return The removed blocks.
+     */
+    List<IndexedBlockStore.BlockInfo> removeBlocksByNumber(long blockNumber);
+
+    /**
+     * Commits the changes to the underlying permanent storage.
+     */
+    void flush();
+}

--- a/rskj-core/src/main/java/co/rsk/db/BlocksIndex.java
+++ b/rskj-core/src/main/java/co/rsk/db/BlocksIndex.java
@@ -30,6 +30,7 @@ import java.util.List;
  * <p>
  * The blocks themselves are not stored, only the smallest information required to access them by hash.
  */
+//TODO(im): Better public methods, this storage should enforce its own invariants.
 public interface BlocksIndex {
     /**
      * Retrieves the max block number stored in the index. It might not belong to the main chain.
@@ -60,11 +61,11 @@ public interface BlocksIndex {
     void putBlocks(long blockNumber, List<IndexedBlockStore.BlockInfo> blocks);
 
     /**
-     * Removes the blocks from the storage.
+     * Removes the blocks with the highest block number from the storage.
      *
      * @return The removed blocks.
      */
-    List<IndexedBlockStore.BlockInfo> removeBlocksByNumber(long blockNumber);
+    List<IndexedBlockStore.BlockInfo> removeLast();
 
     /**
      * Commits the changes to the underlying permanent storage.

--- a/rskj-core/src/main/java/co/rsk/db/MapDBBlocksIndex.java
+++ b/rskj-core/src/main/java/co/rsk/db/MapDBBlocksIndex.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.db;
+
+import org.ethereum.db.IndexedBlockStore;
+import org.mapdb.DB;
+import org.mapdb.Serializer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.ethereum.db.IndexedBlockStore.BLOCK_INFO_SERIALIZER;
+
+/**
+ * MapDBBlocksIndex is a thread safe implementation of BlocksIndex with mapDB providing the underlying functionality.
+ */
+public class MapDBBlocksIndex implements BlocksIndex {
+
+    private final Map<Long, List<IndexedBlockStore.BlockInfo>> index;
+    private final DB indexDB;
+
+    public MapDBBlocksIndex(DB indexDB) {
+        index = indexDB.hashMapCreate("index")
+                .keySerializer(Serializer.LONG)
+                .valueSerializer(BLOCK_INFO_SERIALIZER)
+                .counterEnable()
+                .makeOrGet();
+        this.indexDB = indexDB;
+    }
+
+    //TODO (im): This implementation is a hacky solution which wont work without having the full block chain in the
+    // index. The max number should be either stored in a permanent storage and updated or calculated when initializing
+    // the index.
+    @Override
+    public long getMaxNumber() {
+        return (long)index.size() - 1L;
+    }
+
+    @Override
+    public boolean contains(long blockNumber) {
+        return index.containsKey(blockNumber);
+    }
+
+    @Override
+    public List<IndexedBlockStore.BlockInfo> getBlocksByNumber(long blockNumber) {
+        return index.getOrDefault(blockNumber, new ArrayList<>());
+    }
+
+    @Override
+    public void putBlocks(long blockNumber, List<IndexedBlockStore.BlockInfo> blocks) {
+        index.put(blockNumber, blocks);
+    }
+
+    @Override
+    public List<IndexedBlockStore.BlockInfo> removeBlocksByNumber(long blockNumber) {
+        List<IndexedBlockStore.BlockInfo> result = index.remove(blockNumber);
+        if (result == null) {
+            result = new ArrayList<>();
+        }
+        return result;
+    }
+
+    @Override
+    public void flush() {
+        indexDB.commit();
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -497,10 +497,7 @@ public class IndexedBlockStore implements BlockStore {
     public void rewind(long blockNumber) {
         long maxNumber = getMaxNumber();
         for (long i = maxNumber; i > blockNumber; i--) {
-            List<BlockInfo> blockInfos = index.removeBlocksByNumber(i);
-            if (blockInfos == null) {
-                continue;
-            }
+            List<BlockInfo> blockInfos = index.removeLast();
 
             for (BlockInfo blockInfo : blockInfos) {
                 this.blocks.delete(blockInfo.getHash().getBytes());
@@ -526,6 +523,7 @@ public class IndexedBlockStore implements BlockStore {
                     )
                 );
     }
+
 
     public static class BlockInfo implements Serializable {
         private static final long serialVersionUID = 5906746360128478753L;
@@ -557,7 +555,6 @@ public class IndexedBlockStore implements BlockStore {
         public void setMainChain(boolean mainChain) {
             this.mainChain = mainChain;
         }
-
     }
 
 

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -21,6 +21,7 @@ package org.ethereum.db;
 
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
+import co.rsk.db.BlocksIndex;
 import co.rsk.metrics.profilers.Metric;
 import co.rsk.metrics.profilers.Profiler;
 import co.rsk.metrics.profilers.ProfilerFactory;
@@ -32,7 +33,6 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.datasource.KeyValueDataSource;
-import org.mapdb.DB;
 import org.mapdb.DataIO;
 import org.mapdb.Serializer;
 import org.slf4j.Logger;
@@ -56,19 +56,16 @@ public class IndexedBlockStore implements BlockStore {
     private final BlockCache blockCache;
     private final MaxSizeHashMap<Keccak256, Map<Long, List<Sibling>>> remascCache;
 
-    private final Map<Long, List<BlockInfo>> index;
-    private final DB indexDB;
+    private final BlocksIndex index;
     private final KeyValueDataSource blocks;
     private final BlockFactory blockFactory;
 
     public IndexedBlockStore(
             BlockFactory blockFactory,
-            Map<Long, List<BlockInfo>> index,
             KeyValueDataSource blocks,
-            DB indexDB) {
+            BlocksIndex index) {
         this.index = index;
         this.blocks = blocks;
-        this.indexDB  = indexDB;
         this.blockFactory = blockFactory;
         //TODO(lsebrie): move these maps creation outside blockstore,
         // remascCache should be an external component and not be inside blockstore
@@ -82,7 +79,7 @@ public class IndexedBlockStore implements BlockStore {
         this.remascCache.remove(block.getHash());
         this.blocks.delete(block.getHash().getBytes());
 
-        List<BlockInfo> binfos = this.index.get(block.getNumber());
+        List<BlockInfo> binfos = this.index.getBlocksByNumber(block.getNumber());
 
         if (binfos == null) {
             return;
@@ -127,7 +124,8 @@ public class IndexedBlockStore implements BlockStore {
     public byte[] getBlockHashByNumber(long blockNumber, byte[] branchBlockHash) {
         Block branchBlock = getBlockByHash(branchBlockHash);
         if (branchBlock.getNumber() < blockNumber) {
-            throw new IllegalArgumentException("Requested block number > branch hash number: " + blockNumber + " < " + branchBlock.getNumber());
+            throw new IllegalArgumentException(String.format("Requested block number > branch hash number: %d < %d",
+                    blockNumber, branchBlock.getNumber()));
         }
         while(branchBlock.getNumber() > blockNumber) {
             branchBlock = getBlockByHash(branchBlock.getParentHash().getBytes());
@@ -178,7 +176,7 @@ public class IndexedBlockStore implements BlockStore {
     }
 
     public boolean isBlockInMainChain(long blockNumber, Keccak256 blockHash){
-        List<BlockInfo> blockInfos = index.get(blockNumber);
+        List<BlockInfo> blockInfos = index.getBlocksByNumber(blockNumber);
         if (blockInfos == null) {
             return false;
         }
@@ -195,21 +193,13 @@ public class IndexedBlockStore implements BlockStore {
     @Override
     public synchronized void flush() {
         Metric metric = profiler.start(Profiler.PROFILING_TYPE.DB_WRITE);
-        
-        //long t1 = System.nanoTime();
-        if (indexDB != null) {
-            indexDB.commit();
-        }
-        //long t2 = System.nanoTime(); logger.info("Flush block store in: {} ms", ((float)(t2 - t1) / 1_000_000));
+        index.flush();
         profiler.stop(metric);
     }
 
     @Override
     public synchronized void saveBlock(Block block, BlockDifficulty cummDifficulty, boolean mainChain) {
-        List<BlockInfo> blockInfos = index.get(block.getNumber());
-        if (blockInfos == null) {
-            blockInfos = new ArrayList<>();
-        }
+        List<BlockInfo> blockInfos = index.getBlocksByNumber(block.getNumber());
 
         BlockInfo blockInfo = null;
         for (BlockInfo bi : blockInfos) {
@@ -231,7 +221,8 @@ public class IndexedBlockStore implements BlockStore {
         if (blocks.get(block.getHash().getBytes()) == null) {
             blocks.put(block.getHash().getBytes(), block.getEncoded());
         }
-        index.put(block.getNumber(), blockInfos);
+
+        index.putBlocks(block.getNumber(), blockInfos);
         blockCache.addBlock(block);
         remascCache.put(block.getHash(), getSiblingsFromBlock(block));
     }
@@ -240,11 +231,7 @@ public class IndexedBlockStore implements BlockStore {
     public synchronized List<BlockInformation> getBlocksInformationByNumber(long number) {
         List<BlockInformation> result = new ArrayList<>();
 
-        List<BlockInfo> blockInfos = index.get(number);
-
-        if (blockInfos == null) {
-            return result;
-        }
+        List<BlockInfo> blockInfos = index.getBlocksByNumber(number);
 
         for (BlockInfo blockInfo : blockInfos) {
             byte[] hash = blockInfo.getHash().copy().getBytes();
@@ -259,13 +246,9 @@ public class IndexedBlockStore implements BlockStore {
 
     @Override
     public synchronized Block getChainBlockByNumber(long number){
-        List<BlockInfo> blockInfos = index.get(number);
-        if (blockInfos == null) {
-            return null;
-        }
+        List<BlockInfo> blockInfos = index.getBlocksByNumber(number);
 
         for (BlockInfo blockInfo : blockInfos) {
-
             if (blockInfo.isMainChain()) {
 
                 byte[] hash = blockInfo.getHash().getBytes();
@@ -321,12 +304,8 @@ public class IndexedBlockStore implements BlockStore {
             return ZERO;
         }
 
-        Long level  =  block.getNumber();
-        List<BlockInfo> blockInfos =  index.get(level);
-
-        if (blockInfos == null) {
-            return ZERO;
-        }
+        long level = block.getNumber();
+        List<BlockInfo> blockInfos =  index.getBlocksByNumber(level);
 
         for (BlockInfo blockInfo : blockInfos) {
             if (Arrays.equals(blockInfo.getHash().getBytes(), hash)) {
@@ -338,8 +317,8 @@ public class IndexedBlockStore implements BlockStore {
     }
 
     @Override
-    public synchronized long getMaxNumber() {
-        return (long)index.size() - 1L;
+    public long getMaxNumber() {
+        return index.getMaxNumber();
     }
 
     @Override
@@ -389,12 +368,12 @@ public class IndexedBlockStore implements BlockStore {
         if (forkBlock.getNumber() > bestBlock.getNumber()) {
 
             while(currentLevel > bestBlock.getNumber()) {
-                List<BlockInfo> blocks = index.get(currentLevel);
+                List<BlockInfo> blocks = index.getBlocksByNumber(currentLevel);
                 BlockInfo blockInfo = getBlockInfoForHash(blocks, forkLine.getHash().getBytes());
                 if (blockInfo != null) {
                     blockInfo.setMainChain(true);
-                    if (index.containsKey(currentLevel)) {
-                        index.put(currentLevel, blocks);
+                    if (index.contains(currentLevel)) {
+                        index.putBlocks(currentLevel, blocks);
                     }
                 }
                 forkLine = getBlockByHash(forkLine.getParentHash().getBytes());
@@ -406,12 +385,12 @@ public class IndexedBlockStore implements BlockStore {
         if (bestBlock.getNumber() > forkBlock.getNumber()){
 
             while(currentLevel > forkBlock.getNumber()) {
-                List<BlockInfo> blocks =  index.get(currentLevel);
+                List<BlockInfo> blocks =  index.getBlocksByNumber(currentLevel);
                 BlockInfo blockInfo = getBlockInfoForHash(blocks, bestLine.getHash().getBytes());
                 if (blockInfo != null) {
                     blockInfo.setMainChain(false);
-                    if (index.containsKey(currentLevel)) {
-                        index.put(currentLevel, blocks);
+                    if (index.contains(currentLevel)) {
+                        index.putBlocks(currentLevel, blocks);
                     }
                 }
                 bestLine = getBlockByHash(bestLine.getParentHash().getBytes());
@@ -422,20 +401,20 @@ public class IndexedBlockStore implements BlockStore {
         // 2. Loop back on each level until common block
         while( !bestLine.isEqual(forkLine) ) {
 
-            List<BlockInfo> levelBlocks = index.get(currentLevel);
+            List<BlockInfo> levelBlocks = index.getBlocksByNumber(currentLevel);
             BlockInfo bestInfo = getBlockInfoForHash(levelBlocks, bestLine.getHash().getBytes());
             if (bestInfo != null) {
                 bestInfo.setMainChain(false);
-                if (index.containsKey(currentLevel)) {
-                    index.put(currentLevel, levelBlocks);
+                if (index.contains(currentLevel)) {
+                    index.putBlocks(currentLevel, levelBlocks);
                 }
             }
 
             BlockInfo forkInfo = getBlockInfoForHash(levelBlocks, forkLine.getHash().getBytes());
             if (forkInfo != null) {
                 forkInfo.setMainChain(true);
-                if (index.containsKey(currentLevel)) {
-                    index.put(currentLevel, levelBlocks);
+                if (index.contains(currentLevel)) {
+                    index.putBlocks(currentLevel, levelBlocks);
                 }
             }
 
@@ -453,7 +432,7 @@ public class IndexedBlockStore implements BlockStore {
 
         int i;
         for (i = 0; i < maxBlocks; ++i) {
-            List<BlockInfo> blockInfos =  index.get(number);
+            List<BlockInfo> blockInfos =  index.getBlocksByNumber(number);
             if (blockInfos == null) {
                 break;
             }
@@ -471,71 +450,7 @@ public class IndexedBlockStore implements BlockStore {
         return result;
     }
 
-    public static class BlockInfo implements Serializable {
-        private static final long serialVersionUID = 5906746360128478753L;
 
-        private byte[] hash;
-        private BigInteger cummDifficulty;
-        private boolean mainChain;
-
-        public Keccak256 getHash() {
-            return new Keccak256(hash);
-        }
-
-        private void setHash(byte[] hash) {
-            this.hash = hash;
-        }
-
-        private BlockDifficulty getCummDifficulty() {
-            return new BlockDifficulty(cummDifficulty);
-        }
-
-        private void setCummDifficulty(BlockDifficulty cummDifficulty) {
-            this.cummDifficulty = cummDifficulty.asBigInteger();
-        }
-
-        private boolean isMainChain() {
-            return mainChain;
-        }
-
-        private void setMainChain(boolean mainChain) {
-            this.mainChain = mainChain;
-        }
-    }
-
-
-    public static final Serializer<List<BlockInfo>> BLOCK_INFO_SERIALIZER = new Serializer<List<BlockInfo>>(){
-
-        @Override
-        public void serialize(DataOutput out, List<BlockInfo> value) throws IOException {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ObjectOutputStream oos = new ObjectOutputStream(bos);
-            oos.writeObject(value);
-
-            byte[] data = bos.toByteArray();
-            DataIO.packInt(out, data.length);
-            out.write(data);
-        }
-
-        @Override
-        public List<BlockInfo> deserialize(DataInput in, int available) throws IOException {
-
-            List<BlockInfo> value = null;
-            try {
-                int size = DataIO.unpackInt(in);
-                byte[] data = new byte[size];
-                in.readFully(data);
-
-                ByteArrayInputStream bis = new ByteArrayInputStream(data, 0, data.length);
-                ObjectInputStream ois = new ObjectInputStream(bis);
-                value = (List<BlockInfo>)ois.readObject();
-            } catch (ClassNotFoundException e) {
-                logger.error("Class not found", e);
-            }
-
-            return value;
-        }
-    };
 
     private static BlockInfo getBlockInfoForHash(List<BlockInfo> blocks, byte[] hash){
         if (blocks == null) {
@@ -555,7 +470,7 @@ public class IndexedBlockStore implements BlockStore {
     public synchronized List<Block> getChainBlocksByNumber(long number){
         List<Block> result = new ArrayList<>();
 
-        List<BlockInfo> blockInfos = index.get(number);
+        List<BlockInfo> blockInfos = index.getBlocksByNumber(number);
 
         if (blockInfos == null){
             return result;
@@ -582,7 +497,7 @@ public class IndexedBlockStore implements BlockStore {
     public void rewind(long blockNumber) {
         long maxNumber = getMaxNumber();
         for (long i = maxNumber; i > blockNumber; i--) {
-            List<BlockInfo> blockInfos = index.remove(i);
+            List<BlockInfo> blockInfos = index.removeBlocksByNumber(i);
             if (blockInfos == null) {
                 continue;
             }
@@ -612,4 +527,72 @@ public class IndexedBlockStore implements BlockStore {
                 );
     }
 
+    public static class BlockInfo implements Serializable {
+        private static final long serialVersionUID = 5906746360128478753L;
+
+        private byte[] hash;
+        private BigInteger cummDifficulty;
+        private boolean mainChain;
+
+        public Keccak256 getHash() {
+            return new Keccak256(hash);
+        }
+
+        public void setHash(byte[] hash) {
+            this.hash = hash;
+        }
+
+        public BlockDifficulty getCummDifficulty() {
+            return new BlockDifficulty(cummDifficulty);
+        }
+
+        public void setCummDifficulty(BlockDifficulty cummDifficulty) {
+            this.cummDifficulty = cummDifficulty.asBigInteger();
+        }
+
+        public boolean isMainChain() {
+            return mainChain;
+        }
+
+        public void setMainChain(boolean mainChain) {
+            this.mainChain = mainChain;
+        }
+
+    }
+
+
+    public static final Serializer<List<BlockInfo>> BLOCK_INFO_SERIALIZER = new Serializer<List<BlockInfo>>(){
+
+        @Override
+        public void serialize(DataOutput out, List<BlockInfo> value) throws IOException {
+            ArrayList<BlockInfo> valueToSerialize = new ArrayList<>(value);
+
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+            oos.writeObject(valueToSerialize);
+
+            byte[] data = bos.toByteArray();
+            DataIO.packInt(out, data.length);
+            out.write(data);
+        }
+
+        @Override
+        public List<BlockInfo> deserialize(DataInput in, int available) throws IOException {
+
+            ArrayList<BlockInfo> value = null;
+            try {
+                int size = DataIO.unpackInt(in);
+                byte[] data = new byte[size];
+                in.readFully(data);
+
+                ByteArrayInputStream bis = new ByteArrayInputStream(data, 0, data.length);
+                ObjectInputStream ois = new ObjectInputStream(bis);
+                value = (ArrayList<BlockInfo>)ois.readObject();
+            } catch (ClassNotFoundException e) {
+                logger.error("Class not found", e);
+            }
+
+            return value;
+        }
+    };
 }

--- a/rskj-core/src/test/java/co/rsk/core/CodeReplaceTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CodeReplaceTest.java
@@ -22,6 +22,7 @@ import co.rsk.asm.EVMAssembler;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.genesis.TestGenesisLoader;
+import co.rsk.db.HashMapBlocksIndex;
 import co.rsk.db.MutableTrieImpl;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
@@ -49,7 +50,6 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.HashMap;
 
 /**
  * Created by Sergio on 26/02/2017.
@@ -235,7 +235,7 @@ public class CodeReplaceTest {
     }
 
     private BlockStore getBlockStore() {
-        return new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        return new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
     }
 
     protected Transaction createTx(ECKey sender, byte[] receiveAddress, byte[] data, Repository repository) throws InterruptedException {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockForkTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockForkTest.java
@@ -20,6 +20,7 @@ package co.rsk.core.bc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.BlockDifficulty;
+import co.rsk.db.HashMapBlocksIndex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
@@ -31,7 +32,6 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -169,6 +169,6 @@ public class BlockForkTest {
     }
 
     private static BlockStore createBlockStore() {
-        return new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        return new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -23,6 +23,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.crypto.Keccak256;
+import co.rsk.db.HashMapBlocksIndex;
 import co.rsk.remasc.RemascTransaction;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.BlockChainBuilder;
@@ -41,6 +42,9 @@ import org.powermock.reflect.Whitebox;
 
 import java.math.BigInteger;
 import java.util.*;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by ajlopez on 04/08/2016.
@@ -81,7 +85,7 @@ public class BlockValidatorTest {
 
     @Test
     public void getBlockOneAncestorSet() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
         store.saveBlock(genesis, TEST_DIFFICULTY, true);
@@ -95,7 +99,7 @@ public class BlockValidatorTest {
 
     @Test
     public void getThreeAncestorSet() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
         store.saveBlock(genesis, TEST_DIFFICULTY, true);
@@ -124,7 +128,7 @@ public class BlockValidatorTest {
 
     @Test
     public void getUsedUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
 
@@ -182,7 +186,7 @@ public class BlockValidatorTest {
 
     @Test
     public void validUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -212,7 +216,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidSiblingUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -239,7 +243,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUnclesUncleIncludedMultipeTimes () {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -264,7 +268,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidPOWUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -279,8 +283,8 @@ public class BlockValidatorTest {
         store.saveBlock(genesis, TEST_DIFFICULTY, true);
         store.saveBlock(uncle1a, TEST_DIFFICULTY, false);
 
-        BlockHeaderParentDependantValidationRule parentValidationRule = Mockito.mock(BlockHeaderParentDependantValidationRule.class);
-        Mockito.when(parentValidationRule.isValid(Mockito.any(), Mockito.any())).thenReturn(true);
+        BlockHeaderParentDependantValidationRule parentValidationRule = mock(BlockHeaderParentDependantValidationRule.class);
+        when(parentValidationRule.isValid(Mockito.any(), Mockito.any())).thenReturn(true);
       
         BlockValidatorImpl validator = new BlockValidatorBuilder()
                 .addBlockUnclesValidationRule(store, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), parentValidationRule)
@@ -292,7 +296,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleIsAncestor() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -317,7 +321,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleHasNoSavedParent() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -340,7 +344,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleHasNoCommonAncestor() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -375,7 +379,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleHasParentThatIsNotAncestor() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -407,7 +411,7 @@ public class BlockValidatorTest {
 
     @Test
     public void invalidUncleAlreadyUsed() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -445,7 +449,7 @@ public class BlockValidatorTest {
 
     @Test
     public void tooManyUncles() {
-        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore store = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
 
         BlockGenerator blockGenerator = new BlockGenerator();
 
@@ -484,10 +488,10 @@ public class BlockValidatorTest {
 
     @Test
     public void processBlockWithInvalidMGPTxs() {
-        BlockStore blockStore = Mockito.mock(org.ethereum.db.BlockStore.class);
-        Repository repository = Mockito.mock(Repository.class);
+        BlockStore blockStore = mock(org.ethereum.db.BlockStore.class);
+        Repository repository = mock(Repository.class);
 
-        Mockito.when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
+        when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
 
         Block parent = new BlockBuilder(null, null, null).minGasPrice(BigInteger.ZERO)
                 .parent(new BlockGenerator().getGenesisBlock()).build();
@@ -499,7 +503,7 @@ public class BlockValidatorTest {
         Block block = new BlockBuilder(null, null, null).minGasPrice(BigInteger.TEN).transactions(txs)
                 .parent(parent).build();
 
-        Mockito.when(blockStore.getBlockByHash(block.getParentHash().getBytes())).thenReturn(parent);
+        when(blockStore.getBlockByHash(block.getParentHash().getBytes())).thenReturn(parent);
 
         BlockValidatorImpl validator = new BlockValidatorBuilder()
                 .addTxsMinGasPriceRule()
@@ -511,10 +515,10 @@ public class BlockValidatorTest {
 
     @Test
     public void processBlockWithInvalidPrevMGP() {
-        BlockStore blockStore = Mockito.mock(org.ethereum.db.BlockStore.class);
-        Repository repository = Mockito.mock(Repository.class);
+        BlockStore blockStore = mock(org.ethereum.db.BlockStore.class);
+        Repository repository = mock(Repository.class);
 
-        Mockito.when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
+        when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
 
         Block parent = new BlockBuilder(null, null, null).minGasPrice(BigInteger.ZERO)
                 .parent(new BlockGenerator().getGenesisBlock()).build();
@@ -522,7 +526,7 @@ public class BlockValidatorTest {
         Block block = new BlockBuilder(null, null, null).minGasPrice(BigInteger.TEN)
                 .parent(parent).build();
 
-        Mockito.when(blockStore.getBlockByHash(block.getParentHash().getBytes())).thenReturn(parent);
+        when(blockStore.getBlockByHash(block.getParentHash().getBytes())).thenReturn(parent);
 
         BlockValidatorImpl validator = new BlockValidatorBuilder()
                 .addPrevMinGasPriceRule()
@@ -534,10 +538,10 @@ public class BlockValidatorTest {
 
     @Test
     public void processValidMGPBlock() {
-        BlockStore blockStore = Mockito.mock(org.ethereum.db.BlockStore.class);
-        Repository repository = Mockito.mock(Repository.class);
+        BlockStore blockStore = mock(org.ethereum.db.BlockStore.class);
+        Repository repository = mock(Repository.class);
 
-        Mockito.when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
+        when(repository.getNonce(Mockito.any())).thenReturn(BigInteger.ZERO);
 
         Block parent = new BlockBuilder(null, null, null).minGasPrice(BigInteger.TEN)
                 .parent(new BlockGenerator().getGenesisBlock()).build();
@@ -550,7 +554,7 @@ public class BlockValidatorTest {
         Block block = new BlockBuilder(null, null,null)
                 .transactions(txs).minGasPrice(BigInteger.valueOf(11L)).parent(parent).build();
 
-        Mockito.when(blockStore.getBlockByHash(block.getParentHash().getBytes())).thenReturn(parent);
+        when(blockStore.getBlockByHash(block.getParentHash().getBytes())).thenReturn(parent);
 
         BlockValidatorImpl validator = new BlockValidatorBuilder()
                 .addPrevMinGasPriceRule()
@@ -630,13 +634,13 @@ public class BlockValidatorTest {
 
         int validPeriod = 6000;
 
-        BlockHeader header = Mockito.mock(BlockHeader.class);
-        Block block = Mockito.mock(Block.class);
-        Mockito.when(block.getHeader()).thenReturn(header);
-        Mockito.when(header.getTimestamp())
+        BlockHeader header = mock(BlockHeader.class);
+        Block block = mock(Block.class);
+        when(block.getHeader()).thenReturn(header);
+        when(header.getTimestamp())
                 .thenReturn((System.currentTimeMillis() / 1000) + 2*validPeriod);
 
-        Mockito.when(header.getParentHash()).thenReturn(genesis.getHash());
+        when(header.getParentHash()).thenReturn(genesis.getHash());
 
         BlockValidatorImpl validator = new BlockValidatorBuilder()
                 .addBlockTimeStampValidationRule(validPeriod)
@@ -644,7 +648,7 @@ public class BlockValidatorTest {
 
         Assert.assertFalse(validator.isValid(block));
 
-        Mockito.when(header.getTimestamp())
+        when(header.getTimestamp())
                 .thenReturn((System.currentTimeMillis() / 1000) + validPeriod);
 
         Assert.assertTrue(validator.isValid(block));
@@ -658,11 +662,11 @@ public class BlockValidatorTest {
 
         int validPeriod = 0;
 
-        Block block = Mockito.mock(Block.class);
-        Mockito.when(block.getTimestamp())
+        Block block = mock(Block.class);
+        when(block.getTimestamp())
                 .thenReturn((System.currentTimeMillis() / 1000) + 2000);
 
-        Mockito.when(block.getParentHash()).thenReturn(genesis.getHash());
+        when(block.getParentHash()).thenReturn(genesis.getHash());
 
         BlockValidatorImpl validator = new BlockValidatorBuilder()
                 .addBlockTimeStampValidationRule(validPeriod)
@@ -670,7 +674,7 @@ public class BlockValidatorTest {
 
         Assert.assertTrue(validator.isValid(block));
 
-        Mockito.when(block.getTimestamp())
+        when(block.getTimestamp())
                 .thenReturn((System.currentTimeMillis() / 1000) + 2000);
 
         Assert.assertTrue(validator.isValid(block));

--- a/rskj-core/src/test/java/co/rsk/core/bc/FamilyUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/FamilyUtilsTest.java
@@ -21,6 +21,7 @@ package co.rsk.core.bc;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
+import co.rsk.db.HashMapBlocksIndex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
@@ -32,7 +33,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigInteger;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -256,7 +256,7 @@ public class FamilyUtilsTest {
     }
 
     private static BlockStore createBlockStore() {
-        return new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        return new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
     }
 
     private static boolean containsHash(Keccak256 hash, List<BlockHeader> headers) {

--- a/rskj-core/src/test/java/co/rsk/db/HashMapBlocksIndex.java
+++ b/rskj-core/src/test/java/co/rsk/db/HashMapBlocksIndex.java
@@ -40,8 +40,8 @@ public class HashMapBlocksIndex implements BlocksIndex {
     }
 
     @Override
-    public List<IndexedBlockStore.BlockInfo> removeBlocksByNumber(long blockNumber) {
-        List<IndexedBlockStore.BlockInfo> result = index.remove(blockNumber);
+    public List<IndexedBlockStore.BlockInfo> removeLast() {
+        List<IndexedBlockStore.BlockInfo> result = index.remove(getMaxNumber());
         if (result == null) {
             result = new ArrayList<>();
         }

--- a/rskj-core/src/test/java/co/rsk/db/HashMapBlocksIndex.java
+++ b/rskj-core/src/test/java/co/rsk/db/HashMapBlocksIndex.java
@@ -1,0 +1,54 @@
+package co.rsk.db;
+
+import org.ethereum.db.IndexedBlockStore;
+
+import java.util.*;
+
+public class HashMapBlocksIndex implements BlocksIndex {
+
+    private final Map<Long, List<IndexedBlockStore.BlockInfo>> index;
+
+    public HashMapBlocksIndex() {
+        index = new HashMap<>();
+    }
+
+    @Override
+    public long getMaxNumber() {
+        if (index.isEmpty()) {
+            return -1;
+        }
+
+        return index.keySet().stream().max(Long::compare).get();
+    }
+
+    @Override
+    public boolean contains(long blockNumber) {
+        return index.containsKey(blockNumber);
+    }
+
+    @Override
+    public List<IndexedBlockStore.BlockInfo> getBlocksByNumber(long blockNumber) {
+        return index.getOrDefault(blockNumber, new LinkedList<>());
+    }
+
+    @Override
+    public void putBlocks(long blockNumber, List<IndexedBlockStore.BlockInfo> blocks) {
+        if (blocks == null || blocks.isEmpty()) {
+            throw new IllegalArgumentException("Blocks to store cannot be null nor empty");
+        }
+        index.put(blockNumber, blocks);
+    }
+
+    @Override
+    public List<IndexedBlockStore.BlockInfo> removeBlocksByNumber(long blockNumber) {
+        List<IndexedBlockStore.BlockInfo> result = index.remove(blockNumber);
+        if (result == null) {
+            result = new ArrayList<>();
+        }
+        return result;
+    }
+
+    @Override
+    public void flush() {
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/db/MapDBBlocksIndexTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/MapDBBlocksIndexTest.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.db;
+
+import org.ethereum.db.IndexedBlockStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.mapdb.DB;
+import org.mapdb.HTreeMap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class MapDBBlocksIndexTest {
+
+    private MapDBBlocksIndex target;
+    private HTreeMap indexMap;
+    private DB indexDB;
+
+    @Before
+    public void setUp() {
+        indexDB = mock(DB.class);
+        DB.HTreeMapMaker hTreeMapMaker = mock(DB.HTreeMapMaker.class);
+        indexMap = mock(HTreeMap.class);
+
+        when(indexDB.hashMapCreate(anyString())).thenReturn(hTreeMapMaker);
+        when(hTreeMapMaker.valueSerializer(any())).thenReturn(hTreeMapMaker);
+        when(hTreeMapMaker.keySerializer(any())).thenReturn(hTreeMapMaker);
+        when(hTreeMapMaker.counterEnable()).thenReturn(hTreeMapMaker);
+        when(hTreeMapMaker.makeOrGet()).thenReturn(indexMap);
+
+        target = new MapDBBlocksIndex(indexDB);
+    }
+
+    @Test
+    public void getMaxNumber_empty() {
+        assertEquals(target.getMaxNumber(),-1);
+    }
+
+    @Test
+    public void getMaxNumber_nonEmpty() {
+        when(indexMap.size()).thenReturn(10);
+        assertEquals(target.getMaxNumber(),9);
+    }
+
+    @Test
+    public void contains_true() {
+        long blockNumber = 12;
+        when(indexMap.containsKey(eq(blockNumber))).thenReturn(true);
+
+        assertTrue(target.contains(blockNumber));
+    }
+
+    @Test
+    public void contains_false() {
+        long blockNumber = 12;
+        when(indexMap.containsKey(eq(blockNumber))).thenReturn(false);
+
+        assertFalse(target.contains(blockNumber));
+    }
+
+    @Test
+    public void getBlocksByNumber_noneFound() {
+        long blockNumber = 20;
+        when(indexMap.getOrDefault(eq(blockNumber), anyList())).thenReturn(new ArrayList<>());
+        List<IndexedBlockStore.BlockInfo> result = target.getBlocksByNumber(blockNumber);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getBlocksByNumber_found() {
+        long blockNumber = 20;
+        List expectedResult = mock(List.class);
+
+        when(indexMap.getOrDefault(eq(blockNumber), anyList())).thenReturn(expectedResult);
+        List<IndexedBlockStore.BlockInfo> result = target.getBlocksByNumber(blockNumber);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void putBlocks() {
+        long blockNumber = 20;
+        List<IndexedBlockStore.BlockInfo> putBlocks = mock(List.class);
+
+        target.putBlocks(blockNumber, putBlocks);
+
+        verify(indexMap, times(1)).put(eq(blockNumber), eq(putBlocks));
+    }
+
+    @Test
+    public void removeBlocksByNumber_found() {
+        long blockNumber = 20;
+        List expectedResult = mock(List.class);
+
+        when(indexMap.remove(eq(blockNumber))).thenReturn(expectedResult);
+
+        List<IndexedBlockStore.BlockInfo> result = target.removeBlocksByNumber(blockNumber);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void removeBlocksByNumber_notFound() {
+        long blockNumber = 20;
+
+        List<IndexedBlockStore.BlockInfo> result = target.removeBlocksByNumber(blockNumber);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void flush() {
+        target.flush();
+
+        verify(indexDB, times(1)).commit();
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalStateTest.java
@@ -428,7 +428,7 @@ public class LocalStateTest {
     }
 
     @Test
-    public void stRecursiveCreate() throws ParseException, IOException {
+    public void stRecursiveCreate() throws IOException {
         Set<String> excluded = new HashSet<>();
 
         String json = getJSON("stRecursiveCreate");

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -24,8 +24,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.*;
-import co.rsk.db.RepositoryLocator;
-import co.rsk.db.StateRootHandler;
+import co.rsk.db.*;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.BtcBlockStoreWithCache;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
@@ -150,6 +149,8 @@ public class BlockChainBuilder {
     }
 
     public BlockChainImpl build() {
+        BlocksIndex blocksIndex = new HashMapBlocksIndex();
+
         if (config == null){
             config = new TestSystemProperties();
         }
@@ -177,7 +178,7 @@ public class BlockChainBuilder {
 
         BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
         if (blockStore == null) {
-            blockStore = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+            blockStore = new IndexedBlockStore(blockFactory, new HashMapDB(), blocksIndex);
         }
 
         if (receiptStore == null) {

--- a/rskj-core/src/test/java/co/rsk/validators/BlockUnclesValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockUnclesValidationRuleTest.java
@@ -2,6 +2,7 @@ package co.rsk.validators;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.BlockDifficulty;
+import co.rsk.db.HashMapBlocksIndex;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.datasource.HashMapDB;
@@ -12,7 +13,6 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -31,7 +31,7 @@ public class BlockUnclesValidationRuleTest {
         uncles.add(uncle.getHeader());
 
         Block block = blockGenerator.createChildBlock(block1, null, uncles, 1, null);
-        BlockStore blockStore = new IndexedBlockStore(null, new HashMap<>(), new HashMapDB(), null);
+        BlockStore blockStore = new IndexedBlockStore(null, new HashMapDB(), new HashMapBlocksIndex());
 
         blockStore.saveBlock(genesis, new BlockDifficulty(BigInteger.valueOf(1)), true);
         blockStore.saveBlock(block1, new BlockDifficulty(BigInteger.valueOf(2)), true);
@@ -52,7 +52,7 @@ public class BlockUnclesValidationRuleTest {
         uncles.add(uncle2.getHeader());
 
         Block block = blockGenerator.createChildBlock(block1, null, uncles, 1, null);
-        BlockStore blockStore = new IndexedBlockStore(null, new HashMap<>(), new HashMapDB(), null);
+        BlockStore blockStore = new IndexedBlockStore(null, new HashMapDB(), new HashMapBlocksIndex());
         blockStore.saveBlock(genesis, new BlockDifficulty(BigInteger.valueOf(1)), true);
         blockStore.saveBlock(block1, new BlockDifficulty(BigInteger.valueOf(2)), true);
         BlockUnclesValidationRule rule = new BlockUnclesValidationRule(blockStore, 10, 10, new BlockHeaderCompositeRule(), new BlockHeaderParentCompositeRule());

--- a/rskj-core/src/test/java/org/ethereum/TestUtils.java
+++ b/rskj-core/src/test/java/org/ethereum/TestUtils.java
@@ -26,18 +26,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.IndexedBlockStore;
 import org.ethereum.vm.DataWord;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
-import org.mapdb.Serializer;
 
 import java.io.File;
 import java.math.BigInteger;
 import java.util.*;
 
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
-import static org.ethereum.db.IndexedBlockStore.BLOCK_INFO_SERIALIZER;
 
 public final class TestUtils {
 
@@ -80,16 +77,6 @@ public final class TestUtils {
 
     public static Keccak256 randomHash() {
         return new Keccak256(randomBytes(32));
-    }
-
-    public static Map<Long, List<IndexedBlockStore.BlockInfo>> createIndexMap(DB db){
-
-        Map<Long, List<IndexedBlockStore.BlockInfo>> index = db.hashMapCreate("index")
-                .keySerializer(Serializer.LONG)
-                .valueSerializer(BLOCK_INFO_SERIALIZER)
-                .makeOrGet();
-
-        return index;
     }
 
     public static DB createMapDB(String testDBDir){

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -24,6 +24,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.genesis.TestGenesisLoader;
 import co.rsk.crypto.Keccak256;
+import co.rsk.db.HashMapBlocksIndex;
 import co.rsk.db.MutableTrieImpl;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
@@ -57,7 +58,6 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -597,7 +597,7 @@ public class TransactionTest {
         BigInteger nonce = config.getNetworkConstants().getInitialNonce();
         TrieStore trieStore = new TrieStoreImpl(new HashMapDB());
         MutableRepository repository = new MutableRepository(new MutableTrieImpl(trieStore, new Trie(trieStore)));
-        IndexedBlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(),null);
+        IndexedBlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
         Blockchain blockchain = ImportLightTest.createBlockchain(
                 new TestGenesisLoader(
                         trieStore, getClass().getResourceAsStream("/genesis/genesis-light.json"), nonce,
@@ -675,7 +675,7 @@ public class TransactionTest {
         BigInteger nonce = config.getNetworkConstants().getInitialNonce();
         TrieStore trieStore = new TrieStoreImpl(new HashMapDB());
         MutableRepository repository = new MutableRepository(new MutableTrieImpl(trieStore, new Trie(trieStore)));
-        IndexedBlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
         Blockchain blockchain = ImportLightTest.createBlockchain(
                 new TestGenesisLoader(
                         trieStore, getClass().getResourceAsStream("/genesis/genesis-light.json"), nonce,

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -28,10 +28,7 @@ import co.rsk.core.bc.BlockChainFlusher;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.core.bc.TransactionPoolImpl;
-import co.rsk.db.MutableTrieCache;
-import co.rsk.db.MutableTrieImpl;
-import co.rsk.db.RepositoryLocator;
-import co.rsk.db.StateRootHandler;
+import co.rsk.db.*;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieConverter;
 import co.rsk.trie.TrieStore;
@@ -136,7 +133,7 @@ public class TestRunner {
         TrieStore trieStore = new TrieStoreImpl(new HashMapDB());
         Repository repository = RepositoryBuilder.build(trieStore, testCase.getPre());
 
-        IndexedBlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        IndexedBlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
         blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
 
         CompositeEthereumListener listener = new TestCompositeEthereumListener();

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -26,6 +26,7 @@ import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainFlusher;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
+import co.rsk.db.HashMapBlocksIndex;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.StateRootHandler;
 import co.rsk.trie.TrieConverter;
@@ -130,7 +131,7 @@ public class StateTestRunner {
 
         transaction = TransactionBuilder.build(stateTestCase.getTransaction());
         logger.info("transaction: {}", transaction.toString());
-        BlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMap<>(), new HashMapDB(), null);
+        BlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
         StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
         blockchain = new BlockChainImpl(
                 new BlockChainFlusher(false, 1, trieStore, blockStore),

--- a/rskj-core/src/test/java/org/ethereum/util/RskTestContext.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RskTestContext.java
@@ -19,6 +19,7 @@ package org.ethereum.util;
 
 import co.rsk.RskContext;
 import co.rsk.core.Wallet;
+import co.rsk.db.HashMapBlocksIndex;
 import co.rsk.db.StateRootHandler;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
@@ -46,7 +47,7 @@ public class RskTestContext extends RskContext {
 
     @Override
     protected BlockStore buildBlockStore() {
-        return new IndexedBlockStore(getBlockFactory(), new HashMap<>(), new HashMapDB(), null);
+        return new IndexedBlockStore(getBlockFactory(), new HashMapDB(), new HashMapBlocksIndex());
     }
 
     @Override


### PR DESCRIPTION
This change allows having an index with an arbitrary sequential interval of blocks.
The BlockInfo class cannot be moved from IndexedBlockstore due to the index encoding. An index  migration is required to move it.