### PR TITLE
Extra Data Population Protocol

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -670,6 +670,7 @@ public class RskContext implements NodeBootstrapper {
                     getBlockToMineBuilder(),
                     getMinerClock(),
                     getBlockFactory(),
+                    getBuildInfo(),
                     getMiningConfig()
             );
         }
@@ -812,14 +813,14 @@ public class RskContext implements NodeBootstrapper {
     }
 
     protected GenesisLoader buildGenesisLoader() {
-        RskSystemProperties rskSystemProperties = getRskSystemProperties();
-        ActivationConfig.ForBlock genesisActivations = rskSystemProperties.getActivationConfig().forBlock(0L);
+        RskSystemProperties systemProperties = getRskSystemProperties();
+        ActivationConfig.ForBlock genesisActivations = systemProperties.getActivationConfig().forBlock(0L);
         return new GenesisLoaderImpl(
-                rskSystemProperties.getActivationConfig(),
+                systemProperties.getActivationConfig(),
                 getStateRootHandler(),
                 getTrieStore(),
-                rskSystemProperties.genesisInfo(),
-                rskSystemProperties.getNetworkConstants().getInitialNonce(),
+                systemProperties.genesisInfo(),
+                systemProperties.getNetworkConstants().getInitialNonce(),
                 true,
                 genesisActivations.isActive(ConsensusRule.RSKIP92),
                 genesisActivations.isActive(ConsensusRule.RSKIP126)

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServer.java
@@ -59,5 +59,7 @@ public interface MinerServer extends InternalService {
 
     void setExtraData(byte[] extraData);
 
+    byte[] getExtraData();
+
     Optional<Block> getLatestBlock();
 }

--- a/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MainNetMinerTest.java
@@ -26,6 +26,7 @@ import org.ethereum.core.TransactionPool;
 import org.ethereum.core.genesis.GenesisLoader;
 import org.ethereum.db.BlockStore;
 import org.ethereum.facade.EthereumImpl;
+import org.ethereum.util.BuildInfo;
 import org.ethereum.util.RskTestFactory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -108,6 +109,7 @@ public class MainNetMinerTest {
                 blockToMineBuilder(),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -155,6 +157,7 @@ public class MainNetMinerTest {
                 blockToMineBuilder(),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {

--- a/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerManagerTest.java
@@ -38,6 +38,7 @@ import org.ethereum.core.Blockchain;
 import org.ethereum.core.TransactionPool;
 import org.ethereum.db.BlockStore;
 import org.ethereum.rpc.Simples.SimpleEthereum;
+import org.ethereum.util.BuildInfo;
 import org.ethereum.util.RskTestFactory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -299,6 +300,7 @@ public class MinerManagerTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 miningConfig
         );
     }

--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -39,6 +39,9 @@ import org.ethereum.core.*;
 import org.ethereum.db.BlockStore;
 import org.ethereum.facade.EthereumImpl;
 import org.ethereum.rpc.TypeConverter;
+import org.ethereum.util.BuildInfo;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 import org.ethereum.util.RskTestFactory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -148,6 +151,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
 
@@ -194,6 +198,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -263,6 +268,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -318,6 +324,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -376,6 +383,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -441,6 +449,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -499,6 +508,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -561,6 +571,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
 
@@ -605,6 +616,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -649,6 +661,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
 
@@ -699,6 +712,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 builder,
                 clock,
                 mock(BlockFactory.class),
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -744,6 +758,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 ConfigUtils.getDefaultMiningConfig()
         );
         try {
@@ -761,6 +776,103 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
         } finally {
             minerServer.stop();
         }
+    }
+
+    @Test
+    public void extraDataNotInitializedWithClientData() {
+        MinerServer minerServer = new MinerServerImpl(
+                config,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                new BuildInfo("cb7f28e", "master"),
+                ConfigUtils.getDefaultMiningConfig()
+        );
+
+        byte[] extraData = minerServer.getExtraData();
+        RLPList decodedExtraData = RLP.decodeList(extraData);
+        assertEquals(2, decodedExtraData.size());
+
+        byte[] firstItem = decodedExtraData.get(0).getRLPData();
+        assertNotNull(firstItem);
+        assertEquals(1, (RLP.decodeInt(firstItem,0)));
+
+        byte[] secondItem = decodedExtraData.get(1).getRLPData();
+        assertNotNull(secondItem);
+        assertEquals("SNAPSHOT-cb7f28e", new String(secondItem));
+    }
+
+    @Test
+    public void extraDataWithClientData() {
+        MinerServer minerServer = new MinerServerImpl(
+                config,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                new BuildInfo("cb7f28e", "master"),
+                ConfigUtils.getDefaultMiningConfig()
+        );
+
+        minerServer.setExtraData("tincho".getBytes());
+
+        byte[] extraData = minerServer.getExtraData();
+        RLPList decodedExtraData = RLP.decodeList(extraData);
+        assertEquals(3, decodedExtraData.size());
+
+        byte[] firstItem = decodedExtraData.get(0).getRLPData();
+        assertNotNull(firstItem);
+        assertEquals(1, (RLP.decodeInt(firstItem,0)));
+
+        byte[] secondItem = decodedExtraData.get(1).getRLPData();
+        assertNotNull(secondItem);
+        assertEquals("SNAPSHOT-cb7f28e", new String(secondItem));
+
+        byte[] thirdItem = decodedExtraData.get(2).getRLPData();
+        assertNotNull(thirdItem);
+        assertEquals("tincho", new String(thirdItem));
+    }
+
+    @Test
+    public void extraDataWithClientDataMoreThan32Bytes() {
+        MinerServer minerServer = new MinerServerImpl(
+                config,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                new BuildInfo("cb7f28e", "master"),
+                ConfigUtils.getDefaultMiningConfig()
+        );
+
+        minerServer.setExtraData("tincho is the king of mining".getBytes());
+
+        byte[] extraData = minerServer.getExtraData();
+        assertEquals(32, extraData.length);
+        RLPList decodedExtraData = RLP.decodeList(extraData);
+        assertEquals(3, decodedExtraData.size());
+
+        byte[] firstItem = decodedExtraData.get(0).getRLPData();
+        assertNotNull(firstItem);
+        assertEquals(1, (RLP.decodeInt(firstItem,0)));
+
+        byte[] secondItem = decodedExtraData.get(1).getRLPData();
+        assertNotNull(secondItem);
+        assertEquals("SNAPSHOT-cb7f28e", new String(secondItem));
+
+        byte[] thirdItem = decodedExtraData.get(2).getRLPData();
+        assertNotNull(thirdItem);
+        assertEquals("tincho is th", new String(thirdItem));
     }
 
     private BtcBlock getMergedMiningBlockWithOnlyCoinbase(MinerWork work) {

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -64,6 +64,7 @@ import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.Web3Impl;
 import org.ethereum.rpc.Web3Mocks;
 import org.ethereum.sync.SyncPool;
+import org.ethereum.util.BuildInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Test;
@@ -346,6 +347,7 @@ public class TransactionModuleTest {
                 ),
                 minerClock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 miningConfig
         );
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -42,6 +42,7 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Blockchain;
 import org.ethereum.rpc.Simples.SimpleEthereum;
+import org.ethereum.util.BuildInfo;
 import org.ethereum.util.RskTestFactory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -235,6 +236,7 @@ public class Web3ImplSnapshotTest {
                 ),
                 clock,
                 blockFactory,
+                new BuildInfo("cb7f28e", "master"),
                 miningConfig
         );
     }


### PR DESCRIPTION
### About
This new protocol introduces a new format for saving information in the `extraData` field of the block. 
### Details
Data is stored RLP encoded and the protocol is based on the [following standard ](https://github.com/ethereum/wiki/wiki/Default-Extra-Data-Standard) with the sole difference that RSK starts the protocol versioning number on 1 instead of 0.
*fed:version120* *fit:120*