### PR TITLE
Change behavior of GetBlocksHeader message processing

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
@@ -135,7 +135,7 @@ public class LightSyncProcessor {
         }
 
         byte[] bestBlockHash = status.getBestHash();
-        GetBlockHeadersMessage blockHeaderMessage = new GetBlockHeadersMessage(++lastRequestedId, bestBlockHash, 1);
+        GetBlockHeadersMessage blockHeaderMessage = new GetBlockHeadersMessage(++lastRequestedId, bestBlockHash, 1, 0, false);
         pendingMessages.put(lastRequestedId, BLOCK_HEADER);
         lightPeer.sendMessage(blockHeaderMessage);
     }

--- a/rskj-core/src/main/java/co/rsk/net/light/MessageVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/MessageVisitor.java
@@ -93,7 +93,7 @@ public class MessageVisitor {
 
     public void apply(GetBlockHeadersMessage msg) {
         logger.debug("Read message: {} GET_BLOCK_HEADER", msg);
-        lightProcessor.processGetBlockHeadersMessage(msg.getId(), msg.getBlockHash(), msg.getCount(), lightPeer);
+        lightProcessor.processGetBlockHeadersMessage(msg.getId(), msg.getBlockHash(), msg.getMax(), msg.getSkip(), msg.isReverse(), lightPeer);
     }
 
     public void apply(BlockHeadersMessage msg) {

--- a/rskj-core/src/main/java/co/rsk/net/light/message/GetBlockHeadersMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/message/GetBlockHeadersMessage.java
@@ -30,25 +30,32 @@ public class GetBlockHeadersMessage extends LightClientMessage {
 
     private final long id;
     private final byte[] blockHash;
-    private int count;
+    private final boolean reverse;
+    private int max;
+    private int skip;
 
-    public GetBlockHeadersMessage(long id, byte[] blockHash, int count) {
+    public GetBlockHeadersMessage(long id, byte[] blockHash, int max, int skip, boolean reverse) {
         this.id = id;
         this.blockHash = blockHash.clone();
-        this.count = count;
+        this.max = max;
+        this.skip = skip;
+        this.reverse = reverse;
         this.code = LightClientMessageCodes.GET_BLOCK_HEADER.asByte();
     }
 
     public GetBlockHeadersMessage(byte[] encoded) {
         RLPList paramsList = (RLPList) RLP.decode2(encoded).get(0);
         byte[] rlpId = paramsList.get(0).getRLPData();
-        id = rlpId == null ? 0 : BigIntegers.fromUnsignedByteArray(rlpId).longValue();
-        blockHash = paramsList.get(1).getRLPData();
-        byte[] rlpCount = paramsList.get(2).getRLPData();
-        count = rlpCount == null? 0 : BigIntegers.fromUnsignedByteArray(rlpCount).intValue();
+        this.id = rlpId == null ? 0 : BigIntegers.fromUnsignedByteArray(rlpId).longValue();
+        this.blockHash = paramsList.get(1).getRLPData();
+        byte[] rlpMax = paramsList.get(2).getRLPData();
+        this.max = rlpMax == null? 0 : BigIntegers.fromUnsignedByteArray(rlpMax).intValue();
+        byte[] rlpSkip = paramsList.get(3).getRLPData();
+        this.skip = rlpSkip == null? 0 : BigIntegers.fromUnsignedByteArray(rlpSkip).intValue();
+        byte[] rlpReverse = paramsList.get(4).getRLPData();
+        this.reverse = rlpReverse != null;
         this.code = LightClientMessageCodes.GET_BLOCK_HEADER.asByte();
     }
-
 
     public long getId() {
         return this.id;
@@ -58,13 +65,23 @@ public class GetBlockHeadersMessage extends LightClientMessage {
         return blockHash.clone();
     }
 
+    public int getSkip() {
+        return skip;
+    }
+
+    public boolean isReverse() {
+        return reverse;
+    }
 
     @Override
     public byte[] getEncoded() {
         byte[] rlpId = RLP.encodeBigInteger(BigInteger.valueOf(getId()));
         byte[] rlpHash = RLP.encodeElement(getBlockHash());
-        byte[] rlpCount = RLP.encodeBigInteger(BigInteger.valueOf(getCount()));
-        return RLP.encodeList(rlpId, rlpHash, rlpCount);
+        byte[] rlpMax = RLP.encodeBigInteger(BigInteger.valueOf(getMax()));
+        byte[] rlpSkip = RLP.encodeBigInteger(BigInteger.valueOf(getSkip()));
+        byte[] rlpReverse = RLP.encodeByte((byte)(isReverse() ? 0x01 : 0x00));
+
+        return RLP.encodeList(rlpId, rlpHash, rlpMax, rlpSkip, rlpReverse);
     }
 
     @Override
@@ -83,7 +100,7 @@ public class GetBlockHeadersMessage extends LightClientMessage {
         v.apply(this);
     }
 
-    public int getCount() {
-        return count;
+    public int getMax() {
+        return max;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/LightSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightSyncProcessorTest.java
@@ -111,7 +111,7 @@ public class LightSyncProcessorTest {
         ChannelHandlerContext ctx = ch.pipeline().firstContext();
 
         //Message expected
-        GetBlockHeadersMessage expectedMessage = new GetBlockHeadersMessage(++requestId, blockHash.getBytes(), 1);
+        GetBlockHeadersMessage expectedMessage = new GetBlockHeadersMessage(++requestId, blockHash.getBytes(), 1, 0, false);
 
         ArgumentCaptor<GetBlockHeadersMessage> argument = forClass(GetBlockHeadersMessage.class);
         lightSyncProcessor.processStatusMessage(statusMessage, lightPeer, ctx, lightClientHandler);

--- a/rskj-core/src/test/java/co/rsk/net/eth/LightClientHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/eth/LightClientHandlerTest.java
@@ -338,7 +338,7 @@ public class LightClientHandlerTest {
         when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(block.getHeader()).thenReturn(blockHeader);
 
-        GetBlockHeadersMessage m = new GetBlockHeadersMessage(1, blockHash.getBytes(), 1);
+        GetBlockHeadersMessage m = new GetBlockHeadersMessage(1, blockHash.getBytes(), 1, 0, false);
 
         lightClientHandler.channelRead0(ctx, m);
 

--- a/rskj-core/src/test/java/co/rsk/net/light/message/GetBlockHeadersMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/light/message/GetBlockHeadersMessageTest.java
@@ -42,12 +42,15 @@ public class GetBlockHeadersMessageTest {
     @Test
     public void messageCreationShouldBeCorrect() {
         long id = 1;
-        int count = 2;
-        GetBlockHeadersMessage testMessage = new GetBlockHeadersMessage(id, blockHash, count);
+        int max = 2;
+        int skip = 5;
+        GetBlockHeadersMessage testMessage = new GetBlockHeadersMessage(id, blockHash, max, skip, true);
 
         assertEquals(id, testMessage.getId());
         assertArrayEquals(blockHash, testMessage.getBlockHash());
-        assertEquals(count, testMessage.getCount());
+        assertEquals(max, testMessage.getMax());
+        assertEquals(skip, testMessage.getSkip());
+        assertTrue(testMessage.isReverse());
         assertEquals(BlockHeadersMessage.class, testMessage.getAnswerMessage());
         assertEquals(GET_BLOCK_HEADER, testMessage.getCommand());
     }
@@ -55,25 +58,28 @@ public class GetBlockHeadersMessageTest {
     @Test
     public void messageEncodeDecodeShouldBeCorrect() {
         long id = 1;
-        int count = 2;
-        createMessageAndAssertEncodeDecode(id, count);
+        int max = 2;
+        int skip = 3;
+
+        createMessageAndAssertEncodeDecode(id, max, skip, true);
     }
 
     @Test
     public void messageEncodeDecodeShouldBeCorrectWithZeroParameters() {
         long id = 0;
-        int count = 0;
-        createMessageAndAssertEncodeDecode(id, count);
+        int max = 0;
+        int skip = 0;
+        createMessageAndAssertEncodeDecode(id, max, skip, false);
     }
 
-    private void createMessageAndAssertEncodeDecode(long id, int count) {
-        GetBlockHeadersMessage testMessage = new GetBlockHeadersMessage(id, blockHash, count);
+    private void createMessageAndAssertEncodeDecode(long id, int max, int skip, boolean reverse) {
+        GetBlockHeadersMessage testMessage = new GetBlockHeadersMessage(id, blockHash, max, skip, reverse);
         byte[] encoded = testMessage.getEncoded();
         GetBlockHeadersMessage getBlockHeadersMessage = (GetBlockHeadersMessage) messageFactory.create(GET_BLOCK_HEADER.asByte(), encoded);
 
         assertEquals(id, getBlockHeadersMessage.getId());
         assertArrayEquals(blockHash, getBlockHeadersMessage.getBlockHash());
-        assertEquals(count, getBlockHeadersMessage.getCount());
+        assertEquals(max, getBlockHeadersMessage.getMax());
         assertEquals(GET_BLOCK_HEADER, getBlockHeadersMessage.getCommand());
         assertEquals(testMessage.getAnswerMessage(), getBlockHeadersMessage.getAnswerMessage());
         assertArrayEquals(encoded, getBlockHeadersMessage.getEncoded());


### PR DESCRIPTION
Basing on the Parity's Light Client Sync protocol, the behavior is the following:

1. GetBlockHeaders message adds the fields **skip** and **reverse**, also we replaced the field **count** to **max**. The **reverse** field alters the way the list of block headers resultant is constructed and returned. Then, the parameters of GetBlockHeadersMessage are **reqid**, **blockhash** which is the starting block, **max**, **skip** and **reverse**.
2. In the message processing, light client processor responses with **max** numbers of blocks. But the difference between each block number (Ni, Ni+1 two sequential block numbers) is for all i, Ni+1 - Ni + 1 = **SKIP**. 

The way light processor returns this is, given a list of numbers (0..Max):

If the reverse option is settled, it'll take the numbers lower than the starting block number. Then, for each of these numbers (Ni), it will return the blocks header which number is starting block number - Ni.

On the other hand, if the reverse option is not settled, it'll take the number lower than the difference between the best block's number and the start number. Then for each of these numbers (Ni), it'll return the blocks header which number is starting block + Ni.