### PR TITLE
Talk to me

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/net/message/StaticMessages.java
+++ b/rskj-core/src/main/java/org/ethereum/net/message/StaticMessages.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
  * This class contains static values of messages on the network. These message
  * will always be the same and therefore don't need to be created each time.
  *
- * @author Roman Mandeleil
+ * @author Roman Mandeleil, Dieguito
  * @since 13.04.14
  */
 public class StaticMessages {
@@ -80,7 +80,7 @@ public class StaticMessages {
         }
         String phrase = config.helloPhrase();
 
-        return String.format("Ethereum(J)/v%s/%s/%s/Java/%s", numberVersion, system,
+        return String.format("RSK(J)/v%s/%s/%s/Java/%s", numberVersion, system,
                 config.projectVersionModifier().equalsIgnoreCase("release") ? "Release" : "Dev", phrase);
     }
 }

--- a/rskj-core/src/main/resources/logback.xml
+++ b/rskj-core/src/main/resources/logback.xml
@@ -16,7 +16,7 @@
             <pattern>%date{yyyy-MM-dd-HH:mm:ss.SSSS} %p [%c{1}]  %m%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>OFF</level>
+            <level>INFO</level>
         </filter>
     </appender>
 


### PR DESCRIPTION
I added INFO messages and higher to the standard output to give the node operator with some hints of what's going on at startup. In the future would be great to add at the beginning some pointers on where to find more verbose information (i.e. logs/rsk.log) and how to create a customized configs for different environments (main with DEBUG messages running on port 7777, regtest with TRACE messages on default port).