### PR TITLE
Speed up synchronization with bigger messages

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -956,7 +956,8 @@ public class RskContext implements NodeBootstrapper {
                 rskSystemProperties.getMaxSkeletonChunks(),
                 rskSystemProperties.getChunkSize(),
                 rskSystemProperties.getMaxRequestedBodies(),
-                rskSystemProperties.getLongSyncLimit());
+                rskSystemProperties.getLongSyncLimit(),
+                rskSystemProperties.getMaxMessageCount());
     }
 
     protected StateRootHandler buildStateRootHandler() {

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -300,6 +300,10 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getInt("sync.longSyncLimit");
     }
 
+    public int getMaxMessageCount() {
+        return configFromFiles.getInt("sync.maxMessageCount");
+    }
+
     // its fixed, cannot be set by config file
     public int getChunkSize() {
         return CHUNK_SIZE;

--- a/rskj-core/src/main/java/co/rsk/net/BlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockProcessor.java
@@ -56,7 +56,7 @@ public interface BlockProcessor {
 
     void processBlockHeadersRequest(Peer sender, long requestId, byte[] hash, int count);
 
-    void processBodyRequest(Peer sender, long requestId, byte[] hash);
+    void processBodyRequest(Peer sender, long requestId, byte[][] hashes);
 
     void processBlockHashRequest(Peer sender, long requestId, long height);
 

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -193,11 +193,15 @@ public class SyncProcessor implements SyncEventsHandler {
     }
 
     @Override
-    public long sendBodyRequest(Peer peer, @Nonnull BlockHeader header) {
-        logger.debug("Send body request block {} hash {} to peer {}", header.getNumber(),
-                HashUtil.shortHash(header.getHash().getBytes()), peer.getPeerNodeID());
+    public long sendBodyRequest(Peer peer, @Nonnull List<BlockHeader> headers) {
+        byte[][] headerBytes = new byte[headers.size()][];
+        for (int i = 0 ; i < headers.size() ; i++) {
+            BlockHeader header = headers.get(i);
+            logger.debug("Send body request block {} hash {} to peer {}", header.getNumber(), HashUtil.shortHash(header.getHash().getBytes()), peer.getPeerNodeID());
+            headerBytes[i] = header.getHash().getBytes();
+        }
 
-        BodyRequestMessage message = new BodyRequestMessage(++lastRequestId, header.getHash().getBytes());
+        BodyRequestMessage message = new BodyRequestMessage(++lastRequestId, headerBytes);
         sendMessage(peer, message);
         return message.getId();
     }

--- a/rskj-core/src/main/java/co/rsk/net/messages/BodyRequestMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/BodyRequestMessage.java
@@ -7,19 +7,19 @@ import org.ethereum.util.RLP;
  */
 public class BodyRequestMessage extends MessageWithId {
     private long id;
-    private byte[] hash;
+    private byte[][] hashes;
 
-    public BodyRequestMessage(long id, byte[] hash) {
+    public BodyRequestMessage(long id, byte[]... hashes) {
         this.id = id;
-        this.hash = hash;
+        this.hashes = hashes;
     }
 
     public long getId() {
         return this.id;
     }
 
-    public byte[] getBlockHash() {
-        return this.hash;
+    public byte[][] getBlockHashes() {
+        return this.hashes;
     }
 
     @Override
@@ -34,8 +34,12 @@ public class BodyRequestMessage extends MessageWithId {
 
     @Override
     public byte[] getEncodedMessageWithoutId() {
-        byte[] rlpHash = RLP.encodeElement(this.hash);
-        return RLP.encodeList(rlpHash);
+        byte[][] encoded = new byte[hashes.length][];
+        for (int i = 0 ; i < this.hashes.length ; i++) {
+            byte[] hash = hashes[i];
+            encoded[i] = RLP.encodeElement(hash);
+        }
+        return RLP.encodeList(encoded);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
@@ -172,8 +172,8 @@ public class MessageVisitor {
     }
 
     public void apply(BodyRequestMessage message) {
-        final byte[] hash = message.getBlockHash();
-        this.blockProcessor.processBodyRequest(sender, message.getId(), hash);
+        final byte[][] hashes = message.getBlockHashes();
+        this.blockProcessor.processBodyRequest(sender, message.getId(), hashes);
     }
 
     public void apply(BodyResponseMessage message) {

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
@@ -379,17 +379,10 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
         if (headers.isEmpty()) {
             return;
         }
-        Long messageId = syncEventsHandler.sendBodyRequest(peer, headers);
-        if (messageId != null){
-            pendingBodyResponses.put(messageId, new PendingBodyResponse(peer.getPeerNodeID(), headers));
-            timeElapsedByPeer.put(peer, Duration.ZERO);
-            messagesByPeers.put(peer, messageId);
-        } else {
-            // since a message could fail to be delivered we have to discard peer if can't be reached
-            clearPeerInfo(peer);
-            syncEventsHandler.onSyncIssue("Channel failed to sent on {} to {}",
-                    this.getClass(), peer);
-        }
+        long messageId = syncEventsHandler.sendBodyRequest(peer, headers);
+        pendingBodyResponses.put(messageId, new PendingBodyResponse(peer.getPeerNodeID(), headers));
+        timeElapsedByPeer.put(peer, Duration.ZERO);
+        messagesByPeers.put(peer, messageId);
     }
 
     private boolean isExpectedBody(long requestId, NodeID peerId) {

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
@@ -7,10 +7,10 @@ import java.time.Duration;
 
 @Immutable
 public final class SyncConfiguration {
-    public static final SyncConfiguration DEFAULT = new SyncConfiguration(5, 60, 30, 5, 20, 192, 20, 10);
+    public static final SyncConfiguration DEFAULT = new SyncConfiguration(5, 60, 30, 5, 20, 192, 20, 10, 10);
 
     @VisibleForTesting
-    public static final SyncConfiguration IMMEDIATE_FOR_TESTING = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10);
+    public static final SyncConfiguration IMMEDIATE_FOR_TESTING = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10, 10);
 
     private final int expectedPeers;
     private final Duration timeoutWaitingPeers;
@@ -20,6 +20,7 @@ public final class SyncConfiguration {
     private final int chunkSize;
     private final int longSyncLimit;
     private final int maxRequestedBodies;
+    private final int maxMessageCount;
 
     /**
      * @param expectedPeers The expected number of peers we would want to start finding a connection point.
@@ -30,6 +31,7 @@ public final class SyncConfiguration {
      * @param chunkSize Amount of blocks contained in a chunk
      * @param maxRequestedBodies Amount of bodies to request at the same time when synchronizing backwards.
      * @param longSyncLimit Distance to the tip of the peer's blockchain to enable long synchronization.
+     * @param maxMessageCount max number of elements per message
      */
     public SyncConfiguration(
             int expectedPeers,
@@ -39,7 +41,8 @@ public final class SyncConfiguration {
             int maxSkeletonChunks,
             int chunkSize,
             int maxRequestedBodies,
-            int longSyncLimit) {
+            int longSyncLimit,
+            int maxMessageCount) {
         this.expectedPeers = expectedPeers;
         this.timeoutWaitingPeers = Duration.ofSeconds(timeoutWaitingPeers);
         this.timeoutWaitingRequest = Duration.ofSeconds(timeoutWaitingRequest);
@@ -48,6 +51,7 @@ public final class SyncConfiguration {
         this.chunkSize = chunkSize;
         this.maxRequestedBodies = maxRequestedBodies;
         this.longSyncLimit = longSyncLimit;
+        this.maxMessageCount = maxMessageCount;
     }
 
     public final int getExpectedPeers() {
@@ -80,5 +84,9 @@ public final class SyncConfiguration {
 
     public int getLongSyncLimit() {
         return longSyncLimit;
+    }
+
+    public int getMaxMessageCount() {
+        return maxMessageCount;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
@@ -18,7 +18,7 @@ public interface SyncEventsHandler {
 
     void sendBlockHeadersRequest(Peer peer, ChunkDescriptor chunk);
 
-    long sendBodyRequest(Peer peer, BlockHeader header);
+    long sendBodyRequest(Peer peer, List<BlockHeader> headers);
 
     void startDownloadingBodies(List<Deque<BlockHeader>> pendingHeaders, Map<Peer, List<BlockIdentifier>> skeletons, Peer peer);
 

--- a/rskj-core/src/main/java/org/ethereum/core/BlockBody.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockBody.java
@@ -1,0 +1,23 @@
+package org.ethereum.core;
+
+import java.util.List;
+
+public class BlockBody {
+
+    private final List<Transaction> transactions;
+
+    private final List<BlockHeader> uncles;
+
+    public BlockBody(List<Transaction> transactions, List<BlockHeader> uncles) {
+        this.transactions = transactions;
+        this.uncles = uncles;
+    }
+
+    public List<Transaction> getTransactionsList() {
+        return transactions;
+    }
+
+    public List<BlockHeader> getUncleList() {
+        return uncles;
+    }
+}

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -225,6 +225,9 @@ sync {
     # Amount of blocks contained in a chunk,
     # MUST BE 192 or a divisor of 192
     chunkSize = 192
+
+    # Max number of elements (headers or blocks) per message.
+    maxMessageCount = 100
 }
 
 rpc {

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
@@ -786,7 +786,7 @@ public class NodeBlockProcessorTest {
 
         final SimplePeer sender = new SimplePeer();
 
-        processor.processBodyRequest(sender, 100, block.getHash().getBytes());
+        processor.processBodyRequest(sender, 100, new byte[][] {block.getHash().getBytes()});
 
         Assert.assertFalse(sender.getMessages().isEmpty());
         Assert.assertEquals(1, sender.getMessages().size());
@@ -798,8 +798,9 @@ public class NodeBlockProcessorTest {
         final BodyResponseMessage bMessage = (BodyResponseMessage) message;
 
         Assert.assertEquals(100, bMessage.getId());
-        Assert.assertEquals(block.getTransactionsList(), bMessage.getTransactions());
-        Assert.assertEquals(block.getUncleList(), bMessage.getUncles());
+        Assert.assertEquals(block.getTransactionsList(), bMessage.getBlocks().get(0).getTransactionsList());
+        Assert.assertEquals(block.getUncleList(), bMessage.getBlocks().get(0).getUncleList());
+
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -551,7 +551,7 @@ public class SyncProcessorTest {
                 DIFFICULTY_CALCULATOR, new PeersInformation(getChannelManager(), syncConfiguration, blockchain, RskMockFactory.getPeerScoringManager()),
                 mock(Genesis.class));
 
-        BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), null, null);
+        BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), Collections.singletonList(null));
         processor.registerExpectedMessage(response);
 
         processor.processBodyResponse(sender, response);
@@ -588,7 +588,7 @@ public class SyncProcessorTest {
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
         long lastRequestId = new Random().nextLong();
-        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles);
+        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, Collections.singletonList(new BlockBody(transactions, uncles)));
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();
@@ -601,7 +601,7 @@ public class SyncProcessorTest {
         bids.add(new BlockIdentifier(block.getHash().getBytes(), 1));
 
         processor.startDownloadingBodies(headers, Collections.singletonMap(sender, bids), sender);
-        ((DownloadingBodiesSyncState)processor.getSyncState()).expectBodyResponseFor(lastRequestId, sender.getPeerNodeID(), block.getHeader());
+        ((DownloadingBodiesSyncState)processor.getSyncState()).expectBodyResponseFor(lastRequestId, sender.getPeerNodeID(), Collections.singletonList(block.getHeader()));
 
         processor.processBodyResponse(sender, response);
 
@@ -644,7 +644,7 @@ public class SyncProcessorTest {
         txs.add(tx);
 
         long lastRequestId = new Random().nextLong();
-        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, txs, uncles);
+        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, Collections.singletonList(new BlockBody(txs, uncles)));
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();
@@ -659,7 +659,7 @@ public class SyncProcessorTest {
         bids.add(new BlockIdentifier(block.getHash().getBytes(), 1));
 
         processor.startDownloadingBodies(headers, Collections.singletonMap(sender, bids), sender);
-        ((DownloadingBodiesSyncState)processor.getSyncState()).expectBodyResponseFor(lastRequestId, sender.getPeerNodeID(), block.getHeader());
+        ((DownloadingBodiesSyncState)processor.getSyncState()).expectBodyResponseFor(lastRequestId, sender.getPeerNodeID(), Collections.singletonList(block.getHeader()));
         processor.processBodyResponse(sender, response);
 
         Assert.assertEquals(10, blockchain.getBestBlock().getNumber());
@@ -700,7 +700,7 @@ public class SyncProcessorTest {
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
         long lastRequestId = new Random().nextLong();
-        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles);
+        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, Collections.singletonList(new BlockBody(transactions, uncles)));
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();
@@ -790,7 +790,7 @@ public class SyncProcessorTest {
         List<Transaction> transactions = block.getTransactionsList();
         List<BlockHeader> uncles = block.getUncleList();
         long lastRequestId = new Random().nextLong();
-        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles);
+        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, Collections.singletonList(new BlockBody(transactions, uncles)));
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();
@@ -803,7 +803,7 @@ public class SyncProcessorTest {
         bids.add(new BlockIdentifier(block.getHash().getBytes(), 1));
 
         processor.startDownloadingBodies(headers, Collections.singletonMap(sender, bids), sender);
-        ((DownloadingBodiesSyncState)processor.getSyncState()).expectBodyResponseFor(lastRequestId, sender.getPeerNodeID(), block.getHeader());
+        ((DownloadingBodiesSyncState)processor.getSyncState()).expectBodyResponseFor(lastRequestId, sender.getPeerNodeID(), Collections.singletonList(block.getHeader()));
 
         processor.processBodyResponse(sender, response);
 

--- a/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Random;
 
 
@@ -36,9 +37,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
     @Test
     public void synchronizeNewNodesInAChain() {
-        SimpleAsyncNode node1 = SimpleAsyncNode.createNodeWithWorldBlockChain(100,false, false);
-        SimpleAsyncNode node2 = SimpleAsyncNode.createNodeWithWorldBlockChain(0,false, false);
-        SimpleAsyncNode node3 = SimpleAsyncNode.createNodeWithWorldBlockChain(0,false, false);
+        SimpleAsyncNode node1 = SimpleAsyncNode.createNodeWithWorldBlockChain(100,false, false, SyncConfiguration.IMMEDIATE_FOR_TESTING);
+        SimpleAsyncNode node2 = SimpleAsyncNode.createNodeWithWorldBlockChain(0,false, false, SyncConfiguration.IMMEDIATE_FOR_TESTING);
+        SimpleAsyncNode node3 = SimpleAsyncNode.createNodeWithWorldBlockChain(0,false, false, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         Assert.assertEquals(100, node1.getBestBlock().getNumber());
         Assert.assertEquals(0, node2.getBestBlock().getNumber());
@@ -48,7 +49,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         // sync setup
         node2.waitUntilNTasksWithTimeout(SyncUtils.syncSetupRequests(100, 0, SyncConfiguration.IMMEDIATE_FOR_TESTING));
         // synchronize 100 new blocks from node 1
-        node2.waitExactlyNTasksWithTimeout(100);
+        node2.waitExactlyNTasksWithTimeout(10);
 
         Assert.assertTrue(node1.getSyncProcessor().getExpectedResponses().isEmpty());
         Assert.assertTrue(node2.getSyncProcessor().getExpectedResponses().isEmpty());
@@ -61,7 +62,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         // sync setup
         node3.waitUntilNTasksWithTimeout(SyncUtils.syncSetupRequests(100, 0, SyncConfiguration.IMMEDIATE_FOR_TESTING));
         // synchronize 100 new blocks from node 2
-        node3.waitExactlyNTasksWithTimeout(100);
+        node3.waitExactlyNTasksWithTimeout(10);
 
         Assert.assertEquals(100, node1.getBestBlock().getNumber());
         Assert.assertEquals(100, node2.getBestBlock().getNumber());
@@ -88,9 +89,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
     @Test
     public void synchronizeNewNodeWithBestChain() {
-        SimpleAsyncNode node1 = SimpleAsyncNode.createNodeWithWorldBlockChain(30,false, false);
-        SimpleAsyncNode node2 = SimpleAsyncNode.createNodeWithWorldBlockChain(50,false, false);
-        SimpleAsyncNode node3 = SimpleAsyncNode.createNodeWithWorldBlockChain(0,false, false);
+        SimpleAsyncNode node1 = SimpleAsyncNode.createNodeWithWorldBlockChain(30,false, false, SyncConfiguration.IMMEDIATE_FOR_TESTING);
+        SimpleAsyncNode node2 = SimpleAsyncNode.createNodeWithWorldBlockChain(50,false, false, SyncConfiguration.IMMEDIATE_FOR_TESTING);
+        SimpleAsyncNode node3 = SimpleAsyncNode.createNodeWithWorldBlockChain(0,false, false, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         Assert.assertEquals(30, node1.getBestBlock().getNumber());
         Assert.assertEquals(50, node2.getBestBlock().getNumber());
@@ -100,7 +101,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         // sync setup
         node3.waitUntilNTasksWithTimeout(SyncUtils.syncSetupRequests(30, 0, SyncConfiguration.IMMEDIATE_FOR_TESTING));
         // synchronize 30 new blocks from node 1
-        node3.waitExactlyNTasksWithTimeout(30);
+        node3.waitExactlyNTasksWithTimeout(3);
 
         Assert.assertTrue(node1.getSyncProcessor().getExpectedResponses().isEmpty());
         Assert.assertTrue(node3.getSyncProcessor().getExpectedResponses().isEmpty());
@@ -114,7 +115,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         // sync setup
         node3.waitUntilNTasksWithTimeout(SyncUtils.syncSetupRequests(50, 30, SyncConfiguration.IMMEDIATE_FOR_TESTING));
         // synchronize 50 new blocks from node 2
-        node3.waitExactlyNTasksWithTimeout(20);
+        node3.waitExactlyNTasksWithTimeout(2);
 
         Assert.assertEquals(30, node1.getBestBlock().getNumber());
         Assert.assertEquals(50, node2.getBestBlock().getNumber());
@@ -200,7 +201,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 10);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(50, node1.getBestBlock().getNumber());
@@ -244,7 +245,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 10);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());
@@ -288,7 +289,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,0,1,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,0,1,20,192, 20, 10, 10);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());
@@ -303,7 +304,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node3.waitUntilNTasksWithTimeout(setupRequests);
         node3.waitUntilNTasksWithTimeout(5);
         // synchronize 200 (extra tasks are from old sync protocol messages)
-        BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), null, null);
+        BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), Collections.singletonList(null));
         node3.getSyncProcessor().registerExpectedMessage(response);
         node3.getSyncProcessor().processBodyResponse(node1.getMessageChannel(node3), response);
         node3.waitExactlyNTasksWithTimeout(200 + setupRequests - 15);
@@ -338,7 +339,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b2);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 10);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b3, syncConfiguration);
 
         Assert.assertEquals(193, node1.getBestBlock().getNumber());
@@ -385,7 +386,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b2);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b2);
         SimpleAsyncNode node3 = SimpleAsyncNode.createDefaultNode(b3);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(3,1,10,100,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(3,1,10,100,20,192, 20, 10, 10);
         SimpleAsyncNode node4 = SimpleAsyncNode.createNode(b1, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());

--- a/rskj-core/src/test/java/co/rsk/net/messages/BodyRequestMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/BodyRequestMessageTest.java
@@ -27,11 +27,13 @@ import static org.mockito.Mockito.*;
 public class BodyRequestMessageTest {
     @Test
     public void createWithBlockHash() {
-        byte[] hash = new BlockGenerator().getGenesisBlock().getHash().getBytes();
+        byte[][] hash = new byte[][]{new BlockGenerator().getGenesisBlock().getHash().getBytes(),
+                new BlockGenerator().getGenesisBlock().getHash().getBytes(),
+                new BlockGenerator().getGenesisBlock().getHash().getBytes()};
         BodyRequestMessage message = new BodyRequestMessage(100, hash);
 
         Assert.assertEquals(100, message.getId());
-        Assert.assertArrayEquals(hash, message.getBlockHash());
+        Assert.assertArrayEquals(hash, message.getBlockHashes());
         Assert.assertEquals(MessageType.BODY_REQUEST_MESSAGE, message.getMessageType());
     }
 

--- a/rskj-core/src/test/java/co/rsk/net/messages/BodyResponseMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/BodyResponseMessageTest.java
@@ -5,6 +5,7 @@ import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import org.ethereum.core.Account;
 import org.ethereum.core.Block;
+import org.ethereum.core.BlockBody;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Transaction;
 import org.junit.Assert;
@@ -12,6 +13,7 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -36,22 +38,22 @@ public class BodyResponseMessageTest {
             parent = block;
         }
 
-        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles);
+        BodyResponseMessage message = new BodyResponseMessage(100, Collections.singletonList(new BlockBody(transactions, uncles)));
 
         Assert.assertEquals(100, message.getId());
 
-        Assert.assertNotNull(message.getTransactions());
-        Assert.assertEquals(transactions.size(), message.getTransactions().size());
+        Assert.assertNotNull(message.getBlocks().get(0).getTransactionsList());
+        Assert.assertEquals(transactions.size(), message.getBlocks().get(0).getTransactionsList().size());
 
         Assert.assertEquals(
                 transactions,
-                message.getTransactions());
+                message.getBlocks().get(0).getTransactionsList());
 
-        Assert.assertNotNull(message.getUncles());
-        Assert.assertEquals(uncles.size(), message.getUncles().size());
+        Assert.assertNotNull(message.getBlocks().get(0).getUncleList());
+        Assert.assertEquals(uncles.size(), message.getBlocks().get(0).getUncleList().size());
 
         for (int k = 0; k < uncles.size(); k++)
-            Assert.assertArrayEquals(uncles.get(k).getFullEncoded(), message.getUncles().get(k).getFullEncoded());
+            Assert.assertArrayEquals(uncles.get(k).getFullEncoded(), message.getBlocks().get(0).getUncleList().get(k).getFullEncoded());
     }
 
     private static Transaction createTransaction(int number) {
@@ -69,7 +71,7 @@ public class BodyResponseMessageTest {
         List<Transaction> transactions = new LinkedList<>();
         List<BlockHeader> uncles = new LinkedList<>();
 
-        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles);
+        BodyResponseMessage message = new BodyResponseMessage(100, Collections.singletonList(new BlockBody(transactions, uncles)));
 
         MessageVisitor visitor = mock(MessageVisitor.class);
 

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
@@ -446,11 +446,12 @@ public class MessageTest {
         BodyRequestMessage newmessage = (BodyRequestMessage) result;
 
         Assert.assertEquals(100, newmessage.getId());
-        Assert.assertArrayEquals(block.getHash().getBytes(), newmessage.getBlockHash());
+        Assert.assertArrayEquals(block.getHash().getBytes(), newmessage.getBlockHashes()[0]);
     }
 
     @Test
     public void encodeDecodeBodyResponseMessage() {
+        List<BlockBody> bodies = new ArrayList<>();
         List<Transaction> transactions = new ArrayList<>();
 
         for (int k = 1; k <= 10; k++)
@@ -466,8 +467,9 @@ public class MessageTest {
             uncles.add(block.getHeader());
             parent = block;
         }
+        bodies.add(new BlockBody(transactions, uncles));
 
-        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles);
+        BodyResponseMessage message = new BodyResponseMessage(100, bodies);
 
         byte[] encoded = message.getEncoded();
 
@@ -483,16 +485,16 @@ public class MessageTest {
 
         Assert.assertEquals(100, newmessage.getId());
 
-        Assert.assertNotNull(newmessage.getTransactions());
-        Assert.assertEquals(transactions.size(), newmessage.getTransactions().size());
+        Assert.assertNotNull(newmessage.getBlocks());
+        Assert.assertEquals(transactions.size(), newmessage.getBlocks().get(0).getTransactionsList().size());
 
-        Assert.assertEquals(transactions, newmessage.getTransactions());
+        Assert.assertEquals(transactions, newmessage.getBlocks().get(0).getTransactionsList());
 
-        Assert.assertNotNull(newmessage.getUncles());
-        Assert.assertEquals(uncles.size(), newmessage.getUncles().size());
+        Assert.assertNotNull(newmessage.getBlocks().get(0).getUncleList());
+        Assert.assertEquals(uncles.size(), newmessage.getBlocks().get(0).getUncleList().size());
 
         for (int k = 0; k < uncles.size(); k++)
-            Assert.assertArrayEquals(uncles.get(k).getFullEncoded(), newmessage.getUncles().get(k).getFullEncoded());
+            Assert.assertArrayEquals(uncles.get(k).getFullEncoded(), newmessage.getBlocks().get(0).getUncleList().get(k).getFullEncoded());
     }
 
     private static Transaction createTransaction(int number) {

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageVisitorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageVisitorTest.java
@@ -335,10 +335,10 @@ public class MessageVisitorTest {
     @Test
     public void bodyRequestMessage() {
         BodyRequestMessage message = mock(BodyRequestMessage.class);
-        byte[] blockHash = new byte[]{0x0F};
+        byte[][] blockHash = new byte[][]{{0x0F}};
 
         when(message.getId()).thenReturn(1L);
-        when(message.getBlockHash()).thenReturn(blockHash);
+        when(message.getBlockHashes()).thenReturn(blockHash);
 
         target.apply(message);
 

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -158,9 +158,14 @@ public class SimpleAsyncNode extends SimpleNode {
     }
 
     public static SimpleAsyncNode createNodeWithWorldBlockChain(int size, boolean withUncles, boolean mining) {
+        SyncConfiguration config = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10, 1);
+        return createNodeWithWorldBlockChain(size, withUncles, mining, config);
+    }
+
+    public static SimpleAsyncNode createNodeWithWorldBlockChain(int size, boolean withUncles, boolean mining, SyncConfiguration config) {
         final World world = new World();
         final Blockchain blockchain = world.getBlockChain();
         BlockChainBuilder.extend(blockchain, size, withUncles, mining);
-        return createNode(blockchain, SyncConfiguration.IMMEDIATE_FOR_TESTING, world.getBlockStore());
+        return createNode(blockchain, config, world.getBlockStore());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleBlockProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleBlockProcessor.java
@@ -81,7 +81,7 @@ public class SimpleBlockProcessor implements BlockProcessor {
     }
 
     @Override
-    public void processBodyRequest(Peer sender, long requestId, byte[] hash) {
+    public void processBodyRequest(Peer sender, long requestId, byte[][] hashes) {
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncStateTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
 
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
@@ -31,7 +33,7 @@ public class DownloadingBackwardsBodiesSyncStateTest {
 
     @Before
     public void setUp() {
-        syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
+        syncConfiguration = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10, 1);
         syncEventsHandler = mock(SyncEventsHandler.class);
         peersInformation = mock(PeersInformation.class);
         genesis = mock(Genesis.class);
@@ -150,16 +152,16 @@ public class DownloadingBackwardsBodiesSyncStateTest {
 
             when(headerToRequest.getHash()).thenReturn(headerHash);
             toRequest.addFirst(headerToRequest);
-            when(syncEventsHandler.sendBodyRequest(any(), eq(headerToRequest))).thenReturn(i);
+            when(syncEventsHandler.sendBodyRequest(any(), eq(Collections.singletonList(headerToRequest)))).thenReturn(i);
 
-            BodyResponseMessage response = new BodyResponseMessage(i, new LinkedList<>(), new LinkedList<>());
+            BodyResponseMessage response = new BodyResponseMessage(i, Collections.singletonList(new BlockBody(new ArrayList<>(), new ArrayList<>())));
             responses.addFirst(response);
 
             Block block = mock(Block.class);
             expectedBlocks.addFirst(block);
             when(block.getNumber()).thenReturn(i);
             when(block.getHash()).thenReturn(headerHash);
-            when(blockFactory.newBlock(headerToRequest, response.getTransactions(), response.getUncles()))
+            when(blockFactory.newBlock(headerToRequest, response.getBlocks().get(0).getTransactionsList(), response.getBlocks().get(0).getUncleList()))
                     .thenReturn(block);
 
             when(block.isParentOf(any())).thenReturn(true);
@@ -216,16 +218,16 @@ public class DownloadingBackwardsBodiesSyncStateTest {
 
             when(headerToRequest.getHash()).thenReturn(headerHash);
             toRequest.addFirst(headerToRequest);
-            when(syncEventsHandler.sendBodyRequest(any(), eq(headerToRequest))).thenReturn(i);
+            when(syncEventsHandler.sendBodyRequest(any(),eq(Collections.singletonList(headerToRequest)))).thenReturn(i);
 
-            BodyResponseMessage response = new BodyResponseMessage(i, new LinkedList<>(), new LinkedList<>());
+            BodyResponseMessage response = new BodyResponseMessage(i, Collections.singletonList(new BlockBody(new ArrayList<>(), new ArrayList<>())));
             responses.addFirst(response);
 
             Block block = mock(Block.class);
             expectedBlocks.addFirst(block);
             when(block.getNumber()).thenReturn(i);
             when(block.getHash()).thenReturn(headerHash);
-            when(blockFactory.newBlock(headerToRequest, response.getTransactions(), response.getUncles()))
+            when(blockFactory.newBlock(headerToRequest, response.getBlocks().get(0).getTransactionsList(), response.getBlocks().get(0).getUncleList()))
                     .thenReturn(block);
 
             when(block.isParentOf(any())).thenReturn(true);

--- a/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
@@ -31,7 +31,7 @@ public class SimpleSyncEventsHandler implements SyncEventsHandler {
     }
 
     @Override
-    public long sendBodyRequest(Peer peer, BlockHeader header) { return 0L; }
+    public long sendBodyRequest(Peer peer, @Nonnull List<BlockHeader> headers) { return 0L; }
 
     @Override
     public void startDownloadingBodies(List<Deque<BlockHeader>> pendingHeaders, Map<Peer, List<BlockIdentifier>> skeletons, Peer peer) {


### PR DESCRIPTION
Note: this also removes some object locks used for synchronizations, relying on concurrent data structures instead.

Fixes https://github.com/rsksmart/rskj/issues/1044

This PR is part of the work for bounty https://gitcoin.co/issue/rsksmart/rskj/1044/3579.
It speeds up sync time by agglomerating block body requests so a message may hold many requests. It makes the number of elements per message configurable, so it's possible to tune this during testing.

While this passes all unit tests, this was not tested at large and the measured effect on performance is unknown. As part of the bounty, the team mentioned they would make blockchain data available for testing. Please do so so I can conduct a comparative analysis.

