### PR TITLE
remove thread on which the vm executes programs

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/TransactionExecutorFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/TransactionExecutorFactory.java
@@ -29,8 +29,6 @@ import org.ethereum.vm.program.invoke.ProgramInvokeFactory;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class TransactionExecutorFactory {
 
@@ -40,7 +38,6 @@ public class TransactionExecutorFactory {
     private final BlockFactory blockFactory;
     private final ProgramInvokeFactory programInvokeFactory;
     private final PrecompiledContracts precompiledContracts;
-    private final ExecutorService vmExecutorService;
 
     public TransactionExecutorFactory(
             RskSystemProperties config,
@@ -55,12 +52,6 @@ public class TransactionExecutorFactory {
         this.blockFactory = blockFactory;
         this.programInvokeFactory = programInvokeFactory;
         this.precompiledContracts = precompiledContracts;
-        this.vmExecutorService = Executors.newCachedThreadPool(threadFactory -> new Thread(
-            Thread.currentThread().getThreadGroup(),
-            threadFactory,
-            "vmExecution",
-            config.getVmExecutionStackSize()
-        ));
     }
 
     public TransactionExecutor newInstance(
@@ -115,8 +106,7 @@ public class TransactionExecutorFactory {
                 config.playVM(),
                 config.isRemascEnabled(),
                 precompiledContracts,
-                deletedAccounts,
-                vmExecutorService
+                deletedAccounts
         );
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -440,22 +440,16 @@ public class TransactionExecutor {
                 } else {
                     execError("REVERT opcode executed");
                 }
-            } else {
-                cacheTrack.commit();
             }
-
-        } catch (Throwable e) {
-            // NOTE: we really should about the node, shutdown everything, and fail safe.
-            // TODO: catch whatever they will throw on you !!!
-//            https://github.com/ethereum/cpp-ethereum/blob/develop/libethereum/Executive.cpp#L241
+        } catch (Exception e) {
             cacheTrack.rollback();
             mEndGas = 0;
             execError(e);
-
-        }
-        finally {
             profiler.stop(metric);
+            return;
         }
+        cacheTrack.commit();
+        profiler.stop(metric);
     }
 
     private void createContract() {

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.util.*;
-import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
 import static co.rsk.util.ListArrayUtil.getLength;
@@ -77,7 +76,6 @@ public class TransactionExecutor {
     private final PrecompiledContracts precompiledContracts;
     private final boolean playVm;
     private final boolean enableRemasc;
-    private final ExecutorService vmExecutorService;
     private String executionError = "";
     private final long gasUsedInTheBlock;
     private Coin paidFees;
@@ -106,7 +104,7 @@ public class TransactionExecutor {
             Constants constants, ActivationConfig activationConfig, Transaction tx, int txindex, RskAddress coinbase,
             Repository track, BlockStore blockStore, ReceiptStore receiptStore, BlockFactory blockFactory,
             ProgramInvokeFactory programInvokeFactory, Block executionBlock, long gasUsedInTheBlock, VmConfig vmConfig,
-            boolean playVm, boolean remascEnabled, PrecompiledContracts precompiledContracts, Set<DataWord> deletedAccounts, ExecutorService vmExecution) {
+            boolean playVm, boolean remascEnabled, PrecompiledContracts precompiledContracts, Set<DataWord> deletedAccounts) {
         this.constants = constants;
         this.activations = activationConfig.forBlock(executionBlock.getNumber());
         this.tx = tx;
@@ -125,7 +123,6 @@ public class TransactionExecutor {
         this.playVm = playVm;
         this.enableRemasc = remascEnabled;
         this.deletedAccounts = new HashSet<>(deletedAccounts);
-        this.vmExecutorService = vmExecution;
     }
 
     /**
@@ -424,7 +421,7 @@ public class TransactionExecutor {
             program.spendGas(tx.transactionCost(constants, activations), "TRANSACTION COST");
 
             if (playVm) {
-                playVirtualMachine();
+                vm.play(program);
             }
 
             result = program.getResult();
@@ -483,20 +480,6 @@ public class TransactionExecutor {
             mEndGas = GasCost.subtract(mEndGas,  returnDataGasValue);
             program.spendGas(returnDataGasValue, "CONTRACT DATA COST");
             cacheTrack.saveCode(tx.getContractAddress(), result.getHReturn());
-        }
-    }
-
-    private void playVirtualMachine() throws Throwable {
-        Future<?> vmExecution = vmExecutorService.submit(() -> vm.play(program));
-        try {
-            vmExecution.get();
-        } catch (ExecutionException e) {
-            if (e.getCause() instanceof StackOverflowError) {
-                logger.error("\n !!! StackOverflowError: update your java run command with -Xss32M !!!\n", e);
-                System.exit(-1);
-            } else {
-                throw e.getCause();
-            }
         }
     }
 

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionExecutorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionExecutorTest.java
@@ -49,7 +49,7 @@ public class TransactionExecutorTest {
                 constants, activationConfig, transaction, txIndex, rskAddress,
                 repository, blockStore, receiptStore, blockFactory,
                 programInvokeFactory, executionBlock, gasUsedInTheBlock, vmConfig,
-                true, true, precompiledContracts, deletedAccounts, vmExecution
+                true, true, precompiledContracts, deletedAccounts
         );
 
 


### PR DESCRIPTION
Since the reduction of MAX_DEPTH on commit aaa88a386, this thread
is deprecated, as it helped alleviate a memory issue when depth was
way too big, but now depth is capped so this should no longer be a
issue.

Should improve performance too as a nice side effect :)