### PR TITLE
StartRoundSync from Genesis

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/LightSyncProcessor.java
@@ -27,7 +27,6 @@ import co.rsk.net.light.message.GetBlockHeadersMessage;
 import co.rsk.net.light.message.StatusMessage;
 import co.rsk.net.light.state.*;
 import co.rsk.validators.ProofOfWorkRule;
-import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.ChannelHandlerContext;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Block;
@@ -169,12 +168,11 @@ public class LightSyncProcessor {
         setState(new CommonAncestorSearchSyncState(this, lightPeer, bestBlockHash, bestBlockNumber, blockchain));
     }
 
-    @VisibleForTesting
     public void startSync(LightPeer lightPeer, BlockHeader bestBlockHeader) {
         setState(new DecidingLightSyncState(this, lightPeer, bestBlockHeader));
     }
 
-    public void foundCommonAncestor(LightPeer lightPeer, BlockHeader startBlockHeader) {
+    public void startSyncRound(LightPeer lightPeer, BlockHeader startBlockHeader) {
         final LightStatus lightStatus = lightPeersInformation.getLightStatus(lightPeer);
 
         if (startBlockHeader.getDifficulty().compareTo(lightStatus.getTotalDifficulty()) > 0) {

--- a/rskj-core/src/main/java/co/rsk/net/light/state/DecidingLightSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/light/state/DecidingLightSyncState.java
@@ -27,21 +27,22 @@ import java.util.List;
 public class DecidingLightSyncState implements LightSyncState {
     private final LightSyncProcessor lightSyncProcessor;
     private final LightPeer lightPeer;
-    private final byte[] bestBlockHash;
-    private final long bestBlockNumber;
+    private final BlockHeader bestBlockHeader;
 
     public DecidingLightSyncState(LightSyncProcessor lightSyncProcessor, LightPeer lightPeer, BlockHeader bestBlockHeader) {
         this.lightSyncProcessor = lightSyncProcessor;
         this.lightPeer = lightPeer;
-        this.bestBlockHash = bestBlockHeader.getHash().getBytes();
-        this.bestBlockNumber = bestBlockHeader.getNumber();
+        this.bestBlockHeader = bestBlockHeader;
     }
 
     @Override
     public void sync() {
+        final long bestBlockNumber = bestBlockHeader.getNumber();
         if (bestBlockNumber != 0) {
             lightSyncProcessor.startAncestorSearchFrom(lightPeer,
-                    bestBlockHash, bestBlockNumber);
+                    bestBlockHeader.getHash().getBytes(), bestBlockNumber);
+        } else {
+            lightSyncProcessor.startSyncRound(lightPeer, bestBlockHeader);
         }
     }
 


### PR DESCRIPTION
- Added a new way to transits to StartRoundSync from genesis. If the best block headers of the light peers is Genesis, its transits directly to StartRoundSync otherwise it transits to SearchCommonAncestor. The last way is when the peers common ancestor is Genesis.
- The maxAmountOfHeaders is stored as a instance variable so when the peer receives a list of block headers in CommonAncestorSearch state, it checks against maxAmountOfHeaders if its correct