### PR TITLE
Set upper limit in voteFeeperKbChange

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -52,6 +52,8 @@ public class BridgeConstants {
 
     protected Coin genesisFeePerKb;
 
+    protected Coin maxFeePerKb;
+
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
     }
@@ -99,4 +101,6 @@ public class BridgeConstants {
     public AddressBasedAuthorizer getFeePerKbChangeAuthorizer() { return feePerKbChangeAuthorizer; }
 
     public Coin getGenesisFeePerKb() { return genesisFeePerKb; }
+
+    public Coin getMaxFeePerKb() { return maxFeePerKb; }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -24,8 +24,8 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
 import co.rsk.peg.FederationMember;
-import org.ethereum.crypto.ECKey;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -112,5 +112,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
         );
 
         genesisFeePerKb = Coin.MILLICOIN;
+
+        maxFeePerKb = Coin.valueOf(5_000_000L);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -7,8 +7,8 @@ import co.rsk.peg.AddressBasedAuthorizer;
 import co.rsk.peg.Federation;
 import co.rsk.peg.FederationMember;
 import com.google.common.collect.Lists;
-import org.ethereum.crypto.ECKey;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -52,7 +52,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
         // Currently set to:
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400l);
-        
+
         genesisFederation = new Federation(
                 federationMembers,
                 genesisFederationAddressCreatedAt,
@@ -110,6 +110,8 @@ public class BridgeMainNetConstants extends BridgeConstants {
         );
 
         genesisFeePerKb = Coin.MILLICOIN.multiply(5);
+
+        maxFeePerKb = Coin.valueOf(5_000_000L);
     }
 
     public static BridgeMainNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -76,11 +76,11 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         // Keys generated with GenNodeKey using generators 'auth-a' through 'auth-e'
         List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
