### PR TITLE
TransactionAddResult removal and TransactionPool refactor for addTransaction/s

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -204,6 +204,11 @@ public class TransactionPoolImpl implements TransactionPool {
         return added;
     }
 
+    @Override
+    public synchronized List<Transaction> addTransaction(final Transaction tx) {
+        return this.addTransactions(Collections.singletonList(tx));
+    }
+
     private Optional<Transaction> getQueuedSuccessor(Transaction tx) {
         BigInteger next = tx.getNonceAsInteger().add(BigInteger.ONE);
 
@@ -265,24 +270,6 @@ public class TransactionPoolImpl implements TransactionPool {
         signatureCache.storeSender(tx);
 
         return Collections.singletonList(tx);
-    }
-
-    @Override
-    public synchronized List<Transaction> addTransaction(final Transaction tx) throws RskJsonRpcRequestException {
-        List<Transaction> result = this.internalAddTransaction(tx);
-
-        if (!this.transactionsWereAdded(result)) {
-            return result;
-        }
-
-        List<Transaction> added = new ArrayList<>();
-
-        added.add(tx);
-        added.addAll(this.addSuccessors(tx));
-
-        this.emitEvents(added);
-
-        return result;
     }
 
     private boolean isBumpingGasPriceForSameNonceTx(Transaction tx) {

--- a/rskj-core/src/main/java/co/rsk/net/TransactionGateway.java
+++ b/rskj-core/src/main/java/co/rsk/net/TransactionGateway.java
@@ -42,16 +42,17 @@ public class TransactionGateway {
     }
 
     public void receiveTransactionsFrom(@Nonnull List<Transaction> txs, @Nonnull Set<NodeID> nodeIDS) {
-        List<Transaction> result  = transactionPool.addTransactions(txs);
-        if(!result.isEmpty()) {
-            channelManager.broadcastTransactions(result, nodeIDS);
-        }
+        internalReceiveTransaction(nodeIDS, transactionPool.addTransactions(txs));
     }
 
-    public void receiveTransaction(Transaction transaction) throws RskJsonRpcRequestException {
-        List<Transaction> result  = transactionPool.addTransaction(transaction);
-        if(transactionPool.transactionsWereAdded(result)) {
-            channelManager.broadcastTransactions(result, Collections.emptySet());
+    public void receiveTransaction(@Nonnull Transaction transaction) throws RskJsonRpcRequestException {
+        internalReceiveTransaction(Collections.emptySet(), transactionPool.addTransaction(transaction));
+    }
+
+    private void internalReceiveTransaction(@Nonnull Set<NodeID> nodeIDS, List<Transaction> transactions) {
+        List<Transaction> result = transactions;
+        if (transactionPool.transactionsWereAdded(result)) {
+            channelManager.broadcastTransactions(result, nodeIDS);
         }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/TransactionGateway.java
+++ b/rskj-core/src/main/java/co/rsk/net/TransactionGateway.java
@@ -22,6 +22,7 @@ import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionPool;
 import org.ethereum.core.TransactionPoolAddResult;
 import org.ethereum.net.server.ChannelManager;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
 import javax.annotation.Nonnull;
 import java.util.*;
@@ -48,11 +49,10 @@ public class TransactionGateway {
         }
     }
 
-    public TransactionPoolAddResult receiveTransaction(Transaction transaction) {
-        TransactionPoolAddResult result  = transactionPool.addTransaction(transaction);
-        if(result.transactionsWereAdded()) {
-            channelManager.broadcastTransactions(result.getTransactionsAdded(), Collections.emptySet());
+    public void receiveTransaction(Transaction transaction) throws RskJsonRpcRequestException {
+        List<Transaction> result  = transactionPool.addTransaction(transaction);
+        if(transactionPool.transactionsWereAdded(result)) {
+            channelManager.broadcastTransactions(result, Collections.emptySet());
         }
-        return result;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/TransactionGateway.java
+++ b/rskj-core/src/main/java/co/rsk/net/TransactionGateway.java
@@ -20,7 +20,6 @@ package co.rsk.net;
 
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionPool;
-import org.ethereum.core.TransactionPoolAddResult;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -71,9 +71,7 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
                 BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : transactionPool.getPendingState().getNonce(account.getAddress());
                 Transaction tx = new Transaction(toAddress, value, accountNonce, gasPrice, gasLimit, args.data, constants.getChainId());
                 tx.sign(account.getEcKey().getPrivKeyBytes());
-                transactionGateway.receiveTransaction(tx.toImmutableTransaction())
-                        .ifTransactionWasNotAdded(message -> { throw RskJsonRpcRequestException.transactionError(message); });
-
+                transactionGateway.receiveTransaction(tx.toImmutableTransaction());
                 s = tx.getHash().toJsonString();
             }
 
@@ -96,8 +94,7 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
                 throw invalidParamError("Missing parameter, gasPrice, gas or value");
             }
 
-            transactionGateway.receiveTransaction(tx)
-                    .ifTransactionWasNotAdded(message -> { throw RskJsonRpcRequestException.transactionError(message); });
+            transactionGateway.receiveTransaction(tx);
 
             return s = tx.getHash().toJsonString();
         } finally {

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionPool.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionPool.java
@@ -33,7 +33,7 @@ public interface TransactionPool extends InternalService {
      *
      * @param tx transaction
      */
-    TransactionPoolAddResult addTransaction(Transaction tx);
+    List<Transaction> addTransaction(Transaction tx);
 
     /**
      * Adds a list of transactions to the list of pending state txs or
@@ -76,4 +76,7 @@ public interface TransactionPool extends InternalService {
      * @return pending state
      */
     PendingState getPendingState();
+
+    boolean transactionsWereAdded(List<Transaction> transactionsAdded);
+
 }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionPoolAddResult.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionPoolAddResult.java
@@ -43,16 +43,4 @@ public class TransactionPoolAddResult {
             errorConsumer.accept(errorMessage);
         }
     }
-
-    public static TransactionPoolAddResult ok(Transaction transaction) {
-        return new TransactionPoolAddResult(null, Collections.singletonList(transaction));
-    }
-
-    public static TransactionPoolAddResult withError(String errorMessage) {
-        return new TransactionPoolAddResult(errorMessage, Collections.emptyList());
-    }
-
-    public List<Transaction> getTransactionsAdded() {
-        return transactionsAdded;
-    }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
@@ -1,8 +1,11 @@
 package org.ethereum.rpc.exception;
 
+import org.ethereum.core.Transaction;
+
 public class RskJsonRpcRequestException extends RuntimeException {
 
     private final Integer code;
+    private Transaction errorTransaction;
 
     protected RskJsonRpcRequestException(Integer code, String message, Exception e) {
         super(message, e);
@@ -30,8 +33,10 @@ public class RskJsonRpcRequestException extends RuntimeException {
         return new RskJsonRpcRequestException(-32015, String.format("VM execution error: %s", message));
     }
 
-    public static RskJsonRpcRequestException transactionError(String message) {
-        return new RskJsonRpcRequestException(-32010, message);
+    public static RskJsonRpcRequestException transactionError(String message, Transaction transaction) {
+        RskJsonRpcRequestException exception = new RskJsonRpcRequestException(-32010, message);
+        exception.setErrorTransaction(transaction);
+        return exception;
     }
 
     public static RskJsonRpcRequestException invalidParamError(String message) {
@@ -52,5 +57,13 @@ public class RskJsonRpcRequestException extends RuntimeException {
 
     public static RskJsonRpcRequestException stateNotFound(String message) {
         return new RskJsonRpcRequestException(-32600, message);
+    }
+
+    private void setErrorTransaction(Transaction transaction) {
+        this.errorTransaction = transaction;
+    }
+
+    public Transaction getErrorTransaction() {
+        return this.errorTransaction;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/TransactionGatewayTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/TransactionGatewayTest.java
@@ -18,11 +18,9 @@
 package co.rsk.net;
 
 import co.rsk.core.bc.TransactionPoolImpl;
-import co.rsk.rpc.modules.RskJsonRpcRequest;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionPool;
-import org.ethereum.core.TransactionPoolAddResult;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.Assert;
@@ -100,14 +98,10 @@ public class TransactionGatewayTest {
         when(transactionPool.addTransaction(tx)).thenReturn(transactionsAdded);
         when(transactionPool.transactionsWereAdded(transactionsAdded)).thenCallRealMethod();
 
-        try {
-            this.gateway.receiveTransaction(tx);
-        } catch (RskJsonRpcRequestException e) {
-            Assert.assertEquals("Not added", e.getMessage());
-        } finally {
-            verify(transactionPool, times(1)).addTransaction(tx);
-            verify(channelManager, times(0)).
-                    broadcastTransactions(transactionsAdded, Collections.emptySet());
-        }
+        this.gateway.receiveTransaction(tx);
+
+        verify(transactionPool, times(1)).addTransaction(tx);
+        verify(channelManager, times(0)).
+                broadcastTransactions(transactionsAdded, Collections.emptySet());
     }
 }


### PR DESCRIPTION
This PR is an extension of [previous pr](https://github.com/rsksmart/rskj/pull/1266).

Aims to remove `TransactionAddResult` class which wasn't adding any significant value and was making things more complex.

Also I added a small refactor to `TransactionPool` `addTransaction/s` methods, now `addTransactions` relies on `addTransaction` method. This should have been the first approach of that method but it didn't, now after some refactors we could achieve that approach. 

It's important to mark that when a transaction fails at `addTransactions` for loop, it just logs a warning and continues with the next transaction (since we don't care the status of each one and we don't want to stop the execution)

Plus now an `RskJsonRpcRequestException` has a property for a transaction that produced error