### PR TITLE
light peer modification

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/light/LightPeer.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightPeer.java
@@ -18,6 +18,7 @@
 
 package co.rsk.net.light;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.net.MessageQueue;
 import org.ethereum.net.message.Message;
@@ -36,7 +37,7 @@ public class LightPeer {
     public LightPeer(Channel channel, MessageQueue msgQueue) {
         this.channel = channel;
         this.msgQueue = msgQueue;
-        this.blockHeaders = new LinkedList<>();
+        this.blockHeaders = new LinkedList<>(); //This is a dummy chain of headers. It is going to be replaced by an unique header chain
     }
 
     public String getPeerIdShort() {
@@ -55,6 +56,7 @@ public class LightPeer {
         blockHeaders.add(blockHeader);
     }
 
+    @VisibleForTesting
     public List<BlockHeader> getBlocks() {
         return new LinkedList<>(blockHeaders);
     }


### PR DESCRIPTION
It solves the misunderstanding of the blockheader list variable in light peer. It'll be replaced by a unique header chain and I add the latter as a comment in the code. Also, I added the VisibleForTesting tag in the getBlockHeader method.