### PR TITLE
Message Visitor for the light client handler

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
@@ -45,10 +45,6 @@ public class LightClientHandler extends SimpleChannelInboundHandler<LightClientM
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, LightClientMessage msg) {
-        if (!LightClientMessageCodes.inRange(msg.getCommand().asByte())) {
-            return;
-        }
-
         MessageVisitor visitor = new MessageVisitor(lightPeer, lightProcessor, lightSyncProcessor, ctx,this);
         msg.accept(visitor);
     }

--- a/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
@@ -46,7 +46,7 @@ public class LightClientHandler extends SimpleChannelInboundHandler<LightClientM
     @Override
     public void channelRead0(ChannelHandlerContext ctx, LightClientMessage msg) throws UnsupportedOperationException {
         if (!LightClientMessageCodes.inRange(msg.getCommand().asByte())) {
-            throw new UnsupportedOperationException("Message not in supported Range");
+            return;
         }
 
         MessageVisitor visitor = new MessageVisitor(lightPeer, lightProcessor, lightSyncProcessor, ctx,this);

--- a/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
@@ -45,7 +45,7 @@ public class LightClientHandler extends SimpleChannelInboundHandler<LightClientM
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, LightClientMessage msg) throws UnsupportedOperationException {
-        if (LightClientMessageCodes.inRange(msg.getCommand().asByte())) {
+        if (!LightClientMessageCodes.inRange(msg.getCommand().asByte())) {
             throw new UnsupportedOperationException("Message not in supported Range");
         }
 

--- a/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
@@ -44,7 +44,7 @@ public class LightClientHandler extends SimpleChannelInboundHandler<LightClientM
     }
 
     @Override
-    public void channelRead0(ChannelHandlerContext ctx, LightClientMessage msg) throws UnsupportedOperationException {
+    public void channelRead0(ChannelHandlerContext ctx, LightClientMessage msg) {
         if (!LightClientMessageCodes.inRange(msg.getCommand().asByte())) {
             return;
         }

--- a/rskj-core/src/main/java/co/rsk/net/light/MessageVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/MessageVisitor.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.net.light;
 
 import co.rsk.net.eth.LightClientHandler;
@@ -6,6 +24,9 @@ import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Created by Julian Len and Sebastian Sicardi on 21/04/20.
+ */
 public class MessageVisitor {
     private static final Logger logger = LoggerFactory.getLogger("lightnet");
     private final LightPeer lightPeer;

--- a/rskj-core/src/main/java/co/rsk/net/light/MessageVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/MessageVisitor.java
@@ -1,0 +1,104 @@
+package co.rsk.net.light;
+
+import co.rsk.net.eth.LightClientHandler;
+import co.rsk.net.light.message.*;
+import io.netty.channel.ChannelHandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MessageVisitor {
+    private static final Logger logger = LoggerFactory.getLogger("lightnet");
+    private final LightPeer lightPeer;
+    private final LightSyncProcessor lightSyncProcessor;
+    private final LightProcessor lightProcessor;
+    private final LightClientHandler handler;
+    private final ChannelHandlerContext ctx;
+
+    public MessageVisitor(LightPeer lightPeer, LightProcessor lightProcessor, LightSyncProcessor lightSyncProcessor,
+                          ChannelHandlerContext ctx, LightClientHandler handler) {
+        this.lightProcessor = lightProcessor;
+        this.lightSyncProcessor = lightSyncProcessor;
+        this.lightPeer = lightPeer;
+        this.handler = handler;
+        this.ctx = ctx;
+    }
+
+    public void apply(StatusMessage msg) {
+        logger.debug("Read message: {} STATUS", msg);
+        lightSyncProcessor.processStatusMessage(msg, lightPeer, ctx, handler);
+    }
+
+    public void apply(GetBlockReceiptsMessage msg) {
+        logger.debug("Read message: {} GET_BLOCK_RECEIPTS", msg);
+        lightProcessor.processGetBlockReceiptsMessage(msg.getId(), msg.getBlockHash(), lightPeer);
+    }
+
+    public void apply(BlockReceiptsMessage msg) {
+        logger.debug("Read message: {} BLOCK_RECEIPTS", msg);
+        lightProcessor.processBlockReceiptsMessage(msg.getId(), msg.getBlockReceipts(), lightPeer);
+    }
+
+    public void apply(GetTransactionIndexMessage msg){
+        logger.debug("Read message: {} GET_TRANSACTION_INDEX", msg);
+        lightProcessor.processGetTransactionIndex(msg.getId(), msg.getTxHash(), lightPeer);
+    }
+
+    public void apply(TransactionIndexMessage msg){
+        logger.debug("Read message: {} TRANSACTION_INDEX", msg);
+        lightProcessor.processTransactionIndexMessage(msg.getId(), msg.getBlockNumber(),
+                msg.getBlockHash(), msg.getTransactionIndex(), lightPeer);
+    }
+
+    public void apply(GetCodeMessage msg){
+        logger.debug("Read message: {} GET_CODE", msg);
+        lightProcessor.processGetCodeMessage(msg.getId(), msg.getBlockHash(), msg.getAddress(), lightPeer);
+    }
+
+    public void apply(CodeMessage msg){
+        logger.debug("Read message: {} CODE", msg);
+        lightProcessor.processCodeMessage(msg.getId(), msg.getCodeHash(), lightPeer);
+    }
+
+    public void apply(GetAccountsMessage msg){
+        logger.debug("Read message: {} GET_ACCOUNTS", msg);
+        lightProcessor.processGetAccountsMessage(msg.getId(), msg.getBlockHash(), msg.getAddressHash(), lightPeer);
+    }
+
+    public void apply(AccountsMessage msg){
+        logger.debug("Read message: {} ACCOUNTS", msg);
+        lightProcessor.processAccountsMessage(msg.getId(), msg.getMerkleInclusionProof(),
+                msg.getNonce(), msg.getBalance(), msg.getCodeHash(), msg.getStorageRoot(), lightPeer);
+    }
+
+    public void apply(GetBlockHeaderMessage msg) {
+        logger.debug("Read message: {} GET_BLOCK_HEADER", msg);
+        lightProcessor.processGetBlockHeaderMessage(msg.getId(), msg.getBlockHash(), lightPeer);
+    }
+
+    public void apply(BlockHeaderMessage msg) {
+        logger.debug("Read message: {} BLOCK_HEADER", msg);
+        lightSyncProcessor.processBlockHeaderMessage(msg.getId(), msg.getBlockHeader(), lightPeer);
+    }
+
+    public void apply(GetBlockBodyMessage msg) {
+        logger.debug("Read message: {} GET_BLOCK_BODY", msg);
+        lightProcessor.processGetBlockBodyMessage(msg.getId(), msg.getBlockHash(), lightPeer);
+    }
+
+    public void apply(BlockBodyMessage msg) {
+        logger.debug("Read message: {} BLOCK_BODY", msg);
+        lightProcessor.processBlockBodyMessage(msg.getId(), msg.getUncles(), msg.getTransactions(), lightPeer);
+    }
+
+    public void apply(GetStorageMessage msg) {
+        logger.debug("Read message: {} GET_STORAGE", msg);
+        lightProcessor.processGetStorageMessage(msg.getId(), msg.getBlockHash(), msg.getAddressHash(),
+                msg.getStorageKeyHash(), lightPeer);
+    }
+
+    public void apply(StorageMessage msg) {
+        logger.debug("Read message: {} STORAGE", msg);
+        lightProcessor.processStorageMessage(msg.getId(), msg.getMerkleInclusionProof(), msg.getStorageValue(), lightPeer);
+    }
+}
+

--- a/rskj-core/src/main/java/co/rsk/net/light/message/AccountsMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/AccountsMessage.java
@@ -19,6 +19,7 @@
 package co.rsk.net.light.message;
 
 import co.rsk.net.light.LightClientMessageCodes;
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -112,5 +113,10 @@ public class AccountsMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/BlockBodyMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/BlockBodyMessage.java
@@ -18,6 +18,7 @@
 
 package co.rsk.net.light.message;
 
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
@@ -110,5 +111,10 @@ public class BlockBodyMessage extends LightClientMessage {
 
     public List<BlockHeader> getUncles() {
         return new LinkedList<>(uncles);
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/BlockHeaderMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/BlockHeaderMessage.java
@@ -19,6 +19,7 @@
 package co.rsk.net.light.message;
 
 import co.rsk.net.light.LightClientMessageCodes;
+import co.rsk.net.light.MessageVisitor;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.util.RLP;
@@ -70,5 +71,10 @@ public class BlockHeaderMessage extends LightClientMessage {
 
     public long getId() {
         return id;
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/BlockReceiptsMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/BlockReceiptsMessage.java
@@ -18,6 +18,7 @@
 
 package co.rsk.net.light.message;
 
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.util.RLP;
@@ -92,5 +93,10 @@ public class BlockReceiptsMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/CodeMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/CodeMessage.java
@@ -18,6 +18,7 @@
 
 package co.rsk.net.light.message;
 
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -67,5 +68,10 @@ public class CodeMessage extends LightClientMessage{
 
     public byte[] getCodeHash() {
         return codeHash.clone();
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/GetAccountsMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/GetAccountsMessage.java
@@ -19,6 +19,7 @@
 package co.rsk.net.light.message;
 
 import co.rsk.net.light.LightClientMessageCodes;
+import co.rsk.net.light.MessageVisitor;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.spongycastle.util.BigIntegers;
@@ -80,5 +81,10 @@ public class GetAccountsMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/GetBlockBodyMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/GetBlockBodyMessage.java
@@ -20,6 +20,7 @@ package co.rsk.net.light.message;
 
 
 import co.rsk.net.light.LightClientMessageCodes;
+import co.rsk.net.light.MessageVisitor;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.spongycastle.util.BigIntegers;
@@ -70,5 +71,10 @@ public class GetBlockBodyMessage extends LightClientMessage {
 
     public byte[] getBlockHash() {
         return blockHash.clone();
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/GetBlockHeaderMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/GetBlockHeaderMessage.java
@@ -19,6 +19,7 @@
 package co.rsk.net.light.message;
 
 import co.rsk.net.light.LightClientMessageCodes;
+import co.rsk.net.light.MessageVisitor;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.spongycastle.util.BigIntegers;
@@ -70,5 +71,10 @@ public class GetBlockHeaderMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/GetBlockReceiptsMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/GetBlockReceiptsMessage.java
@@ -18,6 +18,7 @@
 
 package co.rsk.net.light.message;
 
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -68,5 +69,10 @@ public class GetBlockReceiptsMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/GetCodeMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/GetCodeMessage.java
@@ -18,6 +18,7 @@
 
 package co.rsk.net.light.message;
 
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -76,5 +77,10 @@ public class GetCodeMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/GetStorageMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/GetStorageMessage.java
@@ -18,6 +18,7 @@
 
 package co.rsk.net.light.message;
 
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -86,5 +87,10 @@ public class GetStorageMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/GetTransactionIndexMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/GetTransactionIndexMessage.java
@@ -19,6 +19,7 @@
 package co.rsk.net.light.message;
 
 import co.rsk.net.light.LightClientMessageCodes;
+import co.rsk.net.light.MessageVisitor;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.spongycastle.util.BigIntegers;
@@ -68,5 +69,10 @@ public class GetTransactionIndexMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/LightClientMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/LightClientMessage.java
@@ -1,6 +1,7 @@
 package co.rsk.net.light.message;
 
 import co.rsk.net.light.LightClientMessageCodes;
+import co.rsk.net.light.MessageVisitor;
 import org.ethereum.net.message.Message;
 
 public abstract class LightClientMessage extends Message {
@@ -15,4 +16,6 @@ public abstract class LightClientMessage extends Message {
     public LightClientMessageCodes getCommand() {
         return LightClientMessageCodes.fromByte(code);
     }
+
+    public abstract void accept(MessageVisitor v);
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/StatusMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/StatusMessage.java
@@ -21,6 +21,7 @@ package co.rsk.net.light.message;
 
 import co.rsk.net.light.LightClientMessageCodes;
 import co.rsk.net.light.LightStatus;
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -77,5 +78,10 @@ public class StatusMessage extends LightClientMessage {
 
     public long getId() {
         return id;
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/StorageMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/StorageMessage.java
@@ -18,6 +18,7 @@
 
 package co.rsk.net.light.message;
 
+import co.rsk.net.light.MessageVisitor;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -79,5 +80,10 @@ public class StorageMessage extends LightClientMessage{
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/message/TransactionIndexMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/TransactionIndexMessage.java
@@ -19,6 +19,7 @@
 package co.rsk.net.light.message;
 
 import co.rsk.net.light.LightClientMessageCodes;
+import co.rsk.net.light.MessageVisitor;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.bouncycastle.util.BigIntegers;
@@ -89,5 +90,10 @@ public class TransactionIndexMessage extends LightClientMessage {
     @Override
     public String toString() {
         return "";
+    }
+
+    @Override
+    public void accept(MessageVisitor v) {
+        v.apply(this);
     }
 }


### PR DESCRIPTION
Created a visitor pattern to replace the ugly switch we had.

The only concern is the creation of the Visitor each time a new message is created. This is because a message need the ChannelHandlerContext passed to the channelRead0 function, so the context is passed in the constructor.

Other possible solutions:

1. setCtx (not that pretty)
2. pass the ctx to the accept method (I really dont like this because ctx is only needed for the Status message, and this would mean we have to change the whole signature of both accept AND apply in EVERY message for just only one)