### PR TITLE
Alternative Synchronization (available via configuration)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -976,7 +976,8 @@ public class RskContext implements NodeBootstrapper {
                 rskSystemProperties.getMaxSkeletonChunks(),
                 rskSystemProperties.getChunkSize(),
                 rskSystemProperties.getMaxRequestedBodies(),
-                rskSystemProperties.getLongSyncLimit());
+                rskSystemProperties.getLongSyncLimit(),
+                rskSystemProperties.getAlternativeSync());
     }
 
     protected StateRootHandler buildStateRootHandler() {
@@ -1367,21 +1368,32 @@ public class RskContext implements NodeBootstrapper {
 
     private SyncProcessor getSyncProcessor() {
         if (syncProcessor == null) {
-            syncProcessor = new SyncProcessorImpl(
+            SyncConfiguration syncConfig = this.getSyncConfiguration();
+
+            if (syncConfig.getUseAlternative()) {
+                syncProcessor = new AlternativeSyncProcessorImpl(
                     getBlockchain(),
-                    getBlockStore(),
-                    getConsensusValidationMainchainView(),
-                    getBlockSyncService(),
-                    getSyncConfiguration(),
-                    getBlockFactory(),
-                    getProofOfWorkRule(),
-                    new BlockCompositeRule(
-                            new BlockUnclesHashValidationRule(),
-                            new BlockRootValidationRule(getRskSystemProperties().getActivationConfig())
-                    ),
-                    getDifficultyCalculator(),
-                    getPeersInformation(),
-                    getGenesis());
+                    syncConfiguration,
+                    getPeersInformation()
+                );
+            }
+            else {
+                syncProcessor = new SyncProcessorImpl(
+                        getBlockchain(),
+                        getBlockStore(),
+                        getConsensusValidationMainchainView(),
+                        getBlockSyncService(),
+                        getSyncConfiguration(),
+                        getBlockFactory(),
+                        getProofOfWorkRule(),
+                        new BlockCompositeRule(
+                                new BlockUnclesHashValidationRule(),
+                                new BlockRootValidationRule(getRskSystemProperties().getActivationConfig())
+                        ),
+                        getDifficultyCalculator(),
+                        getPeersInformation(),
+                        getGenesis());
+            }
         }
 
         return syncProcessor;

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1367,7 +1367,7 @@ public class RskContext implements NodeBootstrapper {
 
     private SyncProcessor getSyncProcessor() {
         if (syncProcessor == null) {
-            syncProcessor = new SyncProcessor(
+            syncProcessor = new SyncProcessorImpl(
                     getBlockchain(),
                     getBlockStore(),
                     getConsensusValidationMainchainView(),

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -300,6 +300,10 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getInt("sync.longSyncLimit");
     }
 
+    public boolean getAlternativeSync() {
+        return configFromFiles.getBoolean("sync.alternative");
+    }
+
     // its fixed, cannot be set by config file
     public int getChunkSize() {
         return CHUNK_SIZE;

--- a/rskj-core/src/main/java/co/rsk/net/AlternativeSyncProcessorImpl.java
+++ b/rskj-core/src/main/java/co/rsk/net/AlternativeSyncProcessorImpl.java
@@ -1,0 +1,155 @@
+package co.rsk.net;
+
+import co.rsk.core.bc.BlockChainStatus;
+import co.rsk.crypto.Keccak256;
+import co.rsk.net.messages.*;
+import co.rsk.net.sync.PeersInformation;
+import co.rsk.net.sync.SyncConfiguration;
+import io.netty.util.internal.ConcurrentSet;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.BlockIdentifier;
+import org.ethereum.core.Blockchain;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.net.server.ChannelManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+
+public class AlternativeSyncProcessorImpl implements SyncProcessor {
+    private static final Logger logger = LoggerFactory.getLogger("syncprocessor");
+
+    private final Blockchain blockchain;
+    private final PeersInformation peersInformation;
+    private final SyncConfiguration syncConfiguration;
+
+    private Set<Keccak256> sent = new ConcurrentSet<>();
+
+    private long messageId;
+    private boolean paused;
+    private boolean stopped;
+
+    public AlternativeSyncProcessorImpl(Blockchain blockchain,
+                                        SyncConfiguration syncConfiguration,
+                                        PeersInformation peersInformation) {
+        this.blockchain = blockchain;
+        this.syncConfiguration = syncConfiguration;
+        this.peersInformation = peersInformation;
+    }
+
+    @Override
+    public void processStatus(Peer sender, Status status) {
+        logger.debug("Receiving syncState from node {} block {} {}", sender.getPeerNodeID(), status.getBestBlockNumber(), HashUtil.shortHash(status.getBestBlockHash()));
+        peersInformation.registerPeer(sender).setStatus(status);
+
+        BlockChainStatus currentStatus = this.blockchain.getStatus();
+
+        if (currentStatus.getTotalDifficulty().compareTo(status.getTotalDifficulty()) >=0) {
+            return;
+        }
+
+        if (paused || stopped) {
+            return;
+        }
+
+        long number = currentStatus.getBestBlockNumber();
+
+        MessageWithId message = new SkeletonRequestMessage(messageId++, Math.max(1, number - syncConfiguration.getChunkSize()));
+
+        sender.sendMessage(message);
+    }
+
+    @Override
+    public void processSkeletonResponse(Peer peer, SkeletonResponseMessage skeletonResponse) {
+        if (paused || stopped) {
+            return;
+        }
+
+        int nsent = 0;
+
+        List<BlockIdentifier> blockIdentifiers = skeletonResponse.getBlockIdentifiers();
+        long number = this.blockchain.getStatus().getBestBlock().getNumber();
+
+        for (BlockIdentifier blockIdentifier: blockIdentifiers) {
+            byte[] blockHash = blockIdentifier.getHash();
+            Keccak256 hash = new Keccak256(blockHash);
+
+            if (blockIdentifier.getNumber() < number && this.blockchain.hasBlockInSomeBlockchain(blockHash)) {
+                continue;
+            }
+
+            Message message = new BlockHeadersRequestMessage(this.messageId++, blockHash, this.syncConfiguration.getChunkSize());
+
+            peer.sendMessage(message);
+
+            nsent++;
+
+            if (nsent >= 3) {
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void processBlockHashResponse(Peer peer, BlockHashResponseMessage blockHashResponse) {
+
+    }
+
+    @Override
+    public void processBlockHeadersResponse(Peer peer, BlockHeadersResponseMessage blockHeadersResponse) {
+        if (stopped) {
+            return;
+        }
+
+        long number = this.blockchain.getStatus().getBestBlock().getNumber();
+        List<BlockHeader> headers = blockHeadersResponse.getBlockHeaders();
+
+        for (int k = headers.size(); k-- > 0;) {
+            BlockHeader header = headers.get(k);
+
+            Keccak256 hash = header.getHash();
+
+            byte[] blockHash = hash.getBytes();
+
+            if (header.getNumber() < number && this.blockchain.hasBlockInSomeBlockchain(blockHash)) {
+                continue;
+            }
+
+            Message message = new GetBlockMessage(blockHash);
+
+            peer.sendMessage(message);
+        }
+    }
+
+    @Override
+    public void processBodyResponse(Peer peer, BodyResponseMessage message) {
+
+    }
+
+    @Override
+    public void processNewBlockHash(Peer peer, NewBlockHashMessage message) {
+
+    }
+
+    @Override
+    public void processBlockResponse(Peer peer, BlockResponseMessage message) {
+
+    }
+
+    @Override
+    public Set<NodeID> getKnownPeersNodeIDs() {
+        return this.peersInformation.knownNodeIds();
+    }
+
+    @Override
+    public void onTimePassed(Duration timePassed) {
+
+    }
+
+    @Override
+    public void stopSyncing() {
+        this.stopped = true;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -43,22 +43,9 @@ public interface SyncProcessor {
 
     void processBlockResponse(Peer peer, BlockResponseMessage message);
 
-    void sendSkeletonRequest(Peer peer, long height);
-
-    void sendBlockHashRequest(Peer peer, long height);
-
-    void sendBlockHeadersRequest(Peer peer, ChunkDescriptor chunk);
-
-    long sendBodyRequest(Peer peer, @Nonnull BlockHeader header);
-
     Set<NodeID> getKnownPeersNodeIDs();
 
     void onTimePassed(Duration timePassed);
 
-    void startSyncing(Peer peer);
-
     void stopSyncing();
-
-    @VisibleForTesting
-    SyncState getSyncState();
 }

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -1,384 +1,64 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.net;
 
-import co.rsk.core.DifficultyCalculator;
-import co.rsk.core.bc.BlockChainStatus;
-import co.rsk.core.bc.ConsensusValidationMainchainView;
 import co.rsk.net.messages.*;
-import co.rsk.net.sync.*;
-import co.rsk.scoring.EventType;
-import co.rsk.validators.BlockCompositeRule;
-import co.rsk.validators.BlockHeaderValidationRule;
+import co.rsk.net.sync.ChunkDescriptor;
+import co.rsk.net.sync.SyncState;
 import com.google.common.annotations.VisibleForTesting;
-import org.ethereum.core.*;
-import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.BlockStore;
-import org.ethereum.validator.DifficultyRule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.ethereum.core.BlockHeader;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
-import java.util.*;
+import java.util.Set;
 
-/**
- * This class' methods are executed one at a time because NodeMessageHandler is synchronized.
- */
-public class SyncProcessor implements SyncEventsHandler {
-    private static final int MAX_PENDING_MESSAGES = 100_000;
-    private static final Logger logger = LoggerFactory.getLogger("syncprocessor");
+public interface SyncProcessor {
+    void processStatus(Peer sender, Status status);
 
-    private final SyncConfiguration syncConfiguration;
-    private final Blockchain blockchain;
-    private final BlockStore blockStore;
-    private final ConsensusValidationMainchainView consensusValidationMainchainView;
-    private final BlockSyncService blockSyncService;
-    private final BlockFactory blockFactory;
-    private final BlockHeaderValidationRule blockHeaderValidationRule;
-    private final BlockCompositeRule blockValidationRule;
-    private final DifficultyRule difficultyRule;
-    private final Genesis genesis;
+    void processSkeletonResponse(Peer peer, SkeletonResponseMessage message);
 
-    private final PeersInformation peersInformation;
-    private final Map<Long, MessageType> pendingMessages;
+    void processBlockHashResponse(Peer peer, BlockHashResponseMessage message);
 
-    private SyncState syncState;
-    private long lastRequestId;
+    void processBlockHeadersResponse(Peer peer, BlockHeadersResponseMessage message);
 
-    public SyncProcessor(Blockchain blockchain,
-                         BlockStore blockStore,
-                         ConsensusValidationMainchainView consensusValidationMainchainView,
-                         BlockSyncService blockSyncService,
-                         SyncConfiguration syncConfiguration,
-                         BlockFactory blockFactory,
-                         BlockHeaderValidationRule blockHeaderValidationRule,
-                         BlockCompositeRule blockValidationRule,
-                         DifficultyCalculator difficultyCalculator,
-                         PeersInformation peersInformation,
-                         Genesis genesis) {
-        this.blockchain = blockchain;
-        this.blockStore = blockStore;
-        this.consensusValidationMainchainView = consensusValidationMainchainView;
-        this.blockSyncService = blockSyncService;
-        this.syncConfiguration = syncConfiguration;
-        this.blockFactory = blockFactory;
-        this.blockHeaderValidationRule = blockHeaderValidationRule;
-        this.blockValidationRule = blockValidationRule;
-        this.difficultyRule = new DifficultyRule(difficultyCalculator);
-        this.genesis = genesis;
-        this.pendingMessages = new LinkedHashMap<Long, MessageType>() {
-            @Override
-            protected boolean removeEldestEntry(Map.Entry<Long, MessageType> eldest) {
-                boolean shouldDiscard = size() > MAX_PENDING_MESSAGES;
-                if (shouldDiscard) {
-                    logger.trace("Pending {}@{} DISCARDED", eldest.getValue(), eldest.getKey());
-                }
-                return shouldDiscard;
-            }
-        };
+    void processBodyResponse(Peer peer, BodyResponseMessage message);
 
-        this.peersInformation = peersInformation;
-        setSyncState(new DecidingSyncState(syncConfiguration, this, peersInformation, blockStore));
-    }
+    void processNewBlockHash(Peer peer, NewBlockHashMessage message);
 
-    public void processStatus(Peer sender, Status status) {
-        logger.debug("Receiving syncState from node {} block {} {}", sender.getPeerNodeID(), status.getBestBlockNumber(), HashUtil.shortHash(status.getBestBlockHash()));
-        peersInformation.registerPeer(sender).setStatus(status);
-        syncState.newPeerStatus();
-    }
+    void processBlockResponse(Peer peer, BlockResponseMessage message);
 
-    public void processSkeletonResponse(Peer peer, SkeletonResponseMessage message) {
-        logger.debug("Process skeleton response from node {}", peer.getPeerNodeID());
-        peersInformation.getOrRegisterPeer(peer);
+    void sendSkeletonRequest(Peer peer, long height);
 
-        long messageId = message.getId();
-        MessageType messageType = message.getMessageType();
-        if (isPending(messageId, messageType)) {
-            removePendingMessage(messageId, messageType);
-            syncState.newSkeleton(message.getBlockIdentifiers(), peer);
-        } else {
-            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
-        }
-    }
+    void sendBlockHashRequest(Peer peer, long height);
 
-    public void processBlockHashResponse(Peer peer, BlockHashResponseMessage message) {
-        NodeID nodeID = peer.getPeerNodeID();
-        logger.debug("Process block hash response from node {} hash {}", nodeID, HashUtil.shortHash(message.getHash()));
-        peersInformation.getOrRegisterPeer(peer);
+    void sendBlockHeadersRequest(Peer peer, ChunkDescriptor chunk);
 
-        long messageId = message.getId();
-        MessageType messageType = message.getMessageType();
-        if (isPending(messageId, messageType)) {
-            removePendingMessage(messageId, messageType);
-            syncState.newConnectionPointData(message.getHash());
-        } else {
-            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
-        }
-    }
+    long sendBodyRequest(Peer peer, @Nonnull BlockHeader header);
 
-    public void processBlockHeadersResponse(Peer peer, BlockHeadersResponseMessage message) {
-        logger.debug("Process block headers response from node {}", peer.getPeerNodeID());
-        peersInformation.getOrRegisterPeer(peer);
+    Set<NodeID> getKnownPeersNodeIDs();
 
-        long messageId = message.getId();
-        MessageType messageType = message.getMessageType();
-        if (isPending(messageId, messageType)) {
-            removePendingMessage(messageId, messageType);
-            syncState.newBlockHeaders(message.getBlockHeaders());
-        } else {
-            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
-        }
-    }
+    void onTimePassed(Duration timePassed);
 
-    public void processBodyResponse(Peer peer, BodyResponseMessage message) {
-        logger.debug("Process body response from node {}", peer.getPeerNodeID());
-        peersInformation.getOrRegisterPeer(peer);
+    void startSyncing(Peer peer);
 
-        long messageId = message.getId();
-        MessageType messageType = message.getMessageType();
-        if (isPending(messageId, messageType)) {
-            removePendingMessage(messageId, messageType);
-            syncState.newBody(message, peer);
-        } else {
-            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
-        }
-    }
-
-    public void processNewBlockHash(Peer peer, NewBlockHashMessage message) {
-        NodeID nodeID = peer.getPeerNodeID();
-        logger.debug("Process new block hash from node {} hash {}", nodeID, HashUtil.shortHash(message.getBlockHash()));
-        byte[] hash = message.getBlockHash();
-
-        if (syncState instanceof DecidingSyncState && blockSyncService.getBlockFromStoreOrBlockchain(hash) == null) {
-            peersInformation.getOrRegisterPeer(peer);
-            sendMessage(peer, new BlockRequestMessage(++lastRequestId, hash));
-        }
-    }
-
-    public void processBlockResponse(Peer peer, BlockResponseMessage message) {
-        NodeID nodeID = peer.getPeerNodeID();
-        logger.debug("Process block response from node {} block {} {}", nodeID, message.getBlock().getNumber(), message.getBlock().getShortHash());
-        peersInformation.getOrRegisterPeer(peer);
-
-        long messageId = message.getId();
-        MessageType messageType = message.getMessageType();
-        if (isPending(messageId, messageType)) {
-            removePendingMessage(messageId, messageType);
-            blockSyncService.processBlock(message.getBlock(), peer, false);
-        } else {
-            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
-        }
-    }
-
-    @Override
-    public void sendSkeletonRequest(Peer peer, long height) {
-        logger.debug("Send skeleton request to node {} height {}", peer.getPeerNodeID(), height);
-        MessageWithId message = new SkeletonRequestMessage(++lastRequestId, height);
-        sendMessage(peer, message);
-    }
-
-    @Override
-    public void sendBlockHashRequest(Peer peer, long height) {
-        logger.debug("Send hash request to node {} height {}", peer.getPeerNodeID(), height);
-        BlockHashRequestMessage message = new BlockHashRequestMessage(++lastRequestId, height);
-        sendMessage(peer, message);
-    }
-
-    @Override
-    public void sendBlockHeadersRequest(Peer peer, ChunkDescriptor chunk) {
-        logger.debug("Send headers request to node {}", peer.getPeerNodeID());
-
-        BlockHeadersRequestMessage message =
-                new BlockHeadersRequestMessage(++lastRequestId, chunk.getHash(), chunk.getCount());
-        sendMessage(peer, message);
-    }
-
-    @Override
-    public long sendBodyRequest(Peer peer, @Nonnull BlockHeader header) {
-        logger.debug("Send body request block {} hash {} to peer {}", header.getNumber(),
-                HashUtil.shortHash(header.getHash().getBytes()), peer.getPeerNodeID());
-
-        BodyRequestMessage message = new BodyRequestMessage(++lastRequestId, header.getHash().getBytes());
-        sendMessage(peer, message);
-        return message.getId();
-    }
-
-    public Set<NodeID> getKnownPeersNodeIDs() {
-        return this.peersInformation.knownNodeIds();
-    }
-
-    public void onTimePassed(Duration timePassed) {
-        this.syncState.tick(timePassed);
-    }
-
-    @Override
-    public void startSyncing(Peer peer) {
-        NodeID nodeID = peer.getPeerNodeID();
-        logger.info("Start syncing with node {}", nodeID);
-        byte[] bestBlockHash = peersInformation.getPeer(peer).getStatus().getBestBlockHash();
-        setSyncState(new CheckingBestHeaderSyncState(
-                syncConfiguration,
-                this,
-                blockHeaderValidationRule, peer, bestBlockHash));
-    }
-
-    @Override
-    public void startDownloadingBodies(
-            List<Deque<BlockHeader>> pendingHeaders, Map<Peer, List<BlockIdentifier>> skeletons, Peer peer) {
-        // we keep track of best known block and we start to trust it when all headers are validated
-        List<BlockIdentifier> selectedSkeleton = skeletons.get(peer);
-        final long peerBestBlockNumber = selectedSkeleton.get(selectedSkeleton.size() - 1).getNumber();
-
-        if (peerBestBlockNumber > blockSyncService.getLastKnownBlockNumber()) {
-            blockSyncService.setLastKnownBlockNumber(peerBestBlockNumber);
-        }
-
-        setSyncState(new DownloadingBodiesSyncState(syncConfiguration,
-                this,
-                peersInformation,
-                blockchain,
-                blockFactory,
-                blockSyncService,
-                blockValidationRule,
-                pendingHeaders,
-                skeletons));
-    }
-
-    @Override
-    public void startDownloadingHeaders(Map<Peer, List<BlockIdentifier>> skeletons, long connectionPoint, Peer peer) {
-        setSyncState(new DownloadingHeadersSyncState(
-                syncConfiguration,
-                this,
-                consensusValidationMainchainView,
-                difficultyRule,
-                blockHeaderValidationRule,
-                peer,
-                skeletons,
-                connectionPoint));
-    }
-
-    @Override
-    public void startDownloadingSkeleton(long connectionPoint, Peer peer) {
-        setSyncState(new DownloadingSkeletonSyncState(
-                syncConfiguration,
-                this,
-                peersInformation,
-                peer,
-                connectionPoint));
-    }
-
-    @Override
-    public void startFindingConnectionPoint(Peer peer) {
-        NodeID peerId = peer.getPeerNodeID();
-        logger.debug("Find connection point with node {}", peerId);
-        long bestBlockNumber = peersInformation.getPeer(peer).getStatus().getBestBlockNumber();
-        setSyncState(new FindingConnectionPointSyncState(
-                syncConfiguration, this, blockStore, peer, bestBlockNumber));
-    }
-
-    @Override
-    public void backwardSyncing(Peer peer) {
-        NodeID peerId = peer.getPeerNodeID();
-        logger.debug("Starting backwards synchronization with node {}", peerId);
-        setSyncState(new DownloadingBackwardsHeadersSyncState(
-                syncConfiguration,
-                this,
-                blockStore,
-                peer
-        ));
-    }
-
-    @Override
-    public void backwardDownloadBodies(Block child, List<BlockHeader> toRequest, Peer peer) {
-        logger.debug("Starting backwards body download with node {}", peer.getPeerNodeID());
-        setSyncState(new DownloadingBackwardsBodiesSyncState(
-                syncConfiguration,
-                this,
-                peersInformation,
-                genesis,
-                blockFactory,
-                blockStore,
-                child,
-                toRequest,
-                peer
-        ));
-    }
-
-    @Override
-    public void stopSyncing() {
-        int pendingMessagesCount = pendingMessages.size();
-        pendingMessages.clear();
-        logger.trace("Pending {} CLEAR", pendingMessagesCount);
-        // always that a syncing process ends unexpectedly the best block number is reset
-        blockSyncService.setLastKnownBlockNumber(blockchain.getBestBlock().getNumber());
-        peersInformation.clearOldFailedPeers();
-        setSyncState(new DecidingSyncState(syncConfiguration,
-                this,
-                peersInformation,
-                blockStore));
-    }
-
-    @Override
-    public void onErrorSyncing(NodeID peerId, String message, EventType eventType, Object... arguments) {
-        peersInformation.reportErrorEvent(peerId, message, eventType, arguments);
-        stopSyncing();
-    }
-
-    @Override
-    public void onSyncIssue(String message, Object... arguments) {
-        logger.trace(message, arguments);
-        stopSyncing();
-    }
-
-    private void sendMessage(Peer peer, MessageWithId message) {
-        MessageType messageType = message.getResponseMessageType();
-        long messageId = message.getId();
-        pendingMessages.put(messageId, messageType);
-        logger.trace("Pending {}@{} ADDED for {}", messageType, messageId, peer.getPeerNodeID());
-        peer.sendMessage(message);
-    }
-
-    private void setSyncState(SyncState syncState) {
-        this.syncState = syncState;
-        this.syncState.onEnter();
-    }
+    void stopSyncing();
 
     @VisibleForTesting
-    int getPeersCount() {
-        return this.peersInformation.count();
-    }
-
-    @VisibleForTesting
-    int getNoAdvancedPeers() {
-        BlockChainStatus chainStatus = this.blockchain.getStatus();
-
-        if (chainStatus == null) {
-            return this.peersInformation.count();
-        }
-
-        return this.peersInformation.countIf(s -> chainStatus.hasLowerTotalDifficultyThan(s.getStatus()));
-    }
-
-    @VisibleForTesting
-    public void registerExpectedMessage(MessageWithId message) {
-        pendingMessages.put(message.getId(), message.getMessageType());
-    }
-
-    @VisibleForTesting
-    public SyncState getSyncState() {
-        return this.syncState;
-    }
-
-    @VisibleForTesting
-    public Map<Long, MessageType> getExpectedResponses() {
-        return pendingMessages;
-    }
-
-    private boolean isPending(long messageId, MessageType messageType) {
-        return pendingMessages.containsKey(messageId) && pendingMessages.get(messageId) == messageType;
-    }
-
-    private void removePendingMessage(long messageId, MessageType messageType) {
-        pendingMessages.remove(messageId);
-        logger.trace("Pending {}@{} REMOVED", messageType, messageId);
-    }
+    SyncState getSyncState();
 }

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessorImpl.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessorImpl.java
@@ -1,0 +1,412 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.net;
+
+import co.rsk.core.DifficultyCalculator;
+import co.rsk.core.bc.BlockChainStatus;
+import co.rsk.core.bc.ConsensusValidationMainchainView;
+import co.rsk.net.messages.*;
+import co.rsk.net.sync.*;
+import co.rsk.scoring.EventType;
+import co.rsk.validators.BlockCompositeRule;
+import co.rsk.validators.BlockHeaderValidationRule;
+import com.google.common.annotations.VisibleForTesting;
+import org.ethereum.core.*;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.db.BlockStore;
+import org.ethereum.validator.DifficultyRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.util.*;
+
+/**
+ * This class' methods are executed one at a time because NodeMessageHandler is synchronized.
+ */
+public class SyncProcessorImpl implements SyncEventsHandler, SyncProcessor {
+    private static final int MAX_PENDING_MESSAGES = 100_000;
+    private static final Logger logger = LoggerFactory.getLogger("syncprocessor");
+
+    private final SyncConfiguration syncConfiguration;
+    private final Blockchain blockchain;
+    private final BlockStore blockStore;
+    private final ConsensusValidationMainchainView consensusValidationMainchainView;
+    private final BlockSyncService blockSyncService;
+    private final BlockFactory blockFactory;
+    private final BlockHeaderValidationRule blockHeaderValidationRule;
+    private final BlockCompositeRule blockValidationRule;
+    private final DifficultyRule difficultyRule;
+    private final Genesis genesis;
+
+    private final PeersInformation peersInformation;
+    private final Map<Long, MessageType> pendingMessages;
+
+    private SyncState syncState;
+    private long lastRequestId;
+
+    public SyncProcessorImpl(Blockchain blockchain,
+                             BlockStore blockStore,
+                             ConsensusValidationMainchainView consensusValidationMainchainView,
+                             BlockSyncService blockSyncService,
+                             SyncConfiguration syncConfiguration,
+                             BlockFactory blockFactory,
+                             BlockHeaderValidationRule blockHeaderValidationRule,
+                             BlockCompositeRule blockValidationRule,
+                             DifficultyCalculator difficultyCalculator,
+                             PeersInformation peersInformation,
+                             Genesis genesis) {
+        this.blockchain = blockchain;
+        this.blockStore = blockStore;
+        this.consensusValidationMainchainView = consensusValidationMainchainView;
+        this.blockSyncService = blockSyncService;
+        this.syncConfiguration = syncConfiguration;
+        this.blockFactory = blockFactory;
+        this.blockHeaderValidationRule = blockHeaderValidationRule;
+        this.blockValidationRule = blockValidationRule;
+        this.difficultyRule = new DifficultyRule(difficultyCalculator);
+        this.genesis = genesis;
+        this.pendingMessages = new LinkedHashMap<Long, MessageType>() {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<Long, MessageType> eldest) {
+                boolean shouldDiscard = size() > MAX_PENDING_MESSAGES;
+                if (shouldDiscard) {
+                    logger.trace("Pending {}@{} DISCARDED", eldest.getValue(), eldest.getKey());
+                }
+                return shouldDiscard;
+            }
+        };
+
+        this.peersInformation = peersInformation;
+        setSyncState(new DecidingSyncState(syncConfiguration, this, peersInformation, blockStore));
+    }
+
+    @Override
+    public void processStatus(Peer sender, Status status) {
+        logger.debug("Receiving syncState from node {} block {} {}", sender.getPeerNodeID(), status.getBestBlockNumber(), HashUtil.shortHash(status.getBestBlockHash()));
+        peersInformation.registerPeer(sender).setStatus(status);
+        syncState.newPeerStatus();
+    }
+
+    @Override
+    public void processSkeletonResponse(Peer peer, SkeletonResponseMessage message) {
+        logger.debug("Process skeleton response from node {}", peer.getPeerNodeID());
+        peersInformation.getOrRegisterPeer(peer);
+
+        long messageId = message.getId();
+        MessageType messageType = message.getMessageType();
+        if (isPending(messageId, messageType)) {
+            removePendingMessage(messageId, messageType);
+            syncState.newSkeleton(message.getBlockIdentifiers(), peer);
+        } else {
+            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
+        }
+    }
+
+    @Override
+    public void processBlockHashResponse(Peer peer, BlockHashResponseMessage message) {
+        NodeID nodeID = peer.getPeerNodeID();
+        logger.debug("Process block hash response from node {} hash {}", nodeID, HashUtil.shortHash(message.getHash()));
+        peersInformation.getOrRegisterPeer(peer);
+
+        long messageId = message.getId();
+        MessageType messageType = message.getMessageType();
+        if (isPending(messageId, messageType)) {
+            removePendingMessage(messageId, messageType);
+            syncState.newConnectionPointData(message.getHash());
+        } else {
+            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
+        }
+    }
+
+    @Override
+    public void processBlockHeadersResponse(Peer peer, BlockHeadersResponseMessage message) {
+        logger.debug("Process block headers response from node {}", peer.getPeerNodeID());
+        peersInformation.getOrRegisterPeer(peer);
+
+        long messageId = message.getId();
+        MessageType messageType = message.getMessageType();
+        if (isPending(messageId, messageType)) {
+            removePendingMessage(messageId, messageType);
+            syncState.newBlockHeaders(message.getBlockHeaders());
+        } else {
+            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
+        }
+    }
+
+    @Override
+    public void processBodyResponse(Peer peer, BodyResponseMessage message) {
+        logger.debug("Process body response from node {}", peer.getPeerNodeID());
+        peersInformation.getOrRegisterPeer(peer);
+
+        long messageId = message.getId();
+        MessageType messageType = message.getMessageType();
+        if (isPending(messageId, messageType)) {
+            removePendingMessage(messageId, messageType);
+            syncState.newBody(message, peer);
+        } else {
+            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
+        }
+    }
+
+    @Override
+    public void processNewBlockHash(Peer peer, NewBlockHashMessage message) {
+        NodeID nodeID = peer.getPeerNodeID();
+        logger.debug("Process new block hash from node {} hash {}", nodeID, HashUtil.shortHash(message.getBlockHash()));
+        byte[] hash = message.getBlockHash();
+
+        if (syncState instanceof DecidingSyncState && blockSyncService.getBlockFromStoreOrBlockchain(hash) == null) {
+            peersInformation.getOrRegisterPeer(peer);
+            sendMessage(peer, new BlockRequestMessage(++lastRequestId, hash));
+        }
+    }
+
+    @Override
+    public void processBlockResponse(Peer peer, BlockResponseMessage message) {
+        NodeID nodeID = peer.getPeerNodeID();
+        logger.debug("Process block response from node {} block {} {}", nodeID, message.getBlock().getNumber(), message.getBlock().getShortHash());
+        peersInformation.getOrRegisterPeer(peer);
+
+        long messageId = message.getId();
+        MessageType messageType = message.getMessageType();
+        if (isPending(messageId, messageType)) {
+            removePendingMessage(messageId, messageType);
+            blockSyncService.processBlock(message.getBlock(), peer, false);
+        } else {
+            peersInformation.reportEvent(peer.getPeerNodeID(), EventType.UNEXPECTED_MESSAGE);
+        }
+    }
+
+    @Override
+    public void sendSkeletonRequest(Peer peer, long height) {
+        logger.debug("Send skeleton request to node {} height {}", peer.getPeerNodeID(), height);
+        MessageWithId message = new SkeletonRequestMessage(++lastRequestId, height);
+        sendMessage(peer, message);
+    }
+
+    @Override
+    public void sendBlockHashRequest(Peer peer, long height) {
+        logger.debug("Send hash request to node {} height {}", peer.getPeerNodeID(), height);
+        BlockHashRequestMessage message = new BlockHashRequestMessage(++lastRequestId, height);
+        sendMessage(peer, message);
+    }
+
+    @Override
+    public void sendBlockHeadersRequest(Peer peer, ChunkDescriptor chunk) {
+        logger.debug("Send headers request to node {}", peer.getPeerNodeID());
+
+        BlockHeadersRequestMessage message =
+                new BlockHeadersRequestMessage(++lastRequestId, chunk.getHash(), chunk.getCount());
+        sendMessage(peer, message);
+    }
+
+    @Override
+    public long sendBodyRequest(Peer peer, @Nonnull BlockHeader header) {
+        logger.debug("Send body request block {} hash {} to peer {}", header.getNumber(),
+                HashUtil.shortHash(header.getHash().getBytes()), peer.getPeerNodeID());
+
+        BodyRequestMessage message = new BodyRequestMessage(++lastRequestId, header.getHash().getBytes());
+        sendMessage(peer, message);
+        return message.getId();
+    }
+
+    @Override
+    public Set<NodeID> getKnownPeersNodeIDs() {
+        return this.peersInformation.knownNodeIds();
+    }
+
+    @Override
+    public void onTimePassed(Duration timePassed) {
+        this.syncState.tick(timePassed);
+    }
+
+    @Override
+    public void startSyncing(Peer peer) {
+        NodeID nodeID = peer.getPeerNodeID();
+        logger.info("Start syncing with node {}", nodeID);
+        byte[] bestBlockHash = peersInformation.getPeer(peer).getStatus().getBestBlockHash();
+        setSyncState(new CheckingBestHeaderSyncState(
+                syncConfiguration,
+                this,
+                blockHeaderValidationRule, peer, bestBlockHash));
+    }
+
+    @Override
+    public void startDownloadingBodies(
+            List<Deque<BlockHeader>> pendingHeaders, Map<Peer, List<BlockIdentifier>> skeletons, Peer peer) {
+        // we keep track of best known block and we start to trust it when all headers are validated
+        List<BlockIdentifier> selectedSkeleton = skeletons.get(peer);
+        final long peerBestBlockNumber = selectedSkeleton.get(selectedSkeleton.size() - 1).getNumber();
+
+        if (peerBestBlockNumber > blockSyncService.getLastKnownBlockNumber()) {
+            blockSyncService.setLastKnownBlockNumber(peerBestBlockNumber);
+        }
+
+        setSyncState(new DownloadingBodiesSyncState(syncConfiguration,
+                this,
+                peersInformation,
+                blockchain,
+                blockFactory,
+                blockSyncService,
+                blockValidationRule,
+                pendingHeaders,
+                skeletons));
+    }
+
+    @Override
+    public void startDownloadingHeaders(Map<Peer, List<BlockIdentifier>> skeletons, long connectionPoint, Peer peer) {
+        setSyncState(new DownloadingHeadersSyncState(
+                syncConfiguration,
+                this,
+                consensusValidationMainchainView,
+                difficultyRule,
+                blockHeaderValidationRule,
+                peer,
+                skeletons,
+                connectionPoint));
+    }
+
+    @Override
+    public void startDownloadingSkeleton(long connectionPoint, Peer peer) {
+        setSyncState(new DownloadingSkeletonSyncState(
+                syncConfiguration,
+                this,
+                peersInformation,
+                peer,
+                connectionPoint));
+    }
+
+    @Override
+    public void startFindingConnectionPoint(Peer peer) {
+        NodeID peerId = peer.getPeerNodeID();
+        logger.debug("Find connection point with node {}", peerId);
+        long bestBlockNumber = peersInformation.getPeer(peer).getStatus().getBestBlockNumber();
+        setSyncState(new FindingConnectionPointSyncState(
+                syncConfiguration, this, blockStore, peer, bestBlockNumber));
+    }
+
+    @Override
+    public void backwardSyncing(Peer peer) {
+        NodeID peerId = peer.getPeerNodeID();
+        logger.debug("Starting backwards synchronization with node {}", peerId);
+        setSyncState(new DownloadingBackwardsHeadersSyncState(
+                syncConfiguration,
+                this,
+                blockStore,
+                peer
+        ));
+    }
+
+    @Override
+    public void backwardDownloadBodies(Block child, List<BlockHeader> toRequest, Peer peer) {
+        logger.debug("Starting backwards body download with node {}", peer.getPeerNodeID());
+        setSyncState(new DownloadingBackwardsBodiesSyncState(
+                syncConfiguration,
+                this,
+                peersInformation,
+                genesis,
+                blockFactory,
+                blockStore,
+                child,
+                toRequest,
+                peer
+        ));
+    }
+
+    @Override
+    public void stopSyncing() {
+        int pendingMessagesCount = pendingMessages.size();
+        pendingMessages.clear();
+        logger.trace("Pending {} CLEAR", pendingMessagesCount);
+        // always that a syncing process ends unexpectedly the best block number is reset
+        blockSyncService.setLastKnownBlockNumber(blockchain.getBestBlock().getNumber());
+        peersInformation.clearOldFailedPeers();
+        setSyncState(new DecidingSyncState(syncConfiguration,
+                this,
+                peersInformation,
+                blockStore));
+    }
+
+    @Override
+    public void onErrorSyncing(NodeID peerId, String message, EventType eventType, Object... arguments) {
+        peersInformation.reportErrorEvent(peerId, message, eventType, arguments);
+        stopSyncing();
+    }
+
+    @Override
+    public void onSyncIssue(String message, Object... arguments) {
+        logger.trace(message, arguments);
+        stopSyncing();
+    }
+
+    private void sendMessage(Peer peer, MessageWithId message) {
+        MessageType messageType = message.getResponseMessageType();
+        long messageId = message.getId();
+        pendingMessages.put(messageId, messageType);
+        logger.trace("Pending {}@{} ADDED for {}", messageType, messageId, peer.getPeerNodeID());
+        peer.sendMessage(message);
+    }
+
+    private void setSyncState(SyncState syncState) {
+        this.syncState = syncState;
+        this.syncState.onEnter();
+    }
+
+    @VisibleForTesting
+    int getPeersCount() {
+        return this.peersInformation.count();
+    }
+
+    @VisibleForTesting
+    int getNoAdvancedPeers() {
+        BlockChainStatus chainStatus = this.blockchain.getStatus();
+
+        if (chainStatus == null) {
+            return this.peersInformation.count();
+        }
+
+        return this.peersInformation.countIf(s -> chainStatus.hasLowerTotalDifficultyThan(s.getStatus()));
+    }
+
+    @VisibleForTesting
+    public void registerExpectedMessage(MessageWithId message) {
+        pendingMessages.put(message.getId(), message.getMessageType());
+    }
+
+    @Override
+    @VisibleForTesting
+    public SyncState getSyncState() {
+        return this.syncState;
+    }
+
+    @VisibleForTesting
+    public Map<Long, MessageType> getExpectedResponses() {
+        return pendingMessages;
+    }
+
+    private boolean isPending(long messageId, MessageType messageType) {
+        return pendingMessages.containsKey(messageId) && pendingMessages.get(messageId) == messageType;
+    }
+
+    private void removePendingMessage(long messageId, MessageType messageType) {
+        pendingMessages.remove(messageId);
+        logger.trace("Pending {}@{} REMOVED", messageType, messageId);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessorImpl.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessorImpl.java
@@ -390,7 +390,6 @@ public class SyncProcessorImpl implements SyncEventsHandler, SyncProcessor {
         pendingMessages.put(message.getId(), message.getMessageType());
     }
 
-    @Override
     @VisibleForTesting
     public SyncState getSyncState() {
         return this.syncState;

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
@@ -7,10 +7,10 @@ import java.time.Duration;
 
 @Immutable
 public final class SyncConfiguration {
-    public static final SyncConfiguration DEFAULT = new SyncConfiguration(5, 60, 30, 5, 20, 192, 20, 10);
+    public static final SyncConfiguration DEFAULT = new SyncConfiguration(5, 60, 30, 5, 20, 192, 20, 10, false);
 
     @VisibleForTesting
-    public static final SyncConfiguration IMMEDIATE_FOR_TESTING = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10);
+    public static final SyncConfiguration IMMEDIATE_FOR_TESTING = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10, false);
 
     private final int expectedPeers;
     private final Duration timeoutWaitingPeers;
@@ -20,6 +20,7 @@ public final class SyncConfiguration {
     private final int chunkSize;
     private final int longSyncLimit;
     private final int maxRequestedBodies;
+    private final boolean useAlternative;
 
     /**
      * @param expectedPeers The expected number of peers we would want to start finding a connection point.
@@ -30,6 +31,7 @@ public final class SyncConfiguration {
      * @param chunkSize Amount of blocks contained in a chunk
      * @param maxRequestedBodies Amount of bodies to request at the same time when synchronizing backwards.
      * @param longSyncLimit Distance to the tip of the peer's blockchain to enable long synchronization.
+     * @param useAlternative
      */
     public SyncConfiguration(
             int expectedPeers,
@@ -39,7 +41,8 @@ public final class SyncConfiguration {
             int maxSkeletonChunks,
             int chunkSize,
             int maxRequestedBodies,
-            int longSyncLimit) {
+            int longSyncLimit,
+            boolean useAlternative) {
         this.expectedPeers = expectedPeers;
         this.timeoutWaitingPeers = Duration.ofSeconds(timeoutWaitingPeers);
         this.timeoutWaitingRequest = Duration.ofSeconds(timeoutWaitingRequest);
@@ -48,6 +51,7 @@ public final class SyncConfiguration {
         this.chunkSize = chunkSize;
         this.maxRequestedBodies = maxRequestedBodies;
         this.longSyncLimit = longSyncLimit;
+        this.useAlternative = useAlternative;
     }
 
     public final int getExpectedPeers() {
@@ -81,4 +85,6 @@ public final class SyncConfiguration {
     public int getLongSyncLimit() {
         return longSyncLimit;
     }
+
+    public boolean getUseAlternative() { return useAlternative; }
 }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -195,6 +195,9 @@ sync {
     # block chain synchronization can be: [true/false]
     enabled = true
 
+    # use alternative synchronization
+    alternative = false
+
     # maximum blocks hashes to ask sending GET_BLOCK_HASHES msg we specify number of block we want to get, recomended value [1..1000]
     # Default: unlimited
     max.hashes.ask = 10000

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -46,7 +46,6 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
@@ -316,7 +315,7 @@ public class NodeMessageHandlerTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         final NodeBlockProcessor bp = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         final SimplePeer sender = new SimplePeer();
-        final SyncProcessor syncProcessor = new SyncProcessor(
+        final SyncProcessorImpl syncProcessor = new SyncProcessorImpl(
                 blockchain,
                 mock(BlockStore.class), mock(ConsensusValidationMainchainView.class),
                 blockSyncService,

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerUtil.java
@@ -31,7 +31,7 @@ public class NodeMessageHandlerUtil {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
-        SyncProcessor syncProcessor = new SyncProcessor(
+        SyncProcessorImpl syncProcessor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 syncConfiguration, blockFactory, new DummyBlockValidationRule(),
                 new BlockCompositeRule(new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())),
@@ -61,7 +61,7 @@ public class NodeMessageHandlerUtil {
         ProofOfWorkRule blockValidationRule = new ProofOfWorkRule(config);
         PeerScoringManager peerScoringManager = mock(PeerScoringManager.class);
         Mockito.when(peerScoringManager.hasGoodReputation(isA(NodeID.class))).thenReturn(true);
-        SyncProcessor syncProcessor = new SyncProcessor(
+        SyncProcessorImpl syncProcessor = new SyncProcessorImpl(
                 blockchain, blockStore, mock(ConsensusValidationMainchainView.class), blockSyncService, syncConfiguration, blockFactory,
                 blockValidationRule, new BlockCompositeRule(new BlockUnclesHashValidationRule(),
                 new BlockRootValidationRule(config.getActivationConfig())),

--- a/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/OneAsyncNodeTest.java
@@ -60,7 +60,7 @@ public class OneAsyncNodeTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, syncConfiguration);
         NodeBlockProcessor processor = new NodeBlockProcessor(store, blockchain, nodeInformation, blockSyncService, syncConfiguration);
         SimpleChannelManager channelManager = new SimpleChannelManager();
-        SyncProcessor syncProcessor = new SyncProcessor(
+        SyncProcessorImpl syncProcessor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService, syncConfiguration,
                 new BlockFactory(config.getActivationConfig()),
                 new DummyBlockValidationRule(),

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -33,7 +33,6 @@ import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 
 import java.math.BigInteger;
 import java.time.Duration;
@@ -57,7 +56,7 @@ public class SyncProcessorTest {
         BlockNodeInformation nodeInformation = new BlockNodeInformation();
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -92,7 +91,7 @@ public class SyncProcessorTest {
         final ChannelManager channelManager = mock(ChannelManager.class);
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(sender));
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, blockStore, mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -143,7 +142,7 @@ public class SyncProcessorTest {
         final ChannelManager channelManager = mock(ChannelManager.class);
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(sender));
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, blockStore, mock(ConsensusValidationMainchainView.class), blockSyncService,
                 syncConfiguration, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -193,7 +192,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.DEFAULT, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -236,7 +235,7 @@ public class SyncProcessorTest {
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
         final ChannelManager channelManager = mock(ChannelManager.class);
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, blockStore, mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.DEFAULT, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -310,7 +309,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -340,7 +339,7 @@ public class SyncProcessorTest {
         when(channel.getPeerNodeID()).thenReturn(sender.getPeerNodeID());
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), null,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -374,7 +373,7 @@ public class SyncProcessorTest {
         when(channel.getPeerNodeID()).thenReturn(sender.getPeerNodeID());
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), null,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -405,7 +404,7 @@ public class SyncProcessorTest {
         SimplePeer sender = new SimplePeer(new byte[] { 0x01 });
 
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), null,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -424,7 +423,7 @@ public class SyncProcessorTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 syncConfiguration, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -452,7 +451,7 @@ public class SyncProcessorTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 syncConfiguration, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -481,7 +480,7 @@ public class SyncProcessorTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 syncConfiguration, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -513,7 +512,7 @@ public class SyncProcessorTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 syncConfiguration, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -541,7 +540,7 @@ public class SyncProcessorTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 syncConfiguration, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -576,7 +575,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -627,7 +626,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -688,7 +687,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -778,7 +777,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -829,7 +828,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -863,7 +862,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, builder.getBlockStore(), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory, new DummyBlockValidationRule(),
                 new BlockCompositeRule(
@@ -922,7 +921,7 @@ public class SyncProcessorTest {
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, store, blockchain, nodeInformation, SyncConfiguration.IMMEDIATE_FOR_TESTING);
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, blockStore, mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory, new DummyBlockValidationRule(),
                 new BlockCompositeRule(
@@ -978,7 +977,7 @@ public class SyncProcessorTest {
         when(channel.getPeerNodeID()).thenReturn(sender.getPeerNodeID());
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
@@ -1023,7 +1022,7 @@ public class SyncProcessorTest {
         SyncConfiguration syncConfiguration = SyncConfiguration.IMMEDIATE_FOR_TESTING;
         TestSystemProperties config = new TestSystemProperties();
         BlockSyncService blockSyncService = new BlockSyncService(config, new NetBlockStore(), blockchain, new BlockNodeInformation(), syncConfiguration);
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 syncConfiguration, blockFactory, new ProofOfWorkRule(config).setFallbackMiningEnabled(false),
                 new BlockCompositeRule(
@@ -1058,7 +1057,7 @@ public class SyncProcessorTest {
         when(channel.getPeerNodeID()).thenReturn(sender.getPeerNodeID());
         when(channelManager.getActivePeers()).thenReturn(Collections.singletonList(channel));
 
-        SyncProcessor processor = new SyncProcessor(
+        SyncProcessorImpl processor = new SyncProcessorImpl(
                 blockchain, mock(org.ethereum.db.BlockStore.class), mock(ConsensusValidationMainchainView.class), blockSyncService,
                 SyncConfiguration.IMMEDIATE_FOR_TESTING, blockFactory,
                 new ProofOfWorkRule(config).setFallbackMiningEnabled(false),

--- a/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
@@ -200,7 +200,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, false);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(50, node1.getBestBlock().getNumber());
@@ -244,7 +244,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, false);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());
@@ -288,7 +288,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,0,1,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,0,1,20,192, 20, 10, false);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());
@@ -338,7 +338,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b2);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, false);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b3, syncConfiguration);
 
         Assert.assertEquals(193, node1.getBestBlock().getNumber());
@@ -385,7 +385,7 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b2);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b2);
         SimpleAsyncNode node3 = SimpleAsyncNode.createDefaultNode(b3);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(3,1,10,100,20,192, 20, 10);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(3,1,10,100,20,192, 20, 10, false);
         SimpleAsyncNode node4 = SimpleAsyncNode.createNode(b1, syncConfiguration);
 
         Assert.assertEquals(200, node1.getBestBlock().getNumber());

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageVisitorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageVisitorTest.java
@@ -5,7 +5,6 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.net.*;
 import co.rsk.scoring.EventType;
 import co.rsk.scoring.PeerScoringManager;
-import co.rsk.validators.BlockValidationRule;
 import org.ethereum.config.Constants;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
@@ -31,7 +30,7 @@ public class MessageVisitorTest {
     private ChannelManager channelManager;
     private PeerScoringManager peerScoringManager;
     private TransactionGateway transactionGateway;
-    private SyncProcessor syncProcessor;
+    private SyncProcessorImpl syncProcessor;
     private BlockProcessor blockProcessor;
     private RskSystemProperties config;
 
@@ -39,7 +38,7 @@ public class MessageVisitorTest {
     public void setUp() {
         config = mock(RskSystemProperties.class);
         blockProcessor = mock(BlockProcessor.class);
-        syncProcessor = mock(SyncProcessor.class);
+        syncProcessor = mock(SyncProcessorImpl.class);
         transactionGateway = mock(TransactionGateway.class);
         peerScoringManager = mock(PeerScoringManager.class);
         channelManager = mock(ChannelManager.class);

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -51,7 +51,7 @@ public class SimpleAsyncNode extends SimpleNode {
     private static final TestSystemProperties config = new TestSystemProperties();
     private ExecutorService executor = Executors.newSingleThreadExecutor();
     private LinkedBlockingQueue<Future> futures = new LinkedBlockingQueue<>(5000);
-    private SyncProcessor syncProcessor;
+    private SyncProcessorImpl syncProcessor;
     private SimpleChannelManager simpleChannelManager;
 
     public SimpleAsyncNode(MessageHandler handler, Blockchain blockchain) {
@@ -60,7 +60,7 @@ public class SimpleAsyncNode extends SimpleNode {
 
     public SimpleAsyncNode(MessageHandler handler,
                            Blockchain blockchain,
-                           SyncProcessor syncProcessor,
+                           SyncProcessorImpl syncProcessor,
                            SimpleChannelManager simpleChannelManager) {
         super(handler, blockchain);
         this.syncProcessor = syncProcessor;
@@ -110,7 +110,7 @@ public class SimpleAsyncNode extends SimpleNode {
         this.futures.clear();
     }
 
-    public SyncProcessor getSyncProcessor() {
+    public SyncProcessorImpl getSyncProcessor() {
         return this.syncProcessor;
     }
 
@@ -136,7 +136,7 @@ public class SimpleAsyncNode extends SimpleNode {
         PeerScoringManager peerScoringManager = RskMockFactory.getPeerScoringManager();
         SimpleChannelManager channelManager = new SimpleChannelManager();
         BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
-        SyncProcessor syncProcessor = new SyncProcessor(
+        SyncProcessorImpl syncProcessor = new SyncProcessorImpl(
                 blockchain, indexedBlockStore, mock(ConsensusValidationMainchainView.class), blockSyncService, syncConfiguration, blockFactory,
                 blockValidationRule,
                 new BlockCompositeRule(new BlockUnclesHashValidationRule(), new BlockRootValidationRule(config.getActivationConfig())),


### PR DESCRIPTION
This long synchronizations is based on querying all known peers, and accepting their help reconstructing the blockchain.

After more than a year of experiments, the results are promising: the number of repeated blocks is low, the latency time is low, and the queue size is under control.

Skipping these bottlenecks (to be solver):
- Trie conversion #1140 
- Block validation rule #1067 
- Save receipts #1125 

the latests experiments (synchronization from 0) yields:
- testnet +-8hs
- mainnet +- 36hs

but the times depend on machine, and number of peers

The new configuracion flag is `-Dsync.alternative=true`. The default option is to use the current synchronization algorithm