### PR TITLE
Genesis instance is retrieved when decoding block 0

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -77,10 +77,7 @@ import co.rsk.validators.*;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.core.BlockFactory;
-import org.ethereum.core.Blockchain;
-import org.ethereum.core.Genesis;
-import org.ethereum.core.TransactionPool;
+import org.ethereum.core.*;
 import org.ethereum.core.genesis.BlockChainLoader;
 import org.ethereum.core.genesis.GenesisLoader;
 import org.ethereum.core.genesis.GenesisLoaderImpl;
@@ -284,7 +281,7 @@ public class RskContext implements NodeBootstrapper {
 
     public BlockFactory getBlockFactory() {
         if (blockFactory == null) {
-            blockFactory = new BlockFactory(getRskSystemProperties().getActivationConfig());
+            blockFactory = new BlockFactory(getRskSystemProperties().getActivationConfig(), getGenesis());
         }
 
         return blockFactory;

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -44,9 +44,15 @@ public class BlockFactory {
     private static final int RLP_HEADER_SIZE_WITH_MERGED_MINING = 19;
 
     private final ActivationConfig activationConfig;
+    private final Block genesis;
 
-    public BlockFactory(ActivationConfig activationConfig) {
+    /**
+     * @param activationConfig Configuration for different behaviours depending on activations.
+     * @param genesis When the requested block to decode is numnber 0, genesis block is retrieved.
+     */
+    public BlockFactory(ActivationConfig activationConfig, Block genesis) {
         this.activationConfig = activationConfig;
+        this.genesis = genesis;
     }
 
     public Block cloneBlockForModification(Block block) {

--- a/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
+++ b/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockGenerator.java
@@ -69,7 +69,7 @@ public class BlockGenerator {
     public BlockGenerator(Constants networkConstants, ActivationConfig activationConfig) {
         this.activationConfig = activationConfig;
         this.difficultyCalculator = new DifficultyCalculator(activationConfig, networkConstants);
-        this.blockFactory = new BlockFactory(activationConfig);
+        this.blockFactory = new BlockFactory(activationConfig, getGenesisBlock());
     }
 
     public Genesis getGenesisBlock() {

--- a/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockMiner.java
+++ b/rskj-core/src/test/java/co/rsk/blockchain/utils/BlockMiner.java
@@ -10,6 +10,7 @@ import org.ethereum.core.BlockFactory;
 import java.math.BigInteger;
 
 import static co.rsk.mine.MinerServerImpl.compressCoinbase;
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by ajlopez on 13/09/2017.
@@ -22,7 +23,7 @@ public class BlockMiner {
 
     public BlockMiner(ActivationConfig activationConfig) {
         this.activationConfig = activationConfig;
-        this.blockFactory = new BlockFactory(activationConfig);
+        this.blockFactory = new BlockFactory(activationConfig, mock(Block.class));
     }
 
     public Block mineBlock(Block block) {

--- a/rskj-core/src/test/java/co/rsk/core/BlockEncodingTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockEncodingTest.java
@@ -36,13 +36,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by SDL on 12/5/2017.
  */
 public class BlockEncodingTest {
     private static final byte[] EMPTY_LIST_HASH = HashUtil.keccak256(RLP.encodeList());
 
-    private final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
+    private final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class));
 
     @Test(expected = ArithmeticException.class)
     public void testBadBlockEncoding1() {

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -24,6 +24,7 @@ import co.rsk.peg.PegTestUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Bloom;
@@ -49,11 +50,16 @@ public class BlockFactoryTest {
 
     private ActivationConfig activationConfig;
     private BlockFactory factory;
+    private Block genesis;
 
     @Before
     public void setUp() {
         activationConfig = mock(ActivationConfig.class);
-        factory = new BlockFactory(activationConfig);
+        genesis = mock(Block.class);
+        BlockHeader genesisHeader = mock(BlockHeader.class);
+        when(genesis.getHeader()).thenReturn(genesisHeader);
+        when(genesisHeader.getNumber()).thenReturn(0L);
+        factory = new BlockFactory(activationConfig, genesis);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -21,6 +21,7 @@ package co.rsk.core;
 import co.rsk.config.RskMiningConstants;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.PegTestUtils;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -58,8 +59,14 @@ public class BlockFactoryTest {
         genesis = mock(Block.class);
         BlockHeader genesisHeader = mock(BlockHeader.class);
         when(genesis.getHeader()).thenReturn(genesisHeader);
+        when(genesis.getEncoded()).thenReturn(genesisRaw());
         when(genesisHeader.getNumber()).thenReturn(0L);
         factory = new BlockFactory(activationConfig, genesis);
+    }
+
+    @Test
+    public void decodeGenesisBlock() {
+        assertThat(factory.decodeBlock(genesisRaw()), is(genesis));
     }
 
     @Test
@@ -251,5 +258,21 @@ public class BlockFactoryTest {
                 forkDetectionData,
                 Coin.valueOf(10L).getBytes(),
                 0);
+    }
+
+
+
+    private static byte[] genesisRaw() {
+        return Hex.decode("f901dbf901d6a00000000000000000000000000000000000000000000000000000000000000000a" +
+                "01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347943333333333333333333333333" +
+                "333333333333333a045bce5168430c42b3d568331753f900a32457b4f3748697cbd8375ff4da72641a056e81f171" +
+                "bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b4" +
+                "8e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000" +
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000085000" +
+                "010000080834c4b40808085434d272841800080000000c0c0");
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -39,10 +39,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
 public class BlockTest {
     private static final byte[] EMPTY_LIST_HASH = HashUtil.keccak256(RLP.encodeList());
 
-    private final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
+    private final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class));
 
     @Test
     public void testParseRemascTransaction() {

--- a/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
@@ -33,13 +33,15 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 07/05/2017.
  */
 public class CallContractTest {
 
     private static final TestSystemProperties config = new TestSystemProperties();
-    private static final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private static final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
     @Test
     public void callContractReturningOne() {

--- a/rskj-core/src/test/java/co/rsk/core/CodeReplaceTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CodeReplaceTest.java
@@ -33,10 +33,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.core.BlockFactory;
-import org.ethereum.core.Repository;
-import org.ethereum.core.Transaction;
-import org.ethereum.core.TransactionExecutor;
+import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
@@ -51,6 +48,8 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by Sergio on 26/02/2017.
  */
@@ -62,7 +61,7 @@ public class CodeReplaceTest {
             return ActivationConfigsForTest.allBut(ConsensusRule.RSKIP94);
         }
     };
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
     @Test
     public void replaceCodeTest1() throws InterruptedException {

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -39,12 +39,13 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.mock;
 
 public class TransactionTest {
 
     private final TestSystemProperties config = new TestSystemProperties();
     private final byte chainId = config.getNetworkConstants().getChainId();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
     @Test  /* achieve public key of the sender */
     public void test2() throws Exception {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -61,6 +61,7 @@ import java.math.BigInteger;
 import java.util.*;
 
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by ajlopez on 29/07/2016.
@@ -68,7 +69,7 @@ import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
 public class BlockExecutorTest {
     public static final byte[] EMPTY_TRIE_HASH = sha3(RLP.encodeElement(EMPTY_BYTE_ARRAY));
     private static final TestSystemProperties config = new TestSystemProperties();
-    private static final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private static final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
     private Blockchain blockchain;
     private BlockExecutor executor;

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -54,7 +54,7 @@ public class BlockValidatorTest {
     public static final BlockDifficulty TEST_DIFFICULTY = new BlockDifficulty(BigInteger.ONE);
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
     @Test
     public void validEmptyUnclesHash() {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockchainBranchComparatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockchainBranchComparatorTest.java
@@ -34,13 +34,15 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 09/08/2016.
  */
 public class BlockchainBranchComparatorTest {
 
     public static final BlockDifficulty TEST_DIFFICULTY = new BlockDifficulty(BigInteger.ONE);
-    private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
+    private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class));
 
     @Test
     public void calculateParentChild() {

--- a/rskj-core/src/test/java/co/rsk/core/bc/FamilyUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/FamilyUtilsTest.java
@@ -36,13 +36,15 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 12/08/2016.
  */
 public class FamilyUtilsTest {
 
     public static final BlockDifficulty TEST_DIFFICULTY = new BlockDifficulty(BigInteger.ONE);
-    private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
+    private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class));
 
     @Test
     public void getFamilyGetParent() {

--- a/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
+++ b/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
@@ -23,6 +23,7 @@ import co.rsk.core.DifficultyCalculator;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.jsontestsuite.DifficultyTestCase;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Angel J Lopez
@@ -48,7 +50,7 @@ public class LocalBasicTest {
 
     @Test
     public void runDifficultyTest() throws IOException {
-        BlockFactory blockFactory = new BlockFactory(activationConfig);
+        BlockFactory blockFactory = new BlockFactory(activationConfig, mock(Block.class));
 
         String json = getJSON("difficulty");
 

--- a/rskj-core/src/test/java/co/rsk/mine/BlockToMineBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/BlockToMineBuilderTest.java
@@ -84,7 +84,7 @@ public class BlockToMineBuilderTest {
                 new ForkDetectionDataCalculator(),
                 validationRules,
                 mock(MinerClock.class),
-                new BlockFactory(ActivationConfigsForTest.all()),
+                new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class)),
                 blockExecutor,
                 minimumGasPriceCalculator,
                 minerUtils

--- a/rskj-core/src/test/java/co/rsk/mine/GasLimitCalculatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/GasLimitCalculatorTest.java
@@ -20,6 +20,7 @@ package co.rsk.mine;
 
 import co.rsk.config.TestSystemProperties;
 import org.ethereum.config.Constants;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.validator.ParentGasLimitRule;
@@ -29,6 +30,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 
 import static org.ethereum.validator.ParentGasLimitRuleTest.getHeader;
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by Ruben Altman on 5/23/2016.
@@ -36,7 +38,7 @@ import static org.ethereum.validator.ParentGasLimitRuleTest.getHeader;
 public class GasLimitCalculatorTest {
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private Constants constants = Constants.regtest();
     private ParentGasLimitRule rule = new ParentGasLimitRule(1024);
 

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -29,7 +29,6 @@ import co.rsk.db.StateRootHandler;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
 import co.rsk.rpc.ExecutionBlockRetriever;
-import co.rsk.rpc.Web3InformationRetriever;
 import co.rsk.rpc.Web3RskImpl;
 import co.rsk.rpc.modules.debug.DebugModule;
 import co.rsk.rpc.modules.debug.DebugModuleImpl;
@@ -74,9 +73,11 @@ import java.math.BigInteger;
 import java.time.Clock;
 import java.util.HashMap;
 
+import static org.mockito.Mockito.mock;
+
 public class TransactionModuleTest {
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private TransactionExecutorFactory transactionExecutorFactory;
 
     @Test
@@ -333,7 +334,7 @@ public class TransactionModuleTest {
                         new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants()),
                         new GasLimitCalculator(config.getNetworkConstants()),
                         new ForkDetectionDataCalculator(),
-                        Mockito.mock(BlockUnclesValidationRule.class),
+                        mock(BlockUnclesValidationRule.class),
                         minerClock,
                         blockFactory,
                         new BlockExecutor(

--- a/rskj-core/src/test/java/co/rsk/net/NetBlockStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NetBlockStoreTest.java
@@ -33,11 +33,13 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 5/11/2016.
  */
 public class NetBlockStoreTest {
-    private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
+    private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class));
 
     @Test
     public void getUnknownBlockAsNull() {

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.*;
 public class NodeMessageHandlerTest {
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
     @Test
     public void processBlockMessageUsingProcessor() throws UnknownHostException {

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
@@ -8,6 +8,7 @@ import co.rsk.net.sync.SyncConfiguration;
 import co.rsk.scoring.PeerScoringManager;
 import co.rsk.test.World;
 import co.rsk.validators.*;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Genesis;
@@ -22,7 +23,7 @@ import static org.mockito.Mockito.mock;
 
 public class NodeMessageHandlerUtil {
     private static final TestSystemProperties config = new TestSystemProperties();
-    private static final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private static final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants());
 
     public static NodeMessageHandler createHandler(BlockValidationRule validationRule, Blockchain blockchain) {

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -62,7 +62,7 @@ public class OneAsyncNodeTest {
         SimpleChannelManager channelManager = new SimpleChannelManager();
         SyncProcessor syncProcessor = new SyncProcessor(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager, syncConfiguration,
-                new BlockFactory(config.getActivationConfig()),
+                new BlockFactory(config.getActivationConfig(), mock(Block.class)),
                 new DummyBlockValidationRule(),
                 new BlockCompositeRule(new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())),
                 new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants()),

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.*;
 public class SyncProcessorTest {
 
     private static final TestSystemProperties config = new TestSystemProperties();
-    private static final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private static final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     public static final DifficultyCalculator DIFFICULTY_CALCULATOR = new DifficultyCalculator(config.getActivationConfig(), config.getNetworkConstants());
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
@@ -36,11 +36,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 5/11/2016.
  */
 public class MessageTest {
-    private final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
+    private final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class));
 
     @Test
     public void encodeDecodeGetBlockMessage() {

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -32,6 +32,7 @@ import co.rsk.validators.BlockCompositeRule;
 import co.rsk.validators.BlockRootValidationRule;
 import co.rsk.validators.BlockUnclesHashValidationRule;
 import co.rsk.validators.DummyBlockValidationRule;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Genesis;
@@ -135,7 +136,7 @@ public class SimpleAsyncNode extends SimpleNode {
         DummyBlockValidationRule blockValidationRule = new DummyBlockValidationRule();
         PeerScoringManager peerScoringManager = RskMockFactory.getPeerScoringManager();
         SimpleChannelManager channelManager = new SimpleChannelManager();
-        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
         SyncProcessor syncProcessor = new SyncProcessor(
                 blockchain, indexedBlockStore, mock(ConsensusValidationMainchainView.class), blockSyncService, channelManager, syncConfiguration, blockFactory,
                 blockValidationRule,

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderContractTest.java
@@ -96,7 +96,7 @@ public class BlockHeaderContractTest {
     @Before
     public void setUp() {
         config = new TestSystemProperties();
-        blockFactory = new BlockFactory(config.getActivationConfig());
+        blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
         PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/EnvironmentUtils.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/EnvironmentUtils.java
@@ -64,7 +64,7 @@ public class EnvironmentUtils {
         new BlockMiner(config.getActivationConfig()).findNonce(bitcoinMergedMiningBlock, targetBI);
 
         // We need to clone to allow modifications
-        Block newBlock = new BlockFactory(config.getActivationConfig()).cloneBlockForModification(
+        Block newBlock = new BlockFactory(config.getActivationConfig(), mock(Block.class)).cloneBlockForModification(
                 blockGenerator.createChildBlock(
                         parent, new ArrayList<>(), new ArrayList<>(),
                         parent.getDifficulty().asBigInteger().longValue(),

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/GetCoinbasePerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/GetCoinbasePerformanceTestCase.java
@@ -27,7 +27,6 @@ import co.rsk.blockchain.utils.BlockMiner;
 import co.rsk.config.RskMiningConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
-import co.rsk.db.BenchmarkedRepository;
 import co.rsk.mine.MinerUtils;
 import co.rsk.peg.performance.ExecutionStats;
 import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
@@ -45,6 +44,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.LinkedList;
+
+import static org.mockito.Mockito.mock;
 
 @Ignore
 public class GetCoinbasePerformanceTestCase extends PrecompiledContractPerformanceTestCase {
@@ -119,7 +120,7 @@ public class GetCoinbasePerformanceTestCase extends PrecompiledContractPerforman
         new BlockMiner(activationConfig).findNonce(mergedMiningBlock, targetDifficulty);
 
         // We need to clone to allow modifications
-        Block newBlock = new BlockFactory(activationConfig).cloneBlockForModification(
+        Block newBlock = new BlockFactory(activationConfig, blockGenerator.getGenesisBlock()).cloneBlockForModification(
                 blockGenerator.createChildBlock(parent, txPerBlock, parent.getDifficulty().asBigInteger().longValue())
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -127,7 +127,7 @@ public class BridgeTest {
         when(config.getNetworkConstants()).thenReturn(constants);
         activationConfig = spy(ActivationConfigsForTest.genesis());
         when(config.getActivationConfig()).thenReturn(activationConfig);
-        blockFactory = new BlockFactory(activationConfig);
+        blockFactory = new BlockFactory(activationConfig, mock(Block.class));
         btcBlockFactory = new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams());
     }
 
@@ -2833,7 +2833,7 @@ public class BridgeTest {
 //        GenesisConfig mockedConfig = spy(new GenesisConfig());
 //        when(mockedConfig.isRskip88()).thenReturn(false);
 //        config.setBlockchainConfig(mockedConfig);
-        blockFactory = new BlockFactory(config.getActivationConfig());
+        blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
         PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
         EVMAssembler assembler = new EVMAssembler();
@@ -2875,7 +2875,7 @@ public class BridgeTest {
     public void testCallFromContract_afterOrchid() {
         doReturn(false).when(activationConfig).isActive(eq(RSKIP87), anyLong());
         doReturn(true).when(activationConfig).isActive(eq(RSKIP88), anyLong());
-        blockFactory = new BlockFactory(activationConfig);
+        blockFactory = new BlockFactory(activationConfig, mock(Block.class));
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 new RepositoryBtcBlockStoreWithCache.Factory(constants.getBridgeConstants().getBtcParams()),

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -468,7 +468,7 @@ public class RskForksBridgeTest {
                 beforeBambooProperties,
                 blockStore,
                 null,
-                new BlockFactory(beforeBambooProperties.getActivationConfig()),
+                new BlockFactory(beforeBambooProperties.getActivationConfig(), genesis),
                 new ProgramInvokeFactoryImpl(),
                 new PrecompiledContracts(beforeBambooProperties, world.getBridgeSupportFactory())
                 );

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -98,7 +98,7 @@ public class RemascProcessMinerFeesTest {
 
     @Before
     public void setup() {
-        blockFactory = new BlockFactory(config.getActivationConfig());
+        blockFactory = new BlockFactory(config.getActivationConfig(), genesisBlock);
         stateRootHandler = new StateRootHandler(config.getActivationConfig(), new TrieConverter(), new HashMapDB(), new HashMap<>());
         blockchainBuilder = new BlockChainBuilder()
                 .setStateRootHandler(stateRootHandler)

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -456,7 +456,7 @@ public class RemascStorageProviderTest {
                         config,
                         builder.getBlockStore(),
                         null,
-                        new BlockFactory(config.getActivationConfig()),
+                        new BlockFactory(config.getActivationConfig(), genesisBlock),
                         new ProgramInvokeFactoryImpl(),
                         new PrecompiledContracts(config, bridgeSupportFactory)
                 )

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -126,7 +126,7 @@ class RemascTestRunner {
         List<Block> mainChainBlocks = new ArrayList<>();
         this.blockchain.tryToConnect(this.genesis);
 
-        BlockFactory blockFactory = new BlockFactory(builder.getConfig().getActivationConfig());
+        BlockFactory blockFactory = new BlockFactory(builder.getConfig().getActivationConfig(), genesis);
         final ProgramInvokeFactoryImpl programInvokeFactory = new ProgramInvokeFactoryImpl();
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -47,6 +47,8 @@ import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 8/7/2016.
  */
@@ -131,7 +133,7 @@ public class World {
                             config,
                             blockStore,
                             null,
-                            new BlockFactory(config.getActivationConfig()),
+                            new BlockFactory(config.getActivationConfig(), mock(Genesis.class)),
                             programInvokeFactory,
                             new PrecompiledContracts(config, bridgeSupportFactory)
                     )

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
@@ -114,7 +114,7 @@ public class BlockBuilder {
                             config,
                             blockStore,
                             null,
-                            new BlockFactory(config.getActivationConfig()),
+                            new BlockFactory(config.getActivationConfig(), blockGenerator.getGenesisBlock()),
                             new ProgramInvokeFactoryImpl(),
                             new PrecompiledContracts(config, bridgeSupportFactory)
                     )

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -51,6 +51,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 8/6/2016.
  */
@@ -176,7 +178,7 @@ public class BlockChainBuilder {
         genesis.setStateRoot(repository.getRoot());
         genesis.flushRLP();
 
-        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), genesis);
         if (blockStore == null) {
             blockStore = new IndexedBlockStore(blockFactory, new HashMapDB(), blocksIndex);
         }

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -42,6 +42,8 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.StringTokenizer;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 8/7/2016.
  */
@@ -260,7 +262,7 @@ public class WorldDslProcessor {
                             config,
                             world.getBlockStore(),
                             null,
-                            new BlockFactory(config.getActivationConfig()),
+                            new BlockFactory(config.getActivationConfig(), mock(Block.class)),
                             programInvokeFactory,
                             null
                     )

--- a/rskj-core/src/test/java/co/rsk/validators/BlockDifficultyValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockDifficultyValidationRuleTest.java
@@ -34,6 +34,8 @@ import org.mockito.Mockito;
 
 import java.math.BigInteger;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by sergio on 23/01/17.
  */
@@ -42,12 +44,14 @@ public class BlockDifficultyValidationRuleTest {
     private BlockFactory blockFactory;
     private ActivationConfig activationConfig;
     private Constants networkConstants;
+    private Block genesis;
 
     @Before
     public void setUp() {
         activationConfig = ActivationConfigsForTest.all();
         networkConstants = Constants.regtest();
-        blockFactory = new BlockFactory(activationConfig);
+        genesis = mock(Block.class);
+        blockFactory = new BlockFactory(activationConfig, genesis);
     }
 
     private BlockHeader getEmptyHeader(BlockDifficulty difficulty, long blockTimestamp, int uCount) {
@@ -63,8 +67,8 @@ public class BlockDifficultyValidationRuleTest {
         DifficultyCalculator difficultyCalculator = new DifficultyCalculator(activationConfig, networkConstants);
         BlockDifficultyRule validationRule = new BlockDifficultyRule(difficultyCalculator);
 
-        Block block = Mockito.mock(Block.class);
-        Block parent= Mockito.mock(Block.class);
+        Block block = mock(Block.class);
+        Block parent= mock(Block.class);
         long parentTimestamp = 0;
         long blockTimeStamp  = 10;
 
@@ -78,7 +82,7 @@ public class BlockDifficultyValidationRuleTest {
 
         BlockHeader blockHeader =getEmptyHeader(blockDifficulty, blockTimeStamp ,1);
 
-        BlockHeader parentHeader = Mockito.mock(BlockHeader.class);
+        BlockHeader parentHeader = mock(BlockHeader.class);
 
         Mockito.when(parentHeader.getDifficulty())
                 .thenReturn(parentDifficulty);

--- a/rskj-core/src/test/java/co/rsk/vm/Create2Test.java
+++ b/rskj-core/src/test/java/co/rsk/vm/Create2Test.java
@@ -30,6 +30,7 @@ import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Account;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Transaction;
 import org.ethereum.vm.DataWord;
@@ -66,7 +67,7 @@ public class Create2Test {
                             config.getNetworkConstants().getBridgeConstants().getBtcParams()),
                     config.getNetworkConstants().getBridgeConstants(),
                     config.getActivationConfig()));
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private final Transaction transaction = createTransaction();
 
     @Before

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -39,6 +39,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by Sergio on 18/07/2016.
  */
@@ -63,7 +65,7 @@ public class MinerHelper {
         this.repositoryLocator = repositoryLocator;
         this.blockchain = blockchain;
         this.gasLimitCalculator = new GasLimitCalculator(config.getNetworkConstants());
-        this.blockFactory = new BlockFactory(config.getActivationConfig());
+        this.blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     }
 
     public void processBlock( Block block, Block parent) {

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -22,6 +22,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
@@ -49,7 +50,7 @@ public class VMExecutionTest {
     private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private ProgramInvokeMockImpl invoke;
     private BytecodeCompiler compiler;
 

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -24,6 +24,7 @@ import co.rsk.helpers.PerformanceTestConstants;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.OpCode;
@@ -50,6 +51,7 @@ import java.util.List;
 import static org.ethereum.TestUtils.padLeft;
 import static org.ethereum.TestUtils.padRight;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 // Remove junit imports for standalone use
 
@@ -58,7 +60,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class VMPerformanceTest {
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
     private final ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(0);

--- a/rskj-core/src/test/java/co/rsk/vm/VMSpecificOpcodesPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMSpecificOpcodesPerformanceTest.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Account;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Transaction;
 import org.ethereum.vm.PrecompiledContracts;
@@ -39,7 +40,7 @@ public class VMSpecificOpcodesPerformanceTest {
     private VM vm;
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
 

--- a/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -53,7 +53,7 @@ public class ImportLightTest {
             Repository repository,
             BlockStore blockStore,
             TrieStore trieStore) {
-        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), genesis);
         CompositeEthereumListener listener = new TestCompositeEthereumListener();
 
         KeyValueDataSource ds = new HashMapDB();

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -62,11 +62,12 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 public class TransactionTest {
 
     private TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
     @Test /* sign transaction  https://tools.ietf.org/html/rfc6979 */
     public void test1() throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeyException, IOException {

--- a/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
@@ -72,7 +72,7 @@ public class IndexedBlockStoreTest {
         File file = new File(scenario1.toURI());
         List<String> strData = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
         config = new TestSystemProperties();
-        blockFactory = new BlockFactory(config.getActivationConfig());
+        blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
         Block genesis = RskTestFactory.getGenesisInstance(config);
         blocks.add(genesis);
         cumDifficulty = cumDifficulty.add(genesis.getCumulativeDifficulty());

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/GitHubBasicTest.java
@@ -21,6 +21,7 @@ package org.ethereum.jsontestsuite;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.DifficultyCalculator;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.json.simple.parser.ParseException;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Mikhail Kalinin
@@ -51,7 +53,7 @@ public class GitHubBasicTest {
 
     @Test
     public void runDifficultyTest() throws IOException, ParseException {
-        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficulty.json", shacommit);
 
@@ -71,7 +73,7 @@ public class GitHubBasicTest {
     @Test
     public void runDifficultyFrontierTest() throws IOException, ParseException {
 
-        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficultyFrontier.json", shacommit);
 
@@ -91,7 +93,7 @@ public class GitHubBasicTest {
     @Test
     public void runDifficultyHomesteadTest() throws IOException, ParseException {
 
-        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
         String json = JSONReader.loadJSONFromCommit("BasicTests/difficultyHomestead.json", shacommit);
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -84,7 +84,7 @@ public class TestRunner {
     private final TestSystemProperties config = new TestSystemProperties();
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private Logger logger = LoggerFactory.getLogger("TCK-Test");
     private ProgramTrace trace = null;
     private boolean validateGasUsed = false; // until EIP150 test cases are ready.

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -63,13 +63,14 @@ import java.util.List;
 
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
 import static org.ethereum.util.ByteUtil.byteArrayToLong;
+import static org.mockito.Mockito.mock;
 
 public class StateTestRunner {
     private static final byte[] ZERO_BYTE_ARRAY = new byte[]{0};
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
 
     public static List<String> run(StateTestCase stateTestCase2) {
         return new StateTestRunner(stateTestCase2).runImpl();

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -92,7 +92,7 @@ import static org.mockito.Mockito.*;
 public class Web3ImplTest {
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     Wallet wallet;
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
@@ -23,6 +23,7 @@ import org.ethereum.TestUtils;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.vm.DataWord;
@@ -31,6 +32,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Angel J Lopez
@@ -38,7 +40,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class DifficultyRuleTest {
     private final ActivationConfig activationConfig = ActivationConfigsForTest.all();
-    private final BlockFactory blockFactory = new BlockFactory(activationConfig);
+    private final BlockFactory blockFactory = new BlockFactory(activationConfig, mock(Block.class));
     private final DifficultyRule rule = new DifficultyRule(new DifficultyCalculator(activationConfig, Constants.regtest()));
 
     @Ignore

--- a/rskj-core/src/test/java/org/ethereum/validator/ParentGasLimitRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/ParentGasLimitRuleTest.java
@@ -21,6 +21,7 @@ package org.ethereum.validator;
 import co.rsk.core.BlockDifficulty;
 import org.ethereum.TestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.vm.DataWord;
@@ -28,13 +29,14 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Angel J Lopez
  * @since 02.23.2016
  */
 public class ParentGasLimitRuleTest {
-    private final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
+    private final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class));
     private ParentGasLimitRule rule = new ParentGasLimitRule(1024);
 
     @Test // pass rule

--- a/rskj-core/src/test/java/org/ethereum/validator/ParentNumberRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/ParentNumberRuleTest.java
@@ -21,19 +21,21 @@ package org.ethereum.validator;
 import co.rsk.core.BlockDifficulty;
 import org.ethereum.TestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Angel J Lopez
  * @since 02.23.2016
  */
 public class ParentNumberRuleTest {
-    private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all());
+    private static final BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.all(), mock(Block.class));
     private ParentNumberRule rule = new ParentNumberRule();
 
     @Test // pass rule

--- a/rskj-core/src/test/java/org/ethereum/validator/ProofOfWorkRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/ProofOfWorkRuleTest.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Mikhail Kalinin
@@ -61,7 +62,7 @@ public class ProofOfWorkRuleTest extends ParameterizedNetworkUpgradeTest {
         this.rule = new ProofOfWorkRule(config).setFallbackMiningEnabled(false);
         this.activationConfig = config.getActivationConfig();
         this.networkConstants = config.getNetworkConstants();
-        this.blockFactory = new BlockFactory(activationConfig);
+        this.blockFactory = new BlockFactory(activationConfig, mock(Block.class));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/ProgramMemoryTest.java
@@ -21,6 +21,7 @@ package org.ethereum.vm;
 
 import co.rsk.config.TestSystemProperties;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.program.Program;
@@ -45,7 +46,7 @@ public class ProgramMemoryTest {
         TestSystemProperties config = new TestSystemProperties();
 
         program = new Program(config.getVmConfig(), new PrecompiledContracts(config, null),
-                new BlockFactory(config.getActivationConfig()), mock(ActivationConfig.ForBlock.class),
+                new BlockFactory(config.getActivationConfig(), mock(Block.class)), mock(ActivationConfig.ForBlock.class),
                 ByteUtil.EMPTY_BYTE_ARRAY, pi, null, new HashSet<>());
     }
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMComplexTest.java
@@ -26,6 +26,7 @@ import co.rsk.core.RskAddress;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.AccountState;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Repository;
 import org.ethereum.crypto.HashUtil;
@@ -54,7 +55,7 @@ public class VMComplexTest {
 
     private static Logger logger = LoggerFactory.getLogger("TCK-Test");
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
@@ -25,6 +25,7 @@ import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.Program.OutOfGasException;
@@ -50,7 +51,7 @@ import static org.mockito.Mockito.mock;
 public class VMCustomTest {
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
     private ProgramInvokeMockImpl invoke;

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -30,10 +30,7 @@ import co.rsk.vm.BytecodeCompiler;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.core.Account;
-import org.ethereum.core.BlockFactory;
-import org.ethereum.core.Repository;
-import org.ethereum.core.Transaction;
+import org.ethereum.core.*;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.Utils;
 import org.ethereum.vm.program.Program;
@@ -66,7 +63,7 @@ public class VMTest {
     private VM vm;
 
     private final TestSystemProperties config = new TestSystemProperties();
-    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+    private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig(), mock(Block.class));
     private final VmConfig vmConfig = config.getVmConfig();
     private final PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null);
 


### PR DESCRIPTION
fixes #663 

When saving genesis to the blockstore the difficulty value encoding is calculated differently than with a regular block. To generate the same block hash, the same instance must be retrieved.