### PR TITLE
Fixing transaction pool add transaction behaviour

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -255,7 +255,7 @@ public class TransactionPoolImpl implements TransactionPool {
         }
 
         pendingTransactions.addTransaction(tx);
-
+        signatureCache.storeSender(tx);
         return TransactionPoolAddResult.ok();
     }
 
@@ -281,8 +281,6 @@ public class TransactionPoolImpl implements TransactionPool {
         added.addAll(this.addSuccesors(tx));
 
         this.emitEvents(added);
-
-        signatureCache.storeSender(tx);
 
         return result;
     }

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -158,12 +158,12 @@ public class TransactionPoolImpl implements TransactionPool {
         return repositoryLocator.snapshotAt(getBestBlock().getHeader());
     }
 
-    private List<Transaction> addSuccesors(Transaction tx) {
+    private List<Transaction> addSuccessors(Transaction tx) {
         List<Transaction> added = new ArrayList<>();
-        Optional<Transaction> succesor = this.getQueuedSuccesor(tx);
+        Optional<Transaction> successor = this.getQueuedSuccessor(tx);
 
-        while (succesor.isPresent()) {
-            Transaction found = succesor.get();
+        while (successor.isPresent()) {
+            Transaction found = successor.get();
             queuedTransactions.removeTransactionByHash(found.getHash());
 
             if (!this.internalAddTransaction(found).transactionWasAdded()) {
@@ -172,7 +172,7 @@ public class TransactionPoolImpl implements TransactionPool {
 
             added.add(found);
 
-            succesor = this.getQueuedSuccesor(found);
+            successor = this.getQueuedSuccessor(found);
         }
 
         return added;
@@ -196,7 +196,7 @@ public class TransactionPoolImpl implements TransactionPool {
 
             if (result.transactionWasAdded()) {
                 added.add(tx);
-                added.addAll(this.addSuccesors(tx));
+                added.addAll(this.addSuccessors(tx));
             }
         }
 
@@ -205,7 +205,7 @@ public class TransactionPoolImpl implements TransactionPool {
         return added;
     }
 
-    private Optional<Transaction> getQueuedSuccesor(Transaction tx) {
+    private Optional<Transaction> getQueuedSuccessor(Transaction tx) {
         BigInteger next = tx.getNonceAsInteger().add(BigInteger.ONE);
 
         List<Transaction> txsaccount = this.queuedTransactions.getTransactionsWithSender(tx.getSender());
@@ -278,7 +278,7 @@ public class TransactionPoolImpl implements TransactionPool {
         List<Transaction> added = new ArrayList<>();
 
         added.add(tx);
-        added.addAll(this.addSuccesors(tx));
+        added.addAll(this.addSuccessors(tx));
 
         this.emitEvents(added);
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -221,6 +221,14 @@ public class TransactionPoolImpl implements TransactionPool {
     }
 
     private TransactionPoolAddResult internalAddTransaction(final Transaction tx) {
+        if (pendingTransactions.hasTransaction(tx)) {
+            return TransactionPoolAddResult.withError("pending transaction with same hash already exists");
+        }
+
+        if (queuedTransactions.hasTransaction(tx)) {
+            return TransactionPoolAddResult.withError("queued transaction with same hash already exists");
+        }
+
         RepositorySnapshot currentRepository = getCurrentRepository();
         TransactionValidationResult validationResult = shouldAcceptTx(tx, currentRepository);
 
@@ -261,14 +269,6 @@ public class TransactionPoolImpl implements TransactionPool {
 
     @Override
     public synchronized TransactionPoolAddResult addTransaction(final Transaction tx) {
-        if (pendingTransactions.hasTransaction(tx)) {
-            return TransactionPoolAddResult.withError("pending transaction with same hash already exists");
-        }
-
-        if (queuedTransactions.hasTransaction(tx)) {
-            return TransactionPoolAddResult.withError("queued transaction with same hash already exists");
-        }
-
         TransactionPoolAddResult result = this.internalAddTransaction(tx);
 
         if (!result.transactionWasAdded()) {

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionSet.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionSet.java
@@ -106,7 +106,7 @@ public class TransactionSet {
         List<Transaction> list = this.transactionsByAddress.get(senderAddress);
 
         if (list == null) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         return list;

--- a/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.*;
  * Created by ajlopez on 08/08/2016.
  */
 public class TransactionPoolImplTest {
-    private static final int MAX_CACHE_SIZE = 6001;
+    private static final int MAX_CACHE_SIZE = 6000;
     private Blockchain blockChain;
     private TransactionPoolImpl transactionPool;
     private Repository repository;
@@ -766,14 +766,14 @@ public class TransactionPoolImplTest {
     public void firstTxIsRemovedWhenTheCacheLimitSizeIsExceeded() {
         Coin balance = Coin.valueOf(1000000);
         createTestAccounts(6005, balance);
-        Transaction tx = createSampleTransaction(1, 2, 1, 1);
+        Transaction tx = createSampleTransaction(1, 2, 1, 0);
         transactionPool.addTransaction(tx);
 
         for (int i = 0; i < MAX_CACHE_SIZE; i++) {
             if (i == MAX_CACHE_SIZE - 1) {
                 Assert.assertTrue(signatureCache.containsTx(tx));
             }
-            Transaction sampleTransaction = createSampleTransaction(i, 2, 1, 0);
+            Transaction sampleTransaction = createSampleTransaction(i+2, 2, 1, 1);
             transactionPool.addTransaction(sampleTransaction);
             Assert.assertTrue(TransactionPoolAddResult.ok().transactionWasAdded());
 
@@ -807,6 +807,8 @@ public class TransactionPoolImplTest {
 
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx2.getHash())));
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx1.getHash())));
+        Assert.assertTrue(signatureCache.containsTx(tx1));
+        Assert.assertTrue(signatureCache.containsTx(tx2));
     }
 
     @Test
@@ -826,5 +828,7 @@ public class TransactionPoolImplTest {
 
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx2.getHash())));
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx1.getHash())));
+        Assert.assertTrue(signatureCache.containsTx(tx1));
+        Assert.assertTrue(signatureCache.containsTx(tx2));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
@@ -793,4 +793,38 @@ public class TransactionPoolImplTest {
 
         track.commit();
     }
+
+    @Test
+    public void addTwoTransactionsOutOfOrderInNonceUsingAddTransaction() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+
+        Transaction tx1 = createSampleTransactionWithGasPrice(1, 0, 1000, 0, 1);
+        Transaction tx2 = createSampleTransactionWithGasPrice(1, 0, 2000, 1, 2);
+
+        Assert.assertTrue(transactionPool.addTransaction(tx2).transactionWasAdded());
+        Assert.assertTrue(transactionPool.addTransaction(tx1).transactionWasAdded());
+
+        Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx2.getHash())));
+        Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx1.getHash())));
+    }
+
+    @Test
+    public void addTwoTransactionsOutOfOrderInNonceUsingAddTransactions() {
+        Coin balance = Coin.valueOf(1000000);
+        createTestAccounts(2, balance);
+
+        Transaction tx1 = createSampleTransactionWithGasPrice(1, 0, 1000, 0, 1);
+        Transaction tx2 = createSampleTransactionWithGasPrice(1, 0, 2000, 1, 2);
+
+        List<Transaction> txs = new ArrayList<>();
+
+        txs.add(tx2);
+        txs.add(tx1);
+
+        transactionPool.addTransactions(txs);
+
+        Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx2.getHash())));
+        Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx1.getHash())));
+    }
 }


### PR DESCRIPTION
The method `TransactionPoolImpl.addTransaction` was modified to consider the adding of queued successors.

This modificacion fixes #1132 and #1130  The tests mentioned in #1130 were added and run without failure.