### PR TITLE
Ignoring lgtm alert

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/util/CompactEncoder.java
+++ b/rskj-core/src/main/java/org/ethereum/util/CompactEncoder.java
@@ -111,7 +111,7 @@ public class CompactEncoder {
         }
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         for (int i = 0; i < nibbles.length; i += 2) {
-            buffer.write(16 * nibbles[i] + nibbles[i + 1]);
+            buffer.write(16 * nibbles[i] + nibbles[i + 1]); //lgtm [java/index-out-of-bounds]
         }
         return buffer.toByteArray();
     }


### PR DESCRIPTION
Ignores [LGTM Warning](https://lgtm.com/projects/g/rsksmart/rskj?mode=tree&ruleFocus=2049320662)

Related method it's only used for testing and related tests are not compromised by the out of bounds exception.

 