### PR TITLE
Change log data and address format

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/LogFilterElement.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/LogFilterElement.java
@@ -25,6 +25,7 @@ import org.ethereum.vm.LogInfo;
 import java.util.Arrays;
 
 import static org.ethereum.rpc.TypeConverter.toJsonHex;
+import static org.ethereum.rpc.TypeConverter.toUnformattedJsonHex;
 
 /**
  * Created by ajlopez on 5/4/2016.
@@ -45,8 +46,8 @@ public class LogFilterElement {
         blockHash = b == null ? null : toJsonHex(b.getHash().getBytes());
         transactionIndex = b == null ? null : TypeConverter.toQuantityJsonHex(txIndex);
         transactionHash = tx.getHash().toJsonString();
-        address = toJsonHex(logInfo.getAddress());
-        data = toJsonHex(logInfo.getData());
+        address = toUnformattedJsonHex(logInfo.getAddress());
+        data = toUnformattedJsonHex(logInfo.getData());
         topics = new String[logInfo.getTopics().size()];
         for (int i = 0; i < topics.length; i++) {
             topics[i] = toJsonHex(logInfo.getTopics().get(i).getData());

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -53,22 +53,24 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
 public class Web3RskImplTest {
 
     @Test
-    public void web3_ext_dumpState() throws Exception {
-        Ethereum rsk = Mockito.mock(Ethereum.class);
-        Blockchain blockchain = Mockito.mock(Blockchain.class);
-        MiningMainchainView mainchainView = Mockito.mock(MiningMainchainView.class);
+    public void web3_ext_dumpState() {
+        Ethereum rsk = mock(Ethereum.class);
+        Blockchain blockchain = mock(Blockchain.class);
+        MiningMainchainView mainchainView = mock(MiningMainchainView.class);
 
-        NetworkStateExporter networkStateExporter = Mockito.mock(NetworkStateExporter.class);
+        NetworkStateExporter networkStateExporter = mock(NetworkStateExporter.class);
         Mockito.when(networkStateExporter.exportStatus(Mockito.anyString())).thenReturn(true);
 
-        Block block = Mockito.mock(Block.class);
+        Block block = mock(Block.class);
         Mockito.when(block.getHash()).thenReturn(PegTestUtils.createHash3());
         Mockito.when(block.getNumber()).thenReturn(1L);
 
-        BlockStore blockStore = Mockito.mock(BlockStore.class);
+        BlockStore blockStore = mock(BlockStore.class);
         Mockito.when(blockStore.getBestBlock()).thenReturn(block);
         Mockito.when(networkStateExporter.exportStatus(Mockito.anyString())).thenReturn(true);
 
@@ -117,19 +119,19 @@ public class Web3RskImplTest {
     }
 
     @Test
-    public void web3_LogFilterElement_toString() {
-        LogInfo logInfo = Mockito.mock(LogInfo.class);
+    public void web3_LogFilterElementNullAddress_toString() {
+        LogInfo logInfo = mock(LogInfo.class);
         byte[] valueToTest = HashUtil.keccak256(new byte[]{1});
         Mockito.when(logInfo.getData()).thenReturn(valueToTest);
         List<DataWord> topics = new ArrayList<>();
         topics.add(DataWord.valueFromHex("c1"));
         topics.add(DataWord.valueFromHex("c2"));
         Mockito.when(logInfo.getTopics()).thenReturn(topics);
-        Block block = Mockito.mock(Block.class);
+        Block block = mock(Block.class);
         Mockito.when(block.getHash()).thenReturn(new Keccak256(valueToTest));
         Mockito.when(block.getNumber()).thenReturn(1L);
         int txIndex = 1;
-        Transaction tx = Mockito.mock(Transaction.class);
+        Transaction tx = mock(Transaction.class);
         byte[] bytes = new byte[32];
         bytes[0] = 2;
         Mockito.when(tx.getHash()).thenReturn(new Keccak256(bytes));
@@ -137,7 +139,31 @@ public class Web3RskImplTest {
 
         LogFilterElement logFilterElement = new LogFilterElement(logInfo, block, txIndex, tx, logIdx);
 
-        Assert.assertEquals(logFilterElement.toString(), "LogFilterElement{logIndex='0x5', blockNumber='0x1', blockHash='0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2', transactionHash='0x0200000000000000000000000000000000000000000000000000000000000000', transactionIndex='0x1', address='0x00', data='0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2', topics=[0x00000000000000000000000000000000000000000000000000000000000000c1, 0x00000000000000000000000000000000000000000000000000000000000000c2]}");
+        Assert.assertEquals("LogFilterElement{logIndex='0x5', blockNumber='0x1', blockHash='0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2', transactionHash='0x0200000000000000000000000000000000000000000000000000000000000000', transactionIndex='0x1', address='0x', data='0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2', topics=[0x00000000000000000000000000000000000000000000000000000000000000c1, 0x00000000000000000000000000000000000000000000000000000000000000c2]}", logFilterElement.toString());
+    }
+
+    @Test
+    public void web3_LogFilterElementNullData_toString() {
+        LogInfo logInfo = mock(LogInfo.class);
+        byte[] valueToTest = HashUtil.keccak256(new byte[]{1});
+        Mockito.when(logInfo.getData()).thenReturn(null);
+        List<DataWord> topics = new ArrayList<>();
+        topics.add(DataWord.valueFromHex("c1"));
+        topics.add(DataWord.valueFromHex("c2"));
+        Mockito.when(logInfo.getTopics()).thenReturn(topics);
+        Block block = mock(Block.class);
+        Mockito.when(block.getHash()).thenReturn(new Keccak256(valueToTest));
+        Mockito.when(block.getNumber()).thenReturn(1L);
+        int txIndex = 1;
+        Transaction tx = mock(Transaction.class);
+        byte[] bytes = new byte[32];
+        bytes[0] = 2;
+        Mockito.when(tx.getHash()).thenReturn(new Keccak256(bytes));
+        int logIdx = 5;
+
+        LogFilterElement logFilterElement = new LogFilterElement(logInfo, block, txIndex, tx, logIdx);
+
+        Assert.assertEquals("LogFilterElement{logIndex='0x5', blockNumber='0x1', blockHash='0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2', transactionHash='0x0200000000000000000000000000000000000000000000000000000000000000', transactionIndex='0x1', address='0x', data='0x', topics=[0x00000000000000000000000000000000000000000000000000000000000000c1, 0x00000000000000000000000000000000000000000000000000000000000000c2]}", logFilterElement.toString());
     }
 
     @Test


### PR DESCRIPTION
Changing log values based on ethereum specifications. Empty `data` should resolve to `0x` instead of `0x00`, same with `address`
*fed:version120* *fit:120*