### PR TITLE
Improved DataSourceWithCache: auto flush, sync locks; TrieStore avoid to write known state

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -57,6 +57,13 @@ public class TrieStoreImpl implements TrieStore {
      * @param forceSaveRoot allows saving the root node even if it's embeddable
      */
     private void save(Trie trie, boolean forceSaveRoot) {
+        byte[] trieKeyBytes = trie.getHash().getBytes();
+
+        if (forceSaveRoot && this.store.get(trieKeyBytes) != null) {
+            // the full trie is already saved
+            return;
+        }
+
         if (savedTries.contains(trie)) {
             // it is guaranteed that the children of a saved node are also saved
             return;

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -57,15 +57,15 @@ public class TrieStoreImpl implements TrieStore {
      * @param forceSaveRoot allows saving the root node even if it's embeddable
      */
     private void save(Trie trie, boolean forceSaveRoot) {
+        if (savedTries.contains(trie)) {
+            // it is guaranteed that the children of a saved node are also saved
+            return;
+        }
+
         byte[] trieKeyBytes = trie.getHash().getBytes();
 
         if (forceSaveRoot && this.store.get(trieKeyBytes) != null) {
             // the full trie is already saved
-            return;
-        }
-
-        if (savedTries.contains(trie)) {
-            // it is guaranteed that the children of a saved node are also saved
             return;
         }
 
@@ -89,7 +89,7 @@ public class TrieStoreImpl implements TrieStore {
             return;
         }
 
-        this.store.put(trie.getHash().getBytes(), trie.toMessage());
+        this.store.put(trieKeyBytes, trie.toMessage());
         savedTries.add(trie);
     }
 

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -23,6 +23,7 @@ import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -35,6 +36,8 @@ public class DataSourceWithCache implements KeyValueDataSource {
     private final Map<ByteArrayWrapper, byte[]> uncommittedCache;
     private final Map<ByteArrayWrapper, byte[]> committedCache;
 
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
     public DataSourceWithCache(KeyValueDataSource base, int cacheSize) {
         this.cacheSize = cacheSize;
         this.base = base;
@@ -43,28 +46,36 @@ public class DataSourceWithCache implements KeyValueDataSource {
     }
 
     @Override
-    public synchronized byte[] get(byte[] key) {
+    public byte[] get(byte[] key) {
         Objects.requireNonNull(key);
         ByteArrayWrapper wrappedKey = ByteUtil.wrap(key);
+        byte[] value;
 
-        if (committedCache.containsKey(wrappedKey)) {
-            return committedCache.get(wrappedKey);
+        this.lock.readLock().lock();
+
+        try {
+            if (committedCache.containsKey(wrappedKey)) {
+                return committedCache.get(wrappedKey);
+            }
+
+            if (uncommittedCache.containsKey(wrappedKey)) {
+                return uncommittedCache.get(wrappedKey);
+            }
+
+            value = base.get(key);
+
+            //null value, as expected, is allowed here to be stored in committedCache
+            committedCache.put(wrappedKey, value);
         }
-
-        if (uncommittedCache.containsKey(wrappedKey)) {
-            return uncommittedCache.get(wrappedKey);
+        finally {
+            this.lock.readLock().unlock();
         }
-
-        byte[] value = base.get(key);
-
-        //null value, as expected, is allowed here to be stored in committedCache
-        committedCache.put(wrappedKey, value);
 
         return value;
     }
 
     @Override
-    public synchronized byte[] put(byte[] key, byte[] value) {
+    public byte[] put(byte[] key, byte[] value) {
         ByteArrayWrapper wrappedKey = ByteUtil.wrap(key);
 
         return put(wrappedKey, value);
@@ -72,15 +83,23 @@ public class DataSourceWithCache implements KeyValueDataSource {
 
     private byte[] put(ByteArrayWrapper wrappedKey, byte[] value) {
         Objects.requireNonNull(value);
-        // here I could check for equal data or just move to the uncommittedCache.
-        byte[] priorValue = committedCache.get(wrappedKey);
 
-        if (priorValue != null && Arrays.equals(priorValue, value)) {
-            return value;
+        this.lock.writeLock().lock();
+
+        try {
+            // here I could check for equal data or just move to the uncommittedCache.
+            byte[] priorValue = committedCache.get(wrappedKey);
+
+            if (priorValue != null && Arrays.equals(priorValue, value)) {
+                return value;
+            }
+
+            committedCache.remove(wrappedKey);
+            this.putKeyValue(wrappedKey, value);
         }
-
-        committedCache.remove(wrappedKey);
-        this.putKeyValue(wrappedKey, value);
+        finally {
+            this.lock.writeLock().unlock();
+        }
 
         return value;
     }
@@ -94,39 +113,59 @@ public class DataSourceWithCache implements KeyValueDataSource {
     }
 
     @Override
-    public synchronized void delete(byte[] key) {
+    public void delete(byte[] key) {
         delete(ByteUtil.wrap(key));
     }
 
     private void delete(ByteArrayWrapper wrappedKey) {
-        // always mark for deletion if we don't know the state in the underlying store
-        if (!committedCache.containsKey(wrappedKey)) {
-            this.putKeyValue(wrappedKey, null);
-            return;
+        this.lock.writeLock().lock();
+
+        try {
+            // always mark for deletion if we don't know the state in the underlying store
+            if (!committedCache.containsKey(wrappedKey)) {
+                this.putKeyValue(wrappedKey, null);
+                return;
+            }
+
+            byte[] valueToRemove = committedCache.get(wrappedKey);
+
+            // a null value means we know for a fact that the key doesn't exist in the underlying store, so this is a noop
+            if (valueToRemove != null) {
+                this.putKeyValue(wrappedKey, null);
+                committedCache.remove(wrappedKey);
+            }
         }
-
-        byte[] valueToRemove = committedCache.get(wrappedKey);
-
-        // a null value means we know for a fact that the key doesn't exist in the underlying store, so this is a noop
-        if (valueToRemove != null) {
-            this.putKeyValue(wrappedKey, null);
-            committedCache.remove(wrappedKey);
+        finally {
+            this.lock.writeLock().unlock();
         }
     }
 
     @Override
-    public synchronized Set<byte[]> keys() {
-        Stream<ByteArrayWrapper> baseKeys = base.keys().stream().map(ByteArrayWrapper::new);
-        Stream<ByteArrayWrapper> committedKeys = committedCache.entrySet().stream()
-                .filter(e -> e.getValue() != null)
-                .map(Map.Entry::getKey);
-        Stream<ByteArrayWrapper> uncommittedKeys = uncommittedCache.entrySet().stream()
-                .filter(e -> e.getValue() != null)
-                .map(Map.Entry::getKey);
-        Set<ByteArrayWrapper> uncommittedKeysToRemove = uncommittedCache.entrySet().stream()
-                .filter(e -> e.getValue() == null)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toSet());
+    public Set<byte[]> keys() {
+        Stream<ByteArrayWrapper> baseKeys;
+        Stream<ByteArrayWrapper> committedKeys;
+        Stream<ByteArrayWrapper> uncommittedKeys;
+        Set<ByteArrayWrapper> uncommittedKeysToRemove;
+
+        this.lock.readLock().lock();
+
+        try {
+            baseKeys = base.keys().stream().map(ByteArrayWrapper::new);
+            committedKeys = committedCache.entrySet().stream()
+                    .filter(e -> e.getValue() != null)
+                    .map(Map.Entry::getKey);
+            uncommittedKeys = uncommittedCache.entrySet().stream()
+                    .filter(e -> e.getValue() != null)
+                    .map(Map.Entry::getKey);
+            uncommittedKeysToRemove = uncommittedCache.entrySet().stream()
+                    .filter(e -> e.getValue() == null)
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+        }
+        finally {
+            this.lock.readLock().unlock();
+        }
+
         Set<ByteArrayWrapper> knownKeys = Stream.concat(Stream.concat(baseKeys, committedKeys), uncommittedKeys)
                 .collect(Collectors.toSet());
         knownKeys.removeAll(uncommittedKeysToRemove);
@@ -138,7 +177,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
     }
 
     @Override
-    public synchronized void updateBatch(Map<ByteArrayWrapper, byte[]> rows, Set<ByteArrayWrapper> keysToRemove) {
+    public void updateBatch(Map<ByteArrayWrapper, byte[]> rows, Set<ByteArrayWrapper> keysToRemove) {
         if (rows.containsKey(null) || rows.containsValue(null)) {
             throw new IllegalArgumentException("Cannot update null values");
         }
@@ -146,42 +185,63 @@ public class DataSourceWithCache implements KeyValueDataSource {
         // remove overlapping entries
         rows.keySet().removeAll(keysToRemove);
 
-        rows.forEach(this::put);
-        keysToRemove.forEach(this::delete);
+        this.lock.writeLock().lock();
+
+        try {
+            rows.forEach(this::put);
+            keysToRemove.forEach(this::delete);
+        }
+        finally {
+            this.lock.writeLock().unlock();
+        }
     }
 
     @Override
-    public synchronized void flush() {
+    public void flush() {
         Map<ByteArrayWrapper, byte[]> uncommittedBatch = new LinkedHashMap<>();
 
-        this.uncommittedCache.forEach((key, value) -> {
-            if (value != null) {
-                uncommittedBatch.put(key, value);
-            }
-        });
+        this.lock.writeLock().lock();
 
-        Set<ByteArrayWrapper> uncommittedKeysToRemove = uncommittedCache.entrySet().stream().filter(e -> e.getValue() == null).map(Map.Entry::getKey).collect(Collectors.toSet());
-        base.updateBatch(uncommittedBatch, uncommittedKeysToRemove);
-        committedCache.putAll(uncommittedCache);
-        uncommittedCache.clear();
+        try {
+            this.uncommittedCache.forEach((key, value) -> {
+                if (value != null) {
+                    uncommittedBatch.put(key, value);
+                }
+            });
+
+            Set<ByteArrayWrapper> uncommittedKeysToRemove = uncommittedCache.entrySet().stream().filter(e -> e.getValue() == null).map(Map.Entry::getKey).collect(Collectors.toSet());
+            base.updateBatch(uncommittedBatch, uncommittedKeysToRemove);
+            committedCache.putAll(uncommittedCache);
+            uncommittedCache.clear();
+        }
+        finally {
+            this.lock.writeLock().unlock();
+        }
     }
 
     public String getName() {
         return base.getName() + "-with-uncommittedCache";
     }
 
-    public synchronized void init() {
+    public void init() {
         base.init();
     }
 
-    public synchronized boolean isAlive() {
+    public boolean isAlive() {
         return base.isAlive();
     }
 
-    public synchronized void close() {
-        flush();
-        base.close();
-        uncommittedCache.clear();
-        committedCache.clear();
+    public void close() {
+        this.lock.writeLock().lock();
+
+        try {
+            flush();
+            base.close();
+            uncommittedCache.clear();
+            committedCache.clear();
+        }
+        finally {
+            this.lock.writeLock().unlock();
+        }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -43,7 +43,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
         this.cacheSize = cacheSize;
         this.base = base;
         this.uncommittedCache = new LinkedHashMap<>(cacheSize / 8, (float)0.75, false);
-        this.committedCache = new MaxSizeHashMap<>(cacheSize, true);
+        this.committedCache = Collections.synchronizedMap(new MaxSizeHashMap<>(cacheSize, true));
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -38,7 +38,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
     public DataSourceWithCache(KeyValueDataSource base, int cacheSize) {
         this.cacheSize = cacheSize;
         this.base = base;
-        this.uncommittedCache = new LinkedHashMap<>(cacheSize / 8, (float)0.75, true);
+        this.uncommittedCache = new LinkedHashMap<>(cacheSize / 8, (float)0.75, false);
         this.committedCache = new MaxSizeHashMap<>(cacheSize, true);
     }
 

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -43,7 +43,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
         this.cacheSize = cacheSize;
         this.base = base;
         this.uncommittedCache = new LinkedHashMap<>(cacheSize / 8, (float)0.75, false);
-        this.committedCache = Collections.synchronizedMap(new MaxSizeHashMap<>(cacheSize, true));
+        this.committedCache = new MaxSizeHashMap<>(cacheSize, true);
     }
 
     @Override
@@ -64,12 +64,19 @@ public class DataSourceWithCache implements KeyValueDataSource {
             }
 
             value = base.get(key);
+        }
+        finally {
+            this.lock.readLock().unlock();
+        }
 
+        this.lock.writeLock().lock();
+
+        try {
             //null value, as expected, is allowed here to be stored in committedCache
             committedCache.put(wrappedKey, value);
         }
         finally {
-            this.lock.readLock().unlock();
+            this.lock.writeLock().unlock();
         }
 
         return value;

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -143,7 +143,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
-        verify(map, times(2)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.trie;
 
+import co.rsk.crypto.Keccak256;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.HashMapDB;
 import org.junit.Assert;
@@ -48,6 +49,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -58,6 +60,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
 
         Trie newTrie = store.retrieve(trie.getHash().getBytes()).get();
@@ -78,6 +81,7 @@ public class TrieStoreImplTest {
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
         verify(map, times(1)).put(trie.getValueHash().getBytes(), trie.getValue());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
 
         Trie newTrie = store.retrieve(trie.getHash().getBytes()).get();
@@ -95,6 +99,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -106,6 +111,7 @@ public class TrieStoreImplTest {
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
         verify(map, times(1)).put(trie.getValueHash().getBytes(), trie.getValue());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -118,6 +124,8 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(trie.trieSize())).put(any(), any());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -128,9 +136,14 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verifyNoMoreInteractions(map);
 
         store.save(trie);
 
+        verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(2)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -140,13 +153,19 @@ public class TrieStoreImplTest {
 
         store.save(trie);
 
+        Keccak256 hash1 = trie.getHash();
+
         verify(map, times(trie.trieSize())).put(any(), any());
 
         trie = trie.put("foo", "bar2".getBytes());
 
         store.save(trie);
 
+        Keccak256 hash2 = trie.getHash();
+
         verify(map, times(trie.trieSize() + 1)).put(any(), any());
+        verify(map, times(1)).get(hash1.getBytes());
+        verify(map, times(1)).get(hash2.getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -163,6 +182,8 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(trie.trieSize() + 1)).put(any(), any());
+        verify(map, times(2)).get(any());
+
         verifyNoMoreInteractions(map);
     }
 
@@ -182,11 +203,11 @@ public class TrieStoreImplTest {
 
         Trie trie2 = store.retrieve(trie.getHash().getBytes()).get();
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
 
         Assert.assertEquals(size, trie2.trieSize());
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
     }
 
     @Test
@@ -200,11 +221,11 @@ public class TrieStoreImplTest {
 
         Trie trie2 = store.retrieve(trie.getHash().getBytes()).get();
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
 
         Assert.assertEquals(size, trie2.trieSize());
 
-        verify(map, times(size)).get(any());
+        verify(map, times(size + 1)).get(any());
     }
 
     @Test
@@ -217,6 +238,6 @@ public class TrieStoreImplTest {
 
         store.retrieve(trie.getHash().getBytes());
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
@@ -6,6 +6,7 @@ import org.ethereum.util.ByteUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -108,6 +109,24 @@ public class DataSourceWithCacheTest {
 
         dataSourceWithCache.flush();
         assertThat(baseDataSource.get(randomKey), is(randomValue));
+    }
+
+    @Test
+    public void putTwoKeyValuesWrittenInOrder() {
+        InOrder order = inOrder(baseDataSource);
+
+        byte[] randomKey1 = TestUtils.randomBytes(20);
+        byte[] randomValue1 = TestUtils.randomBytes(20);
+        byte[] randomKey2 = TestUtils.randomBytes(20);
+        byte[] randomValue2 = TestUtils.randomBytes(20);
+
+        dataSourceWithCache.put(randomKey1, randomValue1);
+        dataSourceWithCache.put(randomKey2, randomValue2);
+
+        dataSourceWithCache.flush();
+
+        order.verify(baseDataSource).put(randomKey1, randomValue1);
+        order.verify(baseDataSource).put(randomKey2, randomValue2);
     }
 
     @Test


### PR DESCRIPTION
The implementation of `DataSourceWithCache` is improved with:

- Automanage of write flush
- Synchronization locks to support multithreading

And `TrieStoreImpl` avoid the write of a known trie world state

It includes and improve #1079 #1078 #1077