-            "04dde17c5fab31ffc53c91c2390136c325bb8690dc135b0840075dd7b86910d8ab9e88baad0c32f3eea8833446a6bc5ff1cd2efa99ecb17801bcb65fc16fc7d991",
-            "04af886c67231476807e2a8eee9193878b9d94e30aa2ee469a9611d20e1e1c1b438e5044148f65e6e61bf03e9d72e597cb9cdea96d6fc044001b22099f9ec403e2",
-            "045d4dedf9c69ab3ea139d0f0da0ad00160b7663d01ce7a6155cd44a3567d360112b0480ab6f31cac7345b5f64862205ea7ccf555fcf218f87fa0d801008fecb61",
-            "04709f002ac4642b6a87ea0a9dc76eeaa93f71b3185985817ec1827eae34b46b5d869320efb5c5cbe2a5c13f96463fe0210710b53352a4314188daffe07bd54154",
-            "04aff62315e9c18004392a5d9e39496ff5794b2d9f43ab4e8ade64740d7fdfe896969be859b43f26ef5aa4b5a0d11808277b4abfa1a07cc39f2839b89cc2bc6b4c"
+                "04dde17c5fab31ffc53c91c2390136c325bb8690dc135b0840075dd7b86910d8ab9e88baad0c32f3eea8833446a6bc5ff1cd2efa99ecb17801bcb65fc16fc7d991",
+                "04af886c67231476807e2a8eee9193878b9d94e30aa2ee469a9611d20e1e1c1b438e5044148f65e6e61bf03e9d72e597cb9cdea96d6fc044001b22099f9ec403e2",
+                "045d4dedf9c69ab3ea139d0f0da0ad00160b7663d01ce7a6155cd44a3567d360112b0480ab6f31cac7345b5f64862205ea7ccf555fcf218f87fa0d801008fecb61",
+                "04709f002ac4642b6a87ea0a9dc76eeaa93f71b3185985817ec1827eae34b46b5d869320efb5c5cbe2a5c13f96463fe0210710b53352a4314188daffe07bd54154",
+                "04aff62315e9c18004392a5d9e39496ff5794b2d9f43ab4e8ade64740d7fdfe896969be859b43f26ef5aa4b5a0d11808277b4abfa1a07cc39f2839b89cc2bc6b4c"
         }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
         federationChangeAuthorizer = new AddressBasedAuthorizer(
@@ -95,7 +95,7 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         // Key generated with GenNodeKey using generator 'auth-lock-whitelist'
         List<ECKey> lockWhitelistAuthorizedKeys = Arrays.stream(new String[]{
-            "04641fb250d7ca7a1cb4f530588e978013038ec4294d084d248869dd54d98873e45c61d00ceeaeeb9e35eab19fa5fbd8f07cb8a5f0ddba26b4d4b18349c09199ad"
+                "04641fb250d7ca7a1cb4f530588e978013038ec4294d084d248869dd54d98873e45c61d00ceeaeeb9e35eab19fa5fbd8f07cb8a5f0ddba26b4d4b18349c09199ad"
         }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
         lockWhitelistChangeAuthorizer = new AddressBasedAuthorizer(
@@ -114,6 +114,8 @@ public class BridgeRegTestConstants extends BridgeConstants {
         );
 
         genesisFeePerKb = Coin.MILLICOIN;
+
+        maxFeePerKb = Coin.valueOf(5_000_000L);
     }
 
     public static BridgeRegTestConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -38,10 +38,10 @@ public class BridgeTestNetConstants extends BridgeConstants {
     BridgeTestNetConstants() {
         btcParamsString = NetworkParameters.ID_TESTNET;
 
-         BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9"));
-         BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da"));
-         BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a09"));
-         BtcECKey federator3PublicKey = BtcECKey.fromPublicOnly(Hex.decode("034844a99cd7028aa319476674cc381df006628be71bc5593b8b5fdb32bb42ef85"));
+        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9"));
+        BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da"));
+        BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a09"));
+        BtcECKey federator3PublicKey = BtcECKey.fromPublicOnly(Hex.decode("034844a99cd7028aa319476674cc381df006628be71bc5593b8b5fdb32bb42ef85"));
 
         List<BtcECKey> genesisFederationPublicKeys = Arrays.asList(federator0PublicKey, federator1PublicKey, federator2PublicKey, federator3PublicKey);
 
@@ -73,9 +73,9 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         // Passphrases are kept private
         List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
-            "04d9052c2022f6f35da53f04f02856ff5e59f9836eec03daad0328d12c5c66140205da540498e46cd05bf63c1201382dd84c100f0d52a10654159965aea452c3f2",
-            "04bf889f2035c8c441d7d1054b6a449742edd04d202f44a29348b4140b34e2a81ce66e388f40046636fd012bd7e3cecd9b951ffe28422334722d20a1cf6c7926fb",
-            "047e707e4f67655c40c539363fb435d89574b8fe400971ba0290de9c2adbb2bd4e1e5b35a2188b9409ff2cc102292616efc113623483056bb8d8a02bf7695670ea"
+                "04d9052c2022f6f35da53f04f02856ff5e59f9836eec03daad0328d12c5c66140205da540498e46cd05bf63c1201382dd84c100f0d52a10654159965aea452c3f2",
+                "04bf889f2035c8c441d7d1054b6a449742edd04d202f44a29348b4140b34e2a81ce66e388f40046636fd012bd7e3cecd9b951ffe28422334722d20a1cf6c7926fb",
+                "047e707e4f67655c40c539363fb435d89574b8fe400971ba0290de9c2adbb2bd4e1e5b35a2188b9409ff2cc102292616efc113623483056bb8d8a02bf7695670ea"
         }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
         federationChangeAuthorizer = new AddressBasedAuthorizer(
@@ -85,7 +85,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         // Passphrases are kept private
         List<ECKey> lockWhitelistAuthorizedKeys = Arrays.stream(new String[]{
-            "04bf7e3bca7f7c58326382ed9c2516a8773c21f1b806984bb1c5c33bd18046502d97b28c0ea5b16433fbb2b23f14e95b36209f304841e814017f1ede1ecbdcfce3"
+                "04bf7e3bca7f7c58326382ed9c2516a8773c21f1b806984bb1c5c33bd18046502d97b28c0ea5b16433fbb2b23f14e95b36209f304841e814017f1ede1ecbdcfce3"
         }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
         lockWhitelistChangeAuthorizer = new AddressBasedAuthorizer(
@@ -99,9 +99,9 @@ public class BridgeTestNetConstants extends BridgeConstants {
         fundsMigrationAgeSinceActivationEnd = 900L;
 
         List<ECKey> feePerKbAuthorizedKeys = Arrays.stream(new String[]{
-            "04701d1d27f8c2ae97912d96fb1f82f10c2395fd320e7a869049268c6b53d2060dfb2e22e3248955332d88cd2ae29a398f8f3858e48dd6d8ffbc37dfd6d1aa4934",
-            "045ef89e4a5645dc68895dbc33b4c966c3a0a52bb837ecdd2ba448604c4f47266456d1191420e1d32bbe8741f8315fde4d1440908d400e5998dbed6549d499559b",
-            "0455db9b3867c14e84a6f58bd2165f13bfdba0703cb84ea85788373a6a109f3717e40483aa1f8ef947f435ccdf10e530dd8b3025aa2d4a7014f12180ee3a301d27"
+                "04701d1d27f8c2ae97912d96fb1f82f10c2395fd320e7a869049268c6b53d2060dfb2e22e3248955332d88cd2ae29a398f8f3858e48dd6d8ffbc37dfd6d1aa4934",
+                "045ef89e4a5645dc68895dbc33b4c966c3a0a52bb837ecdd2ba448604c4f47266456d1191420e1d32bbe8741f8315fde4d1440908d400e5998dbed6549d499559b",
+                "0455db9b3867c14e84a6f58bd2165f13bfdba0703cb84ea85788373a6a109f3717e40483aa1f8ef947f435ccdf10e530dd8b3025aa2d4a7014f12180ee3a301d27"
         }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
         feePerKbChangeAuthorizer = new AddressBasedAuthorizer(
@@ -110,6 +110,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
         );
 
         genesisFeePerKb = Coin.MILLICOIN;
+
+        maxFeePerKb = Coin.valueOf(5_000_000L);
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -76,6 +76,7 @@ public class BridgeSupport {
     public static final Integer LOCK_WHITELIST_SUCCESS_CODE = 1;
     public static final Integer FEE_PER_KB_GENERIC_ERROR_CODE = -10;
     public static final Integer NEGATIVE_FEE_PER_KB_ERROR_CODE = -1;
+    public static final Integer EXCESSIVE_FEE_PER_KB_ERROR_CODE = -2;
 
     public static final Integer BTC_TRANSACTION_CONFIRMATION_INEXISTENT_BLOCK_HASH_ERROR_CODE = -1;
     public static final Integer BTC_TRANSACTION_CONFIRMATION_BLOCK_NOT_IN_BEST_CHAIN_ERROR_CODE = -2;
@@ -1850,6 +1851,10 @@ public class BridgeSupport {
 
         if(!feePerKb.isPositive()){
             return NEGATIVE_FEE_PER_KB_ERROR_CODE;
+        }
+
+        if(feePerKb.isGreaterThan(bridgeConstants.getMaxFeePerKb())) {
+            return EXCESSIVE_FEE_PER_KB_ERROR_CODE;
         }
 
         ABICallElection feePerKbElection = provider.getFeePerKbElection(authorizer);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1,17 +1,23 @@
 package co.rsk.peg;
 
+import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.config.BridgeConstants;
+import co.rsk.core.RskAddress;
 import co.rsk.peg.utils.BridgeEventLogger;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 public class BridgeSupportTest {
 
@@ -25,13 +31,247 @@ public class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP124)).thenReturn(true);
 
         BridgeSupport bridgeSupport = new BridgeSupport(
-                mock(BridgeConstants.class), provider, mock(BridgeEventLogger.class),
-                mock(Repository.class), block,
+                mock(BridgeConstants.class),
+                provider,
+                mock(BridgeEventLogger.class),
+                mock(Repository.class),
+                block,
                 new Context(constants.getBtcParams()),
                 new FederationSupport(constants, provider, block),
-                mock(BtcBlockStoreWithCache.Factory.class), activations
+                mock(BtcBlockStoreWithCache.Factory.class),
+                activations
         );
 
         Assert.assertTrue(bridgeSupport.getActivations().isActive(ConsensusRule.RSKIP124));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void voteFeePerKbChange_nullFeeThrows() {
+        Block block = mock(Block.class);
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        Transaction tx = mock(Transaction.class);
+        BridgeConstants constants = mock(BridgeConstants.class);
+        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
+
+        when(provider.getFeePerKbElection(any()))
+                .thenReturn(new ABICallElection(null));
+        when(tx.getSender())
+                .thenReturn(new RskAddress(ByteUtil.leftPadBytes(new byte[]{0x43}, 20)));
+        when(constants.getFeePerKbChangeAuthorizer())
+                .thenReturn(authorizer);
+        when(authorizer.isAuthorized(tx))
+                .thenReturn(true);
+
+        BridgeSupport bridgeSupport = new BridgeSupport(
+                constants,
+                provider,
+                mock(BridgeEventLogger.class),
+                mock(Repository.class),
+                block,
+                new Context(constants.getBtcParams()),
+                new FederationSupport(constants, provider, block),
+                mock(BtcBlockStoreWithCache.Factory.class),
+                mock(ActivationConfig.ForBlock.class)
+        );
+
+        bridgeSupport.voteFeePerKbChange(tx, null);
+        verify(provider, never()).setFeePerKb(any());
+    }
+
+    @Test
+    public void voteFeePerKbChange_unsuccessfulVote_unauthorized() {
+        Block block = mock(Block.class);
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        Transaction tx = mock(Transaction.class);
+        BridgeConstants constants = mock(BridgeConstants.class);
+        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
+        byte[] senderBytes = ByteUtil.leftPadBytes(new byte[]{0x43}, 20);
+
+        when(provider.getFeePerKbElection(any()))
+                .thenReturn(new ABICallElection(authorizer));
+        when(tx.getSender())
+                .thenReturn(new RskAddress(senderBytes));
+        when(constants.getFeePerKbChangeAuthorizer())
+                .thenReturn(authorizer);
+        when(authorizer.isAuthorized(tx))
+                .thenReturn(false);
+
+        BridgeSupport bridgeSupport = new BridgeSupport(
+                constants,
+                provider,
+                mock(BridgeEventLogger.class),
+                mock(Repository.class),
+                block,
+                new Context(constants.getBtcParams()),
+                new FederationSupport(constants, provider, block),
+                mock(BtcBlockStoreWithCache.Factory.class),
+                mock(ActivationConfig.ForBlock.class)
+        );
+
+        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(-10));
+        verify(provider, never()).setFeePerKb(any());
+    }
+
+    @Test
+    public void voteFeePerKbChange_unsuccessfulVote_negativeFeePerKb() {
+        Block block = mock(Block.class);
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        Transaction tx = mock(Transaction.class);
+        BridgeConstants constants = mock(BridgeConstants.class);
+        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
+        byte[] senderBytes = ByteUtil.leftPadBytes(new byte[]{0x43}, 20);
+
+        when(provider.getFeePerKbElection(any()))
+                .thenReturn(new ABICallElection(authorizer));
+        when(tx.getSender())
+                .thenReturn(new RskAddress(senderBytes));
+        when(constants.getFeePerKbChangeAuthorizer())
+                .thenReturn(authorizer);
+        when(authorizer.isAuthorized(tx))
+                .thenReturn(true);
+        when(authorizer.isAuthorized(tx.getSender()))
+                .thenReturn(true);
+        when(authorizer.getRequiredAuthorizedKeys())
+                .thenReturn(2);
+
+        BridgeSupport bridgeSupport = new BridgeSupport(
+                constants,
+                provider,
+                mock(BridgeEventLogger.class),
+                mock(Repository.class),
+                block,
+                new Context(constants.getBtcParams()),
+                new FederationSupport(constants, provider, block),
+                mock(BtcBlockStoreWithCache.Factory.class),
+                mock(ActivationConfig.ForBlock.class)
+        );
+
+        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.NEGATIVE_SATOSHI), is(-1));
+        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.ZERO), is(-1));
+        verify(provider, never()).setFeePerKb(any());
+    }
+
+    @Test
+    public void voteFeePerKbChange_unsuccessfulVote_excessiveFeePerKb() {
+        final long MAX_FEE_PER_KB = 5_000_000L;
+        Block block = mock(Block.class);
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        Transaction tx = mock(Transaction.class);
+        BridgeConstants constants = mock(BridgeConstants.class);
+        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
+        byte[] senderBytes = ByteUtil.leftPadBytes(new byte[]{0x43}, 20);
+
+        when(provider.getFeePerKbElection(any()))
+                .thenReturn(new ABICallElection(authorizer));
+        when(tx.getSender())
+                .thenReturn(new RskAddress(senderBytes));
+        when(constants.getFeePerKbChangeAuthorizer())
+                .thenReturn(authorizer);
+        when(authorizer.isAuthorized(tx))
+                .thenReturn(true);
+        when(authorizer.isAuthorized(tx.getSender()))
+                .thenReturn(true);
+        when(authorizer.getRequiredAuthorizedKeys())
+                .thenReturn(2);
+        when(constants.getMaxFeePerKb())
+                .thenReturn(Coin.valueOf(MAX_FEE_PER_KB));
+
+        BridgeSupport bridgeSupport = new BridgeSupport(
+                constants,
+                provider,
+                mock(BridgeEventLogger.class),
+                mock(Repository.class),
+                block,
+                new Context(constants.getBtcParams()),
+                new FederationSupport(constants, provider, block),
+                mock(BtcBlockStoreWithCache.Factory.class),
+                mock(ActivationConfig.ForBlock.class)
+        );
+
+        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.valueOf(MAX_FEE_PER_KB)), is(1));
+        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.valueOf(MAX_FEE_PER_KB + 1)), is(-2));
+        verify(provider, never()).setFeePerKb(any());
+    }
+
+    @Test
+    public void voteFeePerKbChange_successfulVote() {
+        final long MAX_FEE_PER_KB = 5_000_000L;
+        Block block = mock(Block.class);
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        Transaction tx = mock(Transaction.class);
+        BridgeConstants constants = mock(BridgeConstants.class);
+        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
+        byte[] senderBytes = ByteUtil.leftPadBytes(new byte[]{0x43}, 20);
+
+        when(provider.getFeePerKbElection(any()))
+                .thenReturn(new ABICallElection(authorizer));
+        when(tx.getSender())
+                .thenReturn(new RskAddress(senderBytes));
+        when(constants.getFeePerKbChangeAuthorizer())
+                .thenReturn(authorizer);
+        when(authorizer.isAuthorized(tx))
+                .thenReturn(true);
+        when(authorizer.isAuthorized(tx.getSender()))
+                .thenReturn(true);
+        when(authorizer.getRequiredAuthorizedKeys())
+                .thenReturn(2);
+        when(constants.getMaxFeePerKb())
+                .thenReturn(Coin.valueOf(MAX_FEE_PER_KB));
+
+        BridgeSupport bridgeSupport = new BridgeSupport(
+                constants,
+                provider,
+                mock(BridgeEventLogger.class),
+                mock(Repository.class),
+                block,
+                new Context(constants.getBtcParams()),
+                new FederationSupport(constants, provider, block),
+                mock(BtcBlockStoreWithCache.Factory.class),
+                mock(ActivationConfig.ForBlock.class)
+        );
+
+        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
+        verify(provider, never()).setFeePerKb(any());
+    }
+
+    @Test
+    public void voteFeePerKbChange_successfulVoteWithFeeChange() {
+        final long MAX_FEE_PER_KB = 5_000_000L;
+        Block block = mock(Block.class);
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        Transaction tx = mock(Transaction.class);
+        BridgeConstants constants = mock(BridgeConstants.class);
+        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
+        byte[] senderBytes = ByteUtil.leftPadBytes(new byte[]{0x43}, 20);
+
+        when(provider.getFeePerKbElection(any()))
+                .thenReturn(new ABICallElection(authorizer));
+        when(tx.getSender())
+                .thenReturn(new RskAddress(senderBytes));
+        when(constants.getFeePerKbChangeAuthorizer())
+                .thenReturn(authorizer);
+        when(authorizer.isAuthorized(tx))
+                .thenReturn(true);
+        when(authorizer.isAuthorized(tx.getSender()))
+                .thenReturn(true);
+        when(authorizer.getRequiredAuthorizedKeys())
+                .thenReturn(1);
+        when(constants.getMaxFeePerKb())
+                .thenReturn(Coin.valueOf(MAX_FEE_PER_KB));
+
+        BridgeSupport bridgeSupport = new BridgeSupport(
+                constants,
+                provider,
+                mock(BridgeEventLogger.class),
+                mock(Repository.class),
+                block,
+                new Context(constants.getBtcParams()),
+                new FederationSupport(constants, provider, block),
+                mock(BtcBlockStoreWithCache.Factory.class),
+                mock(ActivationConfig.ForBlock.class)
+        );
+
+        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
+        verify(provider).setFeePerKb(Coin.CENT);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
@@ -58,14 +58,12 @@ import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
-import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.db.MutableRepository;
 import org.ethereum.db.ReceiptStore;
-import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
@@ -104,14 +102,14 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 /**
  * Created by ajlopez on 6/9/2016.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ BridgeUtils.class, BtcBlockChain.class, BridgeSupport.class })
+@PrepareForTest({BridgeUtils.class, BtcBlockChain.class, BridgeSupport.class})
 public class BridgeSupportTestPowerMock {
     private static final co.rsk.core.Coin LIMIT_MONETARY_BASE = new co.rsk.core.Coin(new BigInteger("21000000000000000000000000"));
     private static final RskAddress contractAddress = PrecompiledContracts.BRIDGE_ADDR;
@@ -130,7 +128,7 @@ public class BridgeSupportTestPowerMock {
     private BridgeStorageConfiguration bridgeStorageConfigurationAtHeightZero;
 
     @Before
-    public void setUpOnEachTest(){
+    public void setUpOnEachTest() {
         bridgeConstants = BridgeRegTestConstants.getInstance();
         btcParams = bridgeConstants.getBtcParams();
         bridgeStorageConfigurationAtHeightZero = new BridgeStorageConfiguration(true, true);
@@ -269,7 +267,7 @@ public class BridgeSupportTestPowerMock {
     private List<BtcBlock> createBtcBlocks(NetworkParameters _networkParameters, BtcBlock parent, int numberOfBlocksToCreate) {
         List<BtcBlock> list = new ArrayList<>();
         for (int i = 0; i < numberOfBlocksToCreate; i++) {
-            BtcBlock block = new BtcBlock(_networkParameters, 2l, parent.getHash(), Sha256Hash.ZERO_HASH, parent.getTimeSeconds()+1, parent.getDifficultyTarget(), 0, new ArrayList<BtcTransaction>());
+            BtcBlock block = new BtcBlock(_networkParameters, 2l, parent.getHash(), Sha256Hash.ZERO_HASH, parent.getTimeSeconds() + 1, parent.getDifficultyTarget(), 0, new ArrayList<BtcTransaction>());
             block.solve();
             list.add(block);
             parent = block;
@@ -297,8 +295,7 @@ public class BridgeSupportTestPowerMock {
                     dataOutputStream.write(buffer.array());
                     buffer.position(0);
                 }
-            }
-            finally {
+            } finally {
                 dataOutputStream.close();
                 digestOutputStream.close();
                 baOutputStream.close();
@@ -358,15 +355,15 @@ public class BridgeSupportTestPowerMock {
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, bridgeStorageConfigurationAtHeightZero);
 
-        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(30,0));
-        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(20,0));
-        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(10,0));
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(30, 0));
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(20, 0));
+        provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.valueOf(10, 0));
         provider0.setFeePerKb(Coin.MILLICOIN);
 
         provider0.getNewFederationBtcUTXOs().add(new UTXO(
                 PegTestUtils.createHash(),
                 1,
-                Coin.valueOf(12,0),
+                Coin.valueOf(12, 0),
                 0,
                 false,
                 ScriptBuilder.createOutputScript(federation.getAddress())
@@ -947,8 +944,8 @@ public class BridgeSupportTestPowerMock {
         // Assert log data
         Assert.assertNotNull(result.getData());
         List<RLPElement> rlpData = RLP.decode2(result.getData());
-        Assert.assertEquals(1 , rlpData.size());
-        RLPList dataList = (RLPList)rlpData.get(0);
+        Assert.assertEquals(1, rlpData.size());
+        RLPList dataList = (RLPList) rlpData.get(0);
         Assert.assertEquals(3, dataList.size());
         Assert.assertArrayEquals(btcTx.getHashAsString().getBytes(), dataList.get(0).getRLPData());
         Assert.assertArrayEquals(federatorPubKey.getPubKeyHash(), dataList.get(1).getRLPData());
@@ -1077,7 +1074,7 @@ public class BridgeSupportTestPowerMock {
         LogInfo releaseTxEvent = logs.get(4);
         Assert.assertThat(releaseTxEvent.getTopics(), hasSize(1));
         Assert.assertThat(releaseTxEvent.getTopics(), hasItem(Bridge.RELEASE_BTC_TOPIC));
-        BtcTransaction releaseTx = new BtcTransaction(btcParams, ((RLPList)RLP.decode2(releaseTxEvent.getData()).get(0)).get(1).getRLPData());
+        BtcTransaction releaseTx = new BtcTransaction(btcParams, ((RLPList) RLP.decode2(releaseTxEvent.getData()).get(0)).get(1).getRLPData());
         // Verify all inputs fully signed
         for (int i = 0; i < releaseTx.getInputs().size(); i++) {
             Script retrievedScriptSig = releaseTx.getInput(i).getScriptSig();
@@ -1089,11 +1086,12 @@ public class BridgeSupportTestPowerMock {
 
     /**
      * Helper method to test addSignature() with a valid federatorPublicKey parameter and both valid/invalid signatures
+     *
      * @param privateKeysToSignWith keys used to sign the tx. Federator key when we want to produce a valid signature, a random key when we want to produce an invalid signature
-     * @param numberOfInputsToSign There is just 1 input. 1 when testing the happy case, other values to test attacks/bugs.
-     * @param signatureCanonical Signature should be canonical. true when testing the happy case, false to test attacks/bugs.
-     * @param signTwice Sign again with the same key
-     * @param expectedResult "InvalidParameters", "PartiallySigned" or "FullySigned"
+     * @param numberOfInputsToSign  There is just 1 input. 1 when testing the happy case, other values to test attacks/bugs.
+     * @param signatureCanonical    Signature should be canonical. true when testing the happy case, false to test attacks/bugs.
+     * @param signTwice             Sign again with the same key
+     * @param expectedResult        "InvalidParameters", "PartiallySigned" or "FullySigned"
      */
     private void addSignatureFromValidFederator(List<BtcECKey> privateKeysToSignWith, int numberOfInputsToSign, boolean signatureCanonical, boolean signTwice, String expectedResult) throws Exception {
         // Federation is the genesis federation ATM
@@ -1158,7 +1156,7 @@ public class BridgeSupportTestPowerMock {
             BtcECKey.ECDSASignature sig2 = new BtcECKey.ECDSASignature(components[0], components[1]).toCanonicalised();
             bridgeSupport.addSignature(findPublicKeySignedBy(federation.getBtcPublicKeys(), privateKeysToSignWith.get(0)), Lists.newArrayList(sig2.encodeToDER()), keccak256.getBytes());
         }
-        if (privateKeysToSignWith.size()>1) {
+        if (privateKeysToSignWith.size() > 1) {
             BtcECKey.ECDSASignature sig2 = privateKeysToSignWith.get(1).sign(sighash);
             byte[] derEncodedSig2 = sig2.encodeToDER();
             List derEncodedSigs2 = new ArrayList();
@@ -1179,7 +1177,7 @@ public class BridgeSupportTestPowerMock {
             LogInfo releaseTxEvent = logs.get(2);
             Assert.assertThat(releaseTxEvent.getTopics(), hasSize(1));
             Assert.assertThat(releaseTxEvent.getTopics(), hasItem(Bridge.RELEASE_BTC_TOPIC));
-            BtcTransaction releaseTx = new BtcTransaction(btcParams, ((RLPList)RLP.decode2(releaseTxEvent.getData()).get(0)).get(1).getRLPData());
+            BtcTransaction releaseTx = new BtcTransaction(btcParams, ((RLPList) RLP.decode2(releaseTxEvent.getData()).get(0)).get(1).getRLPData());
             Script retrievedScriptSig = releaseTx.getInput(0).getScriptSig();
             Assert.assertEquals(4, retrievedScriptSig.getChunks().size());
             Assert.assertEquals(true, retrievedScriptSig.getChunks().get(1).data.length > 0);
@@ -1210,7 +1208,8 @@ public class BridgeSupportTestPowerMock {
         Repository repository = createRepository();
         Repository track = repository.startTracking();
 
-        org.ethereum.core.Transaction tx = new org.ethereum.core.Transaction (TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA, Constants.REGTEST_CHAIN_ID);;
+        org.ethereum.core.Transaction tx = new org.ethereum.core.Transaction(TO_ADDRESS, DUST_AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA, Constants.REGTEST_CHAIN_ID);
+        ;
 
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
 
@@ -1234,7 +1233,8 @@ public class BridgeSupportTestPowerMock {
         Repository repository = createRepository();
         Repository track = repository.startTracking();
 
-        org.ethereum.core.Transaction tx = new org.ethereum.core.Transaction(TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA, Constants.REGTEST_CHAIN_ID);;
+        org.ethereum.core.Transaction tx = new org.ethereum.core.Transaction(TO_ADDRESS, AMOUNT, NONCE, GAS_PRICE, GAS_LIMIT, DATA, Constants.REGTEST_CHAIN_ID);
+        ;
 
         tx.sign(new org.ethereum.crypto.ECKey().getPrivKeyBytes());
 
@@ -1269,7 +1269,7 @@ public class BridgeSupportTestPowerMock {
                 Hex.decode(DATA),
                 "");
 
-        track.saveCode(tx.getSender(), new byte[] {0x1});
+        track.saveCode(tx.getSender(), new byte[]{0x1});
         BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, bridgeStorageConfigurationAtHeightZero);
         BridgeSupport bridgeSupport = getBridgeSupport(provider, track, null);
 
@@ -2275,7 +2275,7 @@ public class BridgeSupportTestPowerMock {
 
     @Test
     public void getPendingFederationMethods_none() throws IOException {
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, null,  null, null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, null, null, null);
 
         Assert.assertEquals(-1, bridgeSupport.getPendingFederationSize().intValue());
         Assert.assertNull(bridgeSupport.getPendingFederatorPublicKey(0));
@@ -2357,16 +2357,29 @@ public class BridgeSupportTestPowerMock {
             when(election.getWinner()).then((InvocationOnMock m) -> this.getWinner());
         }
 
-        public RskAddress getVoter() { return voter; }
+        public RskAddress getVoter() {
+            return voter;
+        }
 
-        public ABICallElection getElection() { return election; }
+        public ABICallElection getElection() {
+            return election;
+        }
 
-        public ABICallSpec getSpec() { return spec; }
+        public ABICallSpec getSpec() {
+            return spec;
+        }
 
-        public Transaction getTx() { return tx; }
+        public Transaction getTx() {
+            return tx;
+        }
 
-        public ABICallSpec getWinner() { return winner; }
-        public void setWinner(ABICallSpec winner) { this.winner = winner; }
+        public ABICallSpec getWinner() {
+            return winner;
+        }
+
+        public void setWinner(ABICallSpec winner) {
+            this.winner = winner;
+        }
 
         public int execute(BridgeSupport bridgeSupport) {
             return bridgeSupport.voteFederationChange(tx, spec);
@@ -3052,8 +3065,8 @@ public class BridgeSupportTestPowerMock {
         // Mock some utxos in the currently active federation
         for (int i = 0; i < 5; i++) {
             UTXO utxoMock = mock(UTXO.class);
-            when(utxoMock.getIndex()).thenReturn((long)i);
-            when(utxoMock.getValue()).thenReturn(Coin.valueOf((i+1)*1000));
+            when(utxoMock.getIndex()).thenReturn((long) i);
+            when(utxoMock.getValue()).thenReturn(Coin.valueOf((i + 1) * 1000));
             provider.getNewFederationBtcUTXOs().add(utxoMock);
         }
 
@@ -3085,7 +3098,7 @@ public class BridgeSupportTestPowerMock {
         Assert.assertEquals(5, provider.getOldFederationBtcUTXOs().size());
         for (int i = 0; i < 5; i++) {
             Assert.assertEquals((long) i, provider.getOldFederationBtcUTXOs().get(i).getIndex());
-            Assert.assertEquals(Coin.valueOf((i+1)*1000), provider.getOldFederationBtcUTXOs().get(i).getValue());
+            Assert.assertEquals(Coin.valueOf((i + 1) * 1000), provider.getOldFederationBtcUTXOs().get(i).getValue());
         }
         verify(mocksProvider.getElection(), times(1)).clearWinners();
         verify(mocksProvider.getElection(), times(1)).clear();
@@ -3254,7 +3267,7 @@ public class BridgeSupportTestPowerMock {
         NetworkParameters parameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         LockWhitelist mockedWhitelist = mock(LockWhitelist.class);
         when(mockedWhitelist.getSize()).thenReturn(4);
-        List<LockWhitelistEntry> entries = Arrays.stream(new Integer[]{2,3,4,5}).map(i ->
+        List<LockWhitelistEntry> entries = Arrays.stream(new Integer[]{2, 3, 4, 5}).map(i ->
                 new UnlimitedWhiteListEntry(new Address(parameters, BtcECKey.fromPrivate(BigInteger.valueOf(i)).getPubKeyHash()))
         ).collect(Collectors.toList());
         when(mockedWhitelist.getAll()).thenReturn(entries);
@@ -3363,7 +3376,7 @@ public class BridgeSupportTestPowerMock {
         doReturn(Sha256Hash.of(Hex.decode("aa"))).when(btcBlock).getHash();
         doReturn(btcBlock).when(storedBlock).getHeader();
         when(btcBlockStore.getChainHead()).thenReturn(storedBlock);
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist,btcBlockStore);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist, btcBlockStore);
 
         BigInteger disableBlockDelayBI = BigInteger.valueOf(100);
 
@@ -3390,7 +3403,7 @@ public class BridgeSupportTestPowerMock {
         BtcBlock btcBlock = mock(BtcBlock.class);
         doReturn(Sha256Hash.of(Hex.decode("aa"))).when(btcBlock).getHash();
         doReturn(btcBlock).when(storedBlock).getHeader();
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist,btcBlockStore);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist, btcBlockStore);
 
         BigInteger disableBlockDelayBI = BigInteger.valueOf(-2);
 
@@ -3414,9 +3427,9 @@ public class BridgeSupportTestPowerMock {
         StoredBlock storedBlock = mock(StoredBlock.class);
         when(storedBlock.getHeight()).thenReturn(bestChainHeight);
         when(btcBlockStore.getChainHead()).thenReturn(storedBlock);
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist,btcBlockStore);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist, btcBlockStore);
         //Duplicate Int Max Value by 2 because its signed and add 1 to pass the limit
-        BigInteger disableBlockDelayBI = BigInteger.valueOf((long)Integer.MAX_VALUE * 2 + 1);
+        BigInteger disableBlockDelayBI = BigInteger.valueOf((long) Integer.MAX_VALUE * 2 + 1);
 
         bridgeSupport.setLockWhitelistDisableBlockDelay(mockedTx, disableBlockDelayBI);
         verify(mockedWhitelist, never()).put(any(), any());
@@ -3441,7 +3454,7 @@ public class BridgeSupportTestPowerMock {
         BtcBlock btcBlock = mock(BtcBlock.class);
         doReturn(Sha256Hash.of(Hex.decode("aa"))).when(btcBlock).getHash();
         doReturn(btcBlock).when(storedBlock).getHeader();
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist,btcBlockStore);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist, btcBlockStore);
 
         BigInteger disableBlockDelayBI = BigInteger.valueOf(Integer.MAX_VALUE / 2);
 
@@ -3468,7 +3481,7 @@ public class BridgeSupportTestPowerMock {
         BtcBlock btcBlock = mock(BtcBlock.class);
         doReturn(Sha256Hash.of(Hex.decode("aa"))).when(btcBlock).getHash();
         doReturn(btcBlock).when(storedBlock).getHeader();
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist,btcBlockStore);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksAndBtcBlockstoreForWhitelistTests(mockedWhitelist, btcBlockStore);
 
         BigInteger disableBlockDelayBI = BigInteger.valueOf(Integer.MAX_VALUE);
 
@@ -3577,107 +3590,6 @@ public class BridgeSupportTestPowerMock {
 
         Assert.assertEquals(-2, bridgeSupport.removeLockWhitelistAddress(mockedTx, "i-am-invalid").intValue());
         verify(mockedWhitelist, never()).remove(any());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void voteFeePerKbChange_nullFeeThrows() {
-        Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        Transaction tx = mock(Transaction.class);
-        BridgeConstants constants = mock(BridgeConstants.class);
-        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
-
-        when(provider.getFeePerKbElection(any()))
-                .thenReturn(new ABICallElection(null));
-        when(tx.getSender())
-                .thenReturn(new RskAddress(ByteUtil.leftPadBytes(new byte[] {0x43}, 20)));
-        when(constants.getFeePerKbChangeAuthorizer())
-                .thenReturn(authorizer);
-        when(authorizer.isAuthorized(tx))
-                .thenReturn(true);
-
-        BridgeSupport bridgeSupport = getBridgeSupport(constants, provider, repositoryMock, null);
-        bridgeSupport.voteFeePerKbChange(tx, null);
-        verify(provider, never()).setFeePerKb(any());
-    }
-
-    @Test
-    public void voteFeePerKbChange_unsuccessfulVote() {
-        Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        Transaction tx = mock(Transaction.class);
-        BridgeConstants constants = mock(BridgeConstants.class);
-        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
-
-        byte[] senderBytes = ByteUtil.leftPadBytes(new byte[]{0x43}, 20);
-        when(provider.getFeePerKbElection(any()))
-                .thenReturn(new ABICallElection(authorizer));
-        when(tx.getSender())
-                .thenReturn(new RskAddress(senderBytes));
-        when(constants.getFeePerKbChangeAuthorizer())
-                .thenReturn(authorizer);
-        when(authorizer.isAuthorized(tx))
-                .thenReturn(false);
-
-        BridgeSupport bridgeSupport = getBridgeSupport(provider, repositoryMock, null);
-        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(-10));
-        verify(provider, never()).setFeePerKb(any());
-    }
-
-    @Test
-    public void voteFeePerKbChange_successfulVote() {
-        Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        Transaction tx = mock(Transaction.class);
-        BridgeConstants constants = mock(BridgeConstants.class);
-        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
-
-        byte[] senderBytes = ByteUtil.leftPadBytes(new byte[]{0x43}, 20);
-        when(provider.getFeePerKbElection(any()))
-                .thenReturn(new ABICallElection(authorizer));
-        when(tx.getSender())
-                .thenReturn(new RskAddress(senderBytes));
-        when(constants.getFeePerKbChangeAuthorizer())
-                .thenReturn(authorizer);
-        when(authorizer.isAuthorized(tx))
-                .thenReturn(true);
-        when(authorizer.isAuthorized(tx.getSender()))
-                .thenReturn(true);
-        when(authorizer.getRequiredAuthorizedKeys())
-                .thenReturn(2);
-
-        BridgeSupport bridgeSupport = getBridgeSupport(constants, provider, repositoryMock, null);
-        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
-        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.NEGATIVE_SATOSHI), is(-1));
-        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.ZERO), is(-1));
-        verify(provider, never()).setFeePerKb(any());
-    }
-
-    @Test
-    public void voteFeePerKbChange_successfulVoteWithFeeChange() {
-        Repository repositoryMock = mock(Repository.class);
-        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        Transaction tx = mock(Transaction.class);
-        BridgeConstants constants = mock(BridgeConstants.class);
-        AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
-
-        byte[] senderBytes = ByteUtil.leftPadBytes(new byte[]{0x43}, 20);
-        when(provider.getFeePerKbElection(any()))
-                .thenReturn(new ABICallElection(authorizer));
-        when(tx.getSender())
-                .thenReturn(new RskAddress(senderBytes));
-        when(constants.getFeePerKbChangeAuthorizer())
-                .thenReturn(authorizer);
-        when(authorizer.isAuthorized(tx))
-                .thenReturn(true);
-        when(authorizer.isAuthorized(tx.getSender()))
-                .thenReturn(true);
-        when(authorizer.getRequiredAuthorizedKeys())
-                .thenReturn(1);
-
-        BridgeSupport bridgeSupport = getBridgeSupport(constants, provider, repositoryMock, null);
-        assertThat(bridgeSupport.voteFeePerKbChange(tx, Coin.CENT), is(1));
-        verify(provider).setFeePerKb(Coin.CENT);
     }
 
     @Test
@@ -3884,7 +3796,8 @@ public class BridgeSupportTestPowerMock {
         StoredBlock chainHead = new StoredBlock(blockHeader, new BigInteger("0"), 132);
         when(btcBlockStore.getChainHead()).thenReturn(chainHead);
 
-        when(btcBlockStore.getStoredBlockAtMainChainHeight(block.getHeight())).thenThrow(new BlockStoreException("blah"));;
+        when(btcBlockStore.getStoredBlockAtMainChainHeight(block.getHeight())).thenThrow(new BlockStoreException("blah"));
+        ;
 
         BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
         when(mockFactory.newInstance(track)).thenReturn(btcBlockStore);
@@ -3961,7 +3874,7 @@ public class BridgeSupportTestPowerMock {
                 bridgeStorageConfigurationAtHeightZero);
         BridgeSupport bridgeSupport = getBridgeSupport(provider, track, mockFactory);
 
-        Object [] args = new Object[4];
+        Object[] args = new Object[4];
         args[1] = blockHash.getBytes();
         args[3] = new Object[]{};
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(args);
@@ -3990,7 +3903,7 @@ public class BridgeSupportTestPowerMock {
                 bridgeStorageConfigurationAtHeightZero);
         BridgeSupport bridgeSupport = getBridgeSupport(provider, track, mockFactory);
 
-        Object [] args = new Object[4];
+        Object[] args = new Object[4];
         args[1] = blockHash.getBytes();
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(args);
 
@@ -4016,7 +3929,7 @@ public class BridgeSupportTestPowerMock {
                 bridgeStorageConfigurationAtHeightZero);
         BridgeSupport bridgeSupport = getBridgeSupport(provider, track, mockFactory);
 
-        Object [] args = new Object[4];
+        Object[] args = new Object[4];
         args[1] = blockHash.getBytes();
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(args);
 
@@ -4046,7 +3959,7 @@ public class BridgeSupportTestPowerMock {
                 bridgeStorageConfigurationAtHeightZero);
         BridgeSupport bridgeSupport = getBridgeSupport(provider, track, mockFactory);
 
-        Object [] args = new Object[4];
+        Object[] args = new Object[4];
         args[1] = blockHash.getBytes();
         long cost = bridgeSupport.getBtcTransactionConfirmationsGetCost(args);
 
@@ -4071,17 +3984,33 @@ public class BridgeSupportTestPowerMock {
         Assert.assertEquals(btcParams.getGenesisBlock(), chainHead.getHeader());
 
         Assert.assertEquals(btcParams.getGenesisBlock().getHash(), bridgeSupport.getBtcBlockchainBlockHashAtDepth(0));
-        try { bridgeSupport.getBtcBlockchainBlockHashAtDepth(-1); Assert.fail(); } catch (IndexOutOfBoundsException e) {}
-        try { bridgeSupport.getBtcBlockchainBlockHashAtDepth(1); Assert.fail(); } catch (IndexOutOfBoundsException e) {}
+        try {
+            bridgeSupport.getBtcBlockchainBlockHashAtDepth(-1);
+            Assert.fail();
+        } catch (IndexOutOfBoundsException e) {
+        }
+        try {
+            bridgeSupport.getBtcBlockchainBlockHashAtDepth(1);
+            Assert.fail();
+        } catch (IndexOutOfBoundsException e) {
+        }
 
         List<BtcBlock> blocks = createBtcBlocks(btcParams, btcParams.getGenesisBlock(), 10);
         bridgeSupport.receiveHeaders(blocks.toArray(new BtcBlock[]{}));
 
         Assert.assertEquals(btcParams.getGenesisBlock().getHash(), bridgeSupport.getBtcBlockchainBlockHashAtDepth(10));
-        try { bridgeSupport.getBtcBlockchainBlockHashAtDepth(-1); Assert.fail(); } catch (IndexOutOfBoundsException e) {}
-        try { bridgeSupport.getBtcBlockchainBlockHashAtDepth(11); Assert.fail(); } catch (IndexOutOfBoundsException e) {}
+        try {
+            bridgeSupport.getBtcBlockchainBlockHashAtDepth(-1);
+            Assert.fail();
+        } catch (IndexOutOfBoundsException e) {
+        }
+        try {
+            bridgeSupport.getBtcBlockchainBlockHashAtDepth(11);
+            Assert.fail();
+        } catch (IndexOutOfBoundsException e) {
+        }
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(blocks.get(i).getHash(), bridgeSupport.getBtcBlockchainBlockHashAtDepth(9-i));
+            Assert.assertEquals(blocks.get(i).getHash(), bridgeSupport.getBtcBlockchainBlockHashAtDepth(9 - i));
         }
     }
 
@@ -4135,17 +4064,37 @@ public class BridgeSupportTestPowerMock {
             public List<UTXO> retiringUTXOs = new ArrayList<>();
             public List<UTXO> activeUTXOs = new ArrayList<>();
 
-            PendingFederation getPendingFederation() { return pendingFederation; }
-            void setPendingFederation(PendingFederation pendingFederation) { this.pendingFederation = pendingFederation; }
+            PendingFederation getPendingFederation() {
+                return pendingFederation;
+            }
 
-            Federation getActiveFederation() { return activeFederation; }
-            void setActiveFederation(Federation activeFederation) { this.activeFederation = activeFederation; }
+            void setPendingFederation(PendingFederation pendingFederation) {
+                this.pendingFederation = pendingFederation;
+            }
 
-            Federation getRetiringFederation() { return retiringFederation; }
-            void setRetiringFederation(Federation retiringFederation) { this.retiringFederation = retiringFederation; }
+            Federation getActiveFederation() {
+                return activeFederation;
+            }
 
-            public ABICallElection getFederationElection() { return federationElection; }
-            public void setFederationElection(ABICallElection federationElection) { this.federationElection = federationElection; }
+            void setActiveFederation(Federation activeFederation) {
+                this.activeFederation = activeFederation;
+            }
+
+            Federation getRetiringFederation() {
+                return retiringFederation;
+            }
+
+            void setRetiringFederation(Federation retiringFederation) {
+                this.retiringFederation = retiringFederation;
+            }
+
+            public ABICallElection getFederationElection() {
+                return federationElection;
+            }
+
+            public void setFederationElection(ABICallElection federationElection) {
+                this.federationElection = federationElection;
+            }
         }
 
         final FederationHolder holder = new FederationHolder();


### PR DESCRIPTION
Defined a new BridgeConstant with the upper limit for the feePerKb for each network. Using said value in voteFeePerKbChange method, rejecting any value above it.

Confirmed it's not a hard fork using Blockchain verificator tool to check that voteFeePerKbChange method was never called in mainnet or testnet with a value above the maximum defined

*fit: rfs-420*