### PR TITLE
Added missing information to JsonRpc Block Result

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -156,8 +156,10 @@ public class MinerServerImpl implements MinerServer {
         synchronized (lock) {
             started = false;
             ethereum.removeListener(blockListener);
-            refreshWorkTimer.cancel();
-            refreshWorkTimer = null;
+            if(refreshWorkTimer != null) {
+                refreshWorkTimer.cancel();
+                refreshWorkTimer = null;
+            }
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -100,7 +100,11 @@ public interface Web3EthModule {
 
     Web3.BlockResult eth_getBlockByHash(String blockHash, Boolean fullTransactionObjects) throws Exception;
 
+    String eth_getEncodedBlockByHash(String bnOrId) throws Exception;
+
     Web3.BlockResult eth_getBlockByNumber(String bnOrId, Boolean fullTransactionObjects) throws Exception;
+
+    String eth_getEncodedBlockByNumber(String bnOrId) throws Exception;
 
     TransactionResultDTO eth_getTransactionByHash(String transactionHash) throws Exception;
 

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -321,6 +321,10 @@ public class Block {
         return TypeConverter.toJsonHex(getHash().getBytes());
     }
 
+    public String getEncodedForBlockHashJsonString() {
+        return TypeConverter.toJsonHex(this.header.getEncodedForBlockHash());
+    }
+
     public String getParentHashJsonString() {
         return getParentHash().toJsonString();
     }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -294,13 +294,18 @@ public class BlockHeader {
     }
 
     public Keccak256 getHash() {
-        return new Keccak256(HashUtil.keccak256(getEncoded(true, !useRskip92Encoding)));
+        return new Keccak256(HashUtil.keccak256(getEncodedForBlockHash()));
     }
 
     public byte[] getEncoded() {
         // the encoded block header must include all fields, even the bitcoin PMT and coinbase which are not used for
         // calculating RSKIP92 block hashes
         return this.getEncoded(true, true);
+    }
+
+    public byte[] getEncodedForBlockHash() {
+        // the encoded block header used for calculating block hashes including RSKIP92
+        return this.getEncoded(true, !useRskip92Encoding);
     }
 
     @Nullable

--- a/rskj-core/src/main/java/org/ethereum/rpc/TypeConverter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/TypeConverter.java
@@ -20,6 +20,7 @@ package org.ethereum.rpc;
 
 import org.ethereum.util.ByteUtil;
 import org.bouncycastle.util.encoders.Hex;
+import co.rsk.core.Coin;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -73,6 +74,10 @@ public class TypeConverter {
         }
 
         return result;
+    }
+
+    public static String toJsonHex(Coin x) {
+        return x != null ? x.asBigInteger().toString() : "" ;
     }
 
     public static String toJsonHex(String x) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -80,6 +80,10 @@ public interface Web3 extends Web3TxPoolModule, Web3EthModule, Web3EvmModule, We
         public Object[] transactions; //: Array - Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
         public String[] uncles; //: Array - Array of uncle hashes.
         public String minimumGasPrice;
+        public String paidFees;
+        public String bitcoinMergedMiningHeader;
+        public String bitcoinMergedMiningMerkleProof;
+        public String bitcoinMergedMiningCoinbaseTransaction;
 
         @Override
         public String toString() {
@@ -101,6 +105,10 @@ public interface Web3 extends Web3TxPoolModule, Web3EthModule, Web3EvmModule, We
                     ", minimumGasPrice='" + minimumGasPrice + '\'' +
                     ", gasUsed='" + gasUsed + '\'' +
                     ", timestamp='" + timestamp + '\'' +
+                    ", paidFees='" + paidFees + '\'' +
+                    ", bitcoinMergedMiningHeader='" + bitcoinMergedMiningHeader + '\'' +
+                    ", bitcoinMergedMiningMerkleProof='" + bitcoinMergedMiningMerkleProof + '\'' +
+                    ", bitcoinMergedMiningCoinbaseTransaction='" + bitcoinMergedMiningCoinbaseTransaction + '\'' +
                     ", transactions=" + Arrays.toString(transactions) +
                     ", uncles=" + Arrays.toString(uncles) +
                     '}';

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -172,13 +172,27 @@ public class Web3RskImplTest {
         blockResult.extraData = "extraData";
         blockResult.size = "size";
         blockResult.gasLimit = "gasLimit";
+        blockResult.minimumGasPrice = "minimumGasPrice";
         blockResult.gasUsed = "gasUsed";
         blockResult.timestamp = "timestamp";
+        blockResult.paidFees = "paidFees";
+        blockResult.bitcoinMergedMiningHeader = "bitcoinMergedMiningHeader";
+        blockResult.bitcoinMergedMiningMerkleProof = "bitcoinMergedMiningMerkleProof";
+        blockResult.bitcoinMergedMiningCoinbaseTransaction = "bitcoinMergedMiningCoinbaseTransaction";
         blockResult.transactions = new Object[] {"tx1", "tx2"};
         blockResult.uncles = new String[] {"uncle1", "uncle2"};
-        blockResult.minimumGasPrice = "minimumGasPrice";
 
-        Assert.assertEquals(blockResult.toString(), "BlockResult{number='number', hash='hash', parentHash='parentHash', sha3Uncles='sha3Uncles', logsBloom='logsBloom', transactionsRoot='transactionsRoot', stateRoot='stateRoot', receiptsRoot='receiptsRoot', miner='miner', difficulty='difficulty', totalDifficulty='totalDifficulty', extraData='extraData', size='size', gasLimit='gasLimit', minimumGasPrice='minimumGasPrice', gasUsed='gasUsed', timestamp='timestamp', transactions=[tx1, tx2], uncles=[uncle1, uncle2]}");
+
+
+        Assert.assertEquals(blockResult.toString(), "BlockResult{number='number', hash='hash', " +
+                "parentHash='parentHash', sha3Uncles='sha3Uncles', logsBloom='logsBloom', " +
+                "transactionsRoot='transactionsRoot', stateRoot='stateRoot', receiptsRoot='receiptsRoot', " +
+                "miner='miner', difficulty='difficulty', totalDifficulty='totalDifficulty', extraData='extraData', " +
+                "size='size', gasLimit='gasLimit', minimumGasPrice='minimumGasPrice', gasUsed='gasUsed', " +
+                "timestamp='timestamp', paidFees='paidFees', bitcoinMergedMiningHeader='bitcoinMergedMiningHeader', " +
+                "bitcoinMergedMiningMerkleProof='bitcoinMergedMiningMerkleProof', " +
+                "bitcoinMergedMiningCoinbaseTransaction='bitcoinMergedMiningCoinbaseTransaction', " +
+                "transactions=[tx1, tx2], uncles=[uncle1, uncle2]}");
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -21,7 +21,11 @@ package org.ethereum.rpc;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.*;
-import co.rsk.core.bc.*;
+import co.rsk.core.bc.BlockChainImpl;
+import co.rsk.core.bc.MiningMainchainView;
+import co.rsk.core.bc.MiningMainchainViewImpl;
+import co.rsk.core.bc.TransactionPoolImpl;
+import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
@@ -47,6 +51,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
@@ -682,11 +687,16 @@ public class Web3ImplTest {
                                         world.getBlockStore()).trieStore(world.getTrieStore()).parent(genesis).build();
         org.junit.Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
 
-        Web3.BlockResult blockResult = web3.eth_getBlockByNumber("earliest", false);
+        String bnOrId = "earliest";
+        Web3.BlockResult blockResult = web3.eth_getBlockByNumber(bnOrId, false);
 
         Assert.assertNotNull(blockResult);
         String blockHash = genesis.getHashJsonString();
         org.junit.Assert.assertEquals(blockHash, blockResult.hash);
+
+        String hexString = web3.eth_getEncodedBlockByNumber(bnOrId).replace("0x","");
+        Keccak256  obtainedBlockHash = new Keccak256(HashUtil.keccak256(Hex.decode(hexString)));
+        Assert.assertEquals(blockHash, obtainedBlockHash.toJsonString());
     }
 
     @Test
@@ -695,9 +705,13 @@ public class Web3ImplTest {
 
         Web3Impl web3 = createWeb3(world);
 
-        Web3.BlockResult blockResult = web3.eth_getBlockByNumber("0x1234", false);
+        String bnOrId = "0x1234";
+        Web3.BlockResult blockResult = web3.eth_getBlockByNumber(bnOrId, false);
 
         Assert.assertNull(blockResult);
+
+        String hexString = web3.eth_getEncodedBlockByNumber(bnOrId);
+        Assert.assertNull(hexString);
     }
 
     @Test
@@ -737,10 +751,18 @@ public class Web3ImplTest {
         Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block1bHashString, bresult.hash);
 
+        String hexString = web3.eth_getEncodedBlockByHash(block1bHashString).replace("0x","");
+        Keccak256  blockHash = new Keccak256(HashUtil.keccak256(Hex.decode(hexString)));
+        Assert.assertEquals(blockHash.toJsonString(), block1bHashString);
+
         bresult = web3.eth_getBlockByHash(block2bHashString, true);
 
         Assert.assertNotNull(bresult);
         org.junit.Assert.assertEquals(block2bHashString, bresult.hash);
+
+        hexString = web3.eth_getEncodedBlockByHash(block2bHashString).replace("0x","");
+        blockHash = new Keccak256(HashUtil.keccak256(Hex.decode(hexString)));
+        Assert.assertEquals(blockHash.toJsonString(), block2bHashString);
     }
 
     @Test
@@ -807,9 +829,13 @@ public class Web3ImplTest {
 
         Web3Impl web3 = createWeb3(world);
 
-        Web3.BlockResult blockResult = web3.eth_getBlockByHash("0x1234000000000000000000000000000000000000000000000000000000000000", false);
+        String blockHash = "0x1234000000000000000000000000000000000000000000000000000000000000";
+        Web3.BlockResult blockResult = web3.eth_getBlockByHash(blockHash, false);
 
         Assert.assertNull(blockResult);
+
+        String hexString = web3.eth_getEncodedBlockByHash(blockHash);
+        Assert.assertNull(hexString);
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/TypeConverterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/TypeConverterTest.java
@@ -18,10 +18,12 @@
 
 package org.ethereum.rpc.converters;
 
+import co.rsk.core.Coin;
 import org.ethereum.rpc.TypeConverter;
-import org.ethereum.rpc.Web3;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.math.BigInteger;
 
 /**
  * Created by martin.medina on 3/7/17.
@@ -56,5 +58,15 @@ public class TypeConverterTest {
     @Test
     public void toJsonHexNullInput() {
         Assert.assertEquals("0x00", TypeConverter.toJsonHex((byte[])null));
+    }
+
+    @Test
+    public void toJsonHexCoin() {
+        Assert.assertEquals("1234", TypeConverter.toJsonHex(new Coin(new BigInteger("1234"))));
+    }
+
+    @Test
+    public void toJsonHexNullCoin() {
+        Assert.assertEquals("", TypeConverter.toJsonHex((Coin) null));
     }
 }


### PR DESCRIPTION
The missing fields are: paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof and bitcoinMergedMiningCoinbaseTransaction
The extra information is needed to calculate the encoded block and verify that the hash of the block is correct.

Also we extended the web3 interface adding eth_getEncodedBlockByNumber and eth_getEncodedBlockByHash to directly obtain the encoded value without needing to encode it from the json response.
Added corresponding unit test