### PR TITLE
Filling the gap

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1302,8 +1302,8 @@ public class RskContext implements NodeBootstrapper {
                             new BlockRootValidationRule(getRskSystemProperties().getActivationConfig())
                     ),
                     getDifficultyCalculator(),
-                    getPeersInformation()
-            );
+                    getPeersInformation(),
+                    getGenesis());
         }
 
         return syncProcessor;

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -215,6 +215,7 @@ public class RskContext implements NodeBootstrapper {
     private PrecompiledContracts precompiledContracts;
     private BridgeSupportFactory bridgeSupportFactory;
     private PeersInformation peersInformation;
+    private StatusResolver statusResolver;
 
     public RskContext(String[] args) {
         this(new CliArgs.Parser<>(
@@ -1438,17 +1439,23 @@ public class RskContext implements NodeBootstrapper {
         if (nodeMessageHandler == null) {
             nodeMessageHandler = new NodeMessageHandler(
                     getRskSystemProperties(),
-                    getBlockStore(),
                     getNodeBlockProcessor(),
                     getSyncProcessor(),
                     getChannelManager(),
                     getTransactionGateway(),
                     getPeerScoringManager(),
-                    getBlockValidationRule()
-            );
+                    getBlockValidationRule(),
+                    getStatusResolver());
         }
 
         return nodeMessageHandler;
+    }
+
+    private StatusResolver getStatusResolver() {
+        if (statusResolver == null) {
+            statusResolver = new StatusResolver(getBlockStore(), getGenesis());
+        }
+        return statusResolver;
     }
 
     private RskWireProtocol.Factory getRskWireProtocolFactory() {
@@ -1457,10 +1464,10 @@ public class RskContext implements NodeBootstrapper {
                     getRskSystemProperties(),
                     getPeerScoringManager(),
                     getNodeMessageHandler(),
-                    getBlockchain(),
                     getCompositeEthereumListener(),
                     getGenesis(),
-                    getMessageRecorder());
+                    getMessageRecorder(),
+                    getStatusResolver());
         }
 
         return rskWireProtocolFactory;

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -139,7 +139,7 @@ public class RskContext implements NodeBootstrapper {
     private BlockFactory blockFactory;
     private BlockChainLoader blockChainLoader;
     private org.ethereum.db.BlockStore blockStore;
-    private co.rsk.net.BlockStore netBlockStore;
+    private NetBlockStore netBlockStore;
     private TrieStore trieStore;
     private GenesisLoader genesisLoader;
     private Genesis genesis;
@@ -1414,9 +1414,9 @@ public class RskContext implements NodeBootstrapper {
         return jacksonBasedRpcSerializer;
     }
 
-    private co.rsk.net.BlockStore getNetBlockStore() {
+    private NetBlockStore getNetBlockStore() {
         if (netBlockStore == null) {
-            netBlockStore = new co.rsk.net.BlockStore();
+            netBlockStore = new NetBlockStore();
         }
 
         return netBlockStore;

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -895,8 +895,9 @@ public class RskContext implements NodeBootstrapper {
                 rskSystemProperties.getTimeoutWaitingRequest(),
                 rskSystemProperties.getExpirationTimePeerStatus(),
                 rskSystemProperties.getMaxSkeletonChunks(),
-                rskSystemProperties.getChunkSize()
-        );
+                rskSystemProperties.getChunkSize(),
+                rskSystemProperties.getMaxRequestedBodies(),
+                rskSystemProperties.getLongSyncLimit());
     }
 
     protected StateRootHandler buildStateRootHandler() {

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -292,6 +292,14 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getInt("sync.maxSkeletonChunks");
     }
 
+    public int getMaxRequestedBodies() {
+        return configFromFiles.getInt("sync.maxRequestedBodies");
+    }
+
+    public int getLongSyncLimit() {
+        return configFromFiles.getInt("sync.longSyncLimit");
+    }
+
     // its fixed, cannot be set by config file
     public int getChunkSize() {
         return CHUNK_SIZE;

--- a/rskj-core/src/main/java/co/rsk/core/BlockDifficulty.java
+++ b/rskj-core/src/main/java/co/rsk/core/BlockDifficulty.java
@@ -80,6 +80,11 @@ public class BlockDifficulty implements Comparable<BlockDifficulty>, Serializabl
         return new BlockDifficulty(value.add(other.value));
     }
 
+    public BlockDifficulty subtract(BlockDifficulty other) {
+        return new BlockDifficulty(value.subtract(other.value));
+    }
+
+
     @Override
     public int compareTo(@Nonnull BlockDifficulty other) {
         return value.compareTo(other.value);

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockUtils.java
@@ -19,7 +19,7 @@
 package co.rsk.core.bc;
 
 import co.rsk.crypto.Keccak256;
-import co.rsk.net.BlockStore;
+import co.rsk.net.NetBlockStore;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Blockchain;
@@ -44,17 +44,17 @@ public class BlockUtils {
         return blockInformations.stream().anyMatch(bi -> Arrays.equals(blockHash.getBytes(), bi.getHash()));
     }
 
-    public static Set<Keccak256> unknownDirectAncestorsHashes(Block block, Blockchain blockChain, BlockStore store) {
+    public static Set<Keccak256> unknownDirectAncestorsHashes(Block block, Blockchain blockChain, NetBlockStore store) {
         Set<Keccak256> hashes = Collections.singleton(block.getParentHash());
         return unknownAncestorsHashes(hashes, blockChain, store, false);
     }
 
-    public static Set<Keccak256> unknownAncestorsHashes(Keccak256 blockHash, Blockchain blockChain, BlockStore store) {
+    public static Set<Keccak256> unknownAncestorsHashes(Keccak256 blockHash, Blockchain blockChain, NetBlockStore store) {
         Set<Keccak256> hashes = Collections.singleton(blockHash);
         return unknownAncestorsHashes(hashes, blockChain, store, true);
     }
 
-    public static Set<Keccak256> unknownAncestorsHashes(Set<Keccak256> hashesToProcess, Blockchain blockChain, BlockStore store, boolean withUncles) {
+    public static Set<Keccak256> unknownAncestorsHashes(Set<Keccak256> hashesToProcess, Blockchain blockChain, NetBlockStore store, boolean withUncles) {
         Set<Keccak256> unknown = new HashSet<>();
         Set<Keccak256> hashes = hashesToProcess;
 
@@ -65,7 +65,7 @@ public class BlockUtils {
         return unknown;
     }
 
-    private static Set<Keccak256> getNextHashes(Set<Keccak256> previousHashes, Set<Keccak256> unknown, Blockchain blockChain, BlockStore store, boolean withUncles) {
+    private static Set<Keccak256> getNextHashes(Set<Keccak256> previousHashes, Set<Keccak256> unknown, Blockchain blockChain, NetBlockStore store, boolean withUncles) {
         Set<Keccak256> nextHashes = new HashSet<>();
         for (Keccak256 hash : previousHashes) {
             if (unknown.contains(hash)) {

--- a/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
@@ -49,7 +49,7 @@ public class BlockSyncService {
     private long lastKnownBlockNumber = 0;
 
     private static final Logger logger = LoggerFactory.getLogger("blocksyncservice");
-    private final BlockStore store;
+    private final NetBlockStore store;
     private final Blockchain blockchain;
     private final SyncConfiguration syncConfiguration;
     private final BlockNodeInformation nodeInformation; // keep tabs on which nodes know which blocks.
@@ -59,7 +59,7 @@ public class BlockSyncService {
     // and we should use the same objects everywhere to ensure consistency
     public BlockSyncService(
             @Nonnull final RskSystemProperties config,
-            @Nonnull final BlockStore store,
+            @Nonnull final NetBlockStore store,
             @Nonnull final Blockchain blockchain,
             @Nonnull final BlockNodeInformation nodeInformation,
             @Nonnull final SyncConfiguration syncConfiguration) {

--- a/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
@@ -134,8 +134,7 @@ public class BlockSyncService {
     }
 
     public boolean hasBetterBlockToSync() {
-        int blocksDistance = syncConfiguration.getChunkSize() / CHUNK_PART_LIMIT;
-        return getLastKnownBlockNumber() >= getBestBlockNumber() + blocksDistance;
+        return getLastKnownBlockNumber() >= getBestBlockNumber() + syncConfiguration.getLongSyncLimit();
     }
 
     public boolean canBeIgnoredForUnclesRewards(long blockNumber) {

--- a/rskj-core/src/main/java/co/rsk/net/NetBlockStore.java
+++ b/rskj-core/src/main/java/co/rsk/net/NetBlockStore.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 /**
  * Created by ajlopez on 5/11/2016.
  */
-public class BlockStore {
+public class NetBlockStore {
     private Map<Keccak256, Block> blocks = new HashMap<>();
     private Map<Long, Set<Block>> blocksbynumber = new HashMap<>();
     private Map<Keccak256, Set<Block>> blocksbyparent = new HashMap<>();

--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -43,7 +43,7 @@ import java.util.*;
 public class NodeBlockProcessor implements BlockProcessor {
     private static final Logger logger = LoggerFactory.getLogger("blockprocessor");
 
-    private final BlockStore store;
+    private final NetBlockStore store;
     private final Blockchain blockchain;
     private final BlockNodeInformation nodeInformation;
     // keep tabs on which nodes know which blocks.
@@ -61,7 +61,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      * @param blockSyncService
      */
     public NodeBlockProcessor(
-            @Nonnull final BlockStore store,
+            @Nonnull final NetBlockStore store,
             @Nonnull final Blockchain blockchain,
             @Nonnull final BlockNodeInformation nodeInformation,
             @Nonnull final BlockSyncService blockSyncService,

--- a/rskj-core/src/main/java/co/rsk/net/Status.java
+++ b/rskj-core/src/main/java/co/rsk/net/Status.java
@@ -53,6 +53,5 @@ public class Status {
     @Nullable
     public byte[] getBestBlockParentHash() { return this.bestBlockParentHash; }
 
-    @Nullable
     public BlockDifficulty getTotalDifficulty() { return this.totalDifficulty; }
 }

--- a/rskj-core/src/main/java/co/rsk/net/StatusResolver.java
+++ b/rskj-core/src/main/java/co/rsk/net/StatusResolver.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.net;
+
+import co.rsk.core.BlockDifficulty;
+import org.ethereum.core.Block;
+import org.ethereum.core.Genesis;
+import org.ethereum.db.BlockStore;
+
+public class StatusResolver {
+
+    private final BlockStore blockStore;
+    private final Genesis genesis;
+
+    public StatusResolver(BlockStore blockStore, Genesis genesis) {
+
+        this.blockStore = blockStore;
+        this.genesis = genesis;
+    }
+
+
+    /**
+     * Resolves the current status to broadcast and send to peers.
+     */
+    public Status currentStatus() {
+        Status status;
+        if (blockStore.getMinNumber() != 0) {
+            status = new Status(
+                    genesis.getNumber(),
+                    genesis.getHash().getBytes(),
+                    genesis.getParentHash().getBytes(),
+                    genesis.getCumulativeDifficulty());
+        } else {
+            Block block = blockStore.getBestBlock();
+            BlockDifficulty totalDifficulty = blockStore.getTotalDifficultyForHash(block.getHash().getBytes());
+
+            status = new Status(block.getNumber(),
+                    block.getHash().getBytes(),
+                    block.getParentHash().getBytes(),
+                    totalDifficulty);
+        }
+        return status;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/sync/DecidingSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DecidingSyncState.java
@@ -1,31 +1,38 @@
 package co.rsk.net.sync;
 
 
+import co.rsk.net.NodeID;
+import org.ethereum.db.BlockStore;
+
 import java.time.Duration;
+import java.util.Optional;
 
 public class DecidingSyncState extends BaseSyncState {
-    private PeersInformation knownPeers;
+    private PeersInformation peersInformation;
+    private final BlockStore blockStore;
 
     public DecidingSyncState(SyncConfiguration syncConfiguration,
                              SyncEventsHandler syncEventsHandler,
-                             PeersInformation knownPeers) {
+                             PeersInformation peersInformation,
+                             BlockStore blockStore) {
         super(syncEventsHandler, syncConfiguration);
 
-        this.knownPeers = knownPeers;
+        this.peersInformation = peersInformation;
+        this.blockStore = blockStore;
     }
 
     @Override
     public void newPeerStatus() {
-        if (knownPeers.count() >= syncConfiguration.getExpectedPeers()) {
+        if (peersInformation.count() >= syncConfiguration.getExpectedPeers()) {
             tryStartSyncing();
         }
     }
 
     @Override
     public void tick(Duration duration) {
-        knownPeers.cleanExpired();
+        peersInformation.cleanExpired();
         timeElapsed = timeElapsed.plus(duration);
-        if (knownPeers.count() > 0 &&
+        if (peersInformation.count() > 0 &&
                 timeElapsed.compareTo(syncConfiguration.getTimeoutWaitingPeers()) >= 0) {
 
             tryStartSyncing();
@@ -33,6 +40,18 @@ public class DecidingSyncState extends BaseSyncState {
     }
 
     private void tryStartSyncing() {
-        knownPeers.getBestPeer().ifPresent(syncEventsHandler::startSyncing);
+
+        Optional<NodeID> bestPeer = peersInformation.getBestPeer();
+        if (!bestPeer.isPresent()) {
+            return;
+        }
+
+        long bpBestBlockNumber = peersInformation.getPeer(bestPeer.get()).getStatus().getBestBlockNumber();
+        long distanceToTip = bpBestBlockNumber - blockStore.getBestBlock().getNumber();
+        if (distanceToTip > syncConfiguration.getLongSyncLimit() || blockStore.getMinNumber() == 0) {
+            syncEventsHandler.startSyncing(bestPeer.get());
+            return;
+        }
+        syncEventsHandler.backwardSyncing(bestPeer.get());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncState.java
@@ -1,0 +1,162 @@
+package co.rsk.net.sync;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.net.MessageChannel;
+import co.rsk.net.NodeID;
+import co.rsk.net.messages.BodyResponseMessage;
+import co.rsk.scoring.EventType;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockFactory;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Genesis;
+import org.ethereum.db.BlockStore;
+
+import java.util.*;
+
+/**
+ * Given a sequential list of headers to request and an already stored child of the newest header
+ * DownloadingBackwardsBodiesSyncState downloads the bodies of the requested headers and connects them to the child.
+ * <p>
+ * If the child is block number 1 or the requested list contains block number 1 it is connected to genesis.
+ * <p>
+ * Assuming that child is valid, the previous block can be validated by comparing it's hash to the child's parent.
+ */
+public class DownloadingBackwardsBodiesSyncState extends BaseSyncState {
+
+    private final PeersInformation peersInformation;
+    private final Genesis genesis;
+    private final BlockFactory blockFactory;
+    private final BlockStore blockStore;
+    private final Queue<BlockHeader> toRequest;
+    private final NodeID selectedPeerId;
+
+    private final PriorityQueue<Block> responses;
+    private final Map<Long, BlockHeader> inTransit;
+    private Block child;
+
+    public DownloadingBackwardsBodiesSyncState(
+            SyncConfiguration syncConfiguration,
+            SyncEventsHandler syncEventsHandler,
+            PeersInformation peersInformation,
+            Genesis genesis,
+            BlockFactory blockFactory,
+            BlockStore blockStore,
+            Block child,
+            List<BlockHeader> toRequest,
+            NodeID selectedPeerId) {
+
+        super(syncEventsHandler, syncConfiguration);
+        this.peersInformation = peersInformation;
+        this.genesis = genesis;
+        this.blockFactory = blockFactory;
+        this.blockStore = blockStore;
+        this.toRequest = new LinkedList<>(toRequest);
+        this.child = child;
+        this.selectedPeerId = selectedPeerId;
+        this.responses = new PriorityQueue<>(Comparator.comparingLong(Block::getNumber).reversed());
+        this.inTransit = new HashMap<>();
+    }
+
+    /**
+     * Validates and connects the bodies in order.
+     * <p>
+     * As the responses may come in any order, they are stored in a priority queue by block number.
+     * This allows connecting blocks sequentially with the current child.
+     *
+     * @param body The requested message containing the body
+     * @param peer The peer sending the message.
+     */
+    @Override
+    public void newBody(BodyResponseMessage body, MessageChannel peer) {
+        BlockHeader requestedHeader = inTransit.get(body.getId());
+        if (requestedHeader == null) {
+            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.INVALID_MESSAGE);
+            return;
+        }
+
+        Block block = blockFactory.newBlock(requestedHeader, body.getTransactions(), body.getUncles());
+        block.seal();
+
+        if (!block.getHash().equals(requestedHeader.getHash())) {
+            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.INVALID_MESSAGE);
+            return;
+        }
+
+        resetTimeElapsed();
+        inTransit.remove(body.getId());
+        responses.add(block);
+
+        while (!responses.isEmpty() && responses.peek().isParentOf(child)) {
+            Block connectedBlock = responses.poll();
+            BlockDifficulty blockchainDifficulty = blockStore.getTotalDifficultyForHash(child.getHash().getBytes());
+            blockStore.saveBlock(
+                    connectedBlock,
+                    blockchainDifficulty.subtract(child.getCumulativeDifficulty()),
+                    true);
+            child = connectedBlock;
+        }
+
+        if (child.getNumber() == 1) {
+            connectGenesis(child);
+            syncEventsHandler.stopSyncing();
+            return;
+        }
+
+        while (!toRequest.isEmpty() && inTransit.size() < syncConfiguration.getMaxRequestedBodies()) {
+            requestBodies(toRequest.remove());
+        }
+
+        if (toRequest.isEmpty() && inTransit.isEmpty()) {
+            blockStore.flush();
+            syncEventsHandler.stopSyncing();
+        }
+    }
+
+    @Override
+    public void onEnter() {
+        if (child.getNumber() == 1L) {
+            connectGenesis(child);
+            blockStore.flush();
+            syncEventsHandler.stopSyncing();
+            return;
+        }
+
+        if (toRequest.isEmpty()) {
+            syncEventsHandler.stopSyncing();
+            return;
+        }
+
+        while (!toRequest.isEmpty() && inTransit.size() < syncConfiguration.getMaxRequestedBodies()) {
+            BlockHeader headerToRequest = toRequest.remove();
+                requestBodies(headerToRequest);
+        }
+    }
+
+    private void requestBodies(BlockHeader headerToRequest) {
+        Long requestNumber = syncEventsHandler.sendBodyRequest(headerToRequest, selectedPeerId);
+        if (requestNumber == null) {
+            syncEventsHandler.onSyncIssue("Channel failed to sent on {} to {}",
+                    this.getClass(), selectedPeerId);
+        }
+        inTransit.put(requestNumber, headerToRequest);
+    }
+
+    private void connectGenesis(Block child) {
+        if (!genesis.isParentOf(child)) {
+            throw new IllegalStateException("Genesis does not connect to the current chain.");
+        }
+
+        BlockDifficulty blockchainDifficulty = blockStore.getTotalDifficultyForHash(this.child.getHash().getBytes());
+        if (!blockchainDifficulty.subtract(this.child.getCumulativeDifficulty()).equals(genesis.getCumulativeDifficulty())) {
+            throw new IllegalStateException("Blockchain difficulty does not match genesis.");
+        }
+
+        blockStore.saveBlock(genesis, genesis.getCumulativeDifficulty(), true);
+    }
+
+    @Override
+    protected void onMessageTimeOut() {
+        syncEventsHandler.onErrorSyncing(selectedPeerId,
+                "Timeout waiting requests {}", EventType.TIMEOUT_MESSAGE, this.getClass(), selectedPeerId);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsHeadersSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsHeadersSyncState.java
@@ -1,0 +1,58 @@
+package co.rsk.net.sync;
+
+import co.rsk.crypto.Keccak256;
+import co.rsk.net.NodeID;
+import co.rsk.scoring.EventType;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.db.BlockStore;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Retrieves the oldest block in the storage and requests the headers that come before.
+ */
+public class DownloadingBackwardsHeadersSyncState extends BaseSyncState {
+
+    private final Block child;
+    private final NodeID selectedPeerId;
+
+    public DownloadingBackwardsHeadersSyncState(
+            SyncConfiguration syncConfiguration,
+            SyncEventsHandler syncEventsHandler,
+            BlockStore blockStore,
+            NodeID selectedPeerId) {
+        super(syncEventsHandler, syncConfiguration);
+        this.selectedPeerId = selectedPeerId;
+        this.child = blockStore.getChainBlockByNumber(blockStore.getMinNumber());
+    }
+
+    @Override
+    public void newBlockHeaders(List<BlockHeader> toRequest) {
+        syncEventsHandler.backwardDownloadBodies(
+                selectedPeerId,
+                child,
+                toRequest.stream().skip(1).collect(Collectors.toList()));
+    }
+
+    @Override
+    public void onEnter() {
+        Keccak256 hashToRequest = child.getHash();
+        ChunkDescriptor chunkDescriptor = new ChunkDescriptor(
+                hashToRequest.getBytes(),
+                syncConfiguration.getChunkSize());
+
+        boolean sent = syncEventsHandler.sendBlockHeadersRequest(chunkDescriptor, selectedPeerId);
+        if (!sent) {
+            syncEventsHandler.onSyncIssue("Channel failed to sent on {} to {}",
+                    this.getClass(), selectedPeerId);
+        }
+    }
+
+    @Override
+    protected void onMessageTimeOut() {
+        syncEventsHandler.onErrorSyncing(selectedPeerId,
+                "Timeout waiting requests {}", EventType.TIMEOUT_MESSAGE, this.getClass(), selectedPeerId);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
@@ -7,10 +7,10 @@ import java.time.Duration;
 
 @Immutable
 public final class SyncConfiguration {
-    public static final SyncConfiguration DEFAULT = new SyncConfiguration(5, 60, 30, 5, 20, 192);
+    public static final SyncConfiguration DEFAULT = new SyncConfiguration(5, 60, 30, 5, 20, 192, 20, 10);
 
     @VisibleForTesting
-    public static final SyncConfiguration IMMEDIATE_FOR_TESTING = new SyncConfiguration(1, 1, 3, 1, 5, 192);
+    public static final SyncConfiguration IMMEDIATE_FOR_TESTING = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10);
 
     private final int expectedPeers;
     private final Duration timeoutWaitingPeers;
@@ -18,6 +18,8 @@ public final class SyncConfiguration {
     private final Duration expirationTimePeerStatus;
     private final int maxSkeletonChunks;
     private final int chunkSize;
+    private final int longSyncLimit;
+    private final int maxRequestedBodies;
 
     /**
      * @param expectedPeers The expected number of peers we would want to start finding a connection point.
@@ -26,14 +28,26 @@ public final class SyncConfiguration {
      * @param expirationTimePeerStatus Expiration time in minutes for peer status
      * @param maxSkeletonChunks Maximum amount of chunks included in a skeleton message
      * @param chunkSize Amount of blocks contained in a chunk
+     * @param maxRequestedBodies Amount of bodies to request at the same time when synchronizing backwards.
+     * @param longSyncLimit Distance to the tip of the peer's blockchain to enable long synchronization.
      */
-    public SyncConfiguration(int expectedPeers, int timeoutWaitingPeers, int timeoutWaitingRequest, int expirationTimePeerStatus, int maxSkeletonChunks, int chunkSize) {
+    public SyncConfiguration(
+            int expectedPeers,
+            int timeoutWaitingPeers,
+            int timeoutWaitingRequest,
+            int expirationTimePeerStatus,
+            int maxSkeletonChunks,
+            int chunkSize,
+            int maxRequestedBodies,
+            int longSyncLimit) {
         this.expectedPeers = expectedPeers;
         this.timeoutWaitingPeers = Duration.ofSeconds(timeoutWaitingPeers);
         this.timeoutWaitingRequest = Duration.ofSeconds(timeoutWaitingRequest);
         this.expirationTimePeerStatus = Duration.ofMinutes(expirationTimePeerStatus);
         this.maxSkeletonChunks = maxSkeletonChunks;
         this.chunkSize = chunkSize;
+        this.maxRequestedBodies = maxRequestedBodies;
+        this.longSyncLimit = longSyncLimit;
     }
 
     public final int getExpectedPeers() {
@@ -58,5 +72,13 @@ public final class SyncConfiguration {
 
     public final int getChunkSize() {
         return chunkSize;
+    }
+
+    public int getMaxRequestedBodies() {
+        return maxRequestedBodies;
+    }
+
+    public int getLongSyncLimit() {
+        return longSyncLimit;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
@@ -2,6 +2,7 @@ package co.rsk.net.sync;
 
 import co.rsk.net.NodeID;
 import co.rsk.scoring.EventType;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockIdentifier;
 
@@ -27,6 +28,8 @@ public interface SyncEventsHandler {
 
     void startSyncing(NodeID nodeID);
 
+    void backwardDownloadBodies(NodeID peerId, Block parent, List<BlockHeader> toRequest);
+
     void stopSyncing();
 
     void onErrorSyncing(NodeID peerId, String message, EventType eventType, Object... arguments);
@@ -34,4 +37,6 @@ public interface SyncEventsHandler {
     void onSyncIssue(String message, Object... arguments);
 
     void startFindingConnectionPoint(NodeID peerId);
+
+    void backwardSyncing(NodeID peerId);
 }

--- a/rskj-core/src/main/resources/logback.xml
+++ b/rskj-core/src/main/resources/logback.xml
@@ -28,12 +28,12 @@
                 %date{yyyy-MM-dd-HH:mm:ss.SSS} %p [%c{1}]  %m%n
             </Pattern>
         </encoder>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-        <fileNamePattern>./logs/rskj-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-        <maxFileSize>100MB</maxFileSize>
-        <maxHistory>7</maxHistory>
-        <totalSizeCap>1GB</totalSizeCap>
-    </rollingPolicy>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./logs/rskj-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
     </appender>
 
     <logger name="execute" level="INFO"/>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -205,6 +205,12 @@ sync {
     # Maximum amount of chunks included in a skeleton message
     maxSkeletonChunks = 20
 
+    # Maximum amount of bodies to request at the same time when synchronizing backwards
+    maxRequestedBodies = 20
+
+    # Maximum allowed blocks of distance to the tip of the blockchain to prioritize forward synchronization
+    longSyncLimit = 24
+
     # Amount of blocks contained in a chunk,
     # MUST BE 192 or a divisor of 192
     chunkSize = 192

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockUtilsTest.java
@@ -20,7 +20,7 @@ package co.rsk.core.bc;
 
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
-import co.rsk.net.BlockStore;
+import co.rsk.net.NetBlockStore;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.BlockChainBuilder;
 import org.ethereum.core.*;
@@ -63,7 +63,7 @@ public class BlockUtilsTest {
     @Test
     public void unknowAncestorsHashes() {
         BlockChainImpl blockChain = new BlockChainBuilder().build();
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
 
         Block genesis = blockChain.getBestBlock();
 
@@ -112,7 +112,7 @@ public class BlockUtilsTest {
         BlockChainBuilder blockChainBuilder = new BlockChainBuilder();
         BlockChainImpl blockChain = blockChainBuilder.build();
         Genesis genesis = (Genesis) blockChain.getBestBlock();
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
 
         BlockBuilder blockBuilder = new BlockBuilder(blockChain, null,
                                                      blockChainBuilder.getBlockStore()

--- a/rskj-core/src/test/java/co/rsk/net/BlockSyncServiceTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/BlockSyncServiceTest.java
@@ -35,7 +35,7 @@ public class BlockSyncServiceTest {
     public void sendBlockMessagesAndAddThemToBlockchain() {
         for (int i = 0; i < 50; i += 5) {
             Blockchain blockchain = new BlockChainBuilder().ofSize(10 * i);
-            BlockStore store = new BlockStore();
+            NetBlockStore store = new NetBlockStore();
             BlockNodeInformation nodeInformation = new BlockNodeInformation();
             TestSystemProperties config = new TestSystemProperties();
             BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
@@ -54,7 +54,7 @@ public class BlockSyncServiceTest {
     public void sendBlockMessagesAndAddThemToBlockchainInReverseOrder() {
         for (int i = 1; i < 52; i += 5) {
             Blockchain blockchain = new BlockChainBuilder().ofSize(10 * i);
-            BlockStore store = new BlockStore();
+            NetBlockStore store = new NetBlockStore();
             BlockNodeInformation nodeInformation = new BlockNodeInformation();
             TestSystemProperties config = new TestSystemProperties();
             BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
@@ -83,7 +83,7 @@ public class BlockSyncServiceTest {
     @Test
     public void sendBlockMessageAndAddItToBlockchainWithCommonAncestors() {
         Blockchain blockchain = new BlockChainBuilder().ofSize(10);
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);

--- a/rskj-core/src/test/java/co/rsk/net/NetBlockStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NetBlockStoreTest.java
@@ -36,18 +36,18 @@ import java.util.List;
 /**
  * Created by ajlopez on 5/11/2016.
  */
-public class BlockStoreTest {
+public class NetBlockStoreTest {
     private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
 
     @Test
     public void getUnknownBlockAsNull() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Assert.assertNull(store.getBlockByHash(TestUtils.randomBytes(32)));
     }
 
     @Test
     public void minimalAndMaximumHeightInEmptyStore() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
 
         Assert.assertEquals(0, store.minimalHeight());
         Assert.assertEquals(0, store.maximumHeight());
@@ -55,7 +55,7 @@ public class BlockStoreTest {
 
     @Test
     public void saveAndGetBlockByHash() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block block = new BlockGenerator().getGenesisBlock();
 
         store.saveBlock(block);
@@ -67,7 +67,7 @@ public class BlockStoreTest {
 
     @Test
     public void saveRemoveAndGetBlockByHash() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block block = new BlockGenerator().getBlock(1);
 
         store.saveBlock(block);
@@ -85,7 +85,7 @@ public class BlockStoreTest {
 
     @Test
     public void saveRemoveAndGetBlockByHashWithUncles() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockGenerator blockGenerator = new BlockGenerator();
         Block parent = blockGenerator.getGenesisBlock();
         Block son1 = blockGenerator.createChildBlock(parent);
@@ -110,7 +110,7 @@ public class BlockStoreTest {
 
     @Test
     public void saveTwoBlocksRemoveOne() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockGenerator blockGenerator = new BlockGenerator();
         Block parent = blockGenerator.getGenesisBlock();
         Block adam = blockGenerator.createChildBlock(parent);
@@ -151,7 +151,7 @@ public class BlockStoreTest {
 
     @Test
     public void saveAndGetBlocksByNumber() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
         Block block1 = blockGenerator.createChildBlock(genesis);
@@ -171,7 +171,7 @@ public class BlockStoreTest {
 
     @Test
     public void releaseRange() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         final BlockGenerator generator = new BlockGenerator();
         Block genesis = generator.getGenesisBlock();
 
@@ -192,7 +192,7 @@ public class BlockStoreTest {
 
     @Test
     public void saveAndGetBlocksByParentHash() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
         Block block1 = blockGenerator.createChildBlock(genesis);
@@ -210,7 +210,7 @@ public class BlockStoreTest {
 
     @Test
     public void getNoBlocksByNumber() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
 
         List<Block> blocks = store.getBlocksByNumber(42);
 
@@ -220,7 +220,7 @@ public class BlockStoreTest {
 
     @Test
     public void saveHeader() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockHeader blockHeader = blockFactory.newHeader(new byte[]{},
                 new byte[]{},
                 TestUtils.randomAddress().getBytes(),
@@ -245,7 +245,7 @@ public class BlockStoreTest {
 
     @Test
     public void removeHeader() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockHeader blockHeader = blockFactory.newHeader(new byte[]{},
                 new byte[]{},
                 TestUtils.randomAddress().getBytes(),

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.*;
 public class NodeBlockProcessorTest {
     @Test
     public void processBlockSavingInStore() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final MessageChannel sender = new SimpleMessageChannel();
 
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
@@ -69,7 +69,7 @@ public class NodeBlockProcessorTest {
 
     @Test
     public void processBlockWithTooMuchHeight() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final MessageChannel sender = new SimpleMessageChannel();
 
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
@@ -90,7 +90,7 @@ public class NodeBlockProcessorTest {
 
     @Test
     public void advancedBlock() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final MessageChannel sender = new SimpleMessageChannel();
 
         final BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -109,7 +109,7 @@ public class NodeBlockProcessorTest {
 
     @Test
     public void canBeIgnoredForUncles() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final MessageChannel sender = new SimpleMessageChannel();
 
         final BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -133,7 +133,7 @@ public class NodeBlockProcessorTest {
 
         Assert.assertEquals(10, blockchain.getBestBlock().getNumber());
 
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block genesis = blockchain.getBlockByNumber(0);
         store.saveBlock(genesis);
         Block block = new BlockGenerator().createChildBlock(blockchain.getBlockByNumber(10));
@@ -158,7 +158,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processTenBlocksAddingToBlockchain() {
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block genesis = blockchain.getBestBlock();
 
         List<Block> blocks = new BlockGenerator().getBlockChain(genesis, 10);
@@ -182,7 +182,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processTwoBlockListsAddingToBlockchain() {
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block genesis = blockchain.getBestBlock();
         BlockGenerator blockGenerator = new BlockGenerator();
         List<Block> blocks = blockGenerator.getBlockChain(genesis, 10);
@@ -208,7 +208,7 @@ public class NodeBlockProcessorTest {
 
     @Test
     public void processTwoBlockListsAddingToBlockchainWithFork() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         Block genesis = blockchain.getBestBlock();
 
@@ -236,7 +236,7 @@ public class NodeBlockProcessorTest {
 
     @Test
     public void noSyncingWithEmptyBlockchain() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -250,7 +250,7 @@ public class NodeBlockProcessorTest {
 
     @Test @Ignore("Ignored when Process status deleted on block processor")
     public void noSyncingWithEmptyBlockchainAndLowBestBlock() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block block = new BlockGenerator().createBlock(10, 0);
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
@@ -270,7 +270,7 @@ public class NodeBlockProcessorTest {
 
     @Test @Ignore("Ignored when Process status deleted on block processor")
     public void syncingWithEmptyBlockchainAndHighBestBlock() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block block = new BlockGenerator().createBlock(30, 0);
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
@@ -290,7 +290,7 @@ public class NodeBlockProcessorTest {
 
     @Test @Ignore("Ignored when Process status deleted on block processor")
     public void syncingThenNoSyncing() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block block = new BlockGenerator().createBlock(30, 0);
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
@@ -323,7 +323,7 @@ public class NodeBlockProcessorTest {
 
     @Test
     public void processTenBlocksGenesisAtLastAddingToBlockchain() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         Block genesis = blockchain.getBestBlock();
         List<Block> blocks = new BlockGenerator().getBlockChain(genesis, 10);
@@ -346,7 +346,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processTenBlocksInverseOrderAddingToBlockchain() {
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block genesis = blockchain.getBestBlock();
         List<Block> blocks = new BlockGenerator().getBlockChain(genesis, 10);
 
@@ -368,7 +368,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processTenBlocksWithHoleAddingToBlockchain() {
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         Block genesis = blockchain.getBestBlock();
         List<Block> blocks = new BlockGenerator().getBlockChain(genesis, 10);
 
@@ -391,7 +391,7 @@ public class NodeBlockProcessorTest {
 
     @Test
     public void processBlockAddingToBlockchainUsingItsParent() {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
         store.saveBlock(genesis);
@@ -426,7 +426,7 @@ public class NodeBlockProcessorTest {
 
     @Test
     public void processBlockRetrievingParentUsingSender() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -460,7 +460,7 @@ public class NodeBlockProcessorTest {
 
     @Test @Ignore("Ignored when Process status deleted on block processor")
     public void processStatusRetrievingBestBlockUsingSender() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -493,7 +493,7 @@ public class NodeBlockProcessorTest {
 
     @Test @Ignore("Ignored when Process status deleted on block processor")
     public void processStatusHavingBestBlockInStore() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -516,7 +516,7 @@ public class NodeBlockProcessorTest {
 
     @Test @Ignore("Ignored when Process status deleted on block processor")
     public void processStatusHavingBestBlockAsBestBlockInBlockchain() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = new BlockChainBuilder().ofSize(2);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -541,7 +541,7 @@ public class NodeBlockProcessorTest {
 
     @Test @Ignore("Ignored when Process status deleted on block processor")
     public void processStatusHavingBestBlockInBlockchainStore() throws UnknownHostException {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = new BlockChainBuilder().ofSize(2);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -569,7 +569,7 @@ public class NodeBlockProcessorTest {
     public void processGetBlockHeaderMessageUsingBlockInStore() throws UnknownHostException {
         final Block block = new BlockGenerator().getBlock(3);
 
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         store.saveBlock(block);
 
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
@@ -598,7 +598,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processGetBlockHeaderMessageUsingEmptyStore() throws UnknownHostException {
         final Block block = new BlockGenerator().getBlock(3);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -622,7 +622,7 @@ public class NodeBlockProcessorTest {
     public void processGetBlockHeaderMessageUsingBlockInBlockchain() throws UnknownHostException {
         final Blockchain blockchain = new BlockChainBuilder().ofSize(10);
         final Block block = blockchain.getBlockByNumber(5);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -651,7 +651,7 @@ public class NodeBlockProcessorTest {
         final Block block = new BlockGenerator().getBlock(3);
         final Keccak256 blockHash = block.getHash();
 
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         store.saveBlock(block);
 
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
@@ -684,7 +684,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processGetBlockMessageUsingEmptyStore() throws UnknownHostException {
         final Block block = new BlockGenerator().getBlock(3);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -709,7 +709,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = new BlockChainBuilder().ofSize(10);
         final Block block = blockchain.getBlockByNumber(5);
         final Keccak256 blockHash = block.getHash();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -742,7 +742,7 @@ public class NodeBlockProcessorTest {
         final Block block = new BlockGenerator().getBlock(3);
         final Keccak256 blockHash = block.getHash();
 
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         store.saveBlock(block);
 
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
@@ -777,7 +777,7 @@ public class NodeBlockProcessorTest {
     public void processBodyRequestMessageUsingBlockInBlockchain() throws UnknownHostException {
         final Blockchain blockchain = new BlockChainBuilder().ofSize(10);
         final Block block = blockchain.getBlockByNumber(3);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
@@ -806,7 +806,7 @@ public class NodeBlockProcessorTest {
     public void processBlockHashRequestMessageUsingEmptyStore() throws UnknownHostException {
         final Block block = new BlockGenerator().getBlock(3);
         final Keccak256 blockHash = block.getHash();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
@@ -831,7 +831,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = new BlockChainBuilder().ofSize(10);
         final Block block = blockchain.getBlockByNumber(5);
         final Keccak256 blockHash = block.getHash();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -863,7 +863,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processBlockHashRequestMessageUsingOutOfBoundsHeight() throws UnknownHostException {
         final Blockchain blockchain = new BlockChainBuilder().ofSize(10);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
@@ -881,7 +881,7 @@ public class NodeBlockProcessorTest {
     public void processBlockHeadersRequestMessageUsingBlockInBlockchain() throws UnknownHostException {
         final Blockchain blockchain = new BlockChainBuilder().ofSize(100);
         final Block block = blockchain.getBlockByNumber(60);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -913,7 +913,7 @@ public class NodeBlockProcessorTest {
     @Test
     public void processBlockHeadersRequestMessageUsingUnknownHash() throws UnknownHostException {
         final Blockchain blockchain = new BlockChainBuilder().ofSize(100);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -934,7 +934,7 @@ public class NodeBlockProcessorTest {
         final Blockchain blockchain = new BlockChainBuilder().ofSize(skeletonStep / 2);
         final Block blockStart = blockchain.getBlockByNumber(5);
         final Block blockEnd = blockchain.getBlockByNumber(skeletonStep / 2);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -970,7 +970,7 @@ public class NodeBlockProcessorTest {
     public void processSkeletonRequestWithThreeResults() throws UnknownHostException {
         int skeletonStep = 192;
         final Blockchain blockchain = new BlockChainBuilder().ofSize(300);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -1008,7 +1008,7 @@ public class NodeBlockProcessorTest {
     public void processSkeletonRequestNotIncludingGenesis() throws UnknownHostException {
         int skeletonStep = 192;
         final Blockchain blockchain = new BlockChainBuilder().ofSize(400);
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -1059,7 +1059,7 @@ public class NodeBlockProcessorTest {
 
         final Block block = new BlockGenerator().getBlock(3);
 
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         store.saveBlock(block);
 
         final Blockchain blockchain = new BlockChainBuilder().ofSize(0);

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorUnclesTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorUnclesTest.java
@@ -149,7 +149,7 @@ public class NodeBlockProcessorUnclesTest {
     }
 
     private static NodeBlockProcessor createNodeBlockProcessor(BlockChainImpl blockChain) {
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -19,7 +19,6 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.bc.ConsensusValidationMainchainView;
@@ -39,6 +38,7 @@ import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.validators.*;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.db.BlockStore;
 import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
@@ -46,7 +46,6 @@ import org.ethereum.util.RskMockFactory;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
@@ -72,7 +71,7 @@ public class NodeMessageHandlerTest {
         SimpleMessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, scoring, new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, scoring, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
         Block block = new BlockChainBuilder().ofSize(1, true).getBestBlock();
         Message message = new BlockMessage(block);
 
@@ -104,7 +103,7 @@ public class NodeMessageHandlerTest {
         SimpleMessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, scoring, new DummyBlockValidationRule());
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, scoring, new DummyBlockValidationRule(), mock(StatusResolver.class));
         Block block = new BlockGenerator().getGenesisBlock();
         Message message = new BlockMessage(block);
 
@@ -126,7 +125,7 @@ public class NodeMessageHandlerTest {
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
         sbp.setBlockGap(100000);
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, scoring, new DummyBlockValidationRule());
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, scoring, new DummyBlockValidationRule(), mock(StatusResolver.class));
         Block block = new BlockGenerator().createBlock(200000, 0);
         Message message = new BlockMessage(block);
 
@@ -147,8 +146,8 @@ public class NodeMessageHandlerTest {
         MessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, scoring,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
         Block block = new BlockChainBuilder().ofSize(1, true).getBestBlock();
         Message message = new BlockMessage(block);
 
@@ -166,8 +165,8 @@ public class NodeMessageHandlerTest {
     @Test
     public void postBlockMessageUsingProcessor() throws InterruptedException, UnknownHostException {
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
         Block block = new BlockChainBuilder().ofSize(1, true).getBestBlock();
         Message message = new BlockMessage(block);
 
@@ -190,8 +189,8 @@ public class NodeMessageHandlerTest {
         SimpleMessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, scoring,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
         Block block = new BlockChainBuilder().ofSize(1, true).getBestBlock();
         byte[] mergedMiningHeader = block.getBitcoinMergedMiningHeader();
         mergedMiningHeader[76] += 3; //change merged mining nonce.
@@ -217,7 +216,7 @@ public class NodeMessageHandlerTest {
         SimpleMessageChannel sender = new SimpleMessageChannel();
         PeerScoringManager scoring = createPeerScoringManager();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, scoring, new DummyBlockValidationRule());
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, scoring, new DummyBlockValidationRule(), mock(StatusResolver.class));
         BlockGenerator blockGenerator = new BlockGenerator();
         Block block = blockGenerator.getGenesisBlock();
 
@@ -245,8 +244,8 @@ public class NodeMessageHandlerTest {
     @Test
     public void processFutureBlockMessageUsingProcessor() throws UnknownHostException {
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
         Block block = new BlockGenerator().getGenesisBlock();
         Message message = new BlockMessage(block);
         SimpleMessageChannel sender = new SimpleMessageChannel();
@@ -266,8 +265,8 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         final SimpleMessageChannel sender = new SimpleMessageChannel();
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), bp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         BlockGenerator blockGenerator = new BlockGenerator();
         final Block block = blockGenerator.createChildBlock(blockGenerator.getGenesisBlock());
@@ -326,7 +325,7 @@ public class NodeMessageHandlerTest {
         final SimpleMessageChannel sender = new SimpleMessageChannel();
         final SyncProcessor syncProcessor = new SyncProcessor(
                 blockchain,
-                mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class),
+                mock(BlockStore.class), mock(ConsensusValidationMainchainView.class),
                 blockSyncService,
                 RskMockFactory.getChannelManager(),
                 syncConfiguration,
@@ -336,8 +335,8 @@ public class NodeMessageHandlerTest {
                 null,
                 new PeersInformation(RskMockFactory.getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()));
         final NodeMessageHandler handler = new NodeMessageHandler(config,
-                mock(org.ethereum.db.BlockStore.class), bp, syncProcessor, null, null,
-                null, new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+                bp, syncProcessor, null, null,
+                null, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         BlockGenerator blockGenerator = new BlockGenerator();
         final Block block = blockGenerator.createChildBlock(blockGenerator.getGenesisBlock());
@@ -366,8 +365,8 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), bp, null, null, null,
-                null, new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null,
+                null, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -401,8 +400,8 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), bp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -433,7 +432,7 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), bp, null, null, null, null, new DummyBlockValidationRule());
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null, new DummyBlockValidationRule(), mock(StatusResolver.class));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -457,8 +456,8 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), bp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -492,8 +491,8 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), bp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -527,8 +526,8 @@ public class NodeMessageHandlerTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), bp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, bp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         class TestCase {
             protected final NewBlockHashesMessage message;
@@ -636,8 +635,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(true);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), blockProcessor, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         Message message = mock(Message.class);
         Mockito.when(message.getMessageType()).thenReturn(MessageType.NEW_BLOCK_HASHES);
@@ -654,8 +653,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), blockProcessor, null, null, transactionGateway, scoring,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, null, transactionGateway, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
         sender.setPeerNodeID(new NodeID(new byte[] {1}));
@@ -698,8 +697,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), blockProcessor, null, channelManager, transactionGateway, scoring,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, channelManager, transactionGateway, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -729,8 +728,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), blockProcessor, null, channelManager, transactionGateway, scoring,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, channelManager, transactionGateway, scoring,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
@@ -765,8 +764,8 @@ public class NodeMessageHandlerTest {
         BlockProcessor blockProcessor = mock(BlockProcessor.class);
         Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
 
-        final NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), blockProcessor, null, null, transactionGateway, RskMockFactory.getPeerScoringManager(),
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, null, transactionGateway, RskMockFactory.getPeerScoringManager(),
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
 
         final SimpleMessageChannel sender = new SimpleMessageChannel();
         sender.setPeerNodeID(new NodeID(new byte[] {1}));
@@ -788,8 +787,8 @@ public class NodeMessageHandlerTest {
     @Test
     public void processBlockByHashRequestMessageUsingProcessor() throws UnknownHostException {
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
         Block block = new BlockChainBuilder().ofSize(1, true).getBestBlock();
         Message message = new BlockRequestMessage(100, block.getHash().getBytes());
 
@@ -803,8 +802,8 @@ public class NodeMessageHandlerTest {
     public void processBlockHeadersRequestMessageUsingProcessor() throws UnknownHostException {
         byte[] hash = HashUtil.randomHash();
         SimpleBlockProcessor sbp = new SimpleBlockProcessor();
-        NodeMessageHandler processor = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), sbp, null, null, null, null,
-                new ProofOfWorkRule(config).setFallbackMiningEnabled(false));
+        NodeMessageHandler processor = new NodeMessageHandler(config, sbp, null, null, null, null,
+                new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));
         Message message = new BlockHeadersRequestMessage(100, hash, 50);
 
         processor.processMessage(new SimpleMessageChannel(), message);
@@ -820,46 +819,6 @@ public class NodeMessageHandlerTest {
                 new PunishmentParameters(600000, 10, 10000000),
                 new PunishmentParameters(600000, 10, 10000000)
         );
-    }
-
-    @Test
-    public void sendStatusToAll() {
-        org.ethereum.db.BlockStore continuousBlockStore = mock(org.ethereum.db.BlockStore.class);
-        Block bestBlock = mock(Block.class);
-        Keccak256 blockHash = mock(Keccak256.class);
-        byte[] hashBytes = new byte[]{0x00};
-        long blockNumber = 52;
-
-        BlockDifficulty totalDifficulty = mock(BlockDifficulty.class);
-
-        ChannelManager channelManager = mock(ChannelManager.class);
-        NodeMessageHandler nodeMessageHandler = new NodeMessageHandler(
-                mock(RskSystemProperties.class),
-                continuousBlockStore,
-                mock(BlockProcessor.class),
-                mock(SyncProcessor.class),
-                channelManager,
-                mock(TransactionGateway.class),
-                mock(PeerScoringManager.class),
-                mock(BlockValidationRule.class));
-
-        when(continuousBlockStore.getBestBlock()).thenReturn(bestBlock);
-        when(bestBlock.getHash()).thenReturn(blockHash);
-        when(bestBlock.getParentHash()).thenReturn(blockHash);
-        when(blockHash.getBytes()).thenReturn(hashBytes);
-        when(bestBlock.getNumber()).thenReturn(blockNumber);
-        when(continuousBlockStore.getTotalDifficultyForHash(eq(hashBytes))).thenReturn(totalDifficulty);
-
-        nodeMessageHandler.sendStatusToAll();
-
-        ArgumentCaptor<Status> argument = ArgumentCaptor.forClass(Status.class);
-        verify(channelManager, times(1)).broadcastStatus(argument.capture());
-
-        Status value = argument.getValue();
-        Assert.assertEquals(blockNumber, value.getBestBlockNumber());
-        Assert.assertEquals(hashBytes, value.getBestBlockHash());
-        Assert.assertEquals(hashBytes, value.getBestBlockParentHash());
-        Assert.assertEquals(totalDifficulty, value.getTotalDifficulty());
     }
 }
 

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -288,7 +288,7 @@ public class NodeMessageHandlerTest {
     }
 
     @Test()
-    public void processStatusMessageUsingSyncProcessor() throws UnknownHostException {
+    public void processStatusMessageUsingSyncProcessor() {
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
         final ChannelManager channelManager = mock(ChannelManager.class);
@@ -333,7 +333,7 @@ public class NodeMessageHandlerTest {
                 new DummyBlockValidationRule(),
                 new BlockCompositeRule(new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())),
                 null,
-                new PeersInformation(RskMockFactory.getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()));
+                new PeersInformation(RskMockFactory.getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()), mock(Genesis.class));
         final NodeMessageHandler handler = new NodeMessageHandler(config,
                 bp, syncProcessor, null, null,
                 null, new ProofOfWorkRule(config).setFallbackMiningEnabled(false), mock(StatusResolver.class));

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -260,7 +260,7 @@ public class NodeMessageHandlerTest {
     public void processStatusMessageUsingNodeBlockProcessor() throws UnknownHostException {
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
@@ -317,7 +317,7 @@ public class NodeMessageHandlerTest {
     public void processStatusMessageWithKnownBestBlock() throws UnknownHostException {
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -356,7 +356,7 @@ public class NodeMessageHandlerTest {
         final Block block = new BlockGenerator().getBlock(3);
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
 
         store.saveBlock(block);
@@ -389,7 +389,7 @@ public class NodeMessageHandlerTest {
     public void processGetBlockMessageUsingBlockInBlockchain() throws UnknownHostException {
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         List<Block> blocks = new BlockGenerator().getBlockChain(blockchain.getBestBlock(), 10);
 
@@ -426,7 +426,7 @@ public class NodeMessageHandlerTest {
 
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -448,7 +448,7 @@ public class NodeMessageHandlerTest {
 
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         store.saveBlock(block);
 
@@ -480,7 +480,7 @@ public class NodeMessageHandlerTest {
     public void processBlockHeaderRequestMessageUsingBlockInBlockchain() throws UnknownHostException {
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         List<Block> blocks = new BlockGenerator().getBlockChain(blockchain.getBestBlock(), 10);
 
@@ -515,7 +515,7 @@ public class NodeMessageHandlerTest {
     public void processNewBlockHashesMessage() throws UnknownHostException {
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         final List<Block> blocks = new BlockGenerator().getBlockChain(blockchain.getBestBlock(), 15);
         final List<Block> bcBlocks = blocks.subList(0, 10);

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
@@ -39,7 +39,7 @@ public class NodeMessageHandlerUtil {
         );
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
 
-        return new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), processor, syncProcessor, new SimpleChannelManager(), null, RskMockFactory.getPeerScoringManager(), validationRule);
+        return new NodeMessageHandler(config, processor, syncProcessor, new SimpleChannelManager(), null, RskMockFactory.getPeerScoringManager(), validationRule, mock(StatusResolver.class));
     }
 
     public static NodeMessageHandler createHandlerWithSyncProcessor() {
@@ -77,6 +77,6 @@ public class NodeMessageHandlerUtil {
                 blockValidationRule, new BlockCompositeRule(new BlockUnclesHashValidationRule(),
                 new BlockRootValidationRule(config.getActivationConfig())), DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, syncConfiguration, blockchain, peerScoringManager)
         );
-        return new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), processor, syncProcessor, channelManager, null, null, blockValidationRule);
+        return new NodeMessageHandler(config, processor, syncProcessor, channelManager, null, null, blockValidationRule, mock(StatusResolver.class));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
@@ -26,7 +26,7 @@ public class NodeMessageHandlerUtil {
     private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants());
 
     public static NodeMessageHandler createHandler(BlockValidationRule validationRule, Blockchain blockchain) {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
@@ -64,7 +64,7 @@ public class NodeMessageHandlerUtil {
             Blockchain blockchain,
             SyncConfiguration syncConfiguration,
             ChannelManager channelManager) {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
 
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.mock;
 public class OneAsyncNodeTest {
     private static SimpleAsyncNode createNode() {
         final World world = new World();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = world.getBlockChain();
 
         TestSystemProperties config = new TestSystemProperties();

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -34,6 +34,7 @@ import co.rsk.validators.DummyBlockValidationRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Blockchain;
+import org.ethereum.core.Genesis;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
 import org.ethereum.util.RskMockFactory;
 import org.junit.Assert;
@@ -64,7 +65,9 @@ public class OneAsyncNodeTest {
                 new BlockFactory(config.getActivationConfig()),
                 new DummyBlockValidationRule(),
                 new BlockCompositeRule(new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())),
-                new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants()), new PeersInformation(channelManager, syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
+                new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants()),
+                new PeersInformation(channelManager, syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class)
         );
         NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, channelManager, null, RskMockFactory.getPeerScoringManager(), new DummyBlockValidationRule(), mock(StatusResolver.class));
 
@@ -78,7 +81,7 @@ public class OneAsyncNodeTest {
     }
 
     @Test
-    public void buildBlockchain() throws InterruptedException {
+    public void buildBlockchain() {
         SimpleAsyncNode node = createNode();
 
         List<Block> blocks = new BlockGenerator().getBlockChain(getGenesis(), 10);
@@ -94,7 +97,7 @@ public class OneAsyncNodeTest {
     }
 
     @Test
-    public void buildBlockchainInReverse() throws InterruptedException {
+    public void buildBlockchainInReverse() {
         SimpleAsyncNode node = createNode();
 
         List<Block> blocks = new BlockGenerator().getBlockChain(getGenesis(), 10);

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -66,7 +66,7 @@ public class OneAsyncNodeTest {
                 new BlockCompositeRule(new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())),
                 new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants()), new PeersInformation(channelManager, syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
         );
-        NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), processor, syncProcessor, channelManager, null, RskMockFactory.getPeerScoringManager(), new DummyBlockValidationRule());
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, channelManager, null, RskMockFactory.getPeerScoringManager(), new DummyBlockValidationRule(), mock(StatusResolver.class));
 
         return new SimpleAsyncNode(handler, blockchain, syncProcessor, channelManager);
     }

--- a/rskj-core/src/test/java/co/rsk/net/StatusResolverTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/StatusResolverTest.java
@@ -1,0 +1,74 @@
+package co.rsk.net;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.crypto.Keccak256;
+import org.ethereum.core.Block;
+import org.ethereum.core.Genesis;
+import org.ethereum.db.BlockStore;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class StatusResolverTest {
+
+    private StatusResolver target;
+    private Genesis genesis;
+    private BlockStore blockStore;
+
+    @Before
+    public void setUp() {
+        genesis = mock(Genesis.class);
+        blockStore = mock(BlockStore.class);
+        target = new StatusResolver(blockStore, genesis);
+    }
+
+    @Test
+    public void status() {
+        Block bestBlock = mock(Block.class);
+        Keccak256 blockHash = mock(Keccak256.class);
+        byte[] hashBytes = new byte[]{0x00};
+        long blockNumber = 52;
+
+        BlockDifficulty totalDifficulty = mock(BlockDifficulty.class);
+
+        when(blockStore.getBestBlock()).thenReturn(bestBlock);
+        when(bestBlock.getHash()).thenReturn(blockHash);
+        when(bestBlock.getParentHash()).thenReturn(blockHash);
+        when(blockHash.getBytes()).thenReturn(hashBytes);
+        when(bestBlock.getNumber()).thenReturn(blockNumber);
+        when(blockStore.getTotalDifficultyForHash(eq(hashBytes))).thenReturn(totalDifficulty);
+
+        Status status = target.currentStatus();
+
+        Assert.assertEquals(blockNumber, status.getBestBlockNumber());
+        Assert.assertEquals(hashBytes, status.getBestBlockHash());
+        Assert.assertEquals(hashBytes, status.getBestBlockParentHash());
+        Assert.assertEquals(totalDifficulty, status.getTotalDifficulty());
+    }
+
+
+    @Test
+    public void status_incompleteBlockchain() {
+        when(blockStore.getMinNumber()).thenReturn(1L);
+        Keccak256 genesisHash = new Keccak256("ee5c851e70650111887bb6c04e18ef4353391abe37846234c17895a9ca2b33d5");
+        Keccak256 parentHash = new Keccak256("133e83bb305ef21ea7fc86fcced355db2300887274961a136ca5e8c8763687d9");
+        when(genesis.getHash()).thenReturn(genesisHash);
+        when(genesis.getParentHash()).thenReturn(parentHash);
+        when(genesis.getNumber()).thenReturn(0L);
+        BlockDifficulty genesisDifficulty = new BlockDifficulty(BigInteger.valueOf(10L));
+        when(genesis.getCumulativeDifficulty()).thenReturn(genesisDifficulty);
+
+        Status status = target.currentStatus();
+
+        Assert.assertEquals(0L, status.getBestBlockNumber());
+        Assert.assertEquals(genesisHash.getBytes(), status.getBestBlockHash());
+        Assert.assertEquals(parentHash.getBytes(), status.getBestBlockParentHash());
+        Assert.assertEquals(genesisDifficulty, status.getTotalDifficulty());
+
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -52,7 +52,7 @@ public class SyncProcessorTest {
 
     @Test
     public void noPeers() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         TestSystemProperties config = new TestSystemProperties();
@@ -75,7 +75,7 @@ public class SyncProcessorTest {
 
     @Test
     public void processStatusWithAdvancedPeers() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         byte[] hash = HashUtil.randomHash();
         byte[] parentHash = HashUtil.randomHash();
@@ -129,7 +129,7 @@ public class SyncProcessorTest {
 
     @Test
     public void syncWithAdvancedPeerAfterTimeoutWaitingPeers() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         byte[] hash = HashUtil.randomHash();
         byte[] parentHash = HashUtil.randomHash();
@@ -189,7 +189,7 @@ public class SyncProcessorTest {
 
     @Test
     public void dontSyncWithoutAdvancedPeerAfterTimeoutWaitingPeers() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         byte[] hash = HashUtil.randomHash();
         byte[] parentHash = HashUtil.randomHash();
@@ -229,7 +229,7 @@ public class SyncProcessorTest {
 
     @Test
     public void syncWithAdvancedStatusAnd5Peers() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         byte[] hash = HashUtil.randomHash();
         byte[] parentHash = HashUtil.randomHash();
@@ -308,7 +308,7 @@ public class SyncProcessorTest {
 
     @Test
     public void processStatusWithPeerWithSameDifficulty() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(100);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
         byte[] hash = HashUtil.randomHash();
@@ -444,7 +444,7 @@ public class SyncProcessorTest {
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
-        BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
+        BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, getChannelManager(),
                 syncConfiguration, blockFactory,
@@ -472,7 +472,7 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
-        BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
+        BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, getChannelManager(),
                 syncConfiguration, blockFactory,
@@ -501,7 +501,7 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
-        BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
+        BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, getChannelManager(),
                 syncConfiguration, blockFactory,
@@ -533,7 +533,7 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
-        BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
+        BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, getChannelManager(),
                 syncConfiguration, blockFactory,
@@ -561,7 +561,7 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
-        BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
+        BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, getChannelManager(),
                 syncConfiguration, blockFactory,
@@ -582,7 +582,7 @@ public class SyncProcessorTest {
 
     @Test
     public void processBodyResponseAddsToBlockchain() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(10);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
@@ -633,7 +633,7 @@ public class SyncProcessorTest {
 
     @Test
     public void doesntProcessInvalidBodyResponse() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(10);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
@@ -691,7 +691,7 @@ public class SyncProcessorTest {
 
     @Test
     public void doesntProcessUnexpectedBodyResponse() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(10);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[]{0x01});
 
@@ -753,7 +753,7 @@ public class SyncProcessorTest {
         accounts.put(senderAccount.getAddress(), new AccountState(BigInteger.ZERO, Coin.valueOf(20000000)));
         accounts.put(receiverAccount.getAddress(), new AccountState(BigInteger.ZERO, Coin.ZERO));
 
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         BlockChainBuilder blockChainBuilder = new BlockChainBuilder();
         Blockchain blockchain = blockChainBuilder.ofSize(0, false, accounts);
 
@@ -835,7 +835,7 @@ public class SyncProcessorTest {
 
     @Test
     public void processBlockResponseAddsToBlockchain() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(10);
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[] { 0x01 });
 
@@ -886,7 +886,7 @@ public class SyncProcessorTest {
             return true;
         });
 
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
@@ -949,7 +949,7 @@ public class SyncProcessorTest {
             return true;
         });
 
-        BlockStore store = new BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
@@ -996,7 +996,7 @@ public class SyncProcessorTest {
 
     @Test
     public void processSkeletonResponseWithTenBlockIdentifiers() {
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         Blockchain blockchain = new BlockChainBuilder().ofSize(0);
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         TestSystemProperties config = new TestSystemProperties();
@@ -1057,7 +1057,7 @@ public class SyncProcessorTest {
 
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
-        BlockSyncService blockSyncService = new BlockSyncService(config, new BlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
+        BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
         SyncProcessor processor = new SyncProcessor(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, getChannelManager(),
                 syncConfiguration, blockFactory, new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -1082,7 +1082,7 @@ public class SyncProcessorTest {
     public void processSkeletonResponseWithConnectionPoint() {
         Blockchain blockchain = new BlockChainBuilder().ofSize(25);
 
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -25,6 +25,7 @@ import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.datasource.HashMapDB;
+import org.ethereum.db.BlockStore;
 import org.ethereum.net.server.Channel;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
@@ -64,8 +65,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, getPeerScoringManager()),
+                mock(Genesis.class));
 
         Assert.assertEquals(0, processor.getPeersCount());
         Assert.assertEquals(0, processor.getNoAdvancedPeers());
@@ -76,7 +77,9 @@ public class SyncProcessorTest {
     @Test
     public void processStatusWithAdvancedPeers() {
         final NetBlockStore store = new NetBlockStore();
-        Blockchain blockchain = new BlockChainBuilder().ofSize(0);
+        BlockChainBuilder builder = new BlockChainBuilder();
+        Blockchain blockchain = builder.ofSize(0);
+        BlockStore blockStore = builder.getBlockStore();
         byte[] hash = HashUtil.randomHash();
         byte[] parentHash = HashUtil.randomHash();
 
@@ -98,14 +101,14 @@ public class SyncProcessorTest {
         });
 
         SyncProcessor processor = new SyncProcessor(
-                blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager,
+                blockchain, blockStore, mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         processor.processStatus(sender, status);
 
         Assert.assertEquals(1, processor.getPeersCount());
@@ -130,7 +133,9 @@ public class SyncProcessorTest {
     @Test
     public void syncWithAdvancedPeerAfterTimeoutWaitingPeers() {
         final NetBlockStore store = new NetBlockStore();
-        Blockchain blockchain = new BlockChainBuilder().ofSize(0);
+        BlockChainBuilder builder = new BlockChainBuilder();
+        Blockchain blockchain = builder.ofSize(0);
+        BlockStore blockStore = builder.getBlockStore();
         byte[] hash = HashUtil.randomHash();
         byte[] parentHash = HashUtil.randomHash();
 
@@ -153,14 +158,14 @@ public class SyncProcessorTest {
         });
 
         SyncProcessor processor = new SyncProcessor(
-                blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager,
+                blockchain, blockStore, mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager,
                 syncConfiguration, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         processor.processStatus(sender, status);
 
         Assert.assertEquals(1, processor.getPeersCount());
@@ -207,8 +212,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.DEFAULT, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.DEFAULT, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         SimpleMessageChannel sender = new SimpleMessageChannel(new byte[]{0x01});
         processor.processStatus(sender, status);
 
@@ -230,7 +235,9 @@ public class SyncProcessorTest {
     @Test
     public void syncWithAdvancedStatusAnd5Peers() {
         final NetBlockStore store = new NetBlockStore();
-        Blockchain blockchain = new BlockChainBuilder().ofSize(0);
+        BlockChainBuilder builder = new BlockChainBuilder();
+        Blockchain blockchain = builder.ofSize(0);
+        BlockStore blockStore = builder.getBlockStore();
         byte[] hash = HashUtil.randomHash();
         byte[] parentHash = HashUtil.randomHash();
 
@@ -242,14 +249,14 @@ public class SyncProcessorTest {
 
         final ChannelManager channelManager = mock(ChannelManager.class);
         SyncProcessor processor = new SyncProcessor(
-                blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager,
+                blockchain, blockStore, mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager,
                 SyncConfiguration.DEFAULT, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.DEFAULT, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.DEFAULT, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         List<SimpleMessageChannel> senders = new ArrayList<>();
         List<Channel> channels = new ArrayList<>();
@@ -327,8 +334,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         processor.processStatus(sender, status);
 
         Assert.assertEquals(1, processor.getPeersCount());
@@ -362,8 +369,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         processor.sendSkeletonRequest(sender.getPeerNodeID(), 0);
 
@@ -402,8 +409,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         processor.sendBlockHashRequest(100, sender.getPeerNodeID());
 
@@ -433,8 +440,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         processor.processStatus(sender, new Status(100, null));
     }
 
@@ -452,8 +459,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         List<BlockHeader> headers = new ArrayList<>();
 
@@ -480,8 +487,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         List<BlockHeader> headers = new ArrayList<>();
         headers.add(block.getHeader());
@@ -509,8 +516,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         List<BlockHeader> headers = new ArrayList<>();
 
@@ -541,8 +548,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         List<BlockHeader> headers = new ArrayList<>();
         headers.add(block.getHeader());
@@ -569,8 +576,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), null, null);
         processor.registerExpectedMessage(response);
@@ -604,8 +611,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
         long lastRequestId = new Random().nextLong();
@@ -655,8 +662,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
         Account senderAccount = createAccount("sender");
         Account receiverAccount = createAccount("receiver");
@@ -716,8 +723,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
         long lastRequestId = new Random().nextLong();
@@ -806,8 +813,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         List<Transaction> transactions = block.getTransactionsList();
         List<BlockHeader> uncles = block.getUncleList();
         long lastRequestId = new Random().nextLong();
@@ -857,8 +864,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
         BlockResponseMessage response = new BlockResponseMessage(new Random().nextLong(), block);
         processor.registerExpectedMessage(response);
 
@@ -897,8 +904,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         processor.processStatus(sender, StatusUtils.fromBlockchain(advancedBlockchain));
         BlockHeadersRequestMessage requestMessage = (BlockHeadersRequestMessage)messages.get(0);
@@ -960,8 +967,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         Status status = StatusUtils.fromBlockchain(advancedBlockchain);
         processor.processStatus(sender, status);
@@ -1020,8 +1027,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         int connectionPoint = 0;
         int step = 10;
@@ -1064,8 +1071,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         List<BlockIdentifier> blockIdentifiers = new ArrayList<>();
 
@@ -1104,8 +1111,8 @@ public class SyncProcessorTest {
                 new BlockCompositeRule(
                         new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())
                 ),
-                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager())
-        );
+                DIFFICULTY_CALCULATOR, new PeersInformation(channelManager, SyncConfiguration.IMMEDIATE_FOR_TESTING, blockchain, RskMockFactory.getPeerScoringManager()),
+                mock(Genesis.class));
 
         int connectionPoint = 25;
         int step = 10;

--- a/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
@@ -200,7 +200,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(50, node1.getBestBlock().getNumber());
@@ -244,7 +244,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());
@@ -288,7 +288,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,0,1,20,192);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,0,1,20,192, 20, 10);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());
@@ -338,7 +338,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b2);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b3, syncConfiguration);
 
         Assert.assertEquals(193, node1.getBestBlock().getNumber());
@@ -385,7 +385,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b2);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b2);
         SimpleAsyncNode node3 = SimpleAsyncNode.createDefaultNode(b3);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(3,1,10,100,20,192);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(3,1,10,100,20,192, 20, 10);
         SimpleAsyncNode node4 = SimpleAsyncNode.createNode(b1, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());

--- a/rskj-core/src/test/java/co/rsk/net/TwoAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TwoAsyncNodeTest.java
@@ -44,7 +44,7 @@ public class TwoAsyncNodeTest {
 
     private static SimpleAsyncNode createNode(int size) {
         final World world = new World();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = world.getBlockChain();
 
         List<Block> blocks = new BlockGenerator().getBlockChain(blockchain.getBestBlock(), size);
@@ -63,7 +63,7 @@ public class TwoAsyncNodeTest {
 
     private static SimpleAsyncNode createNodeWithUncles(int size) {
         final World world = new World();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = world.getBlockChain();
 
         List<Block> blocks = new BlockGenerator().getBlockChain(blockchain.getBestBlock(), size, 0, true);

--- a/rskj-core/src/test/java/co/rsk/net/TwoAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TwoAsyncNodeTest.java
@@ -56,7 +56,7 @@ public class TwoAsyncNodeTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), processor, null, null, null, null, new DummyBlockValidationRule());
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, null, null, null, null, new DummyBlockValidationRule(), mock(StatusResolver.class));
 
         return new SimpleAsyncNode(handler, blockchain);
     }
@@ -75,7 +75,7 @@ public class TwoAsyncNodeTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), processor, null, null, null, null, new DummyBlockValidationRule());
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, null, null, null, null, new DummyBlockValidationRule(), mock(StatusResolver.class));
 
         return new SimpleAsyncNode(handler, blockchain);
     }

--- a/rskj-core/src/test/java/co/rsk/net/TwoNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TwoNodeTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
 public class TwoNodeTest {
     private static SimpleNode createNode(int size) {
         final World world = new World();
-        final BlockStore store = new BlockStore();
+        final NetBlockStore store = new NetBlockStore();
         final Blockchain blockchain = world.getBlockChain();
 
         List<Block> blocks = new BlockGenerator().getBlockChain(blockchain.getBestBlock(), size);

--- a/rskj-core/src/test/java/co/rsk/net/TwoNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TwoNodeTest.java
@@ -54,7 +54,7 @@ public class TwoNodeTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
-        NodeMessageHandler handler = new NodeMessageHandler(new TestSystemProperties(), mock(org.ethereum.db.BlockStore.class), processor, null, null, null, null, new DummyBlockValidationRule());
+        NodeMessageHandler handler = new NodeMessageHandler(new TestSystemProperties(), processor, null, null, null, null, new DummyBlockValidationRule(), mock(StatusResolver.class));
 
         return new SimpleNode(handler, blockchain);
     }

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -141,7 +141,7 @@ public class SimpleAsyncNode extends SimpleNode {
                 new BlockCompositeRule(new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())),
                 new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants()), new PeersInformation(channelManager, syncConfiguration, blockchain, peerScoringManager)
         );
-        NodeMessageHandler handler = new NodeMessageHandler(config, mock(org.ethereum.db.BlockStore.class), processor, syncProcessor, channelManager, null, peerScoringManager, blockValidationRule);
+        NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, channelManager, null, peerScoringManager, blockValidationRule, mock(StatusResolver.class));
 
         return new SimpleAsyncNode(handler, blockchain, syncProcessor, channelManager);
     }

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -127,7 +127,7 @@ public class SimpleAsyncNode extends SimpleNode {
             Blockchain blockchain,
             SyncConfiguration syncConfiguration,
             org.ethereum.db.BlockStore indexedBlockStore) {
-        BlockStore blockStore = new BlockStore();
+        NetBlockStore blockStore = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         BlockSyncService blockSyncService = new BlockSyncService(config, blockStore, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(blockStore, blockchain, nodeInformation, blockSyncService, syncConfiguration);

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -34,6 +34,7 @@ import co.rsk.validators.BlockUnclesHashValidationRule;
 import co.rsk.validators.DummyBlockValidationRule;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Blockchain;
+import org.ethereum.core.Genesis;
 import org.ethereum.db.IndexedBlockStore;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
 import org.ethereum.util.RskMockFactory;
@@ -139,7 +140,9 @@ public class SimpleAsyncNode extends SimpleNode {
                 blockchain, indexedBlockStore, mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager, syncConfiguration, blockFactory,
                 blockValidationRule,
                 new BlockCompositeRule(new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())),
-                new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants()), new PeersInformation(channelManager, syncConfiguration, blockchain, peerScoringManager)
+                new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants()),
+                new PeersInformation(channelManager, syncConfiguration, blockchain, peerScoringManager),
+                mock(Genesis.class)
         );
         NodeMessageHandler handler = new NodeMessageHandler(config, processor, syncProcessor, channelManager, null, peerScoringManager, blockValidationRule, mock(StatusResolver.class));
 

--- a/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncStateTest.java
@@ -1,0 +1,265 @@
+package co.rsk.net.sync;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.crypto.Keccak256;
+import co.rsk.net.MessageChannel;
+import co.rsk.net.NodeID;
+import co.rsk.net.messages.BodyResponseMessage;
+import org.ethereum.core.*;
+import org.ethereum.db.BlockStore;
+import org.ethereum.util.ByteUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+
+import java.math.BigInteger;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.*;
+
+public class DownloadingBackwardsBodiesSyncStateTest {
+
+    private SyncConfiguration syncConfiguration;
+    private SyncEventsHandler syncEventsHandler;
+    private PeersInformation peersInformation;
+    private Genesis genesis;
+    private BlockFactory blockFactory;
+    private BlockStore blockStore;
+    private Block child;
+    private NodeID selectedPeerId;
+
+    @Before
+    public void setUp() {
+        syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
+        syncEventsHandler = mock(SyncEventsHandler.class);
+        peersInformation = mock(PeersInformation.class);
+        genesis = mock(Genesis.class);
+        blockFactory = mock(BlockFactory.class);
+        blockStore = mock(BlockStore.class);
+        child = mock(Block.class);
+        selectedPeerId = mock(NodeID.class);
+    }
+
+    /**
+     * This situation has no solution except a complete resynchronization.
+     * <p>
+     * The downloaded state was invalid and does not connect to genesis.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void onEnter_connectGenesis_genesisIsNotChildsParent() {
+        List<BlockHeader> toRequest = new LinkedList<>();
+        DownloadingBackwardsBodiesSyncState target = new DownloadingBackwardsBodiesSyncState(
+                syncConfiguration,
+                syncEventsHandler,
+                peersInformation,
+                genesis,
+                blockFactory,
+                blockStore,
+                child,
+                toRequest,
+                selectedPeerId);
+
+        when(child.getNumber()).thenReturn(1L);
+        when(genesis.isParentOf(child)).thenReturn(false);
+
+        target.onEnter();
+    }
+
+    /**
+     * This situation has no solution except a complete resynchronization.
+     * <p>
+     * The downloaded state was invalid and does not connect to genesis.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void onEnter_connectGenesis_difficultyDoesNotMatch() {
+        List<BlockHeader> toRequest = new LinkedList<>();
+        DownloadingBackwardsBodiesSyncState target = new DownloadingBackwardsBodiesSyncState(
+                syncConfiguration,
+                syncEventsHandler,
+                peersInformation,
+                genesis,
+                blockFactory,
+                blockStore,
+                child,
+                toRequest,
+                selectedPeerId);
+
+        Keccak256 childHash = new Keccak256(new byte[32]);
+        when(child.getHash()).thenReturn(childHash);
+        when(child.getNumber()).thenReturn(1L);
+
+        when(genesis.isParentOf(child)).thenReturn(true);
+
+        when(child.getCumulativeDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(50)));
+        when(genesis.getCumulativeDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(50)));
+        when(blockStore.getTotalDifficultyForHash(eq(childHash.getBytes())))
+                .thenReturn(new BlockDifficulty(BigInteger.valueOf(101)));
+
+        target.onEnter();
+    }
+
+    @Test
+    public void onEnter_connectGenesis() {
+        List<BlockHeader> toRequest = new LinkedList<>();
+        DownloadingBackwardsBodiesSyncState target = new DownloadingBackwardsBodiesSyncState(
+                syncConfiguration,
+                syncEventsHandler,
+                peersInformation,
+                genesis,
+                blockFactory,
+                blockStore,
+                child,
+                toRequest,
+                selectedPeerId);
+
+        Keccak256 childHash = new Keccak256(new byte[32]);
+        when(child.getHash()).thenReturn(childHash);
+        when(child.getNumber()).thenReturn(1L);
+
+        when(genesis.isParentOf(child)).thenReturn(true);
+
+        when(child.getCumulativeDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(50)));
+        BlockDifficulty cumulativeDifficulty = new BlockDifficulty(BigInteger.valueOf(50));
+        when(genesis.getCumulativeDifficulty()).thenReturn(cumulativeDifficulty);
+        when(blockStore.getTotalDifficultyForHash(eq(childHash.getBytes())))
+                .thenReturn(new BlockDifficulty(BigInteger.valueOf(100)));
+
+        target.onEnter();
+
+        verify(blockStore).saveBlock(eq(genesis), eq(cumulativeDifficulty), eq(true));
+        verify(blockStore).flush();
+        verify(syncEventsHandler).stopSyncing();
+    }
+
+    @Test
+    public void connectingUntilGenesis() {
+        LinkedList<BlockHeader> toRequest = new LinkedList<>();
+        LinkedList<BodyResponseMessage> responses = new LinkedList<>();
+        LinkedList<Block> expectedBlocks = new LinkedList<>();
+        Function<Long, BlockDifficulty> difficultyForBlockNumber =
+                (n) -> new BlockDifficulty(BigInteger.valueOf(n * (n + 1) / 2));
+
+        // This setup initializes responses and blocks so that the blocks have the same number and difficulty as
+        // their indexes and each one is the children of the previous block.
+        for (long i = 1; i <= 10; i++) {
+            BlockHeader headerToRequest = mock(BlockHeader.class);
+            when(headerToRequest.getNumber()).thenReturn(i);
+
+            Keccak256 headerHash = new Keccak256(ByteUtil.leftPadBytes(ByteUtil.longToBytes(i), 32));
+
+            when(headerToRequest.getHash()).thenReturn(headerHash);
+            toRequest.addFirst(headerToRequest);
+            when(syncEventsHandler.sendBodyRequest(eq(headerToRequest), any())).thenReturn(i);
+
+            BodyResponseMessage response = new BodyResponseMessage(i, new LinkedList<>(), new LinkedList<>());
+            responses.addFirst(response);
+
+            Block block = mock(Block.class);
+            expectedBlocks.addFirst(block);
+            when(block.getNumber()).thenReturn(i);
+            when(block.getHash()).thenReturn(headerHash);
+            when(blockFactory.newBlock(headerToRequest, response.getTransactions(), response.getUncles()))
+                    .thenReturn(block);
+
+            when(block.isParentOf(any())).thenReturn(true);
+            when(blockStore.getTotalDifficultyForHash(headerHash.getBytes()))
+                    .thenReturn(difficultyForBlockNumber.apply(i));
+            when(block.getCumulativeDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(i)));
+        }
+        when(genesis.isParentOf(expectedBlocks.getLast())).thenReturn(true);
+        when(genesis.getCumulativeDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(0L)));
+
+        Keccak256 childHash = new Keccak256(ByteUtil.leftPadBytes(ByteUtil.intToBytes(11), 32));
+        when(child.getHash()).thenReturn(childHash);
+        when(blockStore.getTotalDifficultyForHash(childHash.getBytes()))
+                .thenReturn(difficultyForBlockNumber.apply(11L));
+        when(child.getCumulativeDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(11L)));
+        when(child.getNumber()).thenReturn(11L);
+
+        DownloadingBackwardsBodiesSyncState target = new DownloadingBackwardsBodiesSyncState(
+                syncConfiguration,
+                syncEventsHandler,
+                peersInformation,
+                genesis,
+                blockFactory,
+                blockStore,
+                child,
+                toRequest,
+                selectedPeerId);
+
+        while (!responses.isEmpty()) {
+            target.onEnter();
+            target.newBody(responses.pop(), mock(MessageChannel.class));
+
+            Block block = expectedBlocks.pop();
+            BlockDifficulty expectedDifficulty = difficultyForBlockNumber.apply(block.getNumber());
+            verify(blockStore).saveBlock(eq(block), eq(expectedDifficulty), eq(true));
+        }
+    }
+
+    @Test
+    public void connecting_notGenesis() {
+        LinkedList<BlockHeader> toRequest = new LinkedList<>();
+        LinkedList<BodyResponseMessage> responses = new LinkedList<>();
+        LinkedList<Block> expectedBlocks = new LinkedList<>();
+        Function<Long, BlockDifficulty> difficultyForBlockNumber =
+                (n) -> new BlockDifficulty(BigInteger.valueOf(n*(n+1)/2));
+
+        // This setup initializes responses and blocks so that the blocks have the same number and difficulty as
+        // their indexes and each one is the children of the previous block.
+        for (long i = 2; i <= 10; i++) {
+            BlockHeader headerToRequest = mock(BlockHeader.class);
+            when(headerToRequest.getNumber()).thenReturn(i);
+
+            Keccak256 headerHash = new Keccak256(ByteUtil.leftPadBytes(ByteUtil.longToBytes(i), 32));
+
+            when(headerToRequest.getHash()).thenReturn(headerHash);
+            toRequest.addFirst(headerToRequest);
+            when(syncEventsHandler.sendBodyRequest(eq(headerToRequest), any())).thenReturn(i);
+
+            BodyResponseMessage response = new BodyResponseMessage(i, new LinkedList<>(), new LinkedList<>());
+            responses.addFirst(response);
+
+            Block block = mock(Block.class);
+            expectedBlocks.addFirst(block);
+            when(block.getNumber()).thenReturn(i);
+            when(block.getHash()).thenReturn(headerHash);
+            when(blockFactory.newBlock(headerToRequest, response.getTransactions(), response.getUncles()))
+                    .thenReturn(block);
+
+            when(block.isParentOf(any())).thenReturn(true);
+            when(blockStore.getTotalDifficultyForHash(headerHash.getBytes()))
+                    .thenReturn(difficultyForBlockNumber.apply(i));
+            when(block.getCumulativeDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(i)));
+        }
+
+        Keccak256 childHash = new Keccak256(ByteUtil.leftPadBytes(ByteUtil.intToBytes(11), 32));
+        when(child.getHash()).thenReturn(childHash);
+        when(blockStore.getTotalDifficultyForHash(childHash.getBytes()))
+                .thenReturn(difficultyForBlockNumber.apply(11L));
+        when(child.getCumulativeDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(11L)));
+        when(child.getNumber()).thenReturn(11L);
+
+        DownloadingBackwardsBodiesSyncState target = new DownloadingBackwardsBodiesSyncState(
+                syncConfiguration,
+                syncEventsHandler,
+                peersInformation,
+                genesis,
+                blockFactory,
+                blockStore,
+                child,
+                toRequest,
+                selectedPeerId);
+
+        while(!responses.isEmpty()) {
+            target.onEnter();
+            target.newBody(responses.pop(), mock(MessageChannel.class));
+
+            Block block = expectedBlocks.pop();
+            BlockDifficulty expectedDifficulty = difficultyForBlockNumber.apply(block.getNumber());
+            verify(blockStore).saveBlock(eq(block), eq(expectedDifficulty), eq(true));
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBackwardsHeadersSyncStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBackwardsHeadersSyncStateTest.java
@@ -1,0 +1,107 @@
+package co.rsk.net.sync;
+
+import co.rsk.crypto.Keccak256;
+import co.rsk.net.NodeID;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.db.BlockStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class DownloadingBackwardsHeadersSyncStateTest {
+
+    private SyncConfiguration syncConfiguration;
+    private SyncEventsHandler syncEventsHandler;
+    private BlockStore blockStore;
+    private NodeID selectedPeerId;
+
+    @Before
+    public void setUp () {
+        syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
+        syncEventsHandler = mock(SyncEventsHandler.class);
+        blockStore = mock(BlockStore.class);
+        selectedPeerId = mock(NodeID.class);
+    }
+
+    @Test
+    public void onEnter_requestSent() {
+        when(blockStore.getMinNumber()).thenReturn(50L);
+        Block child = mock(Block.class);
+        Keccak256 hash = new Keccak256(new byte[32]);
+        when(child.getHash()).thenReturn(hash);
+        when(blockStore.getChainBlockByNumber(50L)).thenReturn(child);
+
+        DownloadingBackwardsHeadersSyncState target = new DownloadingBackwardsHeadersSyncState(
+                syncConfiguration,
+                syncEventsHandler,
+                blockStore,
+                selectedPeerId);
+
+        ArgumentCaptor<ChunkDescriptor> descriptorCaptor = ArgumentCaptor.forClass(ChunkDescriptor.class);
+        when(syncEventsHandler.sendBlockHeadersRequest(descriptorCaptor.capture(), any())).thenReturn(true);
+
+        target.onEnter();
+
+        verify(syncEventsHandler).sendBlockHeadersRequest(any(), eq(selectedPeerId));
+        verify(syncEventsHandler, never()).onSyncIssue(any(), any());
+
+        assertEquals(descriptorCaptor.getValue().getHash(), hash.getBytes());
+        assertEquals(descriptorCaptor.getValue().getCount(), syncConfiguration.getChunkSize());
+    }
+
+    @Test
+    public void onEnter_requestNotSent() {
+        when(blockStore.getMinNumber()).thenReturn(50L);
+        Block child = mock(Block.class);
+        Keccak256 hash = new Keccak256(new byte[32]);
+        when(child.getHash()).thenReturn(hash);
+        when(blockStore.getChainBlockByNumber(50L)).thenReturn(child);
+
+        DownloadingBackwardsHeadersSyncState target = new DownloadingBackwardsHeadersSyncState(
+                syncConfiguration,
+                syncEventsHandler,
+                blockStore,
+                selectedPeerId);
+
+        ArgumentCaptor<ChunkDescriptor> descriptorCaptor = ArgumentCaptor.forClass(ChunkDescriptor.class);
+        when(syncEventsHandler.sendBlockHeadersRequest(descriptorCaptor.capture(), any())).thenReturn(false);
+
+        target.onEnter();
+
+        verify(syncEventsHandler).sendBlockHeadersRequest(any(), eq(selectedPeerId));
+        verify(syncEventsHandler).onSyncIssue(any(), any());
+
+        assertEquals(descriptorCaptor.getValue().getHash(), hash.getBytes());
+        assertEquals(descriptorCaptor.getValue().getCount(), syncConfiguration.getChunkSize());
+    }
+
+
+    @Test
+    public void newHeaders() {
+        when(blockStore.getMinNumber()).thenReturn(50L);
+        Block child = mock(Block.class);
+        Keccak256 hash = new Keccak256(new byte[32]);
+        when(child.getHash()).thenReturn(hash);
+        when(blockStore.getChainBlockByNumber(50L)).thenReturn(child);
+
+        DownloadingBackwardsHeadersSyncState target = new DownloadingBackwardsHeadersSyncState(
+                syncConfiguration,
+                syncEventsHandler,
+                blockStore,
+                selectedPeerId);
+
+
+        List<BlockHeader> receivedHeaders = new LinkedList<>();
+        target.newBlockHeaders(receivedHeaders);
+
+
+        verify(syncEventsHandler).backwardDownloadBodies(eq(selectedPeerId), eq(child), eq(receivedHeaders));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
@@ -3,6 +3,7 @@ package co.rsk.net.sync;
 
 import co.rsk.net.NodeID;
 import co.rsk.scoring.EventType;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockIdentifier;
 
@@ -20,6 +21,11 @@ public class SimpleSyncEventsHandler implements SyncEventsHandler {
 
     @Override
     public void startFindingConnectionPoint(NodeID peerId) {
+
+    }
+
+    @Override
+    public void backwardSyncing(NodeID peerId) {
 
     }
 
@@ -45,6 +51,11 @@ public class SimpleSyncEventsHandler implements SyncEventsHandler {
     @Override
     public void startSyncing(NodeID nodeID) {
         this.startSyncingWasCalled_ = true;
+    }
+
+    @Override
+    public void backwardDownloadBodies(NodeID peerId, Block parent, List<BlockHeader> toRequest) {
+
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -29,6 +29,7 @@ import co.rsk.db.StateRootHandler;
 import co.rsk.net.BlockNodeInformation;
 import co.rsk.net.BlockSyncService;
 import co.rsk.net.NodeBlockProcessor;
+import co.rsk.net.NetBlockStore;
 import co.rsk.net.sync.SyncConfiguration;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.BtcBlockStoreWithCache.Factory;
@@ -94,7 +95,7 @@ public class World {
         }
         this.saveBlock("g00", genesis);
 
-        co.rsk.net.BlockStore store = new co.rsk.net.BlockStore();
+        NetBlockStore store = new NetBlockStore();
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();


### PR DESCRIPTION
This PR adds backwards synchronization when importing an advanced blockchain state from a bootstrap file.

The **bootstrap file** contains blocks numbered *b_i, b_i+1 ... b_i+k* and the current addresses states at *b_n*.
Assuming a valid main chain *b_i* block, *b_i-1* can be validated by computing its hash and comparing it to the one indicated by *b_i*, this also indicates that *b_i-1* belongs to the main chain.

**Forward synchronization** from the current state is prioritized when the distance between the node's blockchain the tip of the peer's is over a configured value.

**Backwards synchronization** begins when the node is up to date with the current peers. It retrieves the block with the lowest number on the blockchain belonging to the main chain and synchronizes backwards requesting blocks by hash.

**Status** for broadcasting is considered to be genesis until the gap is filled. Perhaps a future version could broadcast the range of blocks currently connected.