### PR TITLE
Move method from BridgeSupport to BridgeUtils

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1762,7 +1762,7 @@ public class BridgeSupport {
             whitelist.put(entry.address(), entry);
             return LOCK_WHITELIST_SUCCESS_CODE;
         } catch (Exception e) {
-            logger.error("Unexpected error in addLockWhitelistAddress: {}", e);
+            logger.error("Unexpected error in addLockWhitelistAddress: {}", e.getMessage());
             panicProcessor.panic("lock-whitelist", e.getMessage());
             return LOCK_WHITELIST_UNKNOWN_ERROR_CODE;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -857,7 +857,7 @@ public class BridgeSupport {
             TransactionInput input = btcTx.getInput(i);
             Script inputScript = input.getScriptSig();
 
-            boolean alreadySignedByThisFederator = isInputSignedByThisFederator(
+            boolean alreadySignedByThisFederator = BridgeUtils.isInputSignedByThisFederator(
                     federatorPublicKey,
                     sighash,
                     input);
@@ -899,31 +899,6 @@ public class BridgeSupport {
             int signaturesCount = neededSignatures - missingSignatures;
             logger.debug("Tx {} not yet fully signed. Requires {}/{} signatures but has {}", new Keccak256(rskTxHash), neededSignatures, getFederationSize(), signaturesCount);
         }
-    }
-
-    /**
-     * Check if the p2sh multisig scriptsig of the given input was already signed by federatorPublicKey.
-     * @param federatorPublicKey The key that may have been used to sign
-     * @param sighash the sighash that corresponds to the input
-     * @param input The input
-     * @return true if the input was already signed by the specified key, false otherwise.
-     */
-    private boolean isInputSignedByThisFederator(BtcECKey federatorPublicKey, Sha256Hash sighash, TransactionInput input) {
-        List<ScriptChunk> chunks = input.getScriptSig().getChunks();
-        for (int j = 1; j < chunks.size() - 1; j++) {
-            ScriptChunk chunk = chunks.get(j);
-
-            if (chunk.data.length == 0) {
-                continue;
-            }
-
-            TransactionSignature sig2 = TransactionSignature.decodeFromBitcoin(chunk.data, false, false);
-
-            if (federatorPublicKey.verify(sighash, sig2)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -19,6 +19,7 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptChunk;
 import co.rsk.bitcoinj.wallet.Wallet;
@@ -36,7 +37,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Oscar Guindzberg
@@ -309,5 +313,30 @@ public class BridgeUtils {
                 throw new VerificationException.EmptyInputsOrOutputs();
             }
         }
+    }
+
+    /**
+     * Check if the p2sh multisig scriptsig of the given input was already signed by federatorPublicKey.
+     * @param federatorPublicKey The key that may have been used to sign
+     * @param sighash the sighash that corresponds to the input
+     * @param input The input
+     * @return true if the input was already signed by the specified key, false otherwise.
+     */
+    public static boolean isInputSignedByThisFederator(BtcECKey federatorPublicKey, Sha256Hash sighash, TransactionInput input) {
+        List<ScriptChunk> chunks = input.getScriptSig().getChunks();
+        for (int j = 1; j < chunks.size() - 1; j++) {
+            ScriptChunk chunk = chunks.get(j);
+
+            if (chunk.data.length == 0) {
+                continue;
+            }
+
+            TransactionSignature sig2 = TransactionSignature.decodeFromBitcoin(chunk.data, false, false);
+
+            if (federatorPublicKey.verify(sighash, sig2)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Move `isInputSignedByThisFederator` method from `BridgeSupport` to `BridgeUtils`, to be used by the federate node