### PR TITLE
Improved DataSourceWithCache: auto flush, sync locks; TrieStore avoid to write known state

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -58,6 +58,13 @@ public class TrieStoreImpl implements TrieStore {
      * @param forceSaveRoot allows saving the root node even if it's embeddable
      */
     private void save(Trie trie, boolean forceSaveRoot) {
+        byte[] trieKeyBytes = trie.getHash().getBytes();
+
+        if (forceSaveRoot && this.store.get(trieKeyBytes) != null) {
+            // the full trie is already saved
+            return;
+        }
+
         if (savedTries.contains(trie)) {
             // it is guaranteed that the children of a saved node are also saved
             return;

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -58,15 +58,15 @@ public class TrieStoreImpl implements TrieStore {
      * @param forceSaveRoot allows saving the root node even if it's embeddable
      */
     private void save(Trie trie, boolean forceSaveRoot) {
+        if (savedTries.contains(trie)) {
+            // it is guaranteed that the children of a saved node are also saved
+            return;
+        }
+
         byte[] trieKeyBytes = trie.getHash().getBytes();
 
         if (forceSaveRoot && this.store.get(trieKeyBytes) != null) {
             // the full trie is already saved
-            return;
-        }
-
-        if (savedTries.contains(trie)) {
-            // it is guaranteed that the children of a saved node are also saved
             return;
         }
 
@@ -90,7 +90,7 @@ public class TrieStoreImpl implements TrieStore {
             return;
         }
 
-        this.store.put(trie.getHash().getBytes(), trie.toMessage());
+        this.store.put(trieKeyBytes, trie.toMessage());
         savedTries.add(trie);
     }
 

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -43,7 +43,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
         this.cacheSize = cacheSize;
         this.base = base;
         this.uncommittedCache = new LinkedHashMap<>(cacheSize / 8, (float)0.75, false);
-        this.committedCache = new MaxSizeHashMap<>(cacheSize, true);
+        this.committedCache = Collections.synchronizedMap(new MaxSizeHashMap<>(cacheSize, true));
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -43,7 +43,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
         this.cacheSize = cacheSize;
         this.base = base;
         this.uncommittedCache = new LinkedHashMap<>(cacheSize / 8, (float)0.75, false);
-        this.committedCache = Collections.synchronizedMap(new MaxSizeHashMap<>(cacheSize, true));
+        this.committedCache = new MaxSizeHashMap<>(cacheSize, true);
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -21,6 +21,8 @@ package org.ethereum.datasource;
 import co.rsk.util.MaxSizeHashMap;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -28,6 +30,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DataSourceWithCache implements KeyValueDataSource {
+    private static final Logger logger = LoggerFactory.getLogger(DataSourceWithCache.class);
+
+    private final int cacheSize;
     private final KeyValueDataSource base;
     private final Map<ByteArrayWrapper, byte[]> uncommittedCache;
     private final Map<ByteArrayWrapper, byte[]> committedCache;
@@ -35,144 +40,196 @@ public class DataSourceWithCache implements KeyValueDataSource {
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     public DataSourceWithCache(KeyValueDataSource base, int cacheSize) {
+        this.cacheSize = cacheSize;
         this.base = base;
-        this.uncommittedCache = new HashMap<>();
-        this.committedCache = Collections.synchronizedMap(new MaxSizeHashMap<>(cacheSize, true));
+        this.uncommittedCache = new LinkedHashMap<>(cacheSize / 8, (float)0.75, false);
+        this.committedCache = new MaxSizeHashMap<>(cacheSize, true);
     }
 
     @Override
-    public synchronized byte[] get(byte[] key) {
+    public byte[] get(byte[] key) {
         Objects.requireNonNull(key);
         ByteArrayWrapper wrappedKey = ByteUtil.wrap(key);
+        byte[] value;
 
-        lock.readLock().lock();
+        this.lock.readLock().lock();
+
         try {
+            if (committedCache.containsKey(wrappedKey)) {
+                return committedCache.get(wrappedKey);
+            }
+
             if (uncommittedCache.containsKey(wrappedKey)) {
                 return uncommittedCache.get(wrappedKey);
             }
 
-            if (committedCache.containsKey(wrappedKey)) {
-                return committedCache.get(wrappedKey);
-            } else {
-                byte[] value = base.get(key);
-
-                //null value, as expected, is allowed here to be stored in committedCache
-                committedCache.put(wrappedKey, value);
-
-                return value;
-            }
-        } finally {
-            lock.readLock().unlock();
+            value = base.get(key);
         }
-    }
+        finally {
+            this.lock.readLock().unlock();
+        }
 
-    @Override
-    public synchronized byte[] put(byte[] key, byte[] value) {
-        ByteArrayWrapper wrappedKey = ByteUtil.wrap(key);
-        return put(wrappedKey, value);
-    }
+        this.lock.writeLock().lock();
 
-    private byte[] put(ByteArrayWrapper wrappedKey, byte[] value) {
-        Objects.requireNonNull(value);
-
-        lock.writeLock().lock();
         try {
-            // here I could check for equal data or just move to the uncommittedCache.
-            byte[] priorValue = committedCache.get(wrappedKey);
-            if (priorValue != null && Arrays.equals(priorValue, value)) {
-                return value;
-            }
-
-            committedCache.remove(wrappedKey);
-            uncommittedCache.put(wrappedKey, value);
-        } finally {
-            lock.writeLock().unlock();
+            //null value, as expected, is allowed here to be stored in committedCache
+            committedCache.put(wrappedKey, value);
+        }
+        finally {
+            this.lock.writeLock().unlock();
         }
 
         return value;
     }
 
     @Override
-    public synchronized void delete(byte[] key) {
+    public byte[] put(byte[] key, byte[] value) {
+        ByteArrayWrapper wrappedKey = ByteUtil.wrap(key);
+
+        return put(wrappedKey, value);
+    }
+
+    private byte[] put(ByteArrayWrapper wrappedKey, byte[] value) {
+        Objects.requireNonNull(value);
+
+        this.lock.writeLock().lock();
+
+        try {
+            // here I could check for equal data or just move to the uncommittedCache.
+            byte[] priorValue = committedCache.get(wrappedKey);
+
+            if (priorValue != null && Arrays.equals(priorValue, value)) {
+                return value;
+            }
+
+            committedCache.remove(wrappedKey);
+            this.putKeyValue(wrappedKey, value);
+        }
+        finally {
+            this.lock.writeLock().unlock();
+        }
+
+        return value;
+    }
+
+    private void putKeyValue(ByteArrayWrapper key, byte[] value) {
+        uncommittedCache.put(key, value);
+
+        if (uncommittedCache.size() > cacheSize) {
+            this.flush();
+        }
+    }
+
+    @Override
+    public void delete(byte[] key) {
         delete(ByteUtil.wrap(key));
     }
 
     private void delete(ByteArrayWrapper wrappedKey) {
-        lock.writeLock().lock();
+        this.lock.writeLock().lock();
 
         try {
             // always mark for deletion if we don't know the state in the underlying store
             if (!committedCache.containsKey(wrappedKey)) {
-                uncommittedCache.put(wrappedKey, null);
+                this.putKeyValue(wrappedKey, null);
                 return;
             }
 
             byte[] valueToRemove = committedCache.get(wrappedKey);
+
             // a null value means we know for a fact that the key doesn't exist in the underlying store, so this is a noop
             if (valueToRemove != null) {
+                this.putKeyValue(wrappedKey, null);
                 committedCache.remove(wrappedKey);
-                uncommittedCache.put(wrappedKey, null);
             }
-        } finally {
-            lock.writeLock().unlock();
+        }
+        finally {
+            this.lock.writeLock().unlock();
         }
     }
 
     @Override
     public Set<byte[]> keys() {
-        lock.readLock().lock();
+        Stream<ByteArrayWrapper> baseKeys;
+        Stream<ByteArrayWrapper> committedKeys;
+        Stream<ByteArrayWrapper> uncommittedKeys;
+        Set<ByteArrayWrapper> uncommittedKeysToRemove;
+
+        this.lock.readLock().lock();
 
         try {
-            Stream<ByteArrayWrapper> baseKeys = base.keys().stream().map(ByteArrayWrapper::new);
-            Stream<ByteArrayWrapper> uncommittedKeys = uncommittedCache.entrySet().stream()
+            baseKeys = base.keys().stream().map(ByteArrayWrapper::new);
+            committedKeys = committedCache.entrySet().stream()
                     .filter(e -> e.getValue() != null)
                     .map(Map.Entry::getKey);
-            Set<ByteArrayWrapper> uncommittedKeysToRemove = uncommittedCache.entrySet().stream()
+            uncommittedKeys = uncommittedCache.entrySet().stream()
+                    .filter(e -> e.getValue() != null)
+                    .map(Map.Entry::getKey);
+            uncommittedKeysToRemove = uncommittedCache.entrySet().stream()
                     .filter(e -> e.getValue() == null)
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toSet());
-            Set<ByteArrayWrapper> knownKeys = Stream.concat(baseKeys, uncommittedKeys)
-                    .collect(Collectors.toSet());
-            knownKeys.removeAll(uncommittedKeysToRemove);
-
-            // note that toSet doesn't work with byte[], so we have to do this extra step
-            return knownKeys.stream()
-                    .map(ByteArrayWrapper::getData)
-                    .collect(Collectors.toSet());
-        } finally {
-            lock.readLock().unlock();
         }
+        finally {
+            this.lock.readLock().unlock();
+        }
+
+        Set<ByteArrayWrapper> knownKeys = Stream.concat(Stream.concat(baseKeys, committedKeys), uncommittedKeys)
+                .collect(Collectors.toSet());
+        knownKeys.removeAll(uncommittedKeysToRemove);
+
+        // note that toSet doesn't work with byte[], so we have to do this extra step
+        return knownKeys.stream()
+                .map(ByteArrayWrapper::getData)
+                .collect(Collectors.toSet());
     }
 
     @Override
-    public synchronized void updateBatch(Map<ByteArrayWrapper, byte[]> rows, Set<ByteArrayWrapper> keysToRemove) {
+    public void updateBatch(Map<ByteArrayWrapper, byte[]> rows, Set<ByteArrayWrapper> keysToRemove) {
         if (rows.containsKey(null) || rows.containsValue(null)) {
             throw new IllegalArgumentException("Cannot update null values");
         }
 
-        lock.writeLock().lock();
-        try {
-            // remove overlapping entries
-            rows.keySet().removeAll(keysToRemove);
+        // remove overlapping entries
+        rows.keySet().removeAll(keysToRemove);
 
+        this.lock.writeLock().lock();
+
+        try {
             rows.forEach(this::put);
             keysToRemove.forEach(this::delete);
-        } finally {
-            lock.writeLock().unlock();
+        }
+        finally {
+            this.lock.writeLock().unlock();
         }
     }
 
     @Override
-    public synchronized void flush() {
-        lock.writeLock().lock();
+    public void flush() {
+        Map<ByteArrayWrapper, byte[]> uncommittedBatch = new LinkedHashMap<>();
+
+        this.lock.writeLock().lock();
+
         try {
-            Map<ByteArrayWrapper, byte[]> uncommittedBatch = uncommittedCache.entrySet().stream().filter(e -> e.getValue() != null).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            long saveTime = System.nanoTime();
+
+            this.uncommittedCache.forEach((key, value) -> {
+                if (value != null) {
+                    uncommittedBatch.put(key, value);
+                }
+            });
+
             Set<ByteArrayWrapper> uncommittedKeysToRemove = uncommittedCache.entrySet().stream().filter(e -> e.getValue() == null).map(Map.Entry::getKey).collect(Collectors.toSet());
             base.updateBatch(uncommittedBatch, uncommittedKeysToRemove);
             committedCache.putAll(uncommittedCache);
             uncommittedCache.clear();
-        } finally {
-            lock.writeLock().unlock();
+
+            long totalTime = System.nanoTime() - saveTime;
+
+            logger.trace("datasource flush: [{}]nano", totalTime);
+        }
+        finally {
+            this.lock.writeLock().unlock();
         }
     }
 
@@ -180,18 +237,25 @@ public class DataSourceWithCache implements KeyValueDataSource {
         return base.getName() + "-with-uncommittedCache";
     }
 
-    public synchronized void init() {
+    public void init() {
         base.init();
     }
 
-    public synchronized boolean isAlive() {
+    public boolean isAlive() {
         return base.isAlive();
     }
 
-    public synchronized void close() {
-        flush();
-        base.close();
-        uncommittedCache.clear();
-        committedCache.clear();
+    public void close() {
+        this.lock.writeLock().lock();
+
+        try {
+            flush();
+            base.close();
+            uncommittedCache.clear();
+            committedCache.clear();
+        }
+        finally {
+            this.lock.writeLock().unlock();
+        }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -41,7 +41,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
     }
 
     @Override
-    public byte[] get(byte[] key) {
+    public synchronized byte[] get(byte[] key) {
         Objects.requireNonNull(key);
         ByteArrayWrapper wrappedKey = ByteUtil.wrap(key);
 
@@ -67,7 +67,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
     }
 
     @Override
-    public byte[] put(byte[] key, byte[] value) {
+    public synchronized byte[] put(byte[] key, byte[] value) {
         ByteArrayWrapper wrappedKey = ByteUtil.wrap(key);
         return put(wrappedKey, value);
     }
@@ -93,7 +93,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
     }
 
     @Override
-    public void delete(byte[] key) {
+    public synchronized void delete(byte[] key) {
         delete(ByteUtil.wrap(key));
     }
 
@@ -145,7 +145,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
     }
 
     @Override
-    public void updateBatch(Map<ByteArrayWrapper, byte[]> rows, Set<ByteArrayWrapper> keysToRemove) {
+    public synchronized void updateBatch(Map<ByteArrayWrapper, byte[]> rows, Set<ByteArrayWrapper> keysToRemove) {
         if (rows.containsKey(null) || rows.containsValue(null)) {
             throw new IllegalArgumentException("Cannot update null values");
         }
@@ -180,15 +180,15 @@ public class DataSourceWithCache implements KeyValueDataSource {
         return base.getName() + "-with-uncommittedCache";
     }
 
-    public void init() {
+    public synchronized void init() {
         base.init();
     }
 
-    public boolean isAlive() {
+    public synchronized boolean isAlive() {
         return base.isAlive();
     }
 
-    public void close() {
+    public synchronized void close() {
         flush();
         base.close();
         uncommittedCache.clear();

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -143,7 +143,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
-        verify(map, times(2)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.trie;
 
+import co.rsk.crypto.Keccak256;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.HashMapDB;
 import org.junit.Assert;
@@ -48,6 +49,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -58,6 +60,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
 
         Trie newTrie = store.retrieve(trie.getHash().getBytes()).get();
@@ -78,6 +81,7 @@ public class TrieStoreImplTest {
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
         verify(map, times(1)).put(trie.getValueHash().getBytes(), trie.getValue());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
 
         Trie newTrie = store.retrieve(trie.getHash().getBytes()).get();
@@ -95,6 +99,7 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -106,6 +111,7 @@ public class TrieStoreImplTest {
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
         verify(map, times(1)).put(trie.getValueHash().getBytes(), trie.getValue());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -118,6 +124,8 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(trie.trieSize())).put(any(), any());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -128,9 +136,14 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verify(map, times(1)).get(trie.getHash().getBytes());
+        verifyNoMoreInteractions(map);
 
         store.save(trie);
 
+        verify(map, times(1)).put(trie.getHash().getBytes(), trie.toMessage());
+        verify(map, times(2)).get(trie.getHash().getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -140,13 +153,19 @@ public class TrieStoreImplTest {
 
         store.save(trie);
 
+        Keccak256 hash1 = trie.getHash();
+
         verify(map, times(trie.trieSize())).put(any(), any());
 
         trie = trie.put("foo", "bar2".getBytes());
 
         store.save(trie);
 
+        Keccak256 hash2 = trie.getHash();
+
         verify(map, times(trie.trieSize() + 1)).put(any(), any());
+        verify(map, times(1)).get(hash1.getBytes());
+        verify(map, times(1)).get(hash2.getBytes());
         verifyNoMoreInteractions(map);
     }
 
@@ -163,6 +182,8 @@ public class TrieStoreImplTest {
         store.save(trie);
 
         verify(map, times(trie.trieSize() + 1)).put(any(), any());
+        verify(map, times(2)).get(any());
+
         verifyNoMoreInteractions(map);
     }
 
@@ -182,11 +203,11 @@ public class TrieStoreImplTest {
 
         Trie trie2 = store.retrieve(trie.getHash().getBytes()).get();
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
 
         Assert.assertEquals(size, trie2.trieSize());
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
     }
 
     @Test
@@ -200,11 +221,11 @@ public class TrieStoreImplTest {
 
         Trie trie2 = store.retrieve(trie.getHash().getBytes()).get();
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
 
         Assert.assertEquals(size, trie2.trieSize());
 
-        verify(map, times(size)).get(any());
+        verify(map, times(size + 1)).get(any());
     }
 
     @Test
@@ -217,6 +238,6 @@ public class TrieStoreImplTest {
 
         store.retrieve(trie.getHash().getBytes());
 
-        verify(map, times(1)).get(any());
+        verify(map, times(2)).get(any());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
@@ -6,6 +6,7 @@ import org.ethereum.util.ByteUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -108,6 +109,24 @@ public class DataSourceWithCacheTest {
 
         dataSourceWithCache.flush();
         assertThat(baseDataSource.get(randomKey), is(randomValue));
+    }
+
+    @Test
+    public void putTwoKeyValuesWrittenInOrder() {
+        InOrder order = inOrder(baseDataSource);
+
+        byte[] randomKey1 = TestUtils.randomBytes(20);
+        byte[] randomValue1 = TestUtils.randomBytes(20);
+        byte[] randomKey2 = TestUtils.randomBytes(20);
+        byte[] randomValue2 = TestUtils.randomBytes(20);
+
+        dataSourceWithCache.put(randomKey1, randomValue1);
+        dataSourceWithCache.put(randomKey2, randomValue2);
+
+        dataSourceWithCache.flush();
+
+        order.verify(baseDataSource).put(randomKey1, randomValue1);
+        order.verify(baseDataSource).put(randomKey2, randomValue2);
     }
 
     @Test


### PR DESCRIPTION
The implementation of `DataSourceWithCache` is improved with:

Automanage of write flush
Synchronization locks to support multithreading
And `TrieStoreImpl` avoid the write of a known trie world state