### PR TITLE
Improving remasc blocks retrieval; removing unused BlockStore method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
@@ -115,11 +115,11 @@ public class Remasc {
         int uncleGenerationLimit = constants.getUncleGenerationLimit();
         Deque<Map<Long, List<Sibling>>> descendantsBlocks = new LinkedList<>();
 
-        // this search can be optimized if have certainty that the execution block is not in a fork
-        // larger than depth
-        Block currentBlock = blockStore.getBlockByHashAndDepth(
-                executionBlock.getParentHash().getBytes(),
-                remascConstants.getMaturity() - 1 - uncleGenerationLimit
+        // this search is noe optimized if have certainty that the execution block is not in a fork
+        // larger than depth. The optimized algorithm already covers this case
+        Block currentBlock = blockStore.getBlockAtDepthStartingAt(
+                remascConstants.getMaturity() - 1 - uncleGenerationLimit,
+                executionBlock.getParentHash().getBytes()
         );
         descendantsBlocks.push(blockStore.getSiblingsFromBlockByHash(currentBlock.getHash()));
 

--- a/rskj-core/src/main/java/org/ethereum/db/BlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/BlockStore.java
@@ -48,8 +48,6 @@ public interface BlockStore extends RemascCache {
 
     Block getBlockByHash(byte[] hash);
 
-    Block getBlockByHashAndDepth(byte[] hash, long depth);
-
     Block getBlockAtDepthStartingAt(long depth, byte[] hash);
 
     boolean isBlockExist(byte[] hash);

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -131,17 +131,6 @@ public class IndexedBlockStore implements BlockStore {
     }
 
     @Override
-    public Block getBlockByHashAndDepth(byte[] hash, long depth) {
-        Block block = this.getBlockByHash(hash);
-
-        for (long i = 0; i < depth; i++) {
-            block = this.getBlockByHash(block.getParentHash().getBytes());
-        }
-
-        return block;
-    }
-
-    @Override
     // This method is an optimized way to traverse a branch in search for a block at a given depth. Starting at a given
     // block (by hash) it tries to find the first block that is part of the best chain, when it finds one we now that
     // we can jump to the block that is at the remaining depth. If not block is found then it continues traversing the

--- a/rskj-core/src/test/java/org/ethereum/db/BlockStoreDummy.java
+++ b/rskj-core/src/test/java/org/ethereum/db/BlockStoreDummy.java
@@ -54,11 +54,6 @@ public class BlockStoreDummy implements BlockStore {
     }
 
     @Override
-    public Block getBlockByHashAndDepth(byte[] hash, long depth) {
-        return null;
-    }
-
-    @Override
     public Block getBlockAtDepthStartingAt(long depth, byte[] hash) {
         return null;
     }


### PR DESCRIPTION
Remasc precompiled contract usually  retrieved 4000 blocks in mainchain, each time. Now, the retrieve of the execution block (current block - maturity aprox) was replaced by an algorithm using in other uses cases. The old method used was removed.