### PR TITLE
Remove unused code from BlockNodeInformation & TransactionNodeInformation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/BlockNodeInformation.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockNodeInformation.java
@@ -33,22 +33,11 @@ import java.util.*;
  * Peers will only remember the last maxBlocks blocks that were inserted.
  */
 public class BlockNodeInformation {
-    private final Map<NodeID, Set<Keccak256>> blocksByNode;
     private final LinkedHashMap<Keccak256, Set<NodeID>> nodesByBlock;
     private final int maxBlocks;
-    private final int maxPeers;
 
-    public BlockNodeInformation(final int maxBlocks, final int maxPeers) {
+    public BlockNodeInformation(final int maxBlocks) {
         this.maxBlocks = maxBlocks;
-        this.maxPeers = maxPeers;
-
-        // Nodes are evicted in Least-recently-accessed order.
-        blocksByNode = new LinkedHashMap<NodeID, Set<Keccak256>>(BlockNodeInformation.this.maxPeers, 0.75f, true) {
-            @Override
-            protected boolean removeEldestEntry(Map.Entry<NodeID, Set<Keccak256>> eldest) {
-                return size() > BlockNodeInformation.this.maxPeers;
-            }
-        };
         // Blocks are evicted in Least-recently-accessed order.
         nodesByBlock = new LinkedHashMap<Keccak256, Set<NodeID>>(BlockNodeInformation.this.maxBlocks, 0.75f, true) {
             @Override
@@ -59,7 +48,7 @@ public class BlockNodeInformation {
     }
 
     public BlockNodeInformation() {
-        this(1000, 50);
+        this(1000);
     }
 
     /**
@@ -69,20 +58,6 @@ public class BlockNodeInformation {
      * @param nodeID    the node to add the block to.
      */
     public void addBlockToNode(@Nonnull final Keccak256 blockHash, @Nonnull final NodeID nodeID) {
-        Set<Keccak256> nodeBlocks = blocksByNode.get(nodeID);
-        if (nodeBlocks == null) {
-            // Create a new empty LRUCache for the blocks that a node know.
-            // NodeBlocks are evicted in reverse insertion order.
-            nodeBlocks = Collections.newSetFromMap(
-                    new LinkedHashMap<Keccak256, Boolean>() {
-                        protected boolean removeEldestEntry(Map.Entry<Keccak256, Boolean> eldest) {
-                            return size() > maxBlocks;
-                        }
-                    }
-            );
-            blocksByNode.put(nodeID, nodeBlocks);
-        }
-
         Set<NodeID> blockNodes = nodesByBlock.get(blockHash);
         if (blockNodes == null) {
             // Create a new set for the nodes that know about a block.
@@ -91,24 +66,9 @@ public class BlockNodeInformation {
             nodesByBlock.put(blockHash, blockNodes);
         }
 
-        nodeBlocks.add(blockHash);
         blockNodes.add(nodeID);
     }
 
-    /**
-     * getBlocksByNode retrieves all the blocks that a given node knows.
-     *
-     * @param nodeID the node to check.
-     * @return all the blocks known by the given nodeID.
-     */
-    @Nonnull
-    public Set<Keccak256> getBlocksByNode(@Nonnull final NodeID nodeID) {
-        Set<Keccak256> result = blocksByNode.get(nodeID);
-        if (result == null) {
-            result = new HashSet<>();
-        }
-        return Collections.unmodifiableSet(result);
-    }
 
     /**
      * getNodesByBlock retrieves all the nodes that contain a given block.
@@ -136,14 +96,4 @@ public class BlockNodeInformation {
         return getNodesByBlock(new Keccak256(blockHash));
     }
 
-    /**
-     * getBlocksByNode is a convenient function to avoid creating a NodeID.
-     *
-     * @param nodeID the node id.
-     * @return all the hashes of the blocks that the given node knows.
-     */
-    @Nonnull
-    public Set<Keccak256> getBlocksByNode(@Nonnull final byte[] nodeID) {
-        return getBlocksByNode(new NodeID(nodeID));
-    }
 }

--- a/rskj-core/src/main/java/co/rsk/net/BlockNodeInformation.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockNodeInformation.java
@@ -57,7 +57,7 @@ public class BlockNodeInformation {
      * @param blockHash the block hash.
      * @param nodeID    the node to add the block to.
      */
-    public void addBlockToNode(@Nonnull final Keccak256 blockHash, @Nonnull final NodeID nodeID) {
+    public synchronized void addBlockToNode(@Nonnull final Keccak256 blockHash, @Nonnull final NodeID nodeID) {
         Set<NodeID> blockNodes = nodesByBlock.get(blockHash);
         if (blockNodes == null) {
             // Create a new set for the nodes that know about a block.
@@ -68,8 +68,7 @@ public class BlockNodeInformation {
 
         blockNodes.add(nodeID);
     }
-
-
+    
     /**
      * getNodesByBlock retrieves all the nodes that contain a given block.
      *
@@ -77,12 +76,12 @@ public class BlockNodeInformation {
      * @return A set containing all the nodes that have that block.
      */
     @Nonnull
-    public Set<NodeID> getNodesByBlock(@Nonnull final Keccak256 blockHash) {
+    public synchronized Set<NodeID> getNodesByBlock(@Nonnull final Keccak256 blockHash) {
         Set<NodeID> result = nodesByBlock.get(blockHash);
         if (result == null) {
             result = new HashSet<>();
         }
-        return Collections.unmodifiableSet(result);
+        return new HashSet<>(result);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/net/TransactionNodeInformation.java
+++ b/rskj-core/src/main/java/co/rsk/net/TransactionNodeInformation.java
@@ -56,7 +56,7 @@ public class TransactionNodeInformation {
      * @param transactionHash the transaction hash.
      * @param nodeID    the node to add the block to.
      */
-    public void addTransactionToNode(@Nonnull final Keccak256 transactionHash, @Nonnull final NodeID nodeID) {
+    public synchronized void addTransactionToNode(@Nonnull final Keccak256 transactionHash, @Nonnull final NodeID nodeID) {
         Set<NodeID> transactionNodes = nodesByTransaction.get(transactionHash);
         if (transactionNodes == null) {
             // Create a new set for the nodes that know about a block.
@@ -75,12 +75,12 @@ public class TransactionNodeInformation {
      * @return A set containing all the nodes that have that block.
      */
     @Nonnull
-    public Set<NodeID> getNodesByTransaction(@Nonnull final Keccak256 transactionHash) {
+    public synchronized Set<NodeID> getNodesByTransaction(@Nonnull final Keccak256 transactionHash) {
         Set<NodeID> result = nodesByTransaction.get(transactionHash);
         if (result == null) {
             result = new HashSet<>();
         }
-        return Collections.unmodifiableSet(result);
+        return new HashSet<>(result);
     }
 
 }

--- a/rskj-core/src/main/java/co/rsk/net/TransactionNodeInformation.java
+++ b/rskj-core/src/main/java/co/rsk/net/TransactionNodeInformation.java
@@ -34,11 +34,8 @@ import java.util.*;
 public class TransactionNodeInformation {
     private final LinkedHashMap<Keccak256, Set<NodeID>> nodesByTransaction;
     private final int maxTransactions;
-    private final int maxPeers;
-
-    public TransactionNodeInformation(final int maxTransactions, final int maxPeers) {
+    public TransactionNodeInformation(final int maxTransactions) {
         this.maxTransactions = maxTransactions;
-        this.maxPeers = maxPeers;
 
         // Transactions are evicted in Least-recently-accessed order.
         nodesByTransaction = new LinkedHashMap<Keccak256, Set<NodeID>>(TransactionNodeInformation.this.maxTransactions, 0.75f, true) {
@@ -50,7 +47,7 @@ public class TransactionNodeInformation {
     }
 
     public TransactionNodeInformation() {
-        this(1000, 50);
+        this(1000);
     }
 
     /**

--- a/rskj-core/src/test/java/co/rsk/net/BlockNodeInformationTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/BlockNodeInformationTest.java
@@ -38,38 +38,6 @@ public class BlockNodeInformationTest {
     }
 
     @Test
-    public void nodeEvictionPolicy() {
-        final BlockNodeInformation nodeInformation = new BlockNodeInformation();
-        final Keccak256 block = createBlockHash(10);
-
-        // Add a few nodes, not exceeding the node limit.
-        // These nodes should contain the block when we call getBlocksByNode
-        for (int i = 0; i < 30; i++) {
-            final NodeID node = createNodeID(i);
-            nodeInformation.addBlockToNode(block, node);
-        }
-
-        Assert.assertTrue(nodeInformation.getBlocksByNode(createNodeID(10)).contains(block));
-        Assert.assertTrue(nodeInformation.getBlocksByNode(createNodeID(20)).contains(block));
-        Assert.assertFalse(nodeInformation.getBlocksByNode(createNodeID(80)).contains(block));
-
-        // Add more nodes, exceeding the node limit. The previous nodes should be evicted.
-        // Except for node 10, which is being constantly accessed.
-        for (int i = 30; i < 100; i++) {
-            final NodeID node = createNodeID(i);
-            nodeInformation.addBlockToNode(block, node);
-            nodeInformation.getBlocksByNode(createNodeID(10));
-        }
-
-        Assert.assertTrue(nodeInformation.getBlocksByNode(createNodeID(10)).contains(block));
-
-        Assert.assertFalse(nodeInformation.getBlocksByNode(createNodeID(20)).contains(block));
-        Assert.assertFalse(nodeInformation.getBlocksByNode(createNodeID(210)).contains(block));
-
-        Assert.assertTrue(nodeInformation.getBlocksByNode(createNodeID(80)).contains(block));
-    }
-
-    @Test
     public void blockEvictionPolicy() {
         final BlockNodeInformation nodeInformation = new BlockNodeInformation();
         final NodeID nodeID1 = new NodeID(new byte[]{2});
@@ -83,8 +51,8 @@ public class BlockNodeInformationTest {
         Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(15)).contains(nodeID1));
         Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(200)).contains(nodeID1));
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(nodeID1).contains(createBlockHash(15)));
-        Assert.assertTrue(nodeInformation.getBlocksByNode(nodeID1).contains(createBlockHash(300)));
+        Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(15)).contains(nodeID1));
+        Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(300)).contains(nodeID1));
 
         // Add more blocks, exceeding MAX_NODES. All previous blocks should be evicted.
         // Except from block 10, which is being constantly accessed.
@@ -102,19 +70,17 @@ public class BlockNodeInformationTest {
         Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(1900)).contains(nodeID1));
         Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(10)).contains(nodeID1));
 
-        Assert.assertFalse(nodeInformation.getBlocksByNode(nodeID1).contains(createBlockHash(25)));
-        Assert.assertFalse(nodeInformation.getBlocksByNode(nodeID1).contains(createBlockHash(70)));
+        Assert.assertFalse(nodeInformation.getNodesByBlock(createBlockHash(25)).contains(nodeID1));
+        Assert.assertFalse(nodeInformation.getNodesByBlock(createBlockHash(70)).contains(nodeID1));
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(nodeID1).contains(createBlockHash(1901)));
+        Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(1901)).contains(nodeID1));
     }
 
     @Test
     public void getIsEmptyIfNotPresent() {
         final BlockNodeInformation nodeInformation = new BlockNodeInformation();
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(new NodeID(new byte[]{})).size() == 0);
         Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(0)).size() == 0);
-        Assert.assertTrue(nodeInformation.getBlocksByNode(createBlockHash(0).getBytes()).size() == 0);
         Assert.assertTrue(nodeInformation.getNodesByBlock(createBlockHash(0)).size() == 0);
     }
 
@@ -128,13 +94,6 @@ public class BlockNodeInformationTest {
         final NodeID badNode = new NodeID(new byte[]{4});
 
         nodeInformation.addBlockToNode(hash1, nodeID1);
-        Set<Keccak256> blocks = nodeInformation.getBlocksByNode(nodeID1);
-        Assert.assertTrue(blocks.size() == 1);
-        Assert.assertTrue(blocks.contains(hash1));
-        Assert.assertFalse(blocks.contains(badHash));
-
-        blocks = nodeInformation.getBlocksByNode(badNode);
-        Assert.assertTrue(blocks.size() == 0);
 
         Set<NodeID> nodes = nodeInformation.getNodesByBlock(hash1);
         Assert.assertTrue(nodes.size() == 1);
@@ -158,19 +117,12 @@ public class BlockNodeInformationTest {
         nodeInformation.addBlockToNode(hash2, nodeID1);
         nodeInformation.addBlockToNode(hash2, nodeID2);
 
-        Set<Keccak256> blocks1 = nodeInformation.getBlocksByNode(nodeID1);
-        Set<Keccak256> blocks2 = nodeInformation.getBlocksByNode(nodeID2);
         Set<NodeID> nodes1 = nodeInformation.getNodesByBlock(hash1);
         Set<NodeID> nodes2 = nodeInformation.getNodesByBlock(hash2);
 
-        Assert.assertTrue(blocks1.size() == 2);
-        Assert.assertTrue(blocks2.size() == 1);
         Assert.assertTrue(nodes1.size() == 1);
         Assert.assertTrue(nodes2.size() == 2);
 
-        Assert.assertTrue(blocks1.contains(hash1));
-        Assert.assertTrue(blocks1.contains(hash2));
-        Assert.assertTrue(blocks2.contains(hash2));
 
         Assert.assertTrue(nodes1.contains(nodeID1));
         Assert.assertTrue(nodes2.contains(nodeID1));

--- a/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeBlockProcessorTest.java
@@ -533,7 +533,7 @@ public class NodeBlockProcessorTest {
 
 //        processor.processStatus(sender, status);
         Assert.assertTrue(processor.getNodeInformation().getNodesByBlock(block.getHash().getBytes()).size() == 1);
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).contains(blockHash));
+        Assert.assertTrue(processor.getNodeInformation().getNodesByBlock(block.getHash().getBytes()).contains(sender.getPeerNodeID()));
 
         Assert.assertEquals(0, sender.getGetBlockMessages().size());
         Assert.assertEquals(0, store.size());
@@ -557,10 +557,11 @@ public class NodeBlockProcessorTest {
         store.saveBlock(block);
 //        final Status status = new Status(block.getNumber(), block.getHash());
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
+
 
 //        processor.processStatus(sender, status);
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).contains(blockHash));
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).contains(sender.getPeerNodeID()));
 
         Assert.assertEquals(0, sender.getGetBlockMessages().size());
     }
@@ -609,11 +610,11 @@ public class NodeBlockProcessorTest {
 
         final SimplePeer sender = new SimplePeer();
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
 
         processor.processBlockHeadersRequest(sender, 1, block.getHash().getBytes(), 1);
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
 
         Assert.assertTrue(sender.getMessages().isEmpty());
     }
@@ -663,11 +664,11 @@ public class NodeBlockProcessorTest {
 
         final SimplePeer sender = new SimplePeer();
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
 
         processor.processGetBlock(sender, block.getHash().getBytes());
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).contains(blockHash));
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).contains(sender.getPeerNodeID()));
 
         Assert.assertFalse(sender.getMessages().isEmpty());
         Assert.assertEquals(1, sender.getMessages().size());
@@ -695,11 +696,12 @@ public class NodeBlockProcessorTest {
 
         final SimplePeer sender = new SimplePeer();
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
 
         processor.processGetBlock(sender, block.getHash().getBytes());
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
+
 
         Assert.assertTrue(sender.getMessages().isEmpty());
     }
@@ -719,11 +721,11 @@ public class NodeBlockProcessorTest {
 
         final SimplePeer sender = new SimplePeer();
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
 
         processor.processGetBlock(sender, block.getHash().getBytes());
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).contains(blockHash));
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).contains(sender.getPeerNodeID()));
 
         Assert.assertFalse(sender.getMessages().isEmpty());
         Assert.assertEquals(1, sender.getMessages().size());
@@ -754,11 +756,11 @@ public class NodeBlockProcessorTest {
 
         final SimplePeer sender = new SimplePeer();
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
 
         processor.processBlockRequest(sender, 100, block.getHash().getBytes());
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).contains(blockHash));
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).contains(sender.getPeerNodeID()));
 
         Assert.assertFalse(sender.getMessages().isEmpty());
         Assert.assertEquals(1, sender.getMessages().size());
@@ -817,11 +819,12 @@ public class NodeBlockProcessorTest {
 
         final SimplePeer sender = new SimplePeer();
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
 
         processor.processBlockRequest(sender, 100, block.getHash().getBytes());
 
-        Assert.assertFalse(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).contains(blockHash));
+        Assert.assertFalse(nodeInformation.getNodesByBlock(block.getHash()).contains(sender.getPeerNodeID()));
+
 
         Assert.assertTrue(sender.getMessages().isEmpty());
     }
@@ -841,11 +844,11 @@ public class NodeBlockProcessorTest {
 
         final SimplePeer sender = new SimplePeer();
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).isEmpty());
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).isEmpty());
 
         processor.processBlockRequest(sender, 100, block.getHash().getBytes());
 
-        Assert.assertTrue(nodeInformation.getBlocksByNode(sender.getPeerNodeID()).contains(blockHash));
+        Assert.assertTrue(nodeInformation.getNodesByBlock(block.getHash()).contains(sender.getPeerNodeID()));
 
         Assert.assertFalse(sender.getMessages().isEmpty());
         Assert.assertEquals(1, sender.getMessages().size());


### PR DESCRIPTION
# Rationale

See https://github.com/rsksmart/rskj/issues/1145

## BlockNodeInformation

maxPeers here is not actually used for anything. maxPeers is hardcoded to 50 and it limits the total size of a HashMap, the attribute blocksByNode of the BlockNodeInformation class. But, that structure is not actually queried at all in the main code, it should be queried by the getBlocksByNode methods (there are two overrides) but it is only queried on the test code. 

For clarity, this PR removes the unused attribute and changes the test code to make the same assertions in a different way.

## TransactionNodeInformation

In this class, maxPeers here is not actually used for anything, literally the attribute is unused. So we are removing the maxPeers from the class and the constructor.

## maxBlocks & maxTransactions

These two attributes simply limit the amount of blocks/transactions remembered by removing old entries after the 1000th. This means forgetting which node knows about a block/transaction when the block/transaction is old enough. Currently there are no config values for this and in principle it should not be an issue for bootstrapping a node.