### PR TITLE
Light client transaction index message

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/light/LightProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightProcessor.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.net.light;
 
 import co.rsk.net.BlockSyncService;
@@ -10,12 +28,17 @@ import org.ethereum.core.Blockchain;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.db.TransactionInfo;
+import co.rsk.net.messages.TransactionIndexResponseMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.*;
 
+
+/**
+ * Created by Julian Len and Sebastian Sicardi on 20/10/19.
+ */
 public class LightProcessor {
     private static final Logger logger = LoggerFactory.getLogger("lightprocessor");
     // keep tabs on which nodes know which blocks.
@@ -56,6 +79,33 @@ public class LightProcessor {
     }
 
     public void processBlockReceiptsResponse(MessageChannel sender, BlockReceiptsResponseMessage message) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void processTransactionIndexRequest(MessageChannel sender, long id, byte[] hash) {
+        logger.debug("transactionID request Message Received");
+
+        TransactionInfo txinfo = blockchain.getTransactionInfo(hash);
+
+        if (txinfo == null) {
+            // Don't waste time sending an empty response.
+            return;
+        }
+
+        byte[] blockHash = txinfo.getBlockHash();
+        long blockNumber = blockchain.getBlockByHash(blockHash).getNumber();
+        long txIndex = txinfo.getIndex();
+
+        TransactionIndexResponseMessage response = new TransactionIndexResponseMessage(id, blockNumber, blockHash, txIndex);
+        sender.sendMessage(response);
+    }
+
+    public void processTransactionIndexResponseMessage(MessageChannel sender, TransactionIndexResponseMessage message) {
+        logger.debug("transactionIndex response Message Received");
+        logger.debug("ID: " + message.getId());
+        logger.debug("BlockHash: " + Hex.toHexString(message.getBlockHash()));
+        logger.debug("Blocknumber: " + message.getBlockNumber());
+        logger.debug("TxIndex: " + message.getTransactionIndex());
         throw new UnsupportedOperationException();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/messages/MessageType.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/MessageType.java
@@ -260,6 +260,37 @@ public enum MessageType {
 
             return new BlockReceiptsResponseMessage(id, receipts);
         }
+    },
+
+    TRANSACTION_INDEX_REQUEST_MESSAGE(103) {
+        @Override
+        public Message createMessage(BlockFactory blockFactory, RLPList list) {
+            RLPList message = (RLPList)RLP.decode2(list.get(1).getRLPData()).get(0);
+
+            byte[] rlpId = list.get(0).getRLPData();
+            long id = rlpId == null ? 0 : BigIntegers.fromUnsignedByteArray(rlpId).longValue();
+            byte[] txHash = message.get(0).getRLPData();
+            return new TransactionIndexRequestMessage(id, txHash);
+        }
+    },
+    TRANSACTION_INDEX_RESPONSE_MESSAGE(104) {
+        @Override
+        public Message createMessage(BlockFactory blockFactory, RLPList list) {
+            RLPList message = (RLPList)RLP.decode2(list.get(1).getRLPData()).get(0);
+
+            byte[] rlpId = list.get(0).getRLPData();
+            long id = rlpId == null ? 0 : BigIntegers.fromUnsignedByteArray(rlpId).longValue();
+
+            byte[] blockNumberRLP = message.get(0).getRLPData();
+            long blockNumber = blockNumberRLP == null ? 0 : BigIntegers.fromUnsignedByteArray(blockNumberRLP).longValue();
+
+            byte[] blockHash = message.get(1).getRLPData();
+
+            byte[] rlpTx = message.get(2).getRLPData();
+            long txIndex = rlpTx == null ? 0 : BigIntegers.fromUnsignedByteArray(rlpTx).longValue();
+
+            return new TransactionIndexResponseMessage(id, blockNumber,blockHash,txIndex);
+        }
     };
 
     private int type;

--- a/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
@@ -227,6 +227,14 @@ public class MessageVisitor {
         loggerMessageProcess.debug("Tx message process finished after [{}] nano.", System.nanoTime() - start);
     }
 
+    public void apply(TransactionIndexRequestMessage message) {
+        lightProcessor.processTransactionIndexRequest(sender, message.getId(), message.getTransactionHash());
+    }
+
+    public void apply(TransactionIndexResponseMessage message) {
+        lightProcessor.processTransactionIndexResponseMessage(sender, message);
+    }
+
     private void recordEvent(MessageChannel sender, EventType event) {
         if (sender == null) {
             return;

--- a/rskj-core/src/main/java/co/rsk/net/messages/TransactionIndexRequestMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/TransactionIndexRequestMessage.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.net.messages;
+
+import org.ethereum.util.RLP;
+
+/**
+ * Created by Sebastian Sicardi on 22/10/2019.
+ */
+
+public class TransactionIndexRequestMessage extends MessageWithId {
+    private byte[] txHash;
+    private long id;
+
+    public TransactionIndexRequestMessage(long id, byte[] hash) {
+        this.txHash = hash.clone();
+        this.id = id;
+    }
+
+    public byte[] getTransactionHash() {
+        return txHash.clone();
+    }
+
+    @Override
+    public MessageType getMessageType() { return MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE; }
+
+    @Override
+    public MessageType getResponseMessageType() { return MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE; }
+
+    @Override
+    public long getId() {
+        return this.id;
+    }
+
+    @Override
+    public byte[] getEncodedMessageWithoutId() {
+        byte[] rlpHash = RLP.encodeElement(this.txHash);
+        return RLP.encodeList(rlpHash);
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/messages/TransactionIndexResponseMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/TransactionIndexResponseMessage.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.net.messages;
+
+import org.ethereum.util.RLP;
+
+import java.math.BigInteger;
+
+/**
+ * Created by Sebastian Sicardi on 22/10/2019.
+ */
+
+public class TransactionIndexResponseMessage extends MessageWithId {
+    private long id;
+    private long blockNumber;
+    private byte[] blockHash;
+    private long txIndex;
+
+    public TransactionIndexResponseMessage(long id, long blockNumber, byte[] blockHash, long txIndex) {
+        this.id = id;
+        this.blockNumber = blockNumber;
+        this.blockHash = blockHash.clone();
+        this.txIndex = txIndex;
+    }
+
+    @Override
+    public MessageType getMessageType() { return MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE; }
+
+    @Override
+    public long getId() { return this.id; }
+
+    public long getBlockNumber() { return blockNumber; }
+
+    public byte[] getBlockHash() { return blockHash.clone(); }
+
+    public long getTransactionIndex() { return txIndex; }
+
+    @Override
+    public byte[] getEncodedMessageWithoutId() {
+        byte[] rlpBlockHash = RLP.encodeElement(this.blockHash);
+        byte[] rlpBlockNumber = RLP.encodeBigInteger(BigInteger.valueOf(this.blockNumber));
+        byte[] rlpTxIndex = RLP.encodeBigInteger((BigInteger.valueOf(this.txIndex)));
+
+        return RLP.encodeList(rlpBlockNumber, rlpBlockHash, rlpTxIndex);
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/LightProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightProcessorTest.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.net;
 
 import co.rsk.config.TestSystemProperties;
@@ -16,6 +34,7 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.vm.LogInfo;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -25,14 +44,28 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.is;
 
+/**
+ * Created by Julian Len and Sebastian Sicardi on 20/10/19.
+ */
 public class LightProcessorTest {
 
     private static final byte[] HASH_1 = HashUtil.sha256(new byte[]{1});
 
+    private Blockchain blockchain;
+    private LightProcessor lightProcessor;
+    private SimpleMessageChannel sender;
+
+    @Before
+    public void setup(){
+        blockchain = mock(Blockchain.class);
+        lightProcessor = getLightProcessor(blockchain);
+        sender = new SimpleMessageChannel();
+    }
+
     @Test
     public void processBlockReceiptRequestMessageAndReturnsReceiptsCorrectly() {
-        final Blockchain blockchain = mock(Blockchain.class);
         final Block block = mock(Block.class);
         Transaction tx = mock(Transaction.class);
         TransactionInfo transactionInfo = mock(TransactionInfo.class);
@@ -50,7 +83,6 @@ public class LightProcessorTest {
         when(blockchain.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(transactionInfo.getReceipt()).thenReturn(receipt);
 
-        final LightProcessor lightProcessor = getLightProcessor(blockchain);
         final SimpleMessageChannel sender = new SimpleMessageChannel();
 
         lightProcessor.processBlockReceiptsRequest(sender, 100, block.getHash().getBytes());
@@ -70,11 +102,7 @@ public class LightProcessorTest {
 
     @Test
     public void processBlockReceiptRequestMessageWithIncorrectBlockHash() {
-        final Blockchain blockchain = mock(Blockchain.class);
         Keccak256 blockHash = new Keccak256(HASH_1);
-
-        final LightProcessor lightProcessor = getLightProcessor(blockchain);
-        final SimpleMessageChannel sender = new SimpleMessageChannel();
 
         lightProcessor.processBlockReceiptsRequest(sender, 100, blockHash.getBytes());
 
@@ -109,7 +137,7 @@ public class LightProcessorTest {
         // TODO calculate cumulative gas
         TransactionReceipt receipt = new TransactionReceipt(stateRoot, gasUsed, gasUsed, bloom, logs, new byte[]{0x01});
 
-        receipt.setTransaction(new Transaction((byte[]) null, null, null, null, null, null));
+        receipt.setTransaction(new Transaction(null, null, null, null, null, null));
 
         return receipt;
     }

--- a/rskj-core/src/test/java/co/rsk/net/LightProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightProcessorTest.java
@@ -34,15 +34,14 @@ import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.vm.LogInfo;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.hamcrest.Matchers.is;
@@ -79,7 +78,7 @@ public class LightProcessorTest {
         Keccak256 blockHash = new Keccak256(HASH_1);
         when(block.getHash()).thenReturn(blockHash);
         when(block.getTransactionsList()).thenReturn(txs);
-        Mockito.when(tx.getHash()).thenReturn(new Keccak256(TestUtils.randomBytes(32)));
+        when(tx.getHash()).thenReturn(new Keccak256(TestUtils.randomBytes(32)));
         when(blockchain.getTransactionInfo(tx.getHash().getBytes())).thenReturn(transactionInfo);
         when(blockchain.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(transactionInfo.getReceipt()).thenReturn(receipt);
@@ -88,17 +87,17 @@ public class LightProcessorTest {
 
         lightProcessor.processBlockReceiptsRequest(sender, 100, block.getHash().getBytes());
 
-        Assert.assertEquals(1, sender.getMessages().size());
+        assertEquals(1, sender.getMessages().size());
 
         final Message message = sender.getMessages().get(0);
 
-        Assert.assertEquals(MessageType.BLOCK_RECEIPTS_RESPONSE_MESSAGE, message.getMessageType());
+        assertEquals(MessageType.BLOCK_RECEIPTS_RESPONSE_MESSAGE, message.getMessageType());
 
         final BlockReceiptsResponseMessage response = (BlockReceiptsResponseMessage) message;
 
-        Assert.assertEquals(100, response.getId());
-        Assert.assertEquals(receipt, response.getBlockReceipts().get(0));
-        Assert.assertEquals(1, response.getBlockReceipts().size());
+        assertEquals(100, response.getId());
+        assertEquals(receipt, response.getBlockReceipts().get(0));
+        assertEquals(1, response.getBlockReceipts().size());
     }
 
     @Test
@@ -107,7 +106,7 @@ public class LightProcessorTest {
 
         lightProcessor.processBlockReceiptsRequest(sender, 100, blockHash.getBytes());
 
-        Assert.assertEquals(0, sender.getMessages().size());
+        assertEquals(0, sender.getMessages().size());
 
     }
 
@@ -135,24 +134,24 @@ public class LightProcessorTest {
 
         lightProcessor.processTransactionIndexRequest(sender, id, txHash.getBytes());
 
-        Assert.assertThat(sender.getMessages().size(), is(1));
+        assertThat(sender.getMessages().size(), is(1));
 
         final Message message = sender.getMessages().get(0);
 
-        Assert.assertEquals(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE, message.getMessageType());
+        assertEquals(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE, message.getMessageType());
 
         final TransactionIndexResponseMessage response = (TransactionIndexResponseMessage) message;
 
-        Assert.assertThat(response.getId(), is(id));
-        Assert.assertThat(response.getBlockHash(), is(blockHash.getBytes()));
-        Assert.assertThat(response.getTransactionIndex(), is((long)txIndex));
-        Assert.assertThat(response.getBlockNumber(), is(blockNumber));
+        assertThat(response.getId(), is(id));
+        assertThat(response.getBlockHash(), is(blockHash.getBytes()));
+        assertThat(response.getTransactionIndex(), is((long)txIndex));
+        assertThat(response.getBlockNumber(), is(blockNumber));
     }
 
     @Test
     public void processTransactionIndexRequestMessageWithIncorrectBlockHash() {
         lightProcessor.processTransactionIndexRequest(sender, 100, new Keccak256(HASH_1).getBytes());
-        Assert.assertEquals(0, sender.getMessages().size());
+        assertEquals(0, sender.getMessages().size());
     }
 
     private LightProcessor getLightProcessor(Blockchain blockchain) {

--- a/rskj-core/src/test/java/co/rsk/net/messages/BlockReceiptsRequestMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/BlockReceiptsRequestMessageTest.java
@@ -1,9 +1,9 @@
 package co.rsk.net.messages;
 
 import org.ethereum.crypto.HashUtil;
-import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class BlockReceiptsRequestMessageTest {
@@ -11,9 +11,9 @@ public class BlockReceiptsRequestMessageTest {
     public void createMessage() {
         byte[] hash = HashUtil.randomHash();
         BlockReceiptsRequestMessage message = new BlockReceiptsRequestMessage(1, hash);
-        Assert.assertEquals(1, message.getId());
-        Assert.assertArrayEquals(hash, message.getBlockHash());
-        Assert.assertEquals(MessageType.BLOCK_RECEIPTS_REQUEST_MESSAGE, message.getMessageType());
+        assertEquals(1, message.getId());
+        assertArrayEquals(hash, message.getBlockHash());
+        assertEquals(MessageType.BLOCK_RECEIPTS_REQUEST_MESSAGE, message.getMessageType());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/messages/BlockReceiptsResponseMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/BlockReceiptsResponseMessageTest.java
@@ -5,13 +5,13 @@ import org.ethereum.core.Bloom;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.vm.LogInfo;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class BlockReceiptsResponseMessageTest {
@@ -22,9 +22,9 @@ public class BlockReceiptsResponseMessageTest {
         receipts.add(createReceipt());
 
         BlockReceiptsResponseMessage message = new BlockReceiptsResponseMessage(1, receipts);
-        Assert.assertEquals(1, message.getId());
-        Assert.assertEquals(receipts, message.getBlockReceipts());
-        Assert.assertEquals(MessageType.BLOCK_RECEIPTS_RESPONSE_MESSAGE, message.getMessageType());
+        assertEquals(1, message.getId());
+        assertEquals(receipts, message.getBlockReceipts());
+        assertEquals(MessageType.BLOCK_RECEIPTS_RESPONSE_MESSAGE, message.getMessageType());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
@@ -38,6 +38,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 
+import static org.hamcrest.Matchers.is;
+
 /**
  * Created by ajlopez on 5/11/2016.
  */
@@ -439,6 +441,56 @@ public class MessageTest {
 
         Assert.assertEquals(someId, newMessage.getId());
         Assert.assertArrayEquals(hash, newMessage.getBlockHash());
+    }
+
+    @Test
+    public void encodeDecodeTransactionIndexResponseMessage() {
+        long someId = 42;
+        long someBlockNumber = 43;
+        long someTxIndex = 44;
+
+        byte[] someBlockHash = HashUtil.randomHash();
+
+        TransactionIndexResponseMessage message = new TransactionIndexResponseMessage(someId,someBlockNumber,someBlockHash,someTxIndex);
+        byte[] encoded = message.getEncoded();
+
+        Message result = Message.create(blockFactory, encoded);
+
+        Assert.assertNotNull(result);
+        Assert.assertThat(encoded, is(result.getEncoded()));
+        Assert.assertThat(result.getMessageType(), is(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE));
+
+        TransactionIndexResponseMessage newMessage = (TransactionIndexResponseMessage) result;
+
+        long idResult = newMessage.getId();
+        long blockNumberResult = newMessage.getBlockNumber();
+        long txIndexResult = newMessage.getTransactionIndex();
+        byte[] blockHashResult = newMessage.getBlockHash();
+
+        Assert.assertThat(idResult,is(idResult));
+        Assert.assertThat(blockNumberResult,is(someBlockNumber));
+        Assert.assertThat(txIndexResult,is(txIndexResult));
+        Assert.assertThat(blockHashResult,is(blockHashResult));
+    }
+
+    @Test
+    public void encodeDecodeTransactionIndexRequestMessage() {
+        long someId = 42;
+        byte[] hash = HashUtil.randomHash();
+        TransactionIndexRequestMessage message = new TransactionIndexRequestMessage(someId, hash);
+
+        byte[] encoded = message.getEncoded();
+
+        Message result = Message.create(blockFactory, encoded);
+
+        Assert.assertNotNull(result);
+        Assert.assertArrayEquals(encoded, result.getEncoded());
+        Assert.assertEquals(MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE, result.getMessageType());
+
+        TransactionIndexRequestMessage newMessage = (TransactionIndexRequestMessage) result;
+
+        Assert.assertEquals(someId, newMessage.getId());
+        Assert.assertArrayEquals(hash, newMessage.getTransactionHash());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
@@ -29,7 +29,6 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.vm.LogInfo;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -39,6 +38,7 @@ import java.util.List;
 import java.util.Random;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 
 /**
  * Created by ajlopez on 5/11/2016.
@@ -55,13 +55,13 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.GET_BLOCK_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.GET_BLOCK_MESSAGE, result.getMessageType());
 
         GetBlockMessage newmessage = (GetBlockMessage) result;
 
-        Assert.assertArrayEquals(block.getHash().getBytes(), newmessage.getBlockHash());
+        assertArrayEquals(block.getHash().getBytes(), newmessage.getBlockHash());
     }
 
     @Test
@@ -73,14 +73,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_REQUEST_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_REQUEST_MESSAGE, result.getMessageType());
 
         BlockRequestMessage newmessage = (BlockRequestMessage) result;
 
-        Assert.assertEquals(100, newmessage.getId());
-        Assert.assertArrayEquals(block.getHash().getBytes(), newmessage.getBlockHash());
+        assertEquals(100, newmessage.getId());
+        assertArrayEquals(block.getHash().getBytes(), newmessage.getBlockHash());
     }
 
     @Test
@@ -93,16 +93,16 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.STATUS_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.STATUS_MESSAGE, result.getMessageType());
 
         StatusMessage newmessage = (StatusMessage) result;
 
-        Assert.assertArrayEquals(block.getHash().getBytes(), newmessage.getStatus().getBestBlockHash());
-        Assert.assertEquals(block.getNumber(), newmessage.getStatus().getBestBlockNumber());
-        Assert.assertNull(newmessage.getStatus().getBestBlockParentHash());
-        Assert.assertNull(newmessage.getStatus().getTotalDifficulty());
+        assertArrayEquals(block.getHash().getBytes(), newmessage.getStatus().getBestBlockHash());
+        assertEquals(block.getNumber(), newmessage.getStatus().getBestBlockNumber());
+        assertNull(newmessage.getStatus().getBestBlockParentHash());
+        assertNull(newmessage.getStatus().getTotalDifficulty());
     }
 
     @Test
@@ -115,14 +115,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.STATUS_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.STATUS_MESSAGE, result.getMessageType());
 
         StatusMessage newmessage = (StatusMessage) result;
 
-        Assert.assertArrayEquals(block.getHash().getBytes(), newmessage.getStatus().getBestBlockHash());
-        Assert.assertEquals(block.getNumber(), newmessage.getStatus().getBestBlockNumber());
+        assertArrayEquals(block.getHash().getBytes(), newmessage.getStatus().getBestBlockHash());
+        assertEquals(block.getNumber(), newmessage.getStatus().getBestBlockNumber());
     }
 
     @Test
@@ -135,14 +135,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.STATUS_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.STATUS_MESSAGE, result.getMessageType());
 
         StatusMessage newmessage = (StatusMessage) result;
 
-        Assert.assertArrayEquals(block.getHash().getBytes(), newmessage.getStatus().getBestBlockHash());
-        Assert.assertEquals(block.getNumber(), newmessage.getStatus().getBestBlockNumber());
+        assertArrayEquals(block.getHash().getBytes(), newmessage.getStatus().getBestBlockHash());
+        assertEquals(block.getNumber(), newmessage.getStatus().getBestBlockNumber());
     }
 
     @Test
@@ -154,15 +154,15 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_MESSAGE, result.getMessageType());
 
         BlockMessage newmessage = (BlockMessage) result;
 
-        Assert.assertEquals(block.getNumber(), newmessage.getBlock().getNumber());
-        Assert.assertEquals(block.getHash(), newmessage.getBlock().getHash());
-        Assert.assertArrayEquals(block.getEncoded(), newmessage.getBlock().getEncoded());
+        assertEquals(block.getNumber(), newmessage.getBlock().getNumber());
+        assertEquals(block.getHash(), newmessage.getBlock().getHash());
+        assertArrayEquals(block.getEncoded(), newmessage.getBlock().getEncoded());
     }
 
     @Test
@@ -172,20 +172,20 @@ public class MessageTest {
 
         byte[] encoded = message.getEncoded();
 
-        Assert.assertNotNull(encoded);
+        assertNotNull(encoded);
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_RESPONSE_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_RESPONSE_MESSAGE, result.getMessageType());
 
         BlockResponseMessage newmessage = (BlockResponseMessage) result;
 
-        Assert.assertEquals(100, newmessage.getId());
-        Assert.assertEquals(block.getNumber(), newmessage.getBlock().getNumber());
-        Assert.assertEquals(block.getHash(), newmessage.getBlock().getHash());
-        Assert.assertArrayEquals(block.getEncoded(), newmessage.getBlock().getEncoded());
+        assertEquals(100, newmessage.getId());
+        assertEquals(block.getNumber(), newmessage.getBlock().getNumber());
+        assertEquals(block.getHash(), newmessage.getBlock().getHash());
+        assertArrayEquals(block.getEncoded(), newmessage.getBlock().getEncoded());
     }
 
     @Test
@@ -199,24 +199,24 @@ public class MessageTest {
 
         byte[] encoded = message.getEncoded();
 
-        Assert.assertNotNull(encoded);
+        assertNotNull(encoded);
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_HEADERS_RESPONSE_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_HEADERS_RESPONSE_MESSAGE, result.getMessageType());
 
         BlockHeadersResponseMessage newmessage = (BlockHeadersResponseMessage) result;
 
-        Assert.assertEquals(100, newmessage.getId());
+        assertEquals(100, newmessage.getId());
 
-        Assert.assertEquals(headers.size(), newmessage.getBlockHeaders().size());
+        assertEquals(headers.size(), newmessage.getBlockHeaders().size());
 
         for (int k = 0; k < headers.size(); k++) {
-            Assert.assertEquals(headers.get(k).getNumber(), newmessage.getBlockHeaders().get(k).getNumber());
-            Assert.assertEquals(headers.get(k).getHash(), newmessage.getBlockHeaders().get(k).getHash());
-            Assert.assertArrayEquals(headers.get(k).getFullEncoded(), newmessage.getBlockHeaders().get(k).getFullEncoded());
+            assertEquals(headers.get(k).getNumber(), newmessage.getBlockHeaders().get(k).getNumber());
+            assertEquals(headers.get(k).getHash(), newmessage.getBlockHeaders().get(k).getHash());
+            assertArrayEquals(headers.get(k).getFullEncoded(), newmessage.getBlockHeaders().get(k).getFullEncoded());
         }
     }
 
@@ -235,20 +235,20 @@ public class MessageTest {
         byte[] encoded = message.getEncoded();
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.NEW_BLOCK_HASHES, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.NEW_BLOCK_HASHES, result.getMessageType());
 
         NewBlockHashesMessage decodedMessage = (NewBlockHashesMessage) result;
 
-        Assert.assertNotNull(decodedMessage.getBlockIdentifiers());
+        assertNotNull(decodedMessage.getBlockIdentifiers());
 
         List<BlockIdentifier> decodedIdentifiers = decodedMessage.getBlockIdentifiers();
 
-        Assert.assertEquals(identifiers.size(), decodedIdentifiers.size());
+        assertEquals(identifiers.size(), decodedIdentifiers.size());
         for (int i = 0; i < identifiers.size(); i ++) {
-            Assert.assertEquals(identifiers.get(i).getNumber(), decodedIdentifiers.get(i).getNumber());
-            Assert.assertArrayEquals(identifiers.get(i).getHash(), decodedIdentifiers.get(i).getHash());
+            assertEquals(identifiers.get(i).getNumber(), decodedIdentifiers.get(i).getNumber());
+            assertArrayEquals(identifiers.get(i).getHash(), decodedIdentifiers.get(i).getHash());
         }
     }
 
@@ -261,20 +261,20 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.TRANSACTIONS, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.TRANSACTIONS, result.getMessageType());
 
         TransactionsMessage newmessage = (TransactionsMessage) result;
 
-        Assert.assertNotNull(newmessage.getTransactions());
-        Assert.assertEquals(10, newmessage.getTransactions().size());
+        assertNotNull(newmessage.getTransactions());
+        assertEquals(10, newmessage.getTransactions().size());
 
         for (int k = 0; k < 10; k++) {
             Transaction tx1 = txs.get(k);
             Transaction tx2 = newmessage.getTransactions().get(k);
 
-            Assert.assertEquals(tx1.getHash(), tx2.getHash());
+            assertEquals(tx1.getHash(), tx2.getHash());
         }
     }
 
@@ -288,14 +288,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_HASH_REQUEST_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_HASH_REQUEST_MESSAGE, result.getMessageType());
 
         BlockHashRequestMessage newMessage = (BlockHashRequestMessage) result;
 
-        Assert.assertEquals(someId, newMessage.getId());
-        Assert.assertEquals(someHeight, newMessage.getHeight());
+        assertEquals(someId, newMessage.getId());
+        assertEquals(someHeight, newMessage.getHeight());
     }
 
     @Test
@@ -308,14 +308,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_HASH_REQUEST_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_HASH_REQUEST_MESSAGE, result.getMessageType());
 
         BlockHashRequestMessage newMessage = (BlockHashRequestMessage) result;
 
-        Assert.assertEquals(someId, newMessage.getId());
-        Assert.assertEquals(someHeight, newMessage.getHeight());
+        assertEquals(someId, newMessage.getId());
+        assertEquals(someHeight, newMessage.getHeight());
     }
 
     @Test
@@ -331,14 +331,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_HASH_RESPONSE_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_HASH_RESPONSE_MESSAGE, result.getMessageType());
 
         BlockHashResponseMessage newMessage = (BlockHashResponseMessage) result;
 
-        Assert.assertEquals(id, newMessage.getId());
-        Assert.assertArrayEquals(hash, newMessage.getHash());
+        assertEquals(id, newMessage.getId());
+        assertArrayEquals(hash, newMessage.getHash());
     }
 
     @Test
@@ -350,15 +350,15 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_HEADERS_REQUEST_MESSAGE, result.getMessageType());
 
         BlockHeadersRequestMessage newmessage = (BlockHeadersRequestMessage) result;
 
-        Assert.assertEquals(1, newmessage.getId());
-        Assert.assertArrayEquals(hash, newmessage.getHash());
-        Assert.assertEquals(100, newmessage.getCount());
+        assertEquals(1, newmessage.getId());
+        assertArrayEquals(hash, newmessage.getHash());
+        assertEquals(100, newmessage.getCount());
     }
 
     @Test
@@ -378,21 +378,21 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.SKELETON_RESPONSE_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.SKELETON_RESPONSE_MESSAGE, result.getMessageType());
 
         SkeletonResponseMessage newMessage = (SkeletonResponseMessage) result;
 
-        Assert.assertEquals(someId, newMessage.getId());
+        assertEquals(someId, newMessage.getId());
 
         List<BlockIdentifier> newIds = newMessage.getBlockIdentifiers();
         for (int i = 0; i < ids.size(); i++) {
             BlockIdentifier id = ids.get(i);
             BlockIdentifier newId = newIds.get(i);
 
-            Assert.assertEquals(id.getNumber(), newId.getNumber());
-            Assert.assertArrayEquals(id.getHash(), newId.getHash());
+            assertEquals(id.getNumber(), newId.getNumber());
+            assertArrayEquals(id.getHash(), newId.getHash());
         }
     }
 
@@ -408,18 +408,18 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_RECEIPTS_RESPONSE_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_RECEIPTS_RESPONSE_MESSAGE, result.getMessageType());
 
         BlockReceiptsResponseMessage newMessage = (BlockReceiptsResponseMessage) result;
 
-        Assert.assertEquals(someId, newMessage.getId());
+        assertEquals(someId, newMessage.getId());
         List<TransactionReceipt> newReceipts = newMessage.getBlockReceipts();
-        Assert.assertEquals(receipts.size(), newReceipts.size());
+        assertEquals(receipts.size(), newReceipts.size());
 
         for (int i = 0; i < receipts.size(); i++) {
-            Assert.assertArrayEquals(receipts.get(i).getEncoded(), newReceipts.get(i).getEncoded());
+            assertArrayEquals(receipts.get(i).getEncoded(), newReceipts.get(i).getEncoded());
         }
     }
 
@@ -433,14 +433,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BLOCK_RECEIPTS_REQUEST_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BLOCK_RECEIPTS_REQUEST_MESSAGE, result.getMessageType());
 
         BlockReceiptsRequestMessage newMessage = (BlockReceiptsRequestMessage) result;
 
-        Assert.assertEquals(someId, newMessage.getId());
-        Assert.assertArrayEquals(hash, newMessage.getBlockHash());
+        assertEquals(someId, newMessage.getId());
+        assertArrayEquals(hash, newMessage.getBlockHash());
     }
 
     @Test
@@ -453,14 +453,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.SKELETON_REQUEST_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.SKELETON_REQUEST_MESSAGE, result.getMessageType());
 
         SkeletonRequestMessage newMessage = (SkeletonRequestMessage) result;
 
-        Assert.assertEquals(someId, newMessage.getId());
-        Assert.assertEquals(someStartNumber, newMessage.getStartNumber());
+        assertEquals(someId, newMessage.getId());
+        assertEquals(someStartNumber, newMessage.getStartNumber());
     }
 
     @Test
@@ -472,13 +472,13 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.NEW_BLOCK_HASH_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.NEW_BLOCK_HASH_MESSAGE, result.getMessageType());
 
         NewBlockHashMessage newMessage = (NewBlockHashMessage) result;
 
-        Assert.assertArrayEquals(hash, newMessage.getBlockHash());
+        assertArrayEquals(hash, newMessage.getBlockHash());
     }
 
     @Test
@@ -490,14 +490,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BODY_REQUEST_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BODY_REQUEST_MESSAGE, result.getMessageType());
 
         BodyRequestMessage newmessage = (BodyRequestMessage) result;
 
-        Assert.assertEquals(100, newmessage.getId());
-        Assert.assertArrayEquals(block.getHash().getBytes(), newmessage.getBlockHash());
+        assertEquals(100, newmessage.getId());
+        assertArrayEquals(block.getHash().getBytes(), newmessage.getBlockHash());
     }
 
     @Test
@@ -524,26 +524,26 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.BODY_RESPONSE_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.BODY_RESPONSE_MESSAGE, result.getMessageType());
 
         BodyResponseMessage newmessage = (BodyResponseMessage)result;
 
-        Assert.assertNotNull(newmessage);
+        assertNotNull(newmessage);
 
-        Assert.assertEquals(100, newmessage.getId());
+        assertEquals(100, newmessage.getId());
 
-        Assert.assertNotNull(newmessage.getTransactions());
-        Assert.assertEquals(transactions.size(), newmessage.getTransactions().size());
+        assertNotNull(newmessage.getTransactions());
+        assertEquals(transactions.size(), newmessage.getTransactions().size());
 
-        Assert.assertEquals(transactions, newmessage.getTransactions());
+        assertEquals(transactions, newmessage.getTransactions());
 
-        Assert.assertNotNull(newmessage.getUncles());
-        Assert.assertEquals(uncles.size(), newmessage.getUncles().size());
+        assertNotNull(newmessage.getUncles());
+        assertEquals(uncles.size(), newmessage.getUncles().size());
 
         for (int k = 0; k < uncles.size(); k++)
-            Assert.assertArrayEquals(uncles.get(k).getFullEncoded(), newmessage.getUncles().get(k).getFullEncoded());
+            assertArrayEquals(uncles.get(k).getFullEncoded(), newmessage.getUncles().get(k).getFullEncoded());
     }
 
     @Test
@@ -559,16 +559,16 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertThat(result.getEncoded(), is(encoded));
-        Assert.assertThat(result.getMessageType(), is(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE));
+        assertNotNull(result);
+        assertThat(result.getEncoded(), is(encoded));
+        assertThat(result.getMessageType(), is(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE));
 
         TransactionIndexResponseMessage newMessage = (TransactionIndexResponseMessage) result;
 
-        Assert.assertThat(newMessage.getId(),is(someId));
-        Assert.assertThat(newMessage.getBlockNumber(),is(someBlockNumber));
-        Assert.assertThat(newMessage.getTransactionIndex(),is(someTxIndex));
-        Assert.assertThat(newMessage.getBlockHash(),is(someBlockHash));
+        assertThat(newMessage.getId(),is(someId));
+        assertThat(newMessage.getBlockNumber(),is(someBlockNumber));
+        assertThat(newMessage.getTransactionIndex(),is(someTxIndex));
+        assertThat(newMessage.getBlockHash(),is(someBlockHash));
     }
 
     @Test
@@ -581,14 +581,14 @@ public class MessageTest {
 
         Message result = Message.create(blockFactory, encoded);
 
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE, result.getMessageType());
+        assertNotNull(result);
+        assertArrayEquals(encoded, result.getEncoded());
+        assertEquals(MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE, result.getMessageType());
 
         TransactionIndexRequestMessage newMessage = (TransactionIndexRequestMessage) result;
 
-        Assert.assertEquals(someId, newMessage.getId());
-        Assert.assertArrayEquals(hash, newMessage.getTransactionHash());
+        assertEquals(someId, newMessage.getId());
+        assertArrayEquals(hash, newMessage.getTransactionHash());
     }
 
     private static Transaction createTransaction(int number) {

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
@@ -444,56 +444,6 @@ public class MessageTest {
     }
 
     @Test
-    public void encodeDecodeTransactionIndexResponseMessage() {
-        long someId = 42;
-        long someBlockNumber = 43;
-        long someTxIndex = 44;
-
-        byte[] someBlockHash = HashUtil.randomHash();
-
-        TransactionIndexResponseMessage message = new TransactionIndexResponseMessage(someId,someBlockNumber,someBlockHash,someTxIndex);
-        byte[] encoded = message.getEncoded();
-
-        Message result = Message.create(blockFactory, encoded);
-
-        Assert.assertNotNull(result);
-        Assert.assertThat(encoded, is(result.getEncoded()));
-        Assert.assertThat(result.getMessageType(), is(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE));
-
-        TransactionIndexResponseMessage newMessage = (TransactionIndexResponseMessage) result;
-
-        long idResult = newMessage.getId();
-        long blockNumberResult = newMessage.getBlockNumber();
-        long txIndexResult = newMessage.getTransactionIndex();
-        byte[] blockHashResult = newMessage.getBlockHash();
-
-        Assert.assertThat(idResult,is(idResult));
-        Assert.assertThat(blockNumberResult,is(someBlockNumber));
-        Assert.assertThat(txIndexResult,is(txIndexResult));
-        Assert.assertThat(blockHashResult,is(blockHashResult));
-    }
-
-    @Test
-    public void encodeDecodeTransactionIndexRequestMessage() {
-        long someId = 42;
-        byte[] hash = HashUtil.randomHash();
-        TransactionIndexRequestMessage message = new TransactionIndexRequestMessage(someId, hash);
-
-        byte[] encoded = message.getEncoded();
-
-        Message result = Message.create(blockFactory, encoded);
-
-        Assert.assertNotNull(result);
-        Assert.assertArrayEquals(encoded, result.getEncoded());
-        Assert.assertEquals(MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE, result.getMessageType());
-
-        TransactionIndexRequestMessage newMessage = (TransactionIndexRequestMessage) result;
-
-        Assert.assertEquals(someId, newMessage.getId());
-        Assert.assertArrayEquals(hash, newMessage.getTransactionHash());
-    }
-
-    @Test
     public void encodeDecodeSkeletonRequestMessage() {
         long someId = 42;
         long someStartNumber = 99;
@@ -594,6 +544,51 @@ public class MessageTest {
 
         for (int k = 0; k < uncles.size(); k++)
             Assert.assertArrayEquals(uncles.get(k).getFullEncoded(), newmessage.getUncles().get(k).getFullEncoded());
+    }
+
+    @Test
+    public void encodeDecodeTransactionIndexResponseMessage() {
+        long someId = 42;
+        long someBlockNumber = 43;
+        long someTxIndex = 44;
+
+        byte[] someBlockHash = HashUtil.randomHash();
+
+        TransactionIndexResponseMessage message = new TransactionIndexResponseMessage(someId,someBlockNumber,someBlockHash,someTxIndex);
+        byte[] encoded = message.getEncoded();
+
+        Message result = Message.create(blockFactory, encoded);
+
+        Assert.assertNotNull(result);
+        Assert.assertThat(result.getEncoded(), is(encoded));
+        Assert.assertThat(result.getMessageType(), is(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE));
+
+        TransactionIndexResponseMessage newMessage = (TransactionIndexResponseMessage) result;
+
+        Assert.assertThat(newMessage.getId(),is(someId));
+        Assert.assertThat(newMessage.getBlockNumber(),is(someBlockNumber));
+        Assert.assertThat(newMessage.getTransactionIndex(),is(someTxIndex));
+        Assert.assertThat(newMessage.getBlockHash(),is(someBlockHash));
+    }
+
+    @Test
+    public void encodeDecodeTransactionIndexRequestMessage() {
+        long someId = 42;
+        byte[] hash = HashUtil.randomHash();
+        TransactionIndexRequestMessage message = new TransactionIndexRequestMessage(someId, hash);
+
+        byte[] encoded = message.getEncoded();
+
+        Message result = Message.create(blockFactory, encoded);
+
+        Assert.assertNotNull(result);
+        Assert.assertArrayEquals(encoded, result.getEncoded());
+        Assert.assertEquals(MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE, result.getMessageType());
+
+        TransactionIndexRequestMessage newMessage = (TransactionIndexRequestMessage) result;
+
+        Assert.assertEquals(someId, newMessage.getId());
+        Assert.assertArrayEquals(hash, newMessage.getTransactionHash());
     }
 
     private static Transaction createTransaction(int number) {

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageVisitorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageVisitorTest.java
@@ -282,6 +282,30 @@ public class MessageVisitorTest {
     }
 
     @Test
+    public void transactionIndexRequestMessage() {
+        TransactionIndexRequestMessage message = mock(TransactionIndexRequestMessage.class);
+        byte[] hash = new byte[]{0x0F};
+
+        when(message.getTransactionHash()).thenReturn(hash);
+        when(message.getId()).thenReturn(24L);
+
+        target.apply(message);
+
+        verify(lightProcessor, times(1))
+                .processTransactionIndexRequest(eq(sender), eq(24L), eq(hash));
+    }
+
+    @Test
+    public void transactionIndexResponseMessage() {
+        TransactionIndexResponseMessage message = mock(TransactionIndexResponseMessage.class);
+
+        target.apply(message);
+
+        verify(lightProcessor, times(1))
+                .processTransactionIndexResponseMessage(eq(sender), eq(message));
+    }
+
+    @Test
     public void skeletonRequestMessage() {
         SkeletonRequestMessage message = mock(SkeletonRequestMessage.class);
         when(message.getStartNumber()).thenReturn(24L);

--- a/rskj-core/src/test/java/co/rsk/net/messages/TransactionIndexRequestMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/TransactionIndexRequestMessageTest.java
@@ -1,10 +1,10 @@
 package co.rsk.net.messages;
 
 import org.ethereum.crypto.HashUtil;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class TransactionIndexRequestMessageTest {
@@ -16,9 +16,9 @@ public class TransactionIndexRequestMessageTest {
 
         TransactionIndexRequestMessage message = new TransactionIndexRequestMessage(id, hash);
 
-        Assert.assertThat(message.getId(), is(id));
-        Assert.assertThat(message.getTransactionHash(), is(hash));
-        Assert.assertThat(message.getMessageType(), is(MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE));
+        assertThat(message.getId(), is(id));
+        assertThat(message.getTransactionHash(), is(hash));
+        assertThat(message.getMessageType(), is(MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/messages/TransactionIndexRequestMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/TransactionIndexRequestMessageTest.java
@@ -1,0 +1,36 @@
+package co.rsk.net.messages;
+
+import org.ethereum.crypto.HashUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+public class TransactionIndexRequestMessageTest {
+
+    @Test
+    public void createMessage() {
+        long id = 0;
+        byte[] hash = HashUtil.randomHash();
+
+        TransactionIndexRequestMessage message = new TransactionIndexRequestMessage(id, hash);
+
+        Assert.assertThat(message.getId(), is(id));
+        Assert.assertThat(message.getTransactionHash(), is(hash));
+        Assert.assertThat(message.getMessageType(), is(MessageType.TRANSACTION_INDEX_REQUEST_MESSAGE));
+    }
+
+    @Test
+    public void accept() {
+        byte[] hash = new byte[]{0x0F};
+        long id = 100;
+        MessageVisitor visitor = mock(MessageVisitor.class);
+
+        TransactionIndexRequestMessage message = new TransactionIndexRequestMessage(id, hash);
+        message.accept(visitor);
+
+        verify(visitor, times(1)).apply(message);
+    }
+
+}

--- a/rskj-core/src/test/java/co/rsk/net/messages/TransactionIndexResponseMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/TransactionIndexResponseMessageTest.java
@@ -1,0 +1,40 @@
+package co.rsk.net.messages;
+
+import org.ethereum.crypto.HashUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+public class TransactionIndexResponseMessageTest {
+
+    @Test
+    public void createMessage() {
+        long id = 0;
+        byte[] blockHash = HashUtil.randomHash();
+        long blockNumber = 1;
+        long txIdx = 1;
+
+        TransactionIndexResponseMessage message = new TransactionIndexResponseMessage(id, blockNumber, blockHash,txIdx);
+
+        Assert.assertThat(message.getId(), is(id));
+        Assert.assertThat(message.getBlockHash(), is(blockHash));
+        Assert.assertThat(message.getMessageType(), is(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE));
+    }
+
+    @Test
+    public void accept() {
+        long id = 0;
+        byte[] blockHash = HashUtil.randomHash();
+        long blockNumber = 1;
+        long txIdx = 1;
+        MessageVisitor visitor = mock(MessageVisitor.class);
+
+        TransactionIndexResponseMessage message = new TransactionIndexResponseMessage(id, blockNumber, blockHash,txIdx);
+        message.accept(visitor);
+
+        verify(visitor, times(1)).apply(message);
+    }
+
+}

--- a/rskj-core/src/test/java/co/rsk/net/messages/TransactionIndexResponseMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/TransactionIndexResponseMessageTest.java
@@ -1,10 +1,10 @@
 package co.rsk.net.messages;
 
 import org.ethereum.crypto.HashUtil;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class TransactionIndexResponseMessageTest {
@@ -18,9 +18,9 @@ public class TransactionIndexResponseMessageTest {
 
         TransactionIndexResponseMessage message = new TransactionIndexResponseMessage(id, blockNumber, blockHash,txIdx);
 
-        Assert.assertThat(message.getId(), is(id));
-        Assert.assertThat(message.getBlockHash(), is(blockHash));
-        Assert.assertThat(message.getMessageType(), is(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE));
+        assertThat(message.getId(), is(id));
+        assertThat(message.getBlockHash(), is(blockHash));
+        assertThat(message.getMessageType(), is(MessageType.TRANSACTION_INDEX_RESPONSE_MESSAGE));
     }
 
     @Test


### PR DESCRIPTION
Transaction Index Message (branch name is wrong, sorry)

Original Parity message:
// Request for transaction index based on hash.
Request::TransactionIndex {
    ID: 2
    Inputs:
        Loose(H256) // transaction hash
    Outputs:
        U reusable_as(0) // block number
        H256 reusable_as(1) // block hash
        U // index in the block.
}


Our Request:
ID
Input: TransactionHash

Our Response:
ID
Input: BlockNumber, BlockHash, TransactionIndex
