### PR TITLE
First check if the transaction is already added in TransactionPoolAddResult

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -211,6 +211,14 @@ public class TransactionPoolImpl implements TransactionPool {
 
     @Override
     public synchronized TransactionPoolAddResult addTransaction(final Transaction tx) {
+        if (pendingTransactions.hasTransaction(tx)) {
+            return TransactionPoolAddResult.withError("pending transaction with same hash already exists");
+        }
+
+        if (queuedTransactions.hasTransaction(tx)) {
+            return TransactionPoolAddResult.withError("queued transaction with same hash already exists");
+        }
+
         RepositorySnapshot currentRepository = getCurrentRepository();
         TransactionValidationResult validationResult = shouldAcceptTx(tx, currentRepository);
         if (!validationResult.transactionIsValid()) {
@@ -221,14 +229,6 @@ public class TransactionPoolImpl implements TransactionPool {
         logger.trace("add transaction {} {}", toBI(tx.getNonce()), tx.getHash());
 
         Long bnumber = Long.valueOf(getCurrentBestBlockNumber());
-
-        if (pendingTransactions.hasTransaction(tx)) {
-            return TransactionPoolAddResult.withError("pending transaction with same hash already exists");
-        }
-
-        if (queuedTransactions.hasTransaction(tx)) {
-            return TransactionPoolAddResult.withError("queued transaction with same hash already exists");
-        }
 
         if (!isBumpingGasPriceForSameNonceTx(tx)) {
             return TransactionPoolAddResult.withError("gas price not enough to bump transaction");


### PR DESCRIPTION
Validating a transaction is more expensive than verifying if it's already added in a Hash map.
Performing first the check if the Tx hash exists in pendingTransactions or queuedTransactions improves performance