### PR TITLE
Redesign TransactionExecutor interface, using executeTransaction

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -92,10 +92,8 @@ public class ReversibleTransactionExecutor {
                 .newInstance(tx, 0, coinbase, track, executionBlock, 0)
                 .setLocalCall(true);
 
-        executor.init();
-        executor.execute();
-        executor.go();
-        executor.finalization();
+        executor.executeTransaction();
+
         return executor.getResult();
     }
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -244,7 +244,7 @@ public class BlockExecutor {
             Block block,
             BlockHeader parent,
             boolean discardInvalidTxs,
-            boolean ignoreReadyToExecute) {
+            boolean acceptInvalidTransactions) {
         boolean vmTrace = programTraceProcessor != null;
         logger.trace("applyBlock: block: [{}] tx.list: [{}]", block.getNumber(), block.getTransactionsList().size());
 
@@ -274,7 +274,6 @@ public class BlockExecutor {
 
         int txindex = 0;
 
-
         for (Transaction tx : block.getTransactionsList()) {
             logger.trace("apply block: [{}] tx: [{}] ", block.getNumber(), i);
 
@@ -287,10 +286,10 @@ public class BlockExecutor {
                     totalGasUsed,
                     vmTrace,
                     deletedAccounts);
-            boolean readyToExecute = txExecutor.init();
+            boolean transactionExecuted = txExecutor.executeTransaction();
 
 
-            if (!ignoreReadyToExecute && !readyToExecute) {
+            if (!acceptInvalidTransactions && !transactionExecuted) {
                 if (discardInvalidTxs) {
                     logger.warn("block: [{}] discarded tx: [{}]", block.getNumber(), tx.getHash());
                     continue;
@@ -304,9 +303,6 @@ public class BlockExecutor {
 
             executedTransactions.add(tx);
 
-            txExecutor.execute();
-            txExecutor.go();
-            txExecutor.finalization();
             if (vmTrace) {
                 txExecutor.extractTrace(programTraceProcessor);
             }

--- a/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
@@ -174,11 +174,10 @@ public class PendingState implements AccountInformationProvider {
 
     private void executeTransaction(Repository currentRepository, Transaction tx) {
         LOGGER.trace("Apply pending state tx: {} {}", toBI(tx.getNonce()), tx.getHash());
+
         TransactionExecutor executor = transactionExecutorFactory.newInstance(currentRepository, tx);
-        executor.init();
-        executor.execute();
-        executor.go();
-        executor.finalization();
+
+        executor.executeTransaction();
     }
 
     private interface PostExecutionAction<T> {

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -147,11 +147,11 @@ public class TransactionExecutor {
      * set readyToExecute = true
      */
     private boolean init() {
+        basicTxCost = tx.transactionCost(constants, activations);
+
         if (localCall) {
             return true;
         }
-
-        basicTxCost = tx.transactionCost(constants, activations);
 
         BigInteger txGasLimit = new BigInteger(1, tx.getGasLimit());
         BigInteger curBlockGasLimit = new BigInteger(1, executionBlock.getGasLimit());

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -147,43 +147,22 @@ public class TransactionExecutor {
      * set readyToExecute = true
      */
     private boolean init() {
-        basicTxCost = tx.transactionCost(constants, activations);
-
         if (localCall) {
             return true;
         }
 
+        basicTxCost = tx.transactionCost(constants, activations);
+
         BigInteger txGasLimit = new BigInteger(1, tx.getGasLimit());
         BigInteger curBlockGasLimit = new BigInteger(1, executionBlock.getGasLimit());
 
-        boolean cumulativeGasReached = txGasLimit.add(BigInteger.valueOf(gasUsedInTheBlock)).compareTo(curBlockGasLimit) > 0;
-        if (cumulativeGasReached) {
-            execError(String.format("Too much gas used in this block: Require: %s Got: %s",
-                    curBlockGasLimit.longValue() - toBI(tx.getGasLimit()).longValue(),
-                    toBI(tx.getGasLimit()).longValue()));
-
+        if (!gasIsValid(txGasLimit, curBlockGasLimit)) {
             return false;
         }
 
-        if (txGasLimit.compareTo(BigInteger.valueOf(basicTxCost)) < 0) {
-            execError(String.format("Not enough gas for transaction execution: Require: %s Got: %s", basicTxCost, txGasLimit));
+        if (!nonceIsValid()) {
             return false;
         }
-
-        BigInteger reqNonce = track.getNonce(tx.getSender());
-        BigInteger txNonce = toBI(tx.getNonce());
-        if (isNotEqual(reqNonce, txNonce)) {
-
-            if (logger.isWarnEnabled()) {
-                logger.warn("Invalid nonce: sender {}, required: {} , tx.nonce: {}, tx {}", tx.getSender(), reqNonce, txNonce, tx.getHash());
-                logger.warn("Transaction Data: {}", tx);
-                logger.warn("Tx Included in the following block: {}", this.executionBlock.getShortDescr());
-            }
-
-            execError(String.format("Invalid nonce: required: %s , tx.nonce: %s", reqNonce, txNonce));
-            return false;
-        }
-
 
         Coin totalCost = Coin.ZERO;
         if (basicTxCost > 0 ) {
@@ -205,6 +184,14 @@ public class TransactionExecutor {
             return false;
         }
 
+        if (!transactionAddressesAreValid()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean transactionAddressesAreValid() {
         // Prevent transactions with excessive address size
         byte[] receiveAddress = tx.getReceiveAddress().getBytes();
         if (receiveAddress != null && !Arrays.equals(receiveAddress, EMPTY_BYTE_ARRAY) && receiveAddress.length > Constants.getMaxAddressByteLength()) {
@@ -225,6 +212,42 @@ public class TransactionExecutor {
                                                tx.getHash(), tx.getSignature()));
             execError(String.format("Transaction signature not accepted: %s", tx.getSignature()));
 
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean nonceIsValid() {
+        BigInteger reqNonce = track.getNonce(tx.getSender());
+        BigInteger txNonce = toBI(tx.getNonce());
+
+        if (isNotEqual(reqNonce, txNonce)) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Invalid nonce: sender {}, required: {} , tx.nonce: {}, tx {}", tx.getSender(), reqNonce, txNonce, tx.getHash());
+                logger.warn("Transaction Data: {}", tx);
+                logger.warn("Tx Included in the following block: {}", this.executionBlock.getShortDescr());
+            }
+
+            execError(String.format("Invalid nonce: required: %s , tx.nonce: %s", reqNonce, txNonce));
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean gasIsValid(BigInteger txGasLimit, BigInteger curBlockGasLimit) {
+        boolean cumulativeGasReached = txGasLimit.add(BigInteger.valueOf(gasUsedInTheBlock)).compareTo(curBlockGasLimit) > 0;
+        if (cumulativeGasReached) {
+            execError(String.format("Too much gas used in this block: Require: %s Got: %s",
+                    curBlockGasLimit.longValue() - toBI(tx.getGasLimit()).longValue(),
+                    toBI(tx.getGasLimit()).longValue()));
+
+            return false;
+        }
+
+        if (txGasLimit.compareTo(BigInteger.valueOf(basicTxCost)) < 0) {
+            execError(String.format("Not enough gas for transaction execution: Require: %s Got: %s", basicTxCost, txGasLimit));
             return false;
         }
 
@@ -385,45 +408,14 @@ public class TransactionExecutor {
             program.spendGas(tx.transactionCost(constants, activations), "TRANSACTION COST");
 
             if (playVm) {
-                Future<?> vmExecution = vmExecutorService.submit(() -> vm.play(program));
-                try {
-                    vmExecution.get();
-                } catch (ExecutionException e) {
-                    if (e.getCause() instanceof StackOverflowError) {
-                        logger.error("\n !!! StackOverflowError: update your java run command with -Xss32M !!!\n", e);
-                        System.exit(-1);
-                    } else {
-                        throw e.getCause();
-                    }
-                }
+                playVirtualMachine();
             }
 
             result = program.getResult();
             mEndGas = toBI(tx.getGasLimit()).subtract(toBI(program.getResult().getGasUsed()));
 
             if (tx.isContractCreation() && !result.isRevert()) {
-                int createdContractSize = getLength(program.getResult().getHReturn());
-                int returnDataGasValue = createdContractSize * GasCost.CREATE_DATA;
-                if (mEndGas.compareTo(BigInteger.valueOf(returnDataGasValue)) < 0) {
-                    program.setRuntimeFailure(
-                            Program.ExceptionHelper.notEnoughSpendingGas(
-                                    "No gas to return just created contract",
-                                    returnDataGasValue,
-                                    program));
-                    result = program.getResult();
-                    result.setHReturn(EMPTY_BYTE_ARRAY);
-                } else if (createdContractSize > Constants.getMaxContractSize()) {
-                    program.setRuntimeFailure(
-                            Program.ExceptionHelper.tooLargeContractSize(
-                                    Constants.getMaxContractSize(),
-                                    createdContractSize));
-                    result = program.getResult();
-                    result.setHReturn(EMPTY_BYTE_ARRAY);
-                } else {
-                    mEndGas = mEndGas.subtract(BigInteger.valueOf(returnDataGasValue));
-                    program.spendGas(returnDataGasValue, "CONTRACT DATA COST");
-                    cacheTrack.saveCode(tx.getContractAddress(), result.getHReturn());
-                }
+                createContract();
             }
 
             if (result.getException() != null || result.isRevert()) {
@@ -450,6 +442,45 @@ public class TransactionExecutor {
         }
         finally {
             profiler.stop(metric);
+        }
+    }
+
+    private void createContract() {
+        int createdContractSize = getLength(program.getResult().getHReturn());
+        int returnDataGasValue = createdContractSize * GasCost.CREATE_DATA;
+        if (mEndGas.compareTo(BigInteger.valueOf(returnDataGasValue)) < 0) {
+            program.setRuntimeFailure(
+                    Program.ExceptionHelper.notEnoughSpendingGas(
+                            "No gas to return just created contract",
+                            returnDataGasValue,
+                            program));
+            result = program.getResult();
+            result.setHReturn(EMPTY_BYTE_ARRAY);
+        } else if (createdContractSize > Constants.getMaxContractSize()) {
+            program.setRuntimeFailure(
+                    Program.ExceptionHelper.tooLargeContractSize(
+                            Constants.getMaxContractSize(),
+                            createdContractSize));
+            result = program.getResult();
+            result.setHReturn(EMPTY_BYTE_ARRAY);
+        } else {
+            mEndGas = mEndGas.subtract(BigInteger.valueOf(returnDataGasValue));
+            program.spendGas(returnDataGasValue, "CONTRACT DATA COST");
+            cacheTrack.saveCode(tx.getContractAddress(), result.getHReturn());
+        }
+    }
+
+    private void playVirtualMachine() throws Throwable {
+        Future<?> vmExecution = vmExecutorService.submit(() -> vm.play(program));
+        try {
+            vmExecution.get();
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof StackOverflowError) {
+                logger.error("\n !!! StackOverflowError: update your java run command with -Xss32M !!!\n", e);
+                System.exit(-1);
+            } else {
+                throw e.getCause();
+            }
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallContractTest.java
@@ -88,10 +88,7 @@ public class CallContractTest {
                     .newInstance(tx, 0, bestBlock.getCoinbase(), repository, bestBlock, 0)
                     .setLocalCall(true);
 
-            executor.init();
-            executor.execute();
-            executor.go();
-            executor.finalization();
+            executor.executeTransaction();
 
             return executor.getResult();
         } finally {

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -261,10 +261,7 @@ public class TransactionTest {
                             .newInstance(txConst, 0, bestBlock.getCoinbase(), track, bestBlock, 0)
                             .setLocalCall(true);
 
-                    executor.init();
-                    executor.execute();
-                    executor.go();
-                    executor.finalization();
+                    executor.executeTransaction();
 
                     track.rollback();
 

--- a/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/RskForksBridgeTest.java
@@ -477,10 +477,7 @@ public class RskForksBridgeTest {
                 .newInstance(rskTx, 0, blockChain.getBestBlock().getCoinbase(), track, blockChain.getBestBlock(), 0)
                 .setLocalCall(true);
 
-        executor.init();
-        executor.execute();
-        executor.go();
-        executor.finalization();
+        executor.executeTransaction();
 
         ProgramResult res = executor.getResult();
 

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -103,10 +103,7 @@ public class MinerHelper {
             TransactionExecutor executor = transactionExecutorFactory
                     .newInstance(tx, txindex++, block.getCoinbase(), track, block, totalGasUsed);
 
-            executor.init();
-            executor.execute();
-            executor.go();
-            executor.finalization();
+            executor.executeTransaction();
 
             long gasUsed = executor.getGasUsed();
             Coin paidFees = executor.getPaidFees();

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -467,10 +467,7 @@ public class TransactionTest {
                             .newInstance(txConst, 0, bestBlock.getCoinbase(), track, bestBlock, 0)
                             .setLocalCall(true);
 
-                    executor.init();
-                    executor.execute();
-                    executor.go();
-                    executor.finalization();
+                    executor.executeTransaction();
 
                     track.rollback();
 
@@ -749,10 +746,7 @@ public class TransactionTest {
         TransactionExecutor executor = transactionExecutorFactory
                 .newInstance(tx, 0, RskAddress.nullAddress(), repository, blockchain.getBestBlock(), 0);
 
-        executor.init();
-        executor.execute();
-        executor.go();
-        executor.finalization();
+        executor.executeTransaction();
 
         track.commit();
         return executor;

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -120,10 +120,7 @@ public class StateTestRunner {
                 .newInstance(transaction, 0, new RskAddress(env.getCurrentCoinbase()), track, blockchain.getBestBlock(), 0);
 
         try{
-            executor.init();
-            executor.execute();
-            executor.go();
-            executor.finalization();
+            executor.executeTransaction();
         } catch (StackOverflowError soe){
             logger.error(" !!! StackOverflowError: update your java run command with -Xss32M !!!");
             System.exit(-1);

--- a/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ContractRunner.java
@@ -115,11 +115,10 @@ public class ContractRunner {
         Repository track = repository.startTracking();
         TransactionExecutor executor = transactionExecutorFactory
                 .newInstance(transaction, 0, RskAddress.nullAddress(), track, blockchain.getBestBlock(), 0);
-        executor.init();
-        executor.execute();
-        executor.go();
-        executor.finalization();
+
+        executor.executeTransaction();
         track.commit();
+
         return executor;
     }
 }


### PR DESCRIPTION
In many places of the code, `TransactionExecutor` is invoked using

```
executor.init();
executor.execute();
executor.go();
executor.finalization()
```

Now, these calls were replaced by only one method  `executeTransaction`