### PR TITLE
Fix issue #1127: Transactions were lost in reorganizations

### DIFF
--- a/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.test;
 
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockChainStatus;
 import co.rsk.test.dsl.DslParser;
@@ -406,5 +407,18 @@ public class DslFilesTest {
         // Gas consumed SHOULD NOT be all there is available
         Assert.assertNotEquals(200000, gasUsed);
         Assert.assertFalse("Transaction should be reverted", txinfo.getReceipt().isSuccessful());
+    }
+
+
+    @Test
+    public void onReorganizationTxGetsReaddedToTxPool() throws FileNotFoundException, DslProcessorException {
+        DslParser parser = DslParser.fromResource("dsl/reorganization.txt");
+        World world = new World();
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        Assert.assertEquals(1, world.getTransactionPool().getPendingTransactions().size());
+        Assert.assertEquals(Coin.valueOf(1000), world.getTransactionPool().getPendingTransactions().get(0).getValue());
+
     }
 }

--- a/rskj-core/src/test/resources/dsl/reorganization.txt
+++ b/rskj-core/src/test/resources/dsl/reorganization.txt
@@ -1,0 +1,44 @@
+account_new acc1 10000000
+account_new acc2 0
+
+# create the base of our fork
+
+block_chain g00 forkStart
+block_connect forkStart
+
+# FIRST STEP we create a block with a transaction that is connected to the fork
+
+transaction_build tx01
+    sender acc1
+    receiver acc2
+    value 1000
+    build
+
+block_build b01
+    parent forkStart
+    transactions tx01
+    build
+
+block_connect b01
+
+# Assert best block
+assert_best b01
+
+assert_balance acc2 1000
+
+# SECOND STEP we force a reorganization
+
+block_chain g00 u01
+block_chain g00 u02
+
+block_build newBest
+    parent forkStart
+    uncles u01 u02
+    build
+
+block_connect newBest
+
+assert_best newBest
+
+
+

--- a/rskj-core/src/test/resources/dsl/reorganization_different_non_competing_tx.txt
+++ b/rskj-core/src/test/resources/dsl/reorganization_different_non_competing_tx.txt
@@ -1,5 +1,6 @@
 account_new acc1 10000000
-account_new acc2 0
+account_new acc2 10000000
+account_new acc3 0
 
 # create the base of our fork
 
@@ -10,7 +11,7 @@ block_connect forkStart
 
 transaction_build tx01
     sender acc1
-    receiver acc2
+    receiver acc3
     value 1000
     build
 
@@ -24,9 +25,15 @@ block_connect b01
 # Assert best block
 assert_best b01
 
-assert_balance acc2 1000
+assert_balance acc3 1000
 
-# SECOND STEP we force a reorganization
+# SECOND STEP we force a reorganization, and the second block has a tx for the same receiving account but different sender
+
+transaction_build tx02
+    sender acc2
+    receiver acc3
+    value 1000
+    build
 
 block_chain g00 u01
 block_chain g00 u02
@@ -34,6 +41,7 @@ block_chain g00 u02
 block_build newBest
     parent forkStart
     uncles u01 u02
+    transactions tx02
     build
 
 block_connect newBest
@@ -41,7 +49,8 @@ block_connect newBest
 assert_best newBest
 
 assert_balance acc1 10000000
-assert_balance acc2 0
+assert_balance acc3 1000
+
 
 
 

--- a/rskj-core/src/test/resources/dsl/reorganization_different_tx_on_both_same_nonce.txt
+++ b/rskj-core/src/test/resources/dsl/reorganization_different_tx_on_both_same_nonce.txt
@@ -26,7 +26,14 @@ assert_best b01
 
 assert_balance acc2 1000
 
-# SECOND STEP we force a reorganization
+# SECOND STEP we force a reorganization, but the second block has a tx for the same account and a different nonce
+
+transaction_build tx02
+    sender acc1
+    receiver acc2
+    value 777
+    build
+
 
 block_chain g00 u01
 block_chain g00 u02
@@ -34,14 +41,12 @@ block_chain g00 u02
 block_build newBest
     parent forkStart
     uncles u01 u02
+    transactions tx02
     build
 
 block_connect newBest
 
 assert_best newBest
 
-assert_balance acc1 10000000
-assert_balance acc2 0
-
-
+assert_balance acc2 777
 

--- a/rskj-core/src/test/resources/dsl/reorganization_same_tx_on_both.txt
+++ b/rskj-core/src/test/resources/dsl/reorganization_same_tx_on_both.txt
@@ -26,7 +26,7 @@ assert_best b01
 
 assert_balance acc2 1000
 
-# SECOND STEP we force a reorganization
+# SECOND STEP we force a reorganization, but the second block also has the same transaction
 
 block_chain g00 u01
 block_chain g00 u02
@@ -34,14 +34,15 @@ block_chain g00 u02
 block_build newBest
     parent forkStart
     uncles u01 u02
+    transactions tx01
     build
 
 block_connect newBest
 
 assert_best newBest
 
-assert_balance acc1 10000000
-assert_balance acc2 0
+assert_balance acc2 1000
+
 
 
 


### PR DESCRIPTION
As reported in https://github.com/rsksmart/rskj/issues/1127 transactions are being lost in reorganizations.

When a new block is created the method `processBest` of the `TransactionPoolImpl` class is called with the new block, which should calculate the fork, and for each block that is no longer part of the best chain, call `retractBlock` which in turn calls to `addTransaction`.

The current problem is the following: `addTransaction` runs validations on the block, but these validations are run against the wrong AccountState: an account state that is derived from what was the *previous* best block, a block that *included* the same transaction we now want to add again to the transaction pool. This is because currently the `bestBlock` attribute of the `TransactionPoolImpl` is being updated *after* calling retract block. So the tx will be inevitably rejected because of an invalid nonce.

The proposed solution is to update the `bestBlock` attribute before actually calling `retractBlock` so the tx will be validated against the new best block in the chain. 

This PR also includes a small refactor on the call to removeObsoleteTransactions, because the first parameter was, with the change, always the same value.

NOTE: This PR only aims to fix the issue of the transaction being lost in the reorganization. The issue https://github.com/rsksmart/rskj/issues/1127 also mentions "The transaction with the same hash should be able to resend it to the network after a period of time.", that is *not* part of what is being tackled in this PR