### PR TITLE
Generalize Miner Server's extra data tests

### DIFF
--- a/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerServerTest.java
@@ -803,7 +803,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         byte[] secondItem = decodedExtraData.get(1).getRLPData();
         assertNotNull(secondItem);
-        assertEquals("SNAPSHOT-cb7f28e", new String(secondItem));
+        assertEquals(config.projectVersionModifier().concat("-cb7f28e"), new String(secondItem));
     }
 
     @Test
@@ -833,7 +833,7 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         byte[] secondItem = decodedExtraData.get(1).getRLPData();
         assertNotNull(secondItem);
-        assertEquals("SNAPSHOT-cb7f28e", new String(secondItem));
+        assertEquals(config.projectVersionModifier().concat("-cb7f28e"), new String(secondItem));
 
         byte[] thirdItem = decodedExtraData.get(2).getRLPData();
         assertNotNull(thirdItem);
@@ -868,11 +868,18 @@ public class MinerServerTest extends ParameterizedNetworkUpgradeTest {
 
         byte[] secondItem = decodedExtraData.get(1).getRLPData();
         assertNotNull(secondItem);
-        assertEquals("SNAPSHOT-cb7f28e", new String(secondItem));
+        assertEquals(config.projectVersionModifier().concat("-cb7f28e"), new String(secondItem));
 
         byte[] thirdItem = decodedExtraData.get(2).getRLPData();
         assertNotNull(thirdItem);
-        assertEquals("tincho is th", new String(thirdItem));
+
+        // The final client extra data may be truncated by the combined size of the other encoded elements
+        int extraDataMaxLength = 32;
+        int extraDataEncodingOverhead = 3;
+        Integer clientExtraDataSize =
+                extraDataMaxLength - extraDataEncodingOverhead - firstItem.length - secondItem.length;
+
+        assertEquals("tincho is the king of mining".substring(0, clientExtraDataSize), new String(thirdItem));
     }
 
     private BtcBlock getMergedMiningBlockWithOnlyCoinbase(MinerWork work) {

--- a/rskj-core/src/test/java/co/rsk/mine/ParameterizedNetworkUpgradeTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/ParameterizedNetworkUpgradeTest.java
@@ -49,6 +49,9 @@ public abstract class ParameterizedNetworkUpgradeTest {
             public String toString() {
                 return "Bamboo";
             }
+
+            @Override
+            public String projectVersionModifier() { return "Bamboo"; }
         };
         TestSystemProperties orchidConfig = new TestSystemProperties() {
             @Override
@@ -60,6 +63,9 @@ public abstract class ParameterizedNetworkUpgradeTest {
             public String toString() {
                 return "Orchid";
             }
+
+            @Override
+            public String projectVersionModifier() { return "Orchid"; }
         };
         return new Object[] { bambooConfig, orchidConfig };
     }


### PR DESCRIPTION
Miner Server tests relating to the extraData field would break when executing on a non-SNAPSHOT version.

The aim of this PR is to generalize these tests to work under any of the configured test configurations.