### PR TITLE
Remove unused unknownBlockHashes attribute in BlockSyncService

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
@@ -44,7 +44,6 @@ public class BlockSyncService {
     public static final int CHUNK_PART_LIMIT = 8;
     public static final int PROCESSED_BLOCKS_TO_CHECK_STORE = 200;
     public static final int RELEASED_RANGE = 1000;
-    private Map<Keccak256, Integer> unknownBlockHashes;
     private long processedBlocksCounter;
     private long lastKnownBlockNumber = 0;
 
@@ -67,7 +66,6 @@ public class BlockSyncService {
         this.blockchain = blockchain;
         this.syncConfiguration = syncConfiguration;
         this.nodeInformation = nodeInformation;
-        this.unknownBlockHashes = new HashMap<>();
         this.config = config;
     }
 
@@ -80,7 +78,6 @@ public class BlockSyncService {
 
         tryReleaseStore(bestBlockNumber);
         store.removeHeader(block.getHeader());
-        unknownBlockHashes.remove(blockHash);
 
         if (blockNumber > bestBlockNumber + syncMaxDistance) {
             logger.trace("Block too advanced {} {} from {} ", blockNumber, block.getShortHash(),
@@ -209,9 +206,7 @@ public class BlockSyncService {
         if (sender == null) {
             return;
         }
-
-        unknownBlockHashes.put(hash, 1);
-
+        
         logger.trace("Missing block {}", hash.toString().substring(0, 10));
 
         sender.sendMessage(new GetBlockMessage(hash.getBytes()));


### PR DESCRIPTION
The `unknownBlockHashes` attribute in `BlockSyncService` used to have a purpose before but that purpose was removed in this previous commit: https://github.com/rsksmart/rskj/commit/89c206a078351d978aede7e81dae4a2b8de5922f 

Instead, currently it's a Map that's being written to, but it is never read from. This PR removes the attribute entirely.

This will fix a LGTM warning.