### PR TITLE
Additional Check to Avoid Rewrite Known World State

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -57,6 +57,13 @@ public class TrieStoreImpl implements TrieStore {
      * @param forceSaveRoot allows saving the root node even if it's embeddable
      */
     private void save(Trie trie, boolean forceSaveRoot) {
+        byte[] trieKeyBytes = trie.getHash().getBytes();
+
+        if (forceSaveRoot && this.store.get(trieKeyBytes) != null) {
+            // the full trie is already saved
+            return;
+        }
+
         if (savedTries.contains(trie)) {
             // it is guaranteed that the children of a saved node are also saved
             return;

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -57,15 +57,15 @@ public class TrieStoreImpl implements TrieStore {
      * @param forceSaveRoot allows saving the root node even if it's embeddable
      */
     private void save(Trie trie, boolean forceSaveRoot) {
+        if (savedTries.contains(trie)) {
+            // it is guaranteed that the children of a saved node are also saved
+            return;
+        }
+
         byte[] trieKeyBytes = trie.getHash().getBytes();
 
         if (forceSaveRoot && this.store.get(trieKeyBytes) != null) {
             // the full trie is already saved
-            return;
-        }
-
-        if (savedTries.contains(trie)) {
-            // it is guaranteed that the children of a saved node are also saved
             return;
         }
 
@@ -89,7 +89,7 @@ public class TrieStoreImpl implements TrieStore {
             return;
         }
 
-        this.store.put(trie.getHash().getBytes(), trie.toMessage());
+        this.store.put(trieKeyBytes, trie.toMessage());
         savedTries.add(trie);
     }
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -143,7 +143,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
-        verify(map, times(2)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.trie;
 
+import co.rsk.crypto.Keccak256;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.HashMapDB;
 import org.junit.Assert;
@@ -48,6 +49,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -58,6 +60,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
 
         Trie newTrie = store.retrieve(trie.getHash().getBytes()).get();
@@ -78,6 +81,7 @@ public class TrieStoreImplTest {
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
         verify(map, times(1)).put(trie.getValueHash().getBytes(), trie.getValue());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
 
         Trie newTrie = store.retrieve(trie.getHash().getBytes()).get();
@@ -95,6 +99,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -106,6 +111,7 @@ public class TrieStoreImplTest {
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
         verify(map, times(1)).put(trie.getValueHash().getBytes(), trie.getValue());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -118,6 +124,8 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(trie.trieSize())).put(any(), any());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -128,9 +136,14 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verifyNoMoreInteractions(map);
 
         store.save(trie);
 
+        verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(2)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -140,13 +153,19 @@ public class TrieStoreImplTest {
 
         store.save(trie);
 
+        Keccak256 hash1 = trie.getHash();
+
         verify(map, times(trie.trieSize())).put(any(), any());
 
         trie = trie.put("foo", "bar2".getBytes());
 
         store.save(trie);
 
+        Keccak256 hash2 = trie.getHash();
+
         verify(map, times(trie.trieSize() + 1)).put(any(), any());
+        verify(map, times(1)).get(hash1.getBytes());
+        verify(map, times(1)).get(hash2.getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -163,6 +182,8 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(trie.trieSize() + 1)).put(any(), any());
+        verify(map, times(2)).get(any());
+
         verifyNoMoreInteractions(map);
     }
 
@@ -182,11 +203,11 @@ public class TrieStoreImplTest {
 
         Trie trie2 = store.retrieve(trie.getHash().getBytes()).get();
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
 
         Assert.assertEquals(size, trie2.trieSize());
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
     }
 
     @Test
@@ -200,11 +221,11 @@ public class TrieStoreImplTest {
 
         Trie trie2 = store.retrieve(trie.getHash().getBytes()).get();
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
 
         Assert.assertEquals(size, trie2.trieSize());
 
-        verify(map, times(size)).get(any());
+        verify(map, times(size + 1)).get(any());
     }
 
     @Test
@@ -217,6 +238,6 @@ public class TrieStoreImplTest {
 
         store.retrieve(trie.getHash().getBytes());
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
     }
 }


### PR DESCRIPTION
When executing a block, or reexecuting a known block, a world state could be reached that is already known. To avoid the write of the new trie, an additional check is added to `TrieStoreImpl`.

It could be needed in more cases, if the `savedTries` are removed by other logic. Having a FULL trie in that set to catch only the top node of that trie, is a bit excessive. And the set has a size limit.

The added check query to real source of information: the store.