### PR TITLE
State garbage collector v1

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -326,7 +326,7 @@ public class RskContext implements NodeBootstrapper {
 
     public TrieStore getTrieStore() {
         if (trieStore == null) {
-            trieStore = buildTrieStore();
+            trieStore = buildTrieStore("unitrie");
         }
 
         return trieStore;
@@ -787,7 +787,7 @@ public class RskContext implements NodeBootstrapper {
         );
     }
 
-    protected TrieStore buildTrieStore() {
+    protected TrieStore buildTrieStore(String name) {
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
         if (rskSystemProperties.databaseReset()) {
@@ -795,7 +795,7 @@ public class RskContext implements NodeBootstrapper {
         }
 
         int statesCacheSize = rskSystemProperties.getStatesCacheSize();
-        KeyValueDataSource ds = makeDataSource("unitrie", databaseDir);
+        KeyValueDataSource ds = makeDataSource(name, databaseDir);
 
         if (statesCacheSize != 0) {
             ds = new DataSourceWithCache(ds, statesCacheSize);

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -64,9 +64,7 @@ import co.rsk.rpc.netty.*;
 import co.rsk.scoring.PeerScoring;
 import co.rsk.scoring.PeerScoringManager;
 import co.rsk.scoring.PunishmentParameters;
-import co.rsk.trie.TrieConverter;
-import co.rsk.trie.TrieStore;
-import co.rsk.trie.TrieStoreImpl;
+import co.rsk.trie.*;
 import co.rsk.util.RskCustomCache;
 import co.rsk.validators.*;
 import org.ethereum.config.Constants;
@@ -114,9 +112,10 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
+import java.nio.file.*;
 import java.time.Clock;
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * Creates the initial object graph without a DI framework.
@@ -326,7 +325,16 @@ public class RskContext implements NodeBootstrapper {
 
     public TrieStore getTrieStore() {
         if (trieStore == null) {
-            trieStore = buildTrieStore("unitrie");
+            GarbageCollectorConfig gcConfig = getRskSystemProperties().garbageCollectorConfig();
+            if (gcConfig.enabled()) {
+                try {
+                    trieStore = buildMultiTrieStore(gcConfig.numberOfEpochs());
+                } catch (IOException e) {
+                    throw new IllegalStateException("Unable to build multi trie store", e);
+                }
+            } else {
+                trieStore = buildTrieStore("unitrie");
+            }
         }
 
         return trieStore;
@@ -723,6 +731,17 @@ public class RskContext implements NodeBootstrapper {
                 getTrieStore(),
                 getBlockStore()
         ));
+        GarbageCollectorConfig gcConfig = getRskSystemProperties().garbageCollectorConfig();
+        if (gcConfig.enabled()) {
+            internalServices.add(new GarbageCollector(
+                    getCompositeEthereumListener(),
+                    gcConfig.blocksPerEpoch(),
+                    gcConfig.numberOfEpochs(),
+                    (MultiTrieStore) getTrieStore(),
+                    getBlockStore(),
+                    getRepositoryLocator()
+            ));
+        }
         return Collections.unmodifiableList(internalServices);
     }
 
@@ -803,6 +822,32 @@ public class RskContext implements NodeBootstrapper {
 
         return new TrieStoreImpl(ds);
     }
+
+    private TrieStore buildMultiTrieStore(int numberOfEpochs) throws IOException {
+        String multiTrieStoreNamePrefix = "unitrie_";
+        Path databasePath = Paths.get(getRskSystemProperties().databaseDir());
+        int currentEpoch = numberOfEpochs;
+        if (!getRskSystemProperties().databaseReset()) {
+            try (Stream<Path> databasePaths = Files.list(databasePath)) {
+                currentEpoch = databasePaths
+                        .map(Path::getFileName)
+                        .map(Path::toString)
+                        .filter(fileName -> fileName.startsWith(multiTrieStoreNamePrefix))
+                        .map(multiTrieStoreName -> multiTrieStoreName.replaceFirst(multiTrieStoreNamePrefix, ""))
+                        .map(Integer::valueOf)
+                        .max(Comparator.naturalOrder())
+                        .orElse(numberOfEpochs);
+            }
+        }
+
+        return new MultiTrieStore(
+                currentEpoch,
+                numberOfEpochs,
+                name -> buildTrieStore(multiTrieStoreNamePrefix + name),
+                disposedEpoch -> FileUtil.recursiveDelete(databasePath.resolve(multiTrieStoreNamePrefix + disposedEpoch).toString())
+        );
+    }
+
 
     protected RepositoryLocator buildRepositoryLocator() {
         return new RepositoryLocator(getTrieStore(), getStateRootHandler());

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -838,6 +838,15 @@ public class RskContext implements NodeBootstrapper {
                         .max(Comparator.naturalOrder())
                         .orElse(numberOfEpochs);
             }
+            Path unitriePath = databasePath.resolve("unitrie");
+            if(Files.exists(unitriePath)) {
+                // moves the unitrie directory as the currentEpoch. It "knows" the internals of the MultiTrieStore constructor
+                // to assign currentEpoch - 1 as the name
+                Files.move(
+                        unitriePath,
+                        databasePath.resolve(multiTrieStoreNamePrefix + (currentEpoch - 1))
+                );
+            }
         }
 
         return new MultiTrieStore(

--- a/rskj-core/src/main/java/co/rsk/config/GarbageCollectorConfig.java
+++ b/rskj-core/src/main/java/co/rsk/config/GarbageCollectorConfig.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.config;
+
+import com.typesafe.config.Config;
+
+/**
+ * Wraps configuration for the Garbage Collector, which is usually derived from configuration files.
+ */
+public class GarbageCollectorConfig {
+    private final boolean enabled;
+    private final int blocksPerEpoch;
+    private final int numberOfEpochs;
+
+    public GarbageCollectorConfig(boolean enabled, int blocksPerEpoch, int numberOfEpochs) {
+        this.enabled = enabled;
+        this.blocksPerEpoch = blocksPerEpoch;
+        this.numberOfEpochs = numberOfEpochs;
+    }
+
+    public boolean enabled() {
+        return enabled;
+    }
+
+    public int blocksPerEpoch() {
+        return blocksPerEpoch;
+    }
+
+    public int numberOfEpochs() {
+        return numberOfEpochs;
+    }
+
+    /**
+     * Reads configuration in the form of { enabled: boolean, blocksPerEpoch: int, epochs: int }
+     */
+    public static GarbageCollectorConfig fromConfig(Config config) {
+        return new GarbageCollectorConfig(
+                config.getBoolean("enabled"),
+                config.getInt("blocksPerEpoch"),
+                config.getInt("epochs")
+        );
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -180,6 +180,10 @@ public class RskSystemProperties extends SystemProperties {
         return ret;
     }
 
+    public GarbageCollectorConfig garbageCollectorConfig() {
+        return GarbageCollectorConfig.fromConfig(configFromFiles.getConfig("blockchain.gc"));
+    }
+
     public int flushNumberOfBlocks() {
         return configFromFiles.hasPath("blockchain.flushNumberOfBlocks") && configFromFiles.getInt("blockchain.flushNumberOfBlocks") > 0 ?
                 configFromFiles.getInt("blockchain.flushNumberOfBlocks") : 20;

--- a/rskj-core/src/main/java/co/rsk/core/bc/GarbageCollector.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/GarbageCollector.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.core.bc;
+
+import co.rsk.config.InternalService;
+import co.rsk.db.RepositoryLocator;
+import co.rsk.trie.MultiTrieStore;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.db.BlockStore;
+import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.listener.EthereumListener;
+import org.ethereum.listener.EthereumListenerAdapter;
+
+import java.util.List;
+
+public class GarbageCollector implements InternalService {
+    private final CompositeEthereumListener emitter;
+    private final MultiTrieStore multiTrieStore;
+    private final BlockStore blockStore;
+    private final RepositoryLocator repositoryLocator;
+    private final EthereumListener garbageCollectorInvoker;
+
+    public GarbageCollector(CompositeEthereumListener emitter,
+                            int blocksPerEpoch,
+                            int numberOfEpochs,
+                            MultiTrieStore multiTrieStore,
+                            BlockStore blockStore,
+                            RepositoryLocator repositoryLocator) {
+        this.emitter = emitter;
+        this.multiTrieStore = multiTrieStore;
+        this.blockStore = blockStore;
+        this.repositoryLocator = repositoryLocator;
+        this.garbageCollectorInvoker = new GarbageCollectorInvoker(blocksPerEpoch, numberOfEpochs);
+    }
+
+    @Override
+    public void start() {
+        emitter.addListener(garbageCollectorInvoker);
+    }
+
+    @Override
+    public void stop() {
+        emitter.removeListener(garbageCollectorInvoker);
+    }
+
+    private void collect(long untilBlock) {
+        BlockHeader untilHeader = blockStore.getChainBlockByNumber(untilBlock).getHeader();
+        multiTrieStore.collect(repositoryLocator.snapshotAt(untilHeader).getRoot());
+    }
+
+    private class GarbageCollectorInvoker extends EthereumListenerAdapter {
+        private final int blocksPerEpoch;
+        private final int numberOfEpochs;
+
+        public GarbageCollectorInvoker(int blocksPerEpoch, int numberOfEpochs) {
+            this.blocksPerEpoch = blocksPerEpoch;
+            this.numberOfEpochs = numberOfEpochs;
+        }
+
+        /**
+         * It'll collect all states older than <code>blocksPerEpoch * numberOfEpochs - 1</code> from
+         * the store (if there are enough blocks)
+         */
+        @Override
+        public void onBestBlock(Block block, List<TransactionReceipt> receipts) {
+            int statesToKeep = blocksPerEpoch * numberOfEpochs - 1;
+            long currentBlockNumber = block.getNumber();
+            if(currentBlockNumber % blocksPerEpoch == 0 && currentBlockNumber >= statesToKeep) {
+                collect(currentBlockNumber - statesToKeep);
+            }
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java
+++ b/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.trie;
+
+import org.bouncycastle.util.encoders.Hex;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MultiTrieStore implements TrieStore {
+
+    private int currentEpoch;
+    private final List<TrieStore> epochs;
+    private final TrieStoreFactory trieStoreFactory;
+    private final OnEpochDispose disposer;
+
+    /**
+     * Creates a MultiTrieStore
+     * @param currentEpoch number (>= 0) of epoch to begin
+     * @param liveEpochs number (>= 0) of concurrent living epochs
+     * @param trieStoreFactory a trie store factory
+     * @param disposer callback for when an epoch gets disposed
+     */
+    public MultiTrieStore(int currentEpoch, int liveEpochs, TrieStoreFactory trieStoreFactory, OnEpochDispose disposer) {
+        // if currentEpoch < liveEpochs the store for it will be in the expected index in the epochs list
+        this.currentEpoch = Math.max(currentEpoch, liveEpochs);
+        this.trieStoreFactory = trieStoreFactory;
+        this.disposer = disposer;
+        this.epochs = new ArrayList<>(liveEpochs);
+        for (int i = 1; i <= liveEpochs; i++) { // starting in 1 so it's easier to calculate epoch according index
+            epochs.add(trieStoreFactory.newInstance(String.valueOf(this.currentEpoch - i)));
+        }
+    }
+
+    /**
+     * This will save to the current store <b>only</b> the new nodes b/c if there is some child in an older
+     * epoch, it'll be reached by the {@link #retrieve(byte[]) retrieve} method breaking the recursion
+     *
+     * @param trie a {@link Trie} obtained from a {@link MultiTrieStore}
+     */
+    @Override
+    public void save(Trie trie) {
+        getCurrentStore().save(trie);
+    }
+
+    /**
+     * It's not enough to just flush the current one b/c it may occur, if the epoch size doesn't match the flush size,
+     * that some epoch may never get flushed
+     */
+    @Override
+    public void flush() {
+        epochs.forEach(TrieStore::flush);
+    }
+
+    /**
+     * This method will go through all epochs from newest to oldest retrieving the <code>rootHash</code>
+     *
+     * @param rootHash the root of the {@link Trie} to retrieve
+     * @return the {@link Trie} with <code>rootHash</code>
+     * @throws IllegalArgumentException if it's not found
+     */
+    @Override
+    public Trie retrieve(byte[] rootHash) {
+        for (TrieStore epochTrieStore : epochs) {
+            byte[] message = epochTrieStore.retrieveValue(rootHash);
+            if (message == null) {
+                continue;
+            }
+            return Trie.fromMessage(message, this);
+        }
+        throw new IllegalArgumentException(String.format(
+                "The trie with root %s is missing from every epoch", Hex.toHexString(rootHash)
+        ));
+    }
+
+    @Override
+    public byte[] retrieveValue(byte[] hash) {
+        for (TrieStore epochTrieStore : epochs) {
+            byte[] value = epochTrieStore.retrieveValue(hash);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void dispose() {
+        epochs.forEach(TrieStore::dispose);
+    }
+
+    /**
+     * Discards the oldest epoch.
+     *
+     * The children of <code>oldestTrieHashToKeep</code> stored in the oldest epoch will be saved
+     * into the previous one
+     *
+     * @param oldestTrieHashToKeep a trie root hash to ensure epoch survival
+     */
+    public void collect(byte[] oldestTrieHashToKeep) {
+        Trie oldestTrieToKeep = retrieve(oldestTrieHashToKeep);
+        epochs.get(epochs.size() - 2).save(oldestTrieToKeep); // save into the upcoming last epoch
+        epochs.get(epochs.size() - 1).dispose(); // dispose last epoch
+        disposer.callback(currentEpoch - epochs.size());
+        Collections.rotate(epochs, 1); // move last epoch to first place
+        epochs.set(0, trieStoreFactory.newInstance(String.valueOf(currentEpoch))); // update current epoch
+        currentEpoch++;
+    }
+
+    private TrieStore getCurrentStore() {
+        return epochs.get(0);
+    }
+
+    public interface OnEpochDispose {
+        void callback(int disposedEpoch);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreFactory.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreFactory.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of RskJ
- * Copyright (C) 2017 RSK Labs Ltd.
+ * Copyright (C) 2019 RSK Labs Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -18,15 +18,7 @@
 
 package co.rsk.trie;
 
-public interface TrieStore {
-    void save(Trie trie);
+public interface TrieStoreFactory {
 
-    void flush();
-
-    /** Retrieve a trie node with the specified hash from this store */
-    Trie retrieve(byte[] hash);
-
-    byte[] retrieveValue(byte[] hash);
-
-    void dispose();
+    TrieStore newInstance(String name);
 }

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -109,4 +109,9 @@ public class TrieStoreImpl implements TrieStore {
     public byte[] retrieveValue(byte[] hash) {
         return this.store.get(hash);
     }
+
+    @Override
+    public void dispose() {
+        store.close();
+    }
 }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -1,28 +1,35 @@
-blockchain.config {
-    consensusRules = {
-        areBridgeTxsPaid = afterBridgeSync,
-        rskip85 = orchid,
-        rskip87 = orchid,
-        rskip88 = orchid,
-        rskip89 = orchid,
-        rskip90 = orchid,
-        rskip91 = orchid,
-        rskip92 = orchid,
-        rskip94 = orchid,
-        rskip97 = orchid,
-        rskip98 = orchid,
-        rskip103 = orchid060,
-        rskip106 = wasabi100,
-        rskip110 = wasabi100,
-        rskip119 = wasabi100,
-        rskip120 = wasabi100,
-        rskip122 = wasabi100,
-        rskip123 = wasabi100,
-        rskip124 = wasabi100,
-        rskip125 = wasabi100,
-        rskip126 = wasabi100,
-        rskip132 = wasabi100,
-        rskip136 = bahamas
+blockchain = {
+    config = {
+        consensusRules = {
+            areBridgeTxsPaid = afterBridgeSync,
+            rskip85 = orchid,
+            rskip87 = orchid,
+            rskip88 = orchid,
+            rskip89 = orchid,
+            rskip90 = orchid,
+            rskip91 = orchid,
+            rskip92 = orchid,
+            rskip94 = orchid,
+            rskip97 = orchid,
+            rskip98 = orchid,
+            rskip103 = orchid060,
+            rskip106 = wasabi100,
+            rskip110 = wasabi100,
+            rskip119 = wasabi100,
+            rskip120 = wasabi100,
+            rskip122 = wasabi100,
+            rskip123 = wasabi100,
+            rskip124 = wasabi100,
+            rskip125 = wasabi100,
+            rskip126 = wasabi100,
+            rskip132 = wasabi100,
+            rskip136 = bahamas
+        }
+    }
+    gc = {
+        enabled = false
+        epochs = 3
+        blocksPerEpoch = 20000
     }
 }
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/GarbageCollectorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/GarbageCollectorTest.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.core.bc;
+
+import co.rsk.db.RepositoryLocator;
+import co.rsk.db.RepositorySnapshot;
+import co.rsk.trie.MultiTrieStore;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.db.BlockStore;
+import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.listener.EthereumListener;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.Mockito.*;
+
+public class GarbageCollectorTest {
+    private CompositeEthereumListener emitter;
+    private MultiTrieStore multiTrieStore;
+    private BlockStore blockStore;
+    private GarbageCollector collector;
+
+    private EthereumListener listener;
+    private RepositoryLocator repositoryLocator;
+
+    @Before
+    public void setUp() {
+        this.emitter = mock(CompositeEthereumListener.class);
+        this.multiTrieStore = mock(MultiTrieStore.class);
+        this.blockStore = mock(BlockStore.class);
+        this.repositoryLocator = mock(RepositoryLocator.class);
+        this.collector = new GarbageCollector(emitter, 7, 3, multiTrieStore, blockStore, repositoryLocator);
+        this.collector.start();
+
+        ArgumentCaptor<EthereumListener> argument = ArgumentCaptor.forClass(EthereumListener.class);
+        verify(emitter, times(1)).addListener(argument.capture());
+        this.listener = argument.getValue();
+    }
+
+    @After
+    public void tearDown() {
+        verify(emitter, times(0)).removeListener(listener);
+        collector.stop();
+        verify(emitter, times(1)).removeListener(listener);
+    }
+
+    @Test
+    public void collectsOnBlocksPerEpochModulo() {
+        for (int i = 100; i < 105; i++) {
+            Block block = block(i);
+            listener.onBestBlock(block, null);
+        }
+
+        verify(multiTrieStore, never()).collect(any());
+
+        byte[] stateRoot = new byte[] {0x42, 0x43, 0x02};
+        withSnapshotStateRootAtBlockNumber(85, stateRoot);
+
+        Block block = block(105);
+        listener.onBestBlock(block, null);
+        verify(multiTrieStore).collect(stateRoot);
+    }
+
+    @Test
+    public void collectsOnBlocksPerEpochModuloAndMinimumOfStatesToKeep() {
+        for (int i = 0; i < 21; i++) {
+            Block block = block(i);
+            listener.onBestBlock(block, null);
+        }
+
+        verify(multiTrieStore, never()).collect(any());
+
+        byte[] stateRoot = new byte[] {0x42, 0x43, 0x02};
+        withSnapshotStateRootAtBlockNumber(1, stateRoot);
+
+        Block block = block(21);
+        listener.onBestBlock(block, null);
+        verify(multiTrieStore).collect(stateRoot);
+    }
+
+    private void withSnapshotStateRootAtBlockNumber(int i, byte[] stateRoot) {
+        Block block = block(i);
+        when(blockStore.getChainBlockByNumber(i)).thenReturn(block);
+        RepositorySnapshot snapshot = mock(RepositorySnapshot.class);
+        when(repositoryLocator.snapshotAt(block.getHeader())).thenReturn(snapshot);
+        when(snapshot.getRoot()).thenReturn(stateRoot);
+    }
+
+    private Block block(long number) {
+        Block block = mock(Block.class);
+        when(block.getNumber()).thenReturn(number);
+        BlockHeader blockHeader = mock(BlockHeader.class);
+        when(block.getHeader()).thenReturn(blockHeader);
+        return block;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/trie/MultiTrieStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/MultiTrieStoreTest.java
@@ -1,0 +1,232 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.trie;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MultiTrieStoreTest {
+    @Test
+    public void oldestEpochNameIsntNegative() {
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        new MultiTrieStore(3, 3, storeFactory, null);
+
+        verify(storeFactory).newInstance("2");
+        verify(storeFactory).newInstance("1");
+        verify(storeFactory).newInstance("0");
+        verifyNoMoreInteractions(storeFactory);
+    }
+
+    @Test
+    public void openLastThreeEpochsStores() {
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        new MultiTrieStore(49, 3, storeFactory, null);
+
+        verify(storeFactory).newInstance("48");
+        verify(storeFactory).newInstance("47");
+        verify(storeFactory).newInstance("46");
+        verifyNoMoreInteractions(storeFactory);
+    }
+
+    @Test
+    public void callsSaveOnlyOnNewestStore() {
+        TrieStore store1 = mock(TrieStore.class);
+        TrieStore store2 = mock(TrieStore.class);
+        TrieStore store3 = mock(TrieStore.class);
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        when(storeFactory.newInstance("46")).thenReturn(store1);
+        when(storeFactory.newInstance("47")).thenReturn(store2);
+        when(storeFactory.newInstance("48")).thenReturn(store3);
+        MultiTrieStore store = new MultiTrieStore(49, 3, storeFactory, null);
+
+        Trie trie = mock(Trie.class);
+        store.save(trie);
+
+        verify(store1, never()).save(trie);
+        verify(store2, never()).save(trie);
+        verify(store3).save(trie);
+    }
+
+    @Test
+    public void callsFlushOnAllStores() {
+        TrieStore store1 = mock(TrieStore.class);
+        TrieStore store2 = mock(TrieStore.class);
+        TrieStore store3 = mock(TrieStore.class);
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        when(storeFactory.newInstance("46")).thenReturn(store1);
+        when(storeFactory.newInstance("47")).thenReturn(store2);
+        when(storeFactory.newInstance("48")).thenReturn(store3);
+        MultiTrieStore store = new MultiTrieStore(49, 3, storeFactory, null);
+
+        store.flush();
+
+        verify(store1).flush();
+        verify(store2).flush();
+        verify(store3).flush();
+    }
+
+    @Test
+    public void callsDisposeOnAllStores() {
+        TrieStore store1 = mock(TrieStore.class);
+        TrieStore store2 = mock(TrieStore.class);
+        TrieStore store3 = mock(TrieStore.class);
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        when(storeFactory.newInstance("46")).thenReturn(store1);
+        when(storeFactory.newInstance("47")).thenReturn(store2);
+        when(storeFactory.newInstance("48")).thenReturn(store3);
+        MultiTrieStore store = new MultiTrieStore(49, 3, storeFactory, null);
+
+        store.dispose();
+
+        verify(store1).dispose();
+        verify(store2).dispose();
+        verify(store3).dispose();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIllegalArgumentOnMissingTrieToRetrieve() {
+        TrieStoreFactory storeFactory = name -> mock(TrieStore.class);
+        MultiTrieStore store = new MultiTrieStore(49, 3, storeFactory, null);
+
+        Trie testTrie = new Trie();
+        byte[] hashToRetrieve = testTrie.getHash().getBytes();
+        store.retrieve(hashToRetrieve);
+    }
+
+    @Test
+    public void retrievesFromNewestStoreWithValue() {
+        TrieStore store1 = mock(TrieStore.class);
+        TrieStore store2 = mock(TrieStore.class);
+        TrieStore store3 = mock(TrieStore.class);
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        when(storeFactory.newInstance("46")).thenReturn(store1);
+        when(storeFactory.newInstance("47")).thenReturn(store2);
+        when(storeFactory.newInstance("48")).thenReturn(store3);
+        MultiTrieStore store = new MultiTrieStore(49, 3, storeFactory, null);
+
+        Trie testTrie = new Trie();
+        byte[] hashToRetrieve = testTrie.getHash().getBytes();
+        when(store2.retrieveValue(hashToRetrieve)).thenReturn(testTrie.toMessage());
+
+        Trie retrievedTrie = store.retrieve(hashToRetrieve);
+        assertEquals(testTrie, retrievedTrie);
+
+        verify(store1, never()).retrieveValue(hashToRetrieve);
+        verify(store2).retrieveValue(hashToRetrieve);
+        verify(store3).retrieveValue(hashToRetrieve);
+    }
+
+    @Test
+    public void retrievesValueFromNewestStoreWithValue() {
+        TrieStore store1 = mock(TrieStore.class);
+        TrieStore store2 = mock(TrieStore.class);
+        TrieStore store3 = mock(TrieStore.class);
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        when(storeFactory.newInstance("46")).thenReturn(store1);
+        when(storeFactory.newInstance("47")).thenReturn(store2);
+        when(storeFactory.newInstance("48")).thenReturn(store3);
+        MultiTrieStore store = new MultiTrieStore(49, 3, storeFactory, null);
+
+        byte[] testValue = new byte[] {0x32, 0x42};
+        byte[] hashToRetrieve = new byte[] {0x2, 0x4};
+        when(store2.retrieveValue(hashToRetrieve)).thenReturn(testValue);
+
+        byte[] retrievedValue = store.retrieveValue(hashToRetrieve);
+        assertArrayEquals(testValue, retrievedValue);
+
+        verify(store1, never()).retrieveValue(hashToRetrieve);
+        verify(store2).retrieveValue(hashToRetrieve);
+        verify(store3).retrieveValue(hashToRetrieve);
+    }
+
+    @Test
+    public void openStore3OnEpoch0Collection() {
+        MultiTrieStore.OnEpochDispose disposer = mock(MultiTrieStore.OnEpochDispose.class);
+        TrieStore store1 = mock(TrieStore.class);
+        TrieStore store2 = mock(TrieStore.class);
+        TrieStore store3 = mock(TrieStore.class);
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        when(storeFactory.newInstance("0")).thenReturn(store1);
+        when(storeFactory.newInstance("1")).thenReturn(store2);
+        when(storeFactory.newInstance("2")).thenReturn(store3);
+
+        MultiTrieStore store = new MultiTrieStore(0, 3, storeFactory, disposer);
+
+        Trie testTrie = new Trie();
+        byte[] hashToRetrieve = testTrie.getHash().getBytes();
+        when(store1.retrieveValue(hashToRetrieve)).thenReturn(testTrie.toMessage());
+
+        store.collect(hashToRetrieve);
+
+        verify(disposer).callback(0);
+        verify(storeFactory).newInstance("3");
+    }
+
+    @Test
+    public void performsStoreRotationOnCollect() {
+        TrieStore store1 = mock(TrieStore.class);
+        TrieStore store2 = mock(TrieStore.class);
+        TrieStore store3 = mock(TrieStore.class);
+        TrieStore store4 = mock(TrieStore.class);
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        when(storeFactory.newInstance("46")).thenReturn(store1);
+        when(storeFactory.newInstance("47")).thenReturn(store2);
+        when(storeFactory.newInstance("48")).thenReturn(store3);
+        when(storeFactory.newInstance("49")).thenReturn(store4);
+        MultiTrieStore.OnEpochDispose disposer = mock(MultiTrieStore.OnEpochDispose.class);
+        MultiTrieStore store = new MultiTrieStore(49, 3, storeFactory, disposer);
+
+        Trie testTrie = new Trie();
+        byte[] testTrieHash = testTrie.getHash().getBytes();
+        when(store1.retrieveValue(testTrieHash)).thenReturn(testTrie.toMessage());
+
+        store.collect(testTrieHash);
+
+        // 1. save the oldest trie into the second to last store
+        verify(store2).save(testTrie);
+        when(store2.retrieveValue(testTrieHash)).thenReturn(testTrie.toMessage());
+
+        // 2. disposes the last store
+        verify(store1).dispose();
+        verify(disposer).callback(46);
+
+        // 3. oldest trie is still accessible and disposed database is not queried
+        Trie retrievedTrie = store.retrieve(testTrieHash);
+        assertEquals(testTrie, retrievedTrie);
+        // 1 was only called for collect
+        // 2 and 3 were called once during collect and another one for retrieve.
+        // 4 was only called for retrieve
+        verify(store1).retrieveValue(testTrieHash);
+        verify(store2, times(2)).retrieveValue(testTrieHash);
+        verify(store3, times(2)).retrieveValue(testTrieHash);
+        verify(store4).retrieveValue(testTrieHash);
+
+        // 4. disposed database is not queried
+        byte[] hashToRetrieve = new byte[] {0x2, 0x4};
+        byte[] retrievedValue = store.retrieveValue(hashToRetrieve);
+        assertNull(retrievedValue);
+
+        verify(store1, never()).retrieveValue(hashToRetrieve);
+        verify(store2).retrieveValue(hashToRetrieve);
+        verify(store3).retrieveValue(hashToRetrieve);
+        verify(store4).retrieveValue(hashToRetrieve);
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/util/RskTestContext.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RskTestContext.java
@@ -51,7 +51,7 @@ public class RskTestContext extends RskContext {
     }
 
     @Override
-    protected TrieStore buildTrieStore() {
+    protected TrieStore buildTrieStore(String name) {
         return new TrieStoreImpl(new HashMapDB());
     }
 


### PR DESCRIPTION
This is a v1 implementation of the state garbage collection feature. The full definition of the expected feature is in [RSKIP64](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP64.md). This v1 doesn't minimize the nodes stored in each epoch but when we decide to implement that it'll be retrocompatible with this implementation at storage level.

It's disabled by default, you have to opt-in through the `blockchain.gc.enabled` configuration flag.