### PR TITLE
Decouple Transaction sender resolution

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -84,11 +84,12 @@ public class ReversibleTransactionExecutor {
                 gasLimit,
                 toAddress,
                 value,
-                data
+                data,
+                fromAddress
         );
 
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(tx, fromAddress, 0, coinbase, track, executionBlock, 0)
+                .newInstance(tx, 0, coinbase, track, executionBlock, 0)
                 .setLocalCall(true);
 
         executor.init();
@@ -98,7 +99,9 @@ public class ReversibleTransactionExecutor {
         return executor.getResult();
     }
 
-    private static class UnsignedTransaction extends Transaction {
+    public static class UnsignedTransaction extends Transaction {
+
+        private final RskAddress sender;
 
         private UnsignedTransaction(
                 byte[] nonce,
@@ -106,8 +109,10 @@ public class ReversibleTransactionExecutor {
                 byte[] gasLimit,
                 byte[] receiveAddress,
                 byte[] value,
-                byte[] data) {
+                byte[] data,
+                RskAddress sender) {
             super(nonce, gasPrice, gasLimit, receiveAddress, value, data);
+            this.sender = sender;
         }
 
         @Override
@@ -115,6 +120,15 @@ public class ReversibleTransactionExecutor {
             // We only allow executing unsigned transactions
             // in the context of a reversible transaction execution.
             return true;
+        }
+
+        public RskAddress getSender() {
+            return sender;
+        }
+
+        @Override
+        public <T> T accept(TransactionVisitor<T> visitor) {
+            return visitor.visit(this);
         }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -84,12 +84,11 @@ public class ReversibleTransactionExecutor {
                 gasLimit,
                 toAddress,
                 value,
-                data,
-                fromAddress
+                data
         );
 
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(tx, 0, coinbase, track, executionBlock, 0)
+                .newInstance(tx, fromAddress, 0, coinbase, track, executionBlock, 0)
                 .setLocalCall(true);
 
         executor.init();
@@ -107,10 +106,8 @@ public class ReversibleTransactionExecutor {
                 byte[] gasLimit,
                 byte[] receiveAddress,
                 byte[] value,
-                byte[] data,
-                RskAddress fromAddress) {
+                byte[] data) {
             super(nonce, gasPrice, gasLimit, receiveAddress, value, data);
-            this.sender = fromAddress;
         }
 
         @Override

--- a/rskj-core/src/main/java/co/rsk/core/SenderResolverVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/core/SenderResolverVisitor.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.core;
+
+import co.rsk.metrics.profilers.Metric;
+import co.rsk.metrics.profilers.Profiler;
+import co.rsk.metrics.profilers.ProfilerFactory;
+import co.rsk.remasc.RemascTransaction;
+import org.ethereum.core.ImmutableTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.program.InternalTransaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.SignatureException;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+public class SenderResolverVisitor implements TransactionVisitor<RskAddress> {
+
+    private static final Logger logger = LoggerFactory.getLogger(SenderResolverVisitor.class);
+    private static final Profiler profiler = ProfilerFactory.getInstance();
+
+    private final Map<Transaction, RskAddress> senders = new WeakHashMap<>();
+
+    @Override
+    public RskAddress visit(Transaction transaction) {
+        return senders.computeIfAbsent(transaction, this::extractSenderFromSignature);
+    }
+
+    @Override
+    public RskAddress visit(RemascTransaction remascTransaction) {
+        return RemascTransaction.REMASC_ADDRESS;
+    }
+
+    @Override
+    public RskAddress visit(ImmutableTransaction immutableTransaction) {
+        return visit((Transaction)immutableTransaction);
+    }
+
+    @Override
+    public RskAddress visit(InternalTransaction internalTransaction) {
+        return internalTransaction.getSender();
+    }
+
+    public RskAddress visit(ReversibleTransactionExecutor.UnsignedTransaction unsignedTransaction) {
+        return unsignedTransaction.getSender();
+    }
+
+    private RskAddress extractSenderFromSignature(Transaction tx) {
+        Metric metric = profiler.start(Profiler.PROFILING_TYPE.KEY_RECOV_FROM_SIG);
+        try {
+            ECKey key = ECKey.signatureToKey(tx.getRawHash().getBytes(), tx.getSignature());
+            return new RskAddress(key.getAddress());
+        } catch (SignatureException e) {
+            logger.error("Unable to extract signature for tx {}", tx.getHash(), e);
+            return RskAddress.nullAddress();
+        } finally {
+            profiler.stop(metric);
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/core/TransactionExecutorFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/TransactionExecutorFactory.java
@@ -65,16 +65,18 @@ public class TransactionExecutorFactory {
 
     public TransactionExecutor newInstance(
             Transaction tx,
+            RskAddress sender,
             int txindex,
             RskAddress coinbase,
             Repository track,
             Block block,
             long totalGasUsed) {
-        return newInstance(tx, txindex, coinbase, track, block, totalGasUsed, false, new HashSet<>());
+        return newInstance(tx, sender, txindex, coinbase, track, block, totalGasUsed, false, new HashSet<>());
     }
 
     public TransactionExecutor newInstance(
             Transaction tx,
+            RskAddress sender,
             int txindex,
             RskAddress coinbase,
             Repository track,
@@ -99,6 +101,7 @@ public class TransactionExecutorFactory {
                 config.getNetworkConstants(),
                 config.getActivationConfig(),
                 tx,
+                sender,
                 txindex,
                 coinbase,
                 track,

--- a/rskj-core/src/main/java/co/rsk/core/TransactionExecutorFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/TransactionExecutorFactory.java
@@ -41,6 +41,7 @@ public class TransactionExecutorFactory {
     private final ProgramInvokeFactory programInvokeFactory;
     private final PrecompiledContracts precompiledContracts;
     private final ExecutorService vmExecutorService;
+    private final SenderResolverVisitor senderResolver;
 
     public TransactionExecutorFactory(
             RskSystemProperties config,
@@ -48,7 +49,8 @@ public class TransactionExecutorFactory {
             ReceiptStore receiptStore,
             BlockFactory blockFactory,
             ProgramInvokeFactory programInvokeFactory,
-            PrecompiledContracts precompiledContracts) {
+            PrecompiledContracts precompiledContracts,
+            SenderResolverVisitor senderResolver) {
         this.config = config;
         this.blockStore = blockStore;
         this.receiptStore = receiptStore;
@@ -61,22 +63,21 @@ public class TransactionExecutorFactory {
             "vmExecution",
             config.getVmExecutionStackSize()
         ));
+        this.senderResolver = senderResolver;
     }
 
     public TransactionExecutor newInstance(
             Transaction tx,
-            RskAddress sender,
             int txindex,
             RskAddress coinbase,
             Repository track,
             Block block,
             long totalGasUsed) {
-        return newInstance(tx, sender, txindex, coinbase, track, block, totalGasUsed, false, new HashSet<>());
+        return newInstance(tx, txindex, coinbase, track, block, totalGasUsed, false, new HashSet<>());
     }
 
     public TransactionExecutor newInstance(
             Transaction tx,
-            RskAddress sender,
             int txindex,
             RskAddress coinbase,
             Repository track,
@@ -101,7 +102,7 @@ public class TransactionExecutorFactory {
                 config.getNetworkConstants(),
                 config.getActivationConfig(),
                 tx,
-                sender,
+                tx.accept(senderResolver),
                 txindex,
                 coinbase,
                 track,

--- a/rskj-core/src/main/java/co/rsk/core/TransactionUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/TransactionUtils.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.core;
+
+import co.rsk.peg.BridgeUtils;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.core.Transaction;
+
+public class TransactionUtils {
+
+    private TransactionUtils() {
+    }
+
+    public static long getTransactionCost(Transaction tx,
+                                          RskAddress txSender,
+                                          Constants networkConstants,
+                                          ActivationConfig.ForBlock activationsForBlock) {
+        // Federators txs to the bridge are free during system setup
+        if (BridgeUtils.isFreeBridgeTx(tx, txSender, networkConstants, activationsForBlock)) {
+            return 0;
+        }
+        return tx.transactionCost();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/core/TransactionVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/core/TransactionVisitor.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.core;
+
+import co.rsk.remasc.RemascTransaction;
+import org.ethereum.core.ImmutableTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.vm.program.InternalTransaction;
+
+public interface TransactionVisitor<T> {
+
+    T visit(Transaction transaction);
+
+    T visit(RemascTransaction remascTransaction);
+
+    T visit(ImmutableTransaction immutableTransaction);
+
+    T visit(InternalTransaction internalTransaction);
+
+    T visit(ReversibleTransactionExecutor.UnsignedTransaction unsignedTransaction);
+}

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -280,7 +280,7 @@ public class BlockExecutor {
 
             TransactionExecutor txExecutor = transactionExecutorFactory.newInstance(
                     tx,
-                    txindex++,
+                    tx.getSender(), txindex++,
                     block.getCoinbase(),
                     track,
                     block,

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -280,7 +280,7 @@ public class BlockExecutor {
 
             TransactionExecutor txExecutor = transactionExecutorFactory.newInstance(
                     tx,
-                    tx.getSender(), txindex++,
+                    txindex++,
                     block.getCoinbase(),
                     track,
                     block,

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -21,6 +21,7 @@ package co.rsk.core.bc;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.TransactionExecutorFactory;
+import co.rsk.core.TransactionUtils;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.RepositorySnapshot;
@@ -456,18 +457,11 @@ public class TransactionPoolImpl implements TransactionPool {
 
     private Coin getTxBaseCost(Transaction tx) {
         Coin gasCost = tx.getValue();
-        if (bestBlock == null || getTransactionCost(tx, bestBlock.getNumber()) > 0) {
+        if (bestBlock == null || TransactionUtils.getTransactionCost(tx, tx.getSender(), config.getNetworkConstants(), config.getActivationConfig().forBlock(bestBlock.getNumber())) > 0) {
             BigInteger gasLimit = new BigInteger(1, tx.getGasLimit());
             gasCost = gasCost.add(tx.getGasPrice().multiply(gasLimit));
         }
 
         return gasCost;
-    }
-
-    private long getTransactionCost(Transaction tx, long number) {
-        return tx.transactionCost(
-                config.getNetworkConstants(),
-                config.getActivationConfig().forBlock(number)
-        );
     }
 }

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -146,6 +146,7 @@ public class TransactionPoolImpl implements TransactionPool {
                 new TransactionSet(pendingTransactions),
                 (repository, tx) -> transactionExecutorFactory.newInstance(
                         tx,
+                        tx.getSender(),
                         0,
                         bestBlock.getCoinbase(),
                         repository,

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -20,6 +20,7 @@ package co.rsk.core.bc;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.TransactionUtils;
 import co.rsk.crypto.Keccak256;
@@ -54,8 +55,8 @@ public class TransactionPoolImpl implements TransactionPool {
     private static final Logger logger = LoggerFactory.getLogger("txpool");
     private static final byte[] emptyUncleHashList = HashUtil.keccak256(RLP.encodeList(new byte[0]));
 
-    private final TransactionSet pendingTransactions = new TransactionSet();
-    private final TransactionSet queuedTransactions = new TransactionSet();
+    private final TransactionSet pendingTransactions;
+    private final TransactionSet queuedTransactions;
 
     private final Map<Keccak256, Long> transactionBlocks = new HashMap<>();
     private final Map<Keccak256, Long> transactionTimes = new HashMap<>();
@@ -68,6 +69,7 @@ public class TransactionPoolImpl implements TransactionPool {
     private final TransactionExecutorFactory transactionExecutorFactory;
     private final int outdatedThreshold;
     private final int outdatedTimeout;
+    private final SenderResolverVisitor senderResolver;
 
     private ScheduledExecutorService cleanerTimer;
     private ScheduledFuture<?> cleanerFuture;
@@ -84,7 +86,8 @@ public class TransactionPoolImpl implements TransactionPool {
             EthereumListener listener,
             TransactionExecutorFactory transactionExecutorFactory,
             int outdatedThreshold,
-            int outdatedTimeout) {
+            int outdatedTimeout,
+            SenderResolverVisitor senderResolver) {
         this.config = config;
         this.blockStore = blockStore;
         this.repositoryLocator = repositoryLocator;
@@ -94,11 +97,14 @@ public class TransactionPoolImpl implements TransactionPool {
         this.outdatedThreshold = outdatedThreshold;
         this.outdatedTimeout = outdatedTimeout;
 
-        this.validator = new TxPendingValidator(config.getNetworkConstants(), config.getActivationConfig());
+        this.validator = new TxPendingValidator(config.getNetworkConstants(), config.getActivationConfig(), senderResolver);
 
         if (this.outdatedTimeout > 0) {
             this.cleanerTimer = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "TransactionPoolCleanerTimer"));
         }
+        this.senderResolver = senderResolver;
+        pendingTransactions = new TransactionSet(senderResolver);
+        queuedTransactions = new TransactionSet(senderResolver);
     }
 
     @Override
@@ -143,16 +149,16 @@ public class TransactionPoolImpl implements TransactionPool {
         removeObsoleteTransactions(this.getCurrentBestBlockNumber(), this.outdatedThreshold, this.outdatedTimeout);
         return new PendingState(
                 currentRepository,
-                new TransactionSet(pendingTransactions),
+                new TransactionSet(pendingTransactions, senderResolver),
                 (repository, tx) -> transactionExecutorFactory.newInstance(
                         tx,
-                        tx.getSender(),
                         0,
                         bestBlock.getCoinbase(),
                         repository,
                         createFakePendingBlock(bestBlock),
                         0
-                )
+                ),
+                senderResolver
         );
     }
 
@@ -172,7 +178,7 @@ public class TransactionPoolImpl implements TransactionPool {
 
                 while (succesor.isPresent()) {
                     Transaction found = succesor.get();
-                    queuedTransactions.removeTransactionByHash(found.getHash());
+                    queuedTransactions.removeTransactionByHash(found.getHash(), senderResolver);
 
                     if (!this.addTransaction(found).transactionWasAdded()) {
                         break;
@@ -198,7 +204,7 @@ public class TransactionPoolImpl implements TransactionPool {
     private Optional<Transaction> getQueuedSuccesor(Transaction tx) {
         BigInteger next = tx.getNonceAsInteger().add(BigInteger.ONE);
 
-        List<Transaction> txsaccount = this.queuedTransactions.getTransactionsWithSender(tx.getSender());
+        List<Transaction> txsaccount = this.queuedTransactions.getTransactionsWithSender(tx.accept(senderResolver));
 
         if (txsaccount == null) {
             return Optional.empty();
@@ -239,7 +245,7 @@ public class TransactionPoolImpl implements TransactionPool {
         final long timestampSeconds = this.getCurrentTimeInSeconds();
         transactionTimes.put(hash, timestampSeconds);
 
-        BigInteger currentNonce = getPendingState(currentRepository).getNonce(tx.getSender());
+        BigInteger currentNonce = getPendingState(currentRepository).getNonce(tx.accept(senderResolver));
         BigInteger txNonce = tx.getNonceAsInteger();
         if (txNonce.compareTo(currentNonce) > 0) {
             this.addQueuedTransaction(tx);
@@ -265,7 +271,7 @@ public class TransactionPoolImpl implements TransactionPool {
     }
 
     private boolean isBumpingGasPriceForSameNonceTx(Transaction tx) {
-        Optional<Transaction> oldTxWithNonce = pendingTransactions.getTransactionsWithSender(tx.getSender()).stream()
+        Optional<Transaction> oldTxWithNonce = pendingTransactions.getTransactionsWithSender(tx.accept(senderResolver)).stream()
                 .filter(t -> t.getNonceAsInteger().equals(tx.getNonceAsInteger()))
                 .findFirst();
 
@@ -367,8 +373,8 @@ public class TransactionPoolImpl implements TransactionPool {
 
     private void removeTransactionList(List<Keccak256> toremove) {
         for (Keccak256 key : toremove) {
-            pendingTransactions.removeTransactionByHash(key);
-            queuedTransactions.removeTransactionByHash(key);
+            pendingTransactions.removeTransactionByHash(key, senderResolver);
+            queuedTransactions.removeTransactionByHash(key, senderResolver);
 
             transactionBlocks.remove(key);
             transactionTimes.remove(key);
@@ -379,8 +385,8 @@ public class TransactionPoolImpl implements TransactionPool {
     public synchronized void removeTransactions(List<Transaction> txs) {
         for (Transaction tx : txs) {
             Keccak256 khash = tx.getHash();
-            pendingTransactions.removeTransactionByHash(khash);
-            queuedTransactions.removeTransactionByHash(khash);
+            pendingTransactions.removeTransactionByHash(khash, senderResolver);
+            queuedTransactions.removeTransactionByHash(khash, senderResolver);
 
             logger.trace("Clear transaction, hash: [{}]", khash);
         }
@@ -433,7 +439,7 @@ public class TransactionPoolImpl implements TransactionPool {
     }
 
     private TransactionValidationResult shouldAcceptTx(Transaction tx, RepositorySnapshot currentRepository) {
-        AccountState state = currentRepository.getAccountState(tx.getSender());
+        AccountState state = currentRepository.getAccountState(tx.accept(senderResolver));
         return validator.isValid(tx, bestBlock, state);
     }
 
@@ -445,7 +451,7 @@ public class TransactionPoolImpl implements TransactionPool {
     private boolean senderCanPayPendingTransactionsAndNewTx(
             Transaction newTx,
             RepositorySnapshot currentRepository) {
-        List<Transaction> transactions = pendingTransactions.getTransactionsWithSender(newTx.getSender());
+        List<Transaction> transactions = pendingTransactions.getTransactionsWithSender(newTx.accept(senderResolver));
 
         Coin accumTxCost = Coin.ZERO;
         for (Transaction t : transactions) {
@@ -453,12 +459,12 @@ public class TransactionPoolImpl implements TransactionPool {
         }
 
         Coin costWithNewTx = accumTxCost.add(getTxBaseCost(newTx));
-        return costWithNewTx.compareTo(currentRepository.getBalance(newTx.getSender())) <= 0;
+        return costWithNewTx.compareTo(currentRepository.getBalance(newTx.accept(senderResolver))) <= 0;
     }
 
     private Coin getTxBaseCost(Transaction tx) {
         Coin gasCost = tx.getValue();
-        if (bestBlock == null || TransactionUtils.getTransactionCost(tx, tx.getSender(), config.getNetworkConstants(), config.getActivationConfig().forBlock(bestBlock.getNumber())) > 0) {
+        if (bestBlock == null || TransactionUtils.getTransactionCost(tx, tx.accept(senderResolver), config.getNetworkConstants(), config.getActivationConfig().forBlock(bestBlock.getNumber())) > 0) {
             BigInteger gasLimit = new BigInteger(1, tx.getGasLimit());
             gasCost = gasCost.add(tx.getGasPrice().multiply(gasLimit));
         }

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler;
 
 import co.rsk.core.Coin;
+import co.rsk.core.TransactionUtils;
 import co.rsk.net.TransactionValidationResult;
 import co.rsk.net.handler.txvalidator.*;
 import org.ethereum.config.Constants;
@@ -64,7 +65,7 @@ public class TxPendingValidator {
         BigInteger blockGasLimit = BigIntegers.fromUnsignedByteArray(executionBlock.getGasLimit());
         Coin minimumGasPrice = executionBlock.getMinimumGasPrice();
         long bestBlockNumber = executionBlock.getNumber();
-        long basicTxCost = tx.transactionCost(constants, activationConfig.forBlock(bestBlockNumber));
+        long basicTxCost = TransactionUtils.getTransactionCost(tx, tx.getSender(), constants, activationConfig.forBlock(bestBlockNumber));
 
         if (state == null && basicTxCost != 0) {
             logger.trace("[tx={}, sender={}] account doesn't exist", tx.getHash(), tx.getSender());

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidator.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
+import co.rsk.core.TransactionUtils;
 import co.rsk.net.TransactionValidationResult;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -43,7 +44,9 @@ public class TxValidatorIntrinsicGasLimitValidator implements TxValidatorStep {
 
     @Override
     public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
-        if (BigInteger.valueOf(tx.transactionCost(constants, activationConfig.forBlock(bestBlockNumber))).compareTo(tx.getGasLimitAsInteger()) <= 0) {
+        long transactionCost = TransactionUtils.getTransactionCost(tx, tx.getSender(), constants, activationConfig.forBlock(bestBlockNumber));
+
+        if (BigInteger.valueOf(transactionCost).compareTo(tx.getGasLimitAsInteger()) <= 0) {
             return TransactionValidationResult.ok();
         }
 

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidator.java
@@ -20,6 +20,7 @@ package co.rsk.net.handler.txvalidator;
 
 import co.rsk.core.Coin;
 import co.rsk.core.TransactionUtils;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.net.TransactionValidationResult;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -36,15 +37,17 @@ public class TxValidatorIntrinsicGasLimitValidator implements TxValidatorStep {
 
     private final Constants constants;
     private final ActivationConfig activationConfig;
+    private final SenderResolverVisitor senderResolver;
 
-    public TxValidatorIntrinsicGasLimitValidator(Constants constants, ActivationConfig activationConfig) {
+    public TxValidatorIntrinsicGasLimitValidator(Constants constants, ActivationConfig activationConfig, SenderResolverVisitor senderResolver) {
         this.constants = constants;
         this.activationConfig = activationConfig;
+        this.senderResolver = senderResolver;
     }
 
     @Override
     public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
-        long transactionCost = TransactionUtils.getTransactionCost(tx, tx.getSender(), constants, activationConfig.forBlock(bestBlockNumber));
+        long transactionCost = TransactionUtils.getTransactionCost(tx, tx.accept(senderResolver), constants, activationConfig.forBlock(bestBlockNumber));
 
         if (BigInteger.valueOf(transactionCost).compareTo(tx.getGasLimitAsInteger()) <= 0) {
             return TransactionValidationResult.ok();

--- a/rskj-core/src/main/java/co/rsk/peg/AddressBasedAuthorizer.java
+++ b/rskj-core/src/main/java/co/rsk/peg/AddressBasedAuthorizer.java
@@ -19,7 +19,6 @@
 package co.rsk.peg;
 
 import co.rsk.core.RskAddress;
-import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 
 import java.util.Arrays;
@@ -46,10 +45,6 @@ public class AddressBasedAuthorizer {
         return authorizedKeys.stream()
                 .map(key -> key.getAddress())
                 .anyMatch(address -> Arrays.equals(address, sender.getBytes()));
-    }
-
-    public boolean isAuthorized(Transaction tx) {
-        return isAuthorized(tx.getSender());
     }
 
     public int getNumberOfAuthorizedKeys() {

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -214,7 +214,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
             throw new NullPointerException();
         }
 
-        if (BridgeUtils.isFreeBridgeTx(rskTx, constants, activations)) {
+        if (BridgeUtils.isFreeBridgeTx(rskTx, rskTx.getSender(), constants, activations)) {
             return 0;
         }
 
@@ -1037,8 +1037,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return (self, args) -> {
             Federation retiringFederation = self.bridgeSupport.getRetiringFederation();
 
-            if (!BridgeUtils.isFromFederateMember(self.rskTx, self.bridgeSupport.getActiveFederation())
-                    && ( retiringFederation == null || (retiringFederation != null && !BridgeUtils.isFromFederateMember(self.rskTx, retiringFederation)))) {
+            if (!BridgeUtils.isFromFederateMember(self.rskTx.getSender(), self.bridgeSupport.getActiveFederation())
+                    && ( retiringFederation == null || (retiringFederation != null && !BridgeUtils.isFromFederateMember(self.rskTx.getSender(), retiringFederation)))) {
                 String errorMessage = String.format("Sender is not part of the active or retiring federations, so he is not enabled to call the function '%s'",funcName);
                 logger.warn(errorMessage);
                 throw new RuntimeException(errorMessage);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -28,6 +28,7 @@ import co.rsk.bitcoinj.wallet.SendRequest;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.config.BridgeConstants;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.crypto.Keccak256;
 import co.rsk.panic.PanicProcessor;
 import co.rsk.peg.bitcoin.MerkleBranch;
@@ -106,6 +107,7 @@ public class BridgeSupport {
     private final FederationSupport federationSupport;
 
     private final Context btcContext;
+    private final SenderResolverVisitor senderResolver;
     private BtcBlockStoreWithCache.Factory btcBlockStoreFactory;
     private BtcBlockStoreWithCache btcBlockStore;
     private BtcBlockChain btcBlockChain;
@@ -119,7 +121,8 @@ public class BridgeSupport {
             Block executionBlock,
             Context btcContext,
             FederationSupport federationSupport,
-            BtcBlockStoreWithCache.Factory btcBlockStoreFactory) {
+            BtcBlockStoreWithCache.Factory btcBlockStoreFactory,
+            SenderResolverVisitor senderResolver) {
         this.rskRepository = repository;
         this.provider = provider;
         this.rskExecutionBlock = executionBlock;
@@ -128,6 +131,7 @@ public class BridgeSupport {
         this.btcContext = btcContext;
         this.federationSupport = federationSupport;
         this.btcBlockStoreFactory = btcBlockStoreFactory;
+        this.senderResolver = senderResolver;
     }
 
     @VisibleForTesting
@@ -1515,7 +1519,7 @@ public class BridgeSupport {
         AddressBasedAuthorizer authorizer = bridgeConstants.getFederationChangeAuthorizer();
 
         // Must be authorized to vote (checking for signature)
-        if (!authorizer.isAuthorized(tx.getSender())) {
+        if (!authorizer.isAuthorized(tx.accept(senderResolver))) {
             return FEDERATION_CHANGE_GENERIC_ERROR_CODE;
         }
 
@@ -1537,7 +1541,7 @@ public class BridgeSupport {
 
         ABICallElection election = provider.getFederationElection(authorizer);
         // Register the vote. It is expected to succeed, since all previous checks succeeded
-        if (!election.vote(callSpec, tx.getSender())) {
+        if (!election.vote(callSpec, tx.accept(senderResolver))) {
             logger.warn("Unexpected federation change vote failure");
             return FEDERATION_CHANGE_GENERIC_ERROR_CODE;
         }
@@ -1782,7 +1786,7 @@ public class BridgeSupport {
     private boolean isLockWhitelistChangeAuthorized(Transaction tx) {
         AddressBasedAuthorizer authorizer = bridgeConstants.getLockWhitelistChangeAuthorizer();
 
-        return authorizer.isAuthorized(tx.getSender());
+        return authorizer.isAuthorized(tx.accept(senderResolver));
     }
 
     /**
@@ -1834,7 +1838,7 @@ public class BridgeSupport {
      */
     public Integer voteFeePerKbChange(Transaction tx, Coin feePerKb) {
         AddressBasedAuthorizer authorizer = bridgeConstants.getFeePerKbChangeAuthorizer();
-        if (!authorizer.isAuthorized(tx.getSender())) {
+        if (!authorizer.isAuthorized(tx.accept(senderResolver))) {
             return FEE_PER_KB_GENERIC_ERROR_CODE;
         }
 
@@ -1844,7 +1848,7 @@ public class BridgeSupport {
 
         ABICallElection feePerKbElection = provider.getFeePerKbElection(authorizer);
         ABICallSpec feeVote = new ABICallSpec("setFeePerKb", new byte[][]{BridgeSerializationUtils.serializeCoin(feePerKb)});
-        boolean successfulVote = feePerKbElection.vote(feeVote, tx.getSender());
+        boolean successfulVote = feePerKbElection.vote(feeVote, tx.accept(senderResolver));
         if (!successfulVote) {
             return -1;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1515,7 +1515,7 @@ public class BridgeSupport {
         AddressBasedAuthorizer authorizer = bridgeConstants.getFederationChangeAuthorizer();
 
         // Must be authorized to vote (checking for signature)
-        if (!authorizer.isAuthorized(tx)) {
+        if (!authorizer.isAuthorized(tx.getSender())) {
             return FEDERATION_CHANGE_GENERIC_ERROR_CODE;
         }
 
@@ -1782,7 +1782,7 @@ public class BridgeSupport {
     private boolean isLockWhitelistChangeAuthorized(Transaction tx) {
         AddressBasedAuthorizer authorizer = bridgeConstants.getLockWhitelistChangeAuthorizer();
 
-        return authorizer.isAuthorized(tx);
+        return authorizer.isAuthorized(tx.getSender());
     }
 
     /**
@@ -1834,7 +1834,7 @@ public class BridgeSupport {
      */
     public Integer voteFeePerKbChange(Transaction tx, Coin feePerKb) {
         AddressBasedAuthorizer authorizer = bridgeConstants.getFeePerKbChangeAuthorizer();
-        if (!authorizer.isAuthorized(tx)) {
+        if (!authorizer.isAuthorized(tx.getSender())) {
             return FEE_PER_KB_GENERIC_ERROR_CODE;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupportFactory.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupportFactory.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.config.BridgeConstants;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.peg.BtcBlockStoreWithCache.Factory;
 import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.utils.BridgeEventLoggerImpl;
@@ -38,13 +39,17 @@ public class BridgeSupportFactory {
     private final Factory btcBlockStoreFactory;
     private final BridgeConstants bridgeConstants;
     private final ActivationConfig activationConfig;
+    private final SenderResolverVisitor senderResolver;
 
     public BridgeSupportFactory(Factory btcBlockStoreFactory,
-            BridgeConstants bridgeConstants, ActivationConfig activationConfig) {
+                                BridgeConstants bridgeConstants,
+                                ActivationConfig activationConfig,
+                                SenderResolverVisitor senderResolver) {
 
         this.btcBlockStoreFactory = btcBlockStoreFactory;
         this.bridgeConstants = bridgeConstants;
         this.activationConfig = activationConfig;
+        this.senderResolver = senderResolver;
     }
 
 
@@ -67,10 +72,10 @@ public class BridgeSupportFactory {
         if (logs == null) {
             eventLogger = null;
         } else {
-            eventLogger = new BridgeEventLoggerImpl(bridgeConstants, logs);
+            eventLogger = new BridgeEventLoggerImpl(bridgeConstants, logs, senderResolver);
         }
 
         return new BridgeSupport(bridgeConstants, provider, eventLogger, repository, executionBlock, btcContext,
-                federationSupport, btcBlockStoreFactory);
+                federationSupport, btcBlockStoreFactory, senderResolver);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -169,7 +169,7 @@ public class BridgeUtils {
         return BtcECKey.fromPublicOnly(pubKey).toAddress(networkParameters);
     }
 
-    public static boolean isFreeBridgeTx(Transaction rskTx, Constants constants, ActivationConfig.ForBlock activations) {
+    public static boolean isFreeBridgeTx(Transaction rskTx, RskAddress sender, Constants constants, ActivationConfig.ForBlock activations) {
         RskAddress receiveAddress = rskTx.getReceiveAddress();
         if (receiveAddress.equals(RskAddress.nullAddress())) {
             return false;
@@ -184,10 +184,10 @@ public class BridgeUtils {
                !activations.isActive(ConsensusRule.ARE_BRIDGE_TXS_PAID) &&
                rskTx.acceptTransactionSignature(constants.getChainId()) &&
                (
-                       isFromFederateMember(rskTx, bridgeConstants.getGenesisFederation()) ||
-                       isFromFederationChangeAuthorizedSender(rskTx, bridgeConstants) ||
-                       isFromLockWhitelistChangeAuthorizedSender(rskTx, bridgeConstants) ||
-                       isFromFeePerKbChangeAuthorizedSender(rskTx, bridgeConstants)
+                       isFromFederateMember(sender, bridgeConstants.getGenesisFederation()) ||
+                       isFromFederationChangeAuthorizedSender(sender, bridgeConstants) ||
+                       isFromLockWhitelistChangeAuthorizedSender(sender, bridgeConstants) ||
+                       isFromFeePerKbChangeAuthorizedSender(sender, bridgeConstants)
                );
     }
 
@@ -201,22 +201,22 @@ public class BridgeUtils {
         return rskTx.getClass() == org.ethereum.vm.program.InternalTransaction.class;
     }
 
-    public static boolean isFromFederateMember(org.ethereum.core.Transaction rskTx, Federation federation) {
-        return federation.hasMemberWithRskAddress(rskTx.getSender().getBytes());
+    public static boolean isFromFederateMember(RskAddress sender, Federation federation) {
+        return federation.hasMemberWithRskAddress(sender.getBytes());
     }
 
-    private static boolean isFromFederationChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration) {
+    private static boolean isFromFederationChangeAuthorizedSender(RskAddress sender, BridgeConstants bridgeConfiguration) {
         AddressBasedAuthorizer authorizer = bridgeConfiguration.getFederationChangeAuthorizer();
-        return authorizer.isAuthorized(rskTx);
+        return authorizer.isAuthorized(sender);
     }
 
-    private static boolean isFromLockWhitelistChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration) {
+    private static boolean isFromLockWhitelistChangeAuthorizedSender(RskAddress sender, BridgeConstants bridgeConfiguration) {
         AddressBasedAuthorizer authorizer = bridgeConfiguration.getLockWhitelistChangeAuthorizer();
-        return authorizer.isAuthorized(rskTx);
+        return authorizer.isAuthorized(sender);
     }
 
-    private static boolean isFromFeePerKbChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration) {
+    private static boolean isFromFeePerKbChangeAuthorizedSender(RskAddress sender, BridgeConstants bridgeConfiguration) {
         AddressBasedAuthorizer authorizer = bridgeConfiguration.getFeePerKbChangeAuthorizer();
-        return authorizer.isAuthorized(rskTx);
+        return authorizer.isAuthorized(sender);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -21,6 +21,7 @@ package co.rsk.peg.utils;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.config.BridgeConstants;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.Federation;
 import org.ethereum.core.Block;
@@ -44,19 +45,21 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     private static final byte[] BRIDGE_CONTRACT_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
 
     private final BridgeConstants bridgeConstants;
+    private final SenderResolverVisitor senderResolver;
 
     private List<LogInfo> logs;
 
-    public BridgeEventLoggerImpl(BridgeConstants bridgeConstants, List<LogInfo> logs) {
+    public BridgeEventLoggerImpl(BridgeConstants bridgeConstants, List<LogInfo> logs, SenderResolverVisitor senderResolver) {
         this.bridgeConstants = bridgeConstants;
         this.logs = logs;
+        this.senderResolver = senderResolver;
     }
 
     public void logUpdateCollections(Transaction rskTx) {
         this.logs.add(
                 new LogInfo(BRIDGE_CONTRACT_ADDRESS,
                             Collections.singletonList(Bridge.UPDATE_COLLECTIONS_TOPIC),
-                            RLP.encodeElement(rskTx.getSender().getBytes())
+                            RLP.encodeElement(rskTx.accept(senderResolver).getBytes())
                 )
         );
     }

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
@@ -19,8 +19,6 @@
 package co.rsk.remasc;
 
 import co.rsk.core.RskAddress;
-import org.ethereum.config.Constants;
-import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Transaction;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
@@ -67,7 +65,7 @@ public class RemascTransaction extends Transaction {
     }
 
     @Override
-    public long transactionCost(Constants constants, ActivationConfig.ForBlock activations) {
+    public long transactionCost() {
         // RemascTransaction does not pay any fees
         return 0;
     }

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
@@ -19,6 +19,7 @@
 package co.rsk.remasc;
 
 import co.rsk.core.RskAddress;
+import co.rsk.core.TransactionVisitor;
 import org.ethereum.core.Transaction;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
@@ -71,14 +72,13 @@ public class RemascTransaction extends Transaction {
     }
 
     @Override
-    public RskAddress getSender() {
-        return REMASC_ADDRESS;
-    }
-
-    @Override
     public boolean acceptTransactionSignature(byte chainId) {
         // RemascTransaction is not signed and not signature validation should be done
         return true;
     }
 
+    @Override
+    public <T> T accept(TransactionVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -20,6 +20,7 @@ package co.rsk.rpc;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.NetworkStateExporter;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.logfilter.BlocksBloomStore;
 import co.rsk.metrics.HashRateCalculator;
 import co.rsk.mine.*;
@@ -87,11 +88,12 @@ public class Web3RskImpl extends Web3Impl {
             ConfigCapabilities configCapabilities,
             BuildInfo buildInfo,
             BlocksBloomStore blocksBloomStore,
-            Web3InformationRetriever retriever) {
+            Web3InformationRetriever retriever,
+            SenderResolverVisitor senderResolver) {
         super(eth, blockchain, blockStore, receiptStore, properties, minerClient, minerServer,
               personalModule, ethModule, evmModule, txPoolModule, mnrModule, debugModule, rskModule,
               channelManager, peerScoringManager, peerServer, nodeBlockProcessor,
-              hashRateCalculator, configCapabilities, buildInfo, blocksBloomStore, retriever);
+              hashRateCalculator, configCapabilities, buildInfo, blocksBloomStore, retriever, senderResolver);
 
         this.networkStateExporter = networkStateExporter;
         this.blockStore = blockStore;

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
@@ -70,13 +70,6 @@ public class BlockTxsValidationRule implements BlockParentDependantValidationRul
         Map<RskAddress, BigInteger> curNonce = new HashMap<>();
 
         for (Transaction tx : txs) {
-            try {
-                tx.verify();
-            } catch (RuntimeException e) {
-                logger.warn("Unable to verify transaction", e);
-                return false;
-            }
-
             RskAddress sender = tx.getSender();
             BigInteger expectedNonce = curNonce.get(sender);
             if (expectedNonce == null) {

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTxsValidationRule.java
@@ -19,6 +19,7 @@
 package co.rsk.validators;
 
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.RepositorySnapshot;
 import co.rsk.panic.PanicProcessor;
@@ -47,9 +48,11 @@ public class BlockTxsValidationRule implements BlockParentDependantValidationRul
     private static final PanicProcessor panicProcessor = new PanicProcessor();
 
     private final RepositoryLocator repositoryLocator;
+    private final SenderResolverVisitor senderResolver;
 
-    public BlockTxsValidationRule(RepositoryLocator repositoryLocator) {
+    public BlockTxsValidationRule(RepositoryLocator repositoryLocator, SenderResolverVisitor senderResolver) {
         this.repositoryLocator = repositoryLocator;
+        this.senderResolver = senderResolver;
     }
 
     @Override
@@ -70,7 +73,7 @@ public class BlockTxsValidationRule implements BlockParentDependantValidationRul
         Map<RskAddress, BigInteger> curNonce = new HashMap<>();
 
         for (Transaction tx : txs) {
-            RskAddress sender = tx.getSender();
+            RskAddress sender = tx.accept(senderResolver);
             BigInteger expectedNonce = curNonce.get(sender);
             if (expectedNonce == null) {
                 expectedNonce = parentRepo.getNonce(sender);

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -303,15 +303,6 @@ public class Transaction {
         this.sender = null;
     }
 
-    @Nullable
-    public RskAddress getContractAddress() {
-        if (!isContractCreation()) {
-            return null;
-        }
-
-        return new RskAddress(HashUtil.calcNewAddr(this.getSender().getBytes(), this.getNonce()));
-    }
-
     public boolean isContractCreation() {
         return this.receiveAddress.equals(RskAddress.nullAddress());
     }

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -44,7 +44,6 @@ import org.ethereum.vm.PrecompiledContracts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.security.SignatureException;
 import java.util.List;
@@ -216,7 +215,7 @@ public class Transaction {
     //         + zeroVals * GasCost.TX_ZERO_DATA + nonZeroes * GasCost.TX_NO_ZERO_DATA;"
     public long transactionCost(Constants constants, ActivationConfig.ForBlock activations) {
         // Federators txs to the bridge are free during system setup
-        if (BridgeUtils.isFreeBridgeTx(this, constants, activations)) {
+        if (BridgeUtils.isFreeBridgeTx(this, getSender(), constants, activations)) {
             return 0;
         }
 

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -213,12 +213,7 @@ public class Transaction {
     // There was a method called NEW_getTransactionCost that implemented this alternative solution:
     // "return (this.isContractCreation() ? GasCost.TRANSACTION_CREATE_CONTRACT : GasCost.TRANSACTION)
     //         + zeroVals * GasCost.TX_ZERO_DATA + nonZeroes * GasCost.TX_NO_ZERO_DATA;"
-    public long transactionCost(Constants constants, ActivationConfig.ForBlock activations) {
-        // Federators txs to the bridge are free during system setup
-        if (BridgeUtils.isFreeBridgeTx(this, getSender(), constants, activations)) {
-            return 0;
-        }
-
+    public long transactionCost() {
         long nonZeroes = this.nonZeroDataBytes();
         long zeroVals = ListArrayUtil.getLength(this.getData()) - nonZeroes;
 

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -226,39 +226,6 @@ public class Transaction {
         return (this.isContractCreation() ? GasCost.TRANSACTION_CREATE_CONTRACT : GasCost.TRANSACTION) + zeroVals * GasCost.TX_ZERO_DATA + nonZeroes * GasCost.TX_NO_ZERO_DATA;
     }
 
-    public void verify() {
-        validate();
-    }
-
-    private void validate() {
-        if (getNonce().length > DATAWORD_LENGTH) {
-            throw new RuntimeException("Nonce is not valid");
-        }
-        if (receiveAddress != null && receiveAddress.getBytes().length != 0 && receiveAddress.getBytes().length != Constants.getMaxAddressByteLength()) {
-            throw new RuntimeException("Receive address is not valid");
-        }
-        if (gasLimit.length > DATAWORD_LENGTH) {
-            throw new RuntimeException("Gas Limit is not valid");
-        }
-        if (gasPrice != null && gasPrice.getBytes().length > DATAWORD_LENGTH) {
-            throw new RuntimeException("Gas Price is not valid");
-        }
-        if (value.getBytes().length > DATAWORD_LENGTH) {
-            throw new RuntimeException("Value is not valid");
-        }
-        if (getSignature() != null) {
-            if (BigIntegers.asUnsignedByteArray(signature.r).length > DATAWORD_LENGTH) {
-                throw new RuntimeException("Signature R is not valid");
-            }
-            if (BigIntegers.asUnsignedByteArray(signature.s).length > DATAWORD_LENGTH) {
-                throw new RuntimeException("Signature S is not valid");
-            }
-            if (getSender().getBytes() != null && getSender().getBytes().length != Constants.getMaxAddressByteLength()) {
-                throw new RuntimeException("Sender is not valid");
-            }
-        }
-    }
-
     public Keccak256 getHash() {
         if (hash == null) {
             byte[] plainMsg = this.getEncoded();

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -29,6 +29,7 @@ import co.rsk.panic.PanicProcessor;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.vm.*;
@@ -324,7 +325,7 @@ public class TransactionExecutor {
     }
 
     private void create() {
-        RskAddress newContractAddress = tx.getContractAddress();
+        RskAddress newContractAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce());
         cacheTrack.createAccount(newContractAddress); // pre-created
 
         if (isEmpty(tx.getData())) {
@@ -421,7 +422,7 @@ public class TransactionExecutor {
                 } else {
                     mEndGas = mEndGas.subtract(BigInteger.valueOf(returnDataGasValue));
                     program.spendGas(returnDataGasValue, "CONTRACT DATA COST");
-                    cacheTrack.saveCode(tx.getContractAddress(), result.getHReturn());
+                    cacheTrack.saveCode(HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()), result.getHReturn());
                 }
             }
 

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -104,7 +104,7 @@ public class TransactionExecutor {
     private boolean localCall = false;
 
     public TransactionExecutor(
-            Constants constants, ActivationConfig activationConfig, Transaction tx, final RskAddress sender, int txindex, RskAddress coinbase,
+            Constants constants, ActivationConfig activationConfig, Transaction tx, RskAddress sender, int txindex, RskAddress coinbase,
             Repository track, BlockStore blockStore, ReceiptStore receiptStore, BlockFactory blockFactory,
             ProgramInvokeFactory programInvokeFactory, Block executionBlock, long gasUsedInTheBlock, VmConfig vmConfig,
             boolean playVm, boolean remascEnabled, PrecompiledContracts precompiledContracts, Set<DataWord> deletedAccounts, ExecutorService vmExecution) {
@@ -316,7 +316,7 @@ public class TransactionExecutor {
                 result.spendGas(basicTxCost);
             } else {
                 ProgramInvoke programInvoke =
-                        programInvokeFactory.createProgramInvoke(tx, txindex, executionBlock, cacheTrack, blockStore);
+                        programInvokeFactory.createProgramInvoke(tx, sender, txindex, executionBlock, cacheTrack, blockStore);
 
                 this.vm = new VM(vmConfig, precompiledContracts);
                 this.program = new Program(vmConfig, precompiledContracts, blockFactory, activations, code, programInvoke, tx, deletedAccounts);
@@ -338,7 +338,7 @@ public class TransactionExecutor {
             // storage. It doesn't even call setupContract() to setup a storage root
         } else {
             cacheTrack.setupContract(newContractAddress);
-            ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(tx, txindex, executionBlock, cacheTrack, blockStore);
+            ProgramInvoke programInvoke = programInvokeFactory.createProgramInvoke(tx, sender, txindex, executionBlock, cacheTrack, blockStore);
 
             this.vm = new VM(vmConfig, precompiledContracts);
             this.program = new Program(vmConfig, precompiledContracts, blockFactory, activations, tx.getData(), programInvoke, tx, deletedAccounts);

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -22,10 +22,12 @@ package org.ethereum.core;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.TransactionUtils;
 import co.rsk.metrics.profilers.Metric;
 import co.rsk.metrics.profilers.Profiler;
 import co.rsk.metrics.profilers.ProfilerFactory;
 import co.rsk.panic.PanicProcessor;
+import co.rsk.peg.BridgeUtils;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -132,7 +134,7 @@ public class TransactionExecutor {
      * set readyToExecute = true
      */
     public boolean init() {
-        basicTxCost = tx.transactionCost(constants, activations);
+        basicTxCost = TransactionUtils.getTransactionCost(tx, tx.getSender(), constants, activations);
 
         if (localCall) {
             readyToExecute = true;
@@ -382,7 +384,13 @@ public class TransactionExecutor {
         try {
 
             // Charge basic cost of the transaction
-            program.spendGas(tx.transactionCost(constants, activations), "TRANSACTION COST");
+            long transactionCost = 0;
+            // Federators txs to the bridge are free during system setup
+            if (!BridgeUtils.isFreeBridgeTx(tx, tx.getSender(), constants, activations)) {
+                transactionCost = tx.transactionCost();
+            }
+
+            program.spendGas(transactionCost, "TRANSACTION COST");
 
             if (playVm) {
                 Future<?> vmExecution = vmExecutorService.submit(() -> vm.play(program));

--- a/rskj-core/src/main/java/org/ethereum/crypto/HashUtil.java
+++ b/rskj-core/src/main/java/org/ethereum/crypto/HashUtil.java
@@ -109,12 +109,12 @@ public class HashUtil {
      * @param nonce - nonce of creating address
      * @return new address
      */
-    public static byte[] calcNewAddr(byte[] addr, byte[] nonce) {
+    public static RskAddress calcNewAddr(byte[] addr, byte[] nonce) {
 
         byte[] encSender = RLP.encodeElement(addr);
         byte[] encNonce = RLP.encodeBigInteger(new BigInteger(1, nonce));
 
-        return keccak256Omit12(RLP.encodeList(encSender, encNonce));
+        return new RskAddress(keccak256Omit12(RLP.encodeList(encSender, encNonce)));
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
@@ -21,6 +21,7 @@ package org.ethereum.rpc.dto;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
@@ -113,7 +114,7 @@ public class BlockResultDTO {
         this.paidFees = paidFees != null ? TypeConverter.toQuantityJsonHex(paidFees.getBytes()) : null;
     }
 
-    public static BlockResultDTO fromBlock(Block b, boolean fullTx, BlockStore blockStore) {
+    public static BlockResultDTO fromBlock(Block b, boolean fullTx, BlockStore blockStore, SenderResolverVisitor senderResolver) {
         if (b == null) {
             return null;
         }
@@ -127,7 +128,8 @@ public class BlockResultDTO {
         List<Transaction> blockTransactions = b.getTransactionsList();
         if (fullTx) {
             for (int i = 0; i < blockTransactions.size(); i++) {
-                transactions.add(new TransactionResultDTO(b, i, blockTransactions.get(i)));
+                Transaction tx = blockTransactions.get(i);
+                transactions.add(new TransactionResultDTO(b, i, tx, tx.accept(senderResolver)));
             }
         } else {
             for (Transaction tx : blockTransactions) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -18,9 +18,10 @@
 
 package org.ethereum.rpc.dto;
 
-import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.rpc.LogFilterElement;
 import org.ethereum.vm.LogInfo;
@@ -56,9 +57,9 @@ public class TransactionReceiptDTO {
         blockHash = toUnformattedJsonHex(txInfo.getBlockHash());
         blockNumber = toQuantityJsonHex(block.getNumber());
 
-        RskAddress contractAddress = receipt.getTransaction().getContractAddress();
-        if (contractAddress != null) {
-            this.contractAddress = contractAddress.toJsonString();
+        if (receipt.getTransaction().isContractCreation()) {
+            Transaction transaction = receipt.getTransaction();
+            contractAddress = HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).toJsonString();
         }
 
         cumulativeGasUsed = toQuantityJsonHex(receipt.getCumulativeGas());

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -18,6 +18,7 @@
 
 package org.ethereum.rpc.dto;
 
+import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
@@ -48,8 +49,7 @@ public class TransactionReceiptDTO {
     private String status;               // either 1 (success) or 0 (failure)
     private String logsBloom;            // Bloom filter for light clients to quickly retrieve related logs.
 
-
-    public  TransactionReceiptDTO(Block block, TransactionInfo txInfo) {
+    public  TransactionReceiptDTO(Block block, TransactionInfo txInfo, RskAddress sender) {
 
         TransactionReceipt receipt = txInfo.getReceipt();
 
@@ -59,11 +59,11 @@ public class TransactionReceiptDTO {
 
         if (receipt.getTransaction().isContractCreation()) {
             Transaction transaction = receipt.getTransaction();
-            contractAddress = HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).toJsonString();
+            contractAddress = HashUtil.calcNewAddr(sender.getBytes(), transaction.getNonce()).toJsonString();
         }
 
         cumulativeGasUsed = toQuantityJsonHex(receipt.getCumulativeGas());
-        from = receipt.getTransaction().getSender().toJsonString();
+        from = sender.toJsonString();
         gasUsed = toQuantityJsonHex(receipt.getGasUsed());
 
         logs = new LogFilterElement[receipt.getLogInfoList().size()];

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -19,6 +19,7 @@
 package org.ethereum.rpc.dto;
 
 import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
@@ -50,7 +51,7 @@ public class TransactionResultDTO {
     public String r;
     public String s;
 
-    public TransactionResultDTO(Block b, Integer index, Transaction tx) {
+    public TransactionResultDTO(Block b, Integer index, Transaction tx, RskAddress sender) {
         hash = tx.getHash().toJsonString();
 
         if (Arrays.equals(tx.getNonce(), ByteUtil.EMPTY_BYTE_ARRAY)) {
@@ -63,7 +64,7 @@ public class TransactionResultDTO {
         blockNumber = b != null ? TypeConverter.toQuantityJsonHex(b.getNumber()) : null;
         transactionIndex = index != null ? TypeConverter.toQuantityJsonHex(index) : null;
 
-        from = tx.getSender().toJsonString();
+        from = sender.toJsonString();
         to = tx.getReceiveAddress().toJsonString();
         gas = TypeConverter.toQuantityJsonHex(tx.getGasLimit());
         

--- a/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
@@ -23,6 +23,7 @@ import co.rsk.config.RemascConfig;
 import co.rsk.config.RemascConfigFactory;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.pcc.blockheader.BlockHeaderContract;
 import co.rsk.pcc.bto.HDWalletUtils;
 import co.rsk.peg.Bridge;
@@ -110,10 +111,12 @@ public class PrecompiledContracts {
     private static BigIntegerModexp bigIntegerModexp = new BigIntegerModexp();
     private final RskSystemProperties config;
     private final BridgeSupportFactory bridgeSupportFactory;
+    private final SenderResolverVisitor senderResolver;
 
-    public PrecompiledContracts(RskSystemProperties config, BridgeSupportFactory bridgeSupportFactory) {
+    public PrecompiledContracts(RskSystemProperties config, BridgeSupportFactory bridgeSupportFactory, SenderResolverVisitor senderResolver) {
         this.config = config;
         this.bridgeSupportFactory = bridgeSupportFactory;
+        this.senderResolver = senderResolver;
     }
 
 
@@ -136,7 +139,7 @@ public class PrecompiledContracts {
         }
         if (address.equals(BRIDGE_ADDR_DW)) {
             return new Bridge(BRIDGE_ADDR, config.getNetworkConstants(), config.getActivationConfig(),
-                    bridgeSupportFactory);
+                    bridgeSupportFactory, senderResolver);
         }
         if (address.equals(BIG_INT_MODEXP_ADDR_DW)) {
             return bigIntegerModexp;

--- a/rskj-core/src/main/java/org/ethereum/vm/program/InternalTransaction.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/InternalTransaction.java
@@ -19,6 +19,8 @@
 
 package org.ethereum.vm.program;
 
+import co.rsk.core.RskAddress;
+import co.rsk.core.TransactionVisitor;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
@@ -34,6 +36,7 @@ public class InternalTransaction extends Transaction {
     private int index;
     private boolean rejected = false;
     private String note;
+    private final RskAddress sender;
 
     public InternalTransaction(byte[] parentHash, int deep, int index, byte[] nonce, DataWord gasPrice, DataWord gasLimit,
                                byte[] sendAddress, byte[] receiveAddress, byte[] value, byte[] data, String note) {
@@ -84,7 +87,7 @@ public class InternalTransaction extends Transaction {
         } else {
             nonce = RLP.encodeElement(nonce);
         }
-        byte[] senderAddress = RLP.encodeElement(getSender().getBytes());
+        byte[] senderAddress = RLP.encodeElement(sender.getBytes());
         byte[] receiveAddress = RLP.encodeElement(getReceiveAddress().getBytes());
         byte[] value = RLP.encodeCoin(getValue());
         byte[] gasPrice = RLP.encodeCoin(getGasPrice());
@@ -113,5 +116,14 @@ public class InternalTransaction extends Transaction {
     @Override
     public void sign(byte[] privKeyBytes) throws ECKey.MissingPrivateKeyException {
         throw new UnsupportedOperationException("Cannot sign internal transaction.");
+    }
+
+    public RskAddress getSender() {
+        return sender;
+    }
+
+    @Override
+    public <T> T accept(TransactionVisitor<T> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -422,8 +422,7 @@ public class Program {
         RskAddress senderAddress = new RskAddress(getOwnerAddress());
 
         byte[] nonce = getStorage().getNonce(senderAddress).toByteArray();
-        byte[] newAddressBytes = HashUtil.calcNewAddr(getOwnerAddress().getLast20Bytes(), nonce);
-        RskAddress newAddress = new RskAddress(newAddressBytes);
+        RskAddress newAddress = HashUtil.calcNewAddr(getOwnerAddress().getLast20Bytes(), nonce);
 
         createContract(senderAddress, nonce, value, memStart, memSize, newAddress);
     }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactory.java
@@ -20,6 +20,7 @@
 package org.ethereum.vm.program.invoke;
 
 import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -33,7 +34,7 @@ import org.ethereum.vm.program.Program;
  */
 public interface ProgramInvokeFactory {
 
-    ProgramInvoke createProgramInvoke(Transaction tx, int txindex, Block block,
+    ProgramInvoke createProgramInvoke(Transaction tx, RskAddress sender, int txindex, Block block,
                                       Repository repository, BlockStore blockStore);
 
     ProgramInvoke createProgramInvoke(Program program, DataWord toAddress, DataWord callerAddress,

--- a/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
@@ -24,6 +24,7 @@ import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockStore;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
@@ -51,7 +52,7 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
 
         /***         ADDRESS op       ***/
         // YP: Get address of currently executing account.
-        RskAddress addr = tx.isContractCreation() ? tx.getContractAddress() : tx.getReceiveAddress();
+        RskAddress addr = tx.isContractCreation() ? HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()) : tx.getReceiveAddress();
 
         /***         ORIGIN op       ***/
         // YP: This is the sender of original transaction; it is never a contract.

--- a/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
@@ -47,20 +47,20 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
 
     // Invocation by the wire tx
     @Override
-    public ProgramInvoke createProgramInvoke(Transaction tx, int txindex, Block block, Repository repository,
+    public ProgramInvoke createProgramInvoke(Transaction tx, RskAddress sender, int txindex, Block block, Repository repository,
                                              BlockStore blockStore) {
 
         /***         ADDRESS op       ***/
         // YP: Get address of currently executing account.
-        RskAddress addr = tx.isContractCreation() ? HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()) : tx.getReceiveAddress();
+        RskAddress addr = tx.isContractCreation() ? HashUtil.calcNewAddr(sender.getBytes(), tx.getNonce()) : tx.getReceiveAddress();
 
         /***         ORIGIN op       ***/
         // YP: This is the sender of original transaction; it is never a contract.
-        byte[] origin = tx.getSender().getBytes();
+        byte[] origin = sender.getBytes();
 
         /***         CALLER op       ***/
         // YP: This is the address of the account that is directly responsible for this execution.
-        byte[] caller = tx.getSender().getBytes();
+        byte[] caller = sender.getBytes();
 
         /***         BALANCE op       ***/
         Coin balance = repository.getBalance(addr);

--- a/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
+++ b/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
@@ -21,8 +21,8 @@ package co.rsk.TestHelpers;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.BridgeUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Transaction;
 import org.mockito.Mockito;
@@ -61,7 +61,7 @@ public class Tx {
         r.nextBytes(returnReceiveAddressBytes);
         RskAddress returnReceiveAddress = new RskAddress(returnReceiveAddressBytes);
 
-        Mockito.when(transaction.getSender()).thenReturn(returnSender);
+        Mockito.when(transaction.accept(any(SenderResolverVisitor.class))).thenReturn(returnSender);
         Mockito.when(transaction.getHash()).thenReturn(new Keccak256(TestUtils.randomBytes(32)));
         Mockito.when(transaction.acceptTransactionSignature(config.getNetworkConstants().getChainId())).thenReturn(Boolean.TRUE);
         Mockito.when(transaction.getReceiveAddress()).thenReturn(returnReceiveAddress);

--- a/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
+++ b/rskj-core/src/test/java/co/rsk/TestHelpers/Tx.java
@@ -22,6 +22,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
+import co.rsk.peg.BridgeUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Transaction;
 import org.mockito.Mockito;
@@ -83,7 +84,7 @@ public class Tx {
             b[i] = bytes.get(i);
         }
         Mockito.when(transaction.getData()).thenReturn(b);
-        Mockito.when(transaction.transactionCost(any(), any())).thenReturn(amount);
+        Mockito.when(transaction.transactionCost()).thenReturn(amount);
 
         return transaction;
     }

--- a/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
@@ -85,7 +85,7 @@ public class CallContractTest {
                     );
 
             org.ethereum.core.TransactionExecutor executor = transactionExecutorFactory
-                    .newInstance(tx, 0, bestBlock.getCoinbase(), repository, bestBlock, 0)
+                    .newInstance(tx, tx.getSender(), 0, bestBlock.getCoinbase(), repository, bestBlock, 0)
                     .setLocalCall(true);
 
             executor.init();

--- a/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
@@ -65,6 +65,7 @@ public class CallContractTest {
 
         Block bestBlock = world.getBlockChain().getBestBlock();
 
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         Repository repository = world.getRepositoryLocator()
                 .startTrackingAt(world.getBlockChain().getBestBlock().getHeader());
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(
@@ -72,7 +73,7 @@ public class CallContractTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 btcBlockStoreFactory,
                 config.getNetworkConstants().getBridgeConstants(),
-                config.getActivationConfig());
+                config.getActivationConfig(), senderResolver);
 
         try {
             TransactionExecutorFactory transactionExecutorFactory = new TransactionExecutorFactory(
@@ -81,11 +82,12 @@ public class CallContractTest {
                     null,
                     blockFactory,
                     new ProgramInvokeFactoryImpl(),
-                    new PrecompiledContracts(config, bridgeSupportFactory)
+                    new PrecompiledContracts(config, bridgeSupportFactory, senderResolver),
+                    senderResolver
                     );
 
             org.ethereum.core.TransactionExecutor executor = transactionExecutorFactory
-                    .newInstance(tx, tx.getSender(), 0, bestBlock.getCoinbase(), repository, bestBlock, 0)
+                    .newInstance(tx, 0, bestBlock.getCoinbase(), repository, bestBlock, 0)
                     .setLocalCall(true);
 
             executor.init();

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -258,7 +258,7 @@ public class TransactionTest {
                             invokeFactory,
                             precompiledContracts);
                     TransactionExecutor executor = transactionExecutorFactory
-                            .newInstance(txConst, 0, bestBlock.getCoinbase(), track, bestBlock, 0)
+                            .newInstance(txConst, txConst.getSender(), 0, bestBlock.getCoinbase(), track, bestBlock, 0)
                             .setLocalCall(true);
 
                     executor.init();

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
@@ -19,6 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.StateRootHandler;
 import co.rsk.trie.TrieConverter;
@@ -60,7 +61,7 @@ public class BlockValidatorBuilder {
     private BlockStore blockStore;
 
     public BlockValidatorBuilder addBlockTxsFieldsValidationRule() {
-        this.blockTxsFieldsValidationRule = new BlockTxsFieldsValidationRule();
+        this.blockTxsFieldsValidationRule = new BlockTxsFieldsValidationRule(new SenderResolverVisitor());
         return this;
     }
 
@@ -68,7 +69,7 @@ public class BlockValidatorBuilder {
         this.blockTxsValidationRule = new BlockTxsValidationRule(new RepositoryLocator(
                 trieStore,
                 new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>())
-        ));
+        ), new SenderResolverVisitor());
         return this;
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
@@ -26,6 +26,7 @@ import co.rsk.remasc.RemascTransaction;
 import co.rsk.test.builders.BlockBuilder;
 import org.ethereum.core.*;
 import org.ethereum.core.genesis.GenesisLoader;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RskTestContext;
 import org.ethereum.vm.DataWord;
 import org.junit.Assert;
@@ -539,9 +540,9 @@ public class TransactionPoolImplTest {
 
         transactionPool.addTransaction(tx);
 
-        Assert.assertNotNull(tx.getContractAddress().getBytes());
+        Assert.assertNotNull(HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes());
         // Stored value at 0 position should be 1, one more than the blockChain best block
-        Assert.assertEquals(DataWord.ONE, transactionPool.getPendingState().getStorageValue(tx.getContractAddress(), DataWord.ZERO));
+        Assert.assertEquals(DataWord.ONE, transactionPool.getPendingState().getStorageValue(HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()), DataWord.ZERO));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -7,6 +7,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.DifficultyCalculator;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockChainImplTest;
 import co.rsk.core.bc.BlockExecutor;
@@ -221,7 +222,7 @@ public class MainNetMinerTest {
                 blockFactory,
                 blockExecutor,
                 new MinimumGasPriceCalculator(Coin.valueOf(miningConfig.getMinGasPriceTarget())),
-                new MinerUtils()
+                new MinerUtils(new SenderResolverVisitor())
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -23,6 +23,7 @@ import co.rsk.config.MiningConfig;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.DifficultyCalculator;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.SnapshotManager;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.core.bc.MiningMainchainView;
@@ -295,7 +296,7 @@ public class MinerManagerTest {
                         blockFactory,
                         blockExecutor,
                         new MinimumGasPriceCalculator(Coin.valueOf(miningConfig.getMinGasPriceTarget())),
-                        new MinerUtils()
+                        new MinerUtils(new SenderResolverVisitor())
                 ),
                 clock,
                 blockFactory,

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -776,10 +776,11 @@ public class SyncProcessorTest {
         Block block = new BlockGenerator().createChildBlock(genesis, txs, blockChainBuilder.getRepository().getRoot());
 
         StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                 config.getNetworkConstants().getBridgeConstants(),
-                config.getActivationConfig());
+                config.getActivationConfig(), senderResolver);
 
         BlockExecutor blockExecutor = new BlockExecutor(
                 config.getActivationConfig(),
@@ -791,7 +792,8 @@ public class SyncProcessorTest {
                         null,
                         blockFactory,
                         new ProgramInvokeFactoryImpl(),
-                        new PrecompiledContracts(config, bridgeSupportFactory)
+                        new PrecompiledContracts(config, bridgeSupportFactory, senderResolver),
+                        senderResolver
                 )
         );
         Assert.assertEquals(1, block.getTransactionsList().size());

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
@@ -19,6 +19,7 @@
 package co.rsk.net.handler.txvalidator;
 
 import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.core.SenderResolverVisitor;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -84,7 +85,7 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
         BridgeRegTestConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
         tx4.sign(BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS.get(0).getPrivKeyBytes());
 
-        TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(constants, activationConfig);
+        TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(constants, activationConfig, new SenderResolverVisitor());
 
         Assert.assertTrue(tvigpv.validate(tx1, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
         Assert.assertTrue(tvigpv.validate(tx2, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
@@ -132,7 +133,7 @@ public class TxValidatorIntrinsicGasLimitValidatorTest {
                 Constants.REGTEST_CHAIN_ID);
         tx4.sign(new ECKey().getPrivKeyBytes());
 
-        TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(constants, activationConfig);
+        TxValidatorIntrinsicGasLimitValidator tvigpv = new TxValidatorIntrinsicGasLimitValidator(constants, activationConfig, new SenderResolverVisitor());
 
         Assert.assertFalse(tvigpv.validate(tx1, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());
         Assert.assertFalse(tvigpv.validate(tx2, new AccountState(), null, null, Long.MAX_VALUE, false).transactionIsValid());

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderContractTest.java
@@ -28,6 +28,7 @@ import co.rsk.blockchain.utils.BlockMiner;
 import co.rsk.config.RskMiningConstants;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.mine.MinerUtils;
 import co.rsk.pcc.ExecutionEnvironment;
 import co.rsk.pcc.NativeContract;
@@ -97,7 +98,7 @@ public class BlockHeaderContractTest {
     public void setUp() {
         config = new TestSystemProperties();
         blockFactory = new BlockFactory(config.getActivationConfig());
-        PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+        PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
 

--- a/rskj-core/src/test/java/co/rsk/peg/AddressBasedAuthorizerTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/AddressBasedAuthorizerTest.java
@@ -19,6 +19,7 @@
 package co.rsk.peg;
 
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.junit.Assert;
@@ -27,6 +28,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,16 +80,17 @@ public class AddressBasedAuthorizerTest {
                 ECKey.fromPrivate(BigInteger.valueOf(102L))
         ), AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
 
+        SenderResolverVisitor senderResolver = mock(SenderResolverVisitor.class);
         for (long n = 100L; n <= 102L; n++) {
             Transaction mockedTx = mock(Transaction.class);
-            when(mockedTx.getSender()).thenReturn(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress()));
+            when(mockedTx.accept(any(SenderResolverVisitor.class))).thenReturn(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress()));
             Assert.assertTrue(auth.isAuthorized(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress())));
-            Assert.assertTrue(auth.isAuthorized(mockedTx.getSender()));
+            Assert.assertTrue(auth.isAuthorized(mockedTx.accept(senderResolver)));
         }
 
         Assert.assertFalse(auth.isAuthorized(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress())));
         Transaction mockedTx = mock(Transaction.class);
-        when(mockedTx.getSender()).thenReturn(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress()));
-        Assert.assertFalse(auth.isAuthorized(mockedTx.getSender()));
+        when(mockedTx.accept(any(SenderResolverVisitor.class))).thenReturn(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress()));
+        Assert.assertFalse(auth.isAuthorized(mockedTx.accept(senderResolver)));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/AddressBasedAuthorizerTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/AddressBasedAuthorizerTest.java
@@ -82,12 +82,12 @@ public class AddressBasedAuthorizerTest {
             Transaction mockedTx = mock(Transaction.class);
             when(mockedTx.getSender()).thenReturn(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress()));
             Assert.assertTrue(auth.isAuthorized(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(n)).getAddress())));
-            Assert.assertTrue(auth.isAuthorized(mockedTx));
+            Assert.assertTrue(auth.isAuthorized(mockedTx.getSender()));
         }
 
         Assert.assertFalse(auth.isAuthorized(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress())));
         Transaction mockedTx = mock(Transaction.class);
         when(mockedTx.getSender()).thenReturn(new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(50L)).getAddress()));
-        Assert.assertFalse(auth.isAuthorized(mockedTx));
+        Assert.assertFalse(auth.isAuthorized(mockedTx.getSender()));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeCostsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeCostsTest.java
@@ -5,6 +5,7 @@ import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.genesis.TestGenesisLoader;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
@@ -49,7 +50,7 @@ public class BridgeCostsTest {
         bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
     }
 
     @Test
@@ -58,7 +59,7 @@ public class BridgeCostsTest {
 
         Transaction txMock = mock(Transaction.class);
         when(txMock.getReceiveAddress()).thenReturn(RskAddress.nullAddress());
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), null, null, null, null);
 
         for (int numberOfHeaders = 0; numberOfHeaders < 10; numberOfHeaders++) {
@@ -77,7 +78,7 @@ public class BridgeCostsTest {
 
         Transaction txMock = mock(Transaction.class);
         when(txMock.getReceiveAddress()).thenReturn(RskAddress.nullAddress());
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), null, null, null, null);
 
         final long BASE_COST = 66_000L;
@@ -102,7 +103,7 @@ public class BridgeCostsTest {
 
         Transaction txMock = mock(Transaction.class);
         when(txMock.getReceiveAddress()).thenReturn(RskAddress.nullAddress());
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), null, null, null, null);
 
         final long BASE_COST = 25_000L;
@@ -127,8 +128,8 @@ public class BridgeCostsTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory);
+                activationConfig, new SenderResolverVisitor());
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory, new SenderResolverVisitor());
 
         org.ethereum.core.Transaction rskTx = CallTransaction.createCallTransaction(
                 0,
@@ -214,8 +215,8 @@ public class BridgeCostsTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory);
+                activationConfig, new SenderResolverVisitor());
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory, new SenderResolverVisitor());
         org.ethereum.core.Transaction rskTx;
         if (function==null) {
             rskTx = CallTransaction.createRawTransaction(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -3590,7 +3590,7 @@ public class BridgeSupportTest {
                 .thenReturn(new RskAddress(ByteUtil.leftPadBytes(new byte[] {0x43}, 20)));
         when(constants.getFeePerKbChangeAuthorizer())
                 .thenReturn(authorizer);
-        when(authorizer.isAuthorized(tx))
+        when(authorizer.isAuthorized(tx.getSender()))
                 .thenReturn(true);
 
         BridgeSupport bridgeSupport = getBridgeSupport(constants, provider, repositoryMock, null);
@@ -3613,7 +3613,7 @@ public class BridgeSupportTest {
                 .thenReturn(new RskAddress(senderBytes));
         when(constants.getFeePerKbChangeAuthorizer())
                 .thenReturn(authorizer);
-        when(authorizer.isAuthorized(tx))
+        when(authorizer.isAuthorized(tx.getSender()))
                 .thenReturn(false);
 
         BridgeSupport bridgeSupport = getBridgeSupport(provider, repositoryMock, null);
@@ -3636,7 +3636,7 @@ public class BridgeSupportTest {
                 .thenReturn(new RskAddress(senderBytes));
         when(constants.getFeePerKbChangeAuthorizer())
                 .thenReturn(authorizer);
-        when(authorizer.isAuthorized(tx))
+        when(authorizer.isAuthorized(tx.getSender()))
                 .thenReturn(true);
         when(authorizer.isAuthorized(tx.getSender()))
                 .thenReturn(true);
@@ -3665,7 +3665,7 @@ public class BridgeSupportTest {
                 .thenReturn(new RskAddress(senderBytes));
         when(constants.getFeePerKbChangeAuthorizer())
                 .thenReturn(authorizer);
-        when(authorizer.isAuthorized(tx))
+        when(authorizer.isAuthorized(tx.getSender()))
                 .thenReturn(true);
         when(authorizer.isAuthorized(tx.getSender()))
                 .thenReturn(true);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -30,6 +30,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.genesis.TestGenesisLoader;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.MutableTrieCache;
@@ -155,9 +156,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         World world = new World();
         bridge.init(rskTx, world.getBlockChain().getBestBlock(), track, world.getBlockStore(), null, new LinkedList<>());
         try {
@@ -195,9 +196,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         World world = new World();
         bridge.init(rskTx, world.getBlockChain().getBestBlock(), track, world.getBlockStore(), null, new LinkedList<>());
 
@@ -246,9 +247,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, blocks.get(9), track, world.getBlockStore(), null, new LinkedList<>());
 
         bridge.execute(Bridge.UPDATE_COLLECTIONS.encode());
@@ -270,9 +271,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), track, null, null, null);
         try {
             bridge.execute(Bridge.RECEIVE_HEADERS.encode());
@@ -295,9 +296,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         bridge.execute(Bridge.RECEIVE_HEADERS.encode());
@@ -316,9 +317,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         co.rsk.bitcoinj.core.BtcBlock block = new co.rsk.bitcoinj.core.BtcBlock(networkParameters, 1, PegTestUtils.createHash(), PegTestUtils.createHash(), 1, Utils.encodeCompactBits(networkParameters.getMaxTarget()), 1, new ArrayList<>())
@@ -341,9 +342,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         Transaction mockedTx = mock(Transaction.class);
         bridge.init(mockedTx, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         Assert.assertNull(bridge.execute(new byte[3]));
@@ -357,9 +358,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         Transaction mockedTx = mock(Transaction.class);
 
         try {
@@ -377,9 +378,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         Transaction mockedTx = mock(Transaction.class);
         bridge.init(mockedTx, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         Assert.assertNull(bridge.execute(new byte[4]));
@@ -393,9 +394,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         Transaction mockedTx = mock(Transaction.class);
 
         try {
@@ -415,9 +416,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         try {
             bridge.execute(Bridge.RECEIVE_HEADERS.encode());
@@ -440,9 +441,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         Object[] objectArray = new Object[1];
@@ -464,7 +465,7 @@ public class BridgeTest {
 
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
         Bridge bridge = PowerMockito.spy(new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock));
+                bridgeSupportFactoryMock, new SenderResolverVisitor()));
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
@@ -522,13 +523,13 @@ public class BridgeTest {
 
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
         Bridge bridge = PowerMockito.spy(new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock));
+                bridgeSupportFactoryMock, new SenderResolverVisitor()));
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
 
         Bridge spiedBridge = PowerMockito.spy(new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock));
+                bridgeSupportFactoryMock, new SenderResolverVisitor()));
         spiedBridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         final int numBlocks = 10;
@@ -601,9 +602,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
 
@@ -628,9 +629,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         NetworkParameters btcParams = RegTestParams.get();
@@ -679,9 +680,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
 
@@ -728,9 +729,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         byte[] serializedTx = tx.bitcoinSerialize();
@@ -808,9 +809,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         NetworkParameters btcParams = RegTestParams.get();
@@ -834,9 +835,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         NetworkParameters btcParams = RegTestParams.get();
@@ -860,9 +861,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         NetworkParameters btcParams = RegTestParams.get();
@@ -907,9 +908,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         Transaction mockedTx = mock(Transaction.class);
         when(mockedTx.isLocalCallTransaction()).thenReturn(true);
         bridge.init(mockedTx, getGenesisBlock(), track, null, null, null);
@@ -927,9 +928,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         Transaction mockedTx = mock(Transaction.class);
         when(mockedTx.isLocalCallTransaction()).thenReturn(true);
         bridge.init(mockedTx, getGenesisBlock(), track, null, null, null);
@@ -950,9 +951,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new byte[3];
@@ -979,9 +980,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new byte[3];
@@ -1003,9 +1004,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new BtcECKey().getPubKey();
@@ -1027,9 +1028,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, new BlockGenerator().getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new BtcECKey().getPubKey();
@@ -1051,9 +1052,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, new BlockGenerator().getGenesisBlock(), track, null, null, null);
 
         byte[] federatorPublicKeySerialized = new BtcECKey().getPubKey();
@@ -1066,7 +1067,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInUpdateCollection() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
 
         try {
             bridge.updateCollections(null);
@@ -1079,7 +1080,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInReleaseBtc() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
 
         try {
             bridge.releaseBtc(null);
@@ -1092,7 +1093,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInGetStateForBtcReleaseClient() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
 
         try {
             bridge. getStateForBtcReleaseClient(null);
@@ -1105,7 +1106,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInGetStateForDebugging() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
 
         try {
             bridge.getStateForDebugging(null);
@@ -1118,7 +1119,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInGetBtcBlockchainBestChainHeight() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
 
         try {
             bridge.getBtcBlockchainBestChainHeight(null);
@@ -1131,7 +1132,7 @@ public class BridgeTest {
 
     @Test
     public void exceptionInGetBtcBlockchainBlockLocator() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
 
         try {
             bridge.getBtcBlockchainBlockLocator(null);
@@ -1153,7 +1154,7 @@ public class BridgeTest {
 
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
         Bridge bridge = PowerMockito.spy(new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock));
+                bridgeSupportFactoryMock, new SenderResolverVisitor()));
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getBtcBlockchainBlockLocator())
@@ -1180,9 +1181,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), track, null, null, null);
 
@@ -1206,9 +1207,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
 
         org.ethereum.core.Transaction rskTx = CallTransaction.createCallTransaction(
                 0,
@@ -1294,9 +1295,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         org.ethereum.core.Transaction rskTx;
         if (function==null) {
             rskTx = CallTransaction.createRawTransaction(
@@ -1341,9 +1342,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1368,9 +1369,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1388,9 +1389,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1414,9 +1415,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1434,9 +1435,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1450,10 +1451,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1467,9 +1468,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1480,7 +1481,7 @@ public class BridgeTest {
 
     @Test
     public void getFederationCreationBlockNumber() throws IOException {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getFederationCreationBlockNumber()).thenReturn(42L);
@@ -1493,7 +1494,7 @@ public class BridgeTest {
         doReturn(false).when(activationConfig).isActive(eq(RSKIP123), anyLong());
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -1527,7 +1528,7 @@ public class BridgeTest {
         doReturn(true).when(activationConfig).isActive(eq(RSKIP123), anyLong());
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
@@ -1543,7 +1544,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -1560,7 +1561,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -1595,9 +1596,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1611,10 +1612,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1628,9 +1629,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1641,7 +1642,7 @@ public class BridgeTest {
 
     @Test
     public void getRetiringFederationCreationBlockNumber() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getRetiringFederationCreationBlockNumber()).thenReturn(42L);
@@ -1655,7 +1656,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -1690,7 +1691,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -1706,7 +1707,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -1722,7 +1723,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
@@ -1758,10 +1759,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1776,7 +1777,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
@@ -1811,7 +1812,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -1827,7 +1828,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -1843,7 +1844,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
@@ -1880,10 +1881,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -1901,7 +1902,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
@@ -1926,7 +1927,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
 
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
@@ -1948,7 +1949,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
 
 
@@ -1974,7 +1975,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
@@ -2000,9 +2001,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2017,9 +2018,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2034,10 +2035,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2051,9 +2052,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2067,10 +2068,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         OneOffWhiteListEntry mockedEntry10 = new OneOffWhiteListEntry(new BtcECKey().toAddress(networkParameters), Coin.COIN);
@@ -2097,10 +2098,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), track, null, null, null);
 
         Assert.assertNull(bridge.execute(Bridge.GET_LOCK_WHITELIST_ENTRY_BY_ADDRESS.encode(new Object[]{ address.toBase58() })));
@@ -2132,7 +2133,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), track, null, null, null);
 
         // Get the unlimited whitelist address
@@ -2165,14 +2166,14 @@ public class BridgeTest {
         Transaction mockedTransaction = mock(Transaction.class);
         // Just setting a random address as the sender
         RskAddress sender = new RskAddress(fedECPrivateKey.getAddress());
-        when(mockedTransaction.getSender()).thenReturn(sender);
+        when(mockedTransaction.accept(any(SenderResolverVisitor.class))).thenReturn(sender);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), track, null, null, null);
 
         byte[] result = bridge.execute(Bridge.ADD_LOCK_WHITELIST_ADDRESS.encode(new Object[]{
@@ -2197,9 +2198,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), track, null, null, null);
 
         try {
@@ -2224,10 +2225,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), track, null, null, null);
 
         Assert.assertNull(bridge.execute(Bridge.ADD_ONE_OFF_LOCK_WHITELIST_ADDRESS.encode(new Object[]{ "i-am-an-address", BigInteger.valueOf(25L) })));
@@ -2244,14 +2245,14 @@ public class BridgeTest {
         Transaction mockedTransaction = mock(Transaction.class);
         // Just setting a random address as the sender
         RskAddress sender = new RskAddress(fedECPrivateKey.getAddress());
-        when(mockedTransaction.getSender()).thenReturn(sender);
+        when(mockedTransaction.accept(any(SenderResolverVisitor.class))).thenReturn(sender);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), track, null, null, null);
 
         byte[] result = bridge.execute(Bridge.ADD_ONE_OFF_LOCK_WHITELIST_ADDRESS.encode(new Object[]{
@@ -2276,9 +2277,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), track, null, null, null);
 
         Assert.assertNull(bridge.execute(Bridge.ADD_UNLIMITED_LOCK_WHITELIST_ADDRESS.encode(new Object[]{ "i-am-an-address" })));
@@ -2295,14 +2296,14 @@ public class BridgeTest {
         Transaction mockedTransaction = mock(Transaction.class);
         // Just setting a random address as the sender
         RskAddress sender = new RskAddress(fedECPrivateKey.getAddress());
-        when(mockedTransaction.getSender()).thenReturn(sender);
+        when(mockedTransaction.accept(any(SenderResolverVisitor.class))).thenReturn(sender);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), track, null, null, null);
 
         byte[] result = bridge.execute(Bridge.ADD_UNLIMITED_LOCK_WHITELIST_ADDRESS.encode(new Object[]{
@@ -2324,9 +2325,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(mockedTransaction, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2337,7 +2338,7 @@ public class BridgeTest {
 
     @Test
     public void getFeePerKb() {
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, new SenderResolverVisitor());
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
         when(bridgeSupportMock.getFeePerKb())
@@ -2352,10 +2353,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2370,10 +2371,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2408,9 +2409,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(rskTx, new BlockGenerator().getGenesisBlock(), track, null, null, null);
 
         Logger mockedLogger = mock(Logger.class);
@@ -2427,7 +2428,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Address address = new BtcECKey().toAddress(networkParameters);
@@ -2453,7 +2454,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -2479,7 +2480,7 @@ public class BridgeTest {
             BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
             Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                    bridgeSupportFactoryMock);
+                    bridgeSupportFactoryMock, new SenderResolverVisitor());
             when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
             bridge.init(tx, getGenesisBlock(), null, null, null, null);
 
@@ -2509,7 +2510,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -2535,7 +2536,7 @@ public class BridgeTest {
 
     public void getBtcBlockchainInitialBlockHeight() throws  IOException {
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                null);
+                null, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), null, null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2552,7 +2553,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
 
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
@@ -2569,7 +2570,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
 
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
@@ -2629,9 +2630,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = PowerMockito.spy(new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory));
+                bridgeSupportFactory, new SenderResolverVisitor()));
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2695,9 +2696,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = PowerMockito.spy(new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory));
+                bridgeSupportFactory, new SenderResolverVisitor()));
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2749,10 +2750,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         Bridge bridge = PowerMockito.spy(new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory));
+                bridgeSupportFactory, new SenderResolverVisitor()));
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         bridge.init(txMock, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2812,9 +2813,9 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
                 bridgeConstants,
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         bridge.init(null, getGenesisBlock(), createRepository().startTracking(), null, null, null);
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         Whitebox.setInternalState(bridge, "bridgeSupport", bridgeSupportMock);
@@ -2835,7 +2836,7 @@ public class BridgeTest {
 //        config.setBlockchainConfig(mockedConfig);
         blockFactory = new BlockFactory(config.getActivationConfig());
 
-        PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+        PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
         EVMAssembler assembler = new EVMAssembler();
         ProgramInvoke invoke = new ProgramInvokeMockImpl();
 
@@ -2880,10 +2881,10 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
                 
         PrecompiledContracts precompiledContracts = new PrecompiledContracts(config,
-                bridgeSupportFactory);
+                bridgeSupportFactory, new SenderResolverVisitor());
         EVMAssembler assembler = new EVMAssembler();
         ProgramInvoke invoke = new ProgramInvokeMockImpl();
 
@@ -2993,7 +2994,7 @@ public class BridgeTest {
         Transaction txMock = mock(Transaction.class);
         when(txMock.getReceiveAddress()).thenReturn(RskAddress.nullAddress());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                mock(BridgeSupportFactory.class));
+                mock(BridgeSupportFactory.class), new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), null, null, null, null);
 
         for (int numberOfHeaders = 0; numberOfHeaders < 10; numberOfHeaders++) {
@@ -3013,7 +3014,7 @@ public class BridgeTest {
         Transaction txMock = mock(Transaction.class);
         when(txMock.getReceiveAddress()).thenReturn(RskAddress.nullAddress());
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                mock(BridgeSupportFactory.class));
+                mock(BridgeSupportFactory.class), new SenderResolverVisitor());
         bridge.init(txMock, getGenesisBlock(), null, null, null, null);
 
         final long BASE_COST = 66_000L;
@@ -3038,7 +3039,7 @@ public class BridgeTest {
         RskAddress sender = new RskAddress("2acc95758f8b5f583470ba265eb685a8f45fc9d5");
         Transaction txMock = mock(Transaction.class);
         when(txMock.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
-        when(txMock.getSender()).thenReturn(sender);
+        when(txMock.accept(any(SenderResolverVisitor.class))).thenReturn(sender);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getRetiringFederation()).thenReturn(null);
@@ -3047,7 +3048,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
         bridge.init(txMock, getGenesisBlock(), null, null, null, null);
@@ -3074,7 +3075,7 @@ public class BridgeTest {
         RskAddress sender = new RskAddress(ECKey.fromPrivate(HashUtil.keccak256("federator1".getBytes(StandardCharsets.UTF_8))).getAddress());
         Transaction txMock = mock(Transaction.class);
         when(txMock.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
-        when(txMock.getSender()).thenReturn(sender);
+        when(txMock.accept(any(SenderResolverVisitor.class))).thenReturn(sender);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getRetiringFederation()).thenReturn(null);
@@ -3083,7 +3084,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
 
@@ -3105,7 +3106,7 @@ public class BridgeTest {
 
         Transaction txMock = mock(Transaction.class);
         when(txMock.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
-        when(txMock.getSender()).thenReturn(new RskAddress(new ECKey().getAddress()));
+        when(txMock.accept(new SenderResolverVisitor())).thenReturn(new RskAddress(new ECKey().getAddress()));
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getRetiringFederation()).thenReturn(null);
@@ -3114,7 +3115,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
 
@@ -3135,7 +3136,7 @@ public class BridgeTest {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                bridgeSupportFactoryMock);
+                bridgeSupportFactoryMock, new SenderResolverVisitor());
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -507,7 +507,7 @@ public class BridgeUtilsTest {
         Repository repository = new MutableRepository(new MutableTrieCache(new MutableTrieImpl(trieStore, new Trie())));
         Block rskExecutionBlock = new BlockGenerator().createChildBlock(getGenesisInstance(trieStore));
         bridge.init(rskTx, rskExecutionBlock, repository.startTracking(), null, null, null);
-        Assert.assertEquals(expected, BridgeUtils.isFreeBridgeTx(rskTx, constants, activationConfig.forBlock(rskExecutionBlock.getNumber())));
+        Assert.assertEquals(expected, BridgeUtils.isFreeBridgeTx(rskTx, rskTx.getSender(), constants, activationConfig.forBlock(rskExecutionBlock.getNumber())));
     }
 
     private Genesis getGenesisInstance(TrieStore trieStore) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -28,6 +28,7 @@ import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.genesis.TestGenesisLoader;
 import co.rsk.db.MutableTrieCache;
 import co.rsk.db.MutableTrieImpl;
@@ -491,9 +492,9 @@ public class BridgeUtilsTest {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),
                 constants.getBridgeConstants(),
-                activationConfig);
+                activationConfig, new SenderResolverVisitor());
 
-        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory);
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, bridgeSupportFactory, new SenderResolverVisitor());
         org.ethereum.core.Transaction rskTx = CallTransaction.createCallTransaction(
                 0,
                 1,
@@ -507,7 +508,7 @@ public class BridgeUtilsTest {
         Repository repository = new MutableRepository(new MutableTrieCache(new MutableTrieImpl(trieStore, new Trie())));
         Block rskExecutionBlock = new BlockGenerator().createChildBlock(getGenesisInstance(trieStore));
         bridge.init(rskTx, rskExecutionBlock, repository.startTracking(), null, null, null);
-        Assert.assertEquals(expected, BridgeUtils.isFreeBridgeTx(rskTx, rskTx.getSender(), constants, activationConfig.forBlock(rskExecutionBlock.getNumber())));
+        Assert.assertEquals(expected, BridgeUtils.isFreeBridgeTx(rskTx, rskTx.accept(new SenderResolverVisitor()), constants, activationConfig.forBlock(rskExecutionBlock.getNumber())));
     }
 
     private Genesis getGenesisInstance(TrieStore trieStore) {

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.db.RepositoryLocator;
@@ -464,17 +465,19 @@ public class RskForksBridgeTest {
                 Bridge.GET_STATE_FOR_DEBUGGING.encode(new Object[]{}), beforeBambooProperties.getNetworkConstants().getChainId());
         rskTx.sign(new byte[32]);
 
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         TransactionExecutorFactory transactionExecutorFactory = new TransactionExecutorFactory(
                 beforeBambooProperties,
                 blockStore,
                 null,
                 new BlockFactory(beforeBambooProperties.getActivationConfig()),
                 new ProgramInvokeFactoryImpl(),
-                new PrecompiledContracts(beforeBambooProperties, world.getBridgeSupportFactory())
+                new PrecompiledContracts(beforeBambooProperties, world.getBridgeSupportFactory(), senderResolver),
+                senderResolver
                 );
         Repository track = repository.startTracking();
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(rskTx, rskTx.getSender(), 0, blockChain.getBestBlock().getCoinbase(), track, blockChain.getBestBlock(), 0)
+                .newInstance(rskTx, 0, blockChain.getBestBlock().getCoinbase(), track, blockChain.getBestBlock(), 0)
                 .setLocalCall(true);
 
         executor.init();

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -474,7 +474,7 @@ public class RskForksBridgeTest {
                 );
         Repository track = repository.startTracking();
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(rskTx, 0, blockChain.getBestBlock().getCoinbase(), track, blockChain.getBestBlock(), 0)
+                .newInstance(rskTx, rskTx.getSender(), 0, blockChain.getBestBlock().getCoinbase(), track, blockChain.getBestBlock(), 0)
                 .setLocalCall(true);
 
         executor.init();

--- a/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/BridgePerformanceTestCase.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.db.BenchmarkedRepository;
 import co.rsk.db.RepositoryTrackWithBenchmarking;
 import co.rsk.peg.*;
@@ -211,10 +212,10 @@ public abstract class BridgePerformanceTestCase extends PrecompiledContractPerfo
                 Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(
                         constants.getBridgeConstants().getBtcParams());
                 BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                        btcBlockStoreFactory, constants.getBridgeConstants(), activationConfig);
+                        btcBlockStoreFactory, constants.getBridgeConstants(), activationConfig, new SenderResolverVisitor());
 
                 bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
-                        bridgeSupportFactory);
+                        bridgeSupportFactory, new SenderResolverVisitor());
                 BlockChainBuilder blockChainBuilder = new BlockChainBuilder();
                 Blockchain blockchain = blockChainBuilder.ofSize(height);
                 Transaction tx = txBuilder.build(executionIndex);

--- a/rskj-core/src/test/java/co/rsk/peg/simples/SimpleRskTransaction.java
+++ b/rskj-core/src/test/java/co/rsk/peg/simples/SimpleRskTransaction.java
@@ -35,7 +35,7 @@ public class SimpleRskTransaction extends Transaction {
     public SimpleRskTransaction(byte[] hash) {
         super(null, null, null, TestUtils.randomAddress().getBytes(), null, null);
         this.hash = hash == null ? null : new Keccak256(hash);
-        this.sender = new RskAddress(ECKey.fromPrivate(Keccak256Helper.keccak256("cow".getBytes())).getAddress());
+        sign(ECKey.fromPrivate(Keccak256Helper.keccak256("cow".getBytes())).getPrivKeyBytes());
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -22,12 +22,12 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.Federation;
 import co.rsk.peg.FederationMember;
 import co.rsk.peg.FederationTestUtils;
 import org.ethereum.core.Block;
-import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
@@ -42,7 +42,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -61,7 +60,7 @@ public class BridgeEventLoggerImplTest {
         BridgeConstants constantsMock = mock(BridgeConstants.class);
         when(constantsMock.getFederationActivationAge()).thenReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge());
         List<LogInfo> eventLogs = new LinkedList<>();
-        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(constantsMock, eventLogs);
+        BridgeEventLogger eventLogger = new BridgeEventLoggerImpl(constantsMock, eventLogs, new SenderResolverVisitor());
 
         // Setup parameters for test method call
         Block executionBlock = mock(Block.class);

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -25,6 +25,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.crypto.Keccak256;
@@ -1002,10 +1003,11 @@ public class RemascProcessMinerFeesTest {
     }
 
     private BlockExecutor buildBlockExecutor(RepositoryLocator repositoryLocator, BlockStore blockStore) {
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                 config.getNetworkConstants().getBridgeConstants(),
-                config.getActivationConfig());
+                config.getActivationConfig(), senderResolver);
 
         return new BlockExecutor(
                 config.getActivationConfig(),
@@ -1017,7 +1019,8 @@ public class RemascProcessMinerFeesTest {
                         null,
                         blockFactory,
                         new ProgramInvokeFactoryImpl(),
-                        new PrecompiledContracts(config, bridgeSupportFactory)
+                        new PrecompiledContracts(config, bridgeSupportFactory, senderResolver),
+                        senderResolver
                 )
         );
     }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -23,6 +23,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.db.*;
@@ -443,10 +444,11 @@ public class RemascStorageProviderTest {
         StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(),
                 new TrieConverter(), new HashMapDB(), new HashMap<>());
 
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(
                         config.getNetworkConstants().getBridgeConstants().getBtcParams()),
-                config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig());
+                config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig(), senderResolver);
 
         BlockExecutor blockExecutor = new BlockExecutor(
                 config.getActivationConfig(),
@@ -458,7 +460,8 @@ public class RemascStorageProviderTest {
                         null,
                         new BlockFactory(config.getActivationConfig()),
                         new ProgramInvokeFactoryImpl(),
-                        new PrecompiledContracts(config, bridgeSupportFactory)
+                        new PrecompiledContracts(config, bridgeSupportFactory, senderResolver),
+                        senderResolver
                 )
         );
 

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -18,10 +18,7 @@
 
 package co.rsk.remasc;
 
-import co.rsk.core.BlockDifficulty;
-import co.rsk.core.Coin;
-import co.rsk.core.RskAddress;
-import co.rsk.core.TransactionExecutorFactory;
+import co.rsk.core.*;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.core.bc.BlockHashesHelper;
@@ -129,12 +126,13 @@ class RemascTestRunner {
         BlockFactory blockFactory = new BlockFactory(builder.getConfig().getActivationConfig());
         final ProgramInvokeFactoryImpl programInvokeFactory = new ProgramInvokeFactoryImpl();
 
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(
                         builder.getConfig().getNetworkConstants().getBridgeConstants().getBtcParams()),
                 builder.getConfig().getNetworkConstants().getBridgeConstants(),
-                builder.getConfig().getActivationConfig());
-        PrecompiledContracts precompiledContracts = new PrecompiledContracts(builder.getConfig(), bridgeSupportFactory);
+                builder.getConfig().getActivationConfig(), senderResolver);
+        PrecompiledContracts precompiledContracts = new PrecompiledContracts(builder.getConfig(), bridgeSupportFactory, senderResolver);
         BlockExecutor blockExecutor = new BlockExecutor(
                 builder.getConfig().getActivationConfig(),
                 builder.getRepositoryLocator(),
@@ -145,7 +143,8 @@ class RemascTestRunner {
                         null,
                         blockFactory,
                         programInvokeFactory,
-                        precompiledContracts
+                        precompiledContracts,
+                        senderResolver
                 )
         );
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3EthModuleTest.java
@@ -20,6 +20,7 @@ package co.rsk.rpc;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.NetworkStateExporter;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.logfilter.BlocksBloomStore;
 import co.rsk.metrics.HashRateCalculator;
 import co.rsk.mine.MinerClient;
@@ -77,7 +78,8 @@ public class Web3EthModuleTest {
                 mock(ConfigCapabilities.class),
                 mock(BuildInfo.class),
                 mock(BlocksBloomStore.class),
-                mock(Web3InformationRetriever.class));
+                mock(Web3InformationRetriever.class),
+                mock(SenderResolverVisitor.class));
 
         assertThat(web3.eth_chainId(), is("0x21"));
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -19,6 +19,7 @@
 package co.rsk.rpc;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
@@ -48,7 +49,7 @@ public class Web3ImplRpcTest {
                             null, null, null, null,
                             null, null, null, null,
                             null, null, null, null, null,
-                            null, null, null, null, null);
+                            null, null, null, null, null, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -22,6 +22,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.NetworkStateExporter;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
+import co.rsk.core.*;
 import co.rsk.core.bc.MiningMainchainView;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.BridgeSupportFactory;
@@ -84,9 +85,9 @@ public class Web3RskImplTest {
                 null, new ExecutionBlockRetriever(mainchainView, blockchain, null, null),
                 null, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), null,
                 new BridgeSupportFactory(
-                        null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig())
+                        null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig(), new SenderResolverVisitor())
         );
-        TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
+        TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool(), new SenderResolverVisitor());
         DebugModule dm = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null);
         Web3RskImpl web3 = new Web3RskImpl(
                 rsk,
@@ -105,6 +106,7 @@ public class Web3RskImplTest {
                 null,
                 networkStateExporter,
                 blockStore,
+                null,
                 null,
                 null,
                 null,

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -21,6 +21,7 @@ package co.rsk.rpc.modules.eth;
 import co.rsk.config.BridgeConstants;
 import co.rsk.core.ReversibleTransactionExecutor;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.bc.BlockResult;
 import co.rsk.core.bc.PendingState;
 import co.rsk.db.RepositoryLocator;
@@ -73,7 +74,7 @@ public class EthModuleTest {
                 null,
                 null,
                 new BridgeSupportFactory(
-                        null, null, null));
+                        null, null, null, new SenderResolverVisitor()));
 
         String result = eth.call(args, "latest");
         assertThat(result, is(TypeConverter.toJsonHex(hreturn)));
@@ -101,6 +102,7 @@ public class EthModuleTest {
                 null,
                 null,
                 new BridgeSupportFactory(
+                        null,
                         null,
                         null,
                         null

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/txpool/TxPoolModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/txpool/TxPoolModuleImplTest.java
@@ -17,6 +17,7 @@
  */
 package co.rsk.rpc.modules.txpool;
 
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -46,7 +47,7 @@ public class TxPoolModuleImplTest {
     @Before
     public void setup(){
         transactionPool = Web3Mocks.getMockTransactionPool();
-        txPoolModule = new TxPoolModuleImpl(transactionPool);
+        txPoolModule = new TxPoolModuleImpl(transactionPool, new SenderResolverVisitor());
         accountMap = new HashMap();
     }
 
@@ -120,7 +121,7 @@ public class TxPoolModuleImplTest {
 
         checkFieldIsEmpty(node, "queued");
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
-        JsonNode senderNode = checkFieldIsObject(pendingNode, tx.getSender().toString());
+        JsonNode senderNode = checkFieldIsObject(pendingNode, tx.accept(new SenderResolverVisitor()).toString());
         JsonNode nonceNode = checkFieldIsArray(senderNode, tx.getNonceAsInteger().toString());
         nonceNode.elements().forEachRemaining(item -> assertFullTransaction(tx, item));
     }
@@ -133,7 +134,7 @@ public class TxPoolModuleImplTest {
 
         checkFieldIsEmpty(node, "queued");
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
-        JsonNode senderNode = checkFieldIsObject(pendingNode, tx.getSender().toString());
+        JsonNode senderNode = checkFieldIsObject(pendingNode, tx.accept(new SenderResolverVisitor()).toString());
         JsonNode nonceNode = checkFieldIsArray(senderNode, tx.getNonceAsInteger().toString());
         nonceNode.elements().forEachRemaining(item -> assertSummaryTransaction(tx, item));
     }
@@ -149,7 +150,7 @@ public class TxPoolModuleImplTest {
 
         checkFieldIsEmpty(node, "queued");
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
-        JsonNode senderNode = checkFieldIsObject(pendingNode, tx1.getSender().toString());
+        JsonNode senderNode = checkFieldIsObject(pendingNode, tx1.accept(new SenderResolverVisitor()).toString());
         JsonNode nonceNode = checkFieldIsArray(senderNode, tx1.getNonceAsInteger().toString());
 
         int i = 0;
@@ -171,7 +172,7 @@ public class TxPoolModuleImplTest {
 
         checkFieldIsEmpty(node, "queued");
         JsonNode pendingNode = checkFieldIsObject(node, "pending");
-        JsonNode senderNode = checkFieldIsObject(pendingNode, tx1.getSender().toString());
+        JsonNode senderNode = checkFieldIsObject(pendingNode, tx1.accept(new SenderResolverVisitor()).toString());
         JsonNode nonceNode = checkFieldIsArray(senderNode, tx1.getNonceAsInteger().toString());
 
         int i = 0;
@@ -373,7 +374,7 @@ public class TxPoolModuleImplTest {
         Assert.assertTrue(transactionNode.has("blockNumber"));
         Assert.assertEquals(transactionNode.get("blockNumber"), jsonNodeFactory.nullNode());
         Assert.assertTrue(transactionNode.has("from"));
-        Assert.assertEquals(transactionNode.get("from").asText(), TypeConverter.toJsonHex(tx.getSender().getBytes()));
+        Assert.assertEquals(transactionNode.get("from").asText(), TypeConverter.toJsonHex(tx.accept(new SenderResolverVisitor()).getBytes()));
         Assert.assertTrue(transactionNode.has("gas"));
         Assert.assertEquals(transactionNode.get("gas").asText(), TypeConverter.toQuantityJsonHex(tx.getGasLimitAsInteger()));
         Assert.assertTrue(transactionNode.has("gasPrice"));

--- a/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
@@ -19,6 +19,7 @@
 package co.rsk.test;
 
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.bc.BlockChainStatus;
 import co.rsk.test.dsl.DslParser;
 import co.rsk.test.dsl.DslProcessorException;
@@ -241,7 +242,7 @@ public class DslFilesTest {
 
         // only the third log was directly produced by the created contract
         Transaction transaction = txinfo.getReceipt().getTransaction();
-        byte[] contractAddress = HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes();
+        byte[] contractAddress = HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes();
 
         Assert.assertFalse(Arrays.equals(contractAddress, txinfo.getReceipt().getLogInfoList().get(0).getAddress()));
         Assert.assertFalse(Arrays.equals(contractAddress, txinfo.getReceipt().getLogInfoList().get(1).getAddress()));

--- a/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
@@ -28,6 +28,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.MutableRepository;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.vm.DataWord;
@@ -239,7 +240,8 @@ public class DslFilesTest {
         Assert.assertNotEquals(topic2, topic3);
 
         // only the third log was directly produced by the created contract
-        byte[] contractAddress = txinfo.getReceipt().getTransaction().getContractAddress().getBytes();
+        Transaction transaction = txinfo.getReceipt().getTransaction();
+        byte[] contractAddress = HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes();
 
         Assert.assertFalse(Arrays.equals(contractAddress, txinfo.getReceipt().getLogInfoList().get(0).getAddress()));
         Assert.assertFalse(Arrays.equals(contractAddress, txinfo.getReceipt().getLogInfoList().get(1).getAddress()));

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -19,6 +19,7 @@
 package co.rsk.test;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockChainImplTest;
@@ -107,7 +108,7 @@ public class World {
                 new RepositoryBtcBlockStoreWithCache.Factory(
                         config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                 config.getNetworkConstants().getBridgeConstants(),
-                config.getActivationConfig());
+                config.getActivationConfig(), new SenderResolverVisitor());
     }
 
     public NodeBlockProcessor getBlockProcessor() { return this.blockProcessor; }
@@ -119,8 +120,9 @@ public class World {
         Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(
                 config.getNetworkConstants().getBridgeConstants().getBtcParams());
 
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                btcBlockStoreFactory, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig());
+                btcBlockStoreFactory, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig(), senderResolver);
 
         if (this.blockExecutor == null) {
             this.blockExecutor = new BlockExecutor(
@@ -133,7 +135,8 @@ public class World {
                             null,
                             new BlockFactory(config.getActivationConfig()),
                             programInvokeFactory,
-                            new PrecompiledContracts(config, bridgeSupportFactory)
+                            new PrecompiledContracts(config, bridgeSupportFactory, senderResolver),
+                            senderResolver
                     )
             );
         }

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
@@ -20,6 +20,7 @@ package co.rsk.test.builders;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.db.RepositoryLocator;
@@ -106,6 +107,7 @@ public class BlockBuilder {
         if (blockChain != null) {
             final TestSystemProperties config = new TestSystemProperties();
             StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
+            SenderResolverVisitor senderResolver = new SenderResolverVisitor();
             BlockExecutor executor = new BlockExecutor(
                     config.getActivationConfig(),
                     new RepositoryLocator(trieStore, stateRootHandler),
@@ -116,7 +118,8 @@ public class BlockBuilder {
                             null,
                             new BlockFactory(config.getActivationConfig()),
                             new ProgramInvokeFactoryImpl(),
-                            new PrecompiledContracts(config, bridgeSupportFactory)
+                            new PrecompiledContracts(config, bridgeSupportFactory, senderResolver),
+                            senderResolver
                     )
             );
             executor.executeAndFill(block, parent.getHeader());

--- a/rskj-core/src/test/java/co/rsk/test/builderstest/TransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/builderstest/TransactionBuilderTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.test.builderstest;
 
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import org.ethereum.core.Account;
@@ -44,7 +45,7 @@ public class TransactionBuilderTest {
                 .build();
 
         Assert.assertNotNull(tx);
-        Assert.assertArrayEquals(sender.getAddress().getBytes(), tx.getSender().getBytes());
+        Assert.assertArrayEquals(sender.getAddress().getBytes(), tx.accept(new SenderResolverVisitor()).getBytes());
         Assert.assertArrayEquals(receiver.getAddress().getBytes(), tx.getReceiveAddress().getBytes());
         Assert.assertEquals(BigInteger.TEN, tx.getValue().asBigInteger());
         Assert.assertEquals(BigInteger.ONE, tx.getGasPrice().asBigInteger());

--- a/rskj-core/src/test/java/co/rsk/test/dsl/TransactionBuildDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/TransactionBuildDslProcessor.java
@@ -21,6 +21,8 @@ package co.rsk.test.dsl;
 import co.rsk.test.World;
 import co.rsk.test.builders.TransactionBuilder;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
 
 import java.math.BigInteger;
@@ -53,8 +55,10 @@ public class TransactionBuildDslProcessor {
             this.builder.receiver(this.world.getAccountByName(cmd.getArgument(0)));
         else if (cmd.isCommand("nonce"))
             this.builder.nonce(Long.parseLong(cmd.getArgument(0)));
-        else if (cmd.isCommand("contract"))
-            this.builder.receiverAddress(this.world.getTransactionByName(cmd.getArgument(0)).getContractAddress().getBytes());
+        else if (cmd.isCommand("contract")) {
+            Transaction transaction = this.world.getTransactionByName(cmd.getArgument(0));
+            this.builder.receiverAddress(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        }
         else if (cmd.isCommand("receiverAddress"))
             if (cmd.getArgument(0).equals("0") || cmd.getArgument(0).equals("00"))
                 this.builder.receiverAddress(ByteUtil.EMPTY_BYTE_ARRAY);

--- a/rskj-core/src/test/java/co/rsk/test/dsl/TransactionBuildDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/TransactionBuildDslProcessor.java
@@ -18,6 +18,7 @@
 
 package co.rsk.test.dsl;
 
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.test.World;
 import co.rsk.test.builders.TransactionBuilder;
 import org.bouncycastle.util.encoders.Hex;
@@ -57,7 +58,7 @@ public class TransactionBuildDslProcessor {
             this.builder.nonce(Long.parseLong(cmd.getArgument(0)));
         else if (cmd.isCommand("contract")) {
             Transaction transaction = this.world.getTransactionByName(cmd.getArgument(0));
-            this.builder.receiverAddress(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+            this.builder.receiverAddress(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         }
         else if (cmd.isCommand("receiverAddress"))
             if (cmd.getArgument(0).equals("0") || cmd.getArgument(0).equals("00"))

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -33,6 +33,7 @@ import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.trie.TrieConverter;
 import org.ethereum.core.*;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import org.slf4j.Logger;
@@ -135,7 +136,7 @@ public class WorldDslProcessor {
             Transaction tx = world.getTransactionByName(accountName);
 
             if (tx != null)
-                accountAddress = tx.getContractAddress();
+                accountAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce());
             else
                 accountAddress = new RskAddress(accountName);
         }

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -21,6 +21,7 @@ package co.rsk.test.dsl;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
@@ -136,7 +137,7 @@ public class WorldDslProcessor {
             Transaction tx = world.getTransactionByName(accountName);
 
             if (tx != null)
-                accountAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce());
+                accountAddress = HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce());
             else
                 accountAddress = new RskAddress(accountName);
         }
@@ -253,6 +254,7 @@ public class WorldDslProcessor {
             final ProgramInvokeFactoryImpl programInvokeFactory = new ProgramInvokeFactoryImpl();
             final TestSystemProperties config = new TestSystemProperties();
             StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
+            SenderResolverVisitor senderResolver = new SenderResolverVisitor();
             BlockExecutor executor = new BlockExecutor(
                     config.getActivationConfig(),
                     new RepositoryLocator(world.getTrieStore(), stateRootHandler),
@@ -263,7 +265,8 @@ public class WorldDslProcessor {
                             null,
                             new BlockFactory(config.getActivationConfig()),
                             programInvokeFactory,
-                            null
+                            null,
+                            senderResolver
                     )
             );
             executor.executeAndFill(block, parent.getHeader());

--- a/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.test.dsltest;
 
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.db.RepositorySnapshot;
 import co.rsk.test.World;
 import co.rsk.test.dsl.DslParser;
@@ -342,7 +343,7 @@ public class WorldDslProcessorTest {
 
         Assert.assertNotNull(tx01);
 
-        Assert.assertArrayEquals(acc1.getAddress().getBytes(), tx01.getSender().getBytes());
+        Assert.assertArrayEquals(acc1.getAddress().getBytes(), tx01.accept(new SenderResolverVisitor()).getBytes());
         Assert.assertArrayEquals(acc2.getAddress().getBytes(), tx01.getReceiveAddress().getBytes());
         Assert.assertEquals(new BigInteger("1000"), tx01.getValue().asBigInteger());
         Assert.assertNotNull(tx01.getData());
@@ -369,7 +370,7 @@ public class WorldDslProcessorTest {
 
         Assert.assertNotNull(tx01);
 
-        Assert.assertArrayEquals(acc1.getAddress().getBytes(), tx01.getSender().getBytes());
+        Assert.assertArrayEquals(acc1.getAddress().getBytes(), tx01.accept(new SenderResolverVisitor()).getBytes());
         Assert.assertArrayEquals(acc2.getAddress().getBytes(), tx01.getReceiveAddress().getBytes());
         Assert.assertEquals(new BigInteger("1000"), tx01.getValue().asBigInteger());
         Assert.assertNotNull(tx01.getData());
@@ -396,7 +397,7 @@ public class WorldDslProcessorTest {
 
         Assert.assertNotNull(tx01);
 
-        Assert.assertArrayEquals(acc1.getAddress().getBytes(), tx01.getSender().getBytes());
+        Assert.assertArrayEquals(acc1.getAddress().getBytes(), tx01.accept(new SenderResolverVisitor()).getBytes());
         Assert.assertArrayEquals(acc2.getAddress().getBytes(), tx01.getReceiveAddress().getBytes());
         Assert.assertEquals(new BigInteger("1000"), tx01.getValue().asBigInteger());
         Assert.assertNotNull(tx01.getData());
@@ -425,7 +426,7 @@ public class WorldDslProcessorTest {
 
         Assert.assertNotNull(tx01);
 
-        Assert.assertArrayEquals(acc1.getAddress().getBytes(), tx01.getSender().getBytes());
+        Assert.assertArrayEquals(acc1.getAddress().getBytes(), tx01.accept(new SenderResolverVisitor()).getBytes());
         Assert.assertArrayEquals(acc2.getAddress().getBytes(), tx01.getReceiveAddress().getBytes());
         Assert.assertEquals(new BigInteger("1000"), tx01.getValue().asBigInteger());
         Assert.assertNotNull(tx01.getData());

--- a/rskj-core/src/test/java/co/rsk/validators/BlockTxsValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockTxsValidationRuleTest.java
@@ -18,6 +18,7 @@
 package co.rsk.validators;
 
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.RepositorySnapshot;
 import org.bouncycastle.util.BigIntegers;
@@ -32,6 +33,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +52,7 @@ public class BlockTxsValidationRuleTest {
         repositorySnapshot = mock(RepositorySnapshot.class);
         when(repositoryLocator.snapshotAt(parentHeader)).thenReturn(repositorySnapshot);
 
-        rule = new BlockTxsValidationRule(repositoryLocator);
+        rule = new BlockTxsValidationRule(repositoryLocator, new SenderResolverVisitor());
     }
 
     @Test
@@ -137,7 +139,7 @@ public class BlockTxsValidationRuleTest {
 
     private Transaction transaction(RskAddress sender, int nonce) {
         Transaction transaction = mock(Transaction.class);
-        when(transaction.getSender()).thenReturn(sender);
+        when(transaction.accept(any(SenderResolverVisitor.class))).thenReturn(sender);
         when(transaction.getNonce()).thenReturn(BigIntegers.asUnsignedByteArray(BigInteger.valueOf(nonce)));
         return transaction;
     }

--- a/rskj-core/src/test/java/co/rsk/vm/Create2Test.java
+++ b/rskj-core/src/test/java/co/rsk/vm/Create2Test.java
@@ -22,6 +22,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
 import co.rsk.test.builders.AccountBuilder;
@@ -65,7 +66,7 @@ public class Create2Test {
                     new RepositoryBtcBlockStoreWithCache.Factory(
                             config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                     config.getNetworkConstants().getBridgeConstants(),
-                    config.getActivationConfig()));
+                    config.getActivationConfig(), new SenderResolverVisitor()), new SenderResolverVisitor());
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private final Transaction transaction = createTransaction();
 

--- a/rskj-core/src/test/java/co/rsk/vm/ExtCodeHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/ExtCodeHashTest.java
@@ -2,6 +2,7 @@ package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
 import co.rsk.test.builders.AccountBuilder;
@@ -36,13 +37,15 @@ public class ExtCodeHashTest {
     private BytecodeCompiler compiler = new BytecodeCompiler();
     private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
+    private final SenderResolverVisitor senderResolverVisitor = new SenderResolverVisitor();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(
             config,
             new BridgeSupportFactory(
                     new RepositoryBtcBlockStoreWithCache.Factory(
                             config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                     config.getNetworkConstants().getBridgeConstants(),
-                    config.getActivationConfig()));
+                    config.getActivationConfig(), senderResolverVisitor),
+            senderResolverVisitor);
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private final Transaction transaction = createTransaction();
 

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -101,7 +101,7 @@ public class MinerHelper {
                     null,
                     new PrecompiledContracts(config, bridgeSupportFactory));
             TransactionExecutor executor = transactionExecutorFactory
-                    .newInstance(tx, txindex++, block.getCoinbase(), track, block, totalGasUsed);
+                    .newInstance(tx, tx.getSender(), txindex++, block.getCoinbase(), track, block, totalGasUsed);
 
             executor.init();
             executor.execute();

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -20,6 +20,7 @@ package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.db.RepositoryLocator;
@@ -87,10 +88,11 @@ public class MinerHelper {
 
         int txindex = 0;
 
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                 config.getNetworkConstants().getBridgeConstants(),
-                config.getActivationConfig());
+                config.getActivationConfig(), senderResolver);
 
         for (Transaction tx : block.getTransactionsList()) {
             TransactionExecutorFactory transactionExecutorFactory = new TransactionExecutorFactory(
@@ -99,9 +101,10 @@ public class MinerHelper {
                     null,
                     blockFactory,
                     null,
-                    new PrecompiledContracts(config, bridgeSupportFactory));
+                    new PrecompiledContracts(config, bridgeSupportFactory, senderResolver),
+                    senderResolver);
             TransactionExecutor executor = transactionExecutorFactory
-                    .newInstance(tx, tx.getSender(), txindex++, block.getCoinbase(), track, block, totalGasUsed);
+                    .newInstance(tx, txindex++, block.getCoinbase(), track, block, totalGasUsed);
 
             executor.init();
             executor.execute();

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractAddressTests.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractAddressTests.java
@@ -20,6 +20,7 @@ package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.vm.DataWord;
@@ -49,7 +50,7 @@ public class PrecompiledContractAddressTests {
 
     @Test
     public void testGetPrecompile() {
-        PrecompiledContracts pcList = new PrecompiledContracts(config, null);
+        PrecompiledContracts pcList = new PrecompiledContracts(config, null, new SenderResolverVisitor());
         checkAddr(pcList,ECRECOVER_ADDR, "ECRecover");
         checkAddr(pcList,SHA256_ADDR, "Sha256");
         checkAddr(pcList,RIPEMPD160_ADDR ,"Ripempd160");

--- a/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/PrecompiledContractTest.java
@@ -19,6 +19,7 @@
 package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.pcc.blockheader.BlockHeaderContract;
 import co.rsk.peg.Bridge;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -36,7 +37,7 @@ import static org.mockito.Mockito.when;
 public class PrecompiledContractTest {
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
 
     @Test
     public void getBridgeContract() {

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -20,6 +20,7 @@ package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
+import co.rsk.core.SenderResolverVisitor;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.BlockFactory;
@@ -48,7 +49,7 @@ import static org.mockito.Mockito.when;
 public class VMExecutionTest {
     private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private ProgramInvokeMockImpl invoke;
     private BytecodeCompiler compiler;

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -20,6 +20,7 @@ package co.rsk.vm;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.helpers.PerformanceTestConstants;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -60,7 +61,7 @@ public class VMPerformanceTest {
     private final TestSystemProperties config = new TestSystemProperties();
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private final VmConfig vmConfig = config.getVmConfig();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
     private final ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(0);
 
     private ProgramInvokeMockImpl invoke;
@@ -121,7 +122,7 @@ public class VMPerformanceTest {
 
         Boolean old = thread.isThreadCpuTimeEnabled();
         thread.setThreadCpuTimeEnabled(true);
-        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config, null));
+        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config, null, new SenderResolverVisitor()));
         if (useProfiler)
             waitForProfiler();
 
@@ -463,7 +464,7 @@ public class VMPerformanceTest {
 } // contract
         */
 
-        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config, null));
+        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config, null, new SenderResolverVisitor()));
         // Strip the first 16 bytes which are added by Solidity to store the contract.
         byte[] codePlusPrefix = Hex.decode(
                 //---------------------------------------------------------------------------------------------------------------------nn
@@ -549,7 +550,7 @@ public class VMPerformanceTest {
          }
          } // contract
          ********************************************************************************************/
-        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config, null));
+        vm = new VM(config.getVmConfig(), new PrecompiledContracts(config, null, new SenderResolverVisitor()));
         /////////////////////////////////////////////////////////////////////////////////////////////////
         // To increase precesion of the measurement, the maximum k value was increased
         // until the contract took more than 30 seconds

--- a/rskj-core/src/test/java/co/rsk/vm/VMSpecificOpcodesPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMSpecificOpcodesPerformanceTest.java
@@ -4,6 +4,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.helpers.PerformanceTestConstants;
 import co.rsk.helpers.Stopwatch;
 import co.rsk.test.builders.AccountBuilder;
@@ -41,7 +42,7 @@ public class VMSpecificOpcodesPerformanceTest {
     private final TestSystemProperties config = new TestSystemProperties();
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private final VmConfig vmConfig = config.getVmConfig();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
 
     public static String padZeroesLeft(String s, int n) {
         return StringUtils.leftPad(s, n, '0');

--- a/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -21,6 +21,7 @@ package org.ethereum.core;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
@@ -66,12 +67,13 @@ public class ImportLightTest {
                 receiptStore,
                 blockFactory,
                 new ProgramInvokeFactoryImpl(),
-
-                null);
+                null,
+                new SenderResolverVisitor()
+        );
         StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
         RepositoryLocator repositoryLocator = new RepositoryLocator(trieStore, stateRootHandler);
 
-        TransactionPoolImpl transactionPool = new TransactionPoolImpl(config, repositoryLocator, null, blockFactory, listener, transactionExecutorFactory, 10, 100);
+        TransactionPoolImpl transactionPool = new TransactionPoolImpl(config, repositoryLocator, null, blockFactory, listener, transactionExecutorFactory, 10, 100, new SenderResolverVisitor());
 
         BlockChainImpl blockchain = new BlockChainImpl(
                 blockStore,

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionSetTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionSetTest.java
@@ -19,6 +19,7 @@
 package org.ethereum.core;
 
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ import static org.ethereum.util.TransactionFactoryHelper.*;
 public class TransactionSetTest {
     @Test
     public void getEmptyTransactionList() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
 
         List<Transaction> result = txset.getTransactions();
 
@@ -42,7 +43,7 @@ public class TransactionSetTest {
 
     @Test
     public void transactionIsNotInEmptySet() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
         Transaction transaction = createSampleTransaction();
 
         Assert.assertFalse(txset.hasTransaction(transaction));
@@ -54,7 +55,7 @@ public class TransactionSetTest {
 
     @Test
     public void hasTransaction() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
         Transaction transaction1 = createSampleTransaction(10);
         Transaction transaction2 = createSampleTransaction(20);
         Transaction transaction3 = createSampleTransaction(30);
@@ -69,7 +70,7 @@ public class TransactionSetTest {
 
     @Test
     public void addAndRemoveTransactions() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
 
         Transaction transaction1 = createSampleTransaction(1, 2, 100, 0);
         Transaction transaction2 = createSampleTransaction(2, 3, 200, 0);
@@ -79,23 +80,23 @@ public class TransactionSetTest {
         txset.addTransaction(transaction2);
         txset.addTransaction(transaction3);
 
-        txset.removeTransactionByHash(transaction1.getHash());
-        txset.removeTransactionByHash(transaction2.getHash());
-        txset.removeTransactionByHash(transaction3.getHash());
+        txset.removeTransactionByHash(transaction1.getHash(), new SenderResolverVisitor());
+        txset.removeTransactionByHash(transaction2.getHash(), new SenderResolverVisitor());
+        txset.removeTransactionByHash(transaction3.getHash(), new SenderResolverVisitor());
 
         Assert.assertFalse(txset.hasTransaction(transaction1));
         Assert.assertFalse(txset.hasTransaction(transaction2));
         Assert.assertFalse(txset.hasTransaction(transaction3));
 
         Assert.assertTrue(txset.getTransactions().isEmpty());
-        Assert.assertTrue(txset.getTransactionsWithSender(transaction1.getSender()).isEmpty());
-        Assert.assertTrue(txset.getTransactionsWithSender(transaction2.getSender()).isEmpty());
-        Assert.assertTrue(txset.getTransactionsWithSender(transaction3.getSender()).isEmpty());
+        Assert.assertTrue(txset.getTransactionsWithSender(transaction1.accept(new SenderResolverVisitor())).isEmpty());
+        Assert.assertTrue(txset.getTransactionsWithSender(transaction2.accept(new SenderResolverVisitor())).isEmpty());
+        Assert.assertTrue(txset.getTransactionsWithSender(transaction3.accept(new SenderResolverVisitor())).isEmpty());
     }
 
     @Test
     public void addTransactionAndGetListWithOneTransaction() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
         Transaction tx = createSampleTransaction();
 
         txset.addTransaction(tx);
@@ -110,7 +111,7 @@ public class TransactionSetTest {
 
     @Test
     public void addtTransactionTwiceAndGetListWithOneTransaction() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
         Transaction transaction = createSampleTransaction();
 
         txset.addTransaction(transaction);
@@ -126,7 +127,7 @@ public class TransactionSetTest {
 
     @Test
     public void getEmptyTransactionListByUnknownSender() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
 
         List<Transaction> result = txset.getTransactionsWithSender(new RskAddress(new byte[20]));
 
@@ -136,12 +137,12 @@ public class TransactionSetTest {
 
     @Test
     public void addTransactionAndGetListBySenderWithOneTransaction() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
         Transaction transaction = createSampleTransaction();
 
         txset.addTransaction(transaction);
 
-        List<Transaction> result = txset.getTransactionsWithSender(transaction.getSender());
+        List<Transaction> result = txset.getTransactionsWithSender(transaction.accept(new SenderResolverVisitor()));
 
         Assert.assertNotNull(result);
         Assert.assertFalse(result.isEmpty());
@@ -151,13 +152,13 @@ public class TransactionSetTest {
 
     @Test
     public void addTransactionTwiceAndGetListBySenderWithOneTransaction() {
-        TransactionSet txset = new TransactionSet();
+        TransactionSet txset = new TransactionSet(new SenderResolverVisitor());
         Transaction transaction = createSampleTransaction();
 
         txset.addTransaction(transaction);
         txset.addTransaction(transaction);
 
-        List<Transaction> result = txset.getTransactionsWithSender(transaction.getSender());
+        List<Transaction> result = txset.getTransactionsWithSender(transaction.accept(new SenderResolverVisitor()));
 
         Assert.assertNotNull(result);
         Assert.assertFalse(result.isEmpty());

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -464,7 +464,7 @@ public class TransactionTest {
                             invokeFactory,
                             new PrecompiledContracts(config, bridgeSupportFactory));
                     TransactionExecutor executor = transactionExecutorFactory
-                            .newInstance(txConst, 0, bestBlock.getCoinbase(), track, bestBlock, 0)
+                            .newInstance(txConst, txConst.getSender(), 0, bestBlock.getCoinbase(), track, bestBlock, 0)
                             .setLocalCall(true);
 
                     executor.init();
@@ -747,7 +747,7 @@ public class TransactionTest {
                 new ProgramInvokeFactoryImpl(),
                 new PrecompiledContracts(config, bridgeSupportFactory));
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(tx, 0, RskAddress.nullAddress(), repository, blockchain.getBestBlock(), 0);
+                .newInstance(tx, tx.getSender(), 0, RskAddress.nullAddress(), repository, blockchain.getBestBlock(), 0);
 
         executor.init();
         executor.execute();

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -615,7 +615,7 @@ public class TransactionTest {
         Transaction tx = createTx(sender, new byte[0], Hex.decode(code), repository);
         executeTransaction(blockchain, blockStore, tx, repository);
 
-        byte[] contractAddress = tx.getContractAddress().getBytes();
+        byte[] contractAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes();
 
         CallTransaction.Contract contract1 = new CallTransaction.Contract(abi);
         byte[] callData = contract1.getByName("multipleHomicide").encode();
@@ -701,9 +701,9 @@ public class TransactionTest {
         executeTransaction(blockchain, blockStore, tx2, repository);
 
         CallTransaction.Contract contract2 = new CallTransaction.Contract(abi2);
-        byte[] data = contract2.getByName("doIt").encode(Hex.toHexString(tx1.getContractAddress().getBytes()));
+        byte[] data = contract2.getByName("doIt").encode(Hex.toHexString(HashUtil.calcNewAddr(tx1.getSender().getBytes(), tx1.getNonce()).getBytes()));
 
-        Transaction tx3 = createTx(sender, tx2.getContractAddress().getBytes(), data, repository);
+        Transaction tx3 = createTx(sender, HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes(), data, repository);
         TransactionExecutor executor = executeTransaction(blockchain, blockStore, tx3, repository);
         Assert.assertEquals(1, executor.getResult().getLogInfoList().size());
         Assert.assertFalse(executor.getResult().getLogInfoList().get(0).isRejected());

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -21,6 +21,7 @@ package org.ethereum.core;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.genesis.TestGenesisLoader;
 import co.rsk.crypto.Keccak256;
@@ -319,7 +320,7 @@ public class TransactionTest {
         System.out.println("plainTx1: " + plainTx1);
         System.out.println("plainTx2: " + plainTx2);
 
-        System.out.println(tx2.getSender().toString());
+        System.out.println(tx2.accept(new SenderResolverVisitor()).toString());
     }
 
 
@@ -450,11 +451,12 @@ public class TransactionTest {
 
                     Block bestBlock = block;
 
+                    SenderResolverVisitor senderResolver = new SenderResolverVisitor();
                     BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                             new RepositoryBtcBlockStoreWithCache.Factory(
                                     config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                             config.getNetworkConstants().getBridgeConstants(),
-                            config.getActivationConfig());
+                            config.getActivationConfig(), senderResolver);
 
                     TransactionExecutorFactory transactionExecutorFactory = new TransactionExecutorFactory(
                             config,
@@ -462,9 +464,9 @@ public class TransactionTest {
                             null,
                             blockFactory,
                             invokeFactory,
-                            new PrecompiledContracts(config, bridgeSupportFactory));
+                            new PrecompiledContracts(config, bridgeSupportFactory, senderResolver), senderResolver);
                     TransactionExecutor executor = transactionExecutorFactory
-                            .newInstance(txConst, txConst.getSender(), 0, bestBlock.getCoinbase(), track, bestBlock, 0)
+                            .newInstance(txConst, 0, bestBlock.getCoinbase(), track, bestBlock, 0)
                             .setLocalCall(true);
 
                     executor.init();
@@ -615,7 +617,7 @@ public class TransactionTest {
         Transaction tx = createTx(sender, new byte[0], Hex.decode(code), repository);
         executeTransaction(blockchain, blockStore, tx, repository);
 
-        byte[] contractAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes();
+        byte[] contractAddress = HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).getBytes();
 
         CallTransaction.Contract contract1 = new CallTransaction.Contract(abi);
         byte[] callData = contract1.getByName("multipleHomicide").encode();
@@ -701,9 +703,9 @@ public class TransactionTest {
         executeTransaction(blockchain, blockStore, tx2, repository);
 
         CallTransaction.Contract contract2 = new CallTransaction.Contract(abi2);
-        byte[] data = contract2.getByName("doIt").encode(Hex.toHexString(HashUtil.calcNewAddr(tx1.getSender().getBytes(), tx1.getNonce()).getBytes()));
+        byte[] data = contract2.getByName("doIt").encode(Hex.toHexString(HashUtil.calcNewAddr(tx1.accept(new SenderResolverVisitor()).getBytes(), tx1.getNonce()).getBytes()));
 
-        Transaction tx3 = createTx(sender, HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes(), data, repository);
+        Transaction tx3 = createTx(sender, HashUtil.calcNewAddr(tx2.accept(new SenderResolverVisitor()).getBytes(), tx2.getNonce()).getBytes(), data, repository);
         TransactionExecutor executor = executeTransaction(blockchain, blockStore, tx3, repository);
         Assert.assertEquals(1, executor.getResult().getLogInfoList().size());
         Assert.assertFalse(executor.getResult().getLogInfoList().get(0).isRejected());
@@ -733,11 +735,12 @@ public class TransactionTest {
             Transaction tx,
             Repository repository) {
         Repository track = repository.startTracking();
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(
                         config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                 config.getNetworkConstants().getBridgeConstants(),
-                config.getActivationConfig());
+                config.getActivationConfig(), senderResolver);
 
         TransactionExecutorFactory transactionExecutorFactory = new TransactionExecutorFactory(
                 config,
@@ -745,9 +748,10 @@ public class TransactionTest {
                 null,
                 blockFactory,
                 new ProgramInvokeFactoryImpl(),
-                new PrecompiledContracts(config, bridgeSupportFactory));
+                new PrecompiledContracts(config, bridgeSupportFactory, senderResolver),
+                senderResolver);
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(tx, tx.getSender(), 0, RskAddress.nullAddress(), repository, blockchain.getBestBlock(), 0);
+                .newInstance(tx, 0, RskAddress.nullAddress(), repository, blockchain.getBestBlock(), 0);
 
         executor.init();
         executor.execute();

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestProgramInvokeFactory.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestProgramInvokeFactory.java
@@ -21,6 +21,7 @@ package org.ethereum.jsontestsuite;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -47,7 +48,7 @@ public class TestProgramInvokeFactory implements ProgramInvokeFactory {
 
 
     @Override
-    public ProgramInvoke createProgramInvoke(Transaction tx, int txindex, Block block, Repository repository, BlockStore blockStore) {
+    public ProgramInvoke createProgramInvoke(Transaction tx, RskAddress sender, int txindex, Block block, Repository repository, BlockStore blockStore) {
         return generalInvoke(tx, txindex, repository, blockStore);
     }
 
@@ -64,15 +65,15 @@ public class TestProgramInvokeFactory implements ProgramInvokeFactory {
 
         /***         ADDRESS op       ***/
         // YP: Get address of currently executing account.
-        RskAddress addr = tx.isContractCreation() ? HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()) : tx.getReceiveAddress();
+        RskAddress addr = tx.isContractCreation() ? HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()) : tx.getReceiveAddress();
 
         /***         ORIGIN op       ***/
         // YP: This is the sender of original transaction; it is never a contract.
-        RskAddress origin = tx.getSender();
+        RskAddress origin = tx.accept(new SenderResolverVisitor());
 
         /***         CALLER op       ***/
         // YP: This is the address of the account that is directly responsible for this execution.
-        RskAddress caller = tx.getSender();
+        RskAddress caller = tx.accept(new SenderResolverVisitor());
 
         /***         BALANCE op       ***/
         Coin balance = repository.getBalance(addr);

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestProgramInvokeFactory.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestProgramInvokeFactory.java
@@ -24,6 +24,7 @@ import co.rsk.core.RskAddress;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockStore;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
@@ -63,7 +64,7 @@ public class TestProgramInvokeFactory implements ProgramInvokeFactory {
 
         /***         ADDRESS op       ***/
         // YP: Get address of currently executing account.
-        RskAddress addr = tx.isContractCreation() ? tx.getContractAddress() : tx.getReceiveAddress();
+        RskAddress addr = tx.isContractCreation() ? HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()) : tx.getReceiveAddress();
 
         /***         ORIGIN op       ***/
         // YP: This is the sender of original transaction; it is never a contract.

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -23,6 +23,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
@@ -83,7 +84,7 @@ public class TestRunner {
 
     private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private Logger logger = LoggerFactory.getLogger("TCK-Test");
     private ProgramTrace trace = null;
@@ -147,11 +148,12 @@ public class TestRunner {
                 receiptStore,
                 blockFactory,
                 new ProgramInvokeFactoryImpl(),
-                null);
+                null,
+                new SenderResolverVisitor());
         StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
         RepositoryLocator repositoryLocator = new RepositoryLocator(trieStore, stateRootHandler);
 
-        TransactionPoolImpl transactionPool = new TransactionPoolImpl(config, repositoryLocator, null, blockFactory, listener, transactionExecutorFactory, 10, 100);
+        TransactionPoolImpl transactionPool = new TransactionPoolImpl(config, repositoryLocator, null, blockFactory, listener, transactionExecutorFactory, 10, 100, new SenderResolverVisitor());
 
         BlockChainImpl blockchain = new BlockChainImpl(
                 blockStore,

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -108,7 +108,7 @@ public class StateTestRunner {
                 invokeFactory,
                 precompiledContracts);
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(transaction, 0, new RskAddress(env.getCurrentCoinbase()), track, blockchain.getBestBlock(), 0);
+                .newInstance(transaction, transaction.getSender(), 0, new RskAddress(env.getCurrentCoinbase()), track, blockchain.getBestBlock(), 0);
 
         try{
             executor.init();

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -22,6 +22,7 @@ package org.ethereum.jsontestsuite.runners;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
@@ -89,7 +90,7 @@ public class StateTestRunner {
     public StateTestRunner(StateTestCase stateTestCase) {
         this.stateTestCase = stateTestCase;
         setstateTestUSeREMASC(false);
-        precompiledContracts = new PrecompiledContracts(config, null);
+        precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
     }
 
     public StateTestRunner setstateTestUSeREMASC(boolean v) {
@@ -106,9 +107,10 @@ public class StateTestRunner {
                 null,
                 blockFactory,
                 invokeFactory,
-                precompiledContracts);
+                precompiledContracts,
+                new SenderResolverVisitor());
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(transaction, transaction.getSender(), 0, new RskAddress(env.getCurrentCoinbase()), track, blockchain.getBestBlock(), 0);
+                .newInstance(transaction, 0, new RskAddress(env.getCurrentCoinbase()), track, blockchain.getBestBlock(), 0);
 
         try{
             executor.init();
@@ -135,6 +137,7 @@ public class StateTestRunner {
         logger.info("transaction: {}", transaction.toString());
         BlockStore blockStore = new IndexedBlockStore(blockFactory, new HashMapDB(), new HashMapBlocksIndex());
         StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
         blockchain = new BlockChainImpl(
                 blockStore,
                 null,
@@ -151,7 +154,8 @@ public class StateTestRunner {
                                 null,
                                 blockFactory,
                                 new ProgramInvokeFactoryImpl(),
-                                precompiledContracts
+                                precompiledContracts,
+                                senderResolver
                         )
                 ),
                 stateRootHandler

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -20,6 +20,7 @@ package org.ethereum.rpc;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.core.bc.MiningMainchainView;
@@ -171,7 +172,7 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(1, logs.length);
 
-        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -194,7 +195,7 @@ public class Web3ImplLogsTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
         Web3.FilterRequest fr = new Web3.FilterRequest();
-        fr.address = Hex.toHexString(HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes());
+        fr.address = Hex.toHexString(HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).getBytes());
         fr.topics = new Object[] { "06acbfb32bcf8383f3b0a768b70ac9ec234ea0f2d3b9c77fa6a2de69b919aad1" };
         String id = web3.eth_newFilter(fr);
 
@@ -204,7 +205,7 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(1, logs.length);
 
-        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -237,7 +238,7 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(1, logs.length);
 
-        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -281,7 +282,7 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(1, logs.length);
 
-        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -449,7 +450,7 @@ public class Web3ImplLogsTest {
         Web3.FilterRequest fr = new Web3.FilterRequest();
         fr.fromBlock = "earliest";
         Transaction transaction = block1.getTransactionsList().get(0);
-        fr.address = Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        fr.address = Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
@@ -469,7 +470,7 @@ public class Web3ImplLogsTest {
         Web3.FilterRequest fr = new Web3.FilterRequest();
         fr.fromBlock = "earliest";
         Transaction transaction = block1.getTransactionsList().get(0);
-        fr.address = Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        fr.address = Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         web3.eth_getLogs(fr);
         Object[] logs = web3.eth_getLogs(fr);
 
@@ -556,7 +557,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -575,7 +576,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -594,7 +595,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -614,7 +615,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -634,7 +635,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(2, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -658,7 +659,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(2, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -679,7 +680,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -698,7 +699,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -715,7 +716,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(3, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -736,7 +737,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(3, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -757,7 +758,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -779,7 +780,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -800,7 +801,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -822,7 +823,7 @@ public class Web3ImplLogsTest {
 
         Assert.assertNotNull(logs);
         Transaction transaction = block1.getTransactionsList().get(0);
-        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.accept(new SenderResolverVisitor()).getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -881,11 +882,11 @@ public class Web3ImplLogsTest {
         ).trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        String mainAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString();
+        String mainAddress = HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).toString();
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
-        String callerAddress = Hex.toHexString(HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes());
+        String callerAddress = Hex.toHexString(HashUtil.calcNewAddr(tx2.accept(new SenderResolverVisitor()).getBytes(), tx2.getNonce()).getBytes());
 
         List<Transaction> txs2 = new ArrayList<>();
         txs2.add(tx2);
@@ -926,11 +927,11 @@ public class Web3ImplLogsTest {
         ).trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        String mainAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString();
+        String mainAddress = HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).toString();
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
-        String callerAddress = Hex.toHexString(HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes());
+        String callerAddress = Hex.toHexString(HashUtil.calcNewAddr(tx2.accept(new SenderResolverVisitor()).getBytes(), tx2.getNonce()).getBytes());
 
         List<Transaction> txs2 = new ArrayList<>();
         txs2.add(tx2);
@@ -940,7 +941,7 @@ public class Web3ImplLogsTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block2));
 
         Transaction tx3;
-        tx3 = getCallerContractTransactionWithInvoke(acc1, HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes(), mainAddress);
+        tx3 = getCallerContractTransactionWithInvoke(acc1, HashUtil.calcNewAddr(tx2.accept(new SenderResolverVisitor()).getBytes(), tx2.getNonce()).getBytes(), mainAddress);
 
         List<Transaction> txs3 = new ArrayList<>();
         txs3.add(tx3);
@@ -978,7 +979,7 @@ public class Web3ImplLogsTest {
         ).trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        String mainAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString();
+        String mainAddress = HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).toString();
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
@@ -991,7 +992,7 @@ public class Web3ImplLogsTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block2));
 
         Transaction tx3;
-        tx3 = getCallerContractTransactionWithInvoke(acc1, HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes(), mainAddress);
+        tx3 = getCallerContractTransactionWithInvoke(acc1, HashUtil.calcNewAddr(tx2.accept(new SenderResolverVisitor()).getBytes(), tx2.getNonce()).getBytes(), mainAddress);
 
         List<Transaction> txs3 = new ArrayList<>();
         txs3.add(tx3);
@@ -1021,9 +1022,9 @@ public class Web3ImplLogsTest {
                 null, new ExecutionBlockRetriever(mainchainView, blockChain, null, null),
                 null, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), null,
                 new BridgeSupportFactory(
-                        null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig())
+                        null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig(), new SenderResolverVisitor())
         );
-        TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool);
+        TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool, new SenderResolverVisitor());
         DebugModule debugModule = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null);
         return new Web3RskImpl(
                 eth,
@@ -1049,7 +1050,8 @@ public class Web3ImplLogsTest {
                 new SimpleConfigCapabilities(),
                 null,
                 new BlocksBloomStore(2, 0),
-                mock(Web3InformationRetriever.class));
+                mock(Web3InformationRetriever.class),
+                new SenderResolverVisitor());
     }
 
     private void addTwoEmptyBlocks() {
@@ -1144,7 +1146,7 @@ public class Web3ImplLogsTest {
                 .trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        byte[] contractAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes();
+        byte[] contractAddress = HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).getBytes();
 
         Transaction tx2 = getContractTransactionWithInvoke(acc1, contractAddress);
         List<Transaction> tx2s = new ArrayList<>();
@@ -1172,7 +1174,7 @@ public class Web3ImplLogsTest {
                 .trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        byte[] contractAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes();
+        byte[] contractAddress = HashUtil.calcNewAddr(tx.accept(new SenderResolverVisitor()).getBytes(), tx.getNonce()).getBytes();
 
         // Now create a transaction that invokes Increment()
         Transaction tx2 = getContractTransactionWithInvoke(acc1, contractAddress);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -44,6 +44,7 @@ import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.trie.TrieStore;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.*;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.facade.Ethereum;
@@ -170,7 +171,7 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(1, logs.length);
 
-        Assert.assertEquals("0x" + tx.getContractAddress().toString(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -193,7 +194,7 @@ public class Web3ImplLogsTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
         Web3.FilterRequest fr = new Web3.FilterRequest();
-        fr.address = Hex.toHexString(tx.getContractAddress().getBytes());
+        fr.address = Hex.toHexString(HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes());
         fr.topics = new Object[] { "06acbfb32bcf8383f3b0a768b70ac9ec234ea0f2d3b9c77fa6a2de69b919aad1" };
         String id = web3.eth_newFilter(fr);
 
@@ -203,7 +204,7 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(1, logs.length);
 
-        Assert.assertEquals("0x" + tx.getContractAddress().toString(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -236,7 +237,7 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(1, logs.length);
 
-        Assert.assertEquals("0x" + tx.getContractAddress().toString(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -280,7 +281,7 @@ public class Web3ImplLogsTest {
         Assert.assertNotNull(logs);
         Assert.assertEquals(1, logs.length);
 
-        Assert.assertEquals("0x" + tx.getContractAddress().toString(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals("0x" + HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -447,7 +448,8 @@ public class Web3ImplLogsTest {
         Block block1 = blockChain.getBlockByNumber(1l);
         Web3.FilterRequest fr = new Web3.FilterRequest();
         fr.fromBlock = "earliest";
-        fr.address = Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        fr.address = Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
@@ -466,7 +468,8 @@ public class Web3ImplLogsTest {
         Block block1 = blockChain.getBlockByNumber(1l);
         Web3.FilterRequest fr = new Web3.FilterRequest();
         fr.fromBlock = "earliest";
-        fr.address = Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        fr.address = Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         web3.eth_getLogs(fr);
         Object[] logs = web3.eth_getLogs(fr);
 
@@ -552,7 +555,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -570,7 +574,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -588,7 +593,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -607,7 +613,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -626,7 +633,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(2, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -649,7 +657,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(2, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -669,7 +678,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -687,7 +697,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -703,7 +714,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(3, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -723,7 +735,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(3, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -743,7 +756,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -764,7 +778,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -784,7 +799,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -805,7 +821,8 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        Transaction transaction = block1.getTransactionsList().get(0);
+        String address = "0x" + Hex.toHexString(HashUtil.calcNewAddr(transaction.getSender().getBytes(), transaction.getNonce()).getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -864,11 +881,11 @@ public class Web3ImplLogsTest {
         ).trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        String mainAddress = tx.getContractAddress().toString();
+        String mainAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString();
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
-        String callerAddress = Hex.toHexString(tx2.getContractAddress().getBytes());
+        String callerAddress = Hex.toHexString(HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes());
 
         List<Transaction> txs2 = new ArrayList<>();
         txs2.add(tx2);
@@ -909,11 +926,11 @@ public class Web3ImplLogsTest {
         ).trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        String mainAddress = tx.getContractAddress().toString();
+        String mainAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString();
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
-        String callerAddress = Hex.toHexString(tx2.getContractAddress().getBytes());
+        String callerAddress = Hex.toHexString(HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes());
 
         List<Transaction> txs2 = new ArrayList<>();
         txs2.add(tx2);
@@ -923,7 +940,7 @@ public class Web3ImplLogsTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block2));
 
         Transaction tx3;
-        tx3 = getCallerContractTransactionWithInvoke(acc1, tx2.getContractAddress().getBytes(), mainAddress);
+        tx3 = getCallerContractTransactionWithInvoke(acc1, HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes(), mainAddress);
 
         List<Transaction> txs3 = new ArrayList<>();
         txs3.add(tx3);
@@ -961,7 +978,7 @@ public class Web3ImplLogsTest {
         ).trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        String mainAddress = tx.getContractAddress().toString();
+        String mainAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).toString();
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
@@ -974,7 +991,7 @@ public class Web3ImplLogsTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block2));
 
         Transaction tx3;
-        tx3 = getCallerContractTransactionWithInvoke(acc1, tx2.getContractAddress().getBytes(), mainAddress);
+        tx3 = getCallerContractTransactionWithInvoke(acc1, HashUtil.calcNewAddr(tx2.getSender().getBytes(), tx2.getNonce()).getBytes(), mainAddress);
 
         List<Transaction> txs3 = new ArrayList<>();
         txs3.add(tx3);
@@ -1127,7 +1144,7 @@ public class Web3ImplLogsTest {
                 .trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        byte[] contractAddress = tx.getContractAddress().getBytes();
+        byte[] contractAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes();
 
         Transaction tx2 = getContractTransactionWithInvoke(acc1, contractAddress);
         List<Transaction> tx2s = new ArrayList<>();
@@ -1155,7 +1172,7 @@ public class Web3ImplLogsTest {
                 .trieStore(trieStore).parent(genesis).transactions(txs).build();
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
-        byte[] contractAddress = tx.getContractAddress().getBytes();
+        byte[] contractAddress = HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes();
 
         // Now create a transaction that invokes Increment()
         Transaction tx2 = getContractTransactionWithInvoke(acc1, contractAddress);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -19,6 +19,7 @@
 package org.ethereum.rpc;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
 import co.rsk.core.bc.MiningMainchainViewImpl;
@@ -370,9 +371,9 @@ public class Web3ImplScoringTest {
                 null, new ExecutionBlockRetriever(miningMainchainView, world.getBlockChain(), null, null),
                 null, new EthModuleSolidityDisabled(), new EthModuleWalletEnabled(wallet), null,
                 new BridgeSupportFactory(
-                        null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig())
+                        null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig(), new SenderResolverVisitor())
         );
-        TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
+        TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool(), new SenderResolverVisitor());
         DebugModule dm = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null);
         return new Web3RskImpl(
                 rsk,
@@ -389,6 +390,7 @@ public class Web3ImplScoringTest {
                 null,
                 Web3Mocks.getMockChannelManager(),
                 peerScoringManager,
+                null,
                 null,
                 null,
                 null,

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -24,6 +24,7 @@ import co.rsk.config.MiningConfig;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.DifficultyCalculator;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.SnapshotManager;
 import co.rsk.core.bc.BlockChainStatus;
 import co.rsk.core.bc.MiningMainchainView;
@@ -172,7 +173,7 @@ public class Web3ImplSnapshotTest {
                                                 )
         );
         PersonalModule pm = new PersonalModuleWalletDisabled();
-        TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
+        TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool(), new SenderResolverVisitor());
         DebugModule dm = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null);
 
         ethereum.blockchain = blockchain;
@@ -193,6 +194,7 @@ public class Web3ImplSnapshotTest {
                 dm,
                 null,
                 Web3Mocks.getMockChannelManager(),
+                null,
                 null,
                 null,
                 null,
@@ -232,7 +234,7 @@ public class Web3ImplSnapshotTest {
                         blockFactory,
                         factory.getBlockExecutor(),
                         new MinimumGasPriceCalculator(Coin.valueOf(miningConfig.getMinGasPriceTarget())),
-                        new MinerUtils()
+                        new MinerUtils(new SenderResolverVisitor())
                 ),
                 clock,
                 blockFactory,

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -911,7 +911,7 @@ public class Web3ImplTest {
         Web3Impl web3 = createWeb3Mocked(world);
 
         Web3.CallArguments argsForCall = new Web3.CallArguments();
-        argsForCall.to = TypeConverter.toJsonHex(tx.getContractAddress().getBytes());
+        argsForCall.to = TypeConverter.toJsonHex(HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes());
         argsForCall.data = TypeConverter.toJsonHex(greeter.functions.get("greet").encodeSignature());
 
         String result = web3.eth_call(argsForCall, "latest");
@@ -958,7 +958,7 @@ public class Web3ImplTest {
 
         Web3.CallArguments argsForCall = new Web3.CallArguments();
         argsForCall.from = TypeConverter.toJsonHex(acc1.getAddress().getBytes());
-        argsForCall.to = TypeConverter.toJsonHex(tx.getContractAddress().getBytes());
+        argsForCall.to = TypeConverter.toJsonHex(HashUtil.calcNewAddr(tx.getSender().getBytes(), tx.getNonce()).getBytes());
         argsForCall.data = "0xead710c40000000000000000000000000000000000000000000000000000000064617665";
 
         String result = web3.eth_call(argsForCall, "latest");

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -3,6 +3,7 @@ package org.ethereum.rpc;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.bc.AccountInformationProvider;
 import co.rsk.logfilter.BlocksBloomStore;
 import co.rsk.metrics.HashRateCalculator;
@@ -82,7 +83,8 @@ public class Web3ImplUnitTest {
                 mock(ConfigCapabilities.class),
                 mock(BuildInfo.class),
                 mock(BlocksBloomStore.class),
-                retriever);
+                retriever,
+                mock(SenderResolverVisitor.class));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
@@ -18,6 +18,7 @@
 
 package org.ethereum.rpc.dto;
 
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Block;
 import org.junit.Test;
@@ -34,7 +35,8 @@ public class TransactionResultDTOTest {
     public void remascAddressSerialization() {
         RemascTransaction remascTransaction = new RemascTransaction(new Random().nextLong());
 
-        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, remascTransaction);
+        SenderResolverVisitor senderResolver = new SenderResolverVisitor();
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, remascTransaction, remascTransaction.accept(senderResolver));
         assertThat(dto.from, is("0x0000000000000000000000000000000000000000"));
         assertThat(dto.r, is(nullValue()));
         assertThat(dto.s, is(nullValue()));

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -115,7 +115,7 @@ public class ContractRunner {
     private TransactionExecutor executeTransaction(Transaction transaction, RepositorySnapshot repository) {
         Repository track = repository.startTracking();
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(transaction, 0, RskAddress.nullAddress(), track, blockchain.getBestBlock(), 0);
+                .newInstance(transaction, transaction.getSender(), 0, RskAddress.nullAddress(), track, blockchain.getBestBlock(), 0);
         executor.init();
         executor.execute();
         executor.go();

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -2,6 +2,7 @@ package org.ethereum.util;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.RepositorySnapshot;
@@ -84,7 +85,7 @@ public class ContractRunner {
         createContract(bytecode, repository);
         Transaction creationTx = contractCreateTx(bytecode, repository);
         executeTransaction(creationTx, repository);
-        return runContract(HashUtil.calcNewAddr(creationTx.getSender().getBytes(), creationTx.getNonce()).getBytes(), encodedCall, value, localCall, repository);
+        return runContract(HashUtil.calcNewAddr(creationTx.accept(new SenderResolverVisitor()).getBytes(), creationTx.getNonce()).getBytes(), encodedCall, value, localCall, repository);
     }
 
     private Transaction contractCreateTx(byte[] bytecode, RepositorySnapshot repository) {
@@ -115,7 +116,7 @@ public class ContractRunner {
     private TransactionExecutor executeTransaction(Transaction transaction, RepositorySnapshot repository) {
         Repository track = repository.startTracking();
         TransactionExecutor executor = transactionExecutorFactory
-                .newInstance(transaction, transaction.getSender(), 0, RskAddress.nullAddress(), track, blockchain.getBestBlock(), 0);
+                .newInstance(transaction, 0, RskAddress.nullAddress(), track, blockchain.getBestBlock(), 0);
         executor.init();
         executor.execute();
         executor.go();

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -10,6 +10,7 @@ import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.trie.TrieStore;
 import org.ethereum.core.*;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockStore;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.vm.program.ProgramResult;
@@ -83,7 +84,7 @@ public class ContractRunner {
         createContract(bytecode, repository);
         Transaction creationTx = contractCreateTx(bytecode, repository);
         executeTransaction(creationTx, repository);
-        return runContract(creationTx.getContractAddress().getBytes(), encodedCall, value, localCall, repository);
+        return runContract(HashUtil.calcNewAddr(creationTx.getSender().getBytes(), creationTx.getNonce()).getBytes(), encodedCall, value, localCall, repository);
     }
 
     private Transaction contractCreateTx(byte[] bytecode, RepositorySnapshot repository) {

--- a/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
@@ -20,6 +20,7 @@
 package org.ethereum.vm;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.SenderResolverVisitor;
 import org.ethereum.util.BIUtil;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts.PrecompiledContract;
@@ -38,7 +39,7 @@ public class PrecompiledContractTest {
 
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
 
     @Test
     public void identityTest1() {

--- a/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
@@ -20,6 +20,7 @@
 package org.ethereum.vm;
 
 import co.rsk.config.TestSystemProperties;
+import co.rsk.core.SenderResolverVisitor;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.util.ByteUtil;
@@ -44,7 +45,7 @@ public class ProgramMemoryTest {
     public void createProgram() {
         TestSystemProperties config = new TestSystemProperties();
 
-        program = new Program(config.getVmConfig(), new PrecompiledContracts(config, null),
+        program = new Program(config.getVmConfig(), new PrecompiledContracts(config, null, new SenderResolverVisitor()),
                 new BlockFactory(config.getActivationConfig()), mock(ActivationConfig.ForBlock.class),
                 ByteUtil.EMPTY_BYTE_ARRAY, pi, null, new HashSet<>());
     }

--- a/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
@@ -23,6 +23,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.AccountState;
@@ -56,7 +57,7 @@ public class VMComplexTest {
     private final TestSystemProperties config = new TestSystemProperties();
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private final VmConfig vmConfig = config.getVmConfig();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
 
     @Ignore //TODO #POC9
     @Test // contract call recursive

--- a/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
@@ -23,6 +23,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.BlockFactory;
@@ -52,7 +53,7 @@ public class VMCustomTest {
     private final TestSystemProperties config = new TestSystemProperties();
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private final VmConfig vmConfig = config.getVmConfig();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
     private ProgramInvokeMockImpl invoke;
     private Program program;
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -23,6 +23,7 @@ import co.rsk.asm.EVMAssembler;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
+import co.rsk.core.SenderResolverVisitor;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.vm.BitSet;
@@ -68,7 +69,7 @@ public class VMTest {
     private final TestSystemProperties config = new TestSystemProperties();
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private final VmConfig vmConfig = config.getVmConfig();
-    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
+    private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new SenderResolverVisitor());
 
 //    private final RskSystemProperties {
 //        config = new RskSystemProperties();


### PR DESCRIPTION
This work is an intermediate step to implement a _signature cache_ as stated in #768 

🤖, please run with *fed:decouple_tx_sender*