### PR TITLE
Add `newPendingTransactions` subscription support

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -58,6 +58,7 @@ import co.rsk.rpc.modules.debug.DebugModuleImpl;
 import co.rsk.rpc.modules.eth.*;
 import co.rsk.rpc.modules.eth.subscribe.BlockHeaderNotificationEmitter;
 import co.rsk.rpc.modules.eth.subscribe.LogsNotificationEmitter;
+import co.rsk.rpc.modules.eth.subscribe.PendingTransactionNotificationEmitter;
 import co.rsk.rpc.modules.evm.EvmModule;
 import co.rsk.rpc.modules.evm.EvmModuleImpl;
 import co.rsk.rpc.modules.mnr.MnrModule;
@@ -1461,7 +1462,8 @@ public class RskContext implements NodeBootstrapper {
                             jsonRpcSerializer,
                             getReceiptStore(),
                             new BlockchainBranchComparator(getBlockStore())
-                    )
+                    ),
+                    new PendingTransactionNotificationEmitter(rsk, jsonRpcSerializer)
             );
             RskJsonRpcHandler jsonRpcHandler = new RskJsonRpcHandler(emitter, jsonRpcSerializer);
             web3WebSocketServer = new Web3WebSocketServer(

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1463,7 +1463,7 @@ public class RskContext implements NodeBootstrapper {
                             getReceiptStore(),
                             new BlockchainBranchComparator(getBlockStore())
                     ),
-                    new PendingTransactionNotificationEmitter(rsk, jsonRpcSerializer)
+                    new PendingTransactionNotificationEmitter(rsk, jsonRpcSerializer, getWallet())
             );
             RskJsonRpcHandler jsonRpcHandler = new RskJsonRpcHandler(emitter, jsonRpcSerializer);
             web3WebSocketServer = new Web3WebSocketServer(

--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -74,6 +74,12 @@ public class Wallet {
         return addresses;
     }
 
+    public boolean handles(RskAddress address) {
+        return initialAccounts.contains(address)
+                || accounts.containsKey(address)
+                || keyDS.keys().stream().anyMatch(key -> Arrays.equals(key, address.getBytes()));
+    }
+
     public String[] getAccountAddressesAsHex() {
         return getAccountAddresses().stream()
                 .map(TypeConverter::toJsonHex)

--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -80,12 +80,6 @@ public class Wallet {
                 .toArray(String[]::new);
     }
 
-    public RskAddress addAccount() {
-        Account account = new Account(new ECKey());
-        saveAccount(account);
-        return account.getAddress();
-    }
-
     public RskAddress addAccount(String passphrase) {
         Account account = new Account(new ECKey());
         saveAccount(account, passphrase);

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeNewPendingTransactionsParams.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeNewPendingTransactionsParams.java
@@ -1,0 +1,12 @@
+package co.rsk.rpc.modules.eth.subscribe;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.netty.channel.Channel;
+
+@JsonDeserialize
+public class EthSubscribeNewPendingTransactionsParams implements EthSubscribeParams {
+    @Override
+    public SubscriptionId accept(EthSubscribeParamsVisitor visitor, Channel channel) {
+        return visitor.visit(this, channel);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
@@ -38,6 +38,7 @@ public class EthSubscribeParamsDeserializer extends JsonDeserializer {
         this.subscriptionTypes = new HashMap<>();
         this.subscriptionTypes.put("newHeads", EthSubscribeNewHeadsParams.class);
         this.subscriptionTypes.put("logs", EthSubscribeLogsParams.class);
+        this.subscriptionTypes.put("newPendingTransactions", EthSubscribeNewPendingTransactionsParams.class);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsVisitor.java
@@ -36,4 +36,11 @@ public interface EthSubscribeParamsVisitor {
      * @return a subscription id which should be used as an unsubscribe parameter.
      */
     SubscriptionId visit(EthSubscribeLogsParams params, Channel channel);
+
+    /**
+     * @param params new pending transactions subscription request parameters.
+     * @param channel a Netty channel to subscribe notifications to.
+     * @return a subscription id which should be used as an unsubscribe parameter.
+     */
+    SubscriptionId visit(EthSubscribeNewPendingTransactionsParams params, Channel channel);
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotification.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotification.java
@@ -1,0 +1,18 @@
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.crypto.Keccak256;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class PendingTransactionNotification implements EthSubscriptionNotificationDTO {
+
+    private final Keccak256 transactionHash;
+
+    public PendingTransactionNotification(Keccak256 transactionHash) {
+        this.transactionHash = transactionHash;
+    }
+
+    @JsonValue
+    public String getTransactionHash() {
+        return transactionHash.toJsonString();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotificationEmitter.java
@@ -1,0 +1,66 @@
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.rpc.JsonRpcSerializer;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.ethereum.core.Transaction;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.listener.EthereumListenerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PendingTransactionNotificationEmitter {
+    private static final Logger logger = LoggerFactory.getLogger(PendingTransactionNotificationEmitter.class);
+
+
+    private final Map<SubscriptionId, Channel> subscriptions = new ConcurrentHashMap<>();
+    private final JsonRpcSerializer jsonRpcSerializer;
+
+    public PendingTransactionNotificationEmitter(Ethereum ethereum, JsonRpcSerializer jsonRpcSerializer) {
+        this.jsonRpcSerializer = jsonRpcSerializer;
+        ethereum.addListener(new EthereumListenerAdapter() {
+            @Override
+            public void onPendingTransactionsReceived(List<Transaction> transactions) {
+                emitPendingTransactions(transactions);
+            }
+        });
+    }
+
+    public void subscribe(SubscriptionId subscriptionId, Channel channel) {
+        subscriptions.put(subscriptionId, channel);
+    }
+
+    public boolean unsubscribe(SubscriptionId subscriptionId) {
+        return subscriptions.remove(subscriptionId) != null;
+    }
+
+    public void unsubscribe(Channel channel) {
+        subscriptions.values().removeIf(channel::equals);
+    }
+
+    private void emitPendingTransactions(List<Transaction> transactions) {
+        if (subscriptions.isEmpty()) {
+            return;
+        }
+
+        subscriptions.forEach(((id, channel) -> {
+            transactions.forEach(transaction -> {
+                EthSubscriptionNotification request = new EthSubscriptionNotification(
+                        new EthSubscriptionParams(id, new PendingTransactionNotification(transaction.getHash()))
+                );
+                try {
+                    String msg = jsonRpcSerializer.serializeMessage(request);
+                    channel.write(new TextWebSocketFrame(msg));
+                } catch (IOException e) {
+                    logger.error("Couldn't serialize block header result for notification", e);
+                }
+            });
+            channel.flush();
+        }));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/core/WalletTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/WalletTest.java
@@ -271,21 +271,6 @@ public class WalletTest {
     }
 
     @Test
-    public void addAccountWithRandomPrivateKey() {
-        Wallet wallet = WalletFactory.createWallet();
-
-        byte[] address = wallet.addAccount().getBytes();
-
-        Assert.assertNotNull(address);
-
-        Account account = wallet.getAccount(new RskAddress(address));
-
-        Assert.assertNotNull(account);
-
-        Assert.assertArrayEquals(address, account.getAddress().getBytes());
-    }
-
-    @Test
     public void getUnknownAccount() {
         Wallet wallet = WalletFactory.createWallet();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
@@ -30,13 +30,15 @@ import static org.mockito.Mockito.*;
 public class EthSubscriptionNotificationEmitterTest {
     private BlockHeaderNotificationEmitter newHeads;
     private LogsNotificationEmitter logs;
+    private PendingTransactionNotificationEmitter pendingTransactions;
     private EthSubscriptionNotificationEmitter emitter;
 
     @Before
     public void setUp() {
         newHeads = mock(BlockHeaderNotificationEmitter.class);
         logs = mock(LogsNotificationEmitter.class);
-        emitter = new EthSubscriptionNotificationEmitter(newHeads, logs);
+        pendingTransactions = mock(PendingTransactionNotificationEmitter.class);
+        emitter = new EthSubscriptionNotificationEmitter(newHeads, logs, pendingTransactions);
     }
 
     @Test
@@ -62,6 +64,17 @@ public class EthSubscriptionNotificationEmitterTest {
     }
 
     @Test
+    public void subscribeToPendingTransactions() {
+        Channel channel = mock(Channel.class);
+        EthSubscribeNewPendingTransactionsParams params = mock(EthSubscribeNewPendingTransactionsParams.class);
+
+        SubscriptionId subscriptionId = emitter.visit(params, channel);
+
+        assertThat(subscriptionId, notNullValue());
+        verify(pendingTransactions).subscribe(subscriptionId, channel);
+    }
+
+    @Test
     public void unsubscribeUnsuccessfully() {
         SubscriptionId subscriptionId = mock(SubscriptionId.class);
 
@@ -70,6 +83,7 @@ public class EthSubscriptionNotificationEmitterTest {
         assertThat(unsubscribed, is(false));
         verify(newHeads).unsubscribe(subscriptionId);
         verify(logs).unsubscribe(subscriptionId);
+        verify(pendingTransactions).unsubscribe(subscriptionId);
     }
 
     @Test
@@ -82,6 +96,7 @@ public class EthSubscriptionNotificationEmitterTest {
         assertThat(unsubscribed, is(true));
         verify(newHeads).unsubscribe(subscriptionId);
         verify(logs).unsubscribe(subscriptionId);
+        verify(pendingTransactions).unsubscribe(subscriptionId);
     }
 
     @Test
@@ -94,6 +109,20 @@ public class EthSubscriptionNotificationEmitterTest {
         assertThat(unsubscribed, is(true));
         verify(newHeads).unsubscribe(subscriptionId);
         verify(logs).unsubscribe(subscriptionId);
+        verify(pendingTransactions).unsubscribe(subscriptionId);
+    }
+
+    @Test
+    public void unsubscribeSuccessfullyFromNewPendingTransactions() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        when(pendingTransactions.unsubscribe(subscriptionId)).thenReturn(true);
+
+        boolean unsubscribed = emitter.unsubscribe(subscriptionId);
+
+        assertThat(unsubscribed, is(true));
+        verify(newHeads).unsubscribe(subscriptionId);
+        verify(logs).unsubscribe(subscriptionId);
+        verify(pendingTransactions).unsubscribe(subscriptionId);
     }
 
     @Test
@@ -104,5 +133,6 @@ public class EthSubscriptionNotificationEmitterTest {
 
         verify(newHeads).unsubscribe(channel);
         verify(logs).unsubscribe(channel);
+        verify(pendingTransactions).unsubscribe(channel);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeRequestTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeRequestTest.java
@@ -46,6 +46,16 @@ public class EthSubscribeRequestTest {
     }
 
     @Test
+    public void deserializeNewPendingTransactions() throws IOException {
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":333,\"method\":\"eth_subscribe\",\"params\":[\"newPendingTransactions\"]}";
+        RskJsonRpcRequest request = serializer.deserializeRequest(
+                new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8))
+        );
+
+        validateParams(request, EthSubscribeNewPendingTransactionsParams.class);
+    }
+
+    @Test
     public void deserializeLogsWithEmptyConfig() throws IOException {
         String message = "{\"jsonrpc\":\"2.0\",\"id\":333,\"method\":\"eth_subscribe\",\"params\":[\"logs\", {}]}";
         RskJsonRpcRequest request = serializer.deserializeRequest(

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotificationEmitterTest.java
@@ -1,0 +1,110 @@
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.crypto.Keccak256;
+import co.rsk.rpc.JsonRpcSerializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.ethereum.TestUtils;
+import org.ethereum.core.Transaction;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.listener.EthereumListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class PendingTransactionNotificationEmitterTest {
+
+    private JsonRpcSerializer serializer;
+    private PendingTransactionNotificationEmitter emitter;
+    private EthereumListener listener;
+
+    @Before
+    public void setUp() {
+        Ethereum ethereum = mock(Ethereum.class);
+        serializer = mock(JsonRpcSerializer.class);
+        emitter = new PendingTransactionNotificationEmitter(ethereum, serializer);
+
+        ArgumentCaptor<EthereumListener> listenerCaptor = ArgumentCaptor.forClass(EthereumListener.class);
+        verify(ethereum).addListener(listenerCaptor.capture());
+        listener = listenerCaptor.getValue();
+
+    }
+
+    @Test
+    public void onPendingTransactionsReceivedEventTriggersMessageToChannel() throws JsonProcessingException {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+        when(serializer.serializeMessage(any())).thenReturn("serialized");
+
+        listener.onPendingTransactionsReceived(Collections.singletonList(mock(Transaction.class)));
+        verify(channel).write(new TextWebSocketFrame("serialized"));
+        verify(channel).flush();
+    }
+
+    @Test
+    public void onPendingTransactionsEventTriggersOneMessageToChannelPerTransaction() throws JsonProcessingException {
+        SubscriptionId subscriptionId1 = mock(SubscriptionId.class);
+        SubscriptionId subscriptionId2 = mock(SubscriptionId.class);
+        Channel channel1 = mock(Channel.class);
+        Channel channel2 = mock(Channel.class);
+        emitter.subscribe(subscriptionId1, channel1);
+        emitter.subscribe(subscriptionId2, channel2);
+
+        when(serializer.serializeMessage(any()))
+                .thenReturn("serializedTxHash1")
+                .thenReturn("serializedTxHash2")
+                .thenReturn("serializedTxHash1")
+                .thenReturn("serializedTxHash2");
+
+        listener.onPendingTransactionsReceived(testTxs(TestUtils.randomHash(), TestUtils.randomHash()));
+
+        verify(channel1).write(new TextWebSocketFrame("serializedTxHash1"));
+        verify(channel1).write(new TextWebSocketFrame("serializedTxHash2"));
+        verify(channel1).flush();
+        verify(channel2).write(new TextWebSocketFrame("serializedTxHash1"));
+        verify(channel2).write(new TextWebSocketFrame("serializedTxHash2"));
+        verify(channel2).flush();
+    }
+
+    @Test
+    public void unsubscribeSucceedsForExistingSubscriptionId() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+
+        assertThat(emitter.unsubscribe(new SubscriptionId()), is(false));
+        assertThat(emitter.unsubscribe(subscriptionId), is(true));
+    }
+
+    @Test
+    public void unsubscribeChannelThenNothingIsEmitted() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+
+        emitter.unsubscribe(channel);
+
+        listener.onPendingTransactionsReceived(testTxs(TestUtils.randomHash()));
+        verifyNoMoreInteractions(channel);
+    }
+
+    private List<Transaction> testTxs(Keccak256... txHashes) {
+        return Stream.of(txHashes).map(txHash -> {
+            Transaction mockTx = mock(Transaction.class);
+            doReturn(txHash).when(mockTx).getHash();
+            return mockTx;
+        }).collect(Collectors.toList());
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotificationEmitterTest.java
@@ -1,5 +1,6 @@
 package co.rsk.rpc.modules.eth.subscribe;
 
+import co.rsk.core.Wallet;
 import co.rsk.crypto.Keccak256;
 import co.rsk.rpc.JsonRpcSerializer;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -12,6 +13,7 @@ import org.ethereum.listener.EthereumListener;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +35,7 @@ public class PendingTransactionNotificationEmitterTest {
     public void setUp() {
         Ethereum ethereum = mock(Ethereum.class);
         serializer = mock(JsonRpcSerializer.class);
-        emitter = new PendingTransactionNotificationEmitter(ethereum, serializer);
+        emitter = new PendingTransactionNotificationEmitter(ethereum, serializer, Mockito.mock(Wallet.class));
 
         ArgumentCaptor<EthereumListener> listenerCaptor = ArgumentCaptor.forClass(EthereumListener.class);
         verify(ethereum).addListener(listenerCaptor.capture());

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotificationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionNotificationTest.java
@@ -1,0 +1,20 @@
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.crypto.Keccak256;
+import org.ethereum.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class PendingTransactionNotificationTest {
+
+    @Test
+    public void getTransactionHash() {
+        Keccak256 transactionHash = TestUtils.randomHash();
+        PendingTransactionNotification pendingTransactionNotification = new PendingTransactionNotification(transactionHash);
+
+        Assert.assertThat(pendingTransactionNotification.getTransactionHash(), is(transactionHash.toJsonString()));
+    }
+}


### PR DESCRIPTION
This enables support for `newPendingTransactions` subscription to the `eth_subscribe` method
according to [go-ethereum documentation](https://geth.ethereum.org/docs/rpc/pubsub#newpendingtransactions)

This can be smoke tested with the following snippet
```javascript
const Web3 = require("web3");
const web3 = new Web3("ws://localhost:4445/websocket");

async function main() {
  var subscription = web3.eth.subscribe('pendingTransactions',
    function (err, txHash) {
      if (!err) {
        console.info('txHash: %s', txHash);
      } else {
        console.error(err);
      }
    }
  );
}

try {
  main();
} catch (err) {
  console.error(err);
}
```

Draft until implemented the following filter
> ... and signed with a key that is available in the node