### PR TITLE
Fix minor debug logging error in Program class

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -496,7 +496,7 @@ public class Program {
 
             programResult.setException(ExceptionHelper.addressCollisionException(contractAddress));
             if (isLogEnabled) {
-                logger.debug("contract run halted by Exception: contract: [{0}], exception: [{1}]",
+                logger.debug("contract run halted by Exception: contract: [{}], exception: ",
                         contractAddress,
                         programResult.getException());
             }
@@ -522,7 +522,7 @@ public class Program {
                 // the first byte in the init code were an invalid opcode
                 programResult.setException(ExceptionHelper.addressCollisionException(contractAddress));
                 if (isLogEnabled) {
-                    logger.debug("contract run halted by Exception: contract: [{0}], exception: [{1}]",
+                    logger.debug("contract run halted by Exception: contract: [{}], exception: ",
                             contractAddress,
                             programResult.getException());
                 }
@@ -612,7 +612,7 @@ public class Program {
 
         if (programResult.getException() != null || programResult.isRevert()) {
             if (isLogEnabled) {
-                logger.debug("contract run halted by Exception: contract: [{0}], exception: [{1}]",
+                logger.debug("contract run halted by Exception: contract: [{}], exception: ",
                         contractAddress,
                         programResult.getException());
             }
@@ -829,7 +829,7 @@ public class Program {
 
         if (childResult.getException() != null || childResult.isRevert()) {
             if (isGasLogEnabled) {
-                gasLogger.debug("contract run halted by Exception: contract: [{0}], exception: [{1}]",
+                gasLogger.debug("contract run halted by Exception: contract: [{}], exception: ",
                         contextAddress,
                         childResult .getException());
             }


### PR DESCRIPTION
The changed logging lines were mistakenly using a `{number}` positional syntax that's not actually used in the logging methods, instead `{}` simply replaces the corresponding parameter that has been passed. Add further confusion, if the last parameter is an exception, it should not be referenced in the format string, instead the stack trace is printed below the string. 

So to make the fix I removed the 0 from `{0}` and also I removed the format reference to the exception parameter.