### PR TITLE
TrieKeyMapper - accountKeys cache not initialized (LGTM alert).

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
+++ b/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
@@ -45,8 +45,7 @@ public class TrieKeyMapper {
             return Arrays.copyOf(key, key.length);
         }
 
-        byte[] secureKey = secureKeyPrefix(addr.getBytes());
-        byte[] key = ByteUtil.merge(DOMAIN_PREFIX, secureKey, addr.getBytes());
+        byte[] key = mapRskAddressToKey(addr);
 
         accountKeys.put(addr, key);
 
@@ -80,4 +79,10 @@ public class TrieKeyMapper {
     public static byte[] storagePrefix() {
         return Arrays.copyOf(STORAGE_PREFIX, STORAGE_PREFIX.length);
     }
+
+    byte[] mapRskAddressToKey(RskAddress addr) {
+        byte[] secureKey = secureKeyPrefix(addr.getBytes());
+        return ByteUtil.merge(DOMAIN_PREFIX, secureKey, addr.getBytes());
+    }
+
 }

--- a/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
+++ b/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
@@ -48,6 +48,8 @@ public class TrieKeyMapper {
         byte[] secureKey = secureKeyPrefix(addr.getBytes());
         byte[] key = ByteUtil.merge(DOMAIN_PREFIX, secureKey, addr.getBytes());
 
+        accountKeys.put(addr, key);
+
         return Arrays.copyOf(key, key.length);
     }
 

--- a/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
+++ b/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
@@ -28,7 +28,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Utility used for the Repository to translate {@link RskAddress} into keys of the trie.
+ *
+ * It uses internally a map cache of address->key (1:1, due to the immutability of the RskAddress object)
+ */
 public class TrieKeyMapper {
+
     public static final int SECURE_KEY_SIZE = 10;
     public static final int REMASC_ACCOUNT_KEY_SIZE = SECURE_KEY_SIZE + RemascTransaction.REMASC_ADDRESS.getBytes().length;
     public static final int ACCOUNT_KEY_SIZE = RskAddress.LENGTH_IN_BYTES;
@@ -37,7 +43,7 @@ public class TrieKeyMapper {
     private static final byte[] STORAGE_PREFIX = new byte[] {0x00}; // This makes the MSB 0 be branching
     private static final byte[] CODE_PREFIX = new byte[] {(byte) 0x80}; // This makes the MSB 1 be branching
 
-    private final Map<RskAddress, byte[]> accountKeys = new HashMap<>();
+    private final Map<RskAddress, byte[]> accountKeys = new HashMap<>(); //map cache of address->key (1:1) ** RskAddress is immutable.
 
     public synchronized byte[] getAccountKey(RskAddress addr) {
         if (accountKeys.containsKey(addr)) {

--- a/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
+++ b/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java
@@ -80,7 +80,7 @@ public class TrieKeyMapper {
         return Arrays.copyOf(STORAGE_PREFIX, STORAGE_PREFIX.length);
     }
 
-    byte[] mapRskAddressToKey(RskAddress addr) {
+    protected byte[] mapRskAddressToKey(RskAddress addr) {
         byte[] secureKey = secureKeyPrefix(addr.getBytes());
         return ByteUtil.merge(DOMAIN_PREFIX, secureKey, addr.getBytes());
     }

--- a/rskj-core/src/test/java/org/ethereum/db/TrieKeyMapperTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/TrieKeyMapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.db;
+
+import co.rsk.core.RskAddress;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class TrieKeyMapperTest {
+
+    private TrieKeyMapper trieKeyMapper;
+
+    @Before
+    public void setup() {
+        trieKeyMapper = spy(new TrieKeyMapper());
+    }
+
+    @Test
+    public void getAccountKey_new() {
+        RskAddress address = new RskAddress("1000000000000000000000000000000000000000");
+        this.trieKeyMapper.getAccountKey(address);
+        verify(this.trieKeyMapper, times(1)).mapRskAddressToKey(eq(address));
+    }
+
+    @Test
+    public void getAccountKey_fromCache() {
+        RskAddress address = new RskAddress("1000000000000000000000000000000000000001");
+
+        byte[] accountKey = this.trieKeyMapper.getAccountKey(address);
+        verify(this.trieKeyMapper, times(1)).mapRskAddressToKey(eq(address));
+
+        byte[] accountKeyCache = this.trieKeyMapper.getAccountKey(address);
+        verify(this.trieKeyMapper, times(1)).mapRskAddressToKey(eq(address));
+
+        Assert.assertArrayEquals("Account key diff from diff calls.", accountKey, accountKeyCache);
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/db/TrieKeyMapperTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/TrieKeyMapperTest.java
@@ -71,5 +71,14 @@ public class TrieKeyMapperTest {
             Assert.assertArrayEquals("Account key diff from diff calls.", accountKey, accountKeyCache);
         }
 
+        clearInvocations(this.trieKeyMapper);
+
+        for (int i = offset; i < BATCH_TEST + offset; i++) {
+            RskAddress address = new RskAddress(addressPrefix + i);
+            byte[] accountKey = this.trieKeyMapper.getAccountKey(address);
+            verify(this.trieKeyMapper, times(0)).mapRskAddressToKey(eq(address));
+            Assert.assertNotNull("Shouldnt return null value from cache.", accountKey);
+        }
+
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/db/TrieKeyMapperTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/TrieKeyMapperTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.*;
 
 public class TrieKeyMapperTest {
 
+    private static final int BATCH_TEST = 500;
     private TrieKeyMapper trieKeyMapper;
 
     @Before
@@ -50,7 +51,25 @@ public class TrieKeyMapperTest {
 
         byte[] accountKeyCache = this.trieKeyMapper.getAccountKey(address);
         verify(this.trieKeyMapper, times(1)).mapRskAddressToKey(eq(address));
-
         Assert.assertArrayEquals("Account key diff from diff calls.", accountKey, accountKeyCache);
+
+    }
+
+    @Test
+    public void getAccountKey_fromCache_multipleKeys() {
+        String addressPrefix = "1000000000000000000000000000000000000";
+
+        int offset = 100;
+        for (int i = offset; i < BATCH_TEST + offset; i++) {
+
+            RskAddress address = new RskAddress(addressPrefix + i);
+            byte[] accountKey = this.trieKeyMapper.getAccountKey(address);
+            verify(this.trieKeyMapper, times(1)).mapRskAddressToKey(eq(address));
+
+            byte[] accountKeyCache = this.trieKeyMapper.getAccountKey(address);
+            verify(this.trieKeyMapper, times(1)).mapRskAddressToKey(eq(address));
+            Assert.assertArrayEquals("Account key diff from diff calls.", accountKey, accountKeyCache);
+        }
+
     }
 }


### PR DESCRIPTION
Cache was only checked but not element added.

Added a line where the element is added before returning it. 
And added a Unit Test for verifying the functionality.
