### PR TITLE
Message Handler to Support multiple messages from different Light Peers

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
@@ -32,18 +32,18 @@ import io.netty.channel.SimpleChannelInboundHandler;
 public class LightClientHandler extends SimpleChannelInboundHandler<LightClientMessage> {
     private final LightPeer lightPeer;
     private final LightSyncProcessor lightSyncProcessor;
-    private final LightProcessor lightProcessor;
+    private final LightMessageHandler lightMessageHandler;
 
-    public LightClientHandler(LightPeer lightPeer, LightProcessor lightProcessor, LightSyncProcessor lightSyncProcessor) {
-        this.lightProcessor = lightProcessor;
+    public LightClientHandler(LightPeer lightPeer,
+                              LightSyncProcessor lightSyncProcessor, LightMessageHandler lightMessageHandler) {
         this.lightSyncProcessor = lightSyncProcessor;
         this.lightPeer = lightPeer;
+        this.lightMessageHandler = lightMessageHandler;
     }
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, LightClientMessage msg) {
-        LightClientMessageVisitor visitor = new LightClientMessageVisitor(lightPeer, lightProcessor, lightSyncProcessor, ctx,this);
-        msg.accept(visitor);
+        lightMessageHandler.postMessage(lightPeer, msg, ctx, this);
     }
 
     public void activate() {

--- a/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/LightClientHandler.java
@@ -43,7 +43,7 @@ public class LightClientHandler extends SimpleChannelInboundHandler<LightClientM
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, LightClientMessage msg) {
-        lightMessageHandler.postMessage(lightPeer, msg, ctx, this);
+        lightMessageHandler.enqueueMessage(lightPeer, msg, ctx, this);
     }
 
     public void activate() {

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -1,0 +1,30 @@
+package co.rsk.net.light;
+
+import co.rsk.net.eth.LightClientHandler;
+import co.rsk.net.light.message.LightClientMessage;
+import io.netty.channel.ChannelHandlerContext;
+
+public class LightMessageHandler {
+
+    private final LightProcessor lightProcessor;
+    private final LightSyncProcessor lightSyncProcessor;
+
+    public LightMessageHandler(LightProcessor lightProcessor, LightSyncProcessor lightSyncProcessor) {
+        this.lightProcessor = lightProcessor;
+        this.lightSyncProcessor = lightSyncProcessor;
+    }
+
+    public void processMessage(LightPeer lightPeer, LightClientMessage message,
+                               ChannelHandlerContext ctx, LightClientHandler lightClientHandler) {
+        LightClientMessageVisitor visitor = new LightClientMessageVisitor(lightPeer, lightProcessor, lightSyncProcessor, ctx, lightClientHandler);
+        message.accept(visitor);
+    }
+
+    public void postMessage(LightPeer sender, LightClientMessage message) throws InterruptedException {
+
+    }
+
+    public long getMessageQueueSize() {
+        return 0;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2020 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.net.light;
 
 import co.rsk.config.InternalService;

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -38,11 +38,12 @@ public class LightMessageHandler implements InternalService, Runnable {
 
     private final ArrayBlockingQueue<MessageTask> queue;
 
-    private volatile boolean stopped;
+    private volatile boolean stopped = false;
 
     public LightMessageHandler(LightProcessor lightProcessor, LightSyncProcessor lightSyncProcessor) {
         this.lightProcessor = lightProcessor;
         this.lightSyncProcessor = lightSyncProcessor;
+        // Queue capacity is the same as in the NodeMessageHanlder, but it can be changed without any problem
         this.queue = new ArrayBlockingQueue<>(11);
     }
 
@@ -52,8 +53,8 @@ public class LightMessageHandler implements InternalService, Runnable {
         message.accept(visitor);
     }
 
-    public void postMessage(LightPeer lightPeer, LightClientMessage message, ChannelHandlerContext ctx,
-                            LightClientHandler lightClientHandler) {
+    public void enqueueMessage(LightPeer lightPeer, LightClientMessage message, ChannelHandlerContext ctx,
+                               LightClientHandler lightClientHandler) {
         logger.trace("Start post message (queue size {}) (message type {})", queue.size(), message);
 
         if (!queue.offer(new LightMessageHandler.MessageTask(lightPeer, message, ctx, lightClientHandler))) {

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -7,7 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 public class LightMessageHandler implements InternalService, Runnable {
@@ -17,14 +17,14 @@ public class LightMessageHandler implements InternalService, Runnable {
     private final LightProcessor lightProcessor;
     private final LightSyncProcessor lightSyncProcessor;
 
-    private final PriorityBlockingQueue<LightMessageHandler.MessageTask> queue;
+    private final ArrayBlockingQueue<MessageTask> queue;
 
     private boolean stopped = true;
 
     public LightMessageHandler(LightProcessor lightProcessor, LightSyncProcessor lightSyncProcessor) {
         this.lightProcessor = lightProcessor;
         this.lightSyncProcessor = lightSyncProcessor;
-        this.queue = new PriorityBlockingQueue<>(11);
+        this.queue = new ArrayBlockingQueue<>(11);
     }
 
     public void processMessage(LightPeer lightPeer, LightClientMessage message,

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -64,9 +64,9 @@ public class LightMessageHandler implements InternalService, Runnable {
             try {
                 logger.trace("Get task");
 
-                task = this.queue.poll(1, TimeUnit.SECONDS);
+                task = queue.poll(1, TimeUnit.SECONDS);
 
-                loggerMessageProcess.debug("Queued Messages: {}", this.queue.size());
+                loggerMessageProcess.debug("Queued Messages: {}", queue.size());
 
                 if (task != null) {
                     logger.trace("Start task");

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -101,9 +101,6 @@ public class LightMessageHandler implements InternalService, Runnable {
             } else {
                 logger.trace("No task");
             }
-
-            // THIS SHOULD BE IMPLEMENTED? RELATED TO SYNC
-            //updateTimedEvents();
         }
         catch (Exception ex) {
             logger.error("Unexpected error processing: {}", task, ex);

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -95,7 +95,7 @@ public class LightMessageHandler implements InternalService, Runnable {
 
             if (task != null) {
                 logger.trace("Start task");
-                this.processMessage(task.getSender(), task.getMessage(),
+                this.processMessage(task.getLightPeer(), task.getMessage(),
                         task.getCtx(), task.getLightClientHandler());
                 logger.trace("End task");
             } else {
@@ -108,21 +108,21 @@ public class LightMessageHandler implements InternalService, Runnable {
     }
 
     private static class MessageTask  {
-        private final LightPeer sender;
+        private final LightPeer lightPeer;
         private final LightClientMessage message;
         private final ChannelHandlerContext ctx;
         private final LightClientHandler lightClientHandler;
 
-        public MessageTask(LightPeer sender, LightClientMessage message,
+        public MessageTask(LightPeer lightPeer, LightClientMessage message,
                            ChannelHandlerContext ctx, LightClientHandler lightClientHandler) {
-            this.sender = sender;
+            this.lightPeer = lightPeer;
             this.message = message;
             this.ctx = ctx;
             this.lightClientHandler = lightClientHandler;
         }
 
-        public LightPeer getSender() {
-            return this.sender;
+        public LightPeer getLightPeer() {
+            return this.lightPeer;
         }
 
         public LightClientMessage getMessage() {
@@ -140,7 +140,7 @@ public class LightMessageHandler implements InternalService, Runnable {
         @Override
         public String toString() {
             return "MessageTask{" +
-                    "sender=" + sender +
+                    "lightPeer=" + lightPeer +
                     ", message=" + message +
                     ", ctx=" + ctx +
                     ", lightClientHandler=" + lightClientHandler +

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -1,13 +1,33 @@
 package co.rsk.net.light;
 
+import co.rsk.config.InternalService;
+import co.rsk.crypto.Keccak256;
 import co.rsk.net.eth.LightClientHandler;
 import co.rsk.net.light.message.LightClientMessage;
 import io.netty.channel.ChannelHandlerContext;
+import org.ethereum.crypto.HashUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class LightMessageHandler {
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+public class LightMessageHandler implements InternalService, Runnable {
+    private static final Logger logger = LoggerFactory.getLogger("lightmessagehandler");
+    private static final Logger loggerMessageProcess = LoggerFactory.getLogger("lightmessageProcess");
 
     private final LightProcessor lightProcessor;
     private final LightSyncProcessor lightSyncProcessor;
+
+    private PriorityBlockingQueue<LightMessageHandler.MessageTask> queue;
+    private Set<Keccak256> receivedMessages = Collections.synchronizedSet(new HashSet<>());
+
+    private boolean stopped = true;
+
+    public static final int MAX_NUMBER_OF_MESSAGES_CACHED = 5000;
 
     public LightMessageHandler(LightProcessor lightProcessor, LightSyncProcessor lightSyncProcessor) {
         this.lightProcessor = lightProcessor;
@@ -20,11 +40,115 @@ public class LightMessageHandler {
         message.accept(visitor);
     }
 
-    public void postMessage(LightPeer sender, LightClientMessage message) throws InterruptedException {
+    public void postMessage(LightPeer sender, LightClientMessage message, ChannelHandlerContext ctx,
+                            LightClientHandler lightClientHandler) throws InterruptedException {
+        logger.trace("Start post message (queue size {}) (message type {})", this.queue.size(), message);
 
+        //cleanExpiredMessages();
+        tryAddMessage(sender, message, ctx, lightClientHandler);
+        logger.trace("End post message (queue size {})", this.queue.size());
+    }
+
+    private void tryAddMessage(LightPeer sender, LightClientMessage message,
+                               ChannelHandlerContext ctx, LightClientHandler lightClientHandler) {
+        Keccak256 encodedMessage = new Keccak256(HashUtil.keccak256(message.getEncoded()));
+        if (!receivedMessages.contains(encodedMessage)) {
+            //if (message.getMessageType() == MessageType.BLOCK_MESSAGE || message.getMessageType() == MessageType.TRANSACTIONS) {
+                if (this.receivedMessages.size() >= MAX_NUMBER_OF_MESSAGES_CACHED) {
+                    this.receivedMessages.clear();
+                }
+                this.receivedMessages.add(encodedMessage);
+            //}
+
+            if (!this.queue.offer(new LightMessageHandler.MessageTask(sender, message, ctx, lightClientHandler))) {
+                logger.warn("Unexpected path. Is message queue bounded now?");
+            }
+        } else {
+            logger.trace("Received message already known, not added to the queue");
+        }
     }
 
     public long getMessageQueueSize() {
-        return 0;
+        return queue.size();
+    }
+
+    @Override
+    public void start() {
+        new Thread(this).start();
+    }
+
+    @Override
+    public void stop() {
+        this.stopped = true;
+    }
+
+    @Override
+    public void run() {
+        while (!stopped) {
+            LightMessageHandler.MessageTask task = null;
+            try {
+                logger.trace("Get task");
+
+                task = this.queue.poll(1, TimeUnit.SECONDS);
+
+                loggerMessageProcess.debug("Queued Messages: {}", this.queue.size());
+
+                if (task != null) {
+                    logger.trace("Start task");
+                    this.processMessage(task.getSender(), task.getMessage(),
+                            task.getCtx(), task.getLightClientHandler());
+                    logger.trace("End task");
+                } else {
+                    logger.trace("No task");
+                }
+
+                // THIS SHOULD BE IMPLEMENTED? RELATED TO SYNC
+                //updateTimedEvents();
+            }
+            catch (Exception ex) {
+                logger.error("Unexpected error processing: {}", task, ex);
+            }
+        }
+    }
+
+    private static class MessageTask  {
+        private final LightPeer sender;
+        private final LightClientMessage message;
+        private final ChannelHandlerContext ctx;
+
+        private final LightClientHandler lightClientHandler;
+
+        public MessageTask(LightPeer sender, LightClientMessage message,
+                           ChannelHandlerContext ctx, LightClientHandler lightClientHandler) {
+            this.sender = sender;
+            this.message = message;
+            this.ctx = ctx;
+            this.lightClientHandler = lightClientHandler;
+        }
+
+        public LightPeer getSender() {
+            return this.sender;
+        }
+
+        public LightClientMessage getMessage() {
+            return this.message;
+        }
+
+        public ChannelHandlerContext getCtx() {
+            return ctx;
+        }
+
+        public LightClientHandler getLightClientHandler() {
+            return lightClientHandler;
+        }
+
+        @Override
+        public String toString() {
+            return "MessageTask{" +
+                    "sender=" + sender +
+                    ", message=" + message +
+                    '}';
+        }
+
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightMessageHandler.java
@@ -22,8 +22,8 @@ public class LightMessageHandler implements InternalService, Runnable {
     private final LightProcessor lightProcessor;
     private final LightSyncProcessor lightSyncProcessor;
 
-    private PriorityBlockingQueue<LightMessageHandler.MessageTask> queue;
-    private Set<Keccak256> receivedMessages = Collections.synchronizedSet(new HashSet<>());
+    private final PriorityBlockingQueue<LightMessageHandler.MessageTask> queue;
+    private final Set<Keccak256> receivedMessages = Collections.synchronizedSet(new HashSet<>());
 
     private boolean stopped = true;
 
@@ -32,6 +32,7 @@ public class LightMessageHandler implements InternalService, Runnable {
     public LightMessageHandler(LightProcessor lightProcessor, LightSyncProcessor lightSyncProcessor) {
         this.lightProcessor = lightProcessor;
         this.lightSyncProcessor = lightSyncProcessor;
+        this.queue = new PriorityBlockingQueue<>(11);
     }
 
     public void processMessage(LightPeer lightPeer, LightClientMessage message,
@@ -41,7 +42,7 @@ public class LightMessageHandler implements InternalService, Runnable {
     }
 
     public void postMessage(LightPeer sender, LightClientMessage message, ChannelHandlerContext ctx,
-                            LightClientHandler lightClientHandler) throws InterruptedException {
+                            LightClientHandler lightClientHandler) {
         logger.trace("Start post message (queue size {}) (message type {})", this.queue.size(), message);
 
         //cleanExpiredMessages();
@@ -115,7 +116,6 @@ public class LightMessageHandler implements InternalService, Runnable {
         private final LightPeer sender;
         private final LightClientMessage message;
         private final ChannelHandlerContext ctx;
-
         private final LightClientHandler lightClientHandler;
 
         public MessageTask(LightPeer sender, LightClientMessage message,
@@ -135,11 +135,11 @@ public class LightMessageHandler implements InternalService, Runnable {
         }
 
         public ChannelHandlerContext getCtx() {
-            return ctx;
+            return this.ctx;
         }
 
         public LightClientHandler getLightClientHandler() {
-            return lightClientHandler;
+            return this.lightClientHandler;
         }
 
         @Override
@@ -147,8 +147,9 @@ public class LightMessageHandler implements InternalService, Runnable {
             return "MessageTask{" +
                     "sender=" + sender +
                     ", message=" + message +
+                    ", ctx=" + ctx +
+                    ", lightClientHandler=" + lightClientHandler +
                     '}';
         }
-
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
@@ -46,7 +46,7 @@ import static co.rsk.net.light.LightClientMessageCodes.*;
 public class LightSyncProcessor {
 
     private static final int MAX_PENDING_MESSAGES = 10;
-    private static final int MAX_PEER_CONNECTIONS = 10;
+    private static final int MAX_PEER_CONNECTIONS = 1;
     private final LightPeersInformation lightPeersInformation;
     private LightSyncState syncState;
     private final SystemProperties config;

--- a/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
@@ -45,8 +45,8 @@ import static co.rsk.net.light.LightClientMessageCodes.*;
 
 public class LightSyncProcessor {
 
-    private static final int MAX_PENDING_MESSAGES = 1;
-    private static final int MAX_PEER_CONNECTIONS = 1;
+    private static final int MAX_PENDING_MESSAGES = 10;
+    private static final int MAX_PEER_CONNECTIONS = 10;
     private final LightPeersInformation lightPeersInformation;
     private LightSyncState syncState;
     private final SystemProperties config;

--- a/rskj-core/src/test/java/co/rsk/net/LightClientTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightClientTestUtils.java
@@ -1,0 +1,91 @@
+package co.rsk.net;
+
+import co.rsk.db.RepositoryLocator;
+import co.rsk.net.eth.LightClientHandler;
+import co.rsk.net.light.LightMessageHandler;
+import co.rsk.net.light.LightPeer;
+import co.rsk.net.light.LightProcessor;
+import co.rsk.net.light.LightSyncProcessor;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.ethereum.config.SystemProperties;
+import org.ethereum.core.Block;
+import org.ethereum.core.Blockchain;
+import org.ethereum.core.Genesis;
+import org.ethereum.db.BlockStore;
+import org.ethereum.net.MessageQueue;
+import org.ethereum.net.server.Channel;
+
+import static org.mockito.Mockito.*;
+
+public class LightClientTestUtils {
+    private final MessageQueue messageQueue;
+    private final Blockchain blockchain;
+    private final BlockStore blockStore;
+    private final LightSyncProcessor lightSyncProcessor;
+    private final SystemProperties config;
+    private final RepositoryLocator repositoryLocator;
+    private final LightProcessor lightProcessor;
+    private final LightMessageHandler lightMessageHandler;
+    private final LightClientHandler.Factory factory;
+
+    public LightClientTestUtils() {
+        messageQueue = mock(MessageQueue.class);
+        blockchain = mock(Blockchain.class);
+        blockStore = mock(BlockStore.class);
+        config = mock(SystemProperties.class);
+        repositoryLocator = mock(RepositoryLocator.class);
+        Genesis genesis = mock(Genesis.class);
+        lightProcessor = new LightProcessor(blockchain, blockStore, repositoryLocator);
+        lightSyncProcessor = new LightSyncProcessor(config, genesis, blockStore, blockchain);
+        lightMessageHandler = new LightMessageHandler(lightProcessor, lightSyncProcessor);
+        factory = (lightPeer) -> new LightClientHandler(lightPeer, lightSyncProcessor, lightMessageHandler);
+    }
+
+    private void includeBlockInBlockchain(Block block) {
+        when(blockchain.getBlockByNumber(block.getNumber())).thenReturn(block);
+        when(blockchain.getBlockByHash(block.getHash().getBytes())).thenReturn(block);
+    }
+
+    public MessageQueue getMessageQueue() {
+        return messageQueue;
+    }
+
+    public Blockchain getBlockchain() {
+        return blockchain;
+    }
+
+    public BlockStore getBlockStore() {
+        return blockStore;
+    }
+
+    public LightSyncProcessor getLightSyncProcessor() {
+        return lightSyncProcessor;
+    }
+
+    public SystemProperties getConfig() {
+        return config;
+    }
+
+    public RepositoryLocator getRepositoryLocator() {
+        return repositoryLocator;
+    }
+
+    public LightProcessor getLightProcessor() {
+        return lightProcessor;
+    }
+
+    public LightPeer createPeer() {
+        return spy(new LightPeer(mock(Channel.class), messageQueue));
+    }
+
+    public LightClientHandler generateLightClientHandler(LightPeer lightPeer) {
+        return factory.newInstance(lightPeer);
+    }
+
+    public ChannelHandlerContext hookLightPeerToCtx(LightPeer lightPeer, LightClientHandler lightClientHandler) {
+        EmbeddedChannel ch = new EmbeddedChannel();
+        ch.pipeline().addLast(lightClientHandler);
+        return ch.pipeline().firstContext();
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/LightClientTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightClientTestUtils.java
@@ -100,6 +100,9 @@ public class LightClientTestUtils {
         return lightProcessor;
     }
 
+    /**
+     * Its created as a spy so we can check if the message was sent
+     **/
     public LightPeer createPeer() {
         return spy(new LightPeer(mock(Channel.class), messageQueue));
     }
@@ -108,7 +111,7 @@ public class LightClientTestUtils {
         return factory.newInstance(lightPeer);
     }
 
-    public ChannelHandlerContext hookLightPeerToCtx(LightPeer lightPeer, LightClientHandler lightClientHandler) {
+    public ChannelHandlerContext hookLightLCHandlerToCtx(LightClientHandler lightClientHandler) {
         EmbeddedChannel ch = new EmbeddedChannel();
         ch.pipeline().addLast(lightClientHandler);
         return ch.pipeline().firstContext();

--- a/rskj-core/src/test/java/co/rsk/net/LightClientTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightClientTestUtils.java
@@ -23,10 +23,8 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.RepositorySnapshot;
 import co.rsk.net.eth.LightClientHandler;
-import co.rsk.net.light.LightMessageHandler;
-import co.rsk.net.light.LightPeer;
-import co.rsk.net.light.LightProcessor;
-import co.rsk.net.light.LightSyncProcessor;
+import co.rsk.net.light.*;
+import co.rsk.validators.ProofOfWorkRule;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.ethereum.config.SystemProperties;
@@ -62,7 +60,9 @@ public class LightClientTestUtils {
         repositorySnapshot = mock(RepositorySnapshot.class);
         Genesis genesis = mock(Genesis.class);
         lightProcessor = new LightProcessor(blockchain, blockStore, repositoryLocator);
-        lightSyncProcessor = new LightSyncProcessor(config, genesis, blockStore, blockchain);
+        ProofOfWorkRule proofOfWorkRule = mock(ProofOfWorkRule.class);
+        LightPeersInformation lightPeersInformation = mock(LightPeersInformation.class);
+        lightSyncProcessor = new LightSyncProcessor(config, genesis, blockStore, blockchain, proofOfWorkRule, lightPeersInformation);
         lightMessageHandler = new LightMessageHandler(lightProcessor, lightSyncProcessor);
         factory = (lightPeer) -> new LightClientHandler(lightPeer, lightSyncProcessor, lightMessageHandler);
     }

--- a/rskj-core/src/test/java/co/rsk/net/LightClientTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightClientTestUtils.java
@@ -100,6 +100,10 @@ public class LightClientTestUtils {
         return lightProcessor;
     }
 
+    public LightMessageHandler getLightMessageHandler() {
+        return lightMessageHandler;
+    }
+
     /**
      * Its created as a spy so we can check if the message was sent
      **/

--- a/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
@@ -1,4 +1,84 @@
 package co.rsk.net;
 
+import co.rsk.db.RepositoryLocator;
+import co.rsk.net.eth.LightClientHandler;
+import co.rsk.net.light.LightMessageHandler;
+import co.rsk.net.light.LightPeer;
+import co.rsk.net.light.LightProcessor;
+import co.rsk.net.light.LightSyncProcessor;
+import co.rsk.net.light.message.GetAccountsMessage;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.ethereum.config.SystemProperties;
+import org.ethereum.core.Blockchain;
+import org.ethereum.core.Genesis;
+import org.ethereum.db.BlockStore;
+import org.ethereum.net.MessageQueue;
+import org.ethereum.net.server.Channel;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
 public class LightMessageHandlerTest {
+    LightMessageHandler lightMessageHandler;
+    private MessageQueue messageQueue;
+    private Blockchain blockchain;
+    private BlockStore blockStore;
+    private LightSyncProcessor lightSyncProcessor;
+    private LightPeer lightPeer;
+    private LightClientHandler lightClientHandler;
+    private SystemProperties config;
+    private RepositoryLocator repositoryLocator;
+    private ChannelHandlerContext ctx;
+    private LightProcessor lightProcessor;
+
+    @Before
+    public void setUp() {
+        messageQueue = mock(MessageQueue.class);
+        blockchain = mock(Blockchain.class);
+        blockStore = mock(BlockStore.class);
+        config = mock(SystemProperties.class);
+        repositoryLocator = mock(RepositoryLocator.class);
+        Genesis genesis = mock(Genesis.class);
+        lightProcessor = mock(LightProcessor.class);
+        lightSyncProcessor = new LightSyncProcessor(config, genesis, blockStore, blockchain);
+        lightPeer = spy(new LightPeer(mock(Channel.class), messageQueue));
+        LightClientHandler.Factory factory = (lightPeer) -> new LightClientHandler(lightPeer, lightSyncProcessor, lightMessageHandler);
+        lightClientHandler = factory.newInstance(lightPeer);
+        lightMessageHandler = new LightMessageHandler(lightProcessor, lightSyncProcessor);
+
+        EmbeddedChannel ch = new EmbeddedChannel();
+        ch.pipeline().addLast(lightClientHandler);
+        ctx = ch.pipeline().firstContext();
+    }
+
+    /**
+     * We check that, given a random message,
+     * the processing for that message is called
+     */
+
+    @Test
+    public void lightMessageHandlerHandlesAMessageCorrectly() {
+        GetAccountsMessage m = new GetAccountsMessage(0, new byte[] {0x00}, new byte[] {0x00});
+        lightMessageHandler.postMessage(lightPeer, m, ctx, lightClientHandler);
+        assertEquals(1,lightMessageHandler.getMessageQueueSize());
+        lightMessageHandler.handleMessage();
+        assertEquals(0,lightMessageHandler.getMessageQueueSize());
+    }
+
+    @Test
+    public void lightMessageHandlerHandlesTwoMessagesCorrectly() {
+        GetAccountsMessage m1 = new GetAccountsMessage(0, new byte[] {0x00}, new byte[] {0x00});
+        GetAccountsMessage m2 = new GetAccountsMessage(0, new byte[] {0x00}, new byte[] {0x00});
+        lightMessageHandler.postMessage(lightPeer, m1, ctx, lightClientHandler);
+        lightMessageHandler.postMessage(lightPeer, m2, ctx, lightClientHandler);
+        assertEquals(2,lightMessageHandler.getMessageQueueSize());
+        lightMessageHandler.handleMessage();
+        lightMessageHandler.handleMessage();
+        assertEquals(0,lightMessageHandler.getMessageQueueSize());
+    }
+
 }

--- a/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
@@ -31,7 +31,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigInteger;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.ethereum.TestUtils.randomHash;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -116,12 +118,14 @@ public class LightMessageHandlerTest {
     }
 
     @Test
-    public void lightMessageHandlerServicesCorrectlyHandlesMessages() throws InterruptedException {
+    public void lightMessageHandlerServicesCorrectlyHandlesMessages() {
         lightMessageHandler.start();
         lightMessageHandler.postMessage(lightPeer1, m1, ctx1, lightClientHandler1);
         lightMessageHandler.postMessage(lightPeer1, m2, ctx1, lightClientHandler1);
 
-        Thread.sleep(500);
+        // Fails on TIMEOUT
+        await().atMost(1, TimeUnit.SECONDS)
+                .until(() -> lightMessageHandler.getMessageQueueSize() == 0);
 
         lightMessageHandler.stop();
         assertEquals(0,lightMessageHandler.getMessageQueueSize());

--- a/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
@@ -64,8 +64,8 @@ public class LightMessageHandlerTest {
         lightClientHandler1 = lightClientTestUtils.generateLightClientHandler(lightPeer1);
         lightClientHandler2 = lightClientTestUtils.generateLightClientHandler(lightPeer2);
 
-        ctx1 = lightClientTestUtils.hookLightPeerToCtx(lightPeer1, lightClientHandler1);
-        ctx2 = lightClientTestUtils.hookLightPeerToCtx(lightPeer2, lightClientHandler2);
+        ctx1 = lightClientTestUtils.hookLightLCHandlerToCtx(lightClientHandler1);
+        ctx2 = lightClientTestUtils.hookLightLCHandlerToCtx(lightClientHandler2);
 
         lightMessageHandler = new LightMessageHandler(lightClientTestUtils.getLightProcessor(),
                 lightClientTestUtils.getLightSyncProcessor());
@@ -129,11 +129,12 @@ public class LightMessageHandlerTest {
 
     @Test
     public void lightMessageHandlerHandlesAMessageCorrectlyAndResponseIsSent() {
+        Keccak256 blockHash = new Keccak256(m1.getBlockHash());
         Keccak256 codeHash = randomHash();
         byte[] storageRoot = randomHash().getBytes();
         AccountState state = new AccountState(BigInteger.ONE, new Coin(new byte[] {0x10}));
 
-        lightClientTestUtils.includeAccount(new Keccak256(m1.getBlockHash()), m1.getAddressHash(),
+        lightClientTestUtils.includeAccount(blockHash, m1.getAddressHash(),
                 state, codeHash, storageRoot);
 
         lightMessageHandler.postMessage(lightPeer1, m1, ctx1, lightClientHandler1);

--- a/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
@@ -1,0 +1,4 @@
+package co.rsk.net;
+
+public class LightMessageHandlerTest {
+}

--- a/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
@@ -89,7 +89,7 @@ public class LightMessageHandlerTest {
 
     @Test
     public void lightMessageHandlerHandlesAMessageCorrectly() {
-        lightMessageHandler.postMessage(lightPeer1, m1, ctx1, lightClientHandler1);
+        lightMessageHandler.enqueueMessage(lightPeer1, m1, ctx1, lightClientHandler1);
         assertEquals(1,lightMessageHandler.getMessageQueueSize());
         lightMessageHandler.handleMessage();
         assertEquals(0,lightMessageHandler.getMessageQueueSize());
@@ -97,8 +97,8 @@ public class LightMessageHandlerTest {
 
     @Test
     public void lightMessageHandlerHandlesTwoMessagesCorrectly() {
-        lightMessageHandler.postMessage(lightPeer1, m1, ctx1, lightClientHandler1);
-        lightMessageHandler.postMessage(lightPeer1, m2, ctx1, lightClientHandler1);
+        lightMessageHandler.enqueueMessage(lightPeer1, m1, ctx1, lightClientHandler1);
+        lightMessageHandler.enqueueMessage(lightPeer1, m2, ctx1, lightClientHandler1);
         assertEquals(2,lightMessageHandler.getMessageQueueSize());
         lightMessageHandler.handleMessage();
         lightMessageHandler.handleMessage();
@@ -107,8 +107,8 @@ public class LightMessageHandlerTest {
 
     @Test
     public void lightMessageHandlerHandlesMessagesFromTwoPeersCorrectly() {
-        lightMessageHandler.postMessage(lightPeer1, m1, ctx1, lightClientHandler1);
-        lightMessageHandler.postMessage(lightPeer2, m2, ctx2, lightClientHandler2);
+        lightMessageHandler.enqueueMessage(lightPeer1, m1, ctx1, lightClientHandler1);
+        lightMessageHandler.enqueueMessage(lightPeer2, m2, ctx2, lightClientHandler2);
 
         assertEquals(2,lightMessageHandler.getMessageQueueSize());
 
@@ -121,8 +121,8 @@ public class LightMessageHandlerTest {
     @Test
     public void lightMessageHandlerServicesCorrectlyHandlesMessages() {
         lightMessageHandler.start();
-        lightMessageHandler.postMessage(lightPeer1, m1, ctx1, lightClientHandler1);
-        lightMessageHandler.postMessage(lightPeer1, m2, ctx1, lightClientHandler1);
+        lightMessageHandler.enqueueMessage(lightPeer1, m1, ctx1, lightClientHandler1);
+        lightMessageHandler.enqueueMessage(lightPeer1, m2, ctx1, lightClientHandler1);
 
         // Fails on TIMEOUT
         await().atMost(1, TimeUnit.SECONDS)
@@ -134,7 +134,7 @@ public class LightMessageHandlerTest {
 
     @Test
     public void lightMessageHandlerHandlesAMessageCorrectlyAndResponseIsSent() {
-        lightMessageHandler.postMessage(lightPeer1, m1, ctx1, lightClientHandler1);
+        lightMessageHandler.enqueueMessage(lightPeer1, m1, ctx1, lightClientHandler1);
         lightMessageHandler.handleMessage();
 
         assertEquals(0,lightMessageHandler.getMessageQueueSize());

--- a/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/LightMessageHandlerTest.java
@@ -1,14 +1,42 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2020 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.net;
 
+import co.rsk.core.Coin;
+import co.rsk.crypto.Keccak256;
 import co.rsk.net.eth.LightClientHandler;
 import co.rsk.net.light.LightMessageHandler;
 import co.rsk.net.light.LightPeer;
 import co.rsk.net.light.message.GetAccountsMessage;
 import io.netty.channel.ChannelHandlerContext;
+import org.bouncycastle.util.Arrays;
+import org.ethereum.core.AccountState;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.math.BigInteger;
+
+import static org.ethereum.TestUtils.randomHash;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class LightMessageHandlerTest {
 
@@ -24,10 +52,11 @@ public class LightMessageHandlerTest {
     private GetAccountsMessage m1;
     private GetAccountsMessage m2;
 
+    private LightClientTestUtils lightClientTestUtils;
 
     @Before
     public void setUp() {
-        LightClientTestUtils lightClientTestUtils = new LightClientTestUtils();
+        lightClientTestUtils = new LightClientTestUtils();
 
         lightPeer1 = lightClientTestUtils.createPeer();
         lightPeer2 = lightClientTestUtils.createPeer();
@@ -41,8 +70,13 @@ public class LightMessageHandlerTest {
         lightMessageHandler = new LightMessageHandler(lightClientTestUtils.getLightProcessor(),
                 lightClientTestUtils.getLightSyncProcessor());
 
-        m1 = new GetAccountsMessage(0, new byte[] {0x00}, new byte[] {0x00});
-        m2 = new GetAccountsMessage(0, new byte[] {0x00}, new byte[] {0x00});
+        byte[] address1 = randomHash().getBytes();
+        address1 = Arrays.copyOfRange(address1, 12, address1.length);
+        m1 = new GetAccountsMessage(4, randomHash().getBytes(), address1);
+
+        byte[] address2 = randomHash().getBytes();
+        address2 = Arrays.copyOfRange(address2, 12, address2.length);
+        m2 = new GetAccountsMessage(123, randomHash().getBytes(), address2);
     }
 
     /**
@@ -93,4 +127,19 @@ public class LightMessageHandlerTest {
         assertEquals(0,lightMessageHandler.getMessageQueueSize());
     }
 
+    @Test
+    public void lightMessageHandlerHandlesAMessageCorrectlyAndResponseIsSent() {
+        Keccak256 codeHash = randomHash();
+        byte[] storageRoot = randomHash().getBytes();
+        AccountState state = new AccountState(BigInteger.ONE, new Coin(new byte[] {0x10}));
+
+        lightClientTestUtils.includeAccount(new Keccak256(m1.getBlockHash()), m1.getAddressHash(),
+                state, codeHash, storageRoot);
+
+        lightMessageHandler.postMessage(lightPeer1, m1, ctx1, lightClientHandler1);
+        lightMessageHandler.handleMessage();
+
+        assertEquals(0,lightMessageHandler.getMessageQueueSize());
+        verify(lightPeer1, times(1)).sendMessage(any());
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/net/eth/LightClientHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/eth/LightClientHandlerTest.java
@@ -71,6 +71,7 @@ public class LightClientHandlerTest {
     private Keccak256 blockHash;
     private LightPeer lightPeer;
     private ProofOfWorkRule proofOfWorkRule;
+    private LightMessageHandler lightMessageHandler;
 
     @Before
     public void setup() {
@@ -86,7 +87,8 @@ public class LightClientHandlerTest {
         LightPeersInformation lightPeersInformation = mock(LightPeersInformation.class);
         lightSyncProcessor = new LightSyncProcessor(config, genesis, blockStore, blockchain, proofOfWorkRule, lightPeersInformation);
         lightPeer = spy(new LightPeer(mock(Channel.class), messageQueue));
-        LightClientHandler.Factory factory = (lightPeer) -> new LightClientHandler(lightPeer, lightProcessor, lightSyncProcessor);
+        lightMessageHandler = mock(LightMessageHandler.class);
+        LightClientHandler.Factory factory = (lightPeer) -> new LightClientHandler(lightPeer, lightSyncProcessor, lightMessageHandler);
         lightClientHandler = factory.newInstance(lightPeer);
         blockHash = new Keccak256(HashUtil.randomHash());
 

--- a/rskj-core/src/test/java/co/rsk/net/eth/LightClientHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/eth/LightClientHandlerTest.java
@@ -60,7 +60,6 @@ public class LightClientHandlerTest {
     private MessageQueue messageQueue;
     private LightClientHandler lightClientHandler;
     private ChannelHandlerContext ctx;
-    private LightProcessor lightProcessor;
     private Blockchain blockchain;
     private BlockStore blockStore;
     private RepositoryLocator repositoryLocator;
@@ -82,7 +81,6 @@ public class LightClientHandlerTest {
         repositoryLocator = mock(RepositoryLocator.class);
         genesis = mock(Genesis.class);
         genesisHash = new Keccak256(HashUtil.randomHash());
-        lightProcessor = new LightProcessor(blockchain, blockStore, repositoryLocator);
         proofOfWorkRule = mock(ProofOfWorkRule.class);
         LightPeersInformation lightPeersInformation = mock(LightPeersInformation.class);
         lightSyncProcessor = new LightSyncProcessor(config, genesis, blockStore, blockchain, proofOfWorkRule, lightPeersInformation);
@@ -387,7 +385,7 @@ public class LightClientHandlerTest {
 
         BlockHeadersMessage blockHeadersMessage = new BlockHeadersMessage(requestId, bHs);
 
-        lightClientHandler.channelRead0(ctx, blockHeadersMessage);
+        lightMessageHandler.processMessage(lightPeer, blockHeadersMessage, ctx, lightClientHandler);
 
         verify(lightPeer, times(0)).receivedBlockHeaders(any());
     }
@@ -400,7 +398,7 @@ public class LightClientHandlerTest {
 
         BlockHeadersMessage blockHeadersMessage = new BlockHeadersMessage(requestId, bHs);
 
-        lightClientHandler.channelRead0(ctx, blockHeadersMessage);
+        lightMessageHandler.processMessage(lightPeer, blockHeadersMessage, ctx, lightClientHandler);
 
         verify(lightPeer, times(0)).receivedBlockHeaders(any());
     }

--- a/rskj-core/src/test/java/co/rsk/net/light/LightSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/light/LightSyncProcessorTest.java
@@ -141,7 +141,7 @@ public class LightSyncProcessorTest {
 
         BlockHeadersMessage blockHeadersMessage = new BlockHeadersMessage(requestId, bHs);
 
-        lightClientHandler.channelRead0(ctx, blockHeadersMessage);
+        lightMessageHandler.processMessage(lightPeer, blockHeadersMessage, ctx, lightClientHandler);
 
         assertEquals(1, lightPeer.getBlocks().size());
         assertEquals(bHs, lightPeer.getBlocks());

--- a/rskj-core/src/test/java/co/rsk/net/light/LightSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/light/LightSyncProcessorTest.java
@@ -22,7 +22,6 @@ import co.rsk.core.BlockDifficulty;
 import co.rsk.core.bc.BlockChainStatus;
 import co.rsk.crypto.Keccak256;
 import co.rsk.net.eth.LightClientHandler;
-import co.rsk.net.light.*;
 import co.rsk.net.light.message.BlockHeadersMessage;
 import co.rsk.net.light.message.GetBlockHeadersMessage;
 import co.rsk.net.light.message.StatusMessage;
@@ -111,7 +110,8 @@ public class LightSyncProcessorTest {
     public void processStatusMessageAndShouldAskForAndReceiveBlockHeaderCorrectly() {
 
         LightProcessor lightProcessor = mock(LightProcessor.class);
-        LightClientHandler lightClientHandler = new LightClientHandler(lightPeer, lightProcessor, lightSyncProcessor);
+        LightMessageHandler lightMessageHandler = new LightMessageHandler(lightProcessor, lightSyncProcessor);
+        LightClientHandler lightClientHandler = new LightClientHandler(lightPeer, lightSyncProcessor, lightMessageHandler);
 
         EmbeddedChannel ch = new EmbeddedChannel();
         ch.pipeline().addLast(lightClientHandler);

--- a/rskj-core/src/test/java/co/rsk/net/light/LightSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/light/LightSyncProcessorTest.java
@@ -148,6 +148,23 @@ public class LightSyncProcessorTest {
     }
 
     @Test
+    public void morePeersThanAllowedTryToConnectToMeAndShouldBeDiscarded() {
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        LightClientHandler lightClientHandler = mock(LightClientHandler.class);
+
+        //Message sent
+        StatusMessage statusMessage = new StatusMessage(requestId, lightStatus, false);
+
+        LightPeer lightPeer2 = mock(LightPeer.class);
+        lightSyncProcessor.processStatusMessage(statusMessage, lightPeer, ctx, lightClientHandler);
+        lightSyncProcessor.processStatusMessage(statusMessage, lightPeer2, ctx, lightClientHandler);
+
+        verify(lightPeer, times(1)).sendMessage(any());
+        verify(lightPeer2, times(0)).sendMessage(any());
+        assertFalse(lightPeersInformation.hasTxRelay(lightPeer));
+    }
+
+    @Test
     public void peerWithTxRelayActivatedConnectCorrectly() {
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         LightClientHandler lightClientHandler = mock(LightClientHandler.class);

--- a/rskj-core/src/test/java/co/rsk/net/light/LightSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/light/LightSyncProcessorTest.java
@@ -148,23 +148,6 @@ public class LightSyncProcessorTest {
     }
 
     @Test
-    public void morePeersThanAllowedTryToConnectToMeAndShouldBeDiscarded() {
-        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        LightClientHandler lightClientHandler = mock(LightClientHandler.class);
-
-        //Message sent
-        StatusMessage statusMessage = new StatusMessage(requestId, lightStatus, false);
-
-        LightPeer lightPeer2 = mock(LightPeer.class);
-        lightSyncProcessor.processStatusMessage(statusMessage, lightPeer, ctx, lightClientHandler);
-        lightSyncProcessor.processStatusMessage(statusMessage, lightPeer2, ctx, lightClientHandler);
-
-        verify(lightPeer, times(1)).sendMessage(any());
-        verify(lightPeer2, times(0)).sendMessage(any());
-        assertFalse(lightPeersInformation.hasTxRelay(lightPeer));
-    }
-
-    @Test
     public void peerWithTxRelayActivatedConnectCorrectly() {
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         LightClientHandler lightClientHandler = mock(LightClientHandler.class);


### PR DESCRIPTION
This PR improves the Light Client Sync protocol with the possibility to process more than one message at the same time, instead of discarding them.

The process is simple: Once a message arrives it is inserted in a FIFO blocking queue (so we can assure each message is inserted correctly from different threads). 

There is a thread which consists only in getting messages from the queue and processing them, in FIFO order. Each message is linked to its own ChannelContextManager, LightPeer and LightClientHandler (for the sync message only).

Testing is done in order to check whether one and several messages are processed correctly, from the same and different Peers. Also a new TestUtils class is created for this purpose (I created a method to return the correct answer for a given GetAccounts message, and is the basis for new methods for each message) .