### PR TITLE
TxRelay added as option in Status message handshake

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
@@ -139,7 +139,7 @@ public class LightSyncProcessor {
     public void sendStatusMessage(LightPeer lightPeer) {
         Block block = blockStore.getBestBlock();
         LightStatus status = getCurrentStatus(block);
-        StatusMessage statusMessage = new StatusMessage(0L, status);
+        StatusMessage statusMessage = new StatusMessage(0L, status, false);
 
         lightPeer.sendMessage(statusMessage);
 

--- a/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
@@ -55,6 +55,7 @@ public class LightSyncProcessor {
     private final byte version;
     private static final Logger loggerNet = LoggerFactory.getLogger("lightnet");
     private Map<LightPeer, LightStatus> peerStatuses = new HashMap<>();
+    private Map<LightPeer, Boolean> txRelay = new HashMap<>();
     private long lastRequestedId;
     private final Map<Long, LightClientMessageCodes> pendingMessages;
 
@@ -129,6 +130,9 @@ public class LightSyncProcessor {
 
         peerStatuses.put(lightPeer, status);
 
+        if (msg.isTxRelay()) {
+            txRelay.put(lightPeer, true);
+        }
 
         byte[] bestBlockHash = status.getBestHash();
         GetBlockHeaderMessage blockHeaderMessage = new GetBlockHeaderMessage(++lastRequestedId, bestBlockHash);

--- a/rskj-core/src/main/java/co/rsk/net/light/message/StatusMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/StatusMessage.java
@@ -35,10 +35,12 @@ public class StatusMessage extends LightClientMessage {
 
     private final long id;
     private final LightStatus status;
+    private boolean txRelay; // 1 byte - 0x00 = false or 0x01 = true
 
-    public StatusMessage(long id, LightStatus status) {
+    public StatusMessage(long id, LightStatus status, boolean txRelay) {
         this.id = id;
         this.status = status;
+        this.txRelay = txRelay;
         this.code = STATUS.asByte();
     }
 
@@ -47,14 +49,17 @@ public class StatusMessage extends LightClientMessage {
         byte[] rlpId = list.get(0).getRLPData();
         this.id = rlpId == null ? 0 : BigIntegers.fromUnsignedByteArray(rlpId).longValue();
         this.status = new LightStatus(list.get(1).getRLPData());
+        byte[] rlpTxRelay = list.get(2).getRLPData();
+        this.txRelay = rlpTxRelay != null;
         this.code = STATUS.asByte();
     }
 
     @Override
     public byte[] getEncoded() {
         byte[] rlpId = RLP.encodeBigInteger(BigInteger.valueOf(getId()));
-        byte[] rlpStatus = status.getEncoded();
-        return RLP.encodeList(rlpId, rlpStatus);
+        byte[] rlpStatus = getStatus().getEncoded();
+        byte[] rlpTxRelay = RLP.encodeByte((byte)(isTxRelay() ? 0x01 : 0x00));
+        return RLP.encodeList(rlpId, rlpStatus, rlpTxRelay);
     }
 
     @Override
@@ -78,6 +83,10 @@ public class StatusMessage extends LightClientMessage {
 
     public long getId() {
         return id;
+    }
+
+    public boolean isTxRelay() {
+        return txRelay;
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/net/LightSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightSyncProcessorTest.java
@@ -93,7 +93,7 @@ public class LightSyncProcessorTest {
 
         //lastRequestId in a new LightSyncProcessor starts in zero.
         requestId = 0;
-        statusMessage = new StatusMessage(requestId, lightStatus);
+        statusMessage = new StatusMessage(requestId, lightStatus, false);
     }
 
     @Test
@@ -137,7 +137,7 @@ public class LightSyncProcessorTest {
 
         //Message sent
         long requestId = 0; //lastRequestId in a new LightSyncProcessor starts in zero.
-        StatusMessage statusMessage = new StatusMessage(requestId, lightStatus);
+        StatusMessage statusMessage = new StatusMessage(requestId, lightStatus, false);
 
         LightPeer lightPeer2 = mock(LightPeer.class);
         lightSyncProcessor.processStatusMessage(statusMessage, lightPeer, ctx, lightClientHandler);

--- a/rskj-core/src/test/java/co/rsk/net/eth/LightClientHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/eth/LightClientHandlerTest.java
@@ -113,7 +113,7 @@ public class LightClientHandlerTest {
         when(config.networkId()).thenReturn(networkId);
 
         LightStatus status = new LightStatus(protocolVersion, networkId, blockDifficulty, blockHash.getBytes(), bestNumber, genesisHash.getBytes());
-        StatusMessage statusMessage = new StatusMessage(0L, status);
+        StatusMessage statusMessage = new StatusMessage(0L, status, false);
 
         lightClientHandler.activate();
 
@@ -131,7 +131,7 @@ public class LightClientHandlerTest {
         when(genesis.getHash()).thenReturn(genesisHash);
 
         LightStatus status = new LightStatus((byte) 1, 0, blockDifficulty, blockHash.getBytes(), bestNumber, genesisHash.getBytes());
-        StatusMessage m = new StatusMessage(0L, status);
+        StatusMessage m = new StatusMessage(0L, status, false);
 
         lightClientHandler.channelRead0(ctx, m);
 
@@ -146,7 +146,7 @@ public class LightClientHandlerTest {
         when(genesis.getHash()).thenReturn(genesisHash);
 
         LightStatus status = new LightStatus((byte) 0, 55, blockDifficulty, blockHash.getBytes(), bestNumber, genesisHash.getBytes());
-        StatusMessage m = new StatusMessage(0L, status);
+        StatusMessage m = new StatusMessage(0L, status, false);
 
 
         lightClientHandler.channelRead0(ctx, m);
@@ -161,7 +161,7 @@ public class LightClientHandlerTest {
         byte[] invalidHash = HashUtil.randomHash();
 
         LightStatus status = new LightStatus((byte) 0, 0, blockDifficulty, blockHash.getBytes(), bestNumber, invalidHash);
-        StatusMessage m = new StatusMessage(0L, status);
+        StatusMessage m = new StatusMessage(0L, status, false);
         lightClientHandler.channelRead0(ctx, m);
 
         verify(messageQueue).disconnect(eq(ReasonCode.UNEXPECTED_GENESIS));
@@ -179,7 +179,7 @@ public class LightClientHandlerTest {
 
         LightStatus status = new LightStatus((byte) 0, 0, blockDifficulty, blockHash.getBytes(), bestNumber, genesisHash.getBytes());
 
-        StatusMessage m = new StatusMessage(0L, status);
+        StatusMessage m = new StatusMessage(0L, status, false);
         lightClientHandler.channelRead0(ctx, m);
 
         verify(messageQueue, times(0)).sendMessage(any());

--- a/rskj-core/src/test/java/co/rsk/net/light/message/StatusMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/light/message/StatusMessageTest.java
@@ -56,7 +56,7 @@ public class StatusMessageTest {
                 totalDifficulty, bestHash.getBytes(), bestNumber, genesisHash);
 
         long id = 1L;
-        StatusMessage testMessage = new StatusMessage(id, lightStatus);
+        StatusMessage testMessage = new StatusMessage(id, lightStatus, true);
 
         assertEquals(STATUS, testMessage.getCommand());
         assertEquals(id, testMessage.getId());
@@ -71,7 +71,7 @@ public class StatusMessageTest {
         int networkId = 2;
         long bestNumber = 10L;
 
-        createMessageAndAssertEncodeDecode(id, protocolVersion, networkId, totalDifficulty, bestNumber);
+        createMessageAndAssertEncodeDecode(id, protocolVersion, networkId, totalDifficulty, bestNumber, true);
     }
 
     @Test
@@ -81,15 +81,14 @@ public class StatusMessageTest {
         byte protocolVersion = (byte) 0;
         int networkId = 0;
         long bestNumber = 0;
-
-        createMessageAndAssertEncodeDecode(id, protocolVersion, networkId, totalDifficulty, bestNumber);
+        createMessageAndAssertEncodeDecode(id, protocolVersion, networkId, totalDifficulty, bestNumber, false);
     }
 
-    private void createMessageAndAssertEncodeDecode(long id, byte protocolVersion, int networkId, BlockDifficulty totalDifficulty, long bestNumber) {
+    private void createMessageAndAssertEncodeDecode(long id, byte protocolVersion, int networkId, BlockDifficulty totalDifficulty, long bestNumber, boolean txRelay) {
         LightStatus lightStatus = new LightStatus(protocolVersion, networkId,
                 totalDifficulty, bestHash.getBytes(), bestNumber, genesisHash);
         LCMessageFactory lcMessageFactory = new LCMessageFactory(mock(BlockFactory.class));
-        StatusMessage testMessage = new StatusMessage(id, lightStatus);
+        StatusMessage testMessage = new StatusMessage(id, lightStatus, txRelay);
         StatusMessage decodedMessage = (StatusMessage) lcMessageFactory.create(STATUS.asByte(), testMessage.getEncoded());
         assertArrayEquals(testMessage.getEncoded(), decodedMessage.getEncoded());
     }

--- a/rskj-core/src/test/java/org/ethereum/net/rlpx/MessageCodecTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/rlpx/MessageCodecTest.java
@@ -156,7 +156,7 @@ public class MessageCodecTest {
         BlockDifficulty totalDifficulty = new BlockDifficulty(BigInteger.ONE);
         LightStatus status = new LightStatus(protocolVersion, networkId,
                 totalDifficulty, bestHash.getBytes(), bestNumber, genesisHash);
-        StatusMessage lcStatusMessage = new StatusMessage(id, status);
+        StatusMessage lcStatusMessage = new StatusMessage(id, status, false);
 
         List<Capability> cap = new LinkedList<>();
         cap.add(new Capability(Capability.LC, (byte) 0));


### PR DESCRIPTION
TxRelay is used in LC to determine if the newly connected peer is able to relay transactions.