### PR TITLE
Selfbalance opcode

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -44,6 +44,7 @@ public enum ConsensusRule {
     RSKIP136("rskip136"),
     RSKIP140("rskip140"),
     RSKIP150("rskip150"),
+    RSKIP151("rskip151"),
     RSKIP152("rskip152");
 
     private String configKey;

--- a/rskj-core/src/main/java/org/ethereum/vm/OpCode.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/OpCode.java
@@ -262,6 +262,10 @@ public enum OpCode {
      * (0x45) Get the block’s gas limit
      */
     GASLIMIT(0x45, 0, 1, BASE_TIER),
+    /**
+     * (0x47) Get the senders balance
+     */
+    SELFBALANCE(0x47, 0, 1, LOW_TIER),
 
     /**
      * (0x46) Get the chain id
@@ -283,7 +287,7 @@ public enum OpCode {
      */
     MSTORE(0x52, 2, 0, VERY_LOW_TIER),
     /**
-     * (0x53) Save byte to memory
+     * `(0x53) Save byte to memory
      */
     MSTORE8(0x53, 2, 0, VERY_LOW_TIER),
     /**

--- a/rskj-core/src/main/java/org/ethereum/vm/OpCodes.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/OpCodes.java
@@ -264,6 +264,10 @@ public class OpCodes {
      * (0x46) Get the chain id
      */
     public static final byte OP_CHAINID =0x46 ;
+    /**
+     * (0x45) Get the senders balance
+     */
+    public static final byte OP_SELFBALANCE = 0x47 ;
 
     /*  Memory Storage and F Operations */
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1071,6 +1071,19 @@ public class VM {
         program.step();
     }
 
+    protected void doSELFBALANCE(){
+        spendOpCodeGas();
+        // EXECUTION PHASE
+        DataWord balance = program.getBalance(program.getOwnerAddress());
+
+        if (isLogEnabled) {
+            hint = "selfBalance: " + balance;
+        }
+
+        program.stackPush(balance);
+        program.step();
+    }
+
     protected void doPOP(){
         spendOpCodeGas();
         // EXECUTION PHASE
@@ -1789,6 +1802,12 @@ public class VM {
                     throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
                 }
                 doCHAINID();
+            break;
+            case OpCodes.OP_SELFBALANCE:
+                if (!activations.isActive(RSKIP151)) {
+                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                }
+                doSELFBALANCE();
             break;
             case OpCodes.OP_TXINDEX: doTXINDEX();
             break;

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -28,6 +28,7 @@ blockchain = {
             rskip134 = wasabiPlusOne,
             rskip136 = bahamas,
             rskip140 = wasabiPlusOne,
+            rskip151 = wasabiPlusOne,
             rskip152 = wasabiPlusOne
             rskip150 = twoToThree
         }

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -63,6 +63,7 @@ public class ActivationConfigTest {
             "    rskip134: wasabiPlusOne",
             "    rskip136: bahamas",
             "    rskip140: wasabiPlusOne",
+            "    rskip151: wasabiPlusOne",
             "    rskip152: wasabiPlusOne",
             "    rskip150: twoToThree",
             "}"


### PR DESCRIPTION
Simple implementation for the SELFBALANCE opcode, given that it is asking for the balance of the owner of the contract, it is assumed that the balance is already in cache, and thus is cheaper than a call to BALANCE.