### PR TITLE
Get raw block header via JSON RPC

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -58,6 +58,8 @@ import co.rsk.rpc.modules.mnr.MnrModuleImpl;
 import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletDisabled;
 import co.rsk.rpc.modules.personal.PersonalModuleWalletEnabled;
+import co.rsk.rpc.modules.rsk.RskModule;
+import co.rsk.rpc.modules.rsk.RskModuleImpl;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.rpc.modules.txpool.TxPoolModuleImpl;
 import co.rsk.rpc.netty.*;
@@ -196,6 +198,7 @@ public class RskContext implements NodeBootstrapper {
     private DebugModule debugModule;
     private MnrModule mnrModule;
     private TxPoolModule txPoolModule;
+    private RskModule rskModule;
     private RskWireProtocol.Factory rskWireProtocolFactory;
     private Eth62MessageFactory eth62MessageFactory;
     private GasLimitCalculator gasLimitCalculator;
@@ -619,6 +622,17 @@ public class RskContext implements NodeBootstrapper {
         return txPoolModule;
     }
 
+    public RskModule getRskModule() {
+        if (rskModule == null) {
+            rskModule = new RskModuleImpl(
+                    getBlockchain(),
+                    getBlockStore(),
+                    getReceiptStore());
+        }
+
+        return rskModule;
+    }
+
     public NetworkStateExporter getNetworkStateExporter() {
         if (networkStateExporter == null) {
             networkStateExporter = new NetworkStateExporter(getRepositoryLocator(), getBlockchain());
@@ -768,6 +782,7 @@ public class RskContext implements NodeBootstrapper {
                 getTxPoolModule(),
                 getMnrModule(),
                 getDebugModule(),
+                getRskModule(),
                 getChannelManager(),
                 getRepositoryLocator(),
                 getPeerScoringManager(),

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockHashesHelper.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockHashesHelper.java
@@ -22,7 +22,7 @@ public class BlockHashesHelper {
         return trie.getHashOrchid(false).getBytes();
     }
 
-    private static Trie calculateReceiptsTrieRootFor(List<TransactionReceipt> receipts) {
+    public static Trie calculateReceiptsTrieRootFor(List<TransactionReceipt> receipts) {
         Trie receiptsTrie = new Trie();
         for (int i = 0; i < receipts.size(); i++) {
             receiptsTrie = receiptsTrie.put(RLP.encodeInt(i), receipts.get(i).getEncoded());

--- a/rskj-core/src/main/java/co/rsk/net/messages/BlockHeadersResponseMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/BlockHeadersResponseMessage.java
@@ -32,7 +32,7 @@ public class BlockHeadersResponseMessage extends MessageWithId {
     @Override
     protected byte[] getEncodedMessageWithoutId() {
         byte[][] rlpHeaders = this.blockHeaders.stream()
-                .map(BlockHeader::getEncoded)
+                .map(BlockHeader::getFullEncoded)
                 .toArray(byte[][]::new);
 
         return RLP.encodeList(RLP.encodeList(rlpHeaders));

--- a/rskj-core/src/main/java/co/rsk/net/messages/BodyResponseMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/BodyResponseMessage.java
@@ -37,7 +37,7 @@ public class BodyResponseMessage extends MessageWithId {
         }
 
         for (int k = 0; k < this.uncles.size(); k++) {
-            rlpUncles[k] = this.uncles.get(k).getEncoded();
+            rlpUncles[k] = this.uncles.get(k).getFullEncoded();
         }
 
         return RLP.encodeList(RLP.encodeList(rlpTransactions), RLP.encodeList(rlpUncles));

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -30,6 +30,7 @@ import co.rsk.rpc.modules.eth.EthModule;
 import co.rsk.rpc.modules.evm.EvmModule;
 import co.rsk.rpc.modules.mnr.MnrModule;
 import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.PeerScoringManager;
 import org.ethereum.core.*;
@@ -76,6 +77,7 @@ public class Web3RskImpl extends Web3Impl {
             TxPoolModule txPoolModule,
             MnrModule mnrModule,
             DebugModule debugModule,
+            RskModule rskModule,
             ChannelManager channelManager,
             RepositoryLocator repositoryLocator,
             PeerScoringManager peerScoringManager,
@@ -89,7 +91,7 @@ public class Web3RskImpl extends Web3Impl {
             BuildInfo buildInfo,
             BlocksBloomStore blocksBloomStore) {
         super(eth, blockchain, transactionPool, blockStore, receiptStore, properties, minerClient, minerServer,
-              personalModule, ethModule, evmModule, txPoolModule, mnrModule, debugModule,
+              personalModule, ethModule, evmModule, txPoolModule, mnrModule, debugModule, rskModule,
               channelManager, repositoryLocator, peerScoringManager, peerServer, nodeBlockProcessor,
               hashRateCalculator, configCapabilities, buildInfo, blocksBloomStore);
 

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
@@ -1,0 +1,24 @@
+package co.rsk.rpc;
+
+import co.rsk.rpc.modules.rsk.RskModule;
+
+public interface Web3RskModule {
+
+    default String rsk_getRawTransactionReceiptByHash(String transactionHash)  {
+        return getRskModule().getRawTransactionReceiptByHash(transactionHash);
+    }
+
+    default String[] rsk_getTransactionReceiptNodesByHash(String blockHash, String transactionHash) {
+        return getRskModule().getTransactionReceiptNodesByHash(blockHash, transactionHash);
+    }
+
+    default String rsk_getRawBlockHeaderByHash(String blockHash) {
+        return getRskModule().getRawBlockHeaderByHash(blockHash);
+    }
+
+    default String rsk_getRawBlockHeaderByNumber(String bnOrId) {
+        return getRskModule().getRawBlockHeaderByNumber(bnOrId);
+    }
+
+    RskModule getRskModule();
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModule.java
@@ -1,0 +1,13 @@
+package co.rsk.rpc.modules.rsk;
+
+public interface RskModule {
+
+    String getRawTransactionReceiptByHash(String transactionHash);
+
+    String[] getTransactionReceiptNodesByHash(String blockHash, String transactionHash);
+
+    String getRawBlockHeaderByHash(String blockHash);
+
+    String getRawBlockHeaderByNumber(String bnOrId);
+
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModuleImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModuleImpl.java
@@ -1,0 +1,150 @@
+package co.rsk.rpc.modules.rsk;
+
+import co.rsk.core.bc.BlockHashesHelper;
+import co.rsk.crypto.Keccak256;
+import co.rsk.trie.Trie;
+import org.ethereum.core.Block;
+import org.ethereum.core.Blockchain;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.db.TransactionInfo;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.exception.JsonRpcInvalidParamException;
+import org.ethereum.rpc.exception.JsonRpcUnimplementedMethodException;
+import org.ethereum.util.RLP;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.ethereum.rpc.TypeConverter.stringHexToBigInteger;
+import static org.ethereum.rpc.TypeConverter.stringHexToByteArray;
+
+public class RskModuleImpl implements RskModule {
+    private static final Logger logger = LoggerFactory.getLogger("web3");
+
+    private final Blockchain blockchain;
+    private final BlockStore blockStore;
+    private final ReceiptStore receiptStore;
+
+    public RskModuleImpl(Blockchain blockchain, BlockStore blockStore, ReceiptStore receiptStore) {
+        this.blockchain = blockchain;
+        this.blockStore = blockStore;
+        this.receiptStore = receiptStore;
+    }
+
+    @Override
+    public String getRawTransactionReceiptByHash(String transactionHash) {
+        String s = null;
+        try {
+            byte[] hash = stringHexToByteArray(transactionHash);
+            TransactionInfo txInfo = receiptStore.getInMainChain(hash, blockStore);
+
+            if (txInfo == null) {
+                logger.trace("No transaction info for {}", transactionHash);
+                return null;
+            }
+            return TypeConverter.toUnformattedJsonHex(txInfo.getReceipt().getEncoded());
+        } finally {
+            if (logger.isDebugEnabled()) {
+                logger.debug("rsk_getRawTransactionReceiptByHash({}): {}", transactionHash, s);
+            }
+        }
+    }
+
+    @Override
+    public String[] getTransactionReceiptNodesByHash(String blockHash, String transactionHash) {
+        String[] encodedNodes = null;
+
+        try {
+            Keccak256 txHash = new Keccak256(stringHexToByteArray(transactionHash));
+            byte[] bhash = stringHexToByteArray(blockHash);
+            Block block = this.blockchain.getBlockByHash(bhash);
+            List<Transaction> transactions = block.getTransactionsList();
+            List<TransactionReceipt> receipts = new ArrayList<>();
+
+            int ntxs = transactions.size();
+            int ntx = -1;
+
+            for (int k = 0; k < ntxs; k++) {
+                Transaction transaction = transactions.get(k);
+                Keccak256 txh = transaction.getHash();
+
+                TransactionInfo txinfo = this.receiptStore.get(txh.getBytes(), bhash, this.blockStore);
+                receipts.add(txinfo.getReceipt());
+
+                if (txh.equals(txHash)) {
+                    ntx = k;
+                }
+            }
+
+            if (ntx == -1) {
+                return null;
+            }
+            Trie trie = BlockHashesHelper.calculateReceiptsTrieRootFor(receipts);
+
+            List<Trie> nodes = trie.getNodes(RLP.encodeInt(ntx));
+            encodedNodes = new String[nodes.size()];
+
+            for (int k = 0; k < encodedNodes.length; k++) {
+                encodedNodes[k] = TypeConverter.toUnformattedJsonHex(nodes.get(k).toMessage());
+            }
+
+            return encodedNodes;
+        } finally {
+            if (logger.isDebugEnabled()) {
+                logger.debug("rsk_getTransactionReceiptNodesByHash({}): {}", blockHash, Arrays.toString(encodedNodes));
+            }
+        }
+    }
+
+
+    @Override
+    public String getRawBlockHeaderByHash(String blockHash) {
+        String s = null;
+        try {
+            byte[] bhash = stringHexToByteArray(blockHash);
+            Block b = this.blockchain.getBlockByHash(bhash);
+            return s = (b == null ? null : TypeConverter.toUnformattedJsonHex(b.getHeader().getEncoded()));
+        } finally {
+            if (logger.isDebugEnabled()) {
+                logger.debug("rsk_getRawBlockHeaderByHash({}): {}", blockHash, s);
+            }
+        }
+    }
+
+    @Override
+    public String getRawBlockHeaderByNumber(String bnOrId) {
+        String s = null;
+        try {
+            Block b = getByJsonBlockId(bnOrId);
+            return s = (b == null ? null : TypeConverter.toUnformattedJsonHex(b.getHeader().getEncoded()));
+        } finally {
+            if (logger.isDebugEnabled()) {
+                logger.debug("rsk_getRawBlockHeaderByNumber({}): {}", bnOrId, s);
+            }
+        }
+    }
+
+    private Block getByJsonBlockId(String id) {
+        if ("earliest".equalsIgnoreCase(id)) {
+            return this.blockchain.getBlockByNumber(0);
+        } else if ("latest".equalsIgnoreCase(id)) {
+            return this.blockchain.getBestBlock();
+        } else if ("pending".equalsIgnoreCase(id)) {
+            throw new JsonRpcUnimplementedMethodException("The method don't support 'pending' as a parameter yet");
+        } else {
+            try {
+                long blockNumber = stringHexToBigInteger(id).longValue();
+                return this.blockchain.getBlockByNumber(blockNumber);
+            } catch (NumberFormatException | StringIndexOutOfBoundsException e) {
+                throw new JsonRpcInvalidParamException("invalid blocknumber " + id);
+            }
+        }
+    }
+
+}

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -1370,4 +1370,56 @@ public class Trie {
             return TrieKeySlice.fromEncoded(encodedKey, 0, lshared, lencoded);
         }
     }
+
+    // Additional auxiliary methods for Merkle Proof
+
+    @Nullable
+    public List<Trie> getNodes(byte[] key) {
+        return findNodes(key);
+    }
+
+    @Nullable
+    public List<Trie> getNodes(String key) {
+        return this.getNodes(key.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Nullable
+    private List<Trie> findNodes(byte[] key) {
+        return findNodes(TrieKeySlice.fromKey(key));
+    }
+
+    @Nullable
+    private List<Trie> findNodes(TrieKeySlice key) {
+        if (sharedPath.length() > key.length()) {
+            return null;
+        }
+
+        int commonPathLength = key.commonPath(sharedPath).length();
+
+        if (commonPathLength < sharedPath.length()) {
+            return null;
+        }
+
+        if (commonPathLength == key.length()) {
+            List<Trie> nodes = new ArrayList<>();
+            nodes.add(this);
+            return nodes;
+        }
+
+        Trie node = this.retrieveNode(key.get(commonPathLength));
+
+        if (node == null) {
+            return null;
+        }
+
+        List<Trie> subnodes = node.findNodes(key.slice(commonPathLength + 1, key.length()));
+
+        if (subnodes == null) {
+            return null;
+        }
+
+        subnodes.add(this);
+
+        return subnodes;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -28,7 +28,6 @@ import co.rsk.panic.PanicProcessor;
 import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.RLP;
 
 import javax.annotation.Nonnull;

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -28,6 +28,7 @@ import co.rsk.panic.PanicProcessor;
 import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.RLP;
 
 import javax.annotation.Nonnull;
@@ -264,7 +265,7 @@ public class Block {
         byte[][] unclesEncoded = new byte[uncleList.size()][];
         int i = 0;
         for (BlockHeader uncle : uncleList) {
-            unclesEncoded[i] = uncle.getEncoded();
+            unclesEncoded[i] = uncle.getFullEncoded();
             ++i;
         }
         return RLP.encodeList(unclesEncoded);
@@ -272,7 +273,7 @@ public class Block {
 
     public byte[] getEncoded() {
         if (rlpEncoded == null) {
-            byte[] header = this.header.getEncoded();
+            byte[] header = this.header.getFullEncoded();
 
             List<byte[]> block = getBodyElements();
             block.add(0, header);

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -294,13 +294,18 @@ public class BlockHeader {
     }
 
     public Keccak256 getHash() {
-        return new Keccak256(HashUtil.keccak256(getEncoded(true, !useRskip92Encoding)));
+        return new Keccak256(HashUtil.keccak256(getEncoded()));
     }
 
-    public byte[] getEncoded() {
+    public byte[] getFullEncoded() {
         // the encoded block header must include all fields, even the bitcoin PMT and coinbase which are not used for
         // calculating RSKIP92 block hashes
         return this.getEncoded(true, true);
+    }
+
+    public byte[] getEncoded() {
+        // the encoded block header used for calculating block hashes including RSKIP92
+        return this.getEncoded(true, !useRskip92Encoding);
     }
 
     @Nullable
@@ -370,7 +375,7 @@ public class BlockHeader {
         byte[][] unclesEncoded = new byte[uncleList.size()][];
         int i = 0;
         for (BlockHeader uncle : uncleList) {
-            unclesEncoded[i] = uncle.getEncoded();
+            unclesEncoded[i] = uncle.getFullEncoded();
             ++i;
         }
         return RLP.encodeList(unclesEncoded);
@@ -396,7 +401,7 @@ public class BlockHeader {
         byte[][] unclesEncoded = new byte[uncleList.size()][];
         int i = 0;
         for (BlockHeader uncle : uncleList) {
-            unclesEncoded[i] = uncle.getEncoded();
+            unclesEncoded[i] = uncle.getFullEncoded();
             ++i;
         }
         return RLP.encodeList(unclesEncoded);

--- a/rskj-core/src/main/java/org/ethereum/rpc/TypeConverter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/TypeConverter.java
@@ -19,6 +19,7 @@
 package org.ethereum.rpc;
 
 import org.bouncycastle.util.encoders.Hex;
+import co.rsk.core.Coin;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -74,6 +75,10 @@ public class TypeConverter {
         }
 
         return result;
+    }
+
+    public static String toJsonHex(Coin x) {
+        return x != null ? x.asBigInteger().toString() : "" ;
     }
 
     public static String toJsonHex(String x) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -25,7 +25,7 @@ import co.rsk.scoring.PeerScoringInformation;
 import java.util.Arrays;
 import java.util.Map;
 
-public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, Web3EvmModule, Web3MnrModule, Web3DebugModule {
+public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, Web3EvmModule, Web3MnrModule, Web3DebugModule, Web3RskModule {
     class SyncingResult {
         public String startingBlock;
         public String currentBlock;

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -21,7 +21,6 @@ package org.ethereum.rpc;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.AccountInformationProvider;
-import co.rsk.core.bc.BlockResult;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.logfilter.BlocksBloomStore;
@@ -35,6 +34,7 @@ import co.rsk.rpc.modules.eth.EthModule;
 import co.rsk.rpc.modules.evm.EvmModule;
 import co.rsk.rpc.modules.mnr.MnrModule;
 import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.InvalidInetAddressException;
 import co.rsk.scoring.PeerScoringInformation;
@@ -108,6 +108,7 @@ public class Web3Impl implements Web3 {
     private final TxPoolModule txPoolModule;
     private final MnrModule mnrModule;
     private final DebugModule debugModule;
+    private final RskModule rskModule;
 
     protected Web3Impl(
             Ethereum eth,
@@ -124,6 +125,7 @@ public class Web3Impl implements Web3 {
             TxPoolModule txPoolModule,
             MnrModule mnrModule,
             DebugModule debugModule,
+            RskModule rskModule,
             ChannelManager channelManager,
             RepositoryLocator repositoryLocator,
             PeerScoringManager peerScoringManager,
@@ -146,6 +148,7 @@ public class Web3Impl implements Web3 {
         this.txPoolModule = txPoolModule;
         this.mnrModule = mnrModule;
         this.debugModule = debugModule;
+        this.rskModule = rskModule;
         this.channelManager = channelManager;
         this.repositoryLocator = repositoryLocator;
         this.peerScoringManager = peerScoringManager;
@@ -571,11 +574,11 @@ public class Web3Impl implements Web3 {
 
     @Override
     public BlockResultDTO eth_getBlockByHash(String blockHash, Boolean fullTransactionObjects) throws Exception {
-        BlockResult s = null;
+        BlockResultDTO s = null;
         try {
             Block b = getBlockByJSonHash(blockHash);
 
-            return getBlockResult(b, fullTransactionObjects);
+            return s = (b == null ? null : getBlockResult(b, fullTransactionObjects));
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug("eth_getBlockByHash({}, {}): {}", blockHash, fullTransactionObjects, s);
@@ -705,6 +708,7 @@ public class Web3Impl implements Web3 {
 
         return new TransactionReceiptDTO(block, txInfo);
     }
+
 
     @Override
     public BlockResultDTO eth_getUncleByBlockHashAndIndex(String blockHash, String uncleIdx) throws Exception {
@@ -1038,6 +1042,11 @@ public class Web3Impl implements Web3 {
         return debugModule;
     }
 
+    @Override
+    public RskModule getRskModule() {
+        return rskModule;
+    }
+
     /**
      * Adds an address or block to the list of banned addresses
      * It supports IPV4 and IPV6 addresses with an optional number of bits to ignore
@@ -1106,4 +1115,5 @@ public class Web3Impl implements Web3 {
     public String[] sco_bannedAddresses() {
         return this.peerScoringManager.getBannedAddresses().toArray(new String[0]);
     }
+    
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
@@ -57,6 +57,7 @@ public class BlockResultDTO {
     private final String bitcoinMergedMiningCoinbaseTransaction;
     private final String bitcoinMergedMiningMerkleProof;
     private final String hashForMergedMining;
+    private final String paidFees;
 
     public BlockResultDTO(
             Long number,
@@ -81,7 +82,8 @@ public class BlockResultDTO {
             byte[] bitcoinMergedMiningHeader,
             byte[] bitcoinMergedMiningCoinbaseTransaction,
             byte[] bitcoinMergedMiningMerkleProof,
-            byte[] hashForMergedMining) {
+            byte[] hashForMergedMining,
+            Coin paidFees) {
         this.number = number != null ? TypeConverter.toQuantityJsonHex(number) : null;
         this.hash = hash != null ? hash.toJsonString() : null;
         this.parentHash = parentHash.toJsonString();
@@ -108,6 +110,7 @@ public class BlockResultDTO {
         this.bitcoinMergedMiningCoinbaseTransaction = TypeConverter.toUnformattedJsonHex(bitcoinMergedMiningCoinbaseTransaction);
         this.bitcoinMergedMiningMerkleProof = TypeConverter.toUnformattedJsonHex(bitcoinMergedMiningMerkleProof);
         this.hashForMergedMining = TypeConverter.toUnformattedJsonHex(hashForMergedMining);
+        this.paidFees = paidFees != null ? TypeConverter.toQuantityJsonHex(paidFees.getBytes()) : null;
     }
 
     public static BlockResultDTO fromBlock(Block b, boolean fullTx, BlockStore blockStore) {
@@ -161,7 +164,8 @@ public class BlockResultDTO {
                 b.getBitcoinMergedMiningHeader(),
                 b.getBitcoinMergedMiningCoinbaseTransaction(),
                 b.getBitcoinMergedMiningMerkleProof(),
-                b.getHashForMergedMining()
+                b.getHashForMergedMining(),
+                b.getFeesPaidToMiner()
         );
     }
 
@@ -254,5 +258,8 @@ public class BlockResultDTO {
     public String getHashForMergedMining() {
         return hashForMergedMining;
     }
-}
 
+    public String getPaidFees() {
+        return paidFees;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -33,18 +33,19 @@ import static org.ethereum.rpc.TypeConverter.*;
  */
 public class TransactionReceiptDTO {
 
-    public String transactionHash;      // hash of the transaction.
-    public String transactionIndex;     // integer of the transactions index position in the block.
-    public String blockHash;            // hash of the block where this transaction was in.
-    public String blockNumber;          // block number where this transaction was in.
-    public String cumulativeGasUsed;    // The total amount of gas used when this transaction was executed in the block.
-    public String gasUsed;              //The amount of gas used by this specific transaction alone.
-    public String contractAddress;      // The contract address created, if the transaction was a contract creation, otherwise  null .
-    public LogFilterElement[] logs;  // Array of log objects, which this transaction generated.
-    public String from;
-    public String to;
-    public String root;
-    public String status;
+    private String transactionHash;      // hash of the transaction.
+    private String transactionIndex;     // integer of the transactions index position in the block.
+    private String blockHash;            // hash of the block where this transaction was in.
+    private String blockNumber;          // block number where this transaction was in.
+    private String cumulativeGasUsed;    // The total amount of gas used when this transaction was executed in the block.
+    private String gasUsed;              // The amount of gas used by this specific transaction alone.
+    private String contractAddress;      // The contract address created, if the transaction was a contract creation, otherwise  null .
+    private LogFilterElement[] logs;     // Array of log objects, which this transaction generated.
+    private String from;                 // address of the sender.
+    private String to;                   // address of the receiver. null when it's a contract creation transaction.
+    private String root;                 // post-transaction stateroot
+    private String status;               // either 1 (success) or 0 (failure)
+    private String logsBloom;            // Bloom filter for light clients to quickly retrieve related logs.
 
 
     public  TransactionReceiptDTO(Block block, TransactionInfo txInfo) {
@@ -75,5 +76,58 @@ public class TransactionReceiptDTO {
         to = receipt.getTransaction().getReceiveAddress().toJsonString();
         transactionHash = receipt.getTransaction().getHash().toJsonString();
         transactionIndex = toQuantityJsonHex(txInfo.getIndex());
+        logsBloom = toUnformattedJsonHex(txInfo.getReceipt().getBloomFilter().getData());
+    }
+
+    public String getTransactionHash() {
+        return transactionHash;
+    }
+
+    public String getTransactionIndex() {
+        return transactionIndex;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public String getBlockNumber() {
+        return blockNumber;
+    }
+
+    public String getCumulativeGasUsed() {
+        return cumulativeGasUsed;
+    }
+
+    public String getGasUsed() {
+        return gasUsed;
+    }
+
+    public String getContractAddress() {
+        return contractAddress;
+    }
+
+    public LogFilterElement[] getLogs() {
+        return logs.clone();
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public String getRoot() {
+        return root;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getLogsBloom() {
+        return logsBloom;
     }
 }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -288,7 +288,12 @@ rpc {
             name: "debug",
             version: "1.0",
             enabled: "true"
-        }
+        },
+         {
+             name: "rsk",
+             version: "1.0",
+             enabled: "true"
+         }
     ]
 }
 

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -76,7 +76,7 @@ public class BlockFactoryTest {
 
         BlockHeader header = createBlockHeaderWithMergedMiningFields(number, new byte[0]);
 
-        byte[] encodedHeader = header.getEncoded();
+        byte[] encodedHeader = header.getFullEncoded();
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 
@@ -92,7 +92,7 @@ public class BlockFactoryTest {
 
         BlockHeader header = createBlockHeaderWithMergedMiningFields(number, new byte[0]);
 
-        byte[] encodedHeader = header.getEncoded();
+        byte[] encodedHeader = header.getFullEncoded();
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 
@@ -108,7 +108,7 @@ public class BlockFactoryTest {
 
         BlockHeader header = createBlockHeaderWithMergedMiningFields(number, new byte[0]);
 
-        byte[] encodedHeader = header.getEncoded();
+        byte[] encodedHeader = header.getFullEncoded();
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 
@@ -132,7 +132,7 @@ public class BlockFactoryTest {
         header.setBitcoinMergedMiningCoinbaseTransaction(coinbase);
         header.seal();
 
-        byte[] encodedHeader = header.getEncoded();
+        byte[] encodedHeader = header.getFullEncoded();
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
@@ -93,7 +93,7 @@ public class BlockHeaderTest {
     public void getEncodedWithMergedMiningFields() {
         BlockHeader header = createBlockHeaderWithMergedMiningFields(new byte[0], false);
 
-        byte[] headerEncoded = header.getEncoded();
+        byte[] headerEncoded = header.getFullEncoded();
         RLPList headerRLP = RLP.decodeList(headerEncoded);
 
         assertThat(headerRLP.size(), is(19));
@@ -103,7 +103,7 @@ public class BlockHeaderTest {
     public void getEncodedWithoutMergedMiningFields() {
         BlockHeader header = createBlockHeader(new byte[0], false);
 
-        byte[] headerEncoded = header.getEncoded();
+        byte[] headerEncoded = header.getFullEncoded();
         RLPList headerRLP = RLP.decodeList(headerEncoded);
 
         assertThat(headerRLP.size(), is(16));

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -392,6 +392,7 @@ public class TransactionModuleTest {
                 txPoolModule,
                 null,
                 debugModule,
+                null,
                 channelManager,
                 repositoryLocator,
                 null,

--- a/rskj-core/src/test/java/co/rsk/net/messages/BodyResponseMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/BodyResponseMessageTest.java
@@ -51,7 +51,7 @@ public class BodyResponseMessageTest {
         Assert.assertEquals(uncles.size(), message.getUncles().size());
 
         for (int k = 0; k < uncles.size(); k++)
-            Assert.assertArrayEquals(uncles.get(k).getEncoded(), message.getUncles().get(k).getEncoded());
+            Assert.assertArrayEquals(uncles.get(k).getFullEncoded(), message.getUncles().get(k).getFullEncoded());
     }
 
     private static Transaction createTransaction(int number) {

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
@@ -212,7 +212,7 @@ public class MessageTest {
         for (int k = 0; k < headers.size(); k++) {
             Assert.assertEquals(headers.get(k).getNumber(), newmessage.getBlockHeaders().get(k).getNumber());
             Assert.assertEquals(headers.get(k).getHash(), newmessage.getBlockHeaders().get(k).getHash());
-            Assert.assertArrayEquals(headers.get(k).getEncoded(), newmessage.getBlockHeaders().get(k).getEncoded());
+            Assert.assertArrayEquals(headers.get(k).getFullEncoded(), newmessage.getBlockHeaders().get(k).getFullEncoded());
         }
     }
 
@@ -492,7 +492,7 @@ public class MessageTest {
         Assert.assertEquals(uncles.size(), newmessage.getUncles().size());
 
         for (int k = 0; k < uncles.size(); k++)
-            Assert.assertArrayEquals(uncles.get(k).getEncoded(), newmessage.getUncles().get(k).getEncoded());
+            Assert.assertArrayEquals(uncles.get(k).getFullEncoded(), newmessage.getUncles().get(k).getFullEncoded());
     }
 
     private static Transaction createTransaction(int number) {

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3EthModuleTest.java
@@ -31,6 +31,7 @@ import co.rsk.rpc.modules.eth.EthModule;
 import co.rsk.rpc.modules.evm.EvmModule;
 import co.rsk.rpc.modules.mnr.MnrModule;
 import co.rsk.rpc.modules.personal.PersonalModule;
+import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.PeerScoringManager;
 import org.ethereum.core.Blockchain;
@@ -41,13 +42,11 @@ import org.ethereum.facade.Ethereum;
 import org.ethereum.net.client.ConfigCapabilities;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
-import org.ethereum.rpc.Web3Impl;
 import org.ethereum.util.BuildInfo;
 import org.junit.Test;
-import org.mockito.MockSettings;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class Web3EthModuleTest {
@@ -69,6 +68,7 @@ public class Web3EthModuleTest {
                 mock(TxPoolModule.class),
                 mock(MnrModule.class),
                 mock(DebugModule.class),
+                mock(RskModule.class),
                 mock(ChannelManager.class),
                 mock(RepositoryLocator.class),
                 mock(PeerScoringManager.class),

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -46,7 +46,7 @@ public class Web3ImplRpcTest {
         Web3Impl web3 = new Web3RskImpl(eth, blockchain, transactionPool,
                             new TestSystemProperties(), null, null, pm,
                             null, null, null, null,
-                            null, null, repositoryLocator, null,
+                            null, null, null, repositoryLocator, null,
                             null, null, null, null, null,
                             null, null, null, null
         );

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -44,7 +44,6 @@ import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.LogFilterElement;
 import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.Web3Mocks;
-import org.ethereum.rpc.dto.BlockResultDTO;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.junit.Assert;
@@ -53,7 +52,6 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.OptionalLong;
 
 public class Web3RskImplTest {
 
@@ -101,6 +99,7 @@ public class Web3RskImplTest {
                 tpm,
                 null,
                 dm,
+                null,
                 Web3Mocks.getMockChannelManager(),
                 Web3Mocks.getMockRepositoryLocator(),
                 null,

--- a/rskj-core/src/test/java/co/rsk/trie/TrieGetNodesTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieGetNodesTest.java
@@ -1,0 +1,265 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.trie;
+
+import co.rsk.crypto.Keccak256;
+import org.ethereum.crypto.Keccak256Helper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Created by ajlopez on 23/08/2019.
+ */
+public class TrieGetNodesTest {
+    @Test
+    public void getNullForUnknownKey() {
+        Trie trie = new Trie();
+
+        Assert.assertNull(trie.getNodes(new byte[] { 0x01, 0x02, 0x03 }));
+        Assert.assertNull(trie.getNodes("foo"));
+    }
+
+    @Test
+    public void putOneKeyAndGetNodes() {
+        Trie trie = new Trie();
+
+        trie = trie.put("foo", "bar".getBytes());
+
+        List<Trie> nodes = trie.getNodes("foo");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(1, nodes.size());
+        Assert.assertArrayEquals("bar".getBytes(), nodes.get(0).getValue());
+    }
+
+    @Test
+    public void putTwoKeysAndGetNodes() {
+        Trie trie = new Trie();
+
+        trie = trie.put("foo", "bar".getBytes());
+        trie = trie.put("bar", "foo".getBytes());
+
+        List<Trie> nodes = trie.getNodes("foo");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(2, nodes.size());
+
+        Assert.assertArrayEquals("bar".getBytes(StandardCharsets.UTF_8), nodes.get(0).getValue());
+        Assert.assertNull(nodes.get(1).getValue());
+    }
+
+    @Test
+    public void putAndGetKeyValueTwiceWithDifferenteValuesAndGetNodes() {
+        Trie trie = new Trie();
+        Trie trie1 = trie.put("foo", "bar1".getBytes());
+        Trie trie2 = trie1.put("foo", "bar2".getBytes());
+
+        List<Trie> nodes = trie2.getNodes("foo");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(1, nodes.size());
+        Assert.assertArrayEquals("bar2".getBytes(), nodes.get(0).getValue());
+    }
+
+    @Test
+    public void putLongValueAndGetNodes() {
+        Trie trie = new Trie();
+        byte[] value = TrieValueTest.makeValue(100);
+
+        trie = trie.put("foo", value);
+
+        List<Trie> nodes = trie.getNodes("foo");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(1, nodes.size());
+        Assert.assertArrayEquals(value, nodes.get(0).getValue());
+    }
+
+    @Test
+    public void putAndDeleteKeyAndGetNodes() {
+        Trie trie = new Trie();
+
+        trie = trie.put("foo", "bar".getBytes()).delete("foo");
+
+        Assert.assertNull(trie.getNodes("foo"));
+    }
+
+    @Test
+    public void putKeyLongValueAndDeleteKeyAndGetNodes() {
+        Trie trie = new Trie();
+
+        trie = trie.put("foo", TrieValueTest.makeValue(100)).delete("foo");
+
+        Assert.assertNull(trie.getNodes("foo"));
+    }
+
+    @Test
+    public void putAndGetEmptyKeyValueAndGetNodes() {
+        Trie trie = new Trie();
+
+        trie = trie.put("", "bar".getBytes());
+
+        List<Trie> nodes = trie.getNodes("");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(1, nodes.size());
+        Assert.assertArrayEquals("bar".getBytes(), nodes.get(0).getValue());
+    }
+
+    @Test
+    public void putAndGetEmptyKeyLongValueAndGetNodes() {
+        Trie trie = new Trie();
+        byte[] value = TrieValueTest.makeValue(100);
+
+        trie = trie.put("", value);
+
+        List<Trie> nodes = trie.getNodes("");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(1, nodes.size());
+        Assert.assertArrayEquals(value, nodes.get(0).getValue());
+    }
+
+    @Test
+    public void putAndGetTwoKeyLongValues() {
+        Trie trie = new Trie();
+        byte[] value1 = TrieValueTest.makeValue(100);
+        byte[] value2 = TrieValueTest.makeValue(200);
+
+        trie = trie.put("foo", value1);
+        trie = trie.put("bar", value2);
+
+        List<Trie> nodes = trie.getNodes("foo");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(2, nodes.size());
+        Assert.assertArrayEquals(value1, nodes.get(0).getValue());
+        Assert.assertNull(nodes.get(1).getValue());
+    }
+
+    @Test
+    public void putAndGetKeyAndSubKeyValuesAndGetNodes() {
+        Trie trie = new Trie();
+
+        trie = trie.put("foo", "bar".getBytes());
+        trie = trie.put("f", "42".getBytes());
+
+        List<Trie> nodes = trie.getNodes("f");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(1, nodes.size());
+        Assert.assertArrayEquals("42".getBytes(), nodes.get(0).getValue());
+    }
+
+    @Test
+    public void putAndGetKeyAndSubKeyLongValuesAndGetNodes() {
+        Trie trie = new Trie();
+        byte[] value1 = TrieValueTest.makeValue(100);
+        byte[] value2 = TrieValueTest.makeValue(200);
+
+        trie = trie.put("foo", value1);
+        trie = trie.put("f", value2);
+
+        List<Trie> nodes = trie.getNodes("f");
+
+        Assert.assertNotNull(nodes);
+        Assert.assertFalse(nodes.isEmpty());
+        Assert.assertEquals(1, nodes.size());
+        Assert.assertArrayEquals(value2, nodes.get(0).getValue());
+    }
+
+    @Test
+    public void putAndGetOneHundredKeyValuesAndGetNodes() {
+        Trie trie = new Trie();
+
+        for (int k = 0; k < 100; k++)
+            trie = trie.put(k + "", (k + "").getBytes());
+
+        for (int k = 0; k < 100; k++) {
+            String key = k + "";
+            List<Trie> nodes = trie.getNodes(key);
+            Assert.assertNotNull(nodes);
+            Assert.assertTrue(nodes.size() > 1);
+            Assert.assertArrayEquals((k + "").getBytes(), nodes.get(0).getValue());
+
+            Assert.assertTrue(find(nodes.get(0).toMessage(), (k + "").getBytes()));
+
+            for (int j = 1; j < nodes.size(); j++) {
+                Trie childNode = nodes.get(j - 1);
+                Trie node = nodes.get(j);
+
+                Assert.assertTrue(find(node.toMessage(), childNode.getHash().getBytes()) || find(node.toMessage(), childNode.toMessage()));
+            }
+        }
+    }
+
+    @Test
+    public void putAndGetOneHundredKeyLongValues() {
+        Trie trie = new Trie();
+
+        for (int k = 0; k < 100; k++)
+            trie = trie.put(k + "", TrieValueTest.makeValue(k + 100));
+
+        for (int k = 0; k < 100; k++) {
+            String key = k + "";
+            byte[] expected = TrieValueTest.makeValue(k + 100);
+            List<Trie> nodes = trie.getNodes(key);
+            Assert.assertNotNull(nodes);
+            Assert.assertTrue(nodes.size() > 1);
+            Assert.assertArrayEquals(expected, nodes.get(0).getValue());
+
+            Assert.assertTrue(find(nodes.get(0).toMessage(), Keccak256Helper.keccak256(expected)));
+
+            for (int j = 1; j < nodes.size(); j++) {
+                Trie childNode = nodes.get(j - 1);
+                Trie node = nodes.get(j);
+
+                Assert.assertTrue(find(node.toMessage(), childNode.getHash().getBytes()) || find(node.toMessage(), childNode.toMessage()));
+            }
+        }
+    }
+
+    // https://stackoverflow.com/questions/35248973/how-to-search-sequence-of-bytes-in-an-byte-array-of-a-bin-file
+    private static boolean find(byte[] buffer, byte[] key) {
+        for (int i = 0; i <= buffer.length - key.length; i++) {
+            int j = 0;
+
+            while (j < key.length && buffer[i + j] == key[j]) {
+                j++;
+            }
+
+            if (j == key.length) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -354,7 +354,7 @@ public class Web3ImplLogsTest {
         String txhash = ((LogFilterElement)logs[0]).transactionHash;
         TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
 
-        Assert.assertEquals(txdto.contractAddress,((LogFilterElement)logs[0]).address);
+        Assert.assertEquals(txdto.getContractAddress(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -372,7 +372,7 @@ public class Web3ImplLogsTest {
         String txhash = ((LogFilterElement)logs[0]).transactionHash;
         TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
 
-        Assert.assertEquals(txdto.contractAddress,((LogFilterElement)logs[0]).address);
+        Assert.assertEquals(txdto.getContractAddress(),((LogFilterElement)logs[0]).address);
     }
 
     @Test
@@ -389,8 +389,8 @@ public class Web3ImplLogsTest {
         String txhash = ((LogFilterElement)logs[0]).transactionHash;
         TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
 
-        Assert.assertEquals(txdto.contractAddress,((LogFilterElement)logs[0]).address);
-        Assert.assertEquals(txdto.contractAddress,((LogFilterElement)logs[1]).address);
+        Assert.assertEquals(txdto.getContractAddress(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals(txdto.getContractAddress(),((LogFilterElement)logs[1]).address);
     }
 
 
@@ -409,8 +409,8 @@ public class Web3ImplLogsTest {
         String txhash = ((LogFilterElement)logs[0]).transactionHash;
         TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
 
-        Assert.assertEquals(txdto.contractAddress,((LogFilterElement)logs[0]).address);
-        Assert.assertEquals(txdto.contractAddress,((LogFilterElement)logs[1]).address);
+        Assert.assertEquals(txdto.getContractAddress(),((LogFilterElement)logs[0]).address);
+        Assert.assertEquals(txdto.getContractAddress(),((LogFilterElement)logs[1]).address);
     }
 
     @Test
@@ -1018,6 +1018,7 @@ public class Web3ImplLogsTest {
                 txPoolModule,
                 null,
                 debugModule,
+                null,
                 Web3Mocks.getMockChannelManager(),
                 repositoryLocator,
                 null,

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -382,6 +382,7 @@ public class Web3ImplScoringTest {
                 tpm,
                 null,
                 dm,
+                null,
                 Web3Mocks.getMockChannelManager(),
                 null,
                 peerScoringManager,

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -189,6 +189,7 @@ public class Web3ImplSnapshotTest {
                 tpm,
                 null,
                 dm,
+                null,
                 Web3Mocks.getMockChannelManager(),
                 factory.getRepositoryLocator(),
                 null,

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/TypeConverterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/TypeConverterTest.java
@@ -18,10 +18,12 @@
 
 package org.ethereum.rpc.converters;
 
+import co.rsk.core.Coin;
 import org.ethereum.rpc.TypeConverter;
-import org.ethereum.rpc.Web3;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.math.BigInteger;
 
 /**
  * Created by martin.medina on 3/7/17.
@@ -58,7 +60,6 @@ public class TypeConverterTest {
         Assert.assertEquals("0x00", TypeConverter.toJsonHex((byte[])null));
     }
 
-
     @Test
     public void toUnformattedJsonHex() {
         Assert.assertEquals("0x20", TypeConverter.toUnformattedJsonHex(new byte[] { 0x20 }));
@@ -89,5 +90,15 @@ public class TypeConverterTest {
     public void toQuantityJsonHex_Zero() {
         byte[] toEncode = new byte[]{0x00, 0x00};
         Assert.assertEquals("0x0", TypeConverter.toQuantityJsonHex(toEncode));
+    }
+    
+    @Test
+    public void toJsonHexCoin() {
+        Assert.assertEquals("1234", TypeConverter.toJsonHex(new Coin(new BigInteger("1234"))));
+    }
+
+    @Test
+    public void toJsonHexNullCoin() {
+        Assert.assertEquals("", TypeConverter.toJsonHex((Coin) null));
     }
 }


### PR DESCRIPTION
We needed to create json rpc methods to get the rlp encoded information needed to calculate the hash of the block, hash of the transaction receipt, and transaction receipt root.

This methods are:
rsk_getRawBlockHeaderByHash(String blockHash)
rsk_getRawBlockHeaderByNumber(String bnOrId)
rsk_getRawTransactionReceiptByHash(String transactionHash)
rsk_getTransactionReceiptNodesByHash(String blockHash, String transactionHash)

The extra information is needed to calculate the Merkle Tree and verify the Receipt Root
Created RskModule to add this new features from Web3 as they are not from ethereum
:robot: *fed:add-rsk-module*
