### PR TITLE
change random source in tests

### DIFF
--- a/rskj-core/src/test/java/co/rsk/validators/ForkDetectionDataRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/ForkDetectionDataRuleTest.java
@@ -231,12 +231,7 @@ public class ForkDetectionDataRuleTest {
 
     private byte[] getRandomHash() {
         byte[] byteArray = new byte[32];
-        try {
-            SecureRandom.getInstanceStrong().nextBytes(byteArray);
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
-
+        new SecureRandom().nextBytes(byteArray);
         return byteArray;
     }
 }


### PR DESCRIPTION
Linux entropy pool gets emptied out pretty quickly, and honestly in tests there's no need to block waiting for randomness. 