### PR TITLE
Abstract gas cost operations in precompileds

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -402,7 +402,7 @@ public class TransactionExecutor {
 
             if (tx.isContractCreation() && !result.isRevert()) {
                 int createdContractSize = getLength(program.getResult().getHReturn());
-                int returnDataGasValue = createdContractSize * GasCost.CREATE_DATA;
+                long returnDataGasValue = createdContractSize * GasCost.CREATE_DATA;
                 if (mEndGas.compareTo(BigInteger.valueOf(returnDataGasValue)) < 0) {
                     program.setRuntimeFailure(
                             Program.ExceptionHelper.notEnoughSpendingGas(

--- a/rskj-core/src/main/java/org/ethereum/vm/GasCost.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/GasCost.java
@@ -20,75 +20,326 @@
 
 package org.ethereum.vm;
 
+import java.math.BigInteger;
+
 /**
  * The fundamental network cost unit. Paid for exclusively by SBTC, which is converted
  * freely to and from Gas as required. Gas does not exist outside of the internal RSK
  * computation engine; its price is set by the Transaction and miners are free to
  * ignore Transactions whose Gas price is too low.
+ *
+ * GasCost includes static methods to operate on floats which represent Gas. These methods
+ * should always be used when calculating gas.
  */
 public class GasCost {
+    // Everything in this class should be static, do not initialize.
+    private GasCost() { }
 
     /* backwards compatibility, remove eventually */
-    public static final int STEP = 1;
-    public static final int SSTORE = 300;
+    public static final long STEP = 1;
+    public static final long SSTORE = 300;
     /* backwards compatibility, remove eventually */
 
-    public static final int ZEROSTEP = 0;
-    public static final int QUICKSTEP = 2;
-    public static final int FASTESTSTEP = 3;
-    public static final int FASTSTEP = 5;
-    public static final int MIDSTEP = 8;
-    public static final int SLOWSTEP = 10;
-    public static final int EXTSTEP = 20;
+    public static final long ZEROSTEP = 0;
+    public static final long QUICKSTEP = 2;
+    public static final long FASTESTSTEP = 3;
+    public static final long FASTSTEP = 5;
+    public static final long MIDSTEP = 8;
+    public static final long SLOWSTEP = 10;
+    public static final long EXTSTEP = 20;
 
-    public static final int GENESISGASLIMIT = 1000000;
-    public static final int MINGASLIMIT = 125000;
+    public static final long GENESISGASLIMIT = 1000000;
+    public static final long MINGASLIMIT = 125000;
 
-    public static final int BALANCE = 400;
-    public static final int SHA3 = 30;
-    public static final int SHA3_WORD = 6;
-    public static final int SLOAD = 200;
-    public static final int STOP = 0;
-    public static final int SUICIDE = 5000;
-    public static final int CLEAR_SSTORE = 5000;
-    public static final int SET_SSTORE = 20000;
-    public static final int RESET_SSTORE = 5000;
-    public static final int REFUND_SSTORE = 15000;
-    public static final int CREATE = 32000;
+    public static final long BALANCE = 400;
+    public static final long SHA3 = 30;
+    public static final long SHA3_WORD = 6;
+    public static final long SLOAD = 200;
+    public static final long STOP = 0;
+    public static final long SUICIDE = 5000;
+    public static final long CLEAR_SSTORE = 5000;
+    public static final long SET_SSTORE = 20000;
+    public static final long RESET_SSTORE = 5000;
+    public static final long REFUND_SSTORE = 15000;
+    public static final long CREATE = 32000;
 
-    public static final int JUMPDEST = 1;
-    public static final int CREATE_DATA_BYTE = 5;
-    public static final int CALL = 700;
-    public static final int STIPEND_CALL = 2300; // For transferring coins in CALL, this is always passed to child
-    public static final int VT_CALL = 9000;  //value transfer call
-    public static final int NEW_ACCT_CALL = 25000;  //new account call
-    public static final int MEMORY = 3; // TODO: Memory in V0 is more expensive than V1: This MUST be modified before release
-    public static final int MEMORY_V1 =3;
-    public static final int SUICIDE_REFUND = 24000;
-    public static final int QUAD_COEFF_DIV = 512;
-    public static final int CREATE_DATA = 200; // paid for each new byte of code
-    public static final int REPLACE_DATA = 50; // paid for each byte of code replaced
-    public static final int TX_NO_ZERO_DATA = 68;
-    public static final int TX_ZERO_DATA = 4;
-    public static final int TRANSACTION = 21000;
-    public static final int TRANSACTION_DEFAULT = 90000; //compatibility with ethereum (mmarquez)
-    public static final int TRANSACTION_CREATE_CONTRACT = 53000;
-    public static final int LOG_GAS = 375;
-    public static final int LOG_DATA_GAS = 8;
-    public static final int LOG_TOPIC_GAS = 375;
-    public static final int COPY_GAS = 3;
-    public static final int EXP_GAS = 10;
-    public static final int EXP_BYTE_GAS = 50;
-    public static final int IDENTITY = 15;
-    public static final int IDENTITY_WORD = 3;
-    public static final int RIPEMD160 = 600;
-    public static final int RIPEMD160_WORD = 120;
-    public static final int SHA256 = 60;
-    public static final int SHA256_WORD = 12;
-    public static final int EC_RECOVER = 3000;
-    public static final int EXT_CODE_SIZE = 700;
-    public static final int EXT_CODE_COPY = 700;
-    public static final int EXT_CODE_HASH = 400;
-    public static final int NEW_ACCT_SUICIDE = 25000;
-    public static final int RETURN = 0;
+    public static final long JUMPDEST = 1;
+    public static final long CREATE_DATA_BYTE = 5;
+    public static final long CALL = 700;
+    public static final long STIPEND_CALL = 2300; // For transferring coins in CALL, this is always passed to child
+    public static final long VT_CALL = 9000;  //value transfer call
+    public static final long NEW_ACCT_CALL = 25000;  //new account call
+    public static final long MEMORY = 3; // TODO: Memory in V0 is more expensive than V1: This MUST be modified before release
+    public static final long MEMORY_V1 =3;
+    public static final long SUICIDE_REFUND = 24000;
+    public static final long QUAD_COEFF_DIV = 512;
+    public static final long CREATE_DATA = 200; // paid for each new byte of code
+    public static final long REPLACE_DATA = 50; // paid for each byte of code replaced
+    public static final long TX_NO_ZERO_DATA = 68;
+    public static final long TX_ZERO_DATA = 4;
+    public static final long TRANSACTION = 21000;
+    public static final long TRANSACTION_DEFAULT = 90000; //compatibility with ethereum (mmarquez)
+    public static final long TRANSACTION_CREATE_CONTRACT = 53000;
+    public static final long LOG_GAS = 375;
+    public static final long LOG_DATA_GAS = 8;
+    public static final long LOG_TOPIC_GAS = 375;
+    public static final long COPY_GAS = 3;
+    public static final long EXP_GAS = 10;
+    public static final long EXP_BYTE_GAS = 50;
+    public static final long IDENTITY = 15;
+    public static final long IDENTITY_WORD = 3;
+    public static final long RIPEMD160 = 600;
+    public static final long RIPEMD160_WORD = 120;
+    public static final long SHA256 = 60;
+    public static final long SHA256_WORD = 12;
+    public static final long EC_RECOVER = 3000;
+    public static final long EXT_CODE_SIZE = 700;
+    public static final long EXT_CODE_COPY = 700;
+    public static final long EXT_CODE_HASH = 400;
+    public static final long NEW_ACCT_SUICIDE = 25000;
+    public static final long RETURN = 0;
+
+    /**
+     * An exception which is thrown be methods in GasCost when
+     * an operation overflows, has invalid inputs or wants to return
+     * an invalid gas value.
+     */
+    public static class InvalidGasException extends Exception {
+
+        private InvalidGasException(long invalidValue) {
+            super(String.format("Got invalid gas value: %d", invalidValue));
+        }
+
+        private InvalidGasException(BigInteger invalidValue) {
+            super(String.format("Got invalid gas value: %d", invalidValue));
+        }
+
+        private InvalidGasException(String reason) {
+            super(String.format("Got an invalid gas value: Reason: %s", reason));
+        }
+
+    }
+
+    /**
+     * Converts a byte array to gas.
+     * @param bytes represents the number which will be converted to gas.
+     * @return the gas equivalent of the byte array.
+     * @throws InvalidGasException if the number if bigger than .MAX_GAS.
+     */
+    public static long toGas(byte []bytes) throws InvalidGasException {
+        BigInteger bigValue = new BigInteger(1, bytes);
+        // big integer is created as unsigned, no need
+        // to check for negative values
+        if (bigValue.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0 ) {
+            throw new InvalidGasException(bigValue);
+        }
+        long gas =  bigValue.longValue();
+        // make sure sign has not changed
+        if (gas < 0) {
+            throw new InvalidGasException(bigValue);
+        }
+        return gas;
+    }
+
+    /**
+     * Like `toGas`, but if the byte array is bigger than Long.MAX_VALUE,
+     * return Long.MAX_VALUE. Expects the arguments in big endian.
+     */
+    public static long toGasBounded(byte[] bytes) {
+        BigInteger bigValue = new BigInteger(1, bytes);
+        // big integer is created as unsigned, no need
+        // to check for negative values
+        if (bigValue.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0 ) {
+            return Long.MAX_VALUE;
+        }
+        long gas = bigValue.longValue();
+        // make sure sign has not changed
+        if (gas < 0) {
+            return Long.MAX_VALUE;
+        }
+        return gas;
+    }
+
+    public static long toGasBounded(BigInteger big) {
+        return toGasBounded(big.toByteArray());
+    }
+
+    public static long toGasBounded(long number) {
+        if (number < 0) {
+            return Long.MAX_VALUE;
+        }
+        return number;
+    }
+
+    /**
+     * Adds two float numbers representing gas.
+     * @param x some gas.
+     * @param y another gas.
+     * @return the sum of the two numbers.
+     * @throws InvalidGasException if any of the gas inputs is negative
+     *         or if the sum is bigger than Long.MAX_VALUE.
+     */
+    public static long add(long x, long y) throws InvalidGasException {
+        if (x < 0 || y < 0) {
+            long offender = x < 0 ? x : y;
+            throw new InvalidGasException(offender);
+        }
+
+        long result = x + y;
+        if (additionOverflowed(x, y, result)) {
+            throw new InvalidGasException("overflow");
+        }
+        return result;
+    }
+
+
+    /**
+     * Like `add`, but returns Long.MAX_VALUE instead of
+     * throwing `InvalidGasException`.
+     */
+    public static long addBounded(long x, long y) {
+        if (x < 0 || y < 0) {
+            return Long.MAX_VALUE;
+        }
+        long result = x + y;
+        if (additionOverflowed(x, y, result)) {
+            return Long.MAX_VALUE;
+        }
+        return result;
+    }
+
+    public static long multiply(long x, long y) throws InvalidGasException {
+        if (x < 0 || y < 0) {
+            long offender = x < 0 ? x : y;
+            throw new InvalidGasException(offender);
+        }
+        long result = x * y;
+        if (multiplicationOverflowed(x, y, result)) {
+            throw new InvalidGasException("overflow");
+        }
+        return result;
+    }
+
+    /**
+     * Multiply, bounding the result between
+     * 0 and Long.MAX_VALUE
+     */
+    public static long multiplyBounded(long x, long y) {
+        if (x < 0 || y < 0) {
+            return Long.MAX_VALUE;
+        }
+        long result = x * y;
+        if (multiplicationOverflowed(x, y, result)) {
+            return Long.MAX_VALUE;
+        }
+        return result;
+    }
+
+    /**
+     * Substracts two longs representing gas.
+     * @throws InvalidGasException if any of the inputs are invalid
+     *         or the operation overflows or underflows.
+     */
+    public static long subtract(long x, long y) throws InvalidGasException {
+        if (x < 0 || y < 0) {
+            long offender = x < 0 ? x : y;
+            throw new InvalidGasException(offender);
+        }
+        long result = Math.subtractExact(x, y);
+        if (result < 0) {
+            throw new InvalidGasException(result);
+        } else if (subtractionOverflowed(x, y, result)) {
+            throw new InvalidGasException("overflow");
+        }
+        return result;
+    }
+
+    /**
+     * Like `substract`, but returns 0 or `Long.MAX_VALUE` instead
+     * of throwing an exception.
+     */
+    public static long subtractBounded(long x, long y) {
+        if (y < 0) {
+            return addBounded(x, -y);
+        }
+        long result = x - y;
+        if (result < 0 || subtractionOverflowed(x, y, result)) {
+            return Long.MAX_VALUE;
+        }
+        return result;
+    }
+
+    /**
+     * Calculate the total gas cost given a baseline cost, the cost of an unit and how many units
+     * are passed.
+     * @param baseCost a baseline cost.
+     * @param unitCost the cost of a single unit.
+     * @param units how many units.
+     * @return baseCost + unitCost * units
+     * @throws InvalidGasException if any of the inputs are negative, or if the operation overflows.
+     */
+    public static long calculate(long baseCost, long unitCost, long units) throws InvalidGasException {
+        if (baseCost < 0 || unitCost < 0 || units < 0) {
+            long offender = baseCost < 0 ? baseCost : unitCost < 0 ? unitCost : units;
+            throw new InvalidGasException(offender);
+        }
+        long mult = unitCost * units;
+        long result = baseCost + mult;
+        if (multiplicationOverflowed(unitCost, units, mult) || additionOverflowed(baseCost, mult, result)) {
+            throw new InvalidGasException("overflow");
+        }
+        return result;
+    }
+
+    /**
+     * Like `calculate`, but will return Long.MAX_VALUE instead of throwing an exception.
+     */
+    public static long calculateBounded(long baseCost, long unitCost, long units) {
+        if (baseCost < 0 || unitCost < 0 || units < 0) {
+            return Long.MAX_VALUE;
+        }
+        long mult = unitCost * units;
+        long result = baseCost + mult;
+        if (multiplicationOverflowed(unitCost, units, mult) || additionOverflowed(baseCost, mult, result)) {
+            return Long.MAX_VALUE;
+        }
+        return result;
+    }
+
+    /**
+     * Returns whether r is overflowed in `x + y = r`.
+     */
+    private static boolean additionOverflowed(long x, long y, long result) {
+        // This is taken exactly from the implementation of
+        // java.Math.addExact.
+        // https://github.com/frohoff/jdk8u-jdk/blob/master/src/share/classes/java/lang/Math.java#L805
+        // Copied here to avoid exceptions, which are slow.
+        return ((x ^ result) & (y ^ result)) < 0;
+    }
+
+    /**
+     * Returns whether r is overflowed in `x - y = r`.
+     */
+    private static boolean subtractionOverflowed(long x, long y, long result) {
+        // exactly the same as addition.
+        return additionOverflowed(x, y, result);
+    }
+
+    /**
+     * Returns whether r is overflowed in `x * y = r`
+     */
+    private static boolean multiplicationOverflowed(long x, long y, long result) {
+        // Again, taken exactly from java.Math.multiplyExact to avoid
+        // using exceptions.
+        // https://github.com/frohoff/jdk8u-jdk/blob/master/src/share/classes/java/lang/Math.java#L882/
+        long ax = Math.abs(x);
+        long ay = Math.abs(y);
+        if (((ax | ay) >>> 31 != 0)) {
+            // Some bits greater than 2^31 that might cause overflow
+            // Check the result using the divide operator
+            // and check for the special case of Long.MIN_VALUE * -1
+            return (((y != 0) && (result/ y != x)) || (x == Long.MIN_VALUE && y == -1));
+        }
+        return false;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java
@@ -177,11 +177,12 @@ public class PrecompiledContracts {
         public long getGasForData(byte[] data) {
 
             // gas charge for the execution:
-            // minimum 1 and additional 1 for each 32 bytes word (round  up)
+            // minimum 15 and additional 3 for each 32 bytes word (round  up)
             if (data == null) {
                 return 15;
             }
-            return 15l + (data.length + 31) / 32 * 3;
+            long variableCost = GasCost.multiplyBounded(GasCost.addBounded(data.length, 31) / 32, 3);
+            return GasCost.addBounded(15, variableCost);
         }
 
         @Override
@@ -197,11 +198,12 @@ public class PrecompiledContracts {
         public long getGasForData(byte[] data) {
 
             // gas charge for the execution:
-            // minimum 50 and additional 50 for each 32 bytes word (round  up)
+            // minimum 60 and additional 12 for each 32 bytes word (round  up)
             if (data == null) {
                 return 60;
             }
-            return 60l + (data.length + 31) / 32 * 12;
+            long variableCost = GasCost.multiplyBounded(GasCost.addBounded(data.length, 31) / 32, 12);
+            return GasCost.addBounded(60, variableCost);
         }
 
         @Override
@@ -223,11 +225,12 @@ public class PrecompiledContracts {
 
             // TODO Replace magic numbers with constants
             // gas charge for the execution:
-            // minimum 50 and additional 50 for each 32 bytes word (round  up)
+            // minimum 600 and additional 120 for each 32 bytes word (round  up)
             if (data == null) {
                 return 600;
             }
-            return 600l + (data.length + 31) / 32 * 120;
+            long variableCost = GasCost.multiplyBounded(GasCost.addBounded(data.length, 31) / 32, 120);
+            return GasCost.addBounded(600, variableCost);
         }
 
         @Override
@@ -325,14 +328,13 @@ public class PrecompiledContracts {
             int expLen = parseLen(safeData, EXPONENT);
             int modLen = parseLen(safeData, MODULUS);
 
-            long multComplexity = getMultComplexity(Math.max(baseLen, modLen));
+            long multComplexity = GasCost.toGasBounded(getMultComplexity(Math.max(baseLen, modLen)));
 
             byte[] expHighBytes;
             try {
                 int offset = Math.addExact(ARGS_OFFSET, baseLen);
                 expHighBytes = parseBytes(safeData, offset, Math.min(expLen, 32));
-            }
-            catch (ArithmeticException e) {
+            } catch (ArithmeticException e) {
                 expHighBytes = ByteUtil.EMPTY_BYTE_ARRAY;
             }
 
@@ -344,7 +346,7 @@ public class PrecompiledContracts {
                     .divide(GQUAD_DIVISOR);
 
 
-            return gas.min(BigInteger.valueOf(Long.MAX_VALUE)).longValueExact();
+            return GasCost.toGasBounded(gas);
         }
 
         @Override

--- a/rskj-core/src/test/java/org/ethereum/vm/GasCostTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/GasCostTest.java
@@ -1,0 +1,233 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.vm;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+/**
+ * Created by ajlopez on 15/07/2019.
+ */
+public class GasCostTest {
+
+    @Test
+    public void toGasUnsafe() {
+        Assert.assertEquals(0, GasCost.toGasBounded(new byte[0]));
+        Assert.assertEquals(1, GasCost.toGasBounded(new byte[] { 0x01 }));
+        Assert.assertEquals(255, GasCost.toGasBounded(new byte[] { (byte)0xff }));
+
+        byte[] bytes = new byte[32];
+
+        for (int k = 0; k < bytes.length; k++) {
+            bytes[k] = (byte)0xff;
+        }
+
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.toGasBounded(bytes));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void toGasOverflowsSlightly() throws GasCost.InvalidGasException {
+        byte[] bytes = new byte[32];
+
+        for (int k = 0; k < 17; k++) {
+            bytes[k] = (byte)0x00;
+        }
+        bytes[17] = (byte)0x80;
+        for (int k = 18; k < 32; k++) {
+            bytes[k] = (byte)0x00;
+        }
+        GasCost.toGas(bytes);
+    }
+
+    @Test
+    public void toGasBoundedWithBigInteger() {
+        BigInteger bi = BigInteger.valueOf(Long.MAX_VALUE - 10);
+        Assert.assertEquals(Long.MAX_VALUE - 10, GasCost.toGasBounded(bi));
+    }
+
+    @Test
+    public void toGasBoundedWithBigIntegerOverflowing() {
+        BigInteger bi = BigInteger.valueOf(Long.MAX_VALUE + 10);
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.toGasBounded(bi));
+    }
+
+    @Test
+    public void calculateAddGasCost() {
+        Assert.assertEquals(1, GasCost.addBounded(1, 0));
+        Assert.assertEquals(2, GasCost.addBounded(1, 1));
+        Assert.assertEquals(1000000, GasCost.addBounded(500000, 500000));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateAddGasCostWithOverflow() throws GasCost.InvalidGasException {
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.add(Long.MAX_VALUE, 1));
+    }
+
+
+    @Test
+    public void calculateAddUnsafeGasCostWithOverflow() {
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.addBounded(Long.MAX_VALUE, 1));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.addBounded(1, Long.MAX_VALUE));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateAddGasCostWithSecondNegativeInput() throws GasCost.InvalidGasException {
+        GasCost.add(-1, 0);
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateAddGasCostWithFirstNegativeInput() throws GasCost.InvalidGasException {
+        GasCost.add(0, -1);
+    }
+
+    @Test
+    public void calculateAddBoundedGasCostWithNegativeInput() {
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.addBounded(-1, 0));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.addBounded(0, -1));
+    }
+
+
+    @Test
+    public void calculateSubtractGasCost() throws GasCost.InvalidGasException {
+        Assert.assertEquals(1, GasCost.subtract(1, 0));
+        Assert.assertEquals(0, GasCost.subtract(1, 1));
+        Assert.assertEquals(1000000, GasCost.subtract(1500000, 500000));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateSubstractWithNegativeInput() throws GasCost.InvalidGasException {
+        GasCost.subtract(1, -1);
+    }
+
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateSubtractGasToInvalidSubtle() throws GasCost.InvalidGasException {
+        Assert.assertEquals(0, GasCost.subtract(1, 2));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateSubtractGasToInvalidObvious() throws GasCost.InvalidGasException  {
+        Assert.assertEquals(0, GasCost.subtract(1, 159));
+    }
+
+    @Test()
+    public void calculateSubtractBoundedGasCostToMaxGasIfNegative() {
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.subtractBounded(1, 2));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.subtractBounded(1, 10));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateAddGasCostBeyondMaxGas() throws GasCost.InvalidGasException {
+        GasCost.add(Long.MAX_VALUE, 1);
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void multiplyWithNegativeValues() throws GasCost.InvalidGasException {
+        GasCost.multiply(-1, -2);
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void multiplyWithXNegative() throws GasCost.InvalidGasException {
+        GasCost.multiply(-1, 123);
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void multiplyWithYNegative() throws GasCost.InvalidGasException {
+        GasCost.multiply(1, -9123);
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void multiplyOverflowing() throws GasCost.InvalidGasException {
+        GasCost.multiply(4611686018427387903L, 4096L);
+    }
+
+    @Test
+    public void multiplyBounded() throws GasCost.InvalidGasException {
+        long negative = GasCost.multiplyBounded(1, -9123);
+        long x = (long)Math.pow(2, 62);
+        long y = (long)Math.pow(2, 12);
+        long overflowed = GasCost.multiplyBounded(x, y);
+        Assert.assertEquals("negative is converted to max gas", Long.MAX_VALUE, negative);
+        Assert.assertEquals("overflowed is coverted to max gas", Long.MAX_VALUE, overflowed);
+    }
+
+    @Test
+    public void calculateAddUnsafeGasCostBeyondMaxGas() {
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.addBounded(Long.MAX_VALUE, 1));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.addBounded(1, Long.MAX_VALUE));
+    }
+
+    @Test
+    public void calculateGasCost() throws GasCost.InvalidGasException {
+        Assert.assertEquals(1, GasCost.calculate(1, 0, 0));
+        Assert.assertEquals(2, GasCost.calculate(0, 2, 1));
+        Assert.assertEquals(7, GasCost.calculate(1, 2, 3));
+        Assert.assertEquals(GasCost.CREATE + 100 * GasCost.CREATE_DATA, GasCost.calculate(GasCost.CREATE, GasCost.CREATE_DATA, 100));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateGasCostWithOverflow() throws GasCost.InvalidGasException  {
+        GasCost.calculate(1, Long.MAX_VALUE, 1);
+    }
+
+
+    @Test
+    public void calculateGasCostBoundedWithOverflow() {
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.calculateBounded(1, Long.MAX_VALUE, 1));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.calculateBounded(Long.MAX_VALUE, Long.MAX_VALUE, 1));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.calculateBounded(0, Long.MAX_VALUE, 2));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateGasCostWithNegativeSecondInputs() throws GasCost.InvalidGasException {
+        GasCost.calculate(1, -1, 1);
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateGasCostWithNegativeFirstInput() throws GasCost.InvalidGasException {
+        GasCost.calculate(-1, 1, 1);
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateGasCostWithNegativeThirdInput() throws GasCost.InvalidGasException {
+        GasCost.calculate(1, 1, -1);
+    }
+
+    @Test
+    public void calculateGasCostBoundedWithNegativeInputs() {
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.calculateBounded(1, -1, -1));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.calculateBounded(1, -1, 1));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.calculateBounded(-2, 1, 1));
+        Assert.assertEquals(10, GasCost.calculateBounded(4, 3, 2));
+    }
+
+    @Test(expected = GasCost.InvalidGasException.class)
+    public void calculateGasCostBeyondMaxGas() throws GasCost.InvalidGasException {
+        GasCost.calculate(1, Long.MAX_VALUE, 1);
+    }
+
+    @Test
+    public void calculateGasCostBoundedBeyondMaxGas() {
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.calculateBounded(1, Long.MAX_VALUE, 1));
+        Assert.assertEquals(Long.MAX_VALUE, GasCost.calculateBounded(Long.MAX_VALUE, 1, 1));
+    }
+}


### PR DESCRIPTION
This PR introduces a refactor to the `GasCost` class, which now can handle gas operations. The class is just an operation class, like `Math.java`.

This and the explicit choice to try to limit try/catch block inside this class are due to performance concerns when dealing with gas operations. Keep this in mind as gas operations are everywhere in performance-critical parts of the code, so we do want to try to squeeze as milliseconds as possible.

`GasCost` class is implemented firstly for precompiled contracts, but more usage should follow. Constant gas cost values have been changed to `long` for consistency.