### PR TITLE
Check if an account exists before add it.

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -178,7 +178,9 @@ public class Wallet {
         Account account = new Account(ECKey.fromPrivate(privateKeyBytes));
         synchronized (accessLock) {
             RskAddress addr = addAccount(account);
-            this.initialAccounts.add(addr);
+            if (!this.initialAccounts.contains(addr)) {
+                this.initialAccounts.add(addr);
+            }
             return addr.getBytes();
         }
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -84,6 +84,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 /**
@@ -1678,6 +1679,19 @@ public class Web3ImplTest {
         String expectedHash = tx.getHash().toJsonString();
 
         assertTrue("Method is not creating the expected transaction", expectedHash.compareTo(txHash) == 0);
+    }
+
+    @Test
+    public void createNewAccountWithoutDuplicates(){
+        Web3Impl web3 = createWeb3();
+        int originalAccountSize = wallet.getAccountAddresses().size();
+        String testAccountAddress = web3.personal_newAccountWithSeed("testAccount");
+
+        assertEquals("The number of accounts was not increased", originalAccountSize + 1, wallet.getAccountAddresses().size());
+
+        web3.personal_newAccountWithSeed("testAccount");
+
+        assertEquals("The number of accounts was increased", originalAccountSize + 1, wallet.getAccountAddresses().size());
     }
 
     private Web3Impl createWeb3(World world) {


### PR DESCRIPTION
Added logic to check if an account exists before add it to the Wallet.

Now it is possible to added several time the same account using the method `personal_newAccountWithSeed`.
This PR fix this issue adding a logic that checks before add.

Please @ajlopez and @fedejinich take a look of this.
