### PR TITLE
Create Wasabi+1 network upgrade configuration

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
@@ -24,7 +24,8 @@ public enum NetworkUpgrade {
     AFTER_BRIDGE_SYNC("afterBridgeSync"),
     ORCHID("orchid"),
     ORCHID_060("orchid060"),
-    WASABI_100("wasabi100");
+    WASABI_100("wasabi100"),
+    WASABI_PLUS_ONE("wasabiPlusOne");
 
     private String name;
 

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -1,3 +1,6 @@
+# disable wasabi+1 consensus rules by default for every network
+blockchain.config.hardforkActivationHeights.wasabiPlusOne = -1
+
 blockchain = {
     config = {
         consensusRules = {


### PR DESCRIPTION
The entry in the `referece.conf` file must be removed when the actual activation height gets defined for every network.
Also the name must be changed once the committee reaches consensus on it