### PR TITLE
Fix race condition around newPeers in ChannelManagerImpl

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/net/MessageQueue.java
+++ b/rskj-core/src/main/java/org/ethereum/net/MessageQueue.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -55,6 +56,8 @@ import static org.ethereum.net.message.StaticMessages.DISCONNECT_MESSAGE;
 public class MessageQueue {
 
     private static final Logger logger = LoggerFactory.getLogger("net");
+    private static final Logger mqlog = LoggerFactory.getLogger("messagequeue");
+
     private static final PanicProcessor panicProcessor = new PanicProcessor();
 
     private static final ScheduledExecutorService timer = Executors.newScheduledThreadPool(4, new ThreadFactory() {
@@ -64,6 +67,7 @@ public class MessageQueue {
             return new Thread(r, "MessageQueueTimer-" + cnt.getAndIncrement());
         }
     });
+    private final UUID id;
 
     private Queue<MessageRoundtrip> requestQueue = new LinkedBlockingQueue<>();
     private Queue<MessageRoundtrip> respondQueue = new LinkedBlockingQueue<>();
@@ -74,9 +78,14 @@ public class MessageQueue {
     private Channel channel;
 
     public MessageQueue() {
+        //this id is ONLY used for logging purposes.
+        this.id = UUID.randomUUID();
+        mqlog.trace("Created Message Queue - {}", this.id);
+
     }
 
     public void activate(ChannelHandlerContext ctx) {
+        mqlog.trace("Activating Message Queue - {} - with channel {}", this.id, this.channel.getPeerIdShort());
         this.ctx = ctx;
         timerTask = timer.scheduleAtFixedRate(new Runnable() {
             public void run() {
@@ -95,6 +104,8 @@ public class MessageQueue {
     }
 
     public void sendMessage(Message msg) {
+        mqlog.trace("Sending Message Queue - {} - with channel {} - msg {}", this.id, this.channel.getPeerIdShort(), msg.getCommand().toString());
+
         if (msg instanceof PingMessage) {
             if (hasPing) {
                 return;
@@ -105,6 +116,9 @@ public class MessageQueue {
 
         Queue<MessageRoundtrip> queue = msg.getAnswerMessage() != null ? requestQueue : respondQueue;
         queue.add(new MessageRoundtrip(msg));
+        if(queue.size() > 10) {
+            mqlog.warn("Queue size out of control! - {} - with channel {} - queue size {}", this.id, this.channel.getPeerIdShort(), queue.size());
+        }
     }
 
     public void disconnect() {
@@ -116,11 +130,13 @@ public class MessageQueue {
     }
 
     private void disconnect(DisconnectMessage msg) {
+        mqlog.trace("Disconnecting Message Queue - {} - with channel {}", this.id, this.channel.getPeerIdShort());
         ctx.writeAndFlush(msg);
         ctx.close();
     }
 
     public void receivedMessage(Message msg) throws InterruptedException {
+        mqlog.trace("Received Message Queue - {} - with channel {} - msg {}", this.id, this.channel.getPeerIdShort(), msg.getCommand().toString());
 
         MessageRoundtrip messageRoundtrip = requestQueue.peek();
         if (messageRoundtrip != null) {
@@ -173,6 +189,7 @@ public class MessageQueue {
     }
 
     public void close() {
+        mqlog.trace("Cancelling Message Queue - {} - with channel {}", this.id, this.channel.getPeerIdShort());
         if (timerTask != null) {
             timerTask.cancel(false);
         }

--- a/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
@@ -292,10 +292,12 @@ public class ChannelManagerImpl implements ChannelManager {
         channel.onDisconnect();
         synchronized (newPeers) {
             if(newPeers.remove(channel)) {
-                logger.info("Peer removed from active peers: {}", channel.getPeerId());
+                logger.info("Peer removed from new peers list: {}", channel.getPeerId());
             }
             synchronized (activePeersLock){
-                activePeers.values().remove(channel);
+                if(activePeers.values().remove(channel)) {
+                    logger.info("Peer removed from active peers list: {}", channel.getPeerId());
+                }
             }
             syncPool.onDisconnect(channel);
         }

--- a/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
@@ -120,9 +120,11 @@ public class ChannelManagerImpl implements ChannelManager {
     }
 
     private void processNewPeers() {
-        List<Channel> processedChannels = new ArrayList<>();
-        newPeers.stream().filter(Channel::isProtocolsInitialized).forEach(c -> processNewPeer(c, processedChannels));
-        newPeers.removeAll(processedChannels);
+        synchronized (newPeers) {
+            List<Channel> processedChannels = new ArrayList<>();
+            newPeers.stream().filter(Channel::isProtocolsInitialized).forEach(c -> processNewPeer(c, processedChannels));
+            newPeers.removeAll(processedChannels);
+        }
     }
 
     private void processNewPeer(Channel channel, List<Channel> processedChannels) {
@@ -288,12 +290,14 @@ public class ChannelManagerImpl implements ChannelManager {
     public void notifyDisconnect(Channel channel) {
         logger.debug("Peer {}: notifies about disconnect", channel.getPeerIdShort());
         channel.onDisconnect();
-        syncPool.onDisconnect(channel);
-        synchronized (activePeersLock){
-            activePeers.values().remove(channel);
-        }
-        if(newPeers.remove(channel)) {
-            logger.info("Peer removed from active peers: {}", channel.getPeerId());
+        synchronized (newPeers) {
+            if(newPeers.remove(channel)) {
+                logger.info("Peer removed from active peers: {}", channel.getPeerId());
+            }
+            synchronized (activePeersLock){
+                activePeers.values().remove(channel);
+            }
+            syncPool.onDisconnect(channel);
         }
     }
 


### PR DESCRIPTION
This fixes the bug where a MessageQueue was witnessed accumulating messages that are never sent, creating a memory leak.

The root cause of the bug is due to a race condition that happens when there is a disconnection of a channel at the same time the channel is being promoted to active in the ChannelManagerImpl class. 

How it happens

1. There is a disconnection in the channel. Two things happen here. There is a listener set up on EthereumChannelInitializer for disconnection that ends up calling ChannelManagerImpl#notifyDisconnect with the Channel. This ends up removing the channel from activePeers and/or newPeers collection. There is also the P2pHandler channelInactive method which is also called on the disconnection by Netty which ends up calling MessageQueue#close, which stops the MessageQueue timer that sends the messages and empties the queue. 
2. At the same time this is happening, ChannelManagerImpl#handleNewPeersAndDisconnections is being called, since it runs automatically once per second with an ScheduledExecutorService. So the channel got removed from newPeers at the same time it was being promoted to active. This is the sequence being called: ChannelManagerImpl#handleNewPeersAndDisconnections -> ChannelManagerImpl#tryProcessNewPeers -> ChannelManagerImpl#processNewPeers -> ChannelManagerImpl#processNewPeer -> ChannelManagerImpl#addToActives -> SyncPool#addToActives

So after that, the MessageQueue gets deactivated (logged as "Cancelling Message Queue") but because it's still referenced as active by ChannelManagerImpl, it still sends messages. The messages AREN'T actually being sent, the deactivated MessageQueue simply keeps them piling up, thus creating a memory leak.

To reproduce it, I added this at the end of EthereumChannelInitializer

            new Thread(() -> {
                try {
                    int milis = new Random().nextInt(3000);
                    logger.info("sleeping {}", milis);
                    Thread.sleep(milis);
                    logger.info("finished sleeping {}", milis);
                } catch (InterruptedException e) {
                    e.printStackTrace();
                }
                ch.close();
            }).start();

To kill every new connection after a few seconds. Also I added a Thread Sleep at the beginning of ChannelManagerImpl#processNewPeer. This forces the race condition to happen, which can be verified by the new logs I added to MessageQueue.

To fix the race condition I added synchronization blocks around the usage of the newPeers attribute in ChannelManagerImpl. I've verified that, with the code I added to force the race condition, the problem does not appear. If disconnection happens at the same time a promotion to active were to happen, promotion OR disconnection can't run at the same time. So it either gets disconnected so it can't be promoted, or if it happened to be promoted then it's disconnected.

I decided to include the new logs in the MessageQueue in this PR in case we happen to need them again, but by default, those logs are not set up in the logback.xml 