### PR TITLE
Introduce BlockHeaderBuilder class

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/BlockDifficulty.java
+++ b/rskj-core/src/main/java/co/rsk/core/BlockDifficulty.java
@@ -27,6 +27,7 @@ import java.math.BigInteger;
  */
 public class BlockDifficulty implements Comparable<BlockDifficulty>, Serializable {
     public static final BlockDifficulty ZERO = new BlockDifficulty(BigInteger.ZERO);
+    public static final BlockDifficulty ONE = new BlockDifficulty(BigInteger.ONE);
 
     private final BigInteger value;
 

--- a/rskj-core/src/main/java/co/rsk/mine/BlockToMineBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/mine/BlockToMineBuilder.java
@@ -19,6 +19,7 @@
 package co.rsk.mine;
 
 import co.rsk.config.MiningConfig;
+import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.DifficultyCalculator;
 import co.rsk.core.RskAddress;
@@ -42,8 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.util.*;
-
-import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
 
 /**
  * This component helps build a new block to mine.
@@ -196,30 +195,27 @@ public class BlockToMineBuilder {
         byte[] forkDetectionData = forkDetectionDataCalculator.calculateWithBlockHeaders(mainchainHeaders);
 
         long blockNumber = newBlockParentHeader.getNumber() + 1;
-        final BlockHeader newHeader = blockFactory.newHeader(
-                newBlockParentHeader.getHash().getBytes(),
-                unclesListHash,
-                miningConfig.getCoinbaseAddress().getBytes(),
-                EMPTY_TRIE_HASH,
-                BlockHashesHelper.getTxTrieRoot(
+
+        final BlockHeader newHeader = blockFactory
+                .getBlockHeaderBuilder()
+                .setParentHash(newBlockParentHeader.getHash().getBytes())
+                .setUnclesHash(unclesListHash)
+                .setCoinbase(miningConfig.getCoinbaseAddress())
+                .setTxTrieRoot(BlockHashesHelper.getTxTrieRoot(
                         txs, activationConfig.isActive(ConsensusRule.RSKIP126, blockNumber)
-                ),
-                EMPTY_TRIE_HASH,
-                new Bloom().getData(),
-                new byte[]{1},
-                blockNumber,
-                gasLimit.toByteArray(),
-                0,
-                timestampSeconds,
-                extraData,
-                Coin.ZERO,
-                new byte[]{},
-                new byte[]{},
-                new byte[]{},
-                forkDetectionData,
-                minimumGasPrice.getBytes(),
-                uncles.size()
-        );
+                    )
+                )
+                .setDifficulty(BlockDifficulty.ONE)
+                .setNumber(blockNumber)
+                .setGasLimit(gasLimit.toByteArray())
+                .setGasUsed(0)
+                .setTimestamp(timestampSeconds)
+                .setExtraData(extraData)
+                .setMergedMiningForkDetectionData(forkDetectionData)
+                .setMinimumGasPrice(minimumGasPrice)
+                .setUncleCount(uncles.size())
+                .build();
+
         newHeader.setDifficulty(difficultyCalculator.calcDifficulty(newHeader, newBlockParentHeader));
         return newHeader;
     }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -23,7 +23,6 @@ import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.remasc.RemascTransaction;
-import org.bouncycastle.pqc.math.linearalgebra.ByteUtils;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -47,6 +46,10 @@ public class BlockFactory {
 
     public BlockFactory(ActivationConfig activationConfig) {
         this.activationConfig = activationConfig;
+    }
+
+    public BlockHeaderBuilder getBlockHeaderBuilder() {
+        return new BlockHeaderBuilder(activationConfig);
     }
 
     public Block cloneBlockForModification(Block block) {
@@ -82,56 +85,6 @@ public class BlockFactory {
     public Block newBlock(BlockHeader header, List<Transaction> transactionList, List<BlockHeader> uncleList, boolean sealed) {
         boolean isRskip126Enabled = activationConfig.isActive(ConsensusRule.RSKIP126, header.getNumber());
         return new Block(header, transactionList, uncleList, isRskip126Enabled, sealed);
-    }
-
-    public BlockHeader newHeader(
-            byte[] parentHash, byte[] unclesHash, byte[] coinbase,
-            byte[] logsBloom, byte[] difficulty, long number,
-            byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
-            byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
-            byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] miningForkDetectionData,
-            byte[] minimumGasPrice, int uncleCount) {
-        return newHeader(
-                parentHash, unclesHash, coinbase,
-                ByteUtils.clone(EMPTY_TRIE_HASH), null, ByteUtils.clone(EMPTY_TRIE_HASH),
-                logsBloom, difficulty, number, gasLimit, gasUsed, timestamp, extraData, Coin.ZERO,
-                bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
-                bitcoinMergedMiningCoinbaseTransaction, miningForkDetectionData, minimumGasPrice, uncleCount
-        );
-    }
-
-    public BlockHeader newHeader(
-            byte[] parentHash, byte[] unclesHash, byte[] coinbase,
-            byte[] stateRoot, byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] logsBloom, byte[] difficulty, long number,
-            byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
-            Coin paidFees, byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
-            byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] mergedMiningForkDetectionData,
-            byte[] minimumGasPrice, int uncleCount) {
-        boolean useRskip92Encoding = activationConfig.isActive(ConsensusRule.RSKIP92, number);
-        boolean includeForkDetectionData = activationConfig.isActive(ConsensusRule.RSKIP110, number) &&
-                mergedMiningForkDetectionData.length > 0;
-        return new BlockHeader(
-                parentHash, unclesHash, new RskAddress(coinbase),
-                stateRoot, txTrieRoot, receiptTrieRoot,
-                logsBloom, RLP.parseBlockDifficulty(difficulty), number,
-                gasLimit, gasUsed, timestamp, extraData, paidFees,
-                bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
-                mergedMiningForkDetectionData, RLP.parseSignedCoinNonNullZero(minimumGasPrice), uncleCount,
-                false, useRskip92Encoding, includeForkDetectionData
-        );
-    }
-
-    public BlockHeader newHeader(
-            byte[] parentHash, byte[] unclesHash, byte[] coinbase,
-            byte[] logsBloom, byte[] difficulty, long number,
-            byte[] gasLimit, long gasUsed, long timestamp,
-            byte[] extraData, byte[] minimumGasPrice, int uncleCount) {
-        return newHeader(
-                parentHash, unclesHash, coinbase, logsBloom, difficulty,
-                number, gasLimit, gasUsed, timestamp, extraData,
-                null, null, null, new byte[0],
-                minimumGasPrice, uncleCount
-        );
     }
 
     public BlockHeader decodeHeader(byte[] encoded) {

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
@@ -1,0 +1,300 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2020 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.core;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.RLP;
+
+import javax.annotation.Nullable;
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
+
+public class BlockHeaderBuilder {
+
+    private static final byte[] EMPTY_LIST_HASH = HashUtil.keccak256(RLP.encodeList());
+
+    private byte[] parentHash;
+    private byte[] unclesHash;
+    private RskAddress coinbase;
+    private byte[] stateRoot;
+    private byte[] txTrieRoot;
+    private byte[] receiptTrieRoot;
+    private byte[] logsBloom;
+    private BlockDifficulty difficulty;
+    private long timestamp;
+    private long number;
+    private byte[] gasLimit;
+    private long gasUsed;
+    private Coin paidFees;
+
+    private byte[] extraData;
+    private byte[] bitcoinMergedMiningHeader;
+    private byte[] bitcoinMergedMiningMerkleProof;
+    private byte[] bitcoinMergedMiningCoinbaseTransaction;
+    private byte[] mergedMiningForkDetectionData;
+
+    private Coin minimumGasPrice;
+    private int uncleCount;
+
+    private boolean useRskip92Encoding;
+    private boolean includeForkDetectionData;
+
+    private final ActivationConfig activationConfig;
+
+    private boolean createConsensusCompliantHeader;
+
+    public BlockHeaderBuilder(ActivationConfig activationConfig) {
+        this.activationConfig = activationConfig;
+        createConsensusCompliantHeader = true;
+    }
+
+    public BlockHeaderBuilder setCreateConsensusCompliantHeader(boolean createConsensusCompliantHeader) {
+        this.createConsensusCompliantHeader = createConsensusCompliantHeader;
+        return this;
+    }
+
+    public BlockHeaderBuilder setStateRoot(byte[] stateRoot) {
+        this.stateRoot = copy(stateRoot);
+        return this;
+    }
+
+    public BlockHeaderBuilder setDifficulty(BlockDifficulty difficulty) {
+        this.difficulty = difficulty;
+        return this;
+    }
+
+    public BlockHeaderBuilder setPaidFees(Coin paidFees) {
+        this.paidFees = paidFees;
+        return this;
+    }
+
+    public BlockHeaderBuilder setGasUsed(long gasUsed) {
+        this.gasUsed = gasUsed;
+        return this;
+    }
+
+    public BlockHeaderBuilder setLogsBloom(byte[] logsBloom) {
+        this.logsBloom = copy(logsBloom);
+        return this;
+    }
+
+    public BlockHeaderBuilder setBitcoinMergedMiningHeader(byte[] bitcoinMergedMiningHeader) {
+        this.bitcoinMergedMiningHeader = copy(bitcoinMergedMiningHeader);
+        return this;
+    }
+
+    public BlockHeaderBuilder setBitcoinMergedMiningMerkleProof(byte[] bitcoinMergedMiningMerkleProof) {
+        this.bitcoinMergedMiningMerkleProof = copy(bitcoinMergedMiningMerkleProof);
+        return this;
+    }
+
+    public BlockHeaderBuilder setBitcoinMergedMiningCoinbaseTransaction(byte[] bitcoinMergedMiningCoinbaseTransaction) {
+        this.bitcoinMergedMiningCoinbaseTransaction = copy(bitcoinMergedMiningCoinbaseTransaction);
+        return this;
+    }
+
+    public BlockHeaderBuilder setTxTrieRoot(byte[] txTrieRoot) {
+        this.txTrieRoot = copy(txTrieRoot);
+        return this;
+    }
+
+    public BlockHeaderBuilder setEmptyTxTrieRoot() {
+        this.txTrieRoot = EMPTY_TRIE_HASH;
+        return this;
+    }
+
+    public BlockHeaderBuilder setReceiptTrieRoot(byte[] receiptTrieRoot) {
+        this.receiptTrieRoot = copy(receiptTrieRoot);
+        return this;
+    }
+
+    public BlockHeaderBuilder setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    public BlockHeaderBuilder setNumber(long number) {
+        this.number = number;
+        return this;
+    }
+
+    public BlockHeaderBuilder setGasLimit(byte[] gasLimit) {
+        this.gasLimit = copy(gasLimit);
+        return this;
+    }
+
+    public BlockHeaderBuilder setExtraData(byte[] extraData) {
+        this.extraData = copy(extraData);
+        return this;
+    }
+
+    public BlockHeaderBuilder setMergedMiningForkDetectionData(byte[] mergedMiningForkDetectionData) {
+        this.mergedMiningForkDetectionData = copy(mergedMiningForkDetectionData);
+        return this;
+    }
+
+    public BlockHeaderBuilder setMinimumGasPrice(Coin minimumGasPrice) {
+        this.minimumGasPrice = minimumGasPrice;
+        return this;
+    }
+
+    public BlockHeaderBuilder setUncleCount(int uncleCount) {
+        this.uncleCount = uncleCount;
+        return this;
+    }
+
+    public BlockHeaderBuilder setUseRskip92Encoding(boolean useRskip92Encoding) {
+        this.useRskip92Encoding = useRskip92Encoding;
+        return this;
+    }
+
+    public BlockHeaderBuilder setIncludeForkDetectionData(boolean includeForkDetectionData) {
+        this.includeForkDetectionData = includeForkDetectionData;
+        return this;
+    }
+
+    public BlockHeaderBuilder setParentHashFromKeccak256(Keccak256 parentHash) {
+        this.parentHash = copy(parentHash);
+        return this;
+    }
+
+    public BlockHeaderBuilder setParentHash(byte[] parentHash) {
+        this.parentHash = copy(parentHash);
+        return this;
+    }
+
+    public BlockHeaderBuilder setEmptyUnclesHash() {
+        this.unclesHash = EMPTY_LIST_HASH;
+        return this;
+    }
+
+    public BlockHeaderBuilder setUnclesHash(byte[] unclesHash) {
+        this.unclesHash = copy(unclesHash);
+        return this;
+    }
+
+    public BlockHeaderBuilder setCoinbase(RskAddress coinbase) {
+        this.coinbase = coinbase;
+        return this;
+    }
+
+    public BlockHeaderBuilder setDifficultyFromBytes(@Nullable byte[] data) {
+        // This is to make it compatible with RLP.parseBlockDifficulty() which was previously
+        // user (but I think it was wrongly included in the RLP class, because these arguments
+        // do not come from any RLP parsing).
+        if (data != null) {
+            difficulty = new BlockDifficulty(new BigInteger(data));
+        } else {
+            difficulty = null;
+        }
+        return this;
+    }
+
+    public BlockHeaderBuilder setEmptyMergedMiningForkDetectionData() {
+        mergedMiningForkDetectionData = new byte[12];
+        return this;
+    }
+
+    public BlockHeaderBuilder setEmptyExtraData() {
+        extraData = new byte[]{};
+        return this;
+    }
+
+    public BlockHeaderBuilder setEmptyLogsBloom() {
+        logsBloom = copy(new Bloom().getData());
+        return this;
+    }
+
+    public BlockHeaderBuilder setEmptyStateRoot() {
+        stateRoot = EMPTY_TRIE_HASH;
+        return this;
+    }
+
+    public BlockHeaderBuilder setEmptyReceiptTrieRoot() {
+        receiptTrieRoot = EMPTY_TRIE_HASH;
+        return this;
+    }
+
+    private void initializeWithDefaultValues() {
+        extraData = normalizeValue(extraData, new byte[0]);
+        bitcoinMergedMiningHeader = normalizeValue(bitcoinMergedMiningHeader, new byte[0]);
+        bitcoinMergedMiningMerkleProof = normalizeValue(bitcoinMergedMiningMerkleProof, new byte[0]);
+        bitcoinMergedMiningCoinbaseTransaction = normalizeValue(bitcoinMergedMiningCoinbaseTransaction, new byte[0]);
+
+        unclesHash = normalizeValue(unclesHash, EMPTY_LIST_HASH);
+        coinbase = normalizeValue(coinbase, RskAddress.nullAddress());
+        stateRoot = normalizeValue(stateRoot, EMPTY_TRIE_HASH);
+        txTrieRoot = normalizeValue(txTrieRoot, EMPTY_TRIE_HASH);
+        receiptTrieRoot = normalizeValue(receiptTrieRoot, EMPTY_TRIE_HASH);
+        logsBloom = normalizeValue(logsBloom, new Bloom().getData());
+        paidFees = normalizeValue(paidFees, Coin.ZERO);
+        minimumGasPrice = normalizeValue(minimumGasPrice, Coin.ZERO);
+
+        mergedMiningForkDetectionData = normalizeValue(mergedMiningForkDetectionData, new byte[12]);
+    }
+
+    private <T> T normalizeValue(T value, T defaultValue) {
+        return value == null ? defaultValue : value;
+    }
+
+    private byte[] copy(Keccak256 hash) {
+        return copy(hash.getBytes());
+    }
+
+    private byte[] copy(byte[] bytes) {
+        if (bytes == null) {
+            return new byte[0];
+        }
+
+        return Arrays.copyOf(bytes, bytes.length);
+    }
+
+    public BlockHeader build() {
+        // Initial null values in some fields are replaced by empty
+        // arrays
+        initializeWithDefaultValues();
+        if (createConsensusCompliantHeader) {
+            useRskip92Encoding = activationConfig.isActive(ConsensusRule.RSKIP92, number);
+            includeForkDetectionData = activationConfig.isActive(ConsensusRule.RSKIP110, number) &&
+                    mergedMiningForkDetectionData.length > 0;
+        }
+
+        return new BlockHeader(
+                parentHash, unclesHash, coinbase,
+                stateRoot, txTrieRoot, receiptTrieRoot,
+                logsBloom, difficulty, number,
+                gasLimit, gasUsed, timestamp, extraData, paidFees,
+                bitcoinMergedMiningHeader,
+                bitcoinMergedMiningMerkleProof,
+                bitcoinMergedMiningCoinbaseTransaction,
+                mergedMiningForkDetectionData,
+                minimumGasPrice, uncleCount,
+                false, useRskip92Encoding,
+                includeForkDetectionData
+        );
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -496,7 +496,7 @@ public class Program {
 
             programResult.setException(ExceptionHelper.addressCollisionException(contractAddress));
             if (isLogEnabled) {
-                logger.debug("contract run halted by Exception: contract: [{}], exception: [{}]",
+                logger.debug("contract run halted by Exception: contract: [{0}], exception: [{1}]",
                         contractAddress,
                         programResult.getException());
             }
@@ -522,7 +522,7 @@ public class Program {
                 // the first byte in the init code were an invalid opcode
                 programResult.setException(ExceptionHelper.addressCollisionException(contractAddress));
                 if (isLogEnabled) {
-                    logger.debug("contract run halted by Exception: contract: [{}], exception: [{}]",
+                    logger.debug("contract run halted by Exception: contract: [{0}], exception: [{1}]",
                             contractAddress,
                             programResult.getException());
                 }
@@ -612,7 +612,7 @@ public class Program {
 
         if (programResult.getException() != null || programResult.isRevert()) {
             if (isLogEnabled) {
-                logger.debug("contract run halted by Exception: contract: [{}], exception: [{}]",
+                logger.debug("contract run halted by Exception: contract: [{0}], exception: [{1}]",
                         contractAddress,
                         programResult.getException());
             }
@@ -829,7 +829,7 @@ public class Program {
 
         if (childResult.getException() != null || childResult.isRevert()) {
             if (isGasLogEnabled) {
-                gasLogger.debug("contract run halted by Exception: contract: [{}], exception: [{}]",
+                gasLogger.debug("contract run halted by Exception: contract: [{0}], exception: [{1}]",
                         contextAddress,
                         childResult .getException());
             }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -28,9 +28,9 @@ import co.rsk.peg.Bridge;
 import co.rsk.remasc.RemascContract;
 import co.rsk.rpc.modules.trace.CallType;
 import co.rsk.rpc.modules.trace.CreationData;
+import co.rsk.rpc.modules.trace.ProgramSubtrace;
 import co.rsk.vm.BitSet;
 import com.google.common.annotations.VisibleForTesting;
-import org.bouncycastle.pqc.math.linearalgebra.ByteUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -48,7 +48,6 @@ import org.ethereum.vm.PrecompiledContracts.PrecompiledContract;
 import org.ethereum.vm.program.invoke.*;
 import org.ethereum.vm.program.listener.CompositeProgramListener;
 import org.ethereum.vm.program.listener.ProgramListenerAware;
-import co.rsk.rpc.modules.trace.ProgramSubtrace;
 import org.ethereum.vm.trace.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +57,6 @@ import java.util.*;
 
 import static co.rsk.util.ListArrayUtil.*;
 import static java.lang.String.format;
-import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
 import static org.ethereum.util.BIUtil.*;
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
 
@@ -1367,13 +1365,14 @@ public class Program {
             internalTx.setLocalCallTransaction(this.transaction.isLocalCallTransaction());
 
             Block executionBlock = blockFactory.newBlock(
-                    blockFactory.newHeader(
-                            getPrevHash().getData(), EMPTY_BYTE_ARRAY, getCoinbase().getLast20Bytes(),
-                            ByteUtils.clone(EMPTY_TRIE_HASH), ByteUtils.clone(EMPTY_TRIE_HASH),
-                            ByteUtils.clone(EMPTY_TRIE_HASH), EMPTY_BYTE_ARRAY, getDifficulty().getData(),
-                            getNumber().longValue(), getGasLimit().getData(), 0, getTimestamp().longValue(),
-                            EMPTY_BYTE_ARRAY, Coin.ZERO, null, null, null, new byte[0], null, 0
-                    ),
+                    blockFactory.getBlockHeaderBuilder()
+                        .setParentHash(getPrevHash().getData())
+                        .setCoinbase(new RskAddress(getCoinbase().getLast20Bytes()))
+                        .setDifficultyFromBytes(getDifficulty().getData())
+                        .setNumber(getNumber().longValue())
+                        .setGasLimit(getGasLimit().getData())
+                        .setTimestamp(getTimestamp().longValue())
+                        .build(),
                     Collections.emptyList(),
                     Collections.emptyList()
             );

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -202,27 +202,27 @@ public class BlockFactoryTest {
         byte[] gasLimit = BigInteger.valueOf(6800000).toByteArray();
         long timestamp = 7731067; // Friday, 10 May 2019 6:04:05
 
-        return factory.newHeader(
-                PegTestUtils.createHash3().getBytes(),
-                HashUtil.keccak256(RLP.encodeList()),
-                TestUtils.randomAddress().getBytes(),
-                HashUtil.EMPTY_TRIE_HASH,
-                "tx_trie_root".getBytes(),
-                HashUtil.EMPTY_TRIE_HASH,
-                new Bloom().getData(),
-                difficulty,
-                number,
-                gasLimit,
-                3000000L,
-                timestamp,
-                null,
-                Coin.ZERO,
-                new byte[80],
-                new byte[32],
-                new byte[128],
-                forkDetectionData,
-                Coin.valueOf(10L).getBytes(),
-                0);
+        return factory.getBlockHeaderBuilder()
+                .setParentHash(TestUtils.randomHash().getBytes())
+                .setEmptyUnclesHash()
+                .setCoinbase(TestUtils.randomAddress())
+                .setEmptyStateRoot()
+                .setTxTrieRoot("tx_trie_root".getBytes())
+                .setEmptyLogsBloom()
+                .setEmptyReceiptTrieRoot()
+                .setDifficultyFromBytes(difficulty)
+                .setNumber(number)
+                .setGasLimit(gasLimit)
+                .setGasUsed( 3000000L)
+                .setTimestamp(timestamp)
+                .setEmptyExtraData()
+                .setBitcoinMergedMiningHeader(new byte[80])
+                .setBitcoinMergedMiningMerkleProof(new byte[32])
+                .setBitcoinMergedMiningCoinbaseTransaction(new byte[128])
+                .setMergedMiningForkDetectionData(forkDetectionData)
+                .setMinimumGasPrice(Coin.valueOf(10L))
+                .setUncleCount(0)
+                .build();
     }
 
     private BlockHeader createBlockHeader(
@@ -232,27 +232,24 @@ public class BlockFactoryTest {
         byte[] gasLimit = BigInteger.valueOf(6800000).toByteArray();
         long timestamp = 7731067; // Friday, 10 May 2019 6:04:05
 
-        return factory.newHeader(
-                PegTestUtils.createHash3().getBytes(),
-                HashUtil.keccak256(RLP.encodeList()),
-                TestUtils.randomAddress().getBytes(),
-                HashUtil.EMPTY_TRIE_HASH,
-                "tx_trie_root".getBytes(),
-                HashUtil.EMPTY_TRIE_HASH,
-                new Bloom().getData(),
-                difficulty,
-                number,
-                gasLimit,
-                3000000L,
-                timestamp,
-                null,
-                Coin.ZERO,
-                null,
-                null,
-                null,
-                forkDetectionData,
-                Coin.valueOf(10L).getBytes(),
-                0);
+        return factory.getBlockHeaderBuilder()
+                .setParentHash(TestUtils.randomHash().getBytes())
+                .setEmptyUnclesHash()
+                .setCoinbase(TestUtils.randomAddress())
+                .setEmptyStateRoot()
+                .setTxTrieRoot("tx_trie_root".getBytes())
+                .setEmptyLogsBloom()
+                .setEmptyReceiptTrieRoot()
+                .setDifficultyFromBytes(difficulty)
+                .setNumber(number)
+                .setGasLimit(gasLimit)
+                .setGasUsed( 3000000L)
+                .setTimestamp(timestamp)
+                .setEmptyExtraData()
+                .setMergedMiningForkDetectionData(forkDetectionData)
+                .setMinimumGasPrice(Coin.valueOf(10L))
+                .setUncleCount(0)
+                .build();
     }
 
 

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -71,14 +71,27 @@ public class BlockTest {
         Transaction remascTx = new RemascTransaction(1);
         txs.add(remascTx);
 
+        BlockHeader newHeader = blockFactory.getBlockHeaderBuilder()
+                .setParentHashFromKeccak256(PegTestUtils.createHash3())
+                .setEmptyUnclesHash()
+                .setCoinbase(TestUtils.randomAddress())
+                .setEmptyStateRoot()
+                .setTxTrieRoot( BlockHashesHelper.getTxTrieRoot(txs, true))
+                .setEmptyLogsBloom()
+                .setEmptyReceiptTrieRoot()
+                .setDifficultyFromBytes(BigInteger.ONE.toByteArray())
+                .setNumber(1)
+                .setGasLimit(BigInteger.valueOf(4000000).toByteArray())
+                .setGasUsed( 3000000L)
+                .setTimestamp(100)
+                .setEmptyExtraData()
+                .setEmptyMergedMiningForkDetectionData()
+                .setMinimumGasPrice(new Coin(BigInteger.TEN))
+                .setUncleCount(0)
+                .build();
+
         Block block = blockFactory.newBlock(
-                blockFactory.newHeader(
-                        PegTestUtils.createHash3().getBytes(), EMPTY_LIST_HASH, TestUtils.randomAddress().getBytes(),
-                        HashUtil.EMPTY_TRIE_HASH, BlockHashesHelper.getTxTrieRoot(txs, true),
-                        HashUtil.EMPTY_TRIE_HASH, new Bloom().getData(), BigInteger.ONE.toByteArray(), 1,
-                        BigInteger.valueOf(4000000).toByteArray(), 3000000, 100, new byte[0], Coin.ZERO,
-                        null, null, null, new byte[12], BigInteger.TEN.toByteArray(), 0
-                ),
+                newHeader,
                 txs,
                 Collections.emptyList()
         );

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
@@ -156,7 +156,7 @@ public class BlockChainImplTest {
         Block genesis = blockChain.getBestBlock();
         Block block1 = new BlockGenerator().createChildBlock(genesis);
 
-        alterBytes(block1.getHeader().getStateRoot());
+        block1.getHeader().setStateRoot(cloneAlterBytes(block1.getHeader().getStateRoot()));
 
         Assert.assertEquals(ImportResult.INVALID_BLOCK, blockChain.tryToConnect(block1));
     }
@@ -166,7 +166,7 @@ public class BlockChainImplTest {
         Block genesis = blockChain.getBestBlock();
         Block block1 = new BlockGenerator().createChildBlock(genesis);
 
-        alterBytes(block1.getHeader().getReceiptsRoot());
+        block1.getHeader().setReceiptsRoot(cloneAlterBytes(block1.getHeader().getReceiptsRoot()));
 
         Assert.assertEquals(ImportResult.INVALID_BLOCK, blockChain.tryToConnect(block1));
     }
@@ -176,7 +176,7 @@ public class BlockChainImplTest {
         Block genesis = blockChain.getBestBlock();
         Block block1 = new BlockGenerator().createChildBlock(genesis);
 
-        alterBytes(block1.getHeader().getLogsBloom());
+        block1.getHeader().setLogsBloom(cloneAlterBytes(block1.getHeader().getLogsBloom()));
 
         Assert.assertEquals(ImportResult.INVALID_BLOCK, blockChain.tryToConnect(block1));
     }
@@ -662,17 +662,13 @@ public class BlockChainImplTest {
         return block;
     }
 
-    private static void alterBytes(byte[] bytes) {
-        bytes[0] = (byte)((bytes[0] + 1) % 256);
-    }
-
     private static byte[] cloneAlterBytes(byte[] bytes) {
         byte[] cloned = Arrays.clone(bytes);
 
         if (cloned == null)
             return new byte[] { 0x01 };
 
-        alterBytes(cloned);
+        cloned[0] = (byte)((cloned[0] + 1) % 256);
         return cloned;
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -349,14 +349,16 @@ public class BlockValidatorTest {
         BlockGenerator blockGenerator = new BlockGenerator();
 
         Block genesis = blockGenerator.getGenesisBlock();
+
+        BlockHeader newHeader = blockFactory.getBlockHeaderBuilder()
+                .setCoinbase(TestUtils.randomAddress())
+                .setDifficulty(TEST_DIFFICULTY)
+                .setEmptyMergedMiningForkDetectionData()
+                .setMinimumGasPrice(Coin.valueOf(10))
+                .build();
+
         Block uncle1a = blockGenerator.createChildBlock(blockFactory.newBlock(
-                blockFactory.newHeader(
-                        null, null, TestUtils.randomAddress().getBytes(),
-                        null, HashUtil.EMPTY_TRIE_HASH, null,
-                        null, TEST_DIFFICULTY.getBytes(), 0,
-                        null, 0L, 0L, new byte[]{}, Coin.ZERO,
-                        null, null, null, new byte[12], Coin.valueOf(10).getBytes(), 0
-                ),
+                newHeader,
                 Collections.emptyList(),
                 Collections.emptyList()
         ));

--- a/rskj-core/src/test/java/co/rsk/net/NetBlockStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NetBlockStoreTest.java
@@ -19,6 +19,7 @@
 package co.rsk.net;
 
 import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.core.Coin;
 import com.google.common.collect.Lists;
 import org.ethereum.TestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
@@ -221,23 +222,12 @@ public class NetBlockStoreTest {
     @Test
     public void saveHeader() {
         NetBlockStore store = new NetBlockStore();
-        BlockHeader blockHeader = blockFactory.newHeader(new byte[]{},
-                new byte[]{},
-                TestUtils.randomAddress().getBytes(),
-                new Bloom().getData(),
-                null,
-                1,
-                new byte[]{},
-                0,
-                0,
-                new byte[]{},
-                new byte[]{},
-                new byte[]{},
-                new byte[]{},
-                new byte[]{},
-                new byte[]{0},
-                0
-        );
+        BlockHeader blockHeader = blockFactory.getBlockHeaderBuilder()
+                .setParentHash(new byte[0])
+                .setCoinbase(TestUtils.randomAddress())
+                .setNumber(1)
+                .setMinimumGasPrice(Coin.ZERO)
+                .build();
 
         store.saveHeader(blockHeader);
         Assert.assertTrue(store.hasHeader(blockHeader.getHash()));
@@ -246,23 +236,12 @@ public class NetBlockStoreTest {
     @Test
     public void removeHeader() {
         NetBlockStore store = new NetBlockStore();
-        BlockHeader blockHeader = blockFactory.newHeader(new byte[]{},
-                new byte[]{},
-                TestUtils.randomAddress().getBytes(),
-                new Bloom().getData(),
-                null,
-                1,
-                new byte[]{},
-                0,
-                0,
-                new byte[]{},
-                new byte[]{},
-                new byte[]{},
-                new byte[]{},
-                new byte[]{},
-                new byte[]{0},
-                0
-        );
+        BlockHeader blockHeader = blockFactory.getBlockHeaderBuilder()
+                .setParentHash(new byte[0])
+                .setCoinbase(TestUtils.randomAddress())
+                .setNumber(1)
+                .setMinimumGasPrice(Coin.ZERO)
+                .build();
 
         store.saveHeader(blockHeader);
         store.removeHeader(blockHeader);

--- a/rskj-core/src/test/java/co/rsk/validators/BlockDifficultyValidationRuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/BlockDifficultyValidationRuleTest.java
@@ -51,11 +51,12 @@ public class BlockDifficultyValidationRuleTest {
     }
 
     private BlockHeader getEmptyHeader(BlockDifficulty difficulty, long blockTimestamp, int uCount) {
-        BlockHeader header = blockFactory.newHeader(null, null,
-                TestUtils.randomAddress().getBytes(), null, difficulty.getBytes(), 0,
-                null, 0,
-                blockTimestamp, null, null, uCount);
-        return header;
+        return blockFactory.getBlockHeaderBuilder()
+                .setCoinbase(TestUtils.randomAddress())
+                .setDifficulty(difficulty)
+                .setTimestamp(blockTimestamp)
+                .setUncleCount(uCount)
+                .build();
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/TestUtils.java
+++ b/rskj-core/src/test/java/org/ethereum/TestUtils.java
@@ -25,6 +25,7 @@ import co.rsk.crypto.Keccak256;
 import org.apache.commons.lang3.StringUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
+import org.ethereum.core.BlockHeader;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.vm.DataWord;
 import org.mapdb.DB;
@@ -110,14 +111,17 @@ public final class TestUtils {
             byte[] difficutly = new BigInteger(8, new Random()).toByteArray();
             byte[] newHash = HashUtil.randomHash();
 
+            BlockHeader newHeader = blockFactory.getBlockHeaderBuilder()
+                    .setParentHash(lastHash)
+                    .setUnclesHash(newHash)
+                    .setCoinbase(RskAddress.nullAddress())
+                    .setStateRoot(HashUtil.randomHash())
+                    .setDifficultyFromBytes(difficutly)
+                    .setNumber(lastIndex)
+                    .build();
+
             Block block = blockFactory.newBlock(
-                    blockFactory.newHeader(
-                            lastHash, newHash, RskAddress.nullAddress().getBytes(),
-                            HashUtil.randomHash(), EMPTY_TRIE_HASH, null,
-                            null, difficutly, lastIndex,
-                            new byte[] {0}, 0, 0, null, Coin.ZERO,
-                            null, null, null, null, null, 0
-                    ),
+                    newHeader,
                     Collections.emptyList(),
                     Collections.emptyList()
             );

--- a/rskj-core/src/test/java/org/ethereum/core/BlockHeaderBuilderTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockHeaderBuilderTest.java
@@ -1,0 +1,362 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.core;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import org.ethereum.TestUtils;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+public class BlockHeaderBuilderTest {
+    private static final byte[] EMPTY_UNCLES_LIST_HASH = HashUtil.keccak256(RLP.encodeList(new byte[0]));
+
+    private BlockHeaderBuilder blockHeaderBuilder;
+
+    @Before
+    public void setup() {
+        blockHeaderBuilder = new BlockHeaderBuilder(ActivationConfigsForTest.all());
+    }
+
+    @Test
+    public void createsHeaderWithParentHash() {
+        Keccak256 parentHash = TestUtils.randomHash();
+
+        BlockHeader header = blockHeaderBuilder
+                                .setParentHash(parentHash.getBytes())
+                                .build();
+
+        assertEquals(parentHash, header.getParentHash());
+    }
+
+    @Test
+    public void createsHeaderWithUnclesHash() {
+        byte[] unclesHash = TestUtils.randomHash().getBytes();
+
+        BlockHeader header = blockHeaderBuilder
+                .setUnclesHash(unclesHash)
+                .build();
+
+        assertArrayEquals(unclesHash, header.getUnclesHash());
+    }
+
+    @Test
+    public void createsHeaderWithEmptyUnclesHash() {
+        BlockHeader header = blockHeaderBuilder
+                .setEmptyUnclesHash()
+                .build();
+
+        assertTrue(Arrays.equals(EMPTY_UNCLES_LIST_HASH, header.getUnclesHash()));
+    }
+
+    @Test
+    public void createsHeaderWithCoinbase() {
+        RskAddress coinbase = TestUtils.randomAddress();
+
+        BlockHeader header = blockHeaderBuilder
+                .setCoinbase(coinbase)
+                .build();
+
+        assertEquals(coinbase, header.getCoinbase());
+    }
+
+    @Test
+    public void createsHeaderWithStateRoot() {
+        byte[] stateRoot = TestUtils.randomHash().getBytes();
+
+        BlockHeader header = blockHeaderBuilder
+                .setStateRoot(stateRoot)
+                .build();
+
+        assertArrayEquals(stateRoot, header.getStateRoot());
+    }
+
+    @Test
+    public void createsHeaderWithEmptyStateRoot() {
+        BlockHeader header = blockHeaderBuilder.build();
+
+        assertArrayEquals(HashUtil.EMPTY_TRIE_HASH, header.getStateRoot());
+    }
+
+    @Test
+    public void createsHeaderWithTxTrieRoot() {
+        byte[] txTrieRoot = TestUtils.randomHash().getBytes();
+
+        BlockHeader header = blockHeaderBuilder
+                .setTxTrieRoot(txTrieRoot)
+                .build();
+
+        assertArrayEquals(txTrieRoot, header.getTxTrieRoot());
+    }
+
+    @Test
+    public void createsHeaderWithEmptyTxTrieRoot() {
+        BlockHeader header = blockHeaderBuilder.build();
+
+        assertArrayEquals(HashUtil.EMPTY_TRIE_HASH, header.getTxTrieRoot());
+    }
+
+    @Test
+    public void createsHeaderWithReceiptTrieRoot() {
+        byte[] receiptTrieRoot = TestUtils.randomHash().getBytes();
+
+        BlockHeader header = blockHeaderBuilder
+                .setReceiptTrieRoot(receiptTrieRoot)
+                .build();
+
+        assertArrayEquals(receiptTrieRoot, header.getReceiptsRoot());
+    }
+
+    @Test
+    public void createsHeaderWithEmptyReceiptTrieRoot() {
+        BlockHeader header = blockHeaderBuilder.build();
+
+        assertArrayEquals(HashUtil.EMPTY_TRIE_HASH, header.getReceiptsRoot());
+    }
+
+    @Test
+    public void createsHeaderWithLogsBloom() {
+        byte[] logsBloom = TestUtils.randomHash().getBytes();
+
+        BlockHeader header = blockHeaderBuilder
+                .setLogsBloom(logsBloom)
+                .build();
+
+        assertArrayEquals(logsBloom, header.getLogsBloom());
+    }
+
+    @Test
+    public void createsHeaderWithEmptyLogsBloom() {
+        BlockHeader header = blockHeaderBuilder.build();
+
+        assertArrayEquals(new Bloom().getData(), header.getLogsBloom());
+    }
+
+    @Test
+    public void createsHeaderWithDifficulty() {
+        BlockDifficulty bDiff = new BlockDifficulty(BigInteger.valueOf(10));
+
+        BlockHeader header = blockHeaderBuilder
+                .setDifficulty(bDiff)
+                .build();
+
+        assertEquals(bDiff, header.getDifficulty());
+    }
+
+    @Test
+    public void createsHeaderWithDifficultyFromBytes() {
+        byte[] bDiffData = new byte[] { 0, 16 };
+
+        BlockHeader header = blockHeaderBuilder
+                .setDifficultyFromBytes(bDiffData)
+                .build();
+
+        BlockDifficulty bDiff = new BlockDifficulty(BigInteger.valueOf(16));
+        assertEquals(bDiff, header.getDifficulty());
+    }
+
+    @Test
+    public void createsHeaderWithPaidFees() {
+        Coin fees = new Coin(BigInteger.valueOf(10));
+
+        BlockHeader header = blockHeaderBuilder
+                .setPaidFees(fees)
+                .build();
+
+        assertEquals(fees, header.getPaidFees());
+    }
+
+    @Test
+    public void createsHeaderWithEmptyPaidFees() {
+        BlockHeader header = blockHeaderBuilder.build();
+
+        assertEquals(Coin.valueOf(0), header.getPaidFees());
+    }
+
+    @Test
+    public void createsHeaderWithMininmumGasPrice() {
+        Coin minGasPrice = new Coin(BigInteger.valueOf(10));
+
+        BlockHeader header = blockHeaderBuilder
+                .setMinimumGasPrice(minGasPrice)
+                .build();
+
+        assertEquals(minGasPrice, header.getMinimumGasPrice());
+    }
+
+    @Test
+    public void createsHeaderWithEmptyMinimumGasPrice() {
+        BlockHeader header = blockHeaderBuilder.build();
+
+        assertEquals(Coin.valueOf(0), header.getMinimumGasPrice());
+    }
+
+    @Test
+    public void createsHeaderWithMiningFields() {
+        byte[] btcCoinbase = TestUtils.randomBytes(128);
+        byte[] btcHeader = TestUtils.randomBytes(80);
+        byte[] merkleProof = TestUtils.randomBytes(32);
+        byte[] extraData = TestUtils.randomBytes(32);
+
+        BlockHeader header = blockHeaderBuilder
+                .setBitcoinMergedMiningHeader(btcHeader)
+                .setBitcoinMergedMiningMerkleProof(merkleProof)
+                .setBitcoinMergedMiningCoinbaseTransaction(btcCoinbase)
+                .setExtraData(extraData)
+                .build();
+
+        assertTrue(Arrays.equals(btcCoinbase, header.getBitcoinMergedMiningCoinbaseTransaction()));
+        assertTrue(Arrays.equals(btcHeader, header.getBitcoinMergedMiningHeader()));
+        assertTrue(Arrays.equals(merkleProof, header.getBitcoinMergedMiningMerkleProof()));
+        assertTrue(Arrays.equals(extraData, header.getExtraData()));
+    }
+
+    @Test
+    public void createsHeaderWithEmptyMergedMiningFields() {
+        BlockHeader header = blockHeaderBuilder.build();
+
+        assertTrue(Arrays.equals(new byte[0], header.getBitcoinMergedMiningMerkleProof()));
+        assertTrue(Arrays.equals(new byte[0], header.getBitcoinMergedMiningHeader()));
+        assertTrue(Arrays.equals(new byte[0], header.getBitcoinMergedMiningCoinbaseTransaction()));
+        assertTrue(Arrays.equals(new byte[0], header.getExtraData()));
+    }
+
+    @Test
+    public void createsHeaderWithUseRRSKIP92EncodingOn() {
+        byte[] btcCoinbase = TestUtils.randomBytes(128);
+        byte[] btcHeader = TestUtils.randomBytes(80);
+        byte[] merkleProof = TestUtils.randomBytes(32);
+
+        BlockHeader header = blockHeaderBuilder
+                .setCreateConsensusCompliantHeader(false)
+                .setBitcoinMergedMiningHeader(btcHeader)
+                .setBitcoinMergedMiningMerkleProof(merkleProof)
+                .setBitcoinMergedMiningCoinbaseTransaction(btcCoinbase)
+                .setUseRskip92Encoding(true)
+                .build();
+
+        RLPList rlpList = RLP.decodeList(header.getEncoded());
+        assertEquals(17, rlpList.size());
+    }
+
+    @Test
+    public void createsHeaderWithUseRRSKIP92EncodingOff() {
+        byte[] btcCoinbase = TestUtils.randomBytes(128);
+        byte[] btcHeader = TestUtils.randomBytes(80);
+        byte[] merkleProof = TestUtils.randomBytes(32);
+
+        BlockHeader header = blockHeaderBuilder
+                .setCreateConsensusCompliantHeader(false)
+                .setBitcoinMergedMiningHeader(btcHeader)
+                .setBitcoinMergedMiningMerkleProof(merkleProof)
+                .setBitcoinMergedMiningCoinbaseTransaction(btcCoinbase)
+                .setUseRskip92Encoding(false)
+                .build();
+
+        RLPList rlpList = RLP.decodeList(header.getEncoded());
+        assertEquals(19, rlpList.size());
+    }
+
+    @Test
+    public void createsHeaderWithUseRRSKIP92EncodingOffButConsensusCompliantOn() {
+        byte[] btcCoinbase = TestUtils.randomBytes(128);
+        byte[] btcHeader = TestUtils.randomBytes(80);
+        byte[] merkleProof = TestUtils.randomBytes(32);
+
+        BlockHeader header = blockHeaderBuilder
+                .setCreateConsensusCompliantHeader(true)
+                .setBitcoinMergedMiningHeader(btcHeader)
+                .setBitcoinMergedMiningMerkleProof(merkleProof)
+                .setBitcoinMergedMiningCoinbaseTransaction(btcCoinbase)
+                .setUseRskip92Encoding(false)
+                .build();
+
+        // the useRskip92Field should be true, hence the merkle proof and coinbase are not included
+        RLPList rlpList = RLP.decodeList(header.getEncoded());
+        assertEquals(17, rlpList.size());
+    }
+
+    @Test
+    public void createsHeaderWithIncludeForkDetectionDataOn() {
+        byte[] expectedForkDetectionData = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+
+        BlockHeader header = blockHeaderBuilder
+                .setCreateConsensusCompliantHeader(false)
+                .setMergedMiningForkDetectionData(expectedForkDetectionData)
+                .setIncludeForkDetectionData(true)
+                .build();
+
+        byte[] hashForMergedMining = header.getHashForMergedMining();
+        byte[] forkDetectionData = Arrays.copyOfRange(hashForMergedMining, 20, 32);
+
+        assertArrayEquals(expectedForkDetectionData, forkDetectionData);
+    }
+
+    @Test
+    public void createsHeaderWithIncludeForkDetectionDataOff() {
+        byte[] expectedForkDetectionData = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+
+        BlockHeader header = blockHeaderBuilder
+                .setCreateConsensusCompliantHeader(false)
+                .setMergedMiningForkDetectionData(expectedForkDetectionData)
+                .setIncludeForkDetectionData(false)
+                .build();
+
+        byte[] hashForMergedMining = header.getHashForMergedMining();
+        byte[] retrievedForkDetectionData = Arrays.copyOfRange(hashForMergedMining, 20, 32);
+
+        assertFalse(Arrays.equals(expectedForkDetectionData, retrievedForkDetectionData));
+    }
+
+    @Test
+    public void createsHeaderWithIncludeForkDetectionDataOffButConsensusCompliantOn() {
+        byte[] expectedForkDetectionData = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+
+        BlockHeader header = blockHeaderBuilder
+                .setCreateConsensusCompliantHeader(true)
+                .setMergedMiningForkDetectionData(expectedForkDetectionData)
+                .setIncludeForkDetectionData(false)
+                .build();
+
+        byte[] hashForMergedMining = header.getHashForMergedMining();
+        byte[] retrievedForkDetectionData = Arrays.copyOfRange(hashForMergedMining, 20, 32);
+
+        assertArrayEquals(expectedForkDetectionData, retrievedForkDetectionData);
+    }
+
+    @Test
+    public void createsHeaderWithEmptyMergedMiningForkDetectionData() {
+        BlockHeader header = blockHeaderBuilder
+                .setEmptyMergedMiningForkDetectionData()
+                .build();
+
+        assertArrayEquals(new byte[12], header.getMiningForkDetectionData());
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/DifficultyTestCase.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/DifficultyTestCase.java
@@ -94,20 +94,27 @@ public class DifficultyTestCase {
     }
 
     public BlockHeader getCurrent(BlockFactory blockFactory) {
-        return blockFactory.newHeader(
-                EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, TestUtils.randomAddress().getBytes(), EMPTY_BYTE_ARRAY, null,
-                org.ethereum.json.Utils.parseLong(currentBlockNumber), new byte[] {0}, 0,
-                org.ethereum.json.Utils.parseLong(currentTimestamp),
-                EMPTY_BYTE_ARRAY, null, 0);
+        return blockFactory.getBlockHeaderBuilder()
+            .setParentHash(EMPTY_BYTE_ARRAY)
+            .setUnclesHash(EMPTY_BYTE_ARRAY)
+            .setCoinbase(TestUtils.randomAddress())
+            .setLogsBloom(EMPTY_BYTE_ARRAY)
+            .setNumber(org.ethereum.json.Utils.parseLong(currentBlockNumber))
+            .setTimestamp(org.ethereum.json.Utils.parseLong(currentTimestamp))
+            .build();
     }
 
     public BlockHeader getParent(BlockFactory blockFactory) {
-        return blockFactory.newHeader(
-                EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, TestUtils.randomAddress().getBytes(), EMPTY_BYTE_ARRAY,
-                parseDifficulty(parentDifficulty).toByteArray(),
-                org.ethereum.json.Utils.parseLong(currentBlockNumber) - 1, new byte[] {0}, 0,
-                org.ethereum.json.Utils.parseLong(parentTimestamp),
-                EMPTY_BYTE_ARRAY, null, 0);
+        return blockFactory.getBlockHeaderBuilder()
+                .setParentHash(EMPTY_BYTE_ARRAY)
+                .setUnclesHash(EMPTY_BYTE_ARRAY)
+                .setDifficultyFromBytes(parseDifficulty(parentDifficulty).toByteArray())
+                .setCoinbase(TestUtils.randomAddress())
+                .setLogsBloom(EMPTY_BYTE_ARRAY)
+                .setNumber(org.ethereum.json.Utils.parseLong(currentBlockNumber) - 1)
+                .setTimestamp(org.ethereum.json.Utils.parseLong(parentTimestamp))
+                .build();
+
     }
 
     public BlockDifficulty getExpectedDifficulty() {

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -708,27 +708,21 @@ public class TestRunner {
     }
 
     private static BlockHeader buildHeader(BlockFactory blockFactory, BlockHeaderTck headerTck) {
-        return blockFactory.newHeader(
-                parseData(headerTck.getParentHash()),
-                parseData(headerTck.getUncleHash()),
-                parseData(headerTck.getCoinbase()),
-                parseData(headerTck.getStateRoot()),
-                parseData(headerTck.getTransactionsTrie()),
-                parseData(headerTck.getReceiptTrie()),
-                parseData(headerTck.getBloom()),
-                parseNumericData(headerTck.getDifficulty()),
-                getPositiveLong(headerTck.getNumber()),
-                parseData(headerTck.getGasLimit()),
-                getPositiveLong(headerTck.getGasUsed()),
-                getPositiveLong(headerTck.getTimestamp()),
-                parseData(headerTck.getExtraData()),
-                Coin.ZERO,
-                null,
-                null,
-                null,
-                null,
-                null,
-                0
-        );
+        return blockFactory.getBlockHeaderBuilder()
+                .setParentHash(parseData(headerTck.getParentHash()))
+                .setUnclesHash(parseData(headerTck.getUncleHash()))
+                .setCoinbase(new RskAddress(parseData(headerTck.getCoinbase())))
+                .setStateRoot(parseData(headerTck.getStateRoot()))
+                .setTxTrieRoot(parseData(headerTck.getTransactionsTrie()))
+                .setReceiptTrieRoot(parseData(headerTck.getReceiptTrie()))
+                .setLogsBloom(parseData(headerTck.getBloom()))
+                .setDifficultyFromBytes(parseNumericData(headerTck.getDifficulty()))
+                .setNumber(getPositiveLong(headerTck.getNumber()))
+                .setGasLimit(parseData(headerTck.getGasLimit()))
+                .setGasUsed(getPositiveLong(headerTck.getGasUsed()))
+                .setTimestamp(getPositiveLong(headerTck.getTimestamp()))
+                .setExtraData(parseData(headerTck.getExtraData()))
+                .setUncleCount(0)
+                .build();
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -216,17 +216,23 @@ public class StateTestRunner {
 
     public static final byte[] ZERO32_BYTE_ARRAY = new byte[32];
     public Block build(Env env) {
+        BlockHeader newHeader = blockFactory.getBlockHeaderBuilder()
+                // Don't use the empty parent hash because it's used to log and
+                // when log entries are printed with empty parent hash it throws
+                // an exception.
+                .setParentHash(ZERO32_BYTE_ARRAY)
+                .setCoinbase(new RskAddress(env.getCurrentCoinbase()))
+                .setDifficultyFromBytes(env.getCurrentDifficulty())
+                .setNumber(byteArrayToLong(env.getCurrentNumber()))
+                .setGasLimit(env.getCurrentGasLimit())
+                .setGasUsed(0)
+                .setTimestamp(byteArrayToLong(env.getCurrentTimestamp()))
+                .setExtraData(new byte[32])
+                .setUncleCount(0)
+                .build();
+
         return blockFactory.newBlock(
-                blockFactory.newHeader(
-                        // Don't use the empty parent hash because it's used to log and
-                        // when log entries are printed with empty parent hash it throws
-                        // an exception.
-                        ZERO32_BYTE_ARRAY , ByteUtil.EMPTY_BYTE_ARRAY, env.getCurrentCoinbase(),
-                        EMPTY_TRIE_HASH, EMPTY_TRIE_HASH, EMPTY_TRIE_HASH,
-                        ByteUtil.EMPTY_BYTE_ARRAY, env.getCurrentDifficulty(), byteArrayToLong(env.getCurrentNumber()),
-                        env.getCurrentGasLimit(), 0L, byteArrayToLong(env.getCurrentTimestamp()),
-                        new byte[32], Coin.ZERO, ZERO_BYTE_ARRAY, ZERO_BYTE_ARRAY, ZERO_BYTE_ARRAY, ZERO_BYTE_ARRAY,null, 0
-                ),
+                newHeader,
                 Collections.emptyList(),
                 Collections.emptyList(),
                 false

--- a/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/DifficultyRuleTest.java
@@ -59,9 +59,10 @@ public class DifficultyRuleTest {
     private BlockHeader getHeader(long difficultyValue) {
         byte[] difficulty = DataWord.valueOf(difficultyValue).getData();
 
-        BlockHeader header = blockFactory.newHeader(null, null, TestUtils.randomAddress().getBytes(), null, difficulty, 0,
-                null, 0,
-                0, null, null, 0);
+        BlockHeader header = blockFactory.getBlockHeaderBuilder()
+                .setCoinbase(TestUtils.randomAddress())
+                .setDifficultyFromBytes(difficulty)
+                .build();
 
         return header;
     }

--- a/rskj-core/src/test/java/org/ethereum/validator/ParentGasLimitRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/ParentGasLimitRuleTest.java
@@ -88,9 +88,11 @@ public class ParentGasLimitRuleTest {
     public static BlockHeader getHeader(BlockFactory blockFactory, long gasLimitValue) {
         byte[] gasLimit = DataWord.valueOf(gasLimitValue).getData();
 
-        BlockHeader header = blockFactory.newHeader(null, null, TestUtils.randomAddress().getBytes(),
-                null, BlockDifficulty.ZERO.getBytes(), 0, gasLimit, 0,
-                0, null, null, 0);
+        BlockHeader header = blockFactory.getBlockHeaderBuilder()
+                .setCoinbase(TestUtils.randomAddress())
+                .setDifficulty(BlockDifficulty.ZERO)
+                .setGasLimit(gasLimit)
+                .build();
 
         return header;
     }

--- a/rskj-core/src/test/java/org/ethereum/validator/ParentNumberRuleTest.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/ParentNumberRuleTest.java
@@ -58,8 +58,10 @@ public class ParentNumberRuleTest {
     }
 
     private static BlockHeader getHeader(long number) {
-        return blockFactory.newHeader(null, null, TestUtils.randomAddress().getBytes(),
-                null, BlockDifficulty.ZERO.getBytes(), number, null, 0,
-                0, null, null, 0);
+        return blockFactory.getBlockHeaderBuilder()
+                .setCoinbase(TestUtils.randomAddress())
+                .setDifficulty(BlockDifficulty.ZERO)
+                .setNumber(number)
+                .build();
     }
 }


### PR DESCRIPTION
 This new class serves as a more flexible alternative to the newHeader construction methods from BlockFactory

Pending work: decouple BlockHeaderBuilder creation from BlockFactory. There may be some places where it should be carefully thought how the `ActivationConfig` parameter should be obtained to inject into the constructor.

This PR decouples the BlockHeaderBuilder changes from https://github.com/rsksmart/rskj/pull/1171