### PR TITLE
Add snappy compression to RLPx when p2pVersion >= 5

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     compile "org.slf4j:slf4j-api:${slf4jVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:2.8.7"
     compile "org.apache.commons:commons-lang3:3.5"
+    compile "org.xerial.snappy:snappy-java:1.1.7.3"
     compile "com.typesafe:config:1.3.3"
     compile "org.mapdb:mapdb:2.0-beta13"
     compile "co.rsk.bitcoinj:bitcoinj-thin:${bitcoinjVersion}"

--- a/rskj-core/src/main/java/org/ethereum/net/p2p/P2pHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/net/p2p/P2pHandler.java
@@ -48,7 +48,7 @@ import static org.ethereum.net.message.StaticMessages.PONG_MESSAGE;
  */
 public class P2pHandler extends SimpleChannelInboundHandler<P2pMessage> {
 
-    public static final byte VERSION = 4;
+    public static final byte VERSION = 5;
 
     private static final byte[] SUPPORTED_VERSIONS = {4, 5};
 

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -397,6 +397,9 @@ public class HandshakeHandler extends ByteToMessageDecoder {
         if (helloRemote.getP2PVersion() < 5) {
             messageCodec.setSupportChunkedFrames(false);
         }
+        if (helloRemote.getP2PVersion() >= 5) {
+            messageCodec.setApplySnappyCompression(true);
+        }
 
         FrameCodecHandler frameCodecHandler = new FrameCodecHandler(frameCodec, channel);
         ctx.pipeline().addLast("medianFrameCodec", frameCodecHandler);

--- a/rskj-core/src/test/java/org/ethereum/net/rlpx/HandshakeHandlerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/rlpx/HandshakeHandlerTest.java
@@ -36,6 +36,7 @@ import org.ethereum.net.p2p.P2pHandler;
 import org.ethereum.net.server.Channel;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import java.util.Collections;
 import java.util.List;
@@ -52,6 +53,7 @@ public class HandshakeHandlerTest {
     private Channel channel;
     private EmbeddedChannel ch;
     private ChannelHandlerContext ctx;
+    private MessageCodec messageCodecMock = mock(MessageCodec.class);
 
     @Before
     public void setup() {
@@ -61,7 +63,7 @@ public class HandshakeHandlerTest {
                 config,
                 mock(PeerScoringManager.class),
                 mock(P2pHandler.class),
-                mock(MessageCodec.class),
+                messageCodecMock,
                 // this needs to be the real object so we can test changing the HELLO message
                 new ConfigCapabilitiesImpl(config)
         );
@@ -78,6 +80,14 @@ public class HandshakeHandlerTest {
     public void shouldActivateEthIfHandshakeIsSuccessful() throws Exception {
         simulateHandshakeStartedByPeer(Collections.singletonList(new Capability(RSK, (byte) 62)));
         verify(channel, times(1)).activateEth(ctx, EthVersion.V62);
+        assertTrue(ch.isOpen());
+    }
+
+    @Test
+    public void shouldActivateSnappyCompression() throws Exception {
+        simulateHandshakeStartedByPeer(Collections.singletonList(new Capability(RSK, (byte) 62)));
+        verify(channel, times(1)).activateEth(ctx, EthVersion.V62);
+        verify(messageCodecMock, times(1)).setApplySnappyCompression(true);
         assertTrue(ch.isOpen());
     }
 


### PR DESCRIPTION
Fixes https://github.com/rsksmart/rskj/issues/1039.

This PR adds snappy compression support by adding the Xerial snappy library (a JNI wrapper for the official library).
Following the [DevP2P EIP 706](https://eips.ethereum.org/EIPS/eip-706), this PR enables snappy compression after the hello message signals a p2pVersion of 5 or higher.

There is no configuration setting for allowing snappy compression - it's enabled if p2pVersion is 5 or more by default, in the same way framing is implemented.
