### PR TITLE
Support logs parameter in eth_subscribe

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
@@ -266,8 +266,6 @@ public class BlockChainImpl implements Blockchain {
                 logger.trace("Rebranching: {} ~> {} From block {} ~> {} Difficulty {} Challenger difficulty {}",
                         bestBlock.getShortHash(), block.getShortHash(), bestBlock.getNumber(), block.getNumber(),
                         status.getTotalDifficulty(), totalDifficulty);
-                BlockFork fork = new BlockFork();
-                fork.calculate(bestBlock, block, blockStore);
                 blockStore.reBranch(block);
             }
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockFork.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockFork.java
@@ -19,18 +19,23 @@
 package co.rsk.core.bc;
 
 import org.ethereum.core.Block;
-import org.ethereum.db.BlockStore;
 
-import java.util.LinkedList;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * Created by ajlopez on 09/08/2016.
  */
 public class BlockFork {
-    private Block commonAncestor;
-    private List<Block> oldBlocks = new LinkedList<>();
-    private List<Block> newBlocks = new LinkedList<>();
+    private final Block commonAncestor;
+    private final List<Block> oldBlocks;
+    private final List<Block> newBlocks;
+
+    public BlockFork(Block commonAncestor, List<Block> oldBlocks, List<Block> newBlocks) {
+        this.commonAncestor = commonAncestor;
+        this.oldBlocks = Collections.unmodifiableList(oldBlocks);
+        this.newBlocks = Collections.unmodifiableList(newBlocks);
+    }
 
     /**
      * getCommonAncestor gets the common ancestor of the two chains.
@@ -58,35 +63,5 @@ public class BlockFork {
      */
     public List<Block> getNewBlocks() {
         return newBlocks;
-    }
-
-    public void calculate(Block fromBlock, Block toBlock, BlockStore store) {
-        Block oldBlock = fromBlock;
-        Block newBlock = toBlock;
-
-        if (oldBlock.isParentOf(newBlock)) {
-            commonAncestor = oldBlock;
-            newBlocks.add(newBlock);
-            return;
-        }
-
-        while (newBlock.getNumber() > oldBlock.getNumber()) {
-            newBlocks.add(0, newBlock);
-            newBlock = store.getBlockByHash(newBlock.getParentHash().getBytes());
-        }
-
-        while (oldBlock.getNumber() > newBlock.getNumber()) {
-            oldBlocks.add(0, oldBlock);
-            oldBlock = store.getBlockByHash(oldBlock.getParentHash().getBytes());
-        }
-
-        while (!oldBlock.getHash().equals(newBlock.getHash())) {
-            newBlocks.add(0, newBlock);
-            newBlock = store.getBlockByHash(newBlock.getParentHash().getBytes());
-            oldBlocks.add(0, oldBlock);
-            oldBlock = store.getBlockByHash(oldBlock.getParentHash().getBytes());
-        }
-
-        commonAncestor = oldBlock;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockchainBranchComparator.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockchainBranchComparator.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.core.bc;
+
+import org.ethereum.core.Block;
+import org.ethereum.db.BlockStore;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class BlockchainBranchComparator {
+    private final BlockStore blockStore;
+
+    public BlockchainBranchComparator(BlockStore blockStore) {
+        this.blockStore = blockStore;
+    }
+
+    /**
+     * Returns the branches of both blocks up to a common ancestor
+     */
+    public BlockFork calculateFork(Block fromBlock, Block toBlock) {
+        List<Block> oldBlocks = new LinkedList<>();
+        List<Block> newBlocks = new LinkedList<>();
+
+        Block oldBlock = fromBlock;
+        Block newBlock = toBlock;
+
+        if (oldBlock.isParentOf(newBlock)) {
+            newBlocks.add(newBlock);
+            return new BlockFork(oldBlock, oldBlocks, newBlocks);
+        }
+
+        while (newBlock.getNumber() > oldBlock.getNumber()) {
+            newBlocks.add(0, newBlock);
+            newBlock = blockStore.getBlockByHash(newBlock.getParentHash().getBytes());
+        }
+
+        while (oldBlock.getNumber() > newBlock.getNumber()) {
+            oldBlocks.add(0, oldBlock);
+            oldBlock = blockStore.getBlockByHash(oldBlock.getParentHash().getBytes());
+        }
+
+        while (!oldBlock.getHash().equals(newBlock.getHash())) {
+            newBlocks.add(0, newBlock);
+            newBlock = blockStore.getBlockByHash(newBlock.getParentHash().getBytes());
+            oldBlocks.add(0, oldBlock);
+            oldBlock = blockStore.getBlockByHash(oldBlock.getParentHash().getBytes());
+        }
+
+        return new BlockFork(oldBlock, oldBlocks, newBlocks);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -286,8 +286,8 @@ public class TransactionPoolImpl implements TransactionPool {
         logger.trace("Processing best block {} {}", block.getNumber(), block.getShortHash());
 
         if (bestBlock != null) {
-            BlockFork fork = new BlockFork();
-            fork.calculate(bestBlock, block, blockStore);
+            BlockchainBranchComparator branchComparator = new BlockchainBranchComparator(blockStore);
+            BlockFork fork = branchComparator.calculateFork(bestBlock, block);
 
             for (Block blk : fork.getOldBlocks()) {
                 retractBlock(blk);

--- a/rskj-core/src/main/java/co/rsk/rpc/EthSubscriptionNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/EthSubscriptionNotificationEmitter.java
@@ -19,43 +19,33 @@ package co.rsk.rpc;
 
 import co.rsk.rpc.modules.eth.subscribe.*;
 import io.netty.channel.Channel;
-import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
-import org.ethereum.core.Block;
-import org.ethereum.core.TransactionReceipt;
-import org.ethereum.facade.Ethereum;
-import org.ethereum.listener.EthereumListenerAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This manages subscriptions and emits events to interested clients.
  * Can only be used with the WebSockets transport.
  */
 public class EthSubscriptionNotificationEmitter implements EthSubscribeParamsVisitor {
-    private static final Logger LOGGER = LoggerFactory.getLogger(EthSubscriptionNotificationEmitter.class);
+    private final BlockHeaderNotificationEmitter blockHeader;
+    private final LogsNotificationEmitter logs;
 
-    private final Map<SubscriptionId, Channel> subscriptions = new ConcurrentHashMap<>();
-    private final JsonRpcSerializer jsonRpcSerializer;
-
-    public EthSubscriptionNotificationEmitter(Ethereum ethereum, JsonRpcSerializer jsonRpcSerializer) {
-        ethereum.addListener(new EthereumListenerAdapter() {
-            @Override
-            public void onBlock(Block block, List<TransactionReceipt> receipts) {
-                emit(block);
-            }
-        });
-        this.jsonRpcSerializer = jsonRpcSerializer;
+    public EthSubscriptionNotificationEmitter(
+            BlockHeaderNotificationEmitter blockHeader,
+            LogsNotificationEmitter logs) {
+        this.blockHeader = blockHeader;
+        this.logs = logs;
     }
 
     @Override
     public SubscriptionId visit(EthSubscribeNewHeadsParams params, Channel channel) {
         SubscriptionId subscriptionId = new SubscriptionId();
-        subscriptions.put(subscriptionId, channel);
+        blockHeader.subscribe(subscriptionId, channel);
+        return subscriptionId;
+    }
+
+    @Override
+    public SubscriptionId visit(EthSubscribeLogsParams params, Channel channel) {
+        SubscriptionId subscriptionId = new SubscriptionId();
+        logs.subscribe(subscriptionId, channel, params);
         return subscriptionId;
     }
 
@@ -63,30 +53,17 @@ public class EthSubscriptionNotificationEmitter implements EthSubscribeParamsVis
      * @return whether the unsubscription succeeded.
      */
     public boolean unsubscribe(SubscriptionId subscriptionId) {
-        return subscriptions.remove(subscriptionId) != null;
+        // temporal variables avoid short-circuiting behavior
+        boolean unsubscribedBlockHeader = blockHeader.unsubscribe(subscriptionId);
+        boolean unsubscribedLogs = logs.unsubscribe(subscriptionId);
+        return unsubscribedBlockHeader || unsubscribedLogs;
     }
 
     /**
      * Clear all subscriptions for channel.
      */
     public void unsubscribe(Channel channel) {
-        subscriptions.values().removeIf(channel::equals);
-    }
-
-    private void emit(Block block) {
-        BlockHeaderNotification header = new BlockHeaderNotification(block);
-
-        subscriptions.forEach((SubscriptionId id, Channel channel) -> {
-            EthSubscriptionNotification request = new EthSubscriptionNotification(
-                    new EthSubscriptionParams(id, header)
-            );
-
-            try {
-                String msg = jsonRpcSerializer.serializeMessage(request);
-                channel.writeAndFlush(new TextWebSocketFrame(msg));
-            } catch (IOException e) {
-                LOGGER.error("Couldn't serialize block header result for notification", e);
-            }
-        });
+        blockHeader.unsubscribe(channel);
+        logs.unsubscribe(channel);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/EthSubscriptionNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/EthSubscriptionNotificationEmitter.java
@@ -17,10 +17,7 @@
  */
 package co.rsk.rpc;
 
-import co.rsk.rpc.modules.eth.subscribe.BlockHeaderNotification;
-import co.rsk.rpc.modules.eth.subscribe.EthSubscriptionNotification;
-import co.rsk.rpc.modules.eth.subscribe.EthSubscriptionParams;
-import co.rsk.rpc.modules.eth.subscribe.SubscriptionId;
+import co.rsk.rpc.modules.eth.subscribe.*;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import org.ethereum.core.Block;
@@ -39,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * This manages subscriptions and emits events to interested clients.
  * Can only be used with the WebSockets transport.
  */
-public class EthSubscriptionNotificationEmitter {
+public class EthSubscriptionNotificationEmitter implements EthSubscribeParamsVisitor {
     private static final Logger LOGGER = LoggerFactory.getLogger(EthSubscriptionNotificationEmitter.class);
 
     private final Map<SubscriptionId, Channel> subscriptions = new ConcurrentHashMap<>();
@@ -55,11 +52,8 @@ public class EthSubscriptionNotificationEmitter {
         this.jsonRpcSerializer = jsonRpcSerializer;
     }
 
-    /**
-     * @param channel a Netty channel to subscribe notifications to.
-     * @return a subscription id which should be used as an unsubscribe parameter.
-     */
-    public SubscriptionId subscribe(Channel channel) {
+    @Override
+    public SubscriptionId visit(EthSubscribeNewHeadsParams params, Channel channel) {
         SubscriptionId subscriptionId = new SubscriptionId();
         subscriptions.put(subscriptionId, channel);
         return subscriptionId;

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/BlockHeaderNotification.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/BlockHeaderNotification.java
@@ -24,7 +24,7 @@ import org.ethereum.rpc.TypeConverter;
 /**
  * The block header DTO for JSON serialization purposes.
  */
-public class BlockHeaderNotification {
+public class BlockHeaderNotification implements EthSubscriptionNotificationDTO {
     private final String difficulty;
     private final String extraData;
     private final String gasLimit;

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/BlockHeaderNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/BlockHeaderNotificationEmitter.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.rpc.JsonRpcSerializer;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.ethereum.core.Block;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.listener.EthereumListenerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class BlockHeaderNotificationEmitter {
+    private static final Logger logger = LoggerFactory.getLogger(BlockHeaderNotificationEmitter.class);
+
+    private final JsonRpcSerializer jsonRpcSerializer;
+
+    private final Map<SubscriptionId, Channel> subscriptions = new ConcurrentHashMap<>();
+
+    public BlockHeaderNotificationEmitter(Ethereum ethereum, JsonRpcSerializer jsonRpcSerializer) {
+        this.jsonRpcSerializer = jsonRpcSerializer;
+        ethereum.addListener(new EthereumListenerAdapter() {
+            @Override
+            public void onBlock(Block block, List<TransactionReceipt> receipts) {
+                emitBlockHeader(block);
+            }
+        });
+    }
+
+    public void subscribe(SubscriptionId subscriptionId, Channel channel) {
+        subscriptions.put(subscriptionId, channel);
+    }
+
+    public boolean unsubscribe(SubscriptionId subscriptionId) {
+        return subscriptions.remove(subscriptionId) != null;
+    }
+
+    public void unsubscribe(Channel channel) {
+        subscriptions.values().removeIf(channel::equals);
+    }
+
+    private void emitBlockHeader(Block block) {
+        if (subscriptions.isEmpty()) {
+            return;
+        }
+
+        BlockHeaderNotification header = new BlockHeaderNotification(block);
+
+        subscriptions.forEach((SubscriptionId id, Channel channel) -> {
+            EthSubscriptionNotification request = new EthSubscriptionNotification(
+                    new EthSubscriptionParams(id, header)
+            );
+
+            try {
+                String msg = jsonRpcSerializer.serializeMessage(request);
+                channel.writeAndFlush(new TextWebSocketFrame(msg));
+            } catch (IOException e) {
+                logger.error("Couldn't serialize block header result for notification", e);
+            }
+        });
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeLogsParams.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeLogsParams.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth.subscribe;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.netty.channel.Channel;
+
+import java.util.Arrays;
+
+@JsonDeserialize
+public class EthSubscribeLogsParams implements EthSubscribeParams {
+
+    private final String address;
+    private final String[] topics;
+
+    public EthSubscribeLogsParams() {
+        this(null, new String[0]);
+    }
+
+    @JsonCreator
+    public EthSubscribeLogsParams(
+            @JsonProperty("address") String address,
+            @JsonProperty("topics") String[] topics
+    ) {
+        this.address = address;
+        this.topics = topics == null? new String[0]: topics;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String[] getTopics() {
+        return Arrays.copyOf(topics, topics.length);
+    }
+
+    @Override
+    public SubscriptionId accept(EthSubscribeParamsVisitor visitor, Channel channel) {
+        return visitor.visit(this, channel);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeNewHeadsParams.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeNewHeadsParams.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of RskJ
- * Copyright (C) 2018 RSK Labs Ltd.
+ * Copyright (C) 2019 RSK Labs Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -15,25 +15,17 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package co.rsk.rpc.modules.eth.subscribe;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import java.util.Objects;
-
-@JsonDeserialize(using = EthSubscribeParamsDeserializer.class)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-public abstract class EthSubscribeParams {
-
-    private final EthSubscribeTypes subscription;
+@JsonDeserialize
+public class EthSubscribeNewHeadsParams extends EthSubscribeParams {
 
     @JsonCreator
-    public EthSubscribeParams(EthSubscribeTypes subscription) {
-        this.subscription = Objects.requireNonNull(subscription);
-    }
-
-    public EthSubscribeTypes getSubscription() {
-        return subscription;
+    public EthSubscribeNewHeadsParams() {
+        super(EthSubscribeTypes.NEW_HEADS);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeNewHeadsParams.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeNewHeadsParams.java
@@ -18,14 +18,13 @@
 
 package co.rsk.rpc.modules.eth.subscribe;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.netty.channel.Channel;
 
 @JsonDeserialize
-public class EthSubscribeNewHeadsParams extends EthSubscribeParams {
-
-    @JsonCreator
-    public EthSubscribeNewHeadsParams() {
-        super(EthSubscribeTypes.NEW_HEADS);
+public class EthSubscribeNewHeadsParams implements EthSubscribeParams {
+    @Override
+    public SubscriptionId accept(EthSubscribeParamsVisitor visitor, Channel channel) {
+        return visitor.visit(this, channel);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParams.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParams.java
@@ -17,23 +17,12 @@
  */
 package co.rsk.rpc.modules.eth.subscribe;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
-import java.util.Objects;
+import io.netty.channel.Channel;
 
 @JsonDeserialize(using = EthSubscribeParamsDeserializer.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-public abstract class EthSubscribeParams {
-
-    private final EthSubscribeTypes subscription;
-
-    @JsonCreator
-    public EthSubscribeParams(EthSubscribeTypes subscription) {
-        this.subscription = Objects.requireNonNull(subscription);
-    }
-
-    public EthSubscribeTypes getSubscription() {
-        return subscription;
-    }
+public interface EthSubscribeParams {
+    SubscriptionId accept(EthSubscribeParamsVisitor visitor, Channel channel);
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth.subscribe;
+
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+public class EthSubscribeParamsDeserializer extends JsonDeserializer {
+    @Override
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (!p.isExpectedStartArrayToken()) {
+            return ctxt.handleUnexpectedToken(
+                    EthSubscribeParams.class,
+                    p.currentToken(),
+                    p,
+                    "eth_subscribe parameters are expected to be arrays"
+            );
+        }
+        p.nextToken(); // skip '['
+        EthSubscribeTypes subscriptionType = p.readValueAs(EthSubscribeTypes.class);
+        p.nextToken();
+        EthSubscribeParams params;
+        if (p.isExpectedStartObjectToken()) {
+            params = p.readValueAs(subscriptionType.requestClass());
+            p.nextToken();
+        } else {
+            try {
+                params = subscriptionType.requestClass().newInstance();
+            } catch (InstantiationException | IllegalAccessException e) {
+                return ctxt.handleInstantiationProblem(
+                        subscriptionType.requestClass(),
+                        null,
+                        e
+                );
+            }
+        }
+        if (p.currentToken() != JsonToken.END_ARRAY) {
+            return ctxt.handleUnexpectedToken(
+                    EthSubscribeParams.class,
+                    p.currentToken(),
+                    p,
+                    "eth_subscribe can only have one object to configure subscription"
+            );
+        }
+        return params;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
@@ -37,6 +37,7 @@ public class EthSubscribeParamsDeserializer extends JsonDeserializer {
     public EthSubscribeParamsDeserializer() {
         this.subscriptionTypes = new HashMap<>();
         this.subscriptionTypes.put("newHeads", EthSubscribeNewHeadsParams.class);
+        this.subscriptionTypes.put("logs", EthSubscribeLogsParams.class);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
@@ -18,13 +18,27 @@
 
 package co.rsk.rpc.modules.eth.subscribe;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
 import java.io.IOException;
+import java.util.HashMap;
 
+/**
+ * This class is necessary until https://github.com/FasterXML/jackson-databind/issues/2467 is integrated.
+ * It is expected to be included in Jackson 2.10 version.
+ */
 public class EthSubscribeParamsDeserializer extends JsonDeserializer {
+
+    private final HashMap<String, Class<? extends EthSubscribeParams>> subscriptionTypes;
+
+    public EthSubscribeParamsDeserializer() {
+        this.subscriptionTypes = new HashMap<>();
+        this.subscriptionTypes.put("newHeads", EthSubscribeNewHeadsParams.class);
+    }
+
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         if (!p.isExpectedStartArrayToken()) {
@@ -36,18 +50,19 @@ public class EthSubscribeParamsDeserializer extends JsonDeserializer {
             );
         }
         p.nextToken(); // skip '['
-        EthSubscribeTypes subscriptionType = p.readValueAs(EthSubscribeTypes.class);
+        String subscriptionType = p.getText();
+        Class<? extends EthSubscribeParams> subscriptionTypeClass = subscriptionTypes.get(subscriptionType);
         p.nextToken();
         EthSubscribeParams params;
         if (p.isExpectedStartObjectToken()) {
-            params = p.readValueAs(subscriptionType.requestClass());
+            params = p.readValueAs(subscriptionTypeClass);
             p.nextToken();
         } else {
             try {
-                params = subscriptionType.requestClass().newInstance();
+                params = subscriptionTypeClass.newInstance();
             } catch (InstantiationException | IllegalAccessException e) {
                 return ctxt.handleInstantiationProblem(
-                        subscriptionType.requestClass(),
+                        subscriptionTypeClass,
                         null,
                         e
                 );

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsVisitor.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of RskJ
- * Copyright (C) 2018 RSK Labs Ltd.
+ * Copyright (C) 2019 RSK Labs Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,16 +17,16 @@
  */
 package co.rsk.rpc.modules.eth.subscribe;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import io.netty.channel.Channel;
 
-public enum EthSubscribeTypes {
-    @JsonProperty("newHeads")
-    NEW_HEADS {
-        @Override
-        public Class<? extends EthSubscribeParams> requestClass() {
-            return EthSubscribeNewHeadsParams.class;
-        }
-    };
-
-    public abstract Class<? extends EthSubscribeParams> requestClass();
+/**
+ * Classes implementing this interface know how to handle JSON-RPC eth_subscribe requests.
+ */
+public interface EthSubscribeParamsVisitor {
+    /**
+     * @param params new heads subscription request parameters.
+     * @param channel a Netty channel to subscribe notifications to.
+     * @return a subscription id which should be used as an unsubscribe parameter.
+     */
+    SubscriptionId visit(EthSubscribeNewHeadsParams params, Channel channel);
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeTypes.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeTypes.java
@@ -21,5 +21,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum EthSubscribeTypes {
     @JsonProperty("newHeads")
-    NEW_HEADS
+    NEW_HEADS {
+        @Override
+        public Class<? extends EthSubscribeParams> requestClass() {
+            return EthSubscribeNewHeadsParams.class;
+        }
+    };
+
+    public abstract Class<? extends EthSubscribeParams> requestClass();
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscriptionNotificationDTO.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscriptionNotificationDTO.java
@@ -17,23 +17,8 @@
  */
 package co.rsk.rpc.modules.eth.subscribe;
 
-import io.netty.channel.Channel;
-
 /**
- * Classes implementing this interface know how to handle JSON-RPC eth_subscribe requests.
+ * A marker interface for the actual notification contents
  */
-public interface EthSubscribeParamsVisitor {
-    /**
-     * @param params new heads subscription request parameters.
-     * @param channel a Netty channel to subscribe notifications to.
-     * @return a subscription id which should be used as an unsubscribe parameter.
-     */
-    SubscriptionId visit(EthSubscribeNewHeadsParams params, Channel channel);
-
-    /**
-     * @param params logs subscription request parameters.
-     * @param channel a Netty channel to subscribe notifications to.
-     * @return a subscription id which should be used as an unsubscribe parameter.
-     */
-    SubscriptionId visit(EthSubscribeLogsParams params, Channel channel);
+public interface EthSubscriptionNotificationDTO {
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscriptionParams.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscriptionParams.java
@@ -26,9 +26,9 @@ import java.util.Objects;
  */
 public class EthSubscriptionParams {
     private final SubscriptionId subscription;
-    private final BlockHeaderNotification result;
+    private final EthSubscriptionNotificationDTO result;
 
-    public EthSubscriptionParams(SubscriptionId subscription, BlockHeaderNotification result) {
+    public EthSubscriptionParams(SubscriptionId subscription, EthSubscriptionNotificationDTO result) {
         this.subscription = Objects.requireNonNull(subscription);
         this.result = Objects.requireNonNull(result);
     }
@@ -39,7 +39,7 @@ public class EthSubscriptionParams {
     }
 
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    public BlockHeaderNotification getResult() {
+    public EthSubscriptionNotificationDTO getResult() {
         return result;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/LogsNotification.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/LogsNotification.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth.subscribe;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.ethereum.vm.LogInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.ethereum.rpc.TypeConverter.toJsonHex;
+import static org.ethereum.rpc.TypeConverter.toQuantityJsonHex;
+
+/**
+ * The logs DTO for JSON serialization purposes.
+ */
+public class LogsNotification implements EthSubscriptionNotificationDTO {
+    private final String logIndex;
+    private final String blockNumber;
+    private final String blockHash;
+    private final String transactionHash;
+    private final String transactionIndex;
+    private final String address;
+    private final String data;
+    private final List<String> topics;
+    private final boolean removed;
+
+    public LogsNotification(LogInfo logInfo, Block b, int txIndex, Transaction tx, int logIdx, boolean r) {
+        logIndex = toQuantityJsonHex(logIdx);
+        blockNumber = toQuantityJsonHex(b.getNumber());
+        blockHash = b.getHashJsonString();
+        removed = r;
+        transactionIndex = toQuantityJsonHex(txIndex);
+        transactionHash = tx.getHash().toJsonString();
+        address = toJsonHex(logInfo.getAddress());
+        data = toJsonHex(logInfo.getData());
+        topics = logInfo.getTopics().stream()
+                .map(t -> toJsonHex(t.getData()))
+                .collect(Collectors.toList());
+    }
+
+    public String getLogIndex() {
+        return logIndex;
+    }
+
+    public String getBlockNumber() {
+        return blockNumber;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public String getTransactionHash() {
+        return transactionHash;
+    }
+
+    public String getTransactionIndex() {
+        return transactionIndex;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public List<String> getTopics() {
+        return Collections.unmodifiableList(topics);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public boolean getRemoved() {
+        return removed;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/LogsNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/LogsNotificationEmitter.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.core.bc.BlockFork;
+import co.rsk.core.bc.BlockchainBranchComparator;
+import co.rsk.rpc.JsonRpcSerializer;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.db.TransactionInfo;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.listener.EthereumListenerAdapter;
+import org.ethereum.vm.LogInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LogsNotificationEmitter {
+    private static final Logger logger = LoggerFactory.getLogger(LogsNotificationEmitter.class);
+
+    private final JsonRpcSerializer jsonRpcSerializer;
+    private final ReceiptStore receiptStore;
+    private final BlockchainBranchComparator branchComparator;
+
+    private final Map<SubscriptionId, Channel> subscriptions = new ConcurrentHashMap<>();
+    private Block lastEmitted;
+
+    public LogsNotificationEmitter(
+            Ethereum ethereum,
+            JsonRpcSerializer jsonRpcSerializer,
+            ReceiptStore receiptStore,
+            BlockchainBranchComparator branchComparator) {
+        this.jsonRpcSerializer = jsonRpcSerializer;
+        this.receiptStore = receiptStore;
+        this.branchComparator = branchComparator;
+        ethereum.addListener(new EthereumListenerAdapter() {
+            @Override
+            public void onBestBlock(Block block, List<TransactionReceipt> receipts) {
+                emitLogs(block);
+            }
+        });
+    }
+
+    public void subscribe(SubscriptionId subscriptionId, Channel channel, EthSubscribeLogsParams params) {
+        subscriptions.put(subscriptionId, channel);
+    }
+
+    public boolean unsubscribe(SubscriptionId subscriptionId) {
+        return subscriptions.remove(subscriptionId) != null;
+    }
+
+    public void unsubscribe(Channel channel) {
+        subscriptions.values().removeIf(channel::equals);
+    }
+
+    private void emitLogs(Block block) {
+        if (subscriptions.isEmpty()) {
+            return;
+        }
+
+        if (lastEmitted == null) {
+            emitLogs(getLogsNotifications(block, false));
+        } else {
+            BlockFork blockFork = branchComparator.calculateFork(lastEmitted, block);
+            for (Block oldBlock : blockFork.getOldBlocks()) {
+                emitLogs(getLogsNotifications(oldBlock, true));
+            }
+
+            for (Block newBlock : blockFork.getNewBlocks()) {
+                emitLogs(getLogsNotifications(newBlock, false));
+            }
+        }
+
+        lastEmitted = block;
+    }
+
+    private void emitLogs(List<LogsNotification> notifications) {
+        for (Map.Entry<SubscriptionId, Channel> entry : subscriptions.entrySet()) {
+            SubscriptionId id = entry.getKey();
+            Channel channel = entry.getValue();
+
+            for (LogsNotification notification : notifications) {
+                EthSubscriptionNotification request = new EthSubscriptionNotification(
+                        new EthSubscriptionParams(id, notification)
+                );
+
+                try {
+                    String msg = jsonRpcSerializer.serializeMessage(request);
+                    channel.write(new TextWebSocketFrame(msg));
+                } catch (IOException e) {
+                    logger.error("Couldn't serialize block header result for notification", e);
+                }
+            }
+
+            channel.flush();
+        }
+    }
+
+    private List<LogsNotification> getLogsNotifications(Block block, boolean removed) {
+        List<LogsNotification> notifications = new ArrayList<>();
+        for (int transactionIndex = 0; transactionIndex < block.getTransactionsList().size(); transactionIndex++) {
+            Transaction transaction = block.getTransactionsList().get(transactionIndex);
+            Optional<TransactionInfo> transactionInfoOpt = receiptStore.get(transaction.getHash(), block.getHash());
+            if (!transactionInfoOpt.isPresent()) {
+                logger.error("Missing receipt for transaction {} in block {}", transaction.getHash(), block.getHash());
+                continue;
+            }
+
+            TransactionInfo transactionInfo = transactionInfoOpt.get();
+            TransactionReceipt receipt = transactionInfo.getReceipt();
+            List<LogInfo> logInfoList = receipt.getLogInfoList();
+            for (int logIndex = 0; logIndex < logInfoList.size(); logIndex++) {
+                LogInfo logInfo = logInfoList.get(logIndex);
+                LogsNotification notification = new LogsNotification(
+                        logInfo, block, transactionIndex, transaction, logIndex, removed);
+                notifications.add(notification);
+            }
+        }
+
+        return notifications;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskJsonRpcHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskJsonRpcHandler.java
@@ -17,13 +17,14 @@
  */
 package co.rsk.rpc.netty;
 
-import co.rsk.jsonrpc.*;
+import co.rsk.jsonrpc.JsonRpcBooleanResult;
+import co.rsk.jsonrpc.JsonRpcIdentifiableMessage;
+import co.rsk.jsonrpc.JsonRpcResultOrError;
 import co.rsk.rpc.EthSubscriptionNotificationEmitter;
 import co.rsk.rpc.JsonRpcSerializer;
 import co.rsk.rpc.modules.RskJsonRpcRequest;
 import co.rsk.rpc.modules.RskJsonRpcRequestVisitor;
 import co.rsk.rpc.modules.eth.subscribe.EthSubscribeRequest;
-import co.rsk.rpc.modules.eth.subscribe.EthSubscribeTypes;
 import co.rsk.rpc.modules.eth.subscribe.EthUnsubscribeRequest;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.ByteBufInputStream;
@@ -94,13 +95,6 @@ public class RskJsonRpcHandler
 
     @Override
     public JsonRpcResultOrError visit(EthSubscribeRequest request, ChannelHandlerContext ctx) {
-        EthSubscribeTypes subscribeType = request.getParams().getSubscription();
-        switch (subscribeType) {
-            case NEW_HEADS:
-                return emitter.subscribe(ctx.channel());
-            default:
-                LOGGER.error("Subscription type {} is not implemented", subscribeType);
-                return new JsonRpcInternalError();
-        }
+        return request.getParams().accept(emitter, ctx.channel());
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/db/ReceiptStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/ReceiptStore.java
@@ -19,9 +19,11 @@
 
 package org.ethereum.db;
 
+import co.rsk.crypto.Keccak256;
 import org.ethereum.core.TransactionReceipt;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by Ruben on 6/1/2016.
@@ -34,7 +36,7 @@ public interface ReceiptStore {
 
     TransactionInfo get(byte[] transactionHash);
 
-    TransactionInfo get(byte[] transactionHash, byte[] blockHash, BlockStore store);
+    Optional<TransactionInfo> get(Keccak256 transactionHash, Keccak256 blockHash);
 
     TransactionInfo getInMainChain(byte[] transactionHash, BlockStore store);
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockchainBranchComparatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockchainBranchComparatorTest.java
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * Created by ajlopez on 09/08/2016.
  */
-public class BlockForkTest {
+public class BlockchainBranchComparatorTest {
 
     public static final BlockDifficulty TEST_DIFFICULTY = new BlockDifficulty(BigInteger.ONE);
     private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
@@ -52,9 +52,9 @@ public class BlockForkTest {
         store.saveBlock(genesis, TEST_DIFFICULTY, true);
         store.saveBlock(block, TEST_DIFFICULTY, true);
 
-        BlockFork fork = new BlockFork();
+        BlockchainBranchComparator comparator = new BlockchainBranchComparator(store);
 
-        fork.calculate(genesis, block, store);
+        BlockFork fork = comparator.calculateFork(genesis, block);
 
         Assert.assertSame(genesis, fork.getCommonAncestor());
         Assert.assertTrue(fork.getOldBlocks().isEmpty());
@@ -76,9 +76,9 @@ public class BlockForkTest {
         List<Block> oldBranch = makeChain(parent, 2, store, blockGenerator);
         List<Block> newBranch = makeChain(parent, 2, store, blockGenerator);
 
-        BlockFork fork = new BlockFork();
+        BlockchainBranchComparator comparator = new BlockchainBranchComparator(store);
 
-        fork.calculate(oldBranch.get(1), newBranch.get(1) , store);
+        BlockFork fork = comparator.calculateFork(oldBranch.get(1), newBranch.get(1));
 
         Assert.assertEquals(parent.getHash(), fork.getCommonAncestor().getHash());
 
@@ -106,9 +106,9 @@ public class BlockForkTest {
         List<Block> oldBranch = makeChain(parent, 2, store, blockGenerator);
         List<Block> newBranch = makeChain(parent, 3, store, blockGenerator);
 
-        BlockFork fork = new BlockFork();
+        BlockchainBranchComparator comparator = new BlockchainBranchComparator(store);
 
-        fork.calculate(oldBranch.get(1), newBranch.get(2) , store);
+        BlockFork fork = comparator.calculateFork(oldBranch.get(1), newBranch.get(2));
 
         Assert.assertEquals(parent.getHash(), fork.getCommonAncestor().getHash());
 
@@ -137,9 +137,9 @@ public class BlockForkTest {
         List<Block> oldBranch = makeChain(parent, 3, store, blockGenerator);
         List<Block> newBranch = makeChain(parent, 2, store, blockGenerator);
 
-        BlockFork fork = new BlockFork();
+        BlockchainBranchComparator comparator = new BlockchainBranchComparator(store);
 
-        fork.calculate(oldBranch.get(2), newBranch.get(1) , store);
+        BlockFork fork = comparator.calculateFork(oldBranch.get(2), newBranch.get(1));
 
         Assert.assertEquals(parent.getHash(), fork.getCommonAncestor().getHash());
 

--- a/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
@@ -18,6 +18,7 @@
 package co.rsk.rpc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.rpc.modules.eth.subscribe.EthSubscribeNewHeadsParams;
 import co.rsk.rpc.modules.eth.subscribe.SubscriptionId;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.netty.channel.Channel;
@@ -56,13 +57,14 @@ public class EthSubscriptionNotificationEmitterTest {
     public void subscribeReturnsSubscriptionId() {
         Channel channel = mock(Channel.class);
 
-        assertThat(emitter.subscribe(channel), notNullValue());
+        EthSubscribeNewHeadsParams params = mock(EthSubscribeNewHeadsParams.class);
+        assertThat(emitter.visit(params, channel), notNullValue());
     }
 
     @Test
     public void ethereumOnBlockEventTriggersMessageToChannel() throws JsonProcessingException {
         Channel channel = mock(Channel.class);
-        emitter.subscribe(channel);
+        emitter.visit(new EthSubscribeNewHeadsParams(), channel);
         when(serializer.serializeMessage(any()))
                 .thenReturn("serialized");
 
@@ -73,7 +75,7 @@ public class EthSubscriptionNotificationEmitterTest {
     @Test
     public void unsubscribeSucceedsForExistingSubscriptionId() {
         Channel channel = mock(Channel.class);
-        SubscriptionId subscriptionId = emitter.subscribe(channel);
+        SubscriptionId subscriptionId = emitter.visit(new EthSubscribeNewHeadsParams(), channel);
 
         assertThat(emitter.unsubscribe(new SubscriptionId()), is(false));
         assertThat(emitter.unsubscribe(subscriptionId), is(true));

--- a/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
@@ -17,18 +17,10 @@
  */
 package co.rsk.rpc;
 
-import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.rpc.modules.eth.subscribe.EthSubscribeNewHeadsParams;
-import co.rsk.rpc.modules.eth.subscribe.SubscriptionId;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import co.rsk.rpc.modules.eth.subscribe.*;
 import io.netty.channel.Channel;
-import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
-import org.ethereum.core.Block;
-import org.ethereum.facade.Ethereum;
-import org.ethereum.listener.EthereumListener;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -36,48 +28,81 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class EthSubscriptionNotificationEmitterTest {
-    private static final Block TEST_BLOCK = new BlockGenerator().createBlock(12, 0);
-
+    private BlockHeaderNotificationEmitter newHeads;
+    private LogsNotificationEmitter logs;
     private EthSubscriptionNotificationEmitter emitter;
-    private EthereumListener listener;
-    private JsonRpcSerializer serializer;
 
     @Before
     public void setUp() {
-        Ethereum ethereum = mock(Ethereum.class);
-        serializer = mock(JsonRpcSerializer.class);
-        emitter = new EthSubscriptionNotificationEmitter(ethereum, serializer);
-
-        ArgumentCaptor<EthereumListener> listenerCaptor = ArgumentCaptor.forClass(EthereumListener.class);
-        verify(ethereum, times(1)).addListener(listenerCaptor.capture());
-        listener = listenerCaptor.getValue();
+        newHeads = mock(BlockHeaderNotificationEmitter.class);
+        logs = mock(LogsNotificationEmitter.class);
+        emitter = new EthSubscriptionNotificationEmitter(newHeads, logs);
     }
 
     @Test
-    public void subscribeReturnsSubscriptionId() {
+    public void subscribeToNewHeads() {
         Channel channel = mock(Channel.class);
-
         EthSubscribeNewHeadsParams params = mock(EthSubscribeNewHeadsParams.class);
-        assertThat(emitter.visit(params, channel), notNullValue());
+
+        SubscriptionId subscriptionId = emitter.visit(params, channel);
+
+        assertThat(subscriptionId, notNullValue());
+        verify(newHeads).subscribe(subscriptionId, channel);
     }
 
     @Test
-    public void ethereumOnBlockEventTriggersMessageToChannel() throws JsonProcessingException {
+    public void subscribeToLogs() {
         Channel channel = mock(Channel.class);
-        emitter.visit(new EthSubscribeNewHeadsParams(), channel);
-        when(serializer.serializeMessage(any()))
-                .thenReturn("serialized");
+        EthSubscribeLogsParams params = mock(EthSubscribeLogsParams.class);
 
-        listener.onBlock(TEST_BLOCK, null);
-        verify(channel, times(1)).writeAndFlush(new TextWebSocketFrame("serialized"));
+        SubscriptionId subscriptionId = emitter.visit(params, channel);
+
+        assertThat(subscriptionId, notNullValue());
+        verify(logs).subscribe(subscriptionId, channel, params);
     }
 
     @Test
-    public void unsubscribeSucceedsForExistingSubscriptionId() {
-        Channel channel = mock(Channel.class);
-        SubscriptionId subscriptionId = emitter.visit(new EthSubscribeNewHeadsParams(), channel);
+    public void unsubscribeUnsuccessfully() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
 
-        assertThat(emitter.unsubscribe(new SubscriptionId()), is(false));
-        assertThat(emitter.unsubscribe(subscriptionId), is(true));
+        boolean unsubscribed = emitter.unsubscribe(subscriptionId);
+
+        assertThat(unsubscribed, is(false));
+        verify(newHeads).unsubscribe(subscriptionId);
+        verify(logs).unsubscribe(subscriptionId);
+    }
+
+    @Test
+    public void unsubscribeSuccessfullyFromNewHeads() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        when(newHeads.unsubscribe(subscriptionId)).thenReturn(true);
+
+        boolean unsubscribed = emitter.unsubscribe(subscriptionId);
+
+        assertThat(unsubscribed, is(true));
+        verify(newHeads).unsubscribe(subscriptionId);
+        verify(logs).unsubscribe(subscriptionId);
+    }
+
+    @Test
+    public void unsubscribeSuccessfullyFromLogs() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        when(logs.unsubscribe(subscriptionId)).thenReturn(true);
+
+        boolean unsubscribed = emitter.unsubscribe(subscriptionId);
+
+        assertThat(unsubscribed, is(true));
+        verify(newHeads).unsubscribe(subscriptionId);
+        verify(logs).unsubscribe(subscriptionId);
+    }
+
+    @Test
+    public void unsubscribeChannel() {
+        Channel channel = mock(Channel.class);
+
+        emitter.unsubscribe(channel);
+
+        verify(newHeads).unsubscribe(channel);
+        verify(logs).unsubscribe(channel);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/BlockHeaderNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/BlockHeaderNotificationEmitterTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.rpc.JsonRpcSerializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.ethereum.core.Block;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.listener.EthereumListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class BlockHeaderNotificationEmitterTest {
+    private static final Block TEST_BLOCK = new BlockGenerator().createBlock(12, 0);
+
+    private BlockHeaderNotificationEmitter emitter;
+    private EthereumListener listener;
+    private JsonRpcSerializer serializer;
+
+    @Before
+    public void setUp() {
+        Ethereum ethereum = mock(Ethereum.class);
+        serializer = mock(JsonRpcSerializer.class);
+        emitter = new BlockHeaderNotificationEmitter(ethereum, serializer);
+
+        ArgumentCaptor<EthereumListener> listenerCaptor = ArgumentCaptor.forClass(EthereumListener.class);
+        verify(ethereum).addListener(listenerCaptor.capture());
+        listener = listenerCaptor.getValue();
+    }
+
+    @Test
+    public void ethereumOnBlockEventTriggersMessageToChannel() throws JsonProcessingException {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+        when(serializer.serializeMessage(any()))
+                .thenReturn("serialized");
+
+        listener.onBlock(TEST_BLOCK, null);
+
+        verify(channel).writeAndFlush(new TextWebSocketFrame("serialized"));
+    }
+
+    @Test
+    public void unsubscribeSucceedsForExistingSubscriptionId() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+
+        assertThat(emitter.unsubscribe(new SubscriptionId()), is(false));
+        assertThat(emitter.unsubscribe(subscriptionId), is(true));
+    }
+
+    @Test
+    public void unsubscribeChannelThenNothingIsEmitted() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+
+        emitter.unsubscribe(channel);
+
+        listener.onBlock(TEST_BLOCK, null);
+        verifyNoMoreInteractions(channel);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeRequestTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeRequestTest.java
@@ -27,7 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class EthSubscribeRequestTest {
@@ -40,16 +40,64 @@ public class EthSubscribeRequestTest {
                 new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(request, instanceOf(EthSubscribeRequest.class));
-        EthSubscribeRequest subscribeRequest = (EthSubscribeRequest) request;
-        assertThat(subscribeRequest.getParams(), instanceOf(EthSubscribeNewHeadsParams.class));
+        validateParams(request, EthSubscribeNewHeadsParams.class);
+    }
+
+    @Test
+    public void deserializeLogsWithEmptyConfig() throws IOException {
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":333,\"method\":\"eth_subscribe\",\"params\":[\"logs\", {}]}";
+        RskJsonRpcRequest request = serializer.deserializeRequest(
+                new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8))
+        );
+
+        EthSubscribeLogsParams logsParams = validateParams(request, EthSubscribeLogsParams.class);
+
+        assertThat(logsParams.getAddress(), is(nullValue()));
+        assertThat(logsParams.getTopics(), is(arrayWithSize(0)));
+    }
+
+    @Test
+    public void deserializeLogsWithoutConfig() throws IOException {
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":333,\"method\":\"eth_subscribe\",\"params\":[\"logs\"]}";
+        RskJsonRpcRequest request = serializer.deserializeRequest(
+                new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8))
+        );
+
+        EthSubscribeLogsParams logsParams = validateParams(request, EthSubscribeLogsParams.class);
+
+        assertThat(logsParams.getAddress(), is(nullValue()));
+        assertThat(logsParams.getTopics(), is(arrayWithSize(0)));
+    }
+
+    @Test
+    public void deserializeLogs() throws IOException {
+        String logAddress = "0x3e1127bf1a673d378a8570f7a79cea4f10e20489";
+        String logTopic = "0x2809c7e17bf978fbc7194c0a694b638c4215e9140cacc6c38ca36010b45697df";
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":333,\"method\":\"eth_subscribe\",\"params\":[\"logs\", {\"address\":\"" + logAddress + "\",\"topics\":[\"" + logTopic + "\"]}]}";
+        RskJsonRpcRequest request = serializer.deserializeRequest(
+                new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8))
+        );
+
+        EthSubscribeLogsParams logsParams = validateParams(request, EthSubscribeLogsParams.class);
+
+        assertThat(logsParams.getAddress(), is(logAddress));
+        assertThat(logsParams.getTopics(), is(arrayWithSize(1)));
+        assertThat(logsParams.getTopics(), hasItemInArray(logTopic));
     }
 
     @Test(expected = JsonMappingException.class)
-    public void logsIsUnsupported() throws IOException {
-        String message = "{\"jsonrpc\":\"2.0\",\"id\":333,\"method\":\"eth_subscribe\",\"params\":[\"logs\"]}";
+    public void allowOnlyASingleConfiguration() throws IOException {
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":333,\"method\":\"eth_subscribe\",\"params\":[\"logs\", {}, {}]}";
         serializer.deserializeRequest(
                 new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8))
         );
+    }
+
+    private <T extends EthSubscribeParams> T validateParams(RskJsonRpcRequest request, Class<T> paramsClass) {
+        assertThat(request, instanceOf(EthSubscribeRequest.class));
+        EthSubscribeRequest subscribeRequest = (EthSubscribeRequest) request;
+        EthSubscribeParams params = subscribeRequest.getParams();
+        assertThat(params, instanceOf(paramsClass));
+        return paramsClass.cast(params);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeRequestTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeRequestTest.java
@@ -28,8 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class EthSubscribeRequestTest {
     private JsonRpcSerializer serializer = new JacksonBasedRpcSerializer();
@@ -43,7 +42,7 @@ public class EthSubscribeRequestTest {
 
         assertThat(request, instanceOf(EthSubscribeRequest.class));
         EthSubscribeRequest subscribeRequest = (EthSubscribeRequest) request;
-        assertThat(subscribeRequest.getParams().getSubscription(), is(EthSubscribeTypes.NEW_HEADS));
+        assertThat(subscribeRequest.getParams(), instanceOf(EthSubscribeNewHeadsParams.class));
     }
 
     @Test(expected = JsonMappingException.class)

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/LogsNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/LogsNotificationEmitterTest.java
@@ -1,0 +1,218 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.core.bc.BlockFork;
+import co.rsk.core.bc.BlockchainBranchComparator;
+import co.rsk.jsonrpc.JsonRpcMessage;
+import co.rsk.rpc.JsonRpcSerializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.ethereum.TestUtils;
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.db.TransactionInfo;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.listener.EthereumListener;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.vm.LogInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class LogsNotificationEmitterTest {
+    private LogsNotificationEmitter emitter;
+    private EthereumListener listener;
+    private JsonRpcSerializer serializer;
+    private ReceiptStore receiptStore;
+    private BlockchainBranchComparator comparator;
+
+    @Before
+    public void setUp() {
+        Ethereum ethereum = mock(Ethereum.class);
+        serializer = mock(JsonRpcSerializer.class);
+        receiptStore = mock(ReceiptStore.class);
+        comparator = mock(BlockchainBranchComparator.class);
+        emitter = new LogsNotificationEmitter(ethereum, serializer, receiptStore, comparator);
+
+        ArgumentCaptor<EthereumListener> listenerCaptor = ArgumentCaptor.forClass(EthereumListener.class);
+        verify(ethereum).addListener(listenerCaptor.capture());
+        listener = listenerCaptor.getValue();
+    }
+
+    @Test
+    public void onBestBlockEventTriggersMessageToChannel() throws JsonProcessingException {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        EthSubscribeLogsParams params = mock(EthSubscribeLogsParams.class);
+        emitter.subscribe(subscriptionId, channel, params);
+        when(serializer.serializeMessage(any()))
+                .thenReturn("serialized");
+
+        listener.onBestBlock(testBlock(logInfo()), null);
+
+        verify(channel).write(new TextWebSocketFrame("serialized"));
+        verify(channel).flush();
+    }
+
+    @Test
+    public void onBestBlockEventTriggersOneMessageToChannelPerLogInfoAndSubscription() throws JsonProcessingException {
+        SubscriptionId subscriptionId1 = mock(SubscriptionId.class);
+        SubscriptionId subscriptionId2 = mock(SubscriptionId.class);
+        Channel channel1 = mock(Channel.class);
+        Channel channel2 = mock(Channel.class);
+        EthSubscribeLogsParams params = mock(EthSubscribeLogsParams.class);
+        emitter.subscribe(subscriptionId1, channel1, params);
+        emitter.subscribe(subscriptionId2, channel2, params);
+        when(serializer.serializeMessage(any()))
+                .thenReturn("serializedLog1")
+                .thenReturn("serializedLog2")
+                .thenReturn("serializedLog1")
+                .thenReturn("serializedLog2");
+
+        listener.onBestBlock(testBlock(logInfo(), logInfo()), null);
+
+        verify(channel1).write(new TextWebSocketFrame("serializedLog1"));
+        verify(channel1).write(new TextWebSocketFrame("serializedLog2"));
+        verify(channel1).flush();
+        verify(channel2).write(new TextWebSocketFrame("serializedLog1"));
+        verify(channel2).write(new TextWebSocketFrame("serializedLog2"));
+        verify(channel2).flush();
+    }
+
+    @Test
+    public void emitsNewAndRemovedLogs() throws JsonProcessingException {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        EthSubscribeLogsParams params = mock(EthSubscribeLogsParams.class);
+        emitter.subscribe(subscriptionId, channel, params);
+
+        byte[] log1Data = {0x1};
+        byte[] log2Data = {0x2};
+        Block block1 = testBlock(logInfo(log1Data));
+        Block block2 = testBlock(logInfo(log2Data));
+
+        listener.onBestBlock(block1, null);
+        verifyLogsData(log1Data);
+        verifyLogsRemovedStatus(false);
+
+        // configure comparator to return a result for a branch that changed the tip from block1 to block2.
+        // e.g block1 with number N is connected as best, then block2 with the same number replaces block1 as best.
+        BlockFork blockFork = mock(BlockFork.class);
+        when(blockFork.getOldBlocks()).thenReturn(Collections.singletonList(block1));
+        when(blockFork.getNewBlocks()).thenReturn(Collections.singletonList(block2));
+        when(comparator.calculateFork(block1, block2))
+                .thenReturn(blockFork);
+
+        listener.onBestBlock(block2, null);
+        verifyLogsData(log1Data, log1Data, log2Data);
+        verifyLogsRemovedStatus(false, true, false);
+    }
+
+    @Test
+    public void unsubscribeSucceedsForExistingSubscriptionId() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        EthSubscribeLogsParams params = mock(EthSubscribeLogsParams.class);
+        emitter.subscribe(subscriptionId, channel, params);
+
+        assertThat(emitter.unsubscribe(new SubscriptionId()), is(false));
+        assertThat(emitter.unsubscribe(subscriptionId), is(true));
+    }
+
+    @Test
+    public void unsubscribeChannelThenNothingIsEmitted() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        EthSubscribeLogsParams params = mock(EthSubscribeLogsParams.class);
+        emitter.subscribe(subscriptionId, channel, params);
+
+        emitter.unsubscribe(channel);
+
+        listener.onBestBlock(testBlock(logInfo()), null);
+        verifyNoMoreInteractions(channel);
+    }
+
+    private void verifyLogsData(byte[]... results) throws JsonProcessingException {
+        verifyLogs((ln, d) -> assertThat(ln.getData(), is(TypeConverter.toJsonHex(d))), results);
+    }
+
+    private void verifyLogsRemovedStatus(Boolean... results) throws JsonProcessingException {
+        verifyLogs((ln, r) -> assertThat(ln.getRemoved(), is(r)), results);
+    }
+
+    private <T> void verifyLogs(BiConsumer<LogsNotification, T> checker, T... results)
+            throws JsonProcessingException {
+        ArgumentCaptor<JsonRpcMessage> captor = ArgumentCaptor.forClass(JsonRpcMessage.class);
+        verify(serializer, times(results.length)).serializeMessage(captor.capture());
+        assertThat(captor.getAllValues(), hasSize(results.length));
+        for (int i = 0; i < results.length; i++) {
+            EthSubscriptionNotification subscriptionNotification = (EthSubscriptionNotification) captor.getAllValues().get(i);
+            LogsNotification logsNotification = (LogsNotification) subscriptionNotification.getParams().getResult();
+            checker.accept(logsNotification, results[i]);
+        }
+    }
+
+    private Block testBlock(LogInfo... logInfos) {
+        Transaction transaction = transaction();
+        Block block = block(transaction);
+        withTransactionInfo(block, transaction, logInfos);
+        return block;
+    }
+
+    private Block block(Transaction transaction) {
+        Block block = mock(Block.class);
+        when(block.getHash()).thenReturn(TestUtils.randomHash());
+        when(block.getTransactionsList()).thenReturn(Collections.singletonList(transaction));
+        return block;
+    }
+
+    private Transaction transaction() {
+        Transaction tx = mock(Transaction.class);
+        when(tx.getHash()).thenReturn(TestUtils.randomHash());
+        return tx;
+    }
+
+    private LogInfo logInfo(byte... data) {
+        LogInfo logInfo = mock(LogInfo.class);
+        when(logInfo.getData()).thenReturn(data);
+        return logInfo;
+    }
+
+    private void withTransactionInfo(Block block, Transaction transaction, LogInfo... logInfos) {
+        TransactionInfo transactionInfo = mock(TransactionInfo.class);
+        TransactionReceipt receipt = mock(TransactionReceipt.class);
+        when(transactionInfo.getReceipt()).thenReturn(receipt);
+        when(receipt.getLogInfoList()).thenReturn(Arrays.asList(logInfos));
+        when(receiptStore.get(transaction.getHash(), block.getHash()))
+                .thenReturn(Optional.of(transactionInfo));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/RskJsonRpcHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/RskJsonRpcHandlerTest.java
@@ -83,7 +83,7 @@ public class RskJsonRpcHandlerTest {
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         when(ctx.channel())
                 .thenReturn(channel);
-        when(emitter.subscribe(channel))
+        when(emitter.visit(any(EthSubscribeNewHeadsParams.class), eq(channel)))
             .thenReturn(SAMPLE_SUBSCRIPTION_ID);
 
         assertThat(
@@ -101,7 +101,7 @@ public class RskJsonRpcHandlerTest {
 
         when(serializer.deserializeRequest(any()))
                 .thenReturn(SAMPLE_SUBSCRIBE_REQUEST);
-        when(emitter.subscribe(channel))
+        when(emitter.visit(any(EthSubscribeNewHeadsParams.class), eq(channel)))
                 .thenReturn(SAMPLE_SUBSCRIPTION_ID);
         when(serializer.serializeMessage(any()))
                 .thenReturn("serialized");

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/RskJsonRpcHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/RskJsonRpcHandlerTest.java
@@ -43,7 +43,7 @@ public class RskJsonRpcHandlerTest {
             JsonRpcVersion.V2_0,
             RskJsonRpcMethod.ETH_SUBSCRIBE,
             35,
-            new EthSubscribeParams(EthSubscribeTypes.NEW_HEADS)
+            new EthSubscribeNewHeadsParams()
 
     );
 

--- a/rskj-core/src/test/java/org/ethereum/db/ReceiptStoreImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/ReceiptStoreImplTest.java
@@ -19,17 +19,20 @@
 
 package org.ethereum.db;
 
-import co.rsk.test.World;
-import co.rsk.test.builders.BlockBuilder;
-import org.ethereum.core.*;
+import co.rsk.crypto.Keccak256;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.TestUtils;
+import org.ethereum.core.Bloom;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.vm.LogInfo;
 import org.junit.Assert;
 import org.junit.Test;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by ajlopez on 3/1/2016.
@@ -157,11 +160,11 @@ public class ReceiptStoreImplTest {
         ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
         TransactionReceipt receipt = createReceipt();
 
-        byte[] blockHash = Hex.decode("010203040506070809");
+        Keccak256 blockHash = TestUtils.randomHash();
 
-        TransactionInfo result = store.get(receipt.getTransaction().getHash().getBytes(), blockHash, null);
+        Optional<TransactionInfo> resultOpt = store.get(receipt.getTransaction().getHash(), blockHash);
 
-        Assert.assertNull(result);
+        Assert.assertFalse(resultOpt.isPresent());
     }
 
     @Test
@@ -169,14 +172,14 @@ public class ReceiptStoreImplTest {
         ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
         TransactionReceipt receipt = createReceipt();
 
-        byte[] blockHash0 = Hex.decode("0102030405060708000000000000000000000000000000000000000000000000");
-        byte[] blockHash = Hex.decode("0102030405060708090000000000000000000000000000000000000000000000");
+        Keccak256 blockHash0 = new Keccak256("0102030405060708000000000000000000000000000000000000000000000000");
+        Keccak256 blockHash = new Keccak256("0102030405060708090000000000000000000000000000000000000000000000");
 
-        store.add(blockHash, 1, receipt);
+        store.add(blockHash.getBytes(), 1, receipt);
 
-        TransactionInfo result = store.get(receipt.getTransaction().getHash().getBytes(), blockHash0, null);
+        Optional<TransactionInfo> resultOpt = store.get(receipt.getTransaction().getHash(), blockHash0);
 
-        Assert.assertNull(result);
+        Assert.assertFalse(resultOpt.isPresent());
     }
 
     @Test
@@ -184,19 +187,20 @@ public class ReceiptStoreImplTest {
         ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
 
         TransactionReceipt receipt0 = createReceipt();
-        byte[] blockHash0 = Hex.decode("0102030405060708090000000000000000000000000000000000000000000000");
+        Keccak256 blockHash0 = new Keccak256("0102030405060708090000000000000000000000000000000000000000000000");
 
-        store.add(blockHash0, 3, receipt0);
+        store.add(blockHash0.getBytes(), 3, receipt0);
 
         TransactionReceipt receipt = createReceipt();
-        byte[] blockHash = Hex.decode("0102030405060708000000000000000000000000000000000000000000000000");
+        Keccak256 blockHash = new Keccak256("0102030405060708000000000000000000000000000000000000000000000000");
 
-        store.add(blockHash, 42, receipt);
+        store.add(blockHash.getBytes(), 42, receipt);
 
-        TransactionInfo result = store.get(receipt.getTransaction().getHash().getBytes(), blockHash0, null);
+        Optional<TransactionInfo> resultOpt = store.get(receipt.getTransaction().getHash(), blockHash0);
+        TransactionInfo result = resultOpt.get();
 
         Assert.assertNotNull(result.getBlockHash());
-        Assert.assertArrayEquals(blockHash0, result.getBlockHash());
+        Assert.assertArrayEquals(blockHash0.getBytes(), result.getBlockHash());
         Assert.assertEquals(3, result.getIndex());
         Assert.assertArrayEquals(receipt0.getEncoded(), result.getReceipt().getEncoded());
     }
@@ -206,68 +210,22 @@ public class ReceiptStoreImplTest {
         ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
 
         TransactionReceipt receipt0 = createReceipt();
-        byte[] blockHash0 = Hex.decode("0102030405060708090000000000000000000000000000000000000000000000");
+        Keccak256 blockHash0 = new Keccak256("0102030405060708090000000000000000000000000000000000000000000000");
 
-        store.add(blockHash0, 3, receipt0);
-
-        TransactionReceipt receipt = createReceipt();
-        byte[] blockHash = Hex.decode("0102030405060708000000000000000000000000000000000000000000000000");
-
-        store.add(blockHash, 42, receipt);
-
-        TransactionInfo result = store.get(receipt.getTransaction().getHash().getBytes(), blockHash, null);
-
-        Assert.assertNotNull(result.getBlockHash());
-        Assert.assertArrayEquals(blockHash, result.getBlockHash());
-        Assert.assertEquals(42, result.getIndex());
-        Assert.assertArrayEquals(receipt.getEncoded(), result.getReceipt().getEncoded());
-    }
-
-    @Test
-    public void addTwoTransactionsAndGetTransactionByDescendantBlocks() {
-        World world = new World();
-        Block genesis = world.getBlockChain().getBestBlock();
-
-        Block block1a = new BlockBuilder(null, null, null).difficulty(10).parent(genesis).build();
-        Block block1b = new BlockBuilder(null, null,null).difficulty(block1a.getDifficulty().asBigInteger().longValue()-1).parent(genesis).build();
-
-        Block block2a = new BlockBuilder(null, null, null).parent(block1a).build();
-        Block block2b = new BlockBuilder(null, null, null).parent(block1b).build();
-
-        Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1a));
-        Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, world.getBlockChain().tryToConnect(block1b));
-        Assert.assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block2a));
-        Assert.assertEquals(ImportResult.IMPORTED_NOT_BEST, world.getBlockChain().tryToConnect(block2b));
-
-        ReceiptStore store = new ReceiptStoreImpl(new HashMapDB());
-
-        TransactionReceipt receipt0 = createReceipt();
-        byte[] blockHash0 = Hex.decode("010203040506070809");
-
-        store.add(block1a.getHash().getBytes(), 3, receipt0);
+        store.add(blockHash0.getBytes(), 3, receipt0);
 
         TransactionReceipt receipt = createReceipt();
-        byte[] blockHash = Hex.decode("0102030405060708");
+        Keccak256 blockHash = new Keccak256("0102030405060708000000000000000000000000000000000000000000000000");
 
-        store.add(block1b.getHash().getBytes(), 42, receipt);
+        store.add(blockHash.getBytes(), 42, receipt);
 
-        TransactionInfo result = store.get(receipt.getTransaction().getHash().getBytes(), block2a.getHash().getBytes(), world.getBlockStore());
-
-        Assert.assertNotNull(result.getBlockHash());
-        Assert.assertArrayEquals(block1a.getHash().getBytes(), result.getBlockHash());
-        Assert.assertEquals(3, result.getIndex());
-        Assert.assertArrayEquals(receipt.getEncoded(), result.getReceipt().getEncoded());
-
-        result = store.get(receipt.getTransaction().getHash().getBytes(), block2b.getHash().getBytes(), world.getBlockStore());
+        Optional<TransactionInfo> resultOpt = store.get(receipt.getTransaction().getHash(), blockHash);
+        TransactionInfo result = resultOpt.get();
 
         Assert.assertNotNull(result.getBlockHash());
-        Assert.assertArrayEquals(block1b.getHash().getBytes(), result.getBlockHash());
+        Assert.assertArrayEquals(blockHash.getBytes(), result.getBlockHash());
         Assert.assertEquals(42, result.getIndex());
         Assert.assertArrayEquals(receipt.getEncoded(), result.getReceipt().getEncoded());
-
-        result = store.get(receipt.getTransaction().getHash().getBytes(), genesis.getHash().getBytes(), world.getBlockStore());
-
-        Assert.assertNull(result);
     }
 
     // from TransactionTest


### PR DESCRIPTION
This brings initial `eth_subscribe(logs)` support to the RSK node. For now, each and every log will be emitted - i.e there's now filtering support. The client will receive an error when passing parameters.