### PR TITLE
Logging improvements

### DIFF
--- a/rskj-core/src/main/java/co/rsk/GenNodeKeyId.java
+++ b/rskj-core/src/main/java/co/rsk/GenNodeKeyId.java
@@ -21,7 +21,7 @@ package co.rsk;
 
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import java.nio.charset.StandardCharsets;
 
@@ -44,11 +44,11 @@ public class GenNodeKeyId {
             key = ECKey.fromPrivate(HashUtil.keccak256(generator.getBytes(StandardCharsets.UTF_8)));
         }
 
-        String keybytes = Hex.toHexString(key.getPrivKeyBytes());
-        String pubkeybytes = Hex.toHexString(key.getPubKey());
-        String compressedpubkeybytes = Hex.toHexString(key.getPubKey(true));
-        String address = Hex.toHexString(key.getAddress());
-        String nodeid = Hex.toHexString(key.getNodeId());
+        String keybytes = ByteUtil.toHexString(key.getPrivKeyBytes());
+        String pubkeybytes = ByteUtil.toHexString(key.getPubKey());
+        String compressedpubkeybytes = ByteUtil.toHexString(key.getPubKey(true));
+        String address = ByteUtil.toHexString(key.getAddress());
+        String nodeid = ByteUtil.toHexString(key.getNodeId());
 
         System.out.println('{');
         System.out.println("   \"privateKey\": \"" + keybytes + "\",");

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ExportBlocks.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ExportBlocks.java
@@ -19,9 +19,9 @@ package co.rsk.cli.tools;
 
 import co.rsk.RskContext;
 import co.rsk.core.BlockDifficulty;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Block;
 import org.ethereum.db.BlockStore;
+import org.ethereum.util.ByteUtil;
 
 import java.io.PrintStream;
 
@@ -47,9 +47,9 @@ public class ExportBlocks {
 
             writer.println(
                 block.getNumber() + "," +
-                Hex.toHexString(block.getHash().getBytes()) + "," +
-                Hex.toHexString(totalDifficulty.getBytes()) + "," +
-                Hex.toHexString(block.getEncoded())
+                ByteUtil.toHexString(block.getHash().getBytes()) + "," +
+                ByteUtil.toHexString(totalDifficulty.getBytes()) + "," +
+                ByteUtil.toHexString(block.getEncoded())
             );
         }
     }

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ExportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ExportState.java
@@ -21,9 +21,9 @@ import co.rsk.RskContext;
 import co.rsk.trie.NodeReference;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStore;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Block;
 import org.ethereum.db.BlockStore;
+import org.ethereum.util.ByteUtil;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -58,7 +58,7 @@ public class ExportState {
     }
 
     private static void processTrie(Trie trie, PrintStream writer) {
-        writer.println(Hex.toHexString(trie.toMessage()));
+        writer.println(ByteUtil.toHexString(trie.toMessage()));
 
         NodeReference leftReference = trie.getLeft();
 
@@ -73,7 +73,7 @@ public class ExportState {
                 }
 
                 if (leftTrie.hasLongValue()) {
-                    writer.println(Hex.toHexString(leftTrie.getValue()));
+                    writer.println(ByteUtil.toHexString(leftTrie.getValue()));
                 }
             }
         }
@@ -91,13 +91,13 @@ public class ExportState {
                 }
 
                 if (rightTrie.hasLongValue()) {
-                    writer.println(Hex.toHexString(rightTrie.getValue()));
+                    writer.println(ByteUtil.toHexString(rightTrie.getValue()));
                 }
             }
         }
 
         if (trie.hasLongValue()) {
-            writer.println(Hex.toHexString(trie.getValue()));
+            writer.println(ByteUtil.toHexString(trie.getValue()));
         }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ShowStateInfo.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ShowStateInfo.java
@@ -21,9 +21,9 @@ import co.rsk.RskContext;
 import co.rsk.trie.NodeReference;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStore;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Block;
 import org.ethereum.db.BlockStore;
+import org.ethereum.util.ByteUtil;
 
 import java.io.PrintStream;
 import java.util.Optional;
@@ -56,9 +56,9 @@ public class ShowStateInfo {
         }
 
         writer.println("Block number: " + block.getNumber());
-        writer.println("Block hash: " + Hex.toHexString(block.getHash().getBytes()));
-        writer.println("Block parent hash: " + Hex.toHexString(block.getParentHash().getBytes()));
-        writer.println("Block root hash: " + Hex.toHexString(block.getStateRoot()));
+        writer.println("Block hash: " + ByteUtil.toHexString(block.getHash().getBytes()));
+        writer.println("Block parent hash: " + ByteUtil.toHexString(block.getParentHash().getBytes()));
+        writer.println("Block root hash: " + ByteUtil.toHexString(block.getStateRoot()));
 
         Optional<Trie> otrie = trieStore.retrieve(block.getStateRoot());
 

--- a/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
+++ b/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
@@ -26,8 +26,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Blockchain;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.slf4j.Logger;
@@ -82,12 +82,12 @@ public class NetworkStateExporter {
 
     private ObjectNode createContractNode(ObjectNode accountNode, AccountInformationProvider accountInformation, RskAddress addr, Iterator<DataWord> contractKeys) {
         ObjectNode contractNode = accountNode.objectNode();
-        contractNode.put("code", Hex.toHexString(accountInformation.getCode(addr)));
+        contractNode.put("code", ByteUtil.toHexString(accountInformation.getCode(addr)));
         ObjectNode dataNode = contractNode.objectNode();
         while (contractKeys.hasNext()) {
             DataWord key = contractKeys.next();
             byte[] value = accountInformation.getStorageBytes(addr, key);
-            dataNode.put(Hex.toHexString(key.getData()), Hex.toHexString(value));
+            dataNode.put(ByteUtil.toHexString(key.getData()), ByteUtil.toHexString(value));
         }
         contractNode.set("data", dataNode);
         return contractNode;

--- a/rskj-core/src/main/java/co/rsk/core/RskAddress.java
+++ b/rskj-core/src/main/java/co/rsk/core/RskAddress.java
@@ -20,8 +20,8 @@ package co.rsk.core;
 
 import com.google.common.primitives.UnsignedBytes;
 import org.ethereum.rpc.TypeConverter;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -94,7 +94,7 @@ public class RskAddress {
     }
 
     public String toHexString() {
-        return Hex.toHexString(bytes);
+        return ByteUtil.toHexString(bytes);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainImpl.java
@@ -148,7 +148,7 @@ public class BlockChainImpl implements Blockchain {
                 org.slf4j.MDC.put("blockHeight", Long.toString(block.getNumber()));
 
                 logger.trace("Try connect block hash: {}, number: {}",
-                             block.getShortHash(),
+                             block.getPrintableHash(),
                              block.getNumber());
 
                 synchronized (connectLock) {
@@ -156,7 +156,7 @@ public class BlockChainImpl implements Blockchain {
                     long saveTime = System.nanoTime();
                     ImportResult result = internalTryToConnect(block);
                     long totalTime = System.nanoTime() - saveTime;
-                    logger.info("block: num: [{}] hash: [{}], processed after: [{}]nano, result {}", block.getNumber(), block.getShortHash(), totalTime, result);
+                    logger.info("block: num: [{}] hash: [{}], processed after: [{}]nano, result {}", block.getNumber(), block.getPrintableHash(), totalTime, result);
                     return result;
                 }
             } catch (Throwable t) {
@@ -181,7 +181,7 @@ public class BlockChainImpl implements Blockchain {
         if (blockStore.getBlockByHash(block.getHash().getBytes()) != null &&
                 !BlockDifficulty.ZERO.equals(blockStore.getTotalDifficultyForHash(block.getHash().getBytes()))) {
             logger.debug("Block already exist in chain hash: {}, number: {}",
-                         block.getShortHash(),
+                         block.getPrintableHash(),
                          block.getNumber());
             profiler.stop(metric);
             return ImportResult.EXIST;
@@ -257,7 +257,7 @@ public class BlockChainImpl implements Blockchain {
             // to the parent's repository.
 
             long totalTime = System.nanoTime() - saveTime;
-            logger.trace("block: num: [{}] hash: [{}], executed after: [{}]nano", block.getNumber(), block.getShortHash(), totalTime);
+            logger.trace("block: num: [{}] hash: [{}], executed after: [{}]nano", block.getNumber(), block.getPrintableHash(), totalTime);
 
             // the block is valid at this point
             stateRootHandler.register(block.getHeader(), result.getFinalState());
@@ -273,7 +273,7 @@ public class BlockChainImpl implements Blockchain {
         if (SelectionRule.shouldWeAddThisBlock(totalDifficulty, status.getTotalDifficulty(),block, bestBlock)) {
             if (bestBlock != null && !bestBlock.isParentOf(block)) {
                 logger.trace("Rebranching: {} ~> {} From block {} ~> {} Difficulty {} Challenger difficulty {}",
-                        bestBlock.getShortHash(), block.getShortHash(), bestBlock.getNumber(), block.getNumber(),
+                        bestBlock.getPrintableHash(), block.getPrintableHash(), bestBlock.getNumber(), block.getNumber(),
                         status.getTotalDifficulty(), totalDifficulty);
                 blockStore.reBranch(block);
             }
@@ -290,7 +290,7 @@ public class BlockChainImpl implements Blockchain {
             onBlock(block, result);
             logger.trace("Start flushData");
 
-            logger.trace("Better block {} {}", block.getNumber(), block.getShortHash());
+            logger.trace("Better block {} {}", block.getNumber(), block.getPrintableHash());
 
             logger.debug("block added to the blockChain: index: [{}]", block.getNumber());
             if (block.getNumber() % 100 == 0) {
@@ -304,7 +304,7 @@ public class BlockChainImpl implements Blockchain {
         else {
             if (bestBlock != null && !bestBlock.isParentOf(block)) {
                 logger.trace("No rebranch: {} ~> {} From block {} ~> {} Difficulty {} Challenger difficulty {}",
-                        bestBlock.getShortHash(), block.getShortHash(), bestBlock.getNumber(), block.getNumber(),
+                        bestBlock.getPrintableHash(), block.getPrintableHash(), bestBlock.getNumber(), block.getNumber(),
                         status.getTotalDifficulty(), totalDifficulty);
             }
 
@@ -320,7 +320,7 @@ public class BlockChainImpl implements Blockchain {
                 logger.warn("Strange block number state");
             }
 
-            logger.trace("Block not imported {} {}", block.getNumber(), block.getShortHash());
+            logger.trace("Block not imported {} {}", block.getNumber(), block.getPrintableHash());
             profiler.stop(metric);
             return ImportResult.IMPORTED_NOT_BEST;
         }
@@ -450,7 +450,7 @@ public class BlockChainImpl implements Blockchain {
     private void storeBlock(Block block, BlockDifficulty totalDifficulty, boolean inBlockChain) {
         blockStore.saveBlock(block, totalDifficulty, inBlockChain);
         logger.trace("Block saved: number: {}, hash: {}, TD: {}",
-                block.getNumber(), block.getShortHash(), totalDifficulty);
+                block.getNumber(), block.getPrintableHash(), totalDifficulty);
     }
 
     private void saveReceipts(Block block, BlockResult result) {

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -136,34 +136,34 @@ public class BlockExecutor {
     public boolean validate(Block block, BlockResult result) {
         Metric metric = profiler.start(Profiler.PROFILING_TYPE.BLOCK_FINAL_STATE_VALIDATION);
         if (result == BlockResult.INTERRUPTED_EXECUTION_BLOCK_RESULT) {
-            logger.error("Block {} [{}] execution was interrupted because of an invalid transaction", block.getNumber(), block.getShortHash());
+            logger.error("Block {} [{}] execution was interrupted because of an invalid transaction", block.getNumber(), block.getPrintableHash());
             profiler.stop(metric);
             return false;
         }
 
         boolean isValidStateRoot = validateStateRoot(block.getHeader(), result);
         if (!isValidStateRoot) {
-            logger.error("Block {} [{}] given State Root is invalid", block.getNumber(), block.getShortHash());
+            logger.error("Block {} [{}] given State Root is invalid", block.getNumber(), block.getPrintableHash());
             profiler.stop(metric);
             return false;
         }
 
         boolean isValidReceiptsRoot = validateReceiptsRoot(block.getHeader(), result);
         if (!isValidReceiptsRoot) {
-            logger.error("Block {} [{}] given Receipt Root is invalid", block.getNumber(), block.getShortHash());
+            logger.error("Block {} [{}] given Receipt Root is invalid", block.getNumber(), block.getPrintableHash());
             profiler.stop(metric);
             return false;
         }
 
         boolean isValidLogsBloom = validateLogsBloom(block.getHeader(), result);
         if (!isValidLogsBloom) {
-            logger.error("Block {} [{}] given Logs Bloom is invalid", block.getNumber(), block.getShortHash());
+            logger.error("Block {} [{}] given Logs Bloom is invalid", block.getNumber(), block.getPrintableHash());
             profiler.stop(metric);
             return false;
         }
 
         if (result.getGasUsed() != block.getGasUsed()) {
-            logger.error("Block {} [{}] given gasUsed doesn't match: {} != {}", block.getNumber(), block.getShortHash(), block.getGasUsed(), result.getGasUsed());
+            logger.error("Block {} [{}] given gasUsed doesn't match: {} != {}", block.getNumber(), block.getPrintableHash(), block.getGasUsed(), result.getGasUsed());
             profiler.stop(metric);
             return false;
         }
@@ -172,7 +172,7 @@ public class BlockExecutor {
         Coin feesPaidToMiner = block.getFeesPaidToMiner();
 
         if (!paidFees.equals(feesPaidToMiner))  {
-            logger.error("Block {} [{}] given paidFees doesn't match: {} != {}", block.getNumber(), block.getShortHash(), feesPaidToMiner, paidFees);
+            logger.error("Block {} [{}] given paidFees doesn't match: {} != {}", block.getNumber(), block.getPrintableHash(), feesPaidToMiner, paidFees);
             profiler.stop(metric);
             return false;
         }
@@ -181,7 +181,7 @@ public class BlockExecutor {
         List<Transaction> transactionsList = block.getTransactionsList();
 
         if (!executedTransactions.equals(transactionsList))  {
-            logger.error("Block {} [{}] given txs doesn't match: {} != {}", block.getNumber(), block.getShortHash(), transactionsList, executedTransactions);
+            logger.error("Block {} [{}] given txs doesn't match: {} != {}", block.getNumber(), block.getPrintableHash(), transactionsList, executedTransactions);
             profiler.stop(metric);
             return false;
         }

--- a/rskj-core/src/main/java/co/rsk/core/bc/MiningMainchainViewImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/MiningMainchainViewImpl.java
@@ -161,7 +161,7 @@ public class MiningMainchainViewImpl implements MiningMainchainView {
 
             Block nextBlock = blockStore.getBlockByHash(currentHeader.getParentHash().getBytes());
             if (nextBlock == null) {
-                logger.error("Missing parent for block %s, number %d", currentHeader.getShortHash(), currentHeader.getNumber());
+                logger.error("Missing parent for block %s, number %d", currentHeader.getPrintableHash(), currentHeader.getNumber());
                 break;
             }
             currentHeader = nextBlock.getHeader();

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -306,7 +306,7 @@ public class TransactionPoolImpl implements TransactionPool {
 
     @Override
     public synchronized void processBest(Block newBlock) {
-        logger.trace("Processing best block {} {}", newBlock.getNumber(), newBlock.getShortHash());
+        logger.trace("Processing best block {} {}", newBlock.getNumber(), newBlock.getPrintableHash());
 
         BlockFork fork = getFork(this.bestBlock, newBlock);
 
@@ -352,7 +352,7 @@ public class TransactionPoolImpl implements TransactionPool {
     public void retractBlock(Block block) {
         List<Transaction> txs = block.getTransactionsList();
 
-        logger.trace("Retracting block {} {} with {} txs", block.getNumber(), block.getShortHash(), txs.size());
+        logger.trace("Retracting block {} {} with {} txs", block.getNumber(), block.getPrintableHash(), txs.size());
 
         this.addTransactions(txs);
     }

--- a/rskj-core/src/main/java/co/rsk/crypto/Keccak256.java
+++ b/rskj-core/src/main/java/co/rsk/crypto/Keccak256.java
@@ -22,7 +22,6 @@ import co.rsk.bitcoinj.core.Utils;
 import com.google.common.primitives.Ints;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.ByteUtil;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -52,7 +51,7 @@ public class Keccak256 implements Serializable, Comparable<Keccak256> {
     }
 
     public String toHexString() {
-        return Hex.toHexString(bytes);
+        return ByteUtil.toHexString(bytes);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -40,7 +40,9 @@ import org.ethereum.core.*;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.rpc.TypeConverter;
-import org.ethereum.util.*;
+import org.ethereum.util.BuildInfo;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -280,14 +282,14 @@ public class MinerServerImpl implements MinerServer {
         newBlock.seal();
 
         if (!isValid(newBlock)) {
-            String message = "Invalid block supplied by miner: " + newBlock.getShortHash() + " " + newBlock.getShortHashForMergedMining() + " at height " + newBlock.getNumber();
+            String message = "Invalid block supplied by miner: " + newBlock.getPrintableHash() + " " + newBlock.getPrintableHashForMergedMining() + " at height " + newBlock.getNumber();
             logger.error(message);
 
             return new SubmitBlockResult("ERROR", message);
         } else {
             ImportResult importResult = ethereum.addNewMinedBlock(newBlock);
 
-            logger.info("Mined block import result is {}: {} {} at height {}", importResult, newBlock.getShortHash(), newBlock.getShortHashForMergedMining(), newBlock.getNumber());
+            logger.info("Mined block import result is {}: {} {} at height {}", importResult, newBlock.getPrintableHash(), newBlock.getPrintableHashForMergedMining(), newBlock.getNumber());
             SubmittedBlockInfo blockInfo = new SubmittedBlockInfo(importResult, newBlock.getHash().getBytes(), newBlock.getNumber());
 
             return new SubmitBlockResult("OK", "OK", blockInfo);
@@ -298,7 +300,7 @@ public class MinerServerImpl implements MinerServer {
         try {
             return powRule.isValid(block);
         } catch (Exception e) {
-            logger.error("Failed to validate PoW from block {}: {}", block.getShortHash(), e);
+            logger.error("Failed to validate PoW from block {}: {}", block.getPrintableHash(), e);
             return false;
         }
     }
@@ -384,7 +386,7 @@ public class MinerServerImpl implements MinerServer {
         byte[] targetArray = new byte[32];
         System.arraycopy(targetUnknownLengthArray, 0, targetArray, 32 - targetUnknownLengthArray.length, targetUnknownLengthArray.length);
 
-        logger.debug("Sending work for merged mining. Hash: {}", block.getShortHashForMergedMining());
+        logger.debug("Sending work for merged mining. Hash: {}", block.getPrintableHashForMergedMining());
         return new MinerWork(blockMergedMiningHash.toJsonString(), TypeConverter.toJsonHex(targetArray), String.valueOf(block.getFeesPaidToMiner()), notify, block.getParentHashJsonString());
     }
 
@@ -463,9 +465,9 @@ public class MinerServerImpl implements MinerServer {
             logger.debug("blocksWaitingForPoW size {}", blocksWaitingforPoW.size());
         }
 
-        logger.debug("Built block {}. Parent {}", newBlock.getShortHashForMergedMining(), newBlockParentHeader.getShortHashForMergedMining());
+        logger.debug("Built block {}. Parent {}", newBlock.getPrintableHashForMergedMining(), newBlockParentHeader.getPrintableHashForMergedMining());
         for (BlockHeader uncleHeader : newBlock.getUncleList()) {
-            logger.debug("With uncle {}", uncleHeader.getShortHashForMergedMining());
+            logger.debug("With uncle {}", uncleHeader.getPrintableHashForMergedMining());
         }
     }
 
@@ -511,7 +513,7 @@ public class MinerServerImpl implements MinerServer {
 
             logger.debug(
                     "There is a new best block: {}, number: {}",
-                    newBestBlock.getShortHashForMergedMining(),
+                    newBestBlock.getPrintableHashForMergedMining(),
                     newBestBlock.getNumber());
             mainchainView.addBest(newBestBlock.getHeader());
             buildBlockToMine(false);

--- a/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
+++ b/rskj-core/src/main/java/co/rsk/net/BlockSyncService.java
@@ -80,9 +80,9 @@ public class BlockSyncService {
         store.removeHeader(block.getHeader());
 
         if (blockNumber > bestBlockNumber + syncMaxDistance) {
-            logger.trace("Block too advanced {} {} from {} ", blockNumber, block.getShortHash(),
+            logger.trace("Block too advanced {} {} from {} ", blockNumber, block.getPrintableHash(),
                     sender != null ? sender.getPeerNodeID().toString() : "N/A");
-            return new BlockProcessResult(false, null, block.getShortHash(),
+            return new BlockProcessResult(false, null, block.getPrintableHash(),
                     Duration.between(start, Instant.now()));
         }
 
@@ -92,8 +92,8 @@ public class BlockSyncService {
 
         // already in a blockchain
         if (BlockUtils.blockInSomeBlockChain(block, blockchain)) {
-            logger.trace("Block already in a chain {} {}", blockNumber, block.getShortHash());
-            return new BlockProcessResult(false, null, block.getShortHash(),
+            logger.trace("Block already in a chain {} {}", blockNumber, block.getPrintableHash());
+            return new BlockProcessResult(false, null, block.getPrintableHash(),
                     Duration.between(start, Instant.now()));
         }
         trySaveStore(block);
@@ -102,10 +102,10 @@ public class BlockSyncService {
         // We can't add the block if there are missing ancestors or uncles. Request the missing blocks to the sender.
         if (!unknownHashes.isEmpty()) {
             if (!ignoreMissingHashes){
-                logger.trace("Missing hashes for block in process {} {}", blockNumber, block.getShortHash());
+                logger.trace("Missing hashes for block in process {} {}", blockNumber, block.getPrintableHash());
                 requestMissingHashes(sender, unknownHashes);
             }
-            return new BlockProcessResult(false, null, block.getShortHash(),
+            return new BlockProcessResult(false, null, block.getPrintableHash(),
                     Duration.between(start, Instant.now()));
         }
 
@@ -114,7 +114,7 @@ public class BlockSyncService {
         Map<Keccak256, ImportResult> connectResult = connectBlocksAndDescendants(sender,
                 BlockUtils.sortBlocksByNumber(this.getParentsNotInBlockchain(block)), ignoreMissingHashes);
 
-        return new BlockProcessResult(true, connectResult, block.getShortHash(),
+        return new BlockProcessResult(true, connectResult, block.getPrintableHash(),
                 Duration.between(start, Instant.now()));
     }
 
@@ -172,13 +172,13 @@ public class BlockSyncService {
         Set<Block> connected = new HashSet<>();
 
         for (Block block : remainingBlocks) {
-            logger.trace("Trying to add block {} {}", block.getNumber(), block.getShortHash());
+            logger.trace("Trying to add block {} {}", block.getNumber(), block.getPrintableHash());
 
             Set<Keccak256> missingHashes = BlockUtils.unknownDirectAncestorsHashes(block, blockchain, store);
 
             if (!missingHashes.isEmpty()) {
                 if (!ignoreMissingHashes){
-                    logger.trace("Missing hashes for block in process {} {}", block.getNumber(), block.getShortHash());
+                    logger.trace("Missing hashes for block in process {} {}", block.getNumber(), block.getPrintableHash());
                     requestMissingHashes(sender, missingHashes);
                 }
                 continue;
@@ -207,7 +207,7 @@ public class BlockSyncService {
             return;
         }
         
-        logger.trace("Missing block {}", hash.toString().substring(0, 10));
+        logger.trace("Missing block {}", hash.toHexString());
 
         sender.sendMessage(new GetBlockMessage(hash.getBytes()));
     }

--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -25,9 +25,9 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockIdentifier;
 import org.ethereum.core.Blockchain;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -137,7 +137,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processGetBlock(@Nonnull final Peer sender, @Nonnull final byte[] hash) {
-        logger.trace("Processing get block {} from {}", Hex.toHexString(hash).substring(0, 10), sender.getPeerNodeID());
+        logger.trace("Processing get block {} from {}", ByteUtil.toHexString(hash), sender.getPeerNodeID());
         final Block block = blockSyncService.getBlockFromStoreOrBlockchain(hash);
 
         if (block == null) {
@@ -157,7 +157,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processBlockRequest(@Nonnull final Peer sender, long requestId, @Nonnull final byte[] hash) {
-        logger.trace("Processing get block by hash {} {} from {}", requestId, Hex.toHexString(hash).substring(0, 10), sender.getPeerNodeID());
+        logger.trace("Processing get block by hash {} {} from {}", requestId, ByteUtil.toHexString(hash), sender.getPeerNodeID());
         final Block block = blockSyncService.getBlockFromStoreOrBlockchain(hash);
 
         if (block == null) {
@@ -178,7 +178,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processBlockHeadersRequest(@Nonnull final Peer sender, long requestId, @Nonnull final byte[] hash, int count) {
-        logger.trace("Processing headers request {} {} from {}", requestId, Hex.toHexString(hash).substring(0, 10), sender.getPeerNodeID());
+        logger.trace("Processing headers request {} {} from {}", requestId, ByteUtil.toHexString(hash), sender.getPeerNodeID());
 
         if (count > syncConfiguration.getChunkSize()) {
             logger.trace("Headers request from {} failed because size {}", sender.getPeerNodeID(), count);
@@ -218,7 +218,7 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processBodyRequest(@Nonnull final Peer sender, long requestId, @Nonnull final byte[] hash) {
-        logger.trace("Processing body request {} {} from {}", requestId, Hex.toHexString(hash).substring(0, 10), sender.getPeerNodeID());
+        logger.trace("Processing body request {} {} from {}", requestId, ByteUtil.toHexString(hash), sender.getPeerNodeID());
         final Block block = blockSyncService.getBlockFromStoreOrBlockchain(hash);
 
         if (block == null) {

--- a/rskj-core/src/main/java/co/rsk/net/NodeID.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeID.java
@@ -18,7 +18,7 @@
 
 package co.rsk.net;
 
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -59,6 +59,6 @@ public class NodeID {
 
     @Override
     public String toString() {
-        return "NodeID{" + Hex.toHexString(nodeID) + '}';
+        return "NodeID{" + ByteUtil.toHexString(nodeID) + '}';
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -81,7 +81,7 @@ public class SyncProcessor implements SyncEventsHandler {
     }
 
     public void processStatus(Peer sender, Status status) {
-        logger.debug("Receiving syncState from node {} block {} {}", sender.getPeerNodeID(), status.getBestBlockNumber(), HashUtil.shortHash(status.getBestBlockHash()));
+        logger.debug("Receiving syncState from node {} block {} {}", sender.getPeerNodeID(), status.getBestBlockNumber(), HashUtil.toPrintableHash(status.getBestBlockHash()));
         peersInformation.registerPeer(sender).setStatus(status);
         syncState.newPeerStatus();
     }
@@ -102,7 +102,7 @@ public class SyncProcessor implements SyncEventsHandler {
 
     public void processBlockHashResponse(Peer peer, BlockHashResponseMessage message) {
         NodeID nodeID = peer.getPeerNodeID();
-        logger.debug("Process block hash response from node {} hash {}", nodeID, HashUtil.shortHash(message.getHash()));
+        logger.debug("Process block hash response from node {} hash {}", nodeID, HashUtil.toPrintableHash(message.getHash()));
         peersInformation.getOrRegisterPeer(peer);
 
         long messageId = message.getId();
@@ -145,7 +145,7 @@ public class SyncProcessor implements SyncEventsHandler {
 
     public void processNewBlockHash(Peer peer, NewBlockHashMessage message) {
         NodeID nodeID = peer.getPeerNodeID();
-        logger.debug("Process new block hash from node {} hash {}", nodeID, HashUtil.shortHash(message.getBlockHash()));
+        logger.debug("Process new block hash from node {} hash {}", nodeID, HashUtil.toPrintableHash(message.getBlockHash()));
         byte[] hash = message.getBlockHash();
 
         if (syncState instanceof DecidingSyncState && blockSyncService.getBlockFromStoreOrBlockchain(hash) == null) {
@@ -156,7 +156,7 @@ public class SyncProcessor implements SyncEventsHandler {
 
     public void processBlockResponse(Peer peer, BlockResponseMessage message) {
         NodeID nodeID = peer.getPeerNodeID();
-        logger.debug("Process block response from node {} block {} {}", nodeID, message.getBlock().getNumber(), message.getBlock().getShortHash());
+        logger.debug("Process block response from node {} block {} {}", nodeID, message.getBlock().getNumber(), message.getBlock().getPrintableHash());
         peersInformation.getOrRegisterPeer(peer);
 
         long messageId = message.getId();
@@ -195,7 +195,7 @@ public class SyncProcessor implements SyncEventsHandler {
     @Override
     public long sendBodyRequest(Peer peer, @Nonnull BlockHeader header) {
         logger.debug("Send body request block {} hash {} to peer {}", header.getNumber(),
-                HashUtil.shortHash(header.getHash().getBytes()), peer.getPeerNodeID());
+                HashUtil.toPrintableHash(header.getHash().getBytes()), peer.getPeerNodeID());
 
         BodyRequestMessage message = new BodyRequestMessage(++lastRequestId, header.getHash().getBytes());
         sendMessage(peer, message);

--- a/rskj-core/src/main/java/co/rsk/net/discovery/PacketDecoder.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/PacketDecoder.java
@@ -25,9 +25,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -48,7 +48,7 @@ public class PacketDecoder extends MessageToMessageDecoder<DatagramPacket> {
             PeerDiscoveryMessage msg = MessageDecoder.decode(encoded);
             return new DiscoveryEvent(msg, sender);
         } catch (Exception e) {
-            logger.error("Exception processing inbound message from {} : {}", ctx.channel().remoteAddress(), Hex.toHexString(encoded), e);
+            logger.error("Exception processing inbound message from {} : {}", ctx.channel().remoteAddress(), ByteUtil.toHexString(encoded), e);
             throw e;
         }
     }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
@@ -164,7 +164,7 @@ public class PeerExplorer {
 
         if (connectedNode != null) {
             List<Node> nodesToSend = this.distanceTable.getClosestNodes(nodeId);
-            logger.debug("About to send [{}] neighbors to ip[{}] port[{}] nodeId[{}]", nodesToSend.size(), connectedNode.getHost(), connectedNode.getPort(), connectedNode.getHexIdShort());
+            logger.debug("About to send [{}] neighbors to ip[{}] port[{}] nodeId[{}]", nodesToSend.size(), connectedNode.getHost(), connectedNode.getPort(), connectedNode.getHexId());
             this.sendNeighbors(connectedNode.getAddress(), nodesToSend, message.getMessageId());
             updateEntry(connectedNode);
         }
@@ -174,7 +174,7 @@ public class PeerExplorer {
         Node connectedNode = this.establishedConnections.get(message.getNodeId());
 
         if (connectedNode != null) {
-            logger.debug("Neighbors received from [{}]", connectedNode.getHexIdShort());
+            logger.debug("Neighbors received from [{}]", connectedNode.getHexId());
             PeerDiscoveryRequest request = this.pendingFindNodeRequests.remove(message.getMessageId());
 
             if (request != null && request.validateMessageResponse(neighborsResponseAddress, message)) {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/FindNodePeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/FindNodePeerMessage.java
@@ -21,8 +21,10 @@ package co.rsk.net.discovery.message;
 import co.rsk.net.discovery.PeerDiscoveryException;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.ethereum.crypto.ECKey;
-import org.ethereum.util.*;
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPItem;
+import org.ethereum.util.RLPList;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -100,7 +102,7 @@ public class FindNodePeerMessage extends PeerDiscoveryMessage {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .append(Hex.toHexString(this.nodeId))
+                .append(ByteUtil.toHexString(this.nodeId))
                 .append(this.getNetworkId())
                 .append(this.messageId).toString();
     }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
@@ -21,7 +21,6 @@ package co.rsk.net.discovery.message;
 import co.rsk.net.NodeID;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.signature.ECDSASignature;
@@ -171,9 +170,9 @@ public abstract class PeerDiscoveryMessage {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .append("mdc", Hex.toHexString(mdc))
-                .append("signature", Hex.toHexString(signature))
-                .append("type", Hex.toHexString(type))
-                .append("data", Hex.toHexString(data)).toString();
+                .append("mdc", ByteUtil.toHexString(mdc))
+                .append("signature", ByteUtil.toHexString(signature))
+                .append("type", ByteUtil.toHexString(type))
+                .append("data", ByteUtil.toHexString(data)).toString();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/eth/RskWireProtocol.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/RskWireProtocol.java
@@ -20,7 +20,10 @@ package co.rsk.net.eth;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.crypto.Keccak256;
-import co.rsk.net.*;
+import co.rsk.net.MessageHandler;
+import co.rsk.net.NodeID;
+import co.rsk.net.Status;
+import co.rsk.net.StatusResolver;
 import co.rsk.net.messages.BlockMessage;
 import co.rsk.net.messages.GetBlockMessage;
 import co.rsk.net.messages.Message;
@@ -29,7 +32,7 @@ import co.rsk.scoring.EventType;
 import co.rsk.scoring.PeerScoringManager;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import org.ethereum.core.*;
+import org.ethereum.core.Genesis;
 import org.ethereum.listener.CompositeEthereumListener;
 import org.ethereum.net.MessageQueue;
 import org.ethereum.net.eth.EthVersion;
@@ -42,7 +45,6 @@ import org.ethereum.sync.SyncStatistics;
 import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -131,15 +133,15 @@ public class RskWireProtocol extends SimpleChannelInboundHandler<EthMessage> imp
 
                 switch (message.getMessageType()) {
                     case BLOCK_MESSAGE:
-                        loggerNet.trace("RSK Block Message: Block {} {} from {}", ((BlockMessage)message).getBlock().getNumber(), ((BlockMessage)message).getBlock().getShortHash(), channel.getPeerNodeID());
+                        loggerNet.trace("RSK Block Message: Block {} {} from {}", ((BlockMessage)message).getBlock().getNumber(), ((BlockMessage)message).getBlock().getPrintableHash(), channel.getPeerNodeID());
                         syncStats.addBlocks(1);
                         break;
                     case GET_BLOCK_MESSAGE:
-                        loggerNet.trace("RSK Get Block Message: Block {} from {}", Hex.toHexString(((GetBlockMessage)message).getBlockHash()).substring(0, 10), channel.getPeerNodeID());
+                        loggerNet.trace("RSK Get Block Message: Block {} from {}", ByteUtil.toHexString(((GetBlockMessage)message).getBlockHash()), channel.getPeerNodeID());
                         syncStats.getBlock();
                         break;
                     case STATUS_MESSAGE:
-                        loggerNet.trace("RSK Status Message: Block {} {} from {}", ((StatusMessage)message).getStatus().getBestBlockNumber(), Hex.toHexString(((StatusMessage)message).getStatus().getBestBlockHash()).substring(0, 10), channel.getPeerNodeID());
+                        loggerNet.trace("RSK Status Message: Block {} {} from {}", ((StatusMessage)message).getStatus().getBestBlockNumber(), ByteUtil.toHexString(((StatusMessage)message).getStatus().getBestBlockHash()), channel.getPeerNodeID());
                         syncStats.addStatus();
                         break;
                 }
@@ -294,7 +296,7 @@ public class RskWireProtocol extends SimpleChannelInboundHandler<EthMessage> imp
 
         // todo: reduce reputation
 
-        logger.info("Peer {}: is a bad one, drop", channel.getPeerIdShort());
+        logger.info("Peer {}: is a bad one, drop", channel.getPeerId());
         disconnect(USELESS_PEER);
     }
 

--- a/rskj-core/src/main/java/co/rsk/net/eth/WriterMessageRecorder.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/WriterMessageRecorder.java
@@ -20,9 +20,9 @@ package co.rsk.net.eth;
 
 import co.rsk.net.NodeID;
 import org.ethereum.net.message.Message;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -64,12 +64,12 @@ public class WriterMessageRecorder implements MessageRecorder {
 
             writer.write(",");
 
-            writer.write(Hex.toHexString(message.getEncoded()));
+            writer.write(ByteUtil.toHexString(message.getEncoded()));
 
             writer.write(",");
 
             if (sender != null) {
-                writer.write(Hex.toHexString(sender.getID()));
+                writer.write(ByteUtil.toHexString(sender.getID()));
             }
 
             writer.newLine();

--- a/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
@@ -77,34 +77,34 @@ public class MessageVisitor {
     public void apply(BlockMessage message) {
         final Block block = message.getBlock();
 
-        logger.trace("Process block {} {}", block.getNumber(), block.getShortHash());
+        logger.trace("Process block {} {}", block.getNumber(), block.getPrintableHash());
 
         if (block.isGenesis()) {
-            logger.trace("Skip block processing {} {}", block.getNumber(), block.getShortHash());
+            logger.trace("Skip block processing {} {}", block.getNumber(), block.getPrintableHash());
             return;
         }
 
         long blockNumber = block.getNumber();
 
         if (this.blockProcessor.isAdvancedBlock(blockNumber)) {
-            logger.trace("Too advanced block {} {}", blockNumber, block.getShortHash());
+            logger.trace("Too advanced block {} {}", blockNumber, block.getPrintableHash());
             return;
         }
 
         if (blockProcessor.canBeIgnoredForUnclesRewards(block.getNumber())){
-            logger.trace("Block ignored: too far from best block {} {}", blockNumber, block.getShortHash());
+            logger.trace("Block ignored: too far from best block {} {}", blockNumber, block.getPrintableHash());
             return;
         }
 
         if (blockProcessor.hasBlockInSomeBlockchain(block.getHash().getBytes())){
-            logger.trace("Block ignored: it's included in blockchain {} {}", blockNumber, block.getShortHash());
+            logger.trace("Block ignored: it's included in blockchain {} {}", blockNumber, block.getPrintableHash());
             return;
         }
 
         BlockProcessResult result = this.blockProcessor.processBlock(sender, block);
 
         if (result.isInvalidBlock()) {
-            logger.trace("Invalid block {} {}", blockNumber, block.getShortHash());
+            logger.trace("Invalid block {} {}", blockNumber, block.getPrintableHash());
             recordEvent(sender, EventType.INVALID_BLOCK);
             return;
         }

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
@@ -2,8 +2,8 @@ package co.rsk.net.sync;
 
 import co.rsk.crypto.Keccak256;
 import co.rsk.net.BlockSyncService;
-import co.rsk.net.Peer;
 import co.rsk.net.NodeID;
+import co.rsk.net.Peer;
 import co.rsk.net.messages.BodyResponseMessage;
 import co.rsk.scoring.EventType;
 import co.rsk.validators.SyncBlockValidatorRule;
@@ -145,7 +145,7 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
         peersInformation.reportEventWithLog(
                 "Invalid block received from node {} {} {}",
                 peer.getPeerNodeID(), EventType.INVALID_BLOCK,
-                peer.getPeerNodeID(), header.getNumber(), header.getShortHash());
+                peer.getPeerNodeID(), header.getNumber(), header.getPrintableHash());
 
         clearPeerInfo(peer);
         if (suitablePeers.isEmpty()){
@@ -161,7 +161,7 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
         peersInformation.reportEventWithLog(
                 "Invalid body received from node {} {} {}",
                 peer.getPeerNodeID(), EventType.INVALID_MESSAGE,
-                peer.getPeerNodeID(), header.getNumber(), header.getShortHash());
+                peer.getPeerNodeID(), header.getNumber(), header.getPrintableHash());
 
         clearPeerInfo(peer);
         if (suitablePeers.isEmpty()){

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingHeadersSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingHeadersSyncState.java
@@ -83,7 +83,7 @@ public class DownloadingHeadersSyncState extends BaseSyncState {
                 syncEventsHandler.onErrorSyncing(
                         selectedPeer.getPeerNodeID(),
                         "Invalid header received from node {} {} {}", EventType.INVALID_HEADER,
-                        header.getNumber(), header.getShortHash());
+                        header.getNumber(), header.getPrintableHash());
                 return;
             }
 

--- a/rskj-core/src/main/java/co/rsk/pcc/NativeContract.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/NativeContract.java
@@ -20,13 +20,13 @@ package co.rsk.pcc;
 
 import co.rsk.core.RskAddress;
 import co.rsk.panic.PanicProcessor;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.slf4j.Logger;
@@ -122,7 +122,7 @@ public abstract class NativeContract extends PrecompiledContracts.PrecompiledCon
 
             // No function found with the given data? => halt!
             if (!methodWithArguments.isPresent()) {
-                String errorMessage = String.format("Invalid data given: %s.", Hex.toHexString(data));
+                String errorMessage = String.format("Invalid data given: %s.", ByteUtil.toHexString(data));
                 logger.info(errorMessage);
                 throw new NativeContractIllegalArgumentException(errorMessage);
             }
@@ -177,7 +177,7 @@ public abstract class NativeContract extends PrecompiledContracts.PrecompiledCon
 
     private Optional<NativeMethod.WithArguments> parseData(byte[] data) {
         if (data != null && (data.length >= 1 && data.length <= 3)) {
-            logger.warn("Invalid function signature {}.", Hex.toHexString(data));
+            logger.warn("Invalid function signature {}.", ByteUtil.toHexString(data));
             return Optional.empty();
         }
 
@@ -197,7 +197,7 @@ public abstract class NativeContract extends PrecompiledContracts.PrecompiledCon
                     ).findFirst();
 
             if (!maybeMethod.isPresent()) {
-                logger.warn("Invalid function signature {}.", Hex.toHexString(encodedSignature));
+                logger.warn("Invalid function signature {}.", ByteUtil.toHexString(encodedSignature));
                 return Optional.empty();
             }
 
@@ -212,7 +212,7 @@ public abstract class NativeContract extends PrecompiledContracts.PrecompiledCon
                 Object[] arguments = method.getFunction().decode(data);
                 return Optional.of(method.new WithArguments(arguments, data));
             } catch (Exception e) {
-                logger.warn(String.format("Invalid arguments %s for function %s.", Hex.toHexString(data), Hex.toHexString(encodedSignature)), e);
+                logger.warn(String.format("Invalid arguments %s for function %s.", ByteUtil.toHexString(data), ByteUtil.toHexString(encodedSignature)), e);
                 return Optional.empty();
             }
         }

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/GetMultisigScriptHash.java
@@ -24,8 +24,8 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.pcc.ExecutionEnvironment;
 import co.rsk.pcc.NativeContractIllegalArgumentException;
 import co.rsk.pcc.NativeMethod;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.CallTransaction;
+import org.ethereum.util.ByteUtil;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -119,7 +119,7 @@ public class GetMultisigScriptHash extends NativeMethod {
                 btcPublicKeys.add(btcPublicKey);
             } catch (IllegalArgumentException e) {
                 throw new NativeContractIllegalArgumentException(String.format(
-                        "Invalid public key format: %s", Hex.toHexString(publicKey)
+                        "Invalid public key format: %s", ByteUtil.toHexString(publicKey)
                 ), e);
             }
         });

--- a/rskj-core/src/main/java/co/rsk/pcc/bto/ToBase58Check.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/bto/ToBase58Check.java
@@ -21,8 +21,8 @@ package co.rsk.pcc.bto;
 import co.rsk.pcc.ExecutionEnvironment;
 import co.rsk.pcc.NativeContractIllegalArgumentException;
 import co.rsk.pcc.NativeMethod;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.CallTransaction;
+import org.ethereum.util.ByteUtil;
 
 import java.math.BigInteger;
 
@@ -77,7 +77,7 @@ public class ToBase58Check extends NativeMethod {
         if (hash.length != 20) {
             throw new NativeContractIllegalArgumentException(String.format(
                     HASH_INVALID,
-                    Hex.toHexString(hash), hash.length
+                    ByteUtil.toHexString(hash), hash.length
             ));
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -45,13 +45,13 @@ import co.rsk.rpc.modules.trace.CallType;
 import co.rsk.rpc.modules.trace.ProgramSubtrace;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.Program;
@@ -832,21 +832,21 @@ public class BridgeSupport {
             try {
                 sig = BtcECKey.ECDSASignature.decodeFromDER(signatures.get(i));
             } catch (RuntimeException e) {
-                logger.warn("Malformed signature for input {} of tx {}: {}", i, new Keccak256(rskTxHash), Hex.toHexString(signatures.get(i)));
+                logger.warn("Malformed signature for input {} of tx {}: {}", i, new Keccak256(rskTxHash), ByteUtil.toHexString(signatures.get(i)));
                 return;
             }
 
             Sha256Hash sighash = sighashes.get(i);
 
             if (!federatorPublicKey.verify(sighash, sig)) {
-                logger.warn("Signature {} {} is not valid for hash {} and public key {}", i, Hex.toHexString(sig.encodeToDER()), sighash, federatorPublicKey);
+                logger.warn("Signature {} {} is not valid for hash {} and public key {}", i, ByteUtil.toHexString(sig.encodeToDER()), sighash, federatorPublicKey);
                 return;
             }
 
             TransactionSignature txSig = new TransactionSignature(sig, BtcTransaction.SigHash.ALL, false);
             txSigs.add(txSig);
             if (!txSig.isCanonical()) {
-                logger.warn("Signature {} {} is not canonical.", i, Hex.toHexString(signatures.get(i)));
+                logger.warn("Signature {} {} is not canonical.", i, ByteUtil.toHexString(signatures.get(i)));
                 return;
             }
         }
@@ -890,7 +890,7 @@ public class BridgeSupport {
 
         // If tx fully signed
         if (missingSignatures == 0) {
-            logger.info("Tx fully signed {}. Hex: {}", btcTx, Hex.toHexString(btcTx.bitcoinSerialize()));
+            logger.info("Tx fully signed {}. Hex: {}", btcTx, ByteUtil.toHexString(btcTx.bitcoinSerialize()));
             provider.getRskTxsWaitingForSignatures().remove(new Keccak256(rskTxHash));
 
             eventLogger.logReleaseBtc(btcTx, rskTxHash);
@@ -1566,7 +1566,7 @@ public class BridgeSupport {
                     publicKey = BtcECKey.fromPublicOnly(publicKeyBytes);
                     publicKeyEc = ECKey.fromPublicOnly(publicKeyBytes);
                 } catch (Exception e) {
-                    throw new BridgeIllegalArgumentException("Public key could not be parsed " + Hex.toHexString(publicKeyBytes), e);
+                    throw new BridgeIllegalArgumentException("Public key could not be parsed " + ByteUtil.toHexString(publicKeyBytes), e);
                 }
                 executionResult = addFederatorPublicKeyMultikey(dryRun, publicKey, publicKeyEc, publicKeyEc);
                 result = new ABICallVoteResult(executionResult == 1, executionResult);
@@ -1577,19 +1577,19 @@ public class BridgeSupport {
                 try {
                     btcPublicKey = BtcECKey.fromPublicOnly(callSpec.getArguments()[0]);
                 } catch (Exception e) {
-                    throw new BridgeIllegalArgumentException("BTC public key could not be parsed " + Hex.toHexString(callSpec.getArguments()[0]), e);
+                    throw new BridgeIllegalArgumentException("BTC public key could not be parsed " + ByteUtil.toHexString(callSpec.getArguments()[0]), e);
                 }
 
                 try {
                     rskPublicKey = ECKey.fromPublicOnly(callSpec.getArguments()[1]);
                 } catch (Exception e) {
-                    throw new BridgeIllegalArgumentException("RSK public key could not be parsed " + Hex.toHexString(callSpec.getArguments()[1]), e);
+                    throw new BridgeIllegalArgumentException("RSK public key could not be parsed " + ByteUtil.toHexString(callSpec.getArguments()[1]), e);
                 }
 
                 try {
                     mstPublicKey = ECKey.fromPublicOnly(callSpec.getArguments()[2]);
                 } catch (Exception e) {
-                    throw new BridgeIllegalArgumentException("MST public key could not be parsed " + Hex.toHexString(callSpec.getArguments()[2]), e);
+                    throw new BridgeIllegalArgumentException("MST public key could not be parsed " + ByteUtil.toHexString(callSpec.getArguments()[2]), e);
                 }
                 executionResult = addFederatorPublicKeyMultikey(dryRun, btcPublicKey, rskPublicKey, mstPublicKey);
                 result = new ABICallVoteResult(executionResult == 1, executionResult);
@@ -1958,7 +1958,7 @@ public class BridgeSupport {
             }
         } catch (VerificationException e) {
             logger.warn("[btcTx:{}] PartialMerkleTree could not be parsed", btcTxHash);
-            throw new BridgeIllegalArgumentException(String.format("PartialMerkleTree could not be parsed %s", Hex.toHexString(pmtSerialized)), e);
+            throw new BridgeIllegalArgumentException(String.format("PartialMerkleTree could not be parsed %s", ByteUtil.toHexString(pmtSerialized)), e);
         }
 
         // Check merkle root equals btc block merkle root at the specified height in the btc best chain

--- a/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationMember.java
@@ -21,7 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.BtcECKey;
 import com.google.common.primitives.UnsignedBytes;
 import org.ethereum.crypto.ECKey;
-import org.spongycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -157,9 +157,9 @@ public final class FederationMember {
     public String toString() {
         return String.format(
                 "<BTC-%s, RSK-%s, MST-%s> federation member",
-                Hex.toHexString(btcPublicKey.getPubKey()),
-                Hex.toHexString(rskPublicKey.getPubKey()),
-                Hex.toHexString(mstPublicKey.getPubKey())
+                ByteUtil.toHexString(btcPublicKey.getPubKey()),
+                ByteUtil.toHexString(rskPublicKey.getPubKey()),
+                ByteUtil.toHexString(mstPublicKey.getPubKey())
         );
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -27,13 +27,13 @@ import co.rsk.core.RskAddress;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeEvents;
 import co.rsk.peg.Federation;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
@@ -93,7 +93,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     public void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             ECKey key = ECKey.fromPublicOnly(federatorPublicKey.getPubKey());
-            String federatorRskAddress = Hex.toHexString(key.getAddress());
+            String federatorRskAddress = ByteUtil.toHexString(key.getAddress());
             logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federatorPublicKey);
         } else {
             logAddSignatureInRLPFormat(federatorPublicKey, btcTx, rskTxHash);

--- a/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
@@ -163,7 +163,7 @@ public class Remasc {
             Coin minPayableFees = executionBlock.getMinimumGasPrice().multiply(minimumPayableGas);
             if (syntheticReward.compareTo(minPayableFees) < 0) {
                 logger.debug("Synthetic Reward: {} is lower than minPayableFees: {} at block: {}",
-                             syntheticReward, minPayableFees, executionBlock.getShortHash());
+                             syntheticReward, minPayableFees, executionBlock.getPrintableHash());
                 return;
             }
         }

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascContract.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascContract.java
@@ -22,7 +22,6 @@ import co.rsk.config.RemascConfig;
 import co.rsk.core.RskAddress;
 import co.rsk.panic.PanicProcessor;
 import co.rsk.rpc.modules.trace.ProgramSubtrace;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
@@ -32,6 +31,7 @@ import org.ethereum.core.Transaction;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.db.ReceiptStore;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
@@ -135,7 +135,7 @@ public class RemascContract extends PrecompiledContracts.PrecompiledContract {
             function = PROCESS_MINERS_FEES;
         } else {
             if (data.length != 4) {
-                logger.warn("Invalid function: signature longer than expected {}.", Hex.toHexString(data));
+                logger.warn("Invalid function: signature longer than expected {}.", ByteUtil.toHexString(data));
                 throw new RemascInvalidInvocationException("Invalid function signature");
             }
 
@@ -143,7 +143,7 @@ public class RemascContract extends PrecompiledContracts.PrecompiledContract {
             function = functions.get(new ByteArrayWrapper(functionSignature));
 
             if (function == null) {
-                logger.warn("Invalid function: signature does not match an existing function {}.", Hex.toHexString(functionSignature));
+                logger.warn("Invalid function: signature does not match an existing function {}.", ByteUtil.toHexString(functionSignature));
                 throw new RemascInvalidInvocationException("Invalid function signature");
             }
         }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -22,7 +22,8 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.core.NetworkStateExporter;
 import co.rsk.logfilter.BlocksBloomStore;
 import co.rsk.metrics.HashRateCalculator;
-import co.rsk.mine.*;
+import co.rsk.mine.MinerClient;
+import co.rsk.mine.MinerServer;
 import co.rsk.net.BlockProcessor;
 import co.rsk.rpc.modules.debug.DebugModule;
 import co.rsk.rpc.modules.eth.EthModule;
@@ -33,7 +34,10 @@ import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.trace.TraceModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.PeerScoringManager;
-import org.ethereum.core.*;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Blockchain;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.facade.Ethereum;
@@ -44,13 +48,13 @@ import org.ethereum.rpc.Web3Impl;
 import org.ethereum.util.BuildInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.*;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Handles requests for work and block submission.
@@ -125,24 +129,20 @@ public class Web3RskImpl extends Web3Impl {
                 result.addAll(blockStore.getChainBlocksByNumber(i));
             }
             for (Block block : result) {
-                writer.println(toSmallHash(block.getHash().getBytes()) + " " + block.getNumber() + "-" + toSmallHash(
+                writer.println(HashUtil.toPrintableHash(block.getHash().getBytes()) + " " + block.getNumber() + "-" + HashUtil.toPrintableHash(
                         block.getHash().getBytes()));
             }
             writer.println("#");
             for (Block block : result) {
-                writer.println(toSmallHash(block.getHash().getBytes()) + " " + toSmallHash(block.getParentHash().getBytes()) + " P");
+                writer.println(HashUtil.toPrintableHash(block.getHash().getBytes()) + " " + HashUtil.toPrintableHash(block.getParentHash().getBytes()) + " P");
                 if (includeUncles) {
                     for (BlockHeader uncleHeader : block.getUncleList()) {
-                        writer.println(toSmallHash(block.getHash().getBytes()) + " " + toSmallHash(uncleHeader.getHash().getBytes()) + " U");
+                        writer.println(HashUtil.toPrintableHash(block.getHash().getBytes()) + " " + HashUtil.toPrintableHash(uncleHeader.getHash().getBytes()) + " U");
                     }
                 }
             }
         } catch (IOException e) {
             logger.error("Could nos save node graph to file", e);
         }
-    }
-
-    private String toSmallHash(byte[] input) {
-        return Hex.toHexString(input).substring(56, 64);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -21,12 +21,12 @@ package co.rsk.rpc.modules.eth;
 import co.rsk.core.RskAddress;
 import co.rsk.core.Wallet;
 import co.rsk.net.TransactionGateway;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.core.*;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.GasCost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +57,7 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
         Account account = this.wallet.getAccount(new RskAddress(args.from));
         String s = null;
         try {
-            String toAddress = args.to != null ? Hex.toHexString(stringHexToByteArray(args.to)) : null;
+            String toAddress = args.to != null ? ByteUtil.toHexString(stringHexToByteArray(args.to)) : null;
 
             BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
             BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -29,6 +29,7 @@ import org.ethereum.core.TransactionPool;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.Web3;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.GasCost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,7 +173,7 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
                 throw new Exception("Address private key is locked or could not be found in this node");
             }
 
-            return s = TypeConverter.toJsonHex(Hex.toHexString(account.getEcKey().getPrivKeyBytes()));
+            return s = TypeConverter.toJsonHex(ByteUtil.toHexString(account.getEcKey().getPrivKeyBytes()));
         } finally {
             LOGGER.debug("personal_dumpRawKey(*****): {}", s);
         }
@@ -187,7 +188,7 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
             throw new Exception("From address private key could not be found in this node");
         }
 
-        String toAddress = args.to != null ? Hex.toHexString(TypeConverter.stringHexToByteArray(args.to)) : null;
+        String toAddress = args.to != null ? ByteUtil.toHexString(TypeConverter.stringHexToByteArray(args.to)) : null;
 
         BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : transactionPool.getPendingState().getNonce(account.getAddress());
         BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;

--- a/rskj-core/src/main/java/co/rsk/scoring/PeerScoringManager.java
+++ b/rskj-core/src/main/java/co/rsk/scoring/PeerScoringManager.java
@@ -2,7 +2,7 @@ package co.rsk.scoring;
 
 import co.rsk.net.NodeID;
 import com.google.common.annotations.VisibleForTesting;
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.net.InetAddress;
@@ -189,7 +189,7 @@ public class PeerScoringManager {
         synchronized (accessLock) {
             List<PeerScoringInformation> list = new ArrayList<>(this.peersByNodeID.size() + this.peersByAddress.size());
 
-            list.addAll(this.peersByNodeID.entrySet().stream().map(entry -> new PeerScoringInformation(entry.getValue(), Hex.toHexString(entry.getKey().getID()).substring(0, 8), "node")).collect(Collectors.toList()));
+            list.addAll(this.peersByNodeID.entrySet().stream().map(entry -> new PeerScoringInformation(entry.getValue(), ByteUtil.toHexString(entry.getKey().getID()).substring(0, 8), "node")).collect(Collectors.toList()));
             list.addAll(this.peersByAddress.entrySet().stream().map(entry -> new PeerScoringInformation(entry.getValue(), entry.getKey().getHostAddress(), "address")).collect(Collectors.toList()));
 
             return list;

--- a/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java
+++ b/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java
@@ -18,7 +18,7 @@
 
 package co.rsk.trie;
 
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -115,7 +115,7 @@ public class MultiTrieStore implements TrieStore {
         Trie oldestTrieToKeep = retrieve(oldestTrieHashToKeep)
                 .orElseThrow(() ->
                         new IllegalArgumentException(String.format("The trie with root %s is missing from every epoch",
-                                Hex.toHexString(oldestTrieHashToKeep)
+                                ByteUtil.toHexString(oldestTrieHashToKeep)
         )));
 
         epochs.get(epochs.size() - 2).save(oldestTrieToKeep); // save into the upcoming last epoch

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -26,9 +26,9 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.metrics.profilers.Metric;
 import co.rsk.metrics.profilers.Profiler;
 import co.rsk.metrics.profilers.ProfilerFactory;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.db.ByteArrayWrapper;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 
 import javax.annotation.Nullable;
@@ -1068,7 +1068,7 @@ public class Trie {
 
     private String printParam(String s, String name, byte[] param) {
         if (param != null) {
-            s += name + ": " + Hex.toHexString(param) + "\n";
+            s += name + ": " + ByteUtil.toHexString(param) + "\n";
         }
         return s;
     }

--- a/rskj-core/src/main/java/co/rsk/util/ByteBufferUtil.java
+++ b/rskj-core/src/main/java/co/rsk/util/ByteBufferUtil.java
@@ -1,6 +1,6 @@
 package co.rsk.util;
 
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
@@ -13,6 +13,6 @@ public class ByteBufferUtil {
     }
 
     public static String toHexString(@Nonnull ByteBuffer data) {
-        return Hex.toHexString(copyToArray(data));
+        return ByteUtil.toHexString(copyToArray(data));
     }
 }

--- a/rskj-core/src/main/java/co/rsk/validators/BlockCompositeRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockCompositeRule.java
@@ -51,7 +51,7 @@ public class BlockCompositeRule implements BlockValidationRule {
     }
     @Override
     public boolean isValid(Block block) {
-        String shortHash = block.getShortHash();
+        String shortHash = block.getPrintableHash();
         long number = block.getNumber();
         logger.debug("Validating block {} {}", shortHash, number);
         for(BlockValidationRule rule : this.rules) {

--- a/rskj-core/src/main/java/co/rsk/validators/BlockHeaderCompositeRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockHeaderCompositeRule.java
@@ -34,7 +34,7 @@ public class BlockHeaderCompositeRule implements BlockHeaderValidationRule {
 
     @Override
     public boolean isValid(BlockHeader header) {
-        String shortHash = header.getShortHash();
+        String shortHash = header.getPrintableHash();
         long number = header.getNumber();
         logger.debug("Validating header {} {}", shortHash, number);
         for (BlockHeaderValidationRule rule : this.rules) {

--- a/rskj-core/src/main/java/co/rsk/validators/BlockHeaderParentCompositeRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockHeaderParentCompositeRule.java
@@ -35,7 +35,7 @@ public class BlockHeaderParentCompositeRule implements BlockHeaderParentDependan
 
     @Override
     public boolean isValid(BlockHeader header, Block parent) {
-        String shortHash = header.getShortHash();
+        String shortHash = header.getPrintableHash();
         long number = header.getNumber();
         logger.debug("Validating header {} {}", shortHash, number);
         for (BlockHeaderParentDependantValidationRule rule : this.rules) {

--- a/rskj-core/src/main/java/co/rsk/validators/BlockParentCompositeRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockParentCompositeRule.java
@@ -47,7 +47,7 @@ public class BlockParentCompositeRule implements BlockParentDependantValidationR
 
     @Override
     public boolean isValid(Block block, Block parent) {
-        final String shortHash = block.getShortHash();
+        final String shortHash = block.getPrintableHash();
         long number = block.getNumber();
         logger.debug("Validating block {} {}", shortHash, number);
         for(BlockParentDependantValidationRule rule : this.rules) {

--- a/rskj-core/src/main/java/co/rsk/validators/BlockRootValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockRootValidationRule.java
@@ -23,9 +23,9 @@ import co.rsk.panic.PanicProcessor;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.util.Arrays;
 
@@ -55,7 +55,7 @@ public class BlockRootValidationRule implements BlockValidationRule {
 
         if (!Arrays.equals(blockTxRootHash, txListRootHash)) {
             String message = String.format("Block's given Trie Hash doesn't match: %s != %s",
-                      Hex.toHexString(blockTxRootHash), Hex.toHexString(txListRootHash));
+                      ByteUtil.toHexString(blockTxRootHash), ByteUtil.toHexString(txListRootHash));
 
             logger.warn(message);
             panicProcessor.panic("invalidtrie", message);

--- a/rskj-core/src/main/java/co/rsk/validators/BlockUnclesHashValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockUnclesHashValidationRule.java
@@ -7,7 +7,6 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 public class BlockUnclesHashValidationRule implements BlockValidationRule {
 
@@ -21,7 +20,7 @@ public class BlockUnclesHashValidationRule implements BlockValidationRule {
 
         if (!ByteUtil.fastEquals(unclesHeader, unclesBlock)) {
             String message = String.format("Block's given Uncle Hash doesn't match: %s != %s",
-                    Hex.toHexString(unclesHeader), Hex.toHexString(unclesBlock));
+                    ByteUtil.toHexString(unclesHeader), ByteUtil.toHexString(unclesBlock));
             logger.warn(message);
             panicProcessor.panic("invaliduncle", message);
             return false;

--- a/rskj-core/src/main/java/co/rsk/validators/ForkDetectionDataRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/ForkDetectionDataRule.java
@@ -105,8 +105,8 @@ public class ForkDetectionDataRule implements BlockValidationRule, BlockHeaderVa
         byte[] expectedForkDetectionData = forkDetectionDataCalculator.calculateWithBlockHeaders(headersView);
         if (!Arrays.equals(expectedForkDetectionData, header.getMiningForkDetectionData())) {
             logger.warn("Fork detection data does not match. Expected {} Actual: {}",
-                    ByteUtil.toHexString(expectedForkDetectionData),
-                    ByteUtil.toHexString(header.getMiningForkDetectionData())
+                    ByteUtil.toHexStringOrEmpty(expectedForkDetectionData),
+                    ByteUtil.toHexStringOrEmpty(header.getMiningForkDetectionData())
             );
             panicProcessor.panic(
                     PANIC_LOGGING_TOPIC,
@@ -120,7 +120,7 @@ public class ForkDetectionDataRule implements BlockValidationRule, BlockHeaderVa
 
     private boolean hasEnoughBlocksToCalculateForkDetectionData(BlockHeader header, List<BlockHeader> headersView) {
         if (headersView.size() != requiredBlocksForForkDetectionDataCalculation) {
-            logger.error("Missing blocks to calculate fork detection data. Block hash {} ", header.getShortHash());
+            logger.error("Missing blocks to calculate fork detection data. Block hash {} ", header.getPrintableHash());
             panicProcessor.panic(
                     PANIC_LOGGING_TOPIC,
                     "Missing blocks to calculate fork detection data."

--- a/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
@@ -120,7 +120,7 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
         if (isFallbackMiningPossibleAndBlockSigned(header)) {
             boolean isValidFallbackSignature = validFallbackBlockSignature(constants, header, header.getBitcoinMergedMiningHeader());
             if (!isValidFallbackSignature) {
-                logger.warn("Fallback signature failed. Header {}", header.getShortHash());
+                logger.warn("Fallback signature failed. Header {}", header.getPrintableHash());
             }
             return isValidFallbackSignature;
         }
@@ -134,19 +134,19 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
                 mpValidator = new GenesisMerkleProofValidator(bitcoinNetworkParameters, header.getBitcoinMergedMiningMerkleProof());
             }
         } catch (RuntimeException ex) {
-            logger.warn("Merkle proof can't be validated. Header {}", header.getShortHash(), ex);
+            logger.warn("Merkle proof can't be validated. Header {}", header.getPrintableHash(), ex);
             return false;
         }
 
         byte[] bitcoinMergedMiningCoinbaseTransactionCompressed = header.getBitcoinMergedMiningCoinbaseTransaction();
 
         if (bitcoinMergedMiningCoinbaseTransactionCompressed == null) {
-            logger.warn("Compressed coinbase transaction does not exist. Header {}", header.getShortHash());
+            logger.warn("Compressed coinbase transaction does not exist. Header {}", header.getPrintableHash());
             return false;
         }
 
         if (header.getBitcoinMergedMiningHeader() == null) {
-            logger.warn("Bitcoin merged mining header does not exist. Header {}", header.getShortHash());
+            logger.warn("Bitcoin merged mining header does not exist. Header {}", header.getPrintableHash());
             return false;
         }
 

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -33,6 +33,7 @@ import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.net.p2p.P2pHandler;
 import org.ethereum.net.rlpx.MessageCodec;
 import org.ethereum.net.rlpx.Node;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -361,8 +362,8 @@ public abstract class SystemProperties {
                 props.load(new FileReader(file));
             } else {
                 ECKey key = new ECKey();
-                props.setProperty("nodeIdPrivateKey", Hex.toHexString(key.getPrivKeyBytes()));
-                props.setProperty("nodeId", Hex.toHexString(key.getNodeId()));
+                props.setProperty("nodeIdPrivateKey", ByteUtil.toHexString(key.getPrivKeyBytes()));
+                props.setProperty("nodeId", ByteUtil.toHexString(key.getNodeId()));
                 file.getParentFile().mkdirs();
                 props.store(new FileWriter(file), "Generated NodeID. To use your own nodeId please refer to 'peer.privateKey' config option.");
                 logger.info("New nodeID generated: {}", props.getProperty("nodeId"));

--- a/rskj-core/src/main/java/org/ethereum/core/Block.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Block.java
@@ -25,10 +25,10 @@ import co.rsk.core.RskAddress;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.crypto.Keccak256;
 import co.rsk.panic.PanicProcessor;
-import org.bouncycastle.util.Arrays;
 import com.google.common.collect.ImmutableList;
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 
 import javax.annotation.Nonnull;
@@ -208,7 +208,7 @@ public class Block {
     @Override
     public String toString() {
         StringBuilder toStringBuff = new StringBuilder();
-        toStringBuff.append(Hex.toHexString(this.getEncoded())).append("\n");
+        toStringBuff.append(ByteUtil.toHexString(this.getEncoded())).append("\n");
         toStringBuff.append("BlockData [ ");
         toStringBuff.append("hash=").append(this.getHash()).append("\n");
         toStringBuff.append(header.toString());
@@ -305,16 +305,16 @@ public class Block {
         return body;
     }
 
-    public String getShortHash() {
-        return header.getShortHash();
+    public String getPrintableHash() {
+        return header.getPrintableHash();
     }
 
-    private String getParentShortHash() {
-        return header.getParentShortHash();
+    private String getParentPrintableHash() {
+        return header.getParentPrintableHash();
     }
 
-    public String getShortHashForMergedMining() {
-        return this.header.getShortHashForMergedMining();
+    public String getPrintableHashForMergedMining() {
+        return this.header.getPrintableHashForMergedMining();
     }
 
     public byte[] getHashForMergedMining() {
@@ -322,8 +322,8 @@ public class Block {
     }
 
     public String getShortDescr() {
-        return "#" + getNumber() + " (" + getShortHash() + " <~ "
-                + getParentShortHash() + ") Txs:" + getTransactionsList().size() +
+        return "#" + getNumber() + " (" + getPrintableHash() + " <~ "
+                + getParentPrintableHash() + ") Txs:" + getTransactionsList().size() +
                 ", Unc: " + getUncleList().size();
     }
 

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 import static java.lang.System.arraycopy;
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
-import static org.ethereum.util.ByteUtil.toHexString;
+import static org.ethereum.util.ByteUtil.toHexStringOrEmpty;
 
 /**
  * Block header is a value object containing
@@ -421,18 +421,18 @@ public class BlockHeader {
 
     private String toStringWithSuffix(final String suffix) {
         StringBuilder toStringBuff = new StringBuilder();
-        toStringBuff.append("  parentHash=").append(toHexString(parentHash)).append(suffix);
-        toStringBuff.append("  unclesHash=").append(toHexString(unclesHash)).append(suffix);
+        toStringBuff.append("  parentHash=").append(toHexStringOrEmpty(parentHash)).append(suffix);
+        toStringBuff.append("  unclesHash=").append(toHexStringOrEmpty(unclesHash)).append(suffix);
         toStringBuff.append("  coinbase=").append(coinbase).append(suffix);
-        toStringBuff.append("  stateRoot=").append(toHexString(stateRoot)).append(suffix);
-        toStringBuff.append("  txTrieHash=").append(toHexString(txTrieRoot)).append(suffix);
-        toStringBuff.append("  receiptsTrieHash=").append(toHexString(receiptTrieRoot)).append(suffix);
+        toStringBuff.append("  stateRoot=").append(toHexStringOrEmpty(stateRoot)).append(suffix);
+        toStringBuff.append("  txTrieHash=").append(toHexStringOrEmpty(txTrieRoot)).append(suffix);
+        toStringBuff.append("  receiptsTrieHash=").append(toHexStringOrEmpty(receiptTrieRoot)).append(suffix);
         toStringBuff.append("  difficulty=").append(difficulty).append(suffix);
         toStringBuff.append("  number=").append(number).append(suffix);
-        toStringBuff.append("  gasLimit=").append(toHexString(gasLimit)).append(suffix);
+        toStringBuff.append("  gasLimit=").append(toHexStringOrEmpty(gasLimit)).append(suffix);
         toStringBuff.append("  gasUsed=").append(gasUsed).append(suffix);
         toStringBuff.append("  timestamp=").append(timestamp).append(" (").append(Utils.longToDateTime(timestamp)).append(")").append(suffix);
-        toStringBuff.append("  extraData=").append(toHexString(extraData)).append(suffix);
+        toStringBuff.append("  extraData=").append(toHexStringOrEmpty(extraData)).append(suffix);
         toStringBuff.append("  minGasPrice=").append(minimumGasPrice).append(suffix);
 
         return toStringBuff.toString();
@@ -481,8 +481,8 @@ public class BlockHeader {
         this.bitcoinMergedMiningCoinbaseTransaction = bitcoinMergedMiningCoinbaseTransaction;
     }
 
-    public String getShortHashForMergedMining() {
-        return HashUtil.shortHash(getHashForMergedMining());
+    public String getPrintableHashForMergedMining() {
+        return HashUtil.toPrintableHash(getHashForMergedMining());
     }
 
     public boolean isUMMBlock() {
@@ -528,12 +528,12 @@ public class BlockHeader {
         return root256;
     }
 
-    public String getShortHash() {
-        return HashUtil.shortHash(getHash().getBytes());
+    public String getPrintableHash() {
+        return HashUtil.toPrintableHash(getHash().getBytes());
     }
 
-    public String getParentShortHash() {
-        return HashUtil.shortHash(getParentHash().getBytes());
+    public String getParentPrintableHash() {
+        return HashUtil.toPrintableHash(getParentHash().getBytes());
     }
 
     public byte[] getMiningForkDetectionData() {
@@ -555,7 +555,7 @@ public class BlockHeader {
                 int position = Collections.lastIndexOfSubList(coinbaseAsList, hashForMergedMiningPrefixAsList);
                 if (position == -1) {
                     throw new IllegalStateException(
-                            String.format("Mining fork detection data could not be found. Header: %s", getShortHash())
+                            String.format("Mining fork detection data could not be found. Header: %s", getPrintableHash())
                     );
                 }
 

--- a/rskj-core/src/main/java/org/ethereum/core/BlockIdentifier.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockIdentifier.java
@@ -18,9 +18,9 @@ package org.ethereum.core;
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
@@ -74,7 +74,7 @@ public class BlockIdentifier {
     @Override
     public String toString() {
         return "BlockIdentifier {" +
-                "hash=" + Hex.toHexString(hash) +
+                "hash=" + ByteUtil.toHexString(hash) +
                 ", number=" + number +
                 '}';
     }

--- a/rskj-core/src/main/java/org/ethereum/core/Bloom.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Bloom.java
@@ -20,7 +20,6 @@
 package org.ethereum.core;
 
 import org.ethereum.util.ByteUtil;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.util.Arrays;
 
@@ -85,7 +84,7 @@ public class Bloom {
 
     @Override
     public String toString() {
-        return Hex.toHexString(data);
+        return ByteUtil.toHexString(data);
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -33,9 +33,9 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.crypto.ECKey;
-import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.crypto.ECKey.MissingPrivateKeyException;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.crypto.signature.Secp256k1;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
@@ -428,16 +428,16 @@ public class Transaction {
 
     @Override
     public String toString() {
-        return "TransactionData [" + "hash=" + ByteUtil.toHexString(getHash().getBytes()) +
-                "  nonce=" + ByteUtil.toHexString(nonce) +
-                ", gasPrice=" + gasPrice.toString() +
-                ", gas=" + ByteUtil.toHexString(gasLimit) +
-                ", receiveAddress=" + receiveAddress.toString() +
-                ", value=" + value.toString() +
-                ", data=" + ByteUtil.toHexString(data) +
+        return "TransactionData [" + "hash=" + ByteUtil.toHexStringOrEmpty(getHash().getBytes()) +
+                "  nonce=" + ByteUtil.toHexStringOrEmpty(nonce) +
+                ", gasPrice=" + gasPrice +
+                ", gas=" + ByteUtil.toHexStringOrEmpty(gasLimit) +
+                ", receiveAddress=" + receiveAddress +
+                ", value=" + value +
+                ", data=" + ByteUtil.toHexStringOrEmpty(data) +
                 ", signatureV=" + (signature == null ? "" : signature.getV()) +
-                ", signatureR=" + (signature == null ? "" : ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(signature.getR()))) +
-                ", signatureS=" + (signature == null ? "" : ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(signature.getS()))) +
+                ", signatureR=" + (signature == null ? "" : ByteUtil.toHexStringOrEmpty(BigIntegers.asUnsignedByteArray(signature.getR()))) +
+                ", signatureS=" + (signature == null ? "" : ByteUtil.toHexStringOrEmpty(BigIntegers.asUnsignedByteArray(signature.getS()))) +
                 "]";
 
     }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -461,14 +461,15 @@ public class TransactionExecutor {
         if (mEndGas < returnDataGasValue) {
             program.setRuntimeFailure(
                     Program.ExceptionHelper.notEnoughSpendingGas(
+                            program,
                             "No gas to return just created contract",
-                            returnDataGasValue,
-                            program));
+                            returnDataGasValue));
             result = program.getResult();
             result.setHReturn(EMPTY_BYTE_ARRAY);
         } else if (createdContractSize > Constants.getMaxContractSize()) {
             program.setRuntimeFailure(
                     Program.ExceptionHelper.tooLargeContractSize(
+                            program,
                             Constants.getMaxContractSize(),
                             createdContractSize));
             result = program.getResult();

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionReceipt.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionReceipt.java
@@ -19,21 +19,17 @@
 
 package org.ethereum.core;
 
-import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.util.RLP;
-import org.ethereum.util.RLPElement;
-import org.ethereum.util.RLPItem;
-import org.ethereum.util.RLPList;
-import org.ethereum.vm.LogInfo;
+    import org.bouncycastle.util.BigIntegers;
+    import org.ethereum.util.*;
+    import org.ethereum.vm.LogInfo;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+    import java.math.BigInteger;
+    import java.util.ArrayList;
+    import java.util.Arrays;
+    import java.util.List;
 
-import static co.rsk.util.ListArrayUtil.nullToEmpty;
-import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
+    import static co.rsk.util.ListArrayUtil.nullToEmpty;
+    import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
 
 /**
  * The transaction receipt is a tuple of three items
@@ -236,8 +232,8 @@ public class TransactionReceipt {
 
         return "TransactionReceipt[" +
                 "\n  , " + (hasTxStatus() ? ("txStatus=" + (isSuccessful()? "OK" : "FAILED"))
-                        : ("postTxState=" + Hex.toHexString(postTxState))) +
-                "\n  , cumulativeGas=" + Hex.toHexString(cumulativeGas) +
+                        : ("postTxState=" + ByteUtil.toHexString(postTxState))) +
+                "\n  , cumulativeGas=" + ByteUtil.toHexString(cumulativeGas) +
                 "\n  , bloom=" + bloomFilter.toString() +
                 "\n  , logs=" + logInfoList +
                 ']';

--- a/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/genesis/BlockChainLoader.java
@@ -24,13 +24,13 @@ import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.db.StateRootHandler;
 import co.rsk.validators.BlockValidator;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Block;
 import org.ethereum.core.Genesis;
 import org.ethereum.core.TransactionPool;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.listener.EthereumListener;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +89,7 @@ public class BlockChainLoader {
             logger.info("*** Loaded up to block [{}] totalDifficulty [{}] with stateRoot [{}]",
                     bestBlock.getNumber(),
                     totalDifficulty,
-                    Hex.toHexString(bestBlock.getStateRoot()));
+                    ByteUtil.toHexString(bestBlock.getStateRoot()));
         }
 
         BlockChainImpl blockchain = new BlockChainImpl(

--- a/rskj-core/src/main/java/org/ethereum/crypto/ECKey.java
+++ b/rskj-core/src/main/java/org/ethereum/crypto/ECKey.java
@@ -46,8 +46,8 @@ import org.bouncycastle.crypto.signers.ECDSASigner;
 import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.signature.Secp256k1;
+import org.ethereum.util.ByteUtil;
 
 import javax.annotation.Nullable;
 import java.math.BigInteger;
@@ -332,7 +332,7 @@ public class ECKey {
 
     public String toString() {
         StringBuilder b = new StringBuilder();
-        b.append("pub:").append(Hex.toHexString(pub.getEncoded(false)));
+        b.append("pub:").append(ByteUtil.toHexString(pub.getEncoded(false)));
         return b.toString();
     }
 

--- a/rskj-core/src/main/java/org/ethereum/crypto/HashUtil.java
+++ b/rskj-core/src/main/java/org/ethereum/crypto/HashUtil.java
@@ -24,6 +24,7 @@ import org.bouncycastle.crypto.Digest;
 import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.cryptohash.Keccak256;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.Utils;
 
@@ -74,7 +75,6 @@ public class HashUtil {
         return Keccak256Helper.keccak256(input, start, length);
     }
 
-
     /**
      * @param data - message to hash
      * @return - reipmd160 hash of the message
@@ -89,7 +89,6 @@ public class HashUtil {
         }
         throw new NullPointerException("Can't hash a NULL value");
     }
-
 
     /**
      * Calculates RIGTMOST160(KECCAK256(input)). This is used in address calculations.
@@ -176,14 +175,13 @@ public class HashUtil {
      * @return generates random peer id for the HelloMessage
      */
     public static byte[] randomPeerId() {
-
         byte[] peerIdBytes = new BigInteger(512, Utils.getRandom()).toByteArray();
 
         final String peerId;
         if (peerIdBytes.length > 64) {
-            peerId = Hex.toHexString(peerIdBytes, 1, 64);
+            peerId = ByteUtil.toHexString(peerIdBytes, 1, 64);
         } else {
-            peerId = Hex.toHexString(peerIdBytes);
+            peerId = ByteUtil.toHexString(peerIdBytes);
         }
 
         return Hex.decode(peerId);
@@ -192,16 +190,21 @@ public class HashUtil {
     /**
      * @return - generate random 32 byte hash
      */
-    public static byte[] randomHash(){
-
+    public static byte[] randomHash() {
         byte[] randomHash = new byte[32];
         SecureRandom random = new SecureRandom();
         random.nextBytes(randomHash);
         return randomHash;
     }
 
+    /**
+     * Converts {@code hash} in a form of byte array to {@code String}
+     * that's suitable to be printed out in a text form.
+     *
+     * @throws NullPointerException if {@code hash} is {@code null}
+     */
     @Nonnull
-    public static String shortHash(@Nonnull final byte[] hash){
-        return Hex.toHexString(hash).substring(0, Math.min(hash.length, 6));
+    public static String toPrintableHash(@Nonnull final byte[] hash) {
+        return ByteUtil.toHexString(hash);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/crypto/Keccak256Helper.java
+++ b/rskj-core/src/main/java/org/ethereum/crypto/Keccak256Helper.java
@@ -21,6 +21,7 @@ package org.ethereum.crypto;
 
 import org.bouncycastle.crypto.digests.KeccakDigest;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import java.math.BigInteger;
 
@@ -87,7 +88,7 @@ public class Keccak256Helper {
     private static String keccak256String(byte[] message, KeccakDigest digest, boolean bouncyencoder) {
         byte[] hash = doKeccak256(message, digest, bouncyencoder);
         if (bouncyencoder) {
-            return Hex.toHexString(hash);
+            return ByteUtil.toHexString(hash);
         } else {
             BigInteger bigInt = new BigInteger(1, hash);
             return bigInt.toString(16);

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -23,7 +23,6 @@ import co.rsk.metrics.profilers.Metric;
 import co.rsk.metrics.profilers.Profiler;
 import co.rsk.metrics.profilers.ProfilerFactory;
 import co.rsk.panic.PanicProcessor;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
 import org.iq80.leveldb.*;
@@ -147,13 +146,13 @@ public class LevelDbDataSource implements KeyValueDataSource {
         resetDbLock.readLock().lock();
         try {
             if (logger.isTraceEnabled()) {
-                logger.trace("~> LevelDbDataSource.get(): {}, key: {}", name,  Hex.toHexString(key));
+                logger.trace("~> LevelDbDataSource.get(): {}, key: {}", name,  ByteUtil.toHexString(key));
             }
 
             try {
                 byte[] ret = db.get(key);
                 if (logger.isTraceEnabled()) {
-                    logger.trace("<~ LevelDbDataSource.get(): {}, key: {}, return length: {}", name, Hex.toHexString(key), (ret == null ? "null" : ret.length));
+                    logger.trace("<~ LevelDbDataSource.get(): {}, key: {}, return length: {}", name, ByteUtil.toHexString(key), (ret == null ? "null" : ret.length));
                 }
 
                 return ret;
@@ -162,7 +161,7 @@ public class LevelDbDataSource implements KeyValueDataSource {
                 try {
                     byte[] ret = db.get(key);
                     if (logger.isTraceEnabled()) {
-                        logger.trace("<~ LevelDbDataSource.get(): {}, key: {}, return length: {}", name, Hex.toHexString(key), (ret == null ? "null" : ret.length));
+                        logger.trace("<~ LevelDbDataSource.get(): {}, key: {}, return length: {}", name, ByteUtil.toHexString(key), (ret == null ? "null" : ret.length));
                     }
 
                     return ret;
@@ -187,12 +186,12 @@ public class LevelDbDataSource implements KeyValueDataSource {
         resetDbLock.readLock().lock();
         try {
             if (logger.isTraceEnabled()) {
-                logger.trace("~> LevelDbDataSource.put(): {}, key: {}, return length: {}", name, Hex.toHexString(key), value.length);
+                logger.trace("~> LevelDbDataSource.put(): {}, key: {}, return length: {}", name, ByteUtil.toHexString(key), value.length);
             }
 
             db.put(key, value);
             if (logger.isTraceEnabled()) {
-                logger.trace("<~ LevelDbDataSource.put(): {}, key: {}, return length: {}", name, Hex.toHexString(key), value.length);
+                logger.trace("<~ LevelDbDataSource.put(): {}, key: {}, return length: {}", name, ByteUtil.toHexString(key), value.length);
             }
 
             return value;
@@ -208,12 +207,12 @@ public class LevelDbDataSource implements KeyValueDataSource {
         resetDbLock.readLock().lock();
         try {
             if (logger.isTraceEnabled()) {
-                logger.trace("~> LevelDbDataSource.delete(): {}, key: {}", name, Hex.toHexString(key));
+                logger.trace("~> LevelDbDataSource.delete(): {}, key: {}", name, ByteUtil.toHexString(key));
             }
 
             db.delete(key);
             if (logger.isTraceEnabled()) {
-                logger.trace("<~ LevelDbDataSource.delete(): {}, key: {}", name, Hex.toHexString(key));
+                logger.trace("<~ LevelDbDataSource.delete(): {}, key: {}", name, ByteUtil.toHexString(key));
             }
 
         } finally {

--- a/rskj-core/src/main/java/org/ethereum/db/ByteArrayWrapper.java
+++ b/rskj-core/src/main/java/org/ethereum/db/ByteArrayWrapper.java
@@ -22,8 +22,6 @@ package org.ethereum.db;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.FastByteComparisons;
 
-import org.bouncycastle.util.encoders.Hex;
-
 import java.io.Serializable;
 import java.util.Arrays;
 
@@ -70,7 +68,7 @@ public class ByteArrayWrapper implements Comparable<ByteArrayWrapper>, Serializa
 
     @Override
     public String toString() {
-        return Hex.toHexString(data);
+        return ByteUtil.toHexString(data);
     }
 
     public boolean equalsToByteArray(byte[] otherData) {

--- a/rskj-core/src/main/java/org/ethereum/net/NodeHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/net/NodeHandler.java
@@ -20,7 +20,7 @@
 package org.ethereum.net;
 
 import org.ethereum.net.rlpx.Node;
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 /**
  * The instance of this class responsible for discovery messages exchange with the specified Node
@@ -51,7 +51,7 @@ public class NodeHandler {
     @Override
     public String toString() {
         return "NodeHandler[node: " + node.getHost() + ":" + node.getPort() + ", id="
-                + (node.getId().getID().length > 0 ? Hex.toHexString(node.getId().getID(), 0, 4) : "empty") + "]";
+                + (node.getId().getID().length > 0 ? ByteUtil.toHexString(node.getId().getID(), 0, 4) : "empty") + "]";
     }
 
 

--- a/rskj-core/src/main/java/org/ethereum/net/NodeStatistics.java
+++ b/rskj-core/src/main/java/org/ethereum/net/NodeStatistics.java
@@ -148,7 +148,7 @@ public class NodeStatistics {
                 ", rlpx: " + rlpxHandshake + "/" + rlpxAuthMessagesSent + "/" + rlpxConnectionAttempts + " " +
                 rlpxInMessages + "/" + rlpxOutMessages +
                 ", eth: " + ethHandshake + "/" + getEthInbound() + "/" + getEthOutbound() + " " +
-                (ethLastInboundStatusMsg != null ? ByteUtil.toHexString(ethLastInboundStatusMsg.getTotalDifficulty()) : "-") + " " +
+                (ethLastInboundStatusMsg != null ? ByteUtil.toHexStringOrEmpty(ethLastInboundStatusMsg.getTotalDifficulty()) : "-") + " " +
                 (disconnected ? "X " : "") +
                 (rlpxLastLocalDisconnectReason != null ? ("<=" + rlpxLastLocalDisconnectReason) : " ") +
                 (rlpxLastRemoteDisconnectReason != null ? ("=>" + rlpxLastRemoteDisconnectReason) : " ")  +

--- a/rskj-core/src/main/java/org/ethereum/net/eth/message/StatusMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/eth/message/StatusMessage.java
@@ -23,8 +23,6 @@ import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
-import org.bouncycastle.util.encoders.Hex;
-
 import java.math.BigInteger;
 
 /**
@@ -157,9 +155,9 @@ public class StatusMessage extends EthMessage {
         return "[" + this.getCommand().name() +
                 " protocolVersion=" + this.protocolVersion +
                 " networkId=" + this.networkId +
-                " totalDifficulty=" + ByteUtil.toHexString(this.totalDifficulty) +
-                " bestHash=" + Hex.toHexString(this.bestHash) +
-                " genesisHash=" + Hex.toHexString(this.genesisHash) +
+                " totalDifficulty=" + ByteUtil.toHexStringOrEmpty(this.totalDifficulty) +
+                " bestHash=" + ByteUtil.toHexString(this.bestHash) +
+                " genesisHash=" + ByteUtil.toHexString(this.genesisHash) +
                 "]";
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/net/p2p/HelloMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/p2p/HelloMessage.java
@@ -106,7 +106,7 @@ public class HelloMessage extends P2pMessage {
         this.listenPort = ByteUtil.byteArrayToInt(peerPortBytes);
 
         byte[] peerIdBytes = paramsList.get(4).getRLPData();
-        this.peerId = Hex.toHexString(peerIdBytes);
+        this.peerId = ByteUtil.toHexString(peerIdBytes);
         this.parsed = true;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/net/p2p/PeersMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/p2p/PeersMessage.java
@@ -23,11 +23,8 @@ import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
-import org.bouncycastle.util.encoders.Hex;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -67,7 +64,7 @@ public class PeersMessage extends P2pMessage {
                 int peerPort = ByteUtil.byteArrayToInt(portBytes);
                 InetAddress address = InetAddress.getByAddress(ipBytes);
 
-                String peerId = peerIdRaw == null ? "" : Hex.toHexString(peerIdRaw);
+                String peerId = peerIdRaw == null ? "" : ByteUtil.toHexString(peerIdRaw);
                 PeerConnectionData peer = new PeerConnectionData(address, peerPort, peerId);
                 peers.add(peer);
             } catch (UnknownHostException e) {

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/AuthInitiateMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/AuthInitiateMessage.java
@@ -19,13 +19,13 @@
 
 package org.ethereum.net.rlpx;
 
-import org.ethereum.crypto.ECKey;
 import org.bouncycastle.math.ec.ECPoint;
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.signature.ECDSASignature;
+import org.ethereum.util.ByteUtil;
 
-import static org.ethereum.util.ByteUtil.merge;
 import static org.bouncycastle.util.BigIntegers.asUnsignedByteArray;
+import static org.ethereum.util.ByteUtil.merge;
 
 /**
  * Authentication initiation message, to be wrapped inside
@@ -121,10 +121,10 @@ public class AuthInitiateMessage {
                 asUnsignedByteArray(signature.getS()), new byte[]{EncryptionHandshake.recIdFromSignatureV(signature.getV())});
 
         return "AuthInitiateMessage{" +
-                "\n  sigBytes=" + Hex.toHexString(sigBytes) +
-                "\n  ephemeralPublicHash=" + Hex.toHexString(ephemeralPublicHash) +
-                "\n  publicKey=" + Hex.toHexString(publicKey.getEncoded(false)) +
-                "\n  nonce=" + Hex.toHexString(nonce) +
+                "\n  sigBytes=" + ByteUtil.toHexString(sigBytes) +
+                "\n  ephemeralPublicHash=" + ByteUtil.toHexString(ephemeralPublicHash) +
+                "\n  publicKey=" + ByteUtil.toHexString(publicKey.getEncoded(false)) +
+                "\n  nonce=" + ByteUtil.toHexString(nonce) +
                 "\n}";
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/AuthInitiateMessageV4.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/AuthInitiateMessageV4.java
@@ -19,16 +19,15 @@
 
 package org.ethereum.net.rlpx;
 
+import org.bouncycastle.math.ec.ECPoint;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
-import org.bouncycastle.math.ec.ECPoint;
-import org.bouncycastle.util.encoders.Hex;
 
-import static org.ethereum.util.ByteUtil.merge;
 import static org.bouncycastle.util.BigIntegers.asUnsignedByteArray;
+import static org.ethereum.util.ByteUtil.merge;
 
 /**
  * Auth Initiate message defined by EIP-8
@@ -112,9 +111,9 @@ public class AuthInitiateMessageV4 {
                 asUnsignedByteArray(signature.getS()), new byte[]{EncryptionHandshake.recIdFromSignatureV(signature.getV())});
 
         return "AuthInitiateMessage{" +
-                "\n  sigBytes=" + Hex.toHexString(sigBytes) +
-                "\n  publicKey=" + Hex.toHexString(publicKey.getEncoded(false)) +
-                "\n  nonce=" + Hex.toHexString(nonce) +
+                "\n  sigBytes=" + ByteUtil.toHexString(sigBytes) +
+                "\n  publicKey=" + ByteUtil.toHexString(publicKey.getEncoded(false)) +
+                "\n  nonce=" + ByteUtil.toHexString(nonce) +
                 "\n  version=" + version +
                 "\n}";
     }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/AuthResponseMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/AuthResponseMessage.java
@@ -19,9 +19,9 @@
 
 package org.ethereum.net.rlpx;
 
-import org.ethereum.crypto.ECKey;
 import org.bouncycastle.math.ec.ECPoint;
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 
 /**
  * Authentication response message, to be wrapped inside
@@ -74,7 +74,7 @@ public class AuthResponseMessage {
     public String toString() {
         return "AuthResponseMessage{" +
                 "\n  ephemeralPublicKey=" + ephemeralPublicKey +
-                "\n  nonce=" + Hex.toHexString(nonce) +
+                "\n  nonce=" + ByteUtil.toHexString(nonce) +
                 "\n  isTokenUsed=" + isTokenUsed +
                 '}';
     }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/AuthResponseMessageV4.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/AuthResponseMessageV4.java
@@ -19,12 +19,11 @@
 
 package org.ethereum.net.rlpx;
 
+import org.bouncycastle.math.ec.ECPoint;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
-import org.bouncycastle.math.ec.ECPoint;
-import org.bouncycastle.util.encoders.Hex;
 
 /**
  * Auth Response message defined by EIP-8
@@ -75,7 +74,7 @@ public class AuthResponseMessageV4 {
     public String toString() {
         return "AuthResponseMessage{" +
                 "\n  ephemeralPublicKey=" + ephemeralPublicKey +
-                "\n  nonce=" + Hex.toHexString(nonce) +
+                "\n  nonce=" + ByteUtil.toHexString(nonce) +
                 "\n  version=" + version +
                 '}';
     }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/HandshakeHandler.java
@@ -39,6 +39,7 @@ import org.ethereum.net.eth.EthVersion;
 import org.ethereum.net.message.Message;
 import org.ethereum.net.p2p.*;
 import org.ethereum.net.server.Channel;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -188,7 +189,7 @@ public class HandshakeHandler extends ByteToMessageDecoder {
                 this.frameCodec = new FrameCodec(secrets);
 
                 loggerNet.trace("auth exchange done");
-                channel.sendHelloMessage(ctx, frameCodec, Hex.toHexString(nodeId), null);
+                channel.sendHelloMessage(ctx, frameCodec, ByteUtil.toHexString(nodeId), null);
             } else {
                 loggerWire.debug("MessageCodec: Buffer bytes: {}", buffer.readableBytes());
                 List<Frame> frames = frameCodec.readFrames(buffer);
@@ -297,7 +298,7 @@ public class HandshakeHandler extends ByteToMessageDecoder {
                 HelloMessage inboundHelloMessage = (HelloMessage) message;
 
                 // Secret authentication finish here
-                channel.sendHelloMessage(ctx, frameCodec, Hex.toHexString(nodeId), inboundHelloMessage);
+                channel.sendHelloMessage(ctx, frameCodec, ByteUtil.toHexString(nodeId), inboundHelloMessage);
                 processHelloMessage(ctx, inboundHelloMessage);
             }
         }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/MessageCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/MessageCodec.java
@@ -23,7 +23,6 @@ import com.google.common.io.ByteStreams;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageCodec;
 import org.apache.commons.lang3.tuple.Pair;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.client.Capability;
@@ -34,6 +33,7 @@ import org.ethereum.net.message.Message;
 import org.ethereum.net.p2p.P2pMessageCodes;
 import org.ethereum.net.p2p.P2pMessageFactory;
 import org.ethereum.net.server.Channel;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.LRUMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,7 +136,7 @@ public class MessageCodec extends MessageToMessageCodec<Frame, Message> {
         }
 
         if (loggerWire.isDebugEnabled()) {
-            loggerWire.debug("Recv: Encoded: {} [{}]", frameType, Hex.toHexString(payload));
+            loggerWire.debug("Recv: Encoded: {} [{}]", frameType, ByteUtil.toHexString(payload));
         }
 
         Message msg = createMessage((byte) frameType, payload);
@@ -159,7 +159,7 @@ public class MessageCodec extends MessageToMessageCodec<Frame, Message> {
         byte[] encoded = msg.getEncoded();
 
         if (loggerWire.isDebugEnabled()) {
-            loggerWire.debug("Send: Encoded: {} [{}]", getCode(msg.getCommand()), Hex.toHexString(encoded));
+            loggerWire.debug("Send: Encoded: {} [{}]", getCode(msg.getCommand()), ByteUtil.toHexString(encoded));
         }
 
         List<Frame> frames = splitMessageToFrames(msg);
@@ -227,7 +227,7 @@ public class MessageCodec extends MessageToMessageCodec<Frame, Message> {
             return ethMessageFactory.create(resolved, payload);
         }
 
-        throw new IllegalArgumentException("No such message: " + code + " [" + Hex.toHexString(payload) + "]");
+        throw new IllegalArgumentException("No such message: " + code + " [" + ByteUtil.toHexString(payload) + "]");
     }
 
     public void setChannel(Channel channel){

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/Node.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/Node.java
@@ -20,10 +20,10 @@
 package org.ethereum.net.rlpx;
 
 import co.rsk.net.NodeID;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
-import org.ethereum.util.Utils;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.Serializable;
 import java.net.InetAddress;
@@ -92,11 +92,7 @@ public class Node implements Serializable {
     }
 
     public String getHexId() {
-        return Hex.toHexString(id);
-    }
-
-    public String getHexIdShort() {
-        return Utils.getNodeIdShort(getHexId());
+        return ByteUtil.toHexString(id);
     }
 
     public String getHost() {

--- a/rskj-core/src/main/java/org/ethereum/net/server/Channel.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/Channel.java
@@ -126,7 +126,7 @@ public class Channel implements Peer {
         messageCodec.setEthMessageFactory(eth62MessageFactory);
 
         RskWireProtocol handler = rskWireProtocolFactory.newInstance(msgQueue, this);
-        logger.info("Eth{} [ address = {} | id = {} ]", handler.getVersion(), inetSocketAddress, getPeerIdShort());
+        logger.info("Eth{} [ address = {} | id = {} ]", handler.getVersion(), inetSocketAddress, getPeerId());
 
         ctx.pipeline().addLast(Capability.RSK, handler);
 
@@ -169,10 +169,6 @@ public class Channel implements Peer {
 
     public String getPeerId() {
         return node == null ? "<null>" : node.getHexId();
-    }
-
-    public String getPeerIdShort() {
-        return node == null ? "<null>" : node.getHexIdShort();
     }
 
     /**
@@ -269,6 +265,6 @@ public class Channel implements Peer {
 
     @Override
     public String toString() {
-        return String.format("%s | %s", getPeerIdShort(), inetSocketAddress);
+        return String.format("%s | %s", getPeerId(), inetSocketAddress);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
@@ -264,7 +264,7 @@ public class ChannelManagerImpl implements ChannelManager {
     }
 
     public void notifyDisconnect(Channel channel) {
-        logger.debug("Peer {}: notifies about disconnect", channel.getPeerIdShort());
+        logger.debug("Peer {}: notifies about disconnect", channel.getPeerId());
         channel.onDisconnect();
         synchronized (newPeers) {
             if(newPeers.remove(channel)) {

--- a/rskj-core/src/main/java/org/ethereum/net/server/PeerServerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/PeerServerImpl.java
@@ -30,9 +30,9 @@ import io.netty.handler.logging.LoggingHandler;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.EthereumChannelInitializerFactory;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.net.InetAddress;
 import java.util.concurrent.ExecutorService;
@@ -73,7 +73,7 @@ public class PeerServerImpl implements PeerServer {
             peerServiceExecutor.execute(() -> start(config.getBindAddress(), config.getPeerPort()));
         }
 
-        logger.info("RskJ node started: enode://{}@{}:{}" , Hex.toHexString(config.nodeId()), config.getPublicIp(), config.getPeerPort());
+        logger.info("RskJ node started: enode://{}@{}:{}" , ByteUtil.toHexString(config.nodeId()), config.getPublicIp(), config.getPeerPort());
     }
 
     @Override
@@ -110,7 +110,7 @@ public class PeerServerImpl implements PeerServer {
 
             // Start the client.
             logger.info("Listening for incoming connections, host: {}, port: [{}] ", host, port);
-            logger.info("NodeId: [{}] ", Hex.toHexString(config.nodeId()));
+            logger.info("NodeId: [{}] ", ByteUtil.toHexString(config.nodeId()));
 
             ChannelFuture f = b.bind(host, port).sync();
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Topic.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Topic.java
@@ -18,7 +18,7 @@
 
 package org.ethereum.rpc;
 
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import java.util.Arrays;
 
@@ -77,7 +77,7 @@ public final class Topic {
 
     @Override
     public String toString() {
-        return Hex.toHexString(bytes);
+        return ByteUtil.toHexString(bytes);
     }
 
     public String toJsonString() {

--- a/rskj-core/src/main/java/org/ethereum/rpc/TypeConverter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/TypeConverter.java
@@ -18,8 +18,9 @@
 
 package org.ethereum.rpc;
 
-import org.bouncycastle.util.encoders.Hex;
 import co.rsk.core.Coin;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -110,7 +111,7 @@ public class TypeConverter {
      * @return A hex representation of the input with two hex digits per byte
      */
     public static String toUnformattedJsonHex(byte[] x) {
-        return "0x" + (x == null ? "" : Hex.toHexString(x));
+        return "0x" + (x == null ? "" : ByteUtil.toHexString(x));
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/solidity/SolidityType.java
+++ b/rskj-core/src/main/java/org/ethereum/solidity/SolidityType.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.Utils;
 import org.ethereum.vm.DataWord;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.lang.reflect.Array;
 import java.math.BigInteger;
@@ -365,7 +364,7 @@ public abstract class SolidityType {
             byte[] addr = super.encode(value);
             for (int i = 0; i < 12; i++) {
                 if (addr[i] != 0) {
-                    throw new RuntimeException("Invalid address (should be 20 bytes length): " + Hex.toHexString(addr));
+                    throw new RuntimeException("Invalid address (should be 20 bytes length): " + ByteUtil.toHexString(addr));
                 }
             }
             return addr;

--- a/rskj-core/src/main/java/org/ethereum/sync/SyncPool.java
+++ b/rskj-core/src/main/java/org/ethereum/sync/SyncPool.java
@@ -24,7 +24,6 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.net.NodeBlockProcessor;
 import co.rsk.net.NodeID;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Blockchain;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.NodeHandler;
@@ -32,7 +31,7 @@ import org.ethereum.net.NodeManager;
 import org.ethereum.net.client.PeerClient;
 import org.ethereum.net.rlpx.Node;
 import org.ethereum.net.server.Channel;
-import org.ethereum.util.Utils;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,8 +139,8 @@ public class SyncPool implements InternalService {
             return;
         }
 
-        String shortPeerId = peer.getPeerIdShort();
-        logger.trace("Peer {}: adding", shortPeerId);
+        String peerId = peer.getPeerId();
+        logger.trace("Peer {}: adding", peerId);
 
         synchronized (peers) {
             peers.put(peer.getNodeId(), peer);
@@ -152,7 +151,7 @@ public class SyncPool implements InternalService {
         }
 
         ethereumListener.onPeerAddedToSyncPool(peer);
-        logger.info("Peer {}: added to pool", shortPeerId);
+        logger.info("Peer {}: added to pool", peerId);
     }
 
     public void remove(Channel peer) {
@@ -182,14 +181,14 @@ public class SyncPool implements InternalService {
             return;
         }
 
-        logger.info("Peer {}: disconnected", peer.getPeerIdShort());
+        logger.info("Peer {}: disconnected", peer.getPeerId());
     }
 
     private void connect(Node node) {
         if (logger.isTraceEnabled()) {
             logger.trace(
                 "Peer {}: initiate connection",
-                node.getHexIdShort()
+                node.getHexId()
             );
         }
 
@@ -197,7 +196,7 @@ public class SyncPool implements InternalService {
             if (logger.isTraceEnabled()) {
                 logger.trace(
                     "Peer {}: connection already initiated",
-                    node.getHexIdShort()
+                    node.getHexId()
                 );
             }
 
@@ -207,7 +206,7 @@ public class SyncPool implements InternalService {
         synchronized (pendingConnections) {
             String ip = node.getHost();
             int port = node.getPort();
-            String remoteId = Hex.toHexString(node.getId().getID());
+            String remoteId = ByteUtil.toHexString(node.getId().getID());
             logger.info("Connecting to: {}:{}", ip, port);
             PeerClient peerClient = peerClientFactory.newInstance();
             peerClient.connectAsync(ip, port, remoteId);
@@ -299,7 +298,7 @@ public class SyncPool implements InternalService {
         StringBuilder sb = new StringBuilder();
 
         for(NodeHandler n : nodes) {
-            sb.append(Utils.getNodeIdShort(Hex.toHexString(n.getNode().getId().getID())));
+            sb.append(ByteUtil.toHexString(n.getNode().getId().getID()));
             sb.append(", ");
         }
 
@@ -325,7 +324,7 @@ public class SyncPool implements InternalService {
         synchronized (peers) {
             for (Channel peer : peers.values()) {
                 if (peer.getSyncStats().secondsSinceLastUpdate() > config.peerChannelReadTimeout()) {
-                    logger.info("Peer {}: no response after {} seconds", peer.getPeerIdShort(), config.peerChannelReadTimeout());
+                    logger.info("Peer {}: no response after {} seconds", peer.getPeerId(), config.peerChannelReadTimeout());
                     peer.dropConnection();
                 }
             }

--- a/rskj-core/src/main/java/org/ethereum/util/ByteUtil.java
+++ b/rskj-core/src/main/java/org/ethereum/util/ByteUtil.java
@@ -19,14 +19,16 @@
 
 package org.ethereum.util;
 
-import org.ethereum.db.ByteArrayWrapper;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.db.ByteArrayWrapper;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public class ByteUtil {
@@ -225,11 +227,9 @@ public class ByteUtil {
         return result;
     }
 
-
     /**
-     * Convert a byte-array into a hex String.<br>
-     * Works similar to {@link Hex#toHexString}
-     * but allows for <code>null</code>
+     * Converts a byte-array into a hex String.<br>
+     * Works similar to {@link Hex#toHexString}, but allows for {@code null}.
      *
      * @param data - byte-array to convert to a hex-string
      * @return hex representation of the data.<br>
@@ -237,8 +237,41 @@ public class ByteUtil {
      *
      * @see Hex#toHexString
      */
-    public static String toHexString(byte[] data) {
-        return data == null ? "" : Hex.toHexString(data);
+    @Nonnull
+    public static String toHexStringOrEmpty(@Nullable byte[] data) {
+        return data == null ? "" : toHexString(data);
+    }
+
+    /**
+     * Converts a byte-array into a hex String.<br>
+     * Works similar to {@link Hex#toHexString}. {@code data} cannot be {@code null}.
+     *
+     * @param data - byte-array to convert to a hex-string
+     * @return hex representation of the data.<br>
+     * @throws NullPointerException if {@code data} is {@code null}
+     *
+     * @see Hex#toHexString
+     */
+    @Nonnull
+    public static String toHexString(@Nonnull byte[] data) {
+        return Hex.toHexString(Objects.requireNonNull(data));
+    }
+
+    /**
+     * Converts a byte-array into a hex String.<br>
+     * Works similar to {@link Hex#toHexString}. {@code data} cannot be {@code null}.
+     *
+     * @param data - byte-array to convert to a hex-string
+     * @param off - initial offset of the subarray
+     * @param length - length of the subarray
+     * @return hex representation of the data.<br>
+     * @throws NullPointerException if {@code data} is {@code null}
+     *
+     * @see Hex#toHexString
+     */
+    @Nonnull
+    public static String toHexString(@Nonnull byte[] data, int off, int length) {
+        return Hex.toHexString(Objects.requireNonNull(data), off, length);
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/util/Utils.java
+++ b/rskj-core/src/main/java/org/ethereum/util/Utils.java
@@ -24,13 +24,10 @@ import org.bouncycastle.util.encoders.Hex;
 
 import java.lang.reflect.Array;
 import java.math.BigInteger;
-
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -117,7 +114,7 @@ public class Utils {
             throw new Error("not an address");
         }
 
-        String addrShort = Hex.toHexString(addr, 0, 3);
+        String addrShort = ByteUtil.toHexString(addr, 0, 3);
 
         StringBuffer sb = new StringBuffer();
         sb.append(addrShort);
@@ -157,13 +154,9 @@ public class Utils {
         }
 
         StringBuilder sb = new StringBuilder();
-        String firstHash = Hex.toHexString(blockHashes.get(0));
-        String lastHash = Hex.toHexString(blockHashes.get(blockHashes.size() - 1));
+        String firstHash = ByteUtil.toHexString(blockHashes.get(0));
+        String lastHash = ByteUtil.toHexString(blockHashes.get(blockHashes.size() - 1));
         return sb.append(" ").append(firstHash).append("...").append(lastHash).toString();
-    }
-
-    public static String getNodeIdShort(String nodeId) {
-        return nodeId == null ? "<null>" : nodeId.substring(0, 8);
     }
 
     public static long toUnixTime(long javaTime) {

--- a/rskj-core/src/main/java/org/ethereum/util/Value.java
+++ b/rskj-core/src/main/java/org/ethereum/util/Value.java
@@ -20,7 +20,6 @@
 package org.ethereum.util;
 
 import org.ethereum.crypto.HashUtil;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -118,7 +117,7 @@ public class Value {
     }
 
     public String getHex(){
-        return Hex.toHexString(this.encode());
+        return ByteUtil.toHexString(this.encode());
     }
 
     public byte[] getData(){
@@ -312,7 +311,7 @@ public class Value {
 
             StringBuilder output = new StringBuilder();
             if (isHashCode()) {
-                output.append(Hex.toHexString(asBytes()));
+                output.append(ByteUtil.toHexString(asBytes()));
             } else if (isReadableString()) {
                 output.append("'");
                 for (byte oneByte : asBytes()) {
@@ -325,7 +324,7 @@ public class Value {
                 output.append("'");
                 return output.toString();
             }
-            return Hex.toHexString(this.asBytes());
+            return ByteUtil.toHexString(this.asBytes());
         } else if (isString()) {
             return asString();
         }

--- a/rskj-core/src/main/java/org/ethereum/vm/DataWord.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/DataWord.java
@@ -399,7 +399,7 @@ public final class DataWord implements Comparable<DataWord> {
     @JsonValue
     @Override
     public String toString() {
-        return Hex.toHexString(data);
+        return ByteUtil.toHexString(data);
     }
 
     public String toPrefixString() {
@@ -410,14 +410,14 @@ public final class DataWord implements Comparable<DataWord> {
         }
 
         if (pref.length < 7) {
-            return Hex.toHexString(pref);
+            return ByteUtil.toHexString(pref);
         }
 
-        return Hex.toHexString(pref).substring(0, 6);
+        return ByteUtil.toHexString(pref).substring(0, 6);
     }
 
     public String shortHex() {
-        String hexValue = Hex.toHexString(getNoLeadZeroesData()).toUpperCase();
+        String hexValue = ByteUtil.toHexString(getNoLeadZeroesData()).toUpperCase();
         return "0x" + hexValue.replaceFirst("^0+(?!$)", "");
     }
 
@@ -530,7 +530,7 @@ public final class DataWord implements Comparable<DataWord> {
     }
 
     public boolean isHex(String hex) {
-        return Hex.toHexString(data).equals(hex);
+        return ByteUtil.toHexString(data).equals(hex);
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/vm/GasCost.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/GasCost.java
@@ -21,6 +21,7 @@
 package org.ethereum.vm;
 
 import org.ethereum.util.ByteUtil;
+
 import java.math.BigInteger;
 
 /**
@@ -111,7 +112,7 @@ public class GasCost {
         }
 
         private InvalidGasException(byte[] bytes) {
-            super(String.format("Got invalid gas value as bytes array: %s", ByteUtil.toHexString(bytes)));
+            super(String.format("Got invalid gas value as bytes array: %s", ByteUtil.toHexStringOrEmpty(bytes)));
         }
 
         private InvalidGasException(String str) {

--- a/rskj-core/src/main/java/org/ethereum/vm/LogInfo.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/LogInfo.java
@@ -19,13 +19,9 @@ package org.ethereum.vm;
  */
 
 
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Bloom;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.util.RLP;
-import org.ethereum.util.RLPElement;
-import org.ethereum.util.RLPItem;
-import org.ethereum.util.RLPList;
+import org.ethereum.util.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,16 +129,16 @@ public class LogInfo {
         topicsStr.append("[");
 
         for (DataWord topic : topics) {
-            String topicStr = Hex.toHexString(topic.getData());
+            String topicStr = ByteUtil.toHexString(topic.getData());
             topicsStr.append(topicStr).append(" ");
         }
         topicsStr.append("]");
 
 
         return "LogInfo{" +
-                "address=" + Hex.toHexString(address) +
+                "address=" + ByteUtil.toHexString(address) +
                 ", topics=" + topicsStr +
-                ", data=" + Hex.toHexString(data) +
+                ", data=" + ByteUtil.toHexString(data) +
                 '}';
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -23,11 +23,11 @@ import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Repository;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.Keccak256Helper;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.MessageCall.MsgType;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.Stack;
@@ -645,7 +645,7 @@ public class VM {
         DataWord address = program.getOwnerAddress();
 
         if (isLogEnabled) {
-            hint = "address: " + Hex.toHexString(address.getLast20Bytes());
+            hint = "address: " + ByteUtil.toHexString(address.getLast20Bytes());
         }
 
         program.stackPush(address);
@@ -663,7 +663,7 @@ public class VM {
 
         if (isLogEnabled) {
             hint = "address: "
-                    + Hex.toHexString(address.getLast20Bytes())
+                    + ByteUtil.toHexString(address.getLast20Bytes())
                     + " balance: " + balance.toString();
         }
 
@@ -677,7 +677,7 @@ public class VM {
         DataWord originAddress = program.getOriginAddress();
 
         if (isLogEnabled) {
-            hint = "address: " + Hex.toHexString(originAddress.getLast20Bytes());
+            hint = "address: " + ByteUtil.toHexString(originAddress.getLast20Bytes());
         }
 
         program.stackPush(originAddress);
@@ -690,7 +690,7 @@ public class VM {
         DataWord callerAddress = program.getCallerAddress();
 
         if (isLogEnabled) {
-            hint = "address: " + Hex.toHexString(callerAddress.getLast20Bytes());
+            hint = "address: " + ByteUtil.toHexString(callerAddress.getLast20Bytes());
         }
 
         program.stackPush(callerAddress);
@@ -750,7 +750,7 @@ public class VM {
         byte[] msgData = program.getDataCopy(dataOffsetData, lengthData);
 
         if (isLogEnabled) {
-            hint = "data: " + Hex.toHexString(msgData);
+            hint = "data: " + ByteUtil.toHexString(msgData);
         }
 
         program.memorySave(memOffsetData.intValue(), msgData);
@@ -812,7 +812,7 @@ public class VM {
             program.stackPush(DataWord.valueOf(emptyHash));
 
             if (isLogEnabled) {
-                hint = "hash: " + Hex.toHexString(emptyHash);
+                hint = "hash: " + ByteUtil.toHexString(emptyHash);
             }
         } else {
             Keccak256 codeHash = program.getCodeHashAt(address);
@@ -903,7 +903,7 @@ public class VM {
         }
 
         if (isLogEnabled) {
-            hint = "code: " + Hex.toHexString(codeCopy);
+            hint = "code: " + ByteUtil.toHexString(codeCopy);
         }
 
         // TODO: an optimization to avoid double-copying would be to override programSave
@@ -943,7 +943,7 @@ public class VM {
                 });
 
         if (isLogEnabled) {
-            hint = "data: " + Hex.toHexString(msgData);
+            hint = "data: " + ByteUtil.toHexString(msgData);
         }
 
         program.memorySave(memOffsetData.intValueSafe(), msgData);
@@ -999,7 +999,7 @@ public class VM {
         DataWord coinbase = program.getCoinbase();
 
         if (isLogEnabled) {
-            hint = "coinbase: " + Hex.toHexString(coinbase.getLast20Bytes());
+            hint = "coinbase: " + ByteUtil.toHexString(coinbase.getLast20Bytes());
         }
 
         program.stackPush(coinbase);
@@ -1303,7 +1303,7 @@ public class VM {
         DataWord value = program.stackPop();
 
         if (isLogEnabled) {
-            hint = "[" + program.getOwnerAddress().toPrefixString() + "] key: " + addr + " value: " + value;
+            hint = "[" + program.getOwnerAddress() + "] key: " + addr + " value: " + value;
         }
 
         program.storageSave(addr, value);
@@ -1393,7 +1393,7 @@ public class VM {
         DataWord data = program.sweepGetDataWord(nPush);
 
         if (isLogEnabled) {
-            hint = "" + Hex.toHexString(data.getData());
+            hint = "" + ByteUtil.toHexString(data.getData());
         }
 
         program.stackPush(data);
@@ -1537,7 +1537,7 @@ public class VM {
         }
 
         if (isLogEnabled) {
-            hint = "addr: " + Hex.toHexString(codeAddress.getLast20Bytes())
+            hint = "addr: " + ByteUtil.toHexString(codeAddress.getLast20Bytes())
                     + " gas: " + calleeGas
                     + " inOff: " + inDataOffs.shortHex()
                     + " inSize: " + inDataSize.shortHex();
@@ -1638,7 +1638,7 @@ public class VM {
         program.setHReturn(hReturn);
 
         if (isLogEnabled) {
-            hint = "data: " + Hex.toHexString(hReturn)
+            hint = "data: " + ByteUtil.toHexString(hReturn)
                     + " offset: " + offset.value()
                     + " size: " + size.value();
         }
@@ -1665,7 +1665,7 @@ public class VM {
         program.suicide(address);
 
         if (isLogEnabled) {
-            hint = "address: " + Hex.toHexString(program.getOwnerAddress().getLast20Bytes());
+            hint = "address: " + ByteUtil.toHexString(program.getOwnerAddress().getLast20Bytes());
         }
 
         program.stop();
@@ -2098,16 +2098,16 @@ public class VM {
                         DataWord key = keysIterator.next();
                         DataWord value = storage.getStorageValue(ownerAddress, key);
                         dumpLogger.trace("{} {}",
-                                Hex.toHexString(key.getNoLeadZeroesData()),
-                                Hex.toHexString(value.getNoLeadZeroesData()));
+                                ByteUtil.toHexString(key.getNoLeadZeroesData()),
+                                ByteUtil.toHexString(value.getNoLeadZeroesData()));
                     }
                     break;
                 default:
                     break;
             }
-            String addressString = Hex.toHexString(program.getOwnerAddress().getLast20Bytes());
-            String pcString = Hex.toHexString(DataWord.valueOf(program.getPC()).getNoLeadZeroesData());
-            String opString = Hex.toHexString(new byte[]{op.val()});
+            String addressString = ByteUtil.toHexString(program.getOwnerAddress().getLast20Bytes());
+            String pcString = ByteUtil.toHexString(DataWord.valueOf(program.getPC()).getNoLeadZeroesData());
+            String opString = ByteUtil.toHexString(new byte[]{op.val()});
             String gasString = Long.toHexString(program.getRemainingGas());
 
             dumpLogger.trace("{} {} {} {}", addressString, pcString, opString, gasString);
@@ -2132,7 +2132,7 @@ public class VM {
             }
 
             int level = program.getCallDeep();
-            String contract = Hex.toHexString(program.getOwnerAddress().getLast20Bytes());
+            String contract = ByteUtil.toHexString(program.getOwnerAddress().getLast20Bytes());
             String internalSteps = String.format("%4s", Integer.toHexString(program.getPC())).replace(' ', '0').toUpperCase();
             dumpLogger.trace("{} | {} | #{} | {} : {} | {} | -{} | {}x32",
                     level, contract, vmCounter, internalSteps, op,

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -116,13 +116,11 @@ public class VM {
     }
 
     private void checkSizeArgument(long size) {
-        if (size > Program.MAX_MEMORY)
-            // Force exception
-        {
-            throw Program.ExceptionHelper.notEnoughOpGas(op, Long.MAX_VALUE, program.getRemainingGas());
+        if (size > Program.MAX_MEMORY) { // Force exception
+            throw Program.ExceptionHelper.notEnoughOpGas(program, op, Long.MAX_VALUE, program.getRemainingGas());
         }
-
     }
+
     private long calcMemGas(long oldMemSize, long newMemSize, long copySize) {
         long currentGasCost = 0;
 
@@ -180,10 +178,10 @@ public class VM {
 
     protected void checkOpcode() {
         if (op == null) {
-            throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+            throw Program.ExceptionHelper.invalidOpCode(program);
         }
         if (op.scriptVersion() > program.getScriptVersion()) {
-            throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+            throw Program.ExceptionHelper.invalidOpCode(program);
         }
 
     }
@@ -1140,7 +1138,7 @@ public class VM {
 
     protected void doLOG(){
         if (program.isStaticCall() && program.getActivations().isActive(RSKIP91)) {
-            throw Program.ExceptionHelper.modificationException();
+            throw Program.ExceptionHelper.modificationException(program);
         }
 
         DataWord size;
@@ -1271,7 +1269,7 @@ public class VM {
 
     protected void doSSTORE() {
         if (program.isStaticCall() && program.getActivations().isActive(RSKIP91)) {
-            throw Program.ExceptionHelper.modificationException();
+            throw Program.ExceptionHelper.modificationException(program);
         }
 
         if (computeGas) {
@@ -1408,7 +1406,7 @@ public class VM {
 
     protected void doCREATE(){
         if (program.isStaticCall() && program.getActivations().isActive(RSKIP91)) {
-            throw Program.ExceptionHelper.modificationException();
+            throw Program.ExceptionHelper.modificationException(program);
         }
 
         DataWord size;
@@ -1443,7 +1441,7 @@ public class VM {
 
     protected void doCREATE2(){
         if (program.isStaticCall()) {
-            throw Program.ExceptionHelper.modificationException();
+            throw Program.ExceptionHelper.modificationException(program);
         }
 
         if (computeGas){
@@ -1499,7 +1497,7 @@ public class VM {
         DataWord value = calculateCallValue(activations);
 
         if (program.isStaticCall() && op == CALL && !value.isZero()) {
-            throw Program.ExceptionHelper.modificationException();
+            throw Program.ExceptionHelper.modificationException(program);
         }
 
         DataWord inDataOffs = program.stackPop();
@@ -1516,7 +1514,7 @@ public class VM {
         // because we want to throw gasOverflow instead of notEnoughSpendingGas
         long requiredGas = gasCost;
         if (requiredGas > program.getRemainingGas()) {
-            throw Program.ExceptionHelper.gasOverflow(BigInteger.valueOf(program.getRemainingGas()), BigInteger.valueOf(requiredGas));
+            throw Program.ExceptionHelper.gasOverflow(program, BigInteger.valueOf(program.getRemainingGas()), BigInteger.valueOf(requiredGas));
         }
         long remainingGas = GasCost.subtract(program.getRemainingGas(), requiredGas);
         long minimumTransferGas = calculateGetMinimumTransferGas(value, remainingGas);
@@ -1576,7 +1574,7 @@ public class VM {
 
             minimumTransferGas = GasCost.add(minimumTransferGas, GasCost.STIPEND_CALL);
             if (remainingGas < minimumTransferGas) {
-                throw Program.ExceptionHelper.notEnoughSpendingGas(op.name(), minimumTransferGas, program);
+                throw Program.ExceptionHelper.notEnoughSpendingGas(program, op.name(), minimumTransferGas);
             }
         }
 
@@ -1649,7 +1647,7 @@ public class VM {
 
     protected void doSUICIDE(){
         if (program.isStaticCall() && program.getActivations().isActive(RSKIP91)) {
-            throw Program.ExceptionHelper.modificationException();
+            throw Program.ExceptionHelper.modificationException(program);
         }
 
         if (computeGas) {
@@ -1729,19 +1727,19 @@ public class VM {
             break;
             case OpCodes.OP_SHL:
                 if (!activations.isActive(RSKIP120)) {
-                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                    throw Program.ExceptionHelper.invalidOpCode(program);
                 }
                 doSHL();
             break;
             case OpCodes.OP_SHR:
                 if (!activations.isActive(RSKIP120)) {
-                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                    throw Program.ExceptionHelper.invalidOpCode(program);
                 }
                 doSHR();
             break;
             case OpCodes.OP_SAR:
                 if (!activations.isActive(RSKIP120)) {
-                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                    throw Program.ExceptionHelper.invalidOpCode(program);
                 }
                 doSAR();
             break;
@@ -1780,7 +1778,7 @@ public class VM {
 
             case OpCodes.OP_EXTCODEHASH:
                 if (!activations.isActive(RSKIP140)) {
-                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                    throw Program.ExceptionHelper.invalidOpCode(program);
                 }
                 doEXTCODEHASH();
             break;
@@ -1808,13 +1806,13 @@ public class VM {
             break;
             case OpCodes.OP_CHAINID:
                 if (!activations.isActive(RSKIP152)) {
-                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                    throw Program.ExceptionHelper.invalidOpCode(program);
                 }
                 doCHAINID();
             break;
             case OpCodes.OP_SELFBALANCE:
                 if (!activations.isActive(RSKIP151)) {
-                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                    throw Program.ExceptionHelper.invalidOpCode(program);
                 }
                 doSELFBALANCE();
             break;
@@ -1924,7 +1922,7 @@ public class VM {
             break;
             case OpCodes.OP_CREATE2:
                 if (!activations.isActive(RSKIP125)) {
-                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                    throw Program.ExceptionHelper.invalidOpCode(program);
                 }
                 doCREATE2();
             break;
@@ -1935,7 +1933,7 @@ public class VM {
             break;
             case OpCodes.OP_STATICCALL:
                 if (!activations.isActive(RSKIP91)) {
-                    throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                    throw Program.ExceptionHelper.invalidOpCode(program);
                 }
                 doCALL();
             break;
@@ -1952,7 +1950,7 @@ public class VM {
             default:
                 // It should never execute this line.
                 // We rise an exception to prevent DoS attacks that halt the node, in case of a bug.
-                throw Program.ExceptionHelper.invalidOpCode(program.getCurrentOp());
+                throw Program.ExceptionHelper.invalidOpCode(program);
         }
     }
 
@@ -2030,8 +2028,7 @@ public class VM {
                 program.stop();
                 throw e;
         } finally {
-            if (isLogEnabled) // this must be prevented because it's slow!
-            {
+            if (isLogEnabled) { // this must be prevented because it's slow!
                 program.fullTrace();
             }
         }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -51,6 +51,7 @@ import org.ethereum.vm.trace.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.*;
 
@@ -308,7 +309,7 @@ public class Program {
      */
     public void verifyStackSize(int stackSize) {
         if (stackSize < 0 || stack.size() < stackSize) {
-            throw ExceptionHelper.tooSmallStack(stackSize, stack.size());
+            throw ExceptionHelper.tooSmallStack(this, stackSize, stack.size());
         }
     }
 
@@ -493,7 +494,7 @@ public class Program {
                 deletedAccountsInBlock.contains(DataWord.valueOf(contractAddress.getBytes()))) {
             // Check if the address was previously deleted in the same block
 
-            programResult.setException(ExceptionHelper.addressCollisionException(contractAddress));
+            programResult.setException(ExceptionHelper.addressCollisionException(this, contractAddress));
             if (isLogEnabled) {
                 logger.debug("contract run halted by Exception: contract: [{}], exception: ",
                         contractAddress,
@@ -519,7 +520,7 @@ public class Program {
             if (getActivations().isActive(ConsensusRule.RSKIP125) && (hasNonEmptyCode || nonZeroNonce)) {
                 // Contract collision we fail with exactly the same behavior as would arise if
                 // the first byte in the init code were an invalid opcode
-                programResult.setException(ExceptionHelper.addressCollisionException(contractAddress));
+                programResult.setException(ExceptionHelper.addressCollisionException(this, contractAddress));
                 if (isLogEnabled) {
                     logger.debug("contract run halted by Exception: contract: [{}], exception: ",
                             contractAddress,
@@ -643,12 +644,13 @@ public class Program {
             if (afterSpend < 0) {
                 programResult.setException(
                         ExceptionHelper.notEnoughSpendingGas(
+                                this,
                                 "No gas to return just created contract",
-                                storageCost,
-                                this));
+                                storageCost));
             } else if (codeLength > Constants.getMaxContractSize()) {
                 programResult.setException(
                         ExceptionHelper.tooLargeContractSize(
+                                this,
                                 Constants.getMaxContractSize(),
                                 codeLength));
             } else {
@@ -883,7 +885,7 @@ public class Program {
         }
 
         if (getRemainingGas()  < gasValue) {
-            throw ExceptionHelper.notEnoughSpendingGas(cause, gasValue, this);
+            throw ExceptionHelper.notEnoughSpendingGas(this, cause, gasValue);
         }
 
         getResult().spendGas(gasValue);
@@ -1302,11 +1304,11 @@ public class Program {
     public int verifyJumpDest(DataWord nextPC) {
         // This is painstankly slow
         if (nextPC.occupyMoreThan(4)) {
-            throw ExceptionHelper.badJumpDestination(-1);
+            throw ExceptionHelper.badJumpDestination(this, -1);
         }
         int ret = nextPC.intValue(); // could be negative
         if (ret < 0 || ret >= jumpdestSet.size() || !jumpdestSet.get(ret)) {
-            throw ExceptionHelper.badJumpDestination(ret);
+            throw ExceptionHelper.badJumpDestination(this, ret);
         }
         return ret;
     }
@@ -1448,8 +1450,8 @@ public class Program {
 
     @SuppressWarnings("serial")
     public static class StaticCallModificationException extends RuntimeException {
-        public StaticCallModificationException() {
-            super("Attempt to call a state modifying opcode inside STATICCALL");
+        public StaticCallModificationException(String message, Object... args) {
+            super(format(message, args));
         }
     }
 
@@ -1463,51 +1465,56 @@ public class Program {
 
         private ExceptionHelper() { }
 
-        public static StaticCallModificationException modificationException() {
-            return new StaticCallModificationException();
+        public static StaticCallModificationException modificationException(@Nonnull Program program) {
+            return new StaticCallModificationException("Attempt to call a state modifying opcode inside STATICCALL: tx[%s]", extractTxHash(program));
         }
 
-        public static OutOfGasException notEnoughOpGas(OpCode op, long opGas, long programGas) {
-            return new OutOfGasException("Not enough gas for '%s' operation executing: opGas[%d], programGas[%d];", op, opGas, programGas);
+        public static OutOfGasException notEnoughOpGas(@Nonnull Program program, OpCode op, long opGas, long programGas) {
+            return new OutOfGasException("Not enough gas for '%s' operation executing: opGas[%d], programGas[%d], tx[%s]", op, opGas, programGas, extractTxHash(program));
         }
 
-        public static OutOfGasException notEnoughOpGas(OpCode op, DataWord opGas, DataWord programGas) {
-            return notEnoughOpGas(op, opGas.longValue(), programGas.longValue());
+        public static OutOfGasException notEnoughOpGas(Program program, OpCode op, DataWord opGas, DataWord programGas) {
+            return notEnoughOpGas(program, op, opGas.longValue(), programGas.longValue());
         }
 
-        public static OutOfGasException notEnoughOpGas(OpCode op, BigInteger opGas, BigInteger programGas) {
-            return notEnoughOpGas(op, opGas.longValue(), programGas.longValue());
+        public static OutOfGasException notEnoughOpGas(Program program, OpCode op, BigInteger opGas, BigInteger programGas) {
+            return notEnoughOpGas(program, op, opGas.longValue(), programGas.longValue());
         }
 
-        public static OutOfGasException notEnoughSpendingGas(String cause, long gasValue, Program program) {
-            return new OutOfGasException("Not enough gas for '%s' cause spending: invokeGas[%d], gas[%d], usedGas[%d];",
-                    cause, program.invoke.getGas(), gasValue, program.getResult().getGasUsed());
+        public static OutOfGasException notEnoughSpendingGas(@Nonnull Program program, String cause, long gasValue) {
+            return new OutOfGasException("Not enough gas for '%s' cause spending: invokeGas[%d], gas[%d], usedGas[%d], tx[%s]",
+                    cause, program.invoke.getGas(), gasValue, program.getResult().getGasUsed(), extractTxHash(program));
         }
 
-        public static OutOfGasException gasOverflow(BigInteger actualGas, BigInteger gasLimit) {
-            return new OutOfGasException("Gas value overflow: actualGas[%d], gasLimit[%d];", actualGas.longValue(), gasLimit.longValue());
+        public static OutOfGasException gasOverflow(@Nonnull Program program, BigInteger actualGas, BigInteger gasLimit) {
+            return new OutOfGasException("Gas value overflow: actualGas[%d], gasLimit[%d], tx[%s]", actualGas.longValue(), gasLimit.longValue(), extractTxHash(program));
         }
-        public static OutOfGasException gasOverflow(long actualGas, BigInteger gasLimit) {
-            return new OutOfGasException("Gas value overflow: actualGas[%d], gasLimit[%d];", actualGas, gasLimit.longValue());
+        public static OutOfGasException gasOverflow(@Nonnull Program program, long actualGas, BigInteger gasLimit) {
+            return new OutOfGasException("Gas value overflow: actualGas[%d], gasLimit[%d], tx[%s]", actualGas, gasLimit.longValue(), extractTxHash(program));
         }
-        public static IllegalOperationException invalidOpCode(byte... opCode) {
-            return new IllegalOperationException("Invalid operation code: opcode[%s];", ByteUtil.toHexString(opCode, 0, 1));
-        }
-
-        public static BadJumpDestinationException badJumpDestination(int pc) {
-            return new BadJumpDestinationException("Operation with pc isn't 'JUMPDEST': PC[%d];", pc);
+        public static IllegalOperationException invalidOpCode(@Nonnull Program program) {
+            return new IllegalOperationException("Invalid operation code: opcode[%s], tx[%s]", ByteUtil.toHexString(new byte[] {program.getCurrentOp()}, 0, 1), extractTxHash(program));
         }
 
-        public static StackTooSmallException tooSmallStack(int expectedSize, int actualSize) {
-            return new StackTooSmallException("Expected stack size %d but actual %d;", expectedSize, actualSize);
+        public static BadJumpDestinationException badJumpDestination(@Nonnull Program program, int pc) {
+            return new BadJumpDestinationException("Operation with pc isn't 'JUMPDEST': PC[%d], tx[%s]", pc, extractTxHash(program));
         }
 
-        public static RuntimeException tooLargeContractSize(int maxSize, int actualSize) {
-            return new RuntimeException(format("Maximum contract size allowed %d but actual %d;", maxSize, actualSize));
+        public static StackTooSmallException tooSmallStack(@Nonnull Program program, int expectedSize, int actualSize) {
+            return new StackTooSmallException("Expected stack size %d but actual %d, tx: %s", expectedSize, actualSize, extractTxHash(program));
         }
 
-        public static AddressCollisionException addressCollisionException(RskAddress address) {
-            return new AddressCollisionException("Trying to create a contract with existing contract address: 0x" + address.toString());
+        public static RuntimeException tooLargeContractSize(@Nonnull Program program, int maxSize, int actualSize) {
+            return new RuntimeException(format("Maximum contract size allowed %d but actual %d, tx: %s", maxSize, actualSize, extractTxHash(program)));
+        }
+
+        public static AddressCollisionException addressCollisionException(@Nonnull Program program, RskAddress address) {
+            return new AddressCollisionException("Trying to create a contract with existing contract address: 0x" + address + ", tx: " + extractTxHash(program));
+        }
+
+        @Nonnull
+        private static String extractTxHash(@Nonnull Program program) {
+            return program.transaction == null ? "<null>" : "0x" + program.transaction.getHash().toHexString();
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -31,7 +31,6 @@ import co.rsk.rpc.modules.trace.CreationData;
 import co.rsk.rpc.modules.trace.ProgramSubtrace;
 import co.rsk.vm.BitSet;
 import com.google.common.annotations.VisibleForTesting;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -581,7 +580,7 @@ public class Program {
         refundGas(refundGas, "remaining gas from the internal call");
         if (isGasLogEnabled) {
             gasLogger.info("The remaining gas is refunded, account: [{}], gas: [{}] ",
-                    Hex.toHexString(getOwnerAddress().getLast20Bytes()),
+                    ByteUtil.toHexString(getOwnerAddress().getLast20Bytes()),
                     refundGas
             );
         }
@@ -1184,14 +1183,14 @@ public class Program {
 
             if (getResult().getHReturn() != null) {
                 globalOutput.append("\n  HReturn: ").append(
-                        Hex.toHexString(getResult().getHReturn()));
+                        ByteUtil.toHexString(getResult().getHReturn()));
             }
 
             // sophisticated assumption that msg.data != codedata
             // means we are calling the contract not creating it
             byte[] txData = invoke.getDataCopy(DataWord.ZERO, getDataSize());
             if (!Arrays.equals(txData, ops)) {
-                globalOutput.append("\n  msg.data: ").append(Hex.toHexString(txData));
+                globalOutput.append("\n  msg.data: ").append(ByteUtil.toHexString(txData));
             }
             globalOutput.append("\n\n  Spent Gas: ").append(getResult().getGasUsed());
 
@@ -1492,7 +1491,7 @@ public class Program {
             return new OutOfGasException("Gas value overflow: actualGas[%d], gasLimit[%d];", actualGas, gasLimit.longValue());
         }
         public static IllegalOperationException invalidOpCode(byte... opCode) {
-            return new IllegalOperationException("Invalid operation code: opcode[%s];", Hex.toHexString(opCode, 0, 1));
+            return new IllegalOperationException("Invalid operation code: opcode[%s];", ByteUtil.toHexString(opCode, 0, 1));
         }
 
         public static BadJumpDestinationException badJumpDestination(int pc) {

--- a/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
@@ -30,7 +30,6 @@ import org.ethereum.vm.DataWord;
 import org.ethereum.vm.program.Program;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
@@ -115,19 +114,19 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
                             "gaslimit={}\n",
 
                     addr,
-                    Hex.toHexString(origin),
-                    Hex.toHexString(caller),
+                    ByteUtil.toHexString(origin),
+                    ByteUtil.toHexString(caller),
                     balance,
                     gasPrice,
                     new BigInteger(1, gas).longValue(),
                     callValue,
-                    Hex.toHexString(data),
-                    Hex.toHexString(lastHash),
-                    Hex.toHexString(coinbase),
+                    ByteUtil.toHexString(data),
+                    ByteUtil.toHexString(lastHash),
+                    ByteUtil.toHexString(coinbase),
                     timestamp,
                     number,
                     txindex,
-                    Hex.toHexString(difficulty),
+                    ByteUtil.toHexString(difficulty),
                     gaslimit);
         }
 
@@ -182,20 +181,20 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
                             "transactionIndex={}\n" +
                             "difficulty={}\n" +
                             "gaslimit={}\n",
-                    Hex.toHexString(address.getLast20Bytes()),
-                    Hex.toHexString(origin.getLast20Bytes()),
-                    Hex.toHexString(caller.getLast20Bytes()),
+                    ByteUtil.toHexString(address.getLast20Bytes()),
+                    ByteUtil.toHexString(origin.getLast20Bytes()),
+                    ByteUtil.toHexString(caller.getLast20Bytes()),
                     balance.toString(),
                     gasPrice.longValue(),
                     agas,
-                    Hex.toHexString(callValue.getNoLeadZeroesData()),
-                    data == null ? "" : Hex.toHexString(data),
-                    Hex.toHexString(lastHash.getData()),
-                    Hex.toHexString(coinbase.getLast20Bytes()),
+                    ByteUtil.toHexString(callValue.getNoLeadZeroesData()),
+                    data == null ? "" : ByteUtil.toHexString(data),
+                    ByteUtil.toHexString(lastHash.getData()),
+                    ByteUtil.toHexString(coinbase.getLast20Bytes()),
                     timestamp.longValue(),
                     number.longValue(),
                     transactionIndex.intValue(),
-                    Hex.toHexString(difficulty.getNoLeadZeroesData()),
+                    ByteUtil.toHexString(difficulty.getNoLeadZeroesData()),
                     gasLimit.bigIntValue());
         }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/DetailedProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/DetailedProgramTrace.java
@@ -24,6 +24,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.core.bc.AccountInformationProvider;
 import co.rsk.rpc.modules.trace.ProgramSubtrace;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.OpCode;
 import org.ethereum.vm.program.Memory;
@@ -32,12 +33,11 @@ import org.ethereum.vm.program.Storage;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.util.*;
 
 import static java.lang.String.format;
-import static org.ethereum.util.ByteUtil.toHexString;
+import static org.ethereum.util.ByteUtil.toHexStringOrEmpty;
 import static org.ethereum.vm.trace.Serializers.serializeFieldsOnly;
 
 public class DetailedProgramTrace implements ProgramTrace {
@@ -72,7 +72,7 @@ public class DetailedProgramTrace implements ProgramTrace {
         this.programInvoke = programInvoke;
 
         if (config.vmTrace() && programInvoke != null) {
-            contractAddress = Hex.toHexString(programInvoke.getOwnerAddress().getLast20Bytes());
+            contractAddress = ByteUtil.toHexString(programInvoke.getOwnerAddress().getLast20Bytes());
 
             AccountInformationProvider informationProvider = getInformationProvider(programInvoke);
             RskAddress ownerAddress = new RskAddress(programInvoke.getOwnerAddress());
@@ -84,7 +84,7 @@ public class DetailedProgramTrace implements ProgramTrace {
                 if (storageSize <= config.vmTraceInitStorageLimit()) {
                     fullStorage = true;
 
-                    String address = toHexString(programInvoke.getOwnerAddress().getLast20Bytes());
+                    String address = toHexStringOrEmpty(programInvoke.getOwnerAddress().getLast20Bytes());
                     Iterator<DataWord> keysIterator = informationProvider.getStorageKeys(ownerAddress);
                     while (keysIterator.hasNext()) {
                         // TODO: solve NULL key/value storage problem
@@ -184,7 +184,7 @@ public class DetailedProgramTrace implements ProgramTrace {
     }
 
     public ProgramTrace result(byte[] result) {
-        setResult(toHexString(result));
+        setResult(toHexStringOrEmpty(result));
         return this;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/Op.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/Op.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.vm.trace;
 
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.OpCode;
 import org.ethereum.vm.program.Memory;
 import org.ethereum.vm.program.Stack;
@@ -72,7 +72,7 @@ public class Op {
 
         for (int k = 0; k < size; k += 32) {
             byte[] bytes = memory.read(k, Math.min(32, size - k));
-            this.memory.add(Hex.toHexString(bytes));
+            this.memory.add(ByteUtil.toHexString(bytes));
         }
     }
 
@@ -84,7 +84,7 @@ public class Op {
         int size = stack.size();
 
         for (int k = 0; k < size; k++) {
-            this.stack.add(Hex.toHexString(stack.get(k).getData()));
+            this.stack.add(ByteUtil.toHexString(stack.get(k).getData()));
         }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/OpActions.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/OpActions.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.ethereum.util.ByteUtil.toHexString;
+import static org.ethereum.util.ByteUtil.toHexStringOrEmpty;
 
 public class OpActions {
 
@@ -135,7 +135,7 @@ public class OpActions {
     public Action addMemoryWrite(int address, byte[] data, int size) {
         return addAction(memory, Action.Name.WRITE)
                 .addParam("address", address)
-                .addParam("data", toHexString(data).substring(0, size));
+                .addParam("data", toHexStringOrEmpty(data).substring(0, size));
     }
 
     public Action addStoragePut(DataWord key, DataWord value) {

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/Serializers.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/Serializers.java
@@ -19,6 +19,7 @@
 
 package org.ethereum.vm.trace;
 
+import co.rsk.panic.PanicProcessor;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,11 +28,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
-import co.rsk.panic.PanicProcessor;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -55,7 +55,7 @@ public final class Serializers {
 
         @Override
         public void serialize(byte[] memory, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
-            jgen.writeString(Hex.toHexString(memory));
+            jgen.writeString(ByteUtil.toHexString(memory));
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/SummarizedProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/SummarizedProgramTrace.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.lang.String.format;
-import static org.ethereum.util.ByteUtil.toHexString;
+import static org.ethereum.util.ByteUtil.toHexStringOrEmpty;
 
 public class SummarizedProgramTrace implements ProgramTrace {
     private final ProgramInvoke programInvoke;
@@ -96,7 +96,7 @@ public class SummarizedProgramTrace implements ProgramTrace {
 
     @Override
     public ProgramTrace result(byte[] result) {
-        setResult(toHexString(result));
+        setResult(toHexStringOrEmpty(result));
         return this;
     }
 

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -24,9 +24,7 @@ import co.rsk.test.dsl.DslParser;
 import co.rsk.test.dsl.DslProcessorException;
 import co.rsk.test.dsl.WorldDslProcessor;
 import co.rsk.trie.Trie;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
-import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Blockchain;
@@ -35,6 +33,7 @@ import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.db.ReceiptStoreImpl;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -72,7 +71,7 @@ public class CliToolsTest {
             Block block = blockchain.getBlockByNumber(n);
             BlockDifficulty totalDifficulty = blockStore.getTotalDifficultyForHash(block.getHash().getBytes());
 
-            String line = block.getNumber() + "," + block.getHash().toHexString() + "," + Hex.toHexString(totalDifficulty.getBytes()) + "," + Hex.toHexString(block.getEncoded());
+            String line = block.getNumber() + "," + block.getHash().toHexString() + "," + ByteUtil.toHexString(totalDifficulty.getBytes()) + "," + ByteUtil.toHexString(block.getEncoded());
 
             Assert.assertTrue(data.indexOf(line) >= 0);
         }
@@ -106,7 +105,7 @@ public class CliToolsTest {
 
         byte[] encoded = trie.toMessage();
 
-        String line = Hex.toHexString(encoded);
+        String line = ByteUtil.toHexString(encoded);
 
         Assert.assertTrue(data.indexOf(line) >= 0);
     }
@@ -131,7 +130,7 @@ public class CliToolsTest {
 
         Block block = world.getBlockByName("b02");
 
-        String blockLine = "Block hash: " + Hex.toHexString(block.getHash().getBytes());
+        String blockLine = "Block hash: " + ByteUtil.toHexString(block.getHash().getBytes());
 
         Assert.assertTrue(data.indexOf(blockLine) >= 0);
 
@@ -171,14 +170,14 @@ public class CliToolsTest {
 
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("1,");
-        stringBuilder.append(Hex.toHexString(block1.getHash().getBytes()));
+        stringBuilder.append(ByteUtil.toHexString(block1.getHash().getBytes()));
         stringBuilder.append(",02,");
-        stringBuilder.append(Hex.toHexString(block1.getEncoded()));
+        stringBuilder.append(ByteUtil.toHexString(block1.getEncoded()));
         stringBuilder.append("\n");
         stringBuilder.append("1,");
-        stringBuilder.append(Hex.toHexString(block2.getHash().getBytes()));
+        stringBuilder.append(ByteUtil.toHexString(block2.getHash().getBytes()));
         stringBuilder.append(",03,");
-        stringBuilder.append(Hex.toHexString(block2.getEncoded()));
+        stringBuilder.append(ByteUtil.toHexString(block2.getEncoded()));
         stringBuilder.append("\n");
 
         BufferedReader reader = new BufferedReader(new StringReader(stringBuilder.toString()));
@@ -213,14 +212,14 @@ public class CliToolsTest {
 
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("1,");
-        stringBuilder.append(Hex.toHexString(block1.getHash().getBytes()));
+        stringBuilder.append(ByteUtil.toHexString(block1.getHash().getBytes()));
         stringBuilder.append(",02,");
-        stringBuilder.append(Hex.toHexString(block1.getEncoded()));
+        stringBuilder.append(ByteUtil.toHexString(block1.getEncoded()));
         stringBuilder.append("\n");
         stringBuilder.append("1,");
-        stringBuilder.append(Hex.toHexString(block2.getHash().getBytes()));
+        stringBuilder.append(ByteUtil.toHexString(block2.getHash().getBytes()));
         stringBuilder.append(",03,");
-        stringBuilder.append(Hex.toHexString(block2.getEncoded()));
+        stringBuilder.append(ByteUtil.toHexString(block2.getEncoded()));
         stringBuilder.append("\n");
 
         BufferedReader reader = new BufferedReader(new StringReader(stringBuilder.toString()));
@@ -243,7 +242,7 @@ public class CliToolsTest {
         random.nextBytes(value);
 
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(Hex.toHexString(value));
+        stringBuilder.append(ByteUtil.toHexString(value));
         stringBuilder.append("\n");
 
         BufferedReader reader = new BufferedReader(new StringReader(stringBuilder.toString()));

--- a/rskj-core/src/test/java/co/rsk/core/BlockTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockTest.java
@@ -23,12 +23,12 @@ import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.peg.PegTestUtils;
 import co.rsk.remasc.RemascTransaction;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
@@ -342,8 +342,8 @@ public class BlockTest {
         BlockGenerator blockGenerator = new BlockGenerator();
         Block block1 = blockGenerator.createBlock(10, 1);
         Block block2 = blockGenerator.createBlock(10, 2);
-        String trieHash1 = Hex.toHexString(block1.getTxTrieRoot());
-        String trieHash2 = Hex.toHexString(block2.getTxTrieRoot());
+        String trieHash1 = ByteUtil.toHexString(block1.getTxTrieRoot());
+        String trieHash2 = ByteUtil.toHexString(block2.getTxTrieRoot());
         Assert.assertNotEquals(trieHash1, trieHash2);
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/FreeBlockHeader.java
+++ b/rskj-core/src/test/java/co/rsk/core/FreeBlockHeader.java
@@ -5,17 +5,17 @@ package co.rsk.core;
  */
 
 import com.google.common.collect.Lists;
+import org.bouncycastle.pqc.math.linearalgebra.ByteUtils;
+import org.bouncycastle.util.BigIntegers;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
-import org.bouncycastle.pqc.math.linearalgebra.ByteUtils;
-import org.bouncycastle.util.BigIntegers;
 
 import java.math.BigInteger;
 import java.util.List;
 
 import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
-import static org.ethereum.util.ByteUtil.toHexString;
+import static org.ethereum.util.ByteUtil.toHexStringOrEmpty;
 
 /**
  * Block header is a value object containing
@@ -439,19 +439,19 @@ public class FreeBlockHeader {
 
     private String toStringWithSuffix(final String suffix) {
         StringBuilder toStringBuff = new StringBuilder();
-        toStringBuff.append("  parentHash=").append(toHexString(parentHash)).append(suffix);
-        toStringBuff.append("  unclesHash=").append(toHexString(unclesHash)).append(suffix);
-        toStringBuff.append("  coinbase=").append(toHexString(coinbase)).append(suffix);
-        toStringBuff.append("  stateRoot=").append(toHexString(stateRoot)).append(suffix);
-        toStringBuff.append("  txTrieHash=").append(toHexString(txTrieRoot)).append(suffix);
-        toStringBuff.append("  receiptsTrieHash=").append(toHexString(receiptTrieRoot)).append(suffix);
-        toStringBuff.append("  difficulty=").append(toHexString(difficulty)).append(suffix);
-        toStringBuff.append("  number=").append(toHexString(number)).append(suffix);
-        toStringBuff.append("  gasLimit=").append(toHexString(gasLimit)).append(suffix);
-        toStringBuff.append("  gasUsed=").append(toHexString(gasUsed)).append(suffix);
-        toStringBuff.append("  timestamp=").append(toHexString(timestamp)).append(")").append(suffix);
-        toStringBuff.append("  extraData=").append(toHexString(extraData)).append(suffix);
-        toStringBuff.append("  minGasPrice=").append(toHexString(minimumGasPrice)).append(suffix);
+        toStringBuff.append("  parentHash=").append(toHexStringOrEmpty(parentHash)).append(suffix);
+        toStringBuff.append("  unclesHash=").append(toHexStringOrEmpty(unclesHash)).append(suffix);
+        toStringBuff.append("  coinbase=").append(toHexStringOrEmpty(coinbase)).append(suffix);
+        toStringBuff.append("  stateRoot=").append(toHexStringOrEmpty(stateRoot)).append(suffix);
+        toStringBuff.append("  txTrieHash=").append(toHexStringOrEmpty(txTrieRoot)).append(suffix);
+        toStringBuff.append("  receiptsTrieHash=").append(toHexStringOrEmpty(receiptTrieRoot)).append(suffix);
+        toStringBuff.append("  difficulty=").append(toHexStringOrEmpty(difficulty)).append(suffix);
+        toStringBuff.append("  number=").append(toHexStringOrEmpty(number)).append(suffix);
+        toStringBuff.append("  gasLimit=").append(toHexStringOrEmpty(gasLimit)).append(suffix);
+        toStringBuff.append("  gasUsed=").append(toHexStringOrEmpty(gasUsed)).append(suffix);
+        toStringBuff.append("  timestamp=").append(toHexStringOrEmpty(timestamp)).append(")").append(suffix);
+        toStringBuff.append("  extraData=").append(toHexStringOrEmpty(extraData)).append(suffix);
+        toStringBuff.append("  minGasPrice=").append(toHexStringOrEmpty(minimumGasPrice)).append(suffix);
 
         return toStringBuff.toString();
     }
@@ -492,15 +492,15 @@ public class FreeBlockHeader {
         this.bitcoinMergedMiningCoinbaseTransaction = bitcoinMergedMiningCoinbaseTransaction;
     }
 
-    public String getShortHashForMergedMining() {
-        return HashUtil.shortHash(getHashForMergedMining());
+    public String getPrintableHashForMergedMining() {
+        return HashUtil.toPrintableHash(getHashForMergedMining());
     }
 
     public byte[] getHashForMergedMining() {
         return HashUtil.keccak256(getEncoded(false));
     }
 
-    public String getShortHash() {
-        return HashUtil.shortHash(getHash());
+    public String getPrintableHash() {
+        return HashUtil.toPrintableHash(getHash());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/NetworkStateExporterTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/NetworkStateExporterTest.java
@@ -27,13 +27,13 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.io.FileUtils;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Blockchain;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.MutableRepository;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.AfterClass;
@@ -174,11 +174,11 @@ public class NetworkStateExporterTest {
         Map data = (Map) contract.get("data");
         Assert.assertEquals(2, data.keySet().size());
 
-        String addrStr = Hex.toHexString(DataWord.ZERO.getData());
+        String addrStr = ByteUtil.toHexString(DataWord.ZERO.getData());
 
         // A value expanded with leading zeros requires testing in expanded form.
         Assert.assertEquals("01",data.get(addrStr));
-        Assert.assertEquals("05060708", data.get(Hex.toHexString(DataWord.ONE.getData())));
+        Assert.assertEquals("05060708", data.get(ByteUtil.toHexString(DataWord.ONE.getData())));
     }
 
     private Map writeAndReadJson() throws Exception {

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -30,6 +30,7 @@ import org.ethereum.crypto.signature.Secp256k1;
 import org.ethereum.db.BlockStoreDummy;
 import org.ethereum.jsontestsuite.StateTestSuite;
 import org.ethereum.jsontestsuite.runners.StateTestRunner;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
 import org.junit.Assert;
@@ -72,23 +73,23 @@ public class TransactionTest {
 
         tx.sign(senderPrivKey);
 
-        System.out.println("v\t\t\t: " + Hex.toHexString(new byte[]{tx.getSignature().getV()}));
-        System.out.println("r\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getR())));
-        System.out.println("s\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getS())));
+        System.out.println("v\t\t\t: " + ByteUtil.toHexString(new byte[]{tx.getSignature().getV()}));
+        System.out.println("r\t\t\t: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getR())));
+        System.out.println("s\t\t\t: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getS())));
 
-        System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
+        System.out.println("RLP encoded tx\t\t: " + ByteUtil.toHexString(tx.getEncoded()));
 
         // retrieve the signer/sender of the transaction
         ECKey key = Secp256k1.getInstance().signatureToKey(tx.getHash().getBytes(), tx.getSignature());
 
-        System.out.println("Tx unsigned RLP\t\t: " + Hex.toHexString(tx.getEncodedRaw()));
-        System.out.println("Tx signed   RLP\t\t: " + Hex.toHexString(tx.getEncoded()));
+        System.out.println("Tx unsigned RLP\t\t: " + ByteUtil.toHexString(tx.getEncodedRaw()));
+        System.out.println("Tx signed   RLP\t\t: " + ByteUtil.toHexString(tx.getEncoded()));
 
-        System.out.println("Signature public key\t: " + Hex.toHexString(key.getPubKey()));
-        System.out.println("Sender is\t\t: " + Hex.toHexString(key.getAddress()));
+        System.out.println("Signature public key\t: " + ByteUtil.toHexString(key.getPubKey()));
+        System.out.println("Sender is\t\t: " + ByteUtil.toHexString(key.getAddress()));
 
         assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826",
-                Hex.toHexString(key.getAddress()));
+                ByteUtil.toHexString(key.getAddress()));
 
         System.out.println(tx.toString());
     }
@@ -112,11 +113,11 @@ public class TransactionTest {
 
         tx.sign(senderPrivateKey);
 
-        System.out.println("v\t\t\t: " + Hex.toHexString(new byte[]{tx.getSignature().getV()}));
-        System.out.println("r\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getR())));
-        System.out.println("s\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getS())));
+        System.out.println("v\t\t\t: " + ByteUtil.toHexString(new byte[]{tx.getSignature().getV()}));
+        System.out.println("r\t\t\t: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getR())));
+        System.out.println("s\t\t\t: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getS())));
 
-        System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
+        System.out.println("RLP encoded tx\t\t: " + ByteUtil.toHexString(tx.getEncoded()));
 
         // Retrieve sender from transaction
         RskAddress sender = tx.getSender();
@@ -292,9 +293,9 @@ public class TransactionTest {
         Transaction tx = new Transaction(nonce, gasPrice, gas, to, value, data, chainId);
         byte[] encoded = tx.getEncodedRaw();
         byte[] hash = tx.getRawHash().getBytes();
-        String strenc = Hex.toHexString(encoded);
+        String strenc = ByteUtil.toHexString(encoded);
         Assert.assertEquals("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080", strenc);
-        String strhash = Hex.toHexString(hash);
+        String strhash = ByteUtil.toHexString(hash);
         Assert.assertEquals("daf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53", strhash);
         System.out.println(strenc);
         System.out.println(strhash);
@@ -307,9 +308,9 @@ public class TransactionTest {
 
         byte[] encoded = tx.getEncodedRaw();
         byte[] hash = tx.getRawHash().getBytes();
-        String strenc = Hex.toHexString(encoded);
+        String strenc = ByteUtil.toHexString(encoded);
         Assert.assertEquals("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080", strenc);
-        String strhash = Hex.toHexString(hash);
+        String strhash = ByteUtil.toHexString(hash);
         Assert.assertEquals("daf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53", strhash);
         System.out.println(strenc);
         System.out.println(strhash);

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockChainImplTest.java
@@ -29,13 +29,13 @@ import co.rsk.test.builders.BlockBuilder;
 import co.rsk.trie.TrieStore;
 import co.rsk.validators.BlockValidator;
 import org.bouncycastle.util.Arrays;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.*;
 import org.ethereum.core.genesis.GenesisLoader;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.db.BlockStore;
 import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.FastByteComparisons;
 import org.ethereum.util.RskTestFactory;
 import org.junit.Assert;
@@ -649,7 +649,7 @@ public class BlockChainImplTest {
         Block bestBlock = blockChain.getBestBlock();
         RepositorySnapshot repository = objects.getRepositoryLocator().snapshotAt(bestBlock.getHeader());
 
-        String toAddress = Hex.toHexString(catKey.getAddress());
+        String toAddress = ByteUtil.toHexString(catKey.getAddress());
         BigInteger nonce = repository.getNonce(new RskAddress(cowKey.getAddress()));
         Transaction tx = new Transaction(toAddress, BigInteger.TEN, nonce, BigInteger.ONE, BigInteger.valueOf(21000), config.getNetworkConstants().getChainId());
         tx.sign(cowKey.getPrivKeyBytes());

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -35,7 +35,6 @@ import co.rsk.trie.TrieConverter;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
 import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
@@ -49,6 +48,7 @@ import org.ethereum.net.message.Message;
 import org.ethereum.net.p2p.HelloMessage;
 import org.ethereum.net.rlpx.Node;
 import org.ethereum.net.server.Channel;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RskTestFactory;
 import org.ethereum.vm.PrecompiledContracts;
@@ -481,7 +481,7 @@ public class BlockExecutorTest {
     }
 
     private static Transaction createTransaction(Account sender, Account receiver, BigInteger value, BigInteger nonce) {
-        String toAddress = Hex.toHexString(receiver.getAddress().getBytes());
+        String toAddress = ByteUtil.toHexString(receiver.getAddress().getBytes());
         byte[] privateKeyBytes = sender.getEcKey().getPrivKeyBytes();
         Transaction tx = new Transaction(toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000), config.getNetworkConstants().getChainId());
         tx.sign(privateKeyBytes);

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryImplOriginalTest.java
@@ -32,6 +32,7 @@ import org.ethereum.core.Repository;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.MutableRepository;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RskTestFactory;
 import org.ethereum.vm.DataWord;
 import org.junit.Assert;
@@ -669,7 +670,7 @@ public class RepositoryImplOriginalTest {
         track1.commit();
         // leaving level_1
 
-        Assert.assertEquals(Hex.toHexString(HashUtil.EMPTY_TRIE_HASH), Hex.toHexString(repository.getRoot()));
+        Assert.assertEquals(ByteUtil.toHexString(HashUtil.EMPTY_TRIE_HASH), ByteUtil.toHexString(repository.getRoot()));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryMigrationTest.java
@@ -5,11 +5,11 @@ import co.rsk.trie.Trie;
 import co.rsk.trie.TrieConverter;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Repository;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.MutableRepository;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,7 +38,7 @@ public class RepositoryMigrationTest {
         TrieConverter converter = new TrieConverter();
         byte[] oldRoot = converter.getOrchidAccountTrieRoot(repository.getTrie());
         // expected ab158b4a1d2411492194768fbd2669c069b60e5d0bcc859e51fe477855829ae7
-        System.out.println(Hex.toHexString(oldRoot));
+        System.out.println(ByteUtil.toHexString(oldRoot));
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTest.java
@@ -382,7 +382,7 @@ public class RepositoryTest {
         track1.commit();
         // leaving level_1
 
-        Assert.assertEquals(Hex.toHexString(HashUtil.EMPTY_TRIE_HASH), Hex.toHexString(repository.getRoot()));
+        Assert.assertEquals(ByteUtil.toHexString(HashUtil.EMPTY_TRIE_HASH), ByteUtil.toHexString(repository.getRoot()));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/lll/LLLTest.java
+++ b/rskj-core/src/test/java/co/rsk/lll/LLLTest.java
@@ -21,8 +21,9 @@ package co.rsk.lll;
 import co.rsk.asm.EVMDissasembler;
 import co.rsk.lll.asm.CodeBlock;
 import co.rsk.lll.asm.EVMAssemblerHelper;
-import org.junit.Test;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -36,12 +37,12 @@ import java.nio.file.Paths;
 public class LLLTest {
 
     void showCode(byte[] code) {
-        System.out.println("code: " + Hex.toHexString(code));
+        System.out.println("code: " + ByteUtil.toHexString(code));
         System.out.println("dissasemble:");
         System.out.println(EVMDissasembler.getDissasemble(code));
     }
     void showCodeBlock(EVMAssemblerHelper helper, CodeBlock block) {
-        System.out.println("code: " + Hex.toHexString(block.getCode()));
+        System.out.println("code: " + ByteUtil.toHexString(block.getCode()));
         System.out.println("dissasemble:");
         EVMDissasembler dis = new EVMDissasembler();
         System.out.println(dis.dissasembleCodeBlock(block,helper));

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -44,7 +44,6 @@ import co.rsk.trie.TrieConverter;
 import co.rsk.trie.TrieStore;
 import co.rsk.validators.BlockUnclesValidationRule;
 import co.rsk.validators.ProofOfWorkRule;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
@@ -66,6 +65,7 @@ import org.ethereum.rpc.Web3Impl;
 import org.ethereum.rpc.Web3Mocks;
 import org.ethereum.sync.SyncPool;
 import org.ethereum.util.BuildInfo;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Test;
@@ -238,7 +238,7 @@ public class TransactionModuleTest {
                 .nonce(0)
                 .build();
 
-        String rawData = Hex.toHexString(tx.getEncoded());
+        String rawData = ByteUtil.toHexString(tx.getEncoded());
 
         return web3.eth_sendRawTransaction(rawData);
     }

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -20,7 +20,6 @@ import co.rsk.scoring.PeerScoringManager;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.trie.TrieConverter;
 import co.rsk.validators.*;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -28,6 +27,7 @@ import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.rpc.Simples.SimpleChannelManager;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RskMockFactory;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
@@ -38,8 +38,6 @@ import java.math.BigInteger;
 import java.time.Duration;
 import java.util.*;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -1114,7 +1112,7 @@ public class SyncProcessorTest {
     }
 
     private static Transaction createTransaction(Account sender, Account receiver, BigInteger value, BigInteger nonce) {
-        String toAddress = Hex.toHexString(receiver.getAddress().getBytes());
+        String toAddress = ByteUtil.toHexString(receiver.getAddress().getBytes());
         byte[] privateKeyBytes = sender.getEcKey().getPrivKeyBytes();
         Transaction tx = new Transaction(toAddress, value, nonce, BigInteger.ONE, BigInteger.valueOf(21000), config.getNetworkConstants().getChainId());
         tx.sign(privateKeyBytes);

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PeerExplorerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PeerExplorerTest.java
@@ -24,15 +24,19 @@ import co.rsk.net.discovery.table.NodeDistanceTable;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.net.rlpx.Node;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.net.InetSocketAddress;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Created by mario on 15/02/17.
@@ -196,7 +200,7 @@ public class PeerExplorerTest {
         toSenderPong = (PongPeerMessage) pongEvent.getMessage();
         Assert.assertEquals(DiscoveryMessageType.PONG, toSenderPong.getMessageType());
         Assert.assertEquals(new InetSocketAddress(HOST_2, PORT_3), pongEvent.getAddress());
-        Assert.assertEquals(NODE_ID_2, Hex.toHexString(toSenderPong.getKey().getNodeId()));
+        Assert.assertEquals(NODE_ID_2, ByteUtil.toHexString(toSenderPong.getKey().getNodeId()));
     }
 
     @Test
@@ -332,8 +336,8 @@ public class PeerExplorerTest {
 
         List<Node> foundNodes = peerExplorer.getNodes();
         Assert.assertEquals(2, foundNodes.size());
-        Assert.assertEquals(NODE_ID_3, Hex.toHexString(foundNodes.get(0).getId().getID()));
-        Assert.assertEquals(NODE_ID_1, Hex.toHexString(foundNodes.get(1).getId().getID()));
+        Assert.assertEquals(NODE_ID_3, ByteUtil.toHexString(foundNodes.get(0).getId().getID()));
+        Assert.assertEquals(NODE_ID_1, ByteUtil.toHexString(foundNodes.get(1).getId().getID()));
 
         String check = UUID.randomUUID().toString();
         FindNodePeerMessage findNodePeerMessage = FindNodePeerMessage.create(key1.getNodeId(), check, key1, NETWORK_ID1);

--- a/rskj-core/src/test/java/co/rsk/net/messages/SkeletonResponseMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/SkeletonResponseMessageTest.java
@@ -20,15 +20,15 @@
 package co.rsk.net.messages;
 
 import org.ethereum.core.BlockIdentifier;
+import org.ethereum.util.ByteUtil;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.bouncycastle.util.encoders.Hex.decode;
-import static org.bouncycastle.util.encoders.Hex.toHexString;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class SkeletonResponseMessageTest {
@@ -45,7 +45,7 @@ public class SkeletonResponseMessageTest {
         SkeletonResponseMessage skeletonMessage = new SkeletonResponseMessage(someId, identifiers);
 
         String expected = "f8500db84df84b2af848f846e2a04ee6424d776b3f59affc20bc2de59e67f36e22cc07897ff8df152242c921716b01e2a07d2fe4df0dbbc9011da2b3bf177f0c6b7e71a11c509035c5d751efa5cf9b481702";
-        assertEquals(expected, toHexString(skeletonMessage.getEncoded()));
+        assertEquals(expected, ByteUtil.toHexString(skeletonMessage.getEncoded()));
 
         assertEquals(MessageType.SKELETON_RESPONSE_MESSAGE, skeletonMessage.getMessageType());
         assertEquals(42, skeletonMessage.getId());

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleBlockProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleBlockProcessor.java
@@ -50,7 +50,7 @@ public class SimpleBlockProcessor implements BlockProcessor {
         Map<Keccak256, ImportResult> connectionsResult = new HashMap<>();
         this.blocks.add(block);
         connectionsResult.put(block.getHash(), ImportResult.IMPORTED_BEST);
-        return new BlockProcessResult(false, connectionsResult, block.getShortHash(), Duration.ZERO);
+        return new BlockProcessResult(false, connectionsResult, block.getPrintableHash(), Duration.ZERO);
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
@@ -18,12 +18,12 @@
 
 package co.rsk.net.utils;
 
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.Utils;
 
 import java.math.BigInteger;
@@ -45,7 +45,7 @@ public class TransactionUtils {
 
     public static String getAddress() {
         Account targetAcc = new Account(new ECKey(Utils.getRandom()));
-        return Hex.toHexString(targetAcc.getAddress().getBytes());
+        return ByteUtil.toHexString(targetAcc.getAddress().getBytes());
     }
 
     public static byte[] getPrivateKeyBytes() {

--- a/rskj-core/src/test/java/co/rsk/pcc/AltBN128Test.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/AltBN128Test.java
@@ -22,7 +22,9 @@ package co.rsk.pcc;
 import co.rsk.altbn128.cloudflare.Utils;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
-import co.rsk.pcc.altBN128.*;
+import co.rsk.pcc.altBN128.BN128Addition;
+import co.rsk.pcc.altBN128.BN128Multiplication;
+import co.rsk.pcc.altBN128.BN128Pairing;
 import co.rsk.pcc.altBN128.impls.AbstractAltBN128;
 import co.rsk.pcc.altBN128.impls.JavaAltBN128;
 import co.rsk.vm.BytecodeCompiler;
@@ -30,6 +32,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.BlockFactory;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.VM;
@@ -362,7 +365,7 @@ public class AltBN128Test {
                 is(45_000L));
 
         assertThat("Output should be empty",
-                Hex.toHexString(output),
+                ByteUtil.toHexString(output),
                 is("0000000000000000000000000000000000000000000000000000000000000001"));
     }
 
@@ -530,10 +533,10 @@ public class AltBN128Test {
         BigInteger p1x = new BigInteger("0");
         BigInteger p1y = new BigInteger("0");
 
-        String[] inputs = {Hex.toHexString(p0x.toByteArray()),
-                Hex.toHexString(p0y.toByteArray()),
-                Hex.toHexString(p1x.toByteArray()),
-                Hex.toHexString(p1y.toByteArray())};
+        String[] inputs = {ByteUtil.toHexString(p0x.toByteArray()),
+                ByteUtil.toHexString(p0y.toByteArray()),
+                ByteUtil.toHexString(p1x.toByteArray()),
+                ByteUtil.toHexString(p1y.toByteArray())};
 
         String[] expects = {"0000000000000000000000000000000000000000000000000000000000000001",
                 "0000000000000000000000000000000000000000000000000000000000000002"};
@@ -551,10 +554,10 @@ public class AltBN128Test {
         BigInteger p1x = new BigInteger("1");
         BigInteger p1y = new BigInteger("2");
 
-        String[] inputs = {Hex.toHexString(p0x.toByteArray()),
-                Hex.toHexString(p0y.toByteArray()),
-                Hex.toHexString(p1x.toByteArray()),
-                Hex.toHexString(p1y.toByteArray())};
+        String[] inputs = {ByteUtil.toHexString(p0x.toByteArray()),
+                ByteUtil.toHexString(p0y.toByteArray()),
+                ByteUtil.toHexString(p1x.toByteArray()),
+                ByteUtil.toHexString(p1y.toByteArray())};
 
 
         String[] expects = { "030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3",
@@ -596,9 +599,9 @@ public class AltBN128Test {
         String[] expects = {"03d64e49ebb3c56c99e0769c1833879c9b86ead23945e1e7477cbd057e961c50",
                 "0d6840b39f8c2fefe0eced3e7d210b830f50831e756f1cc9039af65dc292e6d0"};
 
-        String[] inputs = {Hex.toHexString(multiplicandX.toByteArray()),
-                Hex.toHexString(multiplicandY.toByteArray()),
-                Hex.toHexString(multiplier.toByteArray())};
+        String[] inputs = {ByteUtil.toHexString(multiplicandX.toByteArray()),
+                ByteUtil.toHexString(multiplicandY.toByteArray()),
+                ByteUtil.toHexString(multiplier.toByteArray())};
 
         executeVMAltBNOperation(inputs, expects, PrecompiledContracts.ALT_BN_128_MUL_ADDR_STR);
     }
@@ -611,7 +614,7 @@ public class AltBN128Test {
         byte[] output = altBN128OperationContract.execute(input);
 
         assertThat("Incorrect gas cost", altBN128OperationContract.getGasForData(input), is(gasCost));
-        assertThat(errorMessage, Hex.toHexString(output), is(expectedOutput));
+        assertThat(errorMessage, ByteUtil.toHexString(output), is(expectedOutput));
 
         runAgainWithJavaImpl(expectedOutput, input, contractAddress);
     }
@@ -628,7 +631,7 @@ public class AltBN128Test {
             } else {
                 altBN128.pairing(input,input.length);
             }
-            assertThat(Hex.toHexString(altBN128.getOutput()), is(expectedOutput));
+            assertThat(ByteUtil.toHexString(altBN128.getOutput()), is(expectedOutput));
         }
     }
 
@@ -643,7 +646,7 @@ public class AltBN128Test {
         System.arraycopy(y1Bytes, 0, input, 64 - y1Bytes.length, y1Bytes.length);
         System.arraycopy(scalarBytes, 0, input, 96 - scalarBytes.length, scalarBytes.length);
 
-        altBN128OperationTest(Hex.toHexString(input), expectedOutput,
+        altBN128OperationTest(ByteUtil.toHexString(input), expectedOutput,
                 "Wrong result of multiplication",
                 PrecompiledContracts.ALT_BN_128_MUL_DW,
                 MUL_GAS_COST);
@@ -663,7 +666,7 @@ public class AltBN128Test {
         System.arraycopy(x2Bytes, 0, input, 96 - x2Bytes.length, x2Bytes.length);
         System.arraycopy(y2Bytes, 0, input, 128 - y2Bytes.length, y2Bytes.length);
 
-        altBN128OperationTest(Hex.toHexString(input), expectedOutput,
+        altBN128OperationTest(ByteUtil.toHexString(input), expectedOutput,
                 errorMessage, PrecompiledContracts.ALT_BN_128_ADD_DW, ADD_GAS_COST);
 
     }
@@ -684,8 +687,8 @@ public class AltBN128Test {
         }
 
         byte[] argsLengthBytes = BigInteger.valueOf(inputs.length * DataWord.BYTES).toByteArray();
-        String retLength = Hex.toHexString(BigInteger.valueOf(expect.length*DataWord.BYTES).toByteArray());
-        String argsLength = Hex.toHexString(argsLengthBytes);
+        String retLength = ByteUtil.toHexString(BigInteger.valueOf(expect.length*DataWord.BYTES).toByteArray());
+        String argsLength = ByteUtil.toHexString(argsLengthBytes);
 
         codeBuilder.append(" PUSH").append(retLength.length()/2)
                 .append(" 0x").append(retLength); // retLength

--- a/rskj-core/src/test/java/co/rsk/pcc/NativeContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/NativeContractTest.java
@@ -29,6 +29,7 @@ import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.LogInfo;
 import org.junit.Assert;
 import org.junit.Before;
@@ -275,7 +276,7 @@ public class NativeContractTest {
         });
         when(contract.getMethods()).thenReturn(Arrays.asList(method));
 
-        Assert.assertEquals("aabbccddeeff112233", Hex.toHexString(contract.execute(Hex.decode("00112233"))));
+        Assert.assertEquals("aabbccddeeff112233", ByteUtil.toHexString(contract.execute(Hex.decode("00112233"))));
         verify(method, times(1)).execute(any());
         verify(contract, times(1)).before();
         verify(contract, times(1)).after();
@@ -380,7 +381,7 @@ public class NativeContractTest {
         });
         when(contract.getMethods()).thenReturn(Arrays.asList(method));
 
-        Assert.assertEquals("ffeeddccbb", Hex.toHexString(contract.execute(Hex.decode("00112233"))));
+        Assert.assertEquals("ffeeddccbb", ByteUtil.toHexString(contract.execute(Hex.decode("00112233"))));
         verify(method, times(1)).execute(any());
         verify(contract, times(1)).before();
         verify(contract, times(1)).after();

--- a/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderContractTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/blockheader/BlockHeaderContractTest.java
@@ -36,7 +36,6 @@ import co.rsk.test.World;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.util.DifficultyUtils;
 import org.bouncycastle.util.Arrays;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -174,7 +173,7 @@ public class BlockHeaderContractTest {
 
         byte[] blockHash = (byte[]) decodedResult[0];
 
-        assertEquals(Hex.toHexString(expectedHash), Hex.toHexString(blockHash));
+        assertEquals(ByteUtil.toHexString(expectedHash), ByteUtil.toHexString(blockHash));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKeyPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKeyPerformanceTestCase.java
@@ -26,11 +26,11 @@ import co.rsk.peg.performance.ExecutionStats;
 import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.spongycastle.util.encoders.Hex;
 
 import java.util.Random;
 
@@ -59,7 +59,7 @@ public class ExtractPublicKeyFromExtendedPublicKeyPerformanceTestCase extends Pr
         NetworkParameters networkParameters = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
 
         byte[] publicKey = new ECKey().getPubKey(true);
-        String expectedHexPublicKey = Hex.toHexString(publicKey);
+        String expectedHexPublicKey = ByteUtil.toHexString(publicKey);
 
         ABIEncoder abiEncoder = (int executionIndex) -> {
             rnd.nextBytes(chainCode);
@@ -84,7 +84,7 @@ public class ExtractPublicKeyFromExtendedPublicKeyPerformanceTestCase extends Pr
                 (EnvironmentBuilder.Environment environment, byte[] result) -> {
                     Object[] decodedResult = function.decodeResult(result);
                     Assert.assertEquals(byte[].class, decodedResult[0].getClass());
-                    String hexPublicKey = Hex.toHexString((byte[]) decodedResult[0]);
+                    String hexPublicKey = ByteUtil.toHexString((byte[]) decodedResult[0]);
                     Assert.assertEquals(expectedHexPublicKey, hexPublicKey);
                 }
         );

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKeyTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/ExtractPublicKeyFromExtendedPublicKeyTest.java
@@ -21,9 +21,9 @@ package co.rsk.pcc.bto;
 
 import co.rsk.pcc.ExecutionEnvironment;
 import co.rsk.pcc.NativeContractIllegalArgumentException;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.solidity.SolidityType;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,7 +66,7 @@ public class ExtractPublicKeyFromExtendedPublicKeyTest {
     public void executes() {
         Assert.assertEquals(
                 "02be517550b9e3be7fe42c80932d51e88e698663b4926e598b269d050e87e34d8c",
-                Hex.toHexString((byte[]) method.execute(new Object[]{
+                ByteUtil.toHexString((byte[]) method.execute(new Object[]{
                     "xpub661MyMwAqRbcFMGNG2YcHvj3x63bAZN9U5cKikaiQ4zu2D1cvpnZYyXNR9nH62sGp4RR39Ui7SVQSq1PY4JbPuEuu5prVJJC3d5Pogft712",
                 })));
     }

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashPerformanceTestCase.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashPerformanceTestCase.java
@@ -26,12 +26,12 @@ import co.rsk.peg.performance.ExecutionStats;
 import co.rsk.peg.performance.PrecompiledContractPerformanceTestCase;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.spongycastle.util.encoders.Hex;
 
 import java.util.Arrays;
 import java.util.Random;
@@ -99,7 +99,7 @@ public class GetMultisigScriptHashPerformanceTestCase extends PrecompiledContrac
             publicKeys[i] = new ECKey().getPubKey(true);
         }
 
-        String expectedHashHex = Hex.toHexString(ScriptBuilder.createP2SHOutputScript(
+        String expectedHashHex = ByteUtil.toHexString(ScriptBuilder.createP2SHOutputScript(
                 minimumSignatures,
                 Arrays.stream(publicKeys).map(BtcECKey::fromPublicOnly).collect(Collectors.toList())
         ).getPubKeyHash());
@@ -119,7 +119,7 @@ public class GetMultisigScriptHashPerformanceTestCase extends PrecompiledContrac
                 (EnvironmentBuilder.Environment environment, byte[] result) -> {
                     Object[] decodedResult = function.decodeResult(result);
                     Assert.assertEquals(byte[].class, decodedResult[0].getClass());
-                    String hexHash = Hex.toHexString((byte[]) decodedResult[0]);
+                    String hexHash = ByteUtil.toHexString((byte[]) decodedResult[0]);
                     Assert.assertEquals(expectedHashHex, hexHash);
                 }
         );

--- a/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/bto/GetMultisigScriptHashTest.java
@@ -22,10 +22,10 @@ package co.rsk.pcc.bto;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.pcc.ExecutionEnvironment;
 import co.rsk.pcc.NativeContractIllegalArgumentException;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.solidity.SolidityType;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,7 +71,7 @@ public class GetMultisigScriptHashTest {
     public void executesWithAllCompressed() {
         Assert.assertEquals(
                 "51f103320b435b5fe417b3f3e0f18972ccc710a0",
-                Hex.toHexString((byte[]) method.execute(new Object[]{
+                ByteUtil.toHexString((byte[]) method.execute(new Object[]{
                         BigInteger.valueOf(8L),
                         new byte[][] {
                                 Hex.decode("03b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2"),
@@ -97,7 +97,7 @@ public class GetMultisigScriptHashTest {
     public void executesWithMixed() {
         Assert.assertEquals(
                 "51f103320b435b5fe417b3f3e0f18972ccc710a0",
-                Hex.toHexString((byte[]) method.execute(new Object[]{
+                ByteUtil.toHexString((byte[]) method.execute(new Object[]{
                         BigInteger.valueOf(8L),
                         new byte[][] {
                                 Hex.decode("04b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2aafaaa2611606699ec4f82777a268b708dab346de4880cd223969f7bbe5422bf"),

--- a/rskj-core/src/test/java/co/rsk/peg/ABICallSpecTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ABICallSpecTest.java
@@ -19,6 +19,7 @@
 package co.rsk.peg;
 
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
@@ -54,7 +55,7 @@ public class ABICallSpecTest {
         });
 
         StringBuilder expectedBuilder = new StringBuilder();
-        expectedBuilder.append(Hex.toHexString("a-function".getBytes(StandardCharsets.UTF_8)));
+        expectedBuilder.append(ByteUtil.toHexString("a-function".getBytes(StandardCharsets.UTF_8)));
         expectedBuilder.append("1122334455");
         Assert.assertTrue(Arrays.equals(Hex.decode(expectedBuilder.toString()), spec.getEncoded()));
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -27,6 +27,7 @@ import com.google.common.primitives.UnsignedBytes;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.junit.Assert;
@@ -43,7 +44,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -58,7 +58,7 @@ public class BridgeSerializationUtilsTest {
 
         byte[] result = BridgeSerializationUtils.serializeMapOfHashesToLong(sample);
 
-        String hexResult = Hex.toHexString(result);
+        String hexResult = ByteUtil.toHexString(result);
         StringBuilder expectedBuilder = new StringBuilder();
 
         expectedBuilder.append("f888");
@@ -158,12 +158,12 @@ public class BridgeSerializationUtilsTest {
 
         federation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
             expectedBuilder.append("a1");
-            expectedBuilder.append(Hex.toHexString(key.getPubKey()));
+            expectedBuilder.append(ByteUtil.toHexString(key.getPubKey()));
         });
 
         String expected = expectedBuilder.toString();
 
-        Assert.assertEquals(expected, Hex.toHexString(result));
+        Assert.assertEquals(expected, ByteUtil.toHexString(result));
     }
 
     @Test
@@ -399,11 +399,11 @@ public class BridgeSerializationUtilsTest {
         expectedBuilder.append("f8cc");
         pendingFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
             expectedBuilder.append("a1");
-            expectedBuilder.append(Hex.toHexString(key.getPubKey()));
+            expectedBuilder.append(ByteUtil.toHexString(key.getPubKey()));
         });
 
         String expected = expectedBuilder.toString();
-        Assert.assertEquals(expected, Hex.toHexString(result));
+        Assert.assertEquals(expected, ByteUtil.toHexString(result));
     }
 
     @Test
@@ -451,14 +451,14 @@ public class BridgeSerializationUtilsTest {
         ABICallElection sample = new ABICallElection(authorizer, sampleVotes);
 
         byte[] result = BridgeSerializationUtils.serializeElection(sample);
-        String hexResult = Hex.toHexString(result);
+        String hexResult = ByteUtil.toHexString(result);
 
         StringBuilder expectedBuilder = new StringBuilder();
 
         expectedBuilder.append("f8d7d6");
 
         expectedBuilder.append("90");
-        expectedBuilder.append(Hex.toHexString("another-function".getBytes(StandardCharsets.UTF_8)));
+        expectedBuilder.append(ByteUtil.toHexString("another-function".getBytes(StandardCharsets.UTF_8)));
         expectedBuilder.append("c4");
         expectedBuilder.append("01");
         expectedBuilder.append("820203");
@@ -469,7 +469,7 @@ public class BridgeSerializationUtilsTest {
 
         expectedBuilder.append("ce");
         expectedBuilder.append("8c");
-        expectedBuilder.append(Hex.toHexString("one-function".getBytes(StandardCharsets.UTF_8)));
+        expectedBuilder.append(ByteUtil.toHexString("one-function".getBytes(StandardCharsets.UTF_8)));
         expectedBuilder.append("c0");
 
         expectedBuilder.append("ea");
@@ -478,7 +478,7 @@ public class BridgeSerializationUtilsTest {
 
         expectedBuilder.append("d9");
         expectedBuilder.append("94");
-        expectedBuilder.append(Hex.toHexString("yet-another-function".getBytes(StandardCharsets.UTF_8)));
+        expectedBuilder.append(ByteUtil.toHexString("yet-another-function".getBytes(StandardCharsets.UTF_8)));
         expectedBuilder.append("c3");
         expectedBuilder.append("820405");
         expectedBuilder.append("ea");
@@ -651,13 +651,13 @@ public class BridgeSerializationUtilsTest {
         expectedBuilder.append("f897");
         Arrays.stream(addressesBytes).sorted(UnsignedBytes.lexicographicalComparator()).forEach(bytes -> {
             expectedBuilder.append("94");
-            expectedBuilder.append(Hex.toHexString(bytes));
+            expectedBuilder.append(ByteUtil.toHexString(bytes));
             expectedBuilder.append("83");
-            expectedBuilder.append(Hex.toHexString(BigInteger.valueOf(maxToTransfer.value).toByteArray()));
+            expectedBuilder.append(ByteUtil.toHexString(BigInteger.valueOf(maxToTransfer.value).toByteArray()));
         });
         expectedBuilder.append("80");
         String expected = expectedBuilder.toString();
-        Assert.assertEquals(expected, Hex.toHexString(result));
+        Assert.assertEquals(expected, ByteUtil.toHexString(result));
     }
 
     @Test
@@ -776,7 +776,7 @@ public class BridgeSerializationUtilsTest {
         ReleaseRequestQueue sample = new ReleaseRequestQueue(sampleEntries);
 
         byte[] result = BridgeSerializationUtils.serializeReleaseRequestQueue(sample);
-        String hexResult = Hex.toHexString(result);
+        String hexResult = ByteUtil.toHexString(result);
         StringBuilder expectedBuilder = new StringBuilder();
         expectedBuilder.append("cd");
         expectedBuilder.append("82ccdd");
@@ -866,7 +866,7 @@ public class BridgeSerializationUtilsTest {
         ReleaseTransactionSet sample = new ReleaseTransactionSet(sampleEntries);
 
         byte[] result = BridgeSerializationUtils.serializeReleaseTransactionSet(sample);
-        String hexResult = Hex.toHexString(result);
+        String hexResult = ByteUtil.toHexString(result);
         StringBuilder expectedBuilder = new StringBuilder();
         expectedBuilder.append("cd");
         expectedBuilder.append("81aa");

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestPowerMock.java
@@ -52,7 +52,7 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.MutableRepository;
 import org.ethereum.rpc.TypeConverter;
-import org.ethereum.solidity.SolidityType;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.VM;
 import org.ethereum.vm.program.Program;
@@ -2842,7 +2842,7 @@ public class BridgeTestPowerMock {
         // Encode a call to the bridge's getMinimumLockTxValue function
         // That means first pushing the corresponding encoded ABI storage to memory (MSTORE)
         // and then doing a DELEGATECALL to the corresponding address with the correct parameters
-        String bridgeFunctionHex = Hex.toHexString(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode());
+        String bridgeFunctionHex = ByteUtil.toHexString(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode());
         bridgeFunctionHex = String.format("0x%s%s", bridgeFunctionHex, String.join("", Collections.nCopies(32 * 2 - bridgeFunctionHex.length(), "0")));
         String asm = String.format("%s 0x00 MSTORE 0x20 0x30 0x20 0x00 0x0000000000000000000000000000000001000006 0x6000 DELEGATECALL", bridgeFunctionHex);
         int numOps = asm.split(" ").length;
@@ -2890,7 +2890,7 @@ public class BridgeTestPowerMock {
         // Encode a call to the bridge's getMinimumLockTxValue function
         // That means first pushing the corresponding encoded ABI storage to memory (MSTORE)
         // and then doing a DELEGATECALL to the corresponding address with the correct parameters
-        String bridgeFunctionHex = Hex.toHexString(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode());
+        String bridgeFunctionHex = ByteUtil.toHexString(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode());
         bridgeFunctionHex = String.format("0x%s%s", bridgeFunctionHex, String.join("", Collections.nCopies(32 * 2 - bridgeFunctionHex.length(), "0")));
         String asm = String.format("%s 0x00 MSTORE 0x20 0x30 0x20 0x00 0x0000000000000000000000000000000001000006 0x6000 DELEGATECALL", bridgeFunctionHex);
         int numOps = asm.split(" ").length;

--- a/rskj-core/src/test/java/co/rsk/peg/performance/LockTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/LockTest.java
@@ -23,13 +23,12 @@ import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import org.ethereum.core.Repository;
+import org.ethereum.util.ByteUtil;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Map;
 import java.util.Random;
 
 // Everything related to locking that is not
@@ -56,13 +55,13 @@ public class LockTest extends BridgePerformanceTestCase {
     }
 
     private void isBtcTxHashAlreadyProcessed_yes(int times, ExecutionStats stats) {
-        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.IS_BTC_TX_HASH_ALREADY_PROCESSED.encode(new Object[]{Hex.toHexString(randomHashInMap.getBytes())});
+        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.IS_BTC_TX_HASH_ALREADY_PROCESSED.encode(new Object[]{ByteUtil.toHexString(randomHashInMap.getBytes())});
         executeAndAverage("isBtcTxHashAlreadyProcessed-yes", times, abiEncoder, buildInitializer(), Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
     }
 
     private void isBtcTxHashAlreadyProcessed_no(int times, ExecutionStats stats) {
         Sha256Hash hash = Sha256Hash.of(BigInteger.valueOf(new Random().nextLong()).toByteArray());
-        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.IS_BTC_TX_HASH_ALREADY_PROCESSED.encode(new Object[]{Hex.toHexString(hash.getBytes())});
+        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.IS_BTC_TX_HASH_ALREADY_PROCESSED.encode(new Object[]{ByteUtil.toHexString(hash.getBytes())});
         executeAndAverage("isBtcTxHashAlreadyProcessed-no", times, abiEncoder, buildInitializer(), Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
     }
 
@@ -75,13 +74,13 @@ public class LockTest extends BridgePerformanceTestCase {
     }
 
     private void getBtcTxHashProcessedHeight_processed(int times, ExecutionStats stats) {
-        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_BTC_TX_HASH_PROCESSED_HEIGHT.encode(new Object[]{Hex.toHexString(randomHashInMap.getBytes())});
+        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_BTC_TX_HASH_PROCESSED_HEIGHT.encode(new Object[]{ByteUtil.toHexString(randomHashInMap.getBytes())});
         executeAndAverage("getBtcTxHashProcessedHeight-processed", times, abiEncoder, buildInitializer(), Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
     }
 
     private void getBtcTxHashProcessedHeight_notProcessed(int times, ExecutionStats stats) {
         Sha256Hash hash = Sha256Hash.of(BigInteger.valueOf(new Random().nextLong()).toByteArray());
-        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_BTC_TX_HASH_PROCESSED_HEIGHT.encode(new Object[]{Hex.toHexString(hash.getBytes())});
+        ABIEncoder abiEncoder = (int executionIndex) -> Bridge.GET_BTC_TX_HASH_PROCESSED_HEIGHT.encode(new Object[]{ByteUtil.toHexString(hash.getBytes())});
         executeAndAverage("getBtcTxHashProcessedHeight-notProcessed", times, abiEncoder, buildInitializer(), Helper.getZeroValueRandomSenderTxBuilder(), Helper.getRandomHeightProvider(10), stats);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -31,6 +31,7 @@ import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
@@ -295,7 +296,7 @@ public class BridgeEventLoggerImplTest {
         // Assert log topics
         Assert.assertEquals(3, logResult.getTopics().size());
         ECKey key = ECKey.fromPublicOnly(federatorPubKey.getPubKey());
-        String federatorRskAddress = Hex.toHexString(key.getAddress());
+        String federatorRskAddress = ByteUtil.toHexString(key.getAddress());
         byte[][] topics = event.encodeEventTopics(rskTxHash.getBytes(), federatorRskAddress);
         for (int i=0; i<topics.length; i++) {
             Assert.assertArrayEquals(topics[i], logResult.getTopics().get(i).getData());

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -45,6 +45,7 @@ import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import org.junit.Before;
@@ -988,7 +989,7 @@ public class RemascProcessMinerFeesTest {
 
         for(Map.Entry<byte[], Coin> entry : otherAccountsBalance.entrySet()) {
             Coin actualBalance = RemascTestRunner.getAccountBalance(repository, entry.getKey());
-            assertEquals("Failed for: " + Hex.toHexString(entry.getKey()), entry.getValue(), actualBalance);
+            assertEquals("Failed for: " + ByteUtil.toHexString(entry.getKey()), entry.getValue(), actualBalance);
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/scoring/PeerScoringManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/scoring/PeerScoringManagerTest.java
@@ -1,9 +1,9 @@
 package co.rsk.scoring;
 
 import co.rsk.net.NodeID;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -337,7 +337,7 @@ public class PeerScoringManagerTest {
         Assert.assertEquals(2, result.size());
 
         PeerScoringInformation info = result.get(0);
-        Assert.assertEquals(Hex.toHexString(node.getID()).substring(0, 8), info.getId());
+        Assert.assertEquals(ByteUtil.toHexString(node.getID()).substring(0, 8), info.getId());
         Assert.assertEquals(1, info.getValidBlocks());
         Assert.assertEquals(0, info.getInvalidBlocks());
         Assert.assertEquals(0, info.getValidTransactions());
@@ -374,7 +374,7 @@ public class PeerScoringManagerTest {
         Assert.assertEquals(2, result.size());
 
         PeerScoringInformation info = result.get(0);
-        Assert.assertEquals(Hex.toHexString(node.getID()).substring(0, 8), info.getId());
+        Assert.assertEquals(ByteUtil.toHexString(node.getID()).substring(0, 8), info.getId());
         Assert.assertEquals(2, info.getValidBlocks());
         Assert.assertEquals(0, info.getInvalidBlocks());
         Assert.assertEquals(1, info.getValidTransactions());

--- a/rskj-core/src/test/java/co/rsk/test/builders/TransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/TransactionBuilder.java
@@ -23,6 +23,7 @@ import org.ethereum.config.Constants;
 import org.ethereum.core.Account;
 import org.ethereum.core.ImmutableTransaction;
 import org.ethereum.core.Transaction;
+import org.ethereum.util.ByteUtil;
 
 import java.math.BigInteger;
 
@@ -92,7 +93,7 @@ public class TransactionBuilder {
 
     public Transaction build() {
         Transaction tx = new Transaction(
-                receiver != null ? Hex.toHexString(receiver.getAddress().getBytes()) : (receiverAddress != null ? Hex.toHexString(receiverAddress) : null),
+                receiver != null ? ByteUtil.toHexString(receiver.getAddress().getBytes()) : (receiverAddress != null ? ByteUtil.toHexString(receiverAddress) : null),
                 value, nonce, gasPrice, gasLimit, data, Constants.REGTEST_CHAIN_ID);
         tx.sign(sender.getEcKey().getPrivKeyBytes());
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieConverterTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieConverterTest.java
@@ -28,6 +28,7 @@ import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.db.MutableRepository;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.junit.Assert;
 import org.junit.Test;
@@ -69,7 +70,7 @@ import static org.hamcrest.Matchers.is;
  *         track.commit();
  *         repository.flush();
  *
- *         System.out.println(Hex.toHexString(repository.getRoot()));
+ *         System.out.println(ByteUtil.toHexString(repository.getRoot()));
  *     }
  * }
  */
@@ -251,7 +252,7 @@ public class TrieConverterTest {
         byte[] oldRoot = tc.getOrchidAccountTrieRoot(repository.getTrie());
         Trie atrie = deserialize(SERIALIZED_ORCHID_TRIESTORE_WITH_LEADING_ZEROES_STORAGE_KEYS);
 
-        Assert.assertThat(Hex.toHexString(oldRoot), is(atrie.getHashOrchid(true).toHexString()));
+        Assert.assertThat(ByteUtil.toHexString(oldRoot), is(atrie.getHashOrchid(true).toHexString()));
     }
 
     @Test
@@ -289,7 +290,7 @@ public class TrieConverterTest {
         byte[] oldRoot = tc.getOrchidAccountTrieRoot(repository.getTrie());
         Trie atrie = deserialize(SERIALIZED_ORCHID_TRIESTORE_SIMPLE);
 
-        Assert.assertThat(Hex.toHexString(oldRoot), is(atrie.getHashOrchid(true).toHexString()));
+        Assert.assertThat(ByteUtil.toHexString(oldRoot), is(atrie.getHashOrchid(true).toHexString()));
     }
 
     private byte[] randomCode(int maxSize) {

--- a/rskj-core/src/test/java/co/rsk/trie/delete/SecureTrieKeyValueTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/delete/SecureTrieKeyValueTest.java
@@ -19,9 +19,9 @@
 package co.rsk.trie.delete;
 
 import co.rsk.trie.Trie;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
-import org.spongycastle.util.encoders.Hex;
 
 import java.util.Arrays;
 import java.util.List;
@@ -81,11 +81,11 @@ public class SecureTrieKeyValueTest {
         byte[] key3 = "11200".getBytes();
         byte[] key4 = "1145".getBytes();
 
-        byte[] msg0 = Hex.toHexString(key0).getBytes();
-        byte[] msg1 = Hex.toHexString(key1).getBytes();
-        byte[] msg2 = Hex.toHexString(key2).getBytes();
-        byte[] msg3 = Hex.toHexString(key3).getBytes();
-        byte[] msg4 = Hex.toHexString(key4).getBytes();
+        byte[] msg0 = ByteUtil.toHexString(key0).getBytes();
+        byte[] msg1 = ByteUtil.toHexString(key1).getBytes();
+        byte[] msg2 = ByteUtil.toHexString(key2).getBytes();
+        byte[] msg3 = ByteUtil.toHexString(key3).getBytes();
+        byte[] msg4 = ByteUtil.toHexString(key4).getBytes();
 
         List<byte[]> keys = Arrays.asList(key0, key1, key2, key3, key4);
         List<byte[]> values = Arrays.asList(msg0, msg1, msg2, msg3, msg4);
@@ -122,11 +122,11 @@ public class SecureTrieKeyValueTest {
         byte[] key3 = "11200".getBytes();
         byte[] key4 = "1145".getBytes();
 
-        byte[] msg0 = Hex.toHexString(key0).getBytes();
-        byte[] msg1 = Hex.toHexString(key1).getBytes();
-        byte[] msg2 = Hex.toHexString(key2).getBytes();
-        byte[] msg3 = Hex.toHexString(key3).getBytes();
-        byte[] msg4 = Hex.toHexString(key4).getBytes();
+        byte[] msg0 = ByteUtil.toHexString(key0).getBytes();
+        byte[] msg1 = ByteUtil.toHexString(key1).getBytes();
+        byte[] msg2 = ByteUtil.toHexString(key2).getBytes();
+        byte[] msg3 = ByteUtil.toHexString(key3).getBytes();
+        byte[] msg4 = ByteUtil.toHexString(key4).getBytes();
 
         List<byte[]> keys = Arrays.asList(key0, key1, key2, key3, key4);
         List<byte[]> values = Arrays.asList(msg0, msg1, msg2, msg3, msg4);

--- a/rskj-core/src/test/java/co/rsk/vm/Create2Test.java
+++ b/rskj-core/src/test/java/co/rsk/vm/Create2Test.java
@@ -27,11 +27,11 @@ import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import org.bouncycastle.util.Arrays;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Account;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Transaction;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.VM;
@@ -46,7 +46,8 @@ import java.math.BigInteger;
 import java.util.HashSet;
 
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP125;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -245,8 +246,8 @@ public class Create2Test {
         Program program = executeCode(codeToExecute);
         Stack stack = program.getStack();
         Assert.assertEquals(2, stack.size());
-        String address2 = Hex.toHexString(stack.pop().getLast20Bytes());
-        String address1 = Hex.toHexString(stack.pop().getLast20Bytes());
+        String address2 = ByteUtil.toHexString(stack.pop().getLast20Bytes());
+        String address1 = ByteUtil.toHexString(stack.pop().getLast20Bytes());
         Assert.assertEquals(expectedAddress1.toUpperCase(), address1.toUpperCase());
         Assert.assertEquals(expectedAddress2.toUpperCase(), address2.toUpperCase());
         Assert.assertEquals(gasExpected, program.getResult().getGasUsed());
@@ -266,7 +267,7 @@ public class Create2Test {
         Program program = executeCode(code);
 
         Stack stack = program.getStack();
-        String address = Hex.toHexString(stack.peek().getLast20Bytes());
+        String address = ByteUtil.toHexString(stack.peek().getLast20Bytes());
         long nonce = program.getStorage().getNonce(new RskAddress(address)).longValue();
 
         Assert.assertEquals(0, nonce);
@@ -307,7 +308,7 @@ public class Create2Test {
                         " PUSH32 " + "0x" + DataWord.valueOf(value) +
                         " CREATE2");
         Stack stack = program.getStack();
-        String result = Hex.toHexString(Arrays.copyOfRange(stack.peek().getData(), 12, stack.peek().getData().length));
+        String result = ByteUtil.toHexString(Arrays.copyOfRange(stack.peek().getData(), 12, stack.peek().getData().length));
 
         Assert.assertEquals(1, stack.size());
         Assert.assertEquals(expected.toUpperCase(), result.toUpperCase());

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -27,9 +27,9 @@ import co.rsk.mine.GasLimitCalculator;
 import co.rsk.panic.PanicProcessor;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
@@ -78,8 +78,8 @@ public class MinerHelper {
         latestStateRootHash = track.getRoot();
 
         // RSK test, remove
-        String stateHash1 = Hex.toHexString(blockchain.getBestBlock().getStateRoot());
-        String stateHash2 = Hex.toHexString(repository.getRoot());
+        String stateHash1 = ByteUtil.toHexString(blockchain.getBestBlock().getStateRoot());
+        String stateHash2 = ByteUtil.toHexString(repository.getRoot());
         if (stateHash1.compareTo(stateHash2) != 0) {
             logger.error("Strange state in block {} {}", block.getNumber(), block.getHash());
             panicProcessor.panic("minerserver", String.format("Strange state in block %d %s", block.getNumber(), block.getHash()));

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -516,7 +516,7 @@ public class VMExecutionTest {
     }
 
     @Test
-    public void txindexExecution() {
+    public void txIndexExecution() {
         invoke.setTransactionIndex(DataWord.valueOf(42));
         Program program = executeCode("TXINDEX", 1);
         Stack stack = program.getStack();
@@ -530,9 +530,8 @@ public class VMExecutionTest {
         try {
             executeCode("PUSH1 0x03 JUMP", 2);
             Assert.fail();
-        }
-        catch (Program.BadJumpDestinationException ex) {
-            Assert.assertEquals("Operation with pc isn't 'JUMPDEST': PC[3];", ex.getMessage());
+        } catch (Program.BadJumpDestinationException ex) {
+            Assert.assertEquals("Operation with pc isn't 'JUMPDEST': PC[3], tx[<null>]", ex.getMessage());
         }
     }
 
@@ -541,9 +540,8 @@ public class VMExecutionTest {
         try {
             executeCode("PUSH1 0x05 JUMP", 2);
             Assert.fail();
-        }
-        catch (Program.BadJumpDestinationException ex) {
-            Assert.assertEquals("Operation with pc isn't 'JUMPDEST': PC[5];", ex.getMessage());
+        } catch (Program.BadJumpDestinationException ex) {
+            Assert.assertEquals("Operation with pc isn't 'JUMPDEST': PC[5], tx[<null>]", ex.getMessage());
         }
     }
 
@@ -552,9 +550,8 @@ public class VMExecutionTest {
         try {
             executeCode("PUSH32 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff JUMP", 2);
             Assert.fail();
-        }
-        catch (Program.BadJumpDestinationException ex) {
-            Assert.assertEquals("Operation with pc isn't 'JUMPDEST': PC[-1];", ex.getMessage());
+        } catch (Program.BadJumpDestinationException ex) {
+            Assert.assertEquals("Operation with pc isn't 'JUMPDEST': PC[-1], tx[<null>]", ex.getMessage());
         }
     }
 
@@ -563,9 +560,8 @@ public class VMExecutionTest {
         try {
             executeCode("PUSH1 0xff JUMP", 2);
             Assert.fail();
-        }
-        catch (Program.BadJumpDestinationException ex) {
-            Assert.assertEquals("Operation with pc isn't 'JUMPDEST': PC[255];", ex.getMessage());
+        } catch (Program.BadJumpDestinationException ex) {
+            Assert.assertEquals("Operation with pc isn't 'JUMPDEST': PC[255], tx[<null>]", ex.getMessage());
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -22,10 +22,10 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.BlockFactory;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.*;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.Stack;
@@ -787,7 +787,7 @@ public class VMExecutionTest {
     private void testCode(byte[] code, int nsteps, String expected) {
         Program program = executeCodeWithActivationConfig(code, nsteps, mock(ActivationConfig.ForBlock.class));
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     private Program executeCodeWithActivationConfig(String code, int nsteps, ActivationConfig.ForBlock activations) {

--- a/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMPerformanceTest.java
@@ -25,6 +25,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.BlockFactory;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.OpCode;
 import org.ethereum.vm.PrecompiledContracts;
@@ -507,7 +508,7 @@ public class VMPerformanceTest {
         //if (!Arrays.equals(expectedHReturn, actualHReturn)) {
 
         // DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(actualHReturn).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(actualHReturn).toUpperCase());
     }
 
     LinkedList<Object> lk;
@@ -621,7 +622,7 @@ public class VMPerformanceTest {
         if (program.getResult().getHReturn() != null) {
             actualHReturn = program.getResult().getHReturn();
         }
-        assertEquals(s_expected, Hex.toHexString(actualHReturn).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(actualHReturn).toUpperCase());
         System.out.println("-----------------------------------------------------------------------------");
     }
     /* TEST CASE LIST END */

--- a/rskj-core/src/test/java/org/ethereum/core/ABITest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ABITest.java
@@ -20,9 +20,9 @@
 package org.ethereum.core;
 
 import co.rsk.core.RskAddress;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.crypto.Keccak256Helper;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -61,16 +61,16 @@ public class ABITest {
         CallTransaction.Function function = CallTransaction.Function.fromJsonInterface(funcJson1);
 
         Assert.assertEquals("5c19a95c0000000000000000000000001234567890abcdef1234567890abcdef12345678",
-                Hex.toHexString(function.encode("1234567890abcdef1234567890abcdef12345678")));
+                ByteUtil.toHexString(function.encode("1234567890abcdef1234567890abcdef12345678")));
         Assert.assertEquals("5c19a95c0000000000000000000000001234567890abcdef1234567890abcdef12345678",
-                Hex.toHexString(function.encode("0x1234567890abcdef1234567890abcdef12345678")));
+                ByteUtil.toHexString(function.encode("0x1234567890abcdef1234567890abcdef12345678")));
         try {
-            Hex.toHexString(function.encode("0xa1234567890abcdef1234567890abcdef12345678"));
+            ByteUtil.toHexString(function.encode("0xa1234567890abcdef1234567890abcdef12345678"));
             Assert.assertTrue(false);
         } catch (Exception e) {}
 
         try {
-            Hex.toHexString(function.encode("blabla"));
+            ByteUtil.toHexString(function.encode("blabla"));
             Assert.assertTrue(false);
         } catch (Exception e) {}
     }
@@ -94,7 +94,7 @@ public class ABITest {
                 new RskAddress("86e0497e32a8e1d79fe38ab87dc80140df5470d9"), 0, function, Constants.REGTEST_CHAIN_ID);
         ctx.sign(Keccak256Helper.keccak256("974f963ee4571e86e5f9bc3b493e453db9c15e5bd19829a4ef9a790de0da0015".getBytes()));
 
-        Assert.assertEquals("91888f2e", Hex.toHexString(ctx.getData()));
+        Assert.assertEquals("91888f2e", ByteUtil.toHexString(ctx.getData()));
     }
 
     static String funcJson3 = "{\n" +
@@ -125,7 +125,7 @@ public class ABITest {
                 "000000000000000000000000000000000000000000000000000000000000007b61" +
                 "000000000000000000000000000000000000000000000000000000000000007468" +
                 "6520737472696e6700000000000000000000000000000000000000000000",
-                Hex.toHexString(function.encode(-1234, 1234, 123, "a", "the string")));
+                ByteUtil.toHexString(function.encode(-1234, 1234, 123, "a", "the string")));
     }
 
     static String funcJson4 = "{\n" +
@@ -148,7 +148,7 @@ public class ABITest {
                         "0000000000000000000000000000000000000000000000000000000000000001" +
                         "0000000000000000000000000000000000000000000000000000000000000002" +
                         "0000000000000000000000000000000000000000000000000000000000000003",
-                Hex.toHexString(function.encode(new int[] {1,2,3})));
+                ByteUtil.toHexString(function.encode(new int[] {1,2,3})));
 
         Assert.assertEquals(
                 "d383b9f60000000000000000000000000000000000000000000000000000000000000001" +
@@ -158,7 +158,7 @@ public class ABITest {
                         "0000000000000000000000000000000000000000000000000000000000000002" +
                         "0000000000000000000000000000000000000000000000000000000000000004" +
                         "0000000000000000000000000000000000000000000000000000000000000005",
-                Hex.toHexString(function.encode(new int[]{1, 2, 3}, new int[]{4, 5})));
+                ByteUtil.toHexString(function.encode(new int[]{1, 2, 3}, new int[]{4, 5})));
 
     }
 
@@ -186,7 +186,7 @@ public class ABITest {
                         "00000000000000000000000000000000000000000000000000000000000000de" +
                         "0000000000000000000000000000000000000000000000000000000000000003" +
                         "abcdef0000000000000000000000000000000000000000000000000000000000",
-            Hex.toHexString(function.encode(111, new byte[] {(byte) 0xab, (byte) 0xcd, (byte) 0xef}, 222)));
+            ByteUtil.toHexString(function.encode(111, new byte[] {(byte) 0xab, (byte) 0xcd, (byte) 0xef}, 222)));
 
     }
 

--- a/rskj-core/src/test/java/org/ethereum/core/AccountStateTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/AccountStateTest.java
@@ -20,9 +20,8 @@
 package org.ethereum.core;
 
 import co.rsk.core.Coin;
+import org.ethereum.util.ByteUtil;
 import org.junit.Test;
-
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
@@ -34,7 +33,7 @@ public class AccountStateTest {
     public void testGetEncoded() {
         String expected = "dc809a0100000000000000000000000000000000000000000000000000";
         AccountState acct = new AccountState(BigInteger.ZERO, new Coin(BigInteger.valueOf(2).pow(200)));
-        assertEquals(expected, Hex.toHexString(acct.getEncoded()));
+        assertEquals(expected, ByteUtil.toHexString(acct.getEncoded()));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/core/LogInfoTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/LogInfoTest.java
@@ -19,16 +19,14 @@
 
 package org.ethereum.core;
 
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.LogInfo;
-
+import org.junit.Ignore;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.bouncycastle.util.encoders.Hex;
-
-import org.junit.Ignore;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -47,8 +45,8 @@ public class LogInfoTest {
         LogInfo logInfo = new LogInfo(rlp);
 
         assertEquals("d5ccd26ba09ce1d85148b5081fa3ed77949417be",
-                Hex.toHexString(logInfo.getAddress()));
-        assertEquals("", Hex.toHexString(logInfo.getData()));
+                ByteUtil.toHexString(logInfo.getAddress()));
+        assertEquals("", ByteUtil.toHexString(logInfo.getData()));
 
         assertEquals("000000000000000000000000459d3a7595df9eba241365f4676803586d7d199c",
                 logInfo.getTopics().get(0).toString());
@@ -62,7 +60,7 @@ public class LogInfoTest {
     public void test_2() {
 
         LogInfo log = new LogInfo(Hex.decode("d5ccd26ba09ce1d85148b5081fa3ed77949417be"), null, null);
-        assertEquals("d794d5ccd26ba09ce1d85148b5081fa3ed77949417bec080", Hex.toHexString(log.getEncoded()));
+        assertEquals("d794d5ccd26ba09ce1d85148b5081fa3ed77949417bec080", ByteUtil.toHexString(log.getEncoded()));
 
         logger.info("{}", log);
     }
@@ -76,13 +74,13 @@ public class LogInfoTest {
         LogInfo logInfo = new LogInfo(rlp);
 
         assertEquals("f2b1a404bcb6112a0ff2c4197cb02f3de40018b3",
-                Hex.toHexString(logInfo.getAddress()));
+                ByteUtil.toHexString(logInfo.getAddress()));
 
         assertEquals("00800000000000000010000000000000000000000000002000000000000000000012000000100000000050000020000000000000000000000000000000000000",
                 logInfo.getBloom().toString());
 
         assertEquals("f85a94f2b1a404bcb6112a0ff2c4197cb02f3de40018b3f842a05a360139cff27713da0fe18a2100048a7ce1b7700c953a82bc3ff011437c8c2aa0588d7ddcc06c14843ea68e690dfd4ec91ba09a8ada15c5b7fa6fead9c8befe4b80",
-                Hex.toHexString(logInfo.getEncoded()));
+                ByteUtil.toHexString(logInfo.getEncoded()));
 
         logger.info("{}", logInfo);
     }

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionReceiptTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionReceiptTest.java
@@ -19,19 +19,17 @@
 
 package org.ethereum.core;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.rpc.TypeConverter;
-
+import org.ethereum.util.ByteUtil;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.bouncycastle.util.encoders.Hex;
-
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 
@@ -68,16 +66,16 @@ public class TransactionReceiptTest {
         assertEquals(1, txReceipt.getLogInfoList().size());
 
         assertEquals("966265cc49fa1f10f0445f035258d116563931022a3570a640af5d73a214a8da",
-                Hex.toHexString(txReceipt.getPostTxState()));
+                ByteUtil.toHexString(txReceipt.getPostTxState()));
 
         assertEquals("2b6f",
-                Hex.toHexString(txReceipt.getCumulativeGas()));
+                ByteUtil.toHexString(txReceipt.getCumulativeGas()));
 
         assertEquals("02",
-                Hex.toHexString(txReceipt.getGasUsed()));
+                ByteUtil.toHexString(txReceipt.getGasUsed()));
 
         assertEquals("00000010000000010000000000008000000000000000000000000000000000000000000000000000000000020000000000000014000000000400000000000440",
-                Hex.toHexString(txReceipt.getBloomFilter().getData()));
+                ByteUtil.toHexString(txReceipt.getBloomFilter().getData()));
 
         logger.info("{}", txReceipt);
     }

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionTest.java
@@ -114,23 +114,23 @@ public class TransactionTest {
 
         tx.sign(senderPrivKey);
 
-        System.out.println("v\t\t\t: " + Hex.toHexString(new byte[]{tx.getSignature().getV()}));
-        System.out.println("r\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getR())));
-        System.out.println("s\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getS())));
+        System.out.println("v\t\t\t: " + ByteUtil.toHexString(new byte[]{tx.getSignature().getV()}));
+        System.out.println("r\t\t\t: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getR())));
+        System.out.println("s\t\t\t: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getS())));
 
-        System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
+        System.out.println("RLP encoded tx\t\t: " + ByteUtil.toHexString(tx.getEncoded()));
 
         // retrieve the signer/sender of the transaction
         ECKey key = Secp256k1.getInstance().signatureToKey(tx.getHash().getBytes(), tx.getSignature());
 
-        System.out.println("Tx unsigned RLP\t\t: " + Hex.toHexString(tx.getEncodedRaw()));
-        System.out.println("Tx signed   RLP\t\t: " + Hex.toHexString(tx.getEncoded()));
+        System.out.println("Tx unsigned RLP\t\t: " + ByteUtil.toHexString(tx.getEncodedRaw()));
+        System.out.println("Tx signed   RLP\t\t: " + ByteUtil.toHexString(tx.getEncoded()));
 
-        System.out.println("Signature public key\t: " + Hex.toHexString(key.getPubKey()));
-        System.out.println("Sender is\t\t: " + Hex.toHexString(key.getAddress()));
+        System.out.println("Signature public key\t: " + ByteUtil.toHexString(key.getPubKey()));
+        System.out.println("Sender is\t\t: " + ByteUtil.toHexString(key.getAddress()));
 
         assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826",
-                Hex.toHexString(key.getAddress()));
+                ByteUtil.toHexString(key.getAddress()));
 
         System.out.println(tx.toString());
     }
@@ -155,23 +155,23 @@ public class TransactionTest {
 
         tx.sign(senderPrivKey);
 
-        System.out.println("v\t\t\t: " + Hex.toHexString(new byte[]{tx.getSignature().getV()}));
-        System.out.println("r\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getR())));
-        System.out.println("s\t\t\t: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getS())));
+        System.out.println("v\t\t\t: " + ByteUtil.toHexString(new byte[]{tx.getSignature().getV()}));
+        System.out.println("r\t\t\t: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getR())));
+        System.out.println("s\t\t\t: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(tx.getSignature().getS())));
 
-        System.out.println("RLP encoded tx\t\t: " + Hex.toHexString(tx.getEncoded()));
+        System.out.println("RLP encoded tx\t\t: " + ByteUtil.toHexString(tx.getEncoded()));
 
         // retrieve the signer/sender of the transaction
         ECKey key = Secp256k1.getInstance().signatureToKey(tx.getHash().getBytes(), tx.getSignature());
 
-        System.out.println("Tx unsigned RLP\t\t: " + Hex.toHexString(tx.getEncodedRaw()));
-        System.out.println("Tx signed   RLP\t\t: " + Hex.toHexString(tx.getEncoded()));
+        System.out.println("Tx unsigned RLP\t\t: " + ByteUtil.toHexString(tx.getEncodedRaw()));
+        System.out.println("Tx signed   RLP\t\t: " + ByteUtil.toHexString(tx.getEncoded()));
 
-        System.out.println("Signature public key\t: " + Hex.toHexString(key.getPubKey()));
-        System.out.println("Sender is\t\t: " + Hex.toHexString(key.getAddress()));
+        System.out.println("Signature public key\t: " + ByteUtil.toHexString(key.getPubKey()));
+        System.out.println("Sender is\t\t: " + ByteUtil.toHexString(key.getAddress()));
 
         assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826",
-                Hex.toHexString(key.getAddress()));
+                ByteUtil.toHexString(key.getAddress()));
     }
 
     // Testdata from: https://github.com/ethereum/tests/blob/master/txtest.json
@@ -194,17 +194,17 @@ public class TransactionTest {
         Transaction txSigned = new ImmutableTransaction(Hex.decode(RLP_ENCODED_SIGNED_TX));
 
         assertEquals(HASH_TX, txSigned.getHash());
-        assertEquals(RLP_ENCODED_SIGNED_TX, Hex.toHexString(txSigned.getEncoded()));
+        assertEquals(RLP_ENCODED_SIGNED_TX, ByteUtil.toHexString(txSigned.getEncoded()));
 
         assertEquals(BigInteger.ZERO, new BigInteger(1, txSigned.getNonce()));
         assertEquals(new BigInteger(1, testGasPrice), txSigned.getGasPrice().asBigInteger());
         assertEquals(new BigInteger(1, testGasLimit), new BigInteger(1, txSigned.getGasLimit()));
-        assertEquals(Hex.toHexString(testReceiveAddress), Hex.toHexString(txSigned.getReceiveAddress().getBytes()));
+        assertEquals(ByteUtil.toHexString(testReceiveAddress), ByteUtil.toHexString(txSigned.getReceiveAddress().getBytes()));
         assertEquals(new BigInteger(1, testValue), txSigned.getValue().asBigInteger());
         assertNull(txSigned.getData());
         assertEquals(27, txSigned.getSignature().getV());
-        assertEquals("eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4", Hex.toHexString(BigIntegers.asUnsignedByteArray(txSigned.getSignature().getR())));
-        assertEquals("14a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1", Hex.toHexString(BigIntegers.asUnsignedByteArray(txSigned.getSignature().getS())));
+        assertEquals("eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4", ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(txSigned.getSignature().getR())));
+        assertEquals("14a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1", ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(txSigned.getSignature().getS())));
     }
 
     @Ignore
@@ -213,19 +213,19 @@ public class TransactionTest {
         Transaction txUnsigned = new ImmutableTransaction(Hex.decode(RLP_ENCODED_UNSIGNED_TX));
 
         assertEquals(HASH_TX, txUnsigned.getHash());
-        assertEquals(RLP_ENCODED_UNSIGNED_TX, Hex.toHexString(txUnsigned.getEncoded()));
+        assertEquals(RLP_ENCODED_UNSIGNED_TX, ByteUtil.toHexString(txUnsigned.getEncoded()));
         txUnsigned.sign(Hex.decode(KEY));
-        assertEquals(RLP_ENCODED_SIGNED_TX, Hex.toHexString(txUnsigned.getEncoded()));
+        assertEquals(RLP_ENCODED_SIGNED_TX, ByteUtil.toHexString(txUnsigned.getEncoded()));
 
         assertEquals(BigInteger.ZERO, new BigInteger(1, txUnsigned.getNonce()));
         assertEquals(new BigInteger(1, testGasPrice), txUnsigned.getGasPrice().asBigInteger());
         assertEquals(new BigInteger(1, testGasLimit), new BigInteger(1, txUnsigned.getGasLimit()));
-        assertEquals(Hex.toHexString(testReceiveAddress), Hex.toHexString(txUnsigned.getReceiveAddress().getBytes()));
+        assertEquals(ByteUtil.toHexString(testReceiveAddress), ByteUtil.toHexString(txUnsigned.getReceiveAddress().getBytes()));
         assertEquals(new BigInteger(1, testValue), txUnsigned.getValue().asBigInteger());
         assertNull(txUnsigned.getData());
         assertEquals(27, txUnsigned.getSignature().getV());
-        assertEquals("eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4", Hex.toHexString(BigIntegers.asUnsignedByteArray(txUnsigned.getSignature().getR())));
-        assertEquals("14a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1", Hex.toHexString(BigIntegers.asUnsignedByteArray(txUnsigned.getSignature().getS())));
+        assertEquals("eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4", ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(txUnsigned.getSignature().getR())));
+        assertEquals("14a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1", ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(txUnsigned.getSignature().getS())));
     }
 
     @Ignore
@@ -233,23 +233,23 @@ public class TransactionTest {
     public void testTransactionFromNew1() throws MissingPrivateKeyException {
         Transaction txNew = new Transaction(testNonce, testGasPrice, testGasLimit, testReceiveAddress, testValue, testData);
 
-        assertEquals("", Hex.toHexString(txNew.getNonce()));
+        assertEquals("", ByteUtil.toHexString(txNew.getNonce()));
         assertEquals(new BigInteger(1, testGasPrice), txNew.getGasPrice().asBigInteger());
         assertEquals(new BigInteger(1, testGasLimit), new BigInteger(1, txNew.getGasLimit()));
-        assertEquals(Hex.toHexString(testReceiveAddress), Hex.toHexString(txNew.getReceiveAddress().getBytes()));
+        assertEquals(ByteUtil.toHexString(testReceiveAddress), ByteUtil.toHexString(txNew.getReceiveAddress().getBytes()));
         assertEquals(new BigInteger(1, testValue), txNew.getValue().asBigInteger());
-        assertEquals("", Hex.toHexString(txNew.getData()));
+        assertEquals("", ByteUtil.toHexString(txNew.getData()));
         assertNull(txNew.getSignature());
 
-        assertEquals(RLP_ENCODED_RAW_TX, Hex.toHexString(txNew.getEncodedRaw()));
+        assertEquals(RLP_ENCODED_RAW_TX, ByteUtil.toHexString(txNew.getEncodedRaw()));
         assertEquals(HASH_TX, txNew.getHash());
-        assertEquals(RLP_ENCODED_UNSIGNED_TX, Hex.toHexString(txNew.getEncoded()));
+        assertEquals(RLP_ENCODED_UNSIGNED_TX, ByteUtil.toHexString(txNew.getEncoded()));
         txNew.sign(Hex.decode(KEY));
-        assertEquals(RLP_ENCODED_SIGNED_TX, Hex.toHexString(txNew.getEncoded()));
+        assertEquals(RLP_ENCODED_SIGNED_TX, ByteUtil.toHexString(txNew.getEncoded()));
 
         assertEquals(27, txNew.getSignature().getV());
-        assertEquals("eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4", Hex.toHexString(BigIntegers.asUnsignedByteArray(txNew.getSignature().getR())));
-        assertEquals("14a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1", Hex.toHexString(BigIntegers.asUnsignedByteArray(txNew.getSignature().getS())));
+        assertEquals("eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4", ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(txNew.getSignature().getR())));
+        assertEquals("14a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1", ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(txNew.getSignature().getS())));
     }
 
     @Ignore
@@ -271,13 +271,13 @@ public class TransactionTest {
         Transaction tx = new Transaction(nonce, gasPrice, gas, recieveAddress, value, data);
 
         // Testing unsigned
-        String encodedUnsigned = Hex.toHexString(tx.getEncoded());
+        String encodedUnsigned = ByteUtil.toHexString(tx.getEncoded());
         assertEquals(RLP_TX_UNSIGNED, encodedUnsigned);
         assertEquals(HASH_TX_UNSIGNED, tx.getHash());
 
         // Testing signed
         tx.sign(privKeyBytes);
-        String encodedSigned = Hex.toHexString(tx.getEncoded());
+        String encodedSigned = ByteUtil.toHexString(tx.getEncoded());
         assertEquals(RLP_TX_SIGNED, encodedSigned);
         assertEquals(HASH_TX_UNSIGNED, tx.getHash());
     }
@@ -306,12 +306,12 @@ public class TransactionTest {
         byte[] payload = tx1.getEncoded();
 
 
-        System.out.println(Hex.toHexString(payload));
+        System.out.println(ByteUtil.toHexString(payload));
         Transaction tx2 = new ImmutableTransaction(payload);
 //        tx2.getSender();
 
-        String plainTx1 = Hex.toHexString(tx1.getEncodedRaw());
-        String plainTx2 = Hex.toHexString(tx2.getEncodedRaw());
+        String plainTx1 = ByteUtil.toHexString(tx1.getEncodedRaw());
+        String plainTx2 = ByteUtil.toHexString(tx2.getEncodedRaw());
 
 //        Transaction tx = new Transaction(Hex.decode(rlp));
 
@@ -348,7 +348,7 @@ public class TransactionTest {
         TransactionReceipt receipt = new TransactionReceipt(stateRoot, gasUsed, gasUsed, bloom, logs, TransactionReceipt.SUCCESS_STATUS);
 
         assertEquals(data,
-                Hex.toHexString(receipt.getEncoded()));
+                ByteUtil.toHexString(receipt.getEncoded()));
     }
 
     @Test
@@ -608,7 +608,7 @@ public class TransactionTest {
         );
 
         ECKey sender = ECKey.fromPrivate(Hex.decode("3ec771c31cac8c0dba77a69e503765701d3c2bb62435888d4ffa38fed60c445c"));
-        System.out.println("address: " + Hex.toHexString(sender.getAddress()));
+        System.out.println("address: " + ByteUtil.toHexString(sender.getAddress()));
 
         String code = "6060604052341561000c57fe5b5b6102938061001c6000396000f3006060604052361561004a576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806309e587a514610053578063de990da914610065575b6100515b5b565b005b341561005b57fe5b610063610077565b005b341561006d57fe5b610075610092565b005b3373ffffffffffffffffffffffffffffffffffffffff16ff5b565b60003090508073ffffffffffffffffffffffffffffffffffffffff166309e587a56040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401809050600060405180830381600087803b15156100fa57fe5b60325a03f1151561010757fe5b5050508073ffffffffffffffffffffffffffffffffffffffff166309e587a56040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401809050600060405180830381600087803b151561016d57fe5b60325a03f1151561017a57fe5b5050508073ffffffffffffffffffffffffffffffffffffffff166309e587a56040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401809050600060405180830381600087803b15156101e057fe5b60325a03f115156101ed57fe5b5050508073ffffffffffffffffffffffffffffffffffffffff166309e587a56040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401809050600060405180830381600087803b151561025357fe5b60325a03f1151561026057fe5b5050505b505600a165627a7a72305820084e74021c556522723b6725354378df2fb4b6732f82dd33f5daa29e2820b37c0029";
         String abi = "[{\"constant\":false,\"inputs\":[],\"name\":\"homicide\",\"outputs\":[],\"payable\":false,\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"multipleHomicide\",\"outputs\":[],\"payable\":false,\"type\":\"function\"},{\"payable\":true,\"type\":\"fallback\"}]";
@@ -687,7 +687,7 @@ public class TransactionTest {
         );
 
         ECKey sender = ECKey.fromPrivate(Hex.decode("3ec771c31cac8c0dba77a69e503765701d3c2bb62435888d4ffa38fed60c445c"));
-        System.out.println("address: " + Hex.toHexString(sender.getAddress()));
+        System.out.println("address: " + ByteUtil.toHexString(sender.getAddress()));
 
         // First contract code TestEventInvoked
         String code1 = "6060604052341561000f57600080fd5b5b60ae8061001e6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063b29f083514603d575b600080fd5b3415604757600080fd5b604d604f565b005b7f95481a538d62f8458d3cecac82408d5ff2630d8335962b1cdbac16f1a9b910e760405160405180910390a1600080fd5b5600a165627a7a723058207d93861daff7f4a0479d7f3eb0ca7ef5cef7e2bbf2c4637ab4f021ecc5afa7ad0029";
@@ -703,7 +703,7 @@ public class TransactionTest {
         executeTransaction(blockchain, blockStore, tx2, repository, blockTxSignatureCache);
 
         CallTransaction.Contract contract2 = new CallTransaction.Contract(abi2);
-        byte[] data = contract2.getByName("doIt").encode(Hex.toHexString(tx1.getContractAddress().getBytes()));
+        byte[] data = contract2.getByName("doIt").encode(ByteUtil.toHexString(tx1.getContractAddress().getBytes()));
 
         Transaction tx3 = createTx(sender, tx2.getContractAddress().getBytes(), data, repository);
         TransactionExecutor executor = executeTransaction(blockchain, blockStore, tx3, repository, blockTxSignatureCache);

--- a/rskj-core/src/test/java/org/ethereum/crypto/CryptoTest.java
+++ b/rskj-core/src/test/java/org/ethereum/crypto/CryptoTest.java
@@ -19,12 +19,6 @@
 
 package org.ethereum.crypto;
 
-import org.ethereum.util.Utils;
-
-import org.junit.Test;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.BufferedBlockCipher;
 import org.bouncycastle.crypto.KeyEncoder;
@@ -41,11 +35,15 @@ import org.bouncycastle.crypto.modes.SICBlockCipher;
 import org.bouncycastle.crypto.params.*;
 import org.bouncycastle.crypto.parsers.ECIESPublicKeyParser;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.util.Utils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
 
-import static org.ethereum.crypto.HashUtil.keccak256;
 import static org.junit.Assert.assertEquals;
 
 public class CryptoTest {
@@ -59,19 +57,19 @@ public class CryptoTest {
         byte[] result = HashUtil.keccak256("horse".getBytes());
 
         assertEquals("c87f65ff3f271bf5dc8643484f66b200109caffe4bf98c4cb393dc35740b28c0",
-                Hex.toHexString(result));
+                ByteUtil.toHexString(result));
 
         result = HashUtil.keccak256("cow".getBytes());
 
         assertEquals("c85ef7d79691fe79573b1a7064c19c1a9819ebdbd1faaab1a8ec92344438aaf4",
-                Hex.toHexString(result));
+                ByteUtil.toHexString(result));
     }
 
     @Test
     public void test3() {
         BigInteger privKey = new BigInteger("cd244b3015703ddf545595da06ada5516628c5feadbf49dc66049c4b370cc5d8", 16);
         byte[] addr = ECKey.fromPrivate(privKey).getAddress();
-        assertEquals("89b44e4d3c81ede05d0f5de8d1a68f754d73d997", Hex.toHexString(addr));
+        assertEquals("89b44e4d3c81ede05d0f5de8d1a68f754d73d997", ByteUtil.toHexString(addr));
     }
 
 
@@ -79,14 +77,14 @@ public class CryptoTest {
     public void test4() {
         byte[] cowBytes = HashUtil.keccak256("cow".getBytes());
         byte[] addr = ECKey.fromPrivate(cowBytes).getAddress();
-        assertEquals("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826", Hex.toHexString(addr).toUpperCase());
+        assertEquals("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826", ByteUtil.toHexString(addr).toUpperCase());
     }
 
     @Test
     public void test5() {
         byte[] horseBytes = HashUtil.keccak256("horse".getBytes());
         byte[] addr = ECKey.fromPrivate(horseBytes).getAddress();
-        assertEquals("13978AEE95F38490E9769C39B2773ED763D9CD5F", Hex.toHexString(addr).toUpperCase());
+        assertEquals("13978AEE95F38490E9769C39B2773ED763D9CD5F", ByteUtil.toHexString(addr).toUpperCase());
     }
 
     @Test   /* performance test */
@@ -98,7 +96,7 @@ public class CryptoTest {
 
             byte[] horseBytes = HashUtil.keccak256("horse".getBytes());
             byte[] addr = ECKey.fromPrivate(horseBytes).getAddress();
-            assertEquals("13978AEE95F38490E9769C39B2773ED763D9CD5F", Hex.toHexString(addr).toUpperCase());
+            assertEquals("13978AEE95F38490E9769C39B2773ED763D9CD5F", ByteUtil.toHexString(addr).toUpperCase());
         }
         long secondTime = System.currentTimeMillis();
         System.out.println(secondTime);
@@ -111,7 +109,7 @@ public class CryptoTest {
 
         String txRaw = "F89D80809400000000000000000000000000000000000000008609184E72A000822710B3606956330C0D630000003359366000530A0D630000003359602060005301356000533557604060005301600054630000000C5884336069571CA07F6EB94576346488C6253197BDE6A7E59DDC36F2773672C849402AA9C402C3C4A06D254E662BF7450DD8D835160CBB053463FED0B53F2CDD7F3EA8731919C8E8CC";
         byte[] txHashB = HashUtil.keccak256(Hex.decode(txRaw));
-        String txHash = Hex.toHexString(txHashB);
+        String txHash = ByteUtil.toHexString(txHashB);
         assertEquals("4b7d9670a92bf120d5b43400543b69304a14d767cf836a7f6abff4edde092895", txHash);
     }
 
@@ -121,7 +119,7 @@ public class CryptoTest {
         String blockRaw = "F885F8818080A01DCC4DE8DEC75D7AAB85B567B6CCD41AD312451B948A7413F0A142FD40D49347940000000000000000000000000000000000000000A0BCDDD284BF396739C224DBA0411566C891C32115FEB998A3E2B4E61F3F35582AA01DCC4DE8DEC75D7AAB85B567B6CCD41AD312451B948A7413F0A142FD40D4934783800000808080C0C0";
 
         byte[] blockHashB = HashUtil.keccak256(Hex.decode(blockRaw));
-        String blockHash = Hex.toHexString(blockHashB);
+        String blockHash = ByteUtil.toHexString(blockHashB);
         System.out.println(blockHash);
     }
 
@@ -138,7 +136,7 @@ public class CryptoTest {
     public void test10() {
         BigInteger privKey = new BigInteger("74ef8a796480dda87b4bc550b94c408ad386af0f65926a392136286784d63858", 16);
         byte[] addr = ECKey.fromPrivate(privKey).getAddress();
-        assertEquals("ba73facb4f8291f09f27f90fe1213537b910065e", Hex.toHexString(addr));
+        assertEquals("ba73facb4f8291f09f27f90fe1213537b910065e", ByteUtil.toHexString(addr));
     }
 
 
@@ -146,7 +144,7 @@ public class CryptoTest {
     public void test11() throws Throwable {
 
         byte[] keyBytes = HashUtil.keccak256("...".getBytes());
-        log.info("key: {}", Hex.toHexString(keyBytes));
+        log.info("key: {}", ByteUtil.toHexString(keyBytes));
         byte[] ivBytes = new byte[16];
         byte[] payload = Hex.decode("22400891000000000000000000000000");
 
@@ -161,15 +159,15 @@ public class CryptoTest {
         byte[] cipher = new byte[16];
         ctrEngine.processBlock(payload, 0, cipher, 0);
 
-        log.info("cipher: {}", Hex.toHexString(cipher));
+        log.info("cipher: {}", ByteUtil.toHexString(cipher));
 
 
         byte[] output = new byte[cipher.length];
         ctrEngine.init(false, params);
         ctrEngine.processBlock(cipher, 0, output, 0);
 
-        assertEquals(Hex.toHexString(output), Hex.toHexString(payload));
-        log.info("original: {}", Hex.toHexString(payload));
+        assertEquals(ByteUtil.toHexString(output), ByteUtil.toHexString(payload));
+        log.info("original: {}", ByteUtil.toHexString(payload));
     }
 
     @Test  // big packet encryption
@@ -208,9 +206,9 @@ public class CryptoTest {
             System.arraycopy(tmpBlock, 0, out, i, in.length - i);
         }
 
-        log.info("cipher: {}", Hex.toHexString(out));
+        log.info("cipher: {}", ByteUtil.toHexString(out));
 
-        assertEquals(Hex.toHexString(cipherText), Hex.toHexString(out));
+        assertEquals(ByteUtil.toHexString(cipherText), ByteUtil.toHexString(out));
     }
 
     @Test  // cpp keys demystified
@@ -223,9 +221,9 @@ public class CryptoTest {
 
         ECKey key = ECKey.fromPrivate(Hex.decode("a4627abc2a3c25315bff732cb22bc128f203912dd2a840f31e66efb27a47d2b1"));
 
-        String address = Hex.toHexString(key.getAddress());
-        String pubkey  = Hex.toHexString(key.getPubKeyPoint().getXCoord().getEncoded()) +  // X cord
-                         Hex.toHexString(key.getPubKeyPoint().getYCoord().getEncoded());   // Y cord
+        String address = ByteUtil.toHexString(key.getAddress());
+        String pubkey  = ByteUtil.toHexString(key.getPubKeyPoint().getXCoord().getEncoded()) +  // X cord
+                         ByteUtil.toHexString(key.getPubKeyPoint().getYCoord().getEncoded());   // Y cord
 
         log.info("address: " + address);
         log.info("pubkey: " + pubkey);
@@ -274,11 +272,11 @@ public class CryptoTest {
         iesEngine.init(true, p1.getPrivate(), p2.getPublic(), parametersWithIV);
 
         byte[] message = Hex.decode("010101");
-        log.info("payload: {}", Hex.toHexString(message));
+        log.info("payload: {}", ByteUtil.toHexString(message));
 
 
         byte[] cipher = iesEngine.processBlock(message, 0, message.length);
-        log.info("cipher: {}", Hex.toHexString(cipher));
+        log.info("cipher: {}", ByteUtil.toHexString(cipher));
 
 
         IESEngine decryptorIES_Engine = new IESEngine(
@@ -291,7 +289,7 @@ public class CryptoTest {
 
         byte[] orig = decryptorIES_Engine.processBlock(cipher, 0, cipher.length);
 
-        log.info("orig: " + Hex.toHexString(orig));
+        log.info("orig: " + ByteUtil.toHexString(orig));
     }
 
 
@@ -348,11 +346,11 @@ public class CryptoTest {
         iesEngine.init(myKey.getPublic(), parametersWithIV, kGen);
 
         byte[] message = Hex.decode("010101");
-        log.info("payload: {}", Hex.toHexString(message));
+        log.info("payload: {}", ByteUtil.toHexString(message));
 
 
         byte[] cipher = iesEngine.processBlock(message, 0, message.length);
-        log.info("cipher: {}", Hex.toHexString(cipher));
+        log.info("cipher: {}", ByteUtil.toHexString(cipher));
 
 
         IESEngine decryptorIES_Engine = new IESEngine(
@@ -365,7 +363,7 @@ public class CryptoTest {
 
         byte[] orig = decryptorIES_Engine.processBlock(cipher, 0, cipher.length);
 
-        log.info("orig: " + Hex.toHexString(orig));
+        log.info("orig: " + ByteUtil.toHexString(orig));
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/crypto/ECIESCoderTest.java
+++ b/rskj-core/src/test/java/org/ethereum/crypto/ECIESCoderTest.java
@@ -19,10 +19,11 @@
 
 package org.ethereum.crypto;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.math.BigInteger;
 
@@ -40,7 +41,7 @@ public class ECIESCoderTest {
         } catch (Throwable e) {e.printStackTrace();}
 
         Assert.assertEquals("802b052f8b066640bba94a4fc39d63815c377fced6fcb84d27f791c9921ddf3e9bf0108e298f490812847109cbd778fae393e80323fd643209841a3b7f110397f37ec61d84cea03dcc5e8385db93248584e8af4b4d1c832d8c7453c0089687a700",
-                Hex.toHexString(payload));
+                ByteUtil.toHexString(payload));
     }
 
 
@@ -59,14 +60,14 @@ public class ECIESCoderTest {
             cipher = ECIESCoder.encrypt(pubKeyPoint, payload);
         } catch (Throwable e) {e.printStackTrace();}
 
-        System.out.println(Hex.toHexString(cipher));
+        System.out.println(ByteUtil.toHexString(cipher));
 
         byte[] decrypted_payload = new byte[0];
         try {
             decrypted_payload = ECIESCoder.decrypt(privKey, cipher);
         } catch (Throwable e) {e.printStackTrace();}
 
-        System.out.println(Hex.toHexString(decrypted_payload));
+        System.out.println(ByteUtil.toHexString(decrypted_payload));
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/crypto/ECKeyTest.java
+++ b/rskj-core/src/test/java/org/ethereum/crypto/ECKeyTest.java
@@ -24,25 +24,20 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import org.ethereum.core.ImmutableTransaction;
-import org.ethereum.core.Transaction;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.security.SignatureException;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.junit.Assert.*;
 
 public class ECKeyTest {
@@ -75,8 +70,8 @@ public class ECKeyTest {
         assertTrue(key.isPubKeyCanonical());
         assertNotNull(key.getPubKey());
         assertNotNull(key.getPrivKeyBytes());
-        log.debug(Hex.toHexString(key.getPrivKeyBytes()) + " :Generated privkey");
-        log.debug(Hex.toHexString(key.getPubKey()) + " :Generated pubkey");
+        log.debug(ByteUtil.toHexString(key.getPrivKeyBytes()) + " :Generated privkey");
+        log.debug(ByteUtil.toHexString(key.getPubKey()) + " :Generated pubkey");
     }
 
     @Test
@@ -130,8 +125,8 @@ public class ECKeyTest {
     public void testEthereumSign() throws IOException {
         // TODO: Understand why key must be decompressed for this to work
         ECKey key = ECKey.fromPrivate(privateKey).decompress();
-        System.out.println("Secret\t: " + Hex.toHexString(key.getPrivKeyBytes()));
-        System.out.println("Pubkey\t: " + Hex.toHexString(key.getPubKey()));
+        System.out.println("Secret\t: " + ByteUtil.toHexString(key.getPrivKeyBytes()));
+        System.out.println("Pubkey\t: " + ByteUtil.toHexString(key.getPubKey()));
         System.out.println("Data\t: " + exampleMessage);
         byte[] messageHash = HashUtil.keccak256(exampleMessage.getBytes());
         ECDSASignature signature = ECDSASignature.fromSignature(key.sign(messageHash));
@@ -234,7 +229,7 @@ public class ECKeyTest {
     public void decryptAECSIC(){
         ECKey key = ECKey.fromPrivate(Hex.decode("abb51256c1324a1350598653f46aa3ad693ac3cf5d05f36eba3f495a1f51590f"));
         byte[] payload = key.decryptAES(Hex.decode("84a727bc81fa4b13947dc9728b88fd08"));
-        System.out.println(Hex.toHexString(payload));
+        System.out.println(ByteUtil.toHexString(payload));
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/crypto/signature/Secp256k1ServiceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/crypto/signature/Secp256k1ServiceTest.java
@@ -73,9 +73,9 @@ public abstract class Secp256k1ServiceTest {
         byte[] rawtx = Hex.decode("f82804881bc16d674ec8000094cd2a3d9f938e13cd947ec05abc7fe734df8dd8268609184e72a0006480");
         try {
             ECKey key = this.getSecp256k1().signatureToKey(HashUtil.keccak256(rawtx), sig);
-            logger.debug("Signature public key\t: {}", Hex.toHexString(key.getPubKey()));
-            logger.debug("Sender is\t\t: {}", Hex.toHexString(key.getAddress()));
-            assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", Hex.toHexString(key.getAddress()));
+            logger.debug("Signature public key\t: {}", ByteUtil.toHexString(key.getPubKey()));
+            logger.debug("Sender is\t\t: {}", ByteUtil.toHexString(key.getAddress()));
+            assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", ByteUtil.toHexString(key.getAddress()));
             assertTrue(this.getSecp256k1().verify(HashUtil.keccak256(rawtx), sig, key.getPubKey()));
         } catch (SignatureException e) {
             fail();
@@ -127,8 +127,8 @@ public abstract class Secp256k1ServiceTest {
         String receiver = "CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826";
         ECKey fromPrivate = ECKey.fromPrivate(pk);
         ECKey fromPrivateDecompress = fromPrivate.decompress();
-        String pubKeyExpected = Hex.toHexString(fromPrivateDecompress.getPubKey());
-        String addressExpected = Hex.toHexString(fromPrivateDecompress.getAddress());
+        String pubKeyExpected = ByteUtil.toHexString(fromPrivateDecompress.getPubKey());
+        String addressExpected = ByteUtil.toHexString(fromPrivateDecompress.getAddress());
 
         // Create tx and sign, then recover from serialized.
         Transaction newTx = new Transaction(2l, 2l, 2l, receiver, 2l, messageHash, (byte) 0);
@@ -140,13 +140,13 @@ public abstract class Secp256k1ServiceTest {
 
         // Recover PK and Address.
 
-        String pubKeyActual = Hex.toHexString(actualKey.getPubKey());
+        String pubKeyActual = ByteUtil.toHexString(actualKey.getPubKey());
         logger.debug("Signature public key\t: {}", pubKeyActual);
         assertEquals(pubKeyExpected, pubKeyActual);
         assertEquals(pubString, pubKeyActual);
         assertArrayEquals(pubKey, actualKey.getPubKey());
 
-        String addressActual = Hex.toHexString(actualKey.getAddress());
+        String addressActual = ByteUtil.toHexString(actualKey.getAddress());
         logger.debug("Sender is\t\t: {}", addressActual);
         assertEquals(addressExpected, addressActual);
     }

--- a/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
+++ b/rskj-core/src/test/java/org/ethereum/db/IndexedBlockStoreTest.java
@@ -30,6 +30,7 @@ import org.ethereum.core.BlockFactory;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.LevelDbDataSource;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.FileUtil;
 import org.ethereum.util.RskTestFactory;
 import org.junit.Assert;
@@ -52,7 +53,8 @@ import static co.rsk.core.BlockDifficulty.ZERO;
 import static org.ethereum.TestUtils.*;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class IndexedBlockStoreTest {
@@ -84,7 +86,7 @@ public class IndexedBlockStoreTest {
 
             if (block.getNumber() % 1000 == 0)
                 logger.info("adding block.hash: [{}] block.number: [{}]",
-                        block.getShortHash(),
+                        block.getPrintableHash(),
                         block.getNumber());
 
             blocks.add(block);
@@ -184,8 +186,8 @@ public class IndexedBlockStoreTest {
         List<byte[]> hashList =  indexedBlockStore.getListHashesEndWith(block.getHash().getBytes(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(8003 - i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
 
@@ -195,8 +197,8 @@ public class IndexedBlockStoreTest {
         hashList =  indexedBlockStore.getListHashesStartWith(block.getNumber(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(7003 + i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
 
@@ -292,8 +294,8 @@ public class IndexedBlockStoreTest {
         List<byte[]> hashList =  indexedBlockStore.getListHashesEndWith(block.getHash().getBytes(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(8003 - i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
 
@@ -303,8 +305,8 @@ public class IndexedBlockStoreTest {
         hashList =  indexedBlockStore.getListHashesStartWith(block.getNumber(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(7003 + i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
 
@@ -402,8 +404,8 @@ public class IndexedBlockStoreTest {
         List<byte[]> hashList =  indexedBlockStore.getListHashesEndWith(block.getHash().getBytes(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(8003 - i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
 
@@ -413,8 +415,8 @@ public class IndexedBlockStoreTest {
         hashList =  indexedBlockStore.getListHashesStartWith(block.getNumber(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(7003 + i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
     }
@@ -519,8 +521,8 @@ public class IndexedBlockStoreTest {
         List<byte[]> hashList =  indexedBlockStore.getListHashesEndWith(block.getHash().getBytes(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(8003 - i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
 
@@ -530,8 +532,8 @@ public class IndexedBlockStoreTest {
         hashList =  indexedBlockStore.getListHashesStartWith(block.getNumber(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(7003 + i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
 
@@ -553,8 +555,8 @@ public class IndexedBlockStoreTest {
         hashList =  indexedBlockStore.getListHashesStartWith(block.getNumber(), 100);
         for (int i = 0; i < 100; ++i){
             block  = blocks.get(7003 + i);
-            String hash  = Hex.toHexString(hashList.get(i));
-            String hash_ = Hex.toHexString( block.getHash().getBytes() );
+            String hash  = ByteUtil.toHexString(hashList.get(i));
+            String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
             assertEquals(hash_, hash);
         }
 
@@ -674,8 +676,8 @@ public class IndexedBlockStoreTest {
             List<byte[]> hashList =  indexedBlockStore.getListHashesEndWith(block.getHash().getBytes(), 100);
             for (int i = 0; i < 100; ++i){
                 block  = blocks.get(8003 - i);
-                String hash  = Hex.toHexString(hashList.get(i));
-                String hash_ = Hex.toHexString( block.getHash().getBytes() );
+                String hash  = ByteUtil.toHexString(hashList.get(i));
+                String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
                 assertEquals(hash_, hash);
             }
 
@@ -685,8 +687,8 @@ public class IndexedBlockStoreTest {
             hashList =  indexedBlockStore.getListHashesStartWith(block.getNumber(), 100);
             for (int i = 0; i < 100; ++i){
                 block  = blocks.get(7003 + i);
-                String hash  = Hex.toHexString(hashList.get(i));
-                String hash_ = Hex.toHexString( block.getHash().getBytes() );
+                String hash  = ByteUtil.toHexString(hashList.get(i));
+                String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
                 assertEquals(hash_, hash);
             }
 
@@ -710,8 +712,8 @@ public class IndexedBlockStoreTest {
             hashList =  indexedBlockStore.getListHashesStartWith(block.getNumber(), 100);
             for (int i = 0; i < 100; ++i){
                 block  = blocks.get(7003 + i);
-                String hash  = Hex.toHexString(hashList.get(i));
-                String hash_ = Hex.toHexString( block.getHash().getBytes() );
+                String hash  = ByteUtil.toHexString(hashList.get(i));
+                String hash_ = ByteUtil.toHexString( block.getHash().getBytes() );
                 assertEquals(hash_, hash);
             }
         } finally {
@@ -933,7 +935,7 @@ public class IndexedBlockStoreTest {
             for (Block currBlock : forkLine) {
                 Long number = currBlock.getNumber();
                 Block chainBlock = indexedBlockStore.getChainBlockByNumber(number);
-                assertEquals(currBlock.getShortHash(), chainBlock.getShortHash());
+                assertEquals(currBlock.getPrintableHash(), chainBlock.getPrintableHash());
             }
 
             // Assert that all fork moved to the main line
@@ -944,7 +946,7 @@ public class IndexedBlockStoreTest {
             for (Block currBlock : bestLine) {
                 Long number = currBlock.getNumber();
                 Block chainBlock = indexedBlockStore.getChainBlockByNumber(number);
-                assertEquals(currBlock.getShortHash(), chainBlock.getShortHash());
+                assertEquals(currBlock.getPrintableHash(), chainBlock.getPrintableHash());
             }
         } finally {
             blocksDB.close();

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/AccountState.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/AccountState.java
@@ -21,10 +21,10 @@ package org.ethereum.jsontestsuite;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.json.simple.JSONObject;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.util.HashMap;
@@ -105,8 +105,8 @@ public class AccountState {
         return "AccountState{" +
                 "address=" + address +
                 ", balance=" + balance +
-                ", code=" + Hex.toHexString(code) +
-                ", nonce=" + Hex.toHexString(nonce) +
+                ", code=" + ByteUtil.toHexString(code) +
+                ", nonce=" + ByteUtil.toHexString(nonce) +
                 ", storage=" + storage +
                 '}';
     }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/CallCreate.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/CallCreate.java
@@ -19,9 +19,9 @@
 
 package org.ethereum.jsontestsuite;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.util.ByteUtil;
 import org.json.simple.JSONObject;
-import org.bouncycastle.util.encoders.Hex;
 
 /**
  * @author Roman Mandeleil
@@ -78,10 +78,10 @@ public class CallCreate {
     @Override
     public String toString() {
         return "CallCreate{" +
-                "data=" + Hex.toHexString(data) +
-                ", destination=" + Hex.toHexString(destination) +
+                "data=" + ByteUtil.toHexString(data) +
+                ", destination=" + ByteUtil.toHexString(destination) +
                 ", gasLimit=" + Long.toHexString(gasLimit) +
-                ", value=" + Hex.toHexString(value) +
+                ", value=" + ByteUtil.toHexString(value) +
                 '}';
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/CryptoTestCase.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/CryptoTestCase.java
@@ -19,11 +19,12 @@
 
 package org.ethereum.jsontestsuite;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECIESCoder;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
@@ -58,12 +59,12 @@ public class CryptoTestCase {
 
         if (decryption_type.equals("ecies_sec1_altered"))
             try {
-                resultPayload = ECIESCoder.decrypt(new BigInteger(Hex.toHexString(key), 16), cipher);
+                resultPayload = ECIESCoder.decrypt(new BigInteger(ByteUtil.toHexString(key), 16), cipher);
             } catch (Throwable e) {e.printStackTrace();}
 
-        if (!Hex.toHexString(resultPayload).equals(payload)){
+        if (!ByteUtil.toHexString(resultPayload).equals(payload)){
             String error = String.format("payload should be: %s, but got that result: %s  ",
-                    payload, Hex.toHexString(resultPayload));
+                    payload, ByteUtil.toHexString(resultPayload));
             logger.info(error);
 
             System.exit(-1);

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/Env.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/Env.java
@@ -19,9 +19,10 @@
 
 package org.ethereum.jsontestsuite;
 
-import org.json.simple.JSONObject;
 import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
+import org.json.simple.JSONObject;
 
 /**
  * @author Roman Mandeleil
@@ -103,12 +104,12 @@ public class Env {
     @Override
     public String toString() {
         return "Env{" +
-                "currentCoinbase=" + Hex.toHexString(currentCoinbase) +
-                ", currentDifficulty=" + Hex.toHexString(currentDifficulty) +
-                ", currentGasLimit=" + Hex.toHexString(currentGasLimit) +
-                ", currentNumber=" + Hex.toHexString(currentNumber) +
-                ", currentTimestamp=" + Hex.toHexString(currentTimestamp) +
-                ", previousHash=" + Hex.toHexString(previousHash) +
+                "currentCoinbase=" + ByteUtil.toHexString(currentCoinbase) +
+                ", currentDifficulty=" + ByteUtil.toHexString(currentDifficulty) +
+                ", currentGasLimit=" + ByteUtil.toHexString(currentGasLimit) +
+                ", currentNumber=" + ByteUtil.toHexString(currentNumber) +
+                ", currentTimestamp=" + ByteUtil.toHexString(currentTimestamp) +
+                ", previousHash=" + ByteUtil.toHexString(previousHash) +
                 '}';
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/Exec.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/Exec.java
@@ -19,9 +19,9 @@
 
 package org.ethereum.jsontestsuite;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.util.ByteUtil;
 import org.json.simple.JSONObject;
-import org.bouncycastle.util.encoders.Hex;
 
 /**
  * @author Roman Mandeleil
@@ -125,14 +125,14 @@ public class Exec {
     @Override
     public String toString() {
         return "Exec{" +
-                "address=" + Hex.toHexString(address) +
-                ", caller=" + Hex.toHexString(caller) +
-                ", data=" + Hex.toHexString(data) +
-                ", code=" + Hex.toHexString(data) +
-                ", gas=" + Hex.toHexString(gas) +
-                ", gasPrice=" + Hex.toHexString(gasPrice) +
-                ", origin=" + Hex.toHexString(origin) +
-                ", value=" + Hex.toHexString(value) +
+                "address=" + ByteUtil.toHexString(address) +
+                ", caller=" + ByteUtil.toHexString(caller) +
+                ", data=" + ByteUtil.toHexString(data) +
+                ", code=" + ByteUtil.toHexString(data) +
+                ", gas=" + ByteUtil.toHexString(gas) +
+                ", gasPrice=" + ByteUtil.toHexString(gasPrice) +
+                ", origin=" + ByteUtil.toHexString(origin) +
+                ", value=" + ByteUtil.toHexString(value) +
                 '}';
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/Logs.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/Logs.java
@@ -19,11 +19,12 @@
 
 package org.ethereum.jsontestsuite;
 
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -68,8 +69,8 @@ public class Logs {
 
             LogInfo realLog = logs.get(i);
 
-            String postAddress = Hex.toHexString(postLog.getAddress());
-            String realAddress = Hex.toHexString(realLog.getAddress());
+            String postAddress = ByteUtil.toHexString(postLog.getAddress());
+            String realAddress = ByteUtil.toHexString(realLog.getAddress());
 
             if (!postAddress.equals(realAddress)) {
 
@@ -78,8 +79,8 @@ public class Logs {
                 results.add(formattedString);
             }
 
-            String postData = Hex.toHexString(postLog.getData());
-            String realData = Hex.toHexString(realLog.getData());
+            String postData = ByteUtil.toHexString(postLog.getData());
+            String realData = ByteUtil.toHexString(realLog.getData());
 
             if (!postData.equals(realData)) {
 
@@ -88,8 +89,8 @@ public class Logs {
                 results.add(formattedString);
             }
 
-            String postBloom = Hex.toHexString(postLog.getBloom().getData());
-            String realBloom = Hex.toHexString(realLog.getBloom().getData());
+            String postBloom = ByteUtil.toHexString(postLog.getBloom().getData());
+            String realBloom = ByteUtil.toHexString(realLog.getBloom().getData());
 
             if (!postData.equals(realData)) {
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/RLPTestCase.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/RLPTestCase.java
@@ -20,13 +20,13 @@
 package org.ethereum.jsontestsuite;
 
 
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPElement;
 import org.ethereum.util.RLPList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -70,7 +70,7 @@ public class RLPTestCase {
     public void doEncode() {
         byte[] in = buildRLP(this.in);
         String expected = this.out.toLowerCase();
-        String computed = Hex.toHexString(in);
+        String computed = ByteUtil.toHexString(in);
         this.computed.add(computed);
         this.expected.add(expected);
     }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestCase.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestCase.java
@@ -20,12 +20,12 @@
 package org.ethereum.jsontestsuite;
 
 import co.rsk.core.RskAddress;
+import org.bouncycastle.util.BigIntegers;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.util.ByteUtil;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
-import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -190,8 +190,8 @@ public class TestCase {
         return "TestCase{" +
                 "" + env +
                 ", " + exec +
-                ", gas=" + Hex.toHexString(gas) +
-                ", out=" + Hex.toHexString(out) +
+                ", gas=" + ByteUtil.toHexString(gas) +
+                ", out=" + ByteUtil.toHexString(out) +
                 ", pre=" + pre +
                 ", post=" + post +
                 ", callcreates=" + callCreateList +

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -68,7 +68,7 @@ import java.lang.management.ThreadMXBean;
 import java.math.BigInteger;
 import java.util.*;
 
-import static org.ethereum.crypto.HashUtil.shortHash;
+import static org.ethereum.crypto.HashUtil.toPrintableHash;
 import static org.ethereum.json.Utils.parseData;
 import static org.ethereum.json.Utils.parseNumericData;
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
@@ -202,16 +202,16 @@ public class TestRunner {
         for (Block block : blockTraffic) {
 
             ImportResult importResult = blockchain.tryToConnect(block);
-            logger.debug("{} ~ {} difficulty: {} ::: {}", block.getShortHash(), shortHash(block.getParentHash().getBytes()),
+            logger.debug("{} ~ {} difficulty: {} ::: {}", block.getPrintableHash(), toPrintableHash(block.getParentHash().getBytes()),
                     block.getCumulativeDifficulty(), importResult.toString());
         }
 
         //Check state root matches last valid block
         List<String> results = new ArrayList<>();
-        String currRoot = Hex.toHexString(repository.getRoot());
+        String currRoot = ByteUtil.toHexString(repository.getRoot());
 
         byte[] bestHash = Hex.decode(testCase.getLastblockhash());
-        String finalRoot = Hex.toHexString(blockStore.getBlockByHash(bestHash).getStateRoot());
+        String finalRoot = ByteUtil.toHexString(blockStore.getBlockByHash(bestHash).getStateRoot());
 
         if (validateStateRoots) {
             if (!finalRoot.equals(currRoot)) {
@@ -392,8 +392,8 @@ public class TestRunner {
                         String output =
                                 String.format("The code result is different. account: [ %s ],  expectedCode: [ %s ] is actualCode: [ %s ] ",
                                         addr,
-                                        Hex.toHexString(expectedCode),
-                                        Hex.toHexString(actualCode));
+                                        ByteUtil.toHexString(expectedCode),
+                                        ByteUtil.toHexString(actualCode));
                         logger.info(output);
                         results.add(output);
                     }
@@ -409,7 +409,7 @@ public class TestRunner {
                         if (!program.getStorage().isContract(accountAddress)) {
                             String output =
                                     String.format("Storage raw doesn't exist: key [ %s ], expectedValue: [ %s ]",
-                                            Hex.toHexString(storageKey.getData()),
+                                            ByteUtil.toHexString(storageKey.getData()),
                                             expectedStValue.toString()
                                     );
 
@@ -431,9 +431,9 @@ public class TestRunner {
 
                             String output =
                                     String.format("Storage value different: key [ %s ], expectedValue: [ %s ], actualValue: [ %s ]",
-                                            Hex.toHexString(storageKey.getData()),
+                                            ByteUtil.toHexString(storageKey.getData()),
                                             expectedStValue.toString(),
-                                            actualValue == null ? "" : Hex.toHexString(actualValue));
+                                            actualValue == null ? "" : ByteUtil.toHexString(actualValue));
                             logger.info(output);
                             results.add(output);
                         }
@@ -463,14 +463,14 @@ public class TestRunner {
                         } else {
                             if (!Arrays.equals(expectedLogInfo.getAddress(), foundLogInfo.getAddress())) {
                                 String output =
-                                        String.format("Expected address [ %s ], found [ %s ]", Hex.toHexString(expectedLogInfo.getAddress()), Hex.toHexString(foundLogInfo.getAddress()));
+                                        String.format("Expected address [ %s ], found [ %s ]", ByteUtil.toHexString(expectedLogInfo.getAddress()), ByteUtil.toHexString(foundLogInfo.getAddress()));
                                 logger.info(output);
                                 results.add(output);
                             }
 
                             if (!Arrays.equals(expectedLogInfo.getData(), foundLogInfo.getData())) {
                                 String output =
-                                        String.format("Expected data [ %s ], found [ %s ]", Hex.toHexString(expectedLogInfo.getData()), Hex.toHexString(foundLogInfo.getData()));
+                                        String.format("Expected data [ %s ], found [ %s ]", ByteUtil.toHexString(expectedLogInfo.getData()), ByteUtil.toHexString(foundLogInfo.getData()));
                                 logger.info(output);
                                 results.add(output);
                             }
@@ -478,8 +478,8 @@ public class TestRunner {
                             if (!expectedLogInfo.getBloom().equals(foundLogInfo.getBloom())) {
                                 String output =
                                         String.format("Expected bloom [ %s ], found [ %s ]",
-                                                Hex.toHexString(expectedLogInfo.getBloom().getData()),
-                                                Hex.toHexString(foundLogInfo.getBloom().getData()));
+                                                ByteUtil.toHexString(expectedLogInfo.getBloom().getData()),
+                                                ByteUtil.toHexString(foundLogInfo.getBloom().getData()));
                                 logger.info(output);
                                 results.add(output);
                             }
@@ -497,7 +497,7 @@ public class TestRunner {
 
                                     if (!Arrays.equals(topic.getData(), foundTopic)) {
                                         String output =
-                                                String.format("Expected topic [ %s ], found [ %s ]", Hex.toHexString(topic.getData()), Hex.toHexString(foundTopic));
+                                                String.format("Expected topic [ %s ], found [ %s ]", ByteUtil.toHexString(topic.getData()), ByteUtil.toHexString(foundTopic));
                                         logger.info(output);
                                         results.add(output);
                                     }
@@ -532,10 +532,10 @@ public class TestRunner {
 
                         String output =
                                 String.format("Missing call/create invoke: to: [ %s ], data: [ %s ], gas: [ %s ], value: [ %s ]",
-                                        Hex.toHexString(expectedCallCreate.getDestination()),
-                                        Hex.toHexString(expectedCallCreate.getData()),
+                                        ByteUtil.toHexString(expectedCallCreate.getDestination()),
+                                        ByteUtil.toHexString(expectedCallCreate.getData()),
                                         Long.toHexString(expectedCallCreate.getGasLimit()),
-                                        Hex.toHexString(expectedCallCreate.getValue()));
+                                        ByteUtil.toHexString(expectedCallCreate.getValue()));
                         logger.info(output);
                         results.add(output);
 
@@ -549,8 +549,8 @@ public class TestRunner {
 
                         String output =
                                 String.format("Call/Create destination is different. Expected: [ %s ], result: [ %s ]",
-                                        Hex.toHexString(expectedCallCreate.getDestination()),
-                                        Hex.toHexString(resultCallCreate.getDestination()));
+                                        ByteUtil.toHexString(expectedCallCreate.getDestination()),
+                                        ByteUtil.toHexString(resultCallCreate.getDestination()));
                         logger.info(output);
                         results.add(output);
                     }
@@ -562,8 +562,8 @@ public class TestRunner {
 
                         String output =
                                 String.format("Call/Create data is different. Expected: [ %s ], result: [ %s ]",
-                                        Hex.toHexString(expectedCallCreate.getData()),
-                                        Hex.toHexString(resultCallCreate.getData()));
+                                        ByteUtil.toHexString(expectedCallCreate.getData()),
+                                        ByteUtil.toHexString(resultCallCreate.getData()));
                         logger.info(output);
                         results.add(output);
                     }
@@ -586,8 +586,8 @@ public class TestRunner {
                     if (!assertValue) {
                         String output =
                                 String.format("Call/Create value is different. Expected: [ %s ], result: [ %s ]",
-                                        Hex.toHexString(expectedCallCreate.getValue()),
-                                        Hex.toHexString(resultCallCreate.getValue()));
+                                        ByteUtil.toHexString(expectedCallCreate.getValue()),
+                                        ByteUtil.toHexString(resultCallCreate.getValue()));
                         logger.info(output);
                         results.add(output);
                     }
@@ -604,8 +604,8 @@ public class TestRunner {
 
                     String output =
                             String.format("HReturn is different. Expected hReturn: [ %s ], actual hReturn: [ %s ]",
-                                    Hex.toHexString(expectedHReturn),
-                                    Hex.toHexString(actualHReturn));
+                                    ByteUtil.toHexString(expectedHReturn),
+                                    ByteUtil.toHexString(actualHReturn));
                     logger.info(output);
                     results.add(output);
                 }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/Transaction.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/Transaction.java
@@ -23,7 +23,7 @@ import org.json.simple.JSONObject;
 
 import java.math.BigInteger;
 
-import static org.ethereum.util.ByteUtil.toHexString;
+import static org.ethereum.util.ByteUtil.toHexStringOrEmpty;
 
 /**
  * @author Roman Mandeleil
@@ -101,12 +101,12 @@ public class Transaction {
     @Override
     public String toString() {
         return "Transaction{" +
-                "data=" + toHexString(data) +
+                "data=" + toHexStringOrEmpty(data) +
                 ", gasLimit=" + gasLimit +
                 ", gasPrice=" + gasPrice +
                 ", nonce=" + nonce +
-                ", secretKey=" + toHexString(secretKey) +
-                ", to=" + toHexString(to) +
+                ", secretKey=" + toHexStringOrEmpty(secretKey) +
+                ", to=" + toHexStringOrEmpty(to) +
                 ", value=" + value +
                 '}';
     }

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -21,7 +21,6 @@ package org.ethereum.jsontestsuite.runners;
 
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.config.TestSystemProperties;
-import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockChainImpl;
@@ -33,7 +32,6 @@ import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
 import co.rsk.trie.TrieConverter;
 import co.rsk.trie.TrieStoreImpl;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.*;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
@@ -64,7 +62,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
 import static org.ethereum.util.ByteUtil.byteArrayToLong;
 
 public class StateTestRunner {
@@ -192,7 +189,7 @@ public class StateTestRunner {
 
         logger.info("--------- POST Validation---------");
         List<String> outputResults =
-                OutputValidator.valid(Hex.toHexString(programResult.getHReturn()), stateTestCase.getOut(),vStats);
+                OutputValidator.valid(ByteUtil.toHexString(programResult.getHReturn()), stateTestCase.getOut(),vStats);
 
         List<String> results = new ArrayList<>();
         results.addAll(repoResults);

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/AccountValidator.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/AccountValidator.java
@@ -21,10 +21,10 @@ package org.ethereum.jsontestsuite.validators;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.AccountState;
 import org.ethereum.core.Repository;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 
 import java.math.BigInteger;
@@ -85,7 +85,7 @@ public class AccountValidator {
         if (vStats!=null) vStats.accountChecks++;
         if (!Arrays.equals(expectedRepository.getCode(addr), currentRepository.getCode(addr))) {
             String formattedString = String.format("Account: %s: has unexpected code, expected code: %s found code: %s",
-                    addr, Hex.toHexString(expectedRepository.getCode(addr)), Hex.toHexString(currentRepository.getCode(addr)));
+                    addr, ByteUtil.toHexString(expectedRepository.getCode(addr)), ByteUtil.toHexString(currentRepository.getCode(addr)));
             results.add(formattedString);
         }
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/BlockHeaderValidator.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/BlockHeaderValidator.java
@@ -24,7 +24,7 @@ import org.ethereum.core.BlockHeader;
 import java.math.BigInteger;
 import java.util.ArrayList;
 
-import static org.ethereum.util.ByteUtil.toHexString;
+import static org.ethereum.util.ByteUtil.toHexStringOrEmpty;
 
 public class BlockHeaderValidator {
 
@@ -37,20 +37,20 @@ public class BlockHeaderValidator {
 
             String output =
                     String.format("wrong block.parentHash: \n expected: %s \n got: %s",
-                            toHexString(valid.getParentHash().getBytes()),
-                            toHexString(orig.getParentHash().getBytes())
+                            toHexStringOrEmpty(valid.getParentHash().getBytes()),
+                            toHexStringOrEmpty(orig.getParentHash().getBytes())
                     );
 
             outputSummary.add(output);
         }
         if (vStats!=null) vStats.blockChecks++;
-        if (!toHexString(orig.getUnclesHash())
-                .equals(toHexString(valid.getUnclesHash()))) {
+        if (!toHexStringOrEmpty(orig.getUnclesHash())
+                .equals(toHexStringOrEmpty(valid.getUnclesHash()))) {
 
             String output =
                     String.format("wrong block.unclesHash: \n expected: %s \n got: %s",
-                            toHexString(valid.getUnclesHash()),
-                            toHexString(orig.getUnclesHash())
+                            toHexStringOrEmpty(valid.getUnclesHash()),
+                            toHexStringOrEmpty(orig.getUnclesHash())
                     );
 
             outputSummary.add(output);
@@ -67,49 +67,49 @@ public class BlockHeaderValidator {
             outputSummary.add(output);
         }
         if (vStats!=null) vStats.blockChecks++;
-        if (!toHexString(orig.getStateRoot())
-                .equals(toHexString(valid.getStateRoot()))) {
+        if (!toHexStringOrEmpty(orig.getStateRoot())
+                .equals(toHexStringOrEmpty(valid.getStateRoot()))) {
 
             String output =
                     String.format("wrong block.stateRoot: \n expected: %s \n got: %s",
-                            toHexString(valid.getStateRoot()),
-                            toHexString(orig.getStateRoot())
+                            toHexStringOrEmpty(valid.getStateRoot()),
+                            toHexStringOrEmpty(orig.getStateRoot())
                     );
 
             outputSummary.add(output);
         }
         if (vStats!=null) vStats.blockChecks++;
-        if (!toHexString(orig.getTxTrieRoot())
-                .equals(toHexString(valid.getTxTrieRoot()))) {
+        if (!toHexStringOrEmpty(orig.getTxTrieRoot())
+                .equals(toHexStringOrEmpty(valid.getTxTrieRoot()))) {
 
             String output =
                     String.format("wrong block.txTrieRoot: \n expected: %s \n got: %s",
-                            toHexString(valid.getTxTrieRoot()),
-                            toHexString(orig.getTxTrieRoot())
+                            toHexStringOrEmpty(valid.getTxTrieRoot()),
+                            toHexStringOrEmpty(orig.getTxTrieRoot())
                     );
 
             outputSummary.add(output);
         }
         if (vStats!=null) vStats.blockChecks++;
-        if (!toHexString(orig.getReceiptsRoot())
-                .equals(toHexString(valid.getReceiptsRoot()))) {
+        if (!toHexStringOrEmpty(orig.getReceiptsRoot())
+                .equals(toHexStringOrEmpty(valid.getReceiptsRoot()))) {
 
             String output =
                     String.format("wrong block.receiptsRoot: \n expected: %s \n got: %s",
-                            toHexString(valid.getReceiptsRoot()),
-                            toHexString(orig.getReceiptsRoot())
+                            toHexStringOrEmpty(valid.getReceiptsRoot()),
+                            toHexStringOrEmpty(orig.getReceiptsRoot())
                     );
 
             outputSummary.add(output);
         }
         if (vStats!=null) vStats.blockChecks++;
-        if (!toHexString(orig.getLogsBloom())
-                .equals(toHexString(valid.getLogsBloom()))) {
+        if (!toHexStringOrEmpty(orig.getLogsBloom())
+                .equals(toHexStringOrEmpty(valid.getLogsBloom()))) {
 
             String output =
                     String.format("wrong block.logsBloom: \n expected: %s \n got: %s",
-                            toHexString(valid.getLogsBloom()),
-                            toHexString(orig.getLogsBloom())
+                            toHexStringOrEmpty(valid.getLogsBloom()),
+                            toHexStringOrEmpty(orig.getLogsBloom())
                     );
 
             outputSummary.add(output);
@@ -170,13 +170,13 @@ public class BlockHeaderValidator {
             outputSummary.add(output);
         }
         if (vStats!=null) vStats.blockChecks++;
-        if (!toHexString(orig.getExtraData())
-                .equals(toHexString(valid.getExtraData()))) {
+        if (!toHexStringOrEmpty(orig.getExtraData())
+                .equals(toHexStringOrEmpty(valid.getExtraData()))) {
 
             String output =
                     String.format("wrong block.extraData: \n expected: %s \n got: %s",
-                            toHexString(valid.getExtraData()),
-                            toHexString(orig.getExtraData())
+                            toHexStringOrEmpty(valid.getExtraData()),
+                            toHexStringOrEmpty(orig.getExtraData())
                     );
 
             outputSummary.add(output);

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/LogsValidator.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/LogsValidator.java
@@ -19,9 +19,9 @@
 
 package org.ethereum.jsontestsuite.validators;
 
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +37,7 @@ public class LogsValidator {
             if (vStats!=null) vStats.logChecks++;
             if (origLogs == null || origLogs.size() - 1 < i){
                 String formattedString = String.format("Log: %s: was expected but doesn't exist: address: %s",
-                        i, Hex.toHexString(postLog.getAddress()));
+                        i, ByteUtil.toHexString(postLog.getAddress()));
                 results.add(formattedString);
 
                 continue;
@@ -45,8 +45,8 @@ public class LogsValidator {
 
             LogInfo realLog = origLogs.get(i);
 
-            String postAddress = Hex.toHexString(postLog.getAddress());
-            String realAddress = Hex.toHexString(realLog.getAddress());
+            String postAddress = ByteUtil.toHexString(postLog.getAddress());
+            String realAddress = ByteUtil.toHexString(realLog.getAddress());
             if (vStats!=null) vStats.logChecks++;
             if (!postAddress.equals(realAddress)) {
 
@@ -55,8 +55,8 @@ public class LogsValidator {
                 results.add(formattedString);
             }
 
-            String postData = Hex.toHexString(postLog.getData());
-            String realData = Hex.toHexString(realLog.getData());
+            String postData = ByteUtil.toHexString(postLog.getData());
+            String realData = ByteUtil.toHexString(realLog.getData());
             if (vStats!=null) vStats.logChecks++;
             if (!postData.equals(realData)) {
 
@@ -65,8 +65,8 @@ public class LogsValidator {
                 results.add(formattedString);
             }
 
-            String postBloom = Hex.toHexString(postLog.getBloom().getData());
-            String realBloom = Hex.toHexString(realLog.getBloom().getData());
+            String postBloom = ByteUtil.toHexString(postLog.getBloom().getData());
+            String realBloom = ByteUtil.toHexString(realLog.getBloom().getData());
             if (vStats!=null) vStats.logChecks++;
             if (!postData.equals(realData)) {
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/OutputValidator.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/OutputValidator.java
@@ -19,7 +19,7 @@
 
 package org.ethereum.jsontestsuite.validators;
 
-import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +32,7 @@ public class OutputValidator {
 
         List<String> results = new ArrayList<>();
 
-        String postOutputFormated = Hex.toHexString(parseData(postOutput));
+        String postOutputFormated = ByteUtil.toHexString(parseData(postOutput));
         if (vStats!=null) vStats.outputChecks++;
         if (!origOutput.equals(postOutputFormated)){
             String formattedString = String.format("HReturn: wrong expected: %s, current: %s",

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/RepositoryValidator.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/validators/RepositoryValidator.java
@@ -20,7 +20,6 @@
 package org.ethereum.jsontestsuite.validators;
 
 import co.rsk.core.RskAddress;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Repository;
 import org.ethereum.util.ByteUtil;
 
@@ -62,8 +61,8 @@ public class RepositoryValidator {
 
         if (validateRootHash) {
             // Compare roots
-            String postRoot = Hex.toHexString(postRepository.getRoot());
-            String currRoot = Hex.toHexString(currentRepository.getRoot());
+            String postRoot = ByteUtil.toHexString(postRepository.getRoot());
+            String currRoot = ByteUtil.toHexString(currentRepository.getRoot());
 
             if (vStats!=null) vStats.stateChecks++;
             if (!postRoot.equals(currRoot)) {

--- a/rskj-core/src/test/java/org/ethereum/net/DisconnectMessageTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/DisconnectMessageTest.java
@@ -19,16 +19,16 @@
 
 package org.ethereum.net;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.net.message.ReasonCode;
 import org.ethereum.net.p2p.DisconnectMessage;
-
+import org.ethereum.util.ByteUtil;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DisconnectMessageTest {
 
@@ -64,7 +64,7 @@ public class DisconnectMessageTest {
         logger.trace("{}" + disconnectMessage);
 
         String expected = "c107";
-        assertEquals(expected, Hex.toHexString(disconnectMessage.getEncoded()));
+        assertEquals(expected, ByteUtil.toHexString(disconnectMessage.getEncoded()));
 
         assertEquals(ReasonCode.NULL_IDENTITY, disconnectMessage.getReason());
     }

--- a/rskj-core/src/test/java/org/ethereum/net/PeerConnectionDataTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/PeerConnectionDataTest.java
@@ -21,13 +21,10 @@ package org.ethereum.net;
 
 import org.ethereum.net.client.Capability;
 import org.ethereum.net.p2p.PeerConnectionData;
-
+import org.ethereum.util.ByteUtil;
 import org.junit.Test;
 
-import org.bouncycastle.util.encoders.Hex;
-
 import java.net.InetAddress;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,7 +60,7 @@ public class PeerConnectionDataTest {
         assertEquals(capabilities, peer.getCapabilities());
 
         //getEncoded
-        assertEquals("CC847F0000018203F2821010C0", Hex.toHexString(peer.getEncoded()).toUpperCase());
+        assertEquals("CC847F0000018203F2821010C0", ByteUtil.toHexString(peer.getEncoded()).toUpperCase());
 
         //toString
         assertEquals("[ip=" + address.getHostAddress() + " port=" + Integer.toString(port) + " peerId=" + peerId + "]", peer.toString());

--- a/rskj-core/src/test/java/org/ethereum/net/StatusMessageTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/StatusMessageTest.java
@@ -19,13 +19,12 @@
 
 package org.ethereum.net;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.net.eth.message.StatusMessage;
+import org.ethereum.util.ByteUtil;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.bouncycastle.util.encoders.Hex;
 
 import static org.junit.Assert.assertEquals;
 
@@ -44,9 +43,9 @@ public class StatusMessageTest {
 
         assertEquals(39, statusMessage.getProtocolVersion());
         assertEquals("25c60144",
-                Hex.toHexString(statusMessage.getTotalDifficulty()));
+                ByteUtil.toHexString(statusMessage.getTotalDifficulty()));
         assertEquals("832056d3c93ff2739ace7199952e5365aa29f18805be05634c4db125c5340216",
-                Hex.toHexString(statusMessage.getBestHash()));
+                ByteUtil.toHexString(statusMessage.getBestHash()));
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/net/rlpx/HandshakeHandlerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/rlpx/HandshakeHandlerTest.java
@@ -24,7 +24,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.net.NodeStatistics;
@@ -34,6 +33,7 @@ import org.ethereum.net.eth.EthVersion;
 import org.ethereum.net.p2p.HelloMessage;
 import org.ethereum.net.p2p.P2pHandler;
 import org.ethereum.net.server.Channel;
+import org.ethereum.util.ByteUtil;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -113,7 +113,7 @@ public class HandshakeHandlerTest {
         responsePacketByteBuf.readBytes(responsePacket);
         handshake.handleAuthResponseV4(remoteKey, initiatePacket, responsePacket);
 
-        HelloMessage helloMessage = new HelloMessage(P2pHandler.VERSION, "", capabilities, 4321, Hex.toHexString(HashUtil.randomPeerId()));
+        HelloMessage helloMessage = new HelloMessage(P2pHandler.VERSION, "", capabilities, 4321, ByteUtil.toHexString(HashUtil.randomPeerId()));
         byte[] payload = helloMessage.getEncoded();
         FrameCodec frameCodec = new FrameCodec(handshake.getSecrets());
         ByteBuf byteBufMsg = ch.alloc().buffer();

--- a/rskj-core/src/test/java/org/ethereum/net/rlpx/NodeTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/rlpx/NodeTest.java
@@ -21,11 +21,11 @@ package org.ethereum.net.rlpx;
 
 import org.apache.commons.lang3.StringUtils;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
@@ -65,7 +65,7 @@ public class NodeTest {
         String host_2 = node_2.getHost();
         int port_2 = node_2.getPort();
 
-        assertEquals(Hex.toHexString(NODE_ID_1), Hex.toHexString(id_2));
+        assertEquals(ByteUtil.toHexString(NODE_ID_1), ByteUtil.toHexString(id_2));
         assertEquals(NODE_HOST_1, host_2);
         assertTrue(NODE_PORT_1 == port_2);
     }

--- a/rskj-core/src/test/java/org/ethereum/net/rlpx/RlpxConnection.java
+++ b/rskj-core/src/test/java/org/ethereum/net/rlpx/RlpxConnection.java
@@ -20,11 +20,14 @@
 package org.ethereum.net.rlpx;
 
 import org.ethereum.net.p2p.P2pMessage;
+import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.util.encoders.Hex;
 
-import java.io.*;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Created by devrandom on 2015-04-12.
@@ -60,14 +63,14 @@ public class RlpxConnection {
             // TODO handle disconnect
             byte[] wire = new byte[frame.size];
             frame.payload.read(wire);
-            System.out.println("packet " + Hex.toHexString(wire));
+            System.out.println("packet " + ByteUtil.toHexString(wire));
             handshakeMessage = HandshakeMessage.parse(wire);
             logger.info(" ===> " + handshakeMessage);
         } else {
             System.out.println("packet type " + frame.type);
             byte[] wire = new byte[frame.size];
             frame.payload.read(wire);
-            System.out.println("packet " + Hex.toHexString(wire));
+            System.out.println("packet " + ByteUtil.toHexString(wire));
         }
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -41,13 +41,13 @@ import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.trie.TrieStore;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.*;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.Simples.SimpleConfigCapabilities;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RskTestFactory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -192,7 +192,7 @@ public class Web3ImplLogsTest {
         Assert.assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
 
         Web3.FilterRequest fr = new Web3.FilterRequest();
-        fr.address = Hex.toHexString(tx.getContractAddress().getBytes());
+        fr.address = ByteUtil.toHexString(tx.getContractAddress().getBytes());
         fr.topics = new Object[] { "06acbfb32bcf8383f3b0a768b70ac9ec234ea0f2d3b9c77fa6a2de69b919aad1" };
         String id = web3.eth_newFilter(fr);
 
@@ -447,7 +447,7 @@ public class Web3ImplLogsTest {
         Block block1 = blockChain.getBlockByNumber(1l);
         Web3.FilterRequest fr = new Web3.FilterRequest();
         fr.fromBlock = "earliest";
-        fr.address = Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        fr.address = ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
@@ -466,7 +466,7 @@ public class Web3ImplLogsTest {
         Block block1 = blockChain.getBlockByNumber(1l);
         Web3.FilterRequest fr = new Web3.FilterRequest();
         fr.fromBlock = "earliest";
-        fr.address = Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        fr.address = ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         web3.eth_getLogs(fr);
         Object[] logs = web3.eth_getLogs(fr);
 
@@ -487,7 +487,7 @@ public class Web3ImplLogsTest {
         Web3.FilterRequest fr = new Web3.FilterRequest();
         fr.fromBlock = "earliest";
         List<String> addresses = new ArrayList<>();
-        addresses.add(Hex.toHexString(new byte[20]));
+        addresses.add(ByteUtil.toHexString(new byte[20]));
         fr.address = addresses;
         Object[] logs = web3.eth_getLogs(fr);
 
@@ -502,7 +502,7 @@ public class Web3ImplLogsTest {
         Web3.FilterRequest fr = new Web3.FilterRequest();
         fr.fromBlock = "earliest";
         List<String> addresses = new ArrayList<>();
-        addresses.add(Hex.toHexString(new byte[20]));
+        addresses.add(ByteUtil.toHexString(new byte[20]));
         fr.address = addresses;
         web3.eth_getLogs(fr);
         Object[] logs = web3.eth_getLogs(fr);
@@ -552,7 +552,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -570,7 +570,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -588,7 +588,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -607,7 +607,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -626,7 +626,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(2, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -649,7 +649,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(2, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -669,7 +669,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -687,7 +687,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
         Assert.assertEquals(address,((LogFilterElement)logs[0]).address);
     }
@@ -703,7 +703,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(3, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -723,7 +723,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(3, logs.length);
 
         for (int k = 0; k < logs.length; k++) {
@@ -743,7 +743,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -764,7 +764,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -784,7 +784,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -805,7 +805,7 @@ public class Web3ImplLogsTest {
         Object[] logs = web3.eth_getLogs(fr);
 
         Assert.assertNotNull(logs);
-        String address = "0x" + Hex.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
+        String address = "0x" + ByteUtil.toHexString(block1.getTransactionsList().get(0).getContractAddress().getBytes());
         Assert.assertEquals(1, logs.length);
 
         Assert.assertEquals(address, ((LogFilterElement) logs[0]).address);
@@ -868,7 +868,7 @@ public class Web3ImplLogsTest {
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
-        String callerAddress = Hex.toHexString(tx2.getContractAddress().getBytes());
+        String callerAddress = ByteUtil.toHexString(tx2.getContractAddress().getBytes());
 
         List<Transaction> txs2 = new ArrayList<>();
         txs2.add(tx2);
@@ -913,7 +913,7 @@ public class Web3ImplLogsTest {
 
         Transaction tx2;
         tx2 = getCallerContractTransaction(acc1, mainAddress);
-        String callerAddress = Hex.toHexString(tx2.getContractAddress().getBytes());
+        String callerAddress = ByteUtil.toHexString(tx2.getContractAddress().getBytes());
 
         List<Transaction> txs2 = new ArrayList<>();
         txs2.add(tx2);
@@ -1302,7 +1302,7 @@ contract caller {
                 .receiverAddress(receiverAddress)
                 .gasLimit(BigInteger.valueOf(1000000))
                 .gasPrice(BigInteger.ONE)
-                .data(Hex.toHexString(func.encode("0x" + address)))
+                .data(ByteUtil.toHexString(func.encode("0x" + address)))
                 .nonce(2)
                 .build();
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -21,8 +21,8 @@ package org.ethereum.rpc;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Wallet;
 import co.rsk.core.WalletFactory;
-import co.rsk.core.bc.MiningMainchainViewImpl;
 import co.rsk.core.bc.MiningMainchainView;
+import co.rsk.core.bc.MiningMainchainViewImpl;
 import co.rsk.net.NodeID;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.rpc.ExecutionBlockRetriever;
@@ -37,18 +37,16 @@ import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.rpc.modules.txpool.TxPoolModuleImpl;
 import co.rsk.scoring.*;
 import co.rsk.test.World;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.rpc.Simples.SimpleEthereum;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Random;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * Created by ajlopez on 12/07/2017.
@@ -258,7 +256,7 @@ public class Web3ImplScoringTest {
         Assert.assertEquals(2, result.length);
 
         PeerScoringInformation info = result[0];
-        Assert.assertEquals(Hex.toHexString(node.getID()).substring(0, 8), info.getId());
+        Assert.assertEquals(ByteUtil.toHexString(node.getID()).substring(0, 8), info.getId());
         Assert.assertEquals(2, info.getValidBlocks());
         Assert.assertEquals(0, info.getInvalidBlocks());
         Assert.assertEquals(1, info.getValidTransactions());

--- a/rskj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
@@ -19,16 +19,13 @@
 
 package org.ethereum.util;
 
+import org.bouncycastle.util.BigIntegers;
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
-
 import java.math.BigInteger;
-
 import java.nio.ByteBuffer;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,8 +65,19 @@ public class ByteUtilTest {
     }
 
     @Test
-    public void testToHexString() {
+    public void testToHexString_ProducedHex() {
+        byte[] data = new byte[] {(byte) 0xff, 0x0, 0x13, (byte) 0x88};
+        assertEquals(Hex.toHexString(data), ByteUtil.toHexString(data));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testToHexString_NullPointerExceptionForNull() {
         assertEquals("", ByteUtil.toHexString(null));
+    }
+
+    @Test
+    public void testToHexStringOrEmpty_EmptyStringForNull() {
+        assertEquals("", ByteUtil.toHexStringOrEmpty(null));
     }
 
     @Test
@@ -247,7 +255,7 @@ public class ByteUtilTest {
                     break;
                 }
             }
-            System.out.println(System.currentTimeMillis() - start1 + "ms to reach: " + Hex.toHexString(counter1));
+            System.out.println(System.currentTimeMillis() - start1 + "ms to reach: " + ByteUtil.toHexString(counter1));
 
             BigInteger counter2 = BigInteger.ZERO;
             long start2 = System.currentTimeMillis();
@@ -257,7 +265,7 @@ public class ByteUtilTest {
                 }
                 counter2 = counter2.add(BigInteger.ONE);
             }
-            System.out.println(System.currentTimeMillis() - start2 + "ms to reach: " + Hex.toHexString(BigIntegers.asUnsignedByteArray(4, counter2)));
+            System.out.println(System.currentTimeMillis() - start2 + "ms to reach: " + ByteUtil.toHexString(BigIntegers.asUnsignedByteArray(4, counter2)));
         }
     }
 

--- a/rskj-core/src/test/java/org/ethereum/util/HashUtilTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/HashUtilTest.java
@@ -20,11 +20,9 @@
 package org.ethereum.util;
 
 import co.rsk.core.RskAddress;
-import org.ethereum.crypto.HashUtil;
-
-import org.junit.Test;
-
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.HashUtil;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,75 +31,75 @@ public class HashUtilTest {
     @Test
     public void testSha256_EmptyString() {
         String expected1 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-        String result1 = Hex.toHexString(HashUtil.sha256(new byte[0]));
+        String result1 = ByteUtil.toHexString(HashUtil.sha256(new byte[0]));
         assertEquals(expected1, result1);
     }
 
     @Test
     public void testSha256_Test() {
         String expected2 = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
-        String result2 = Hex.toHexString(HashUtil.sha256("test".getBytes()));
+        String result2 = ByteUtil.toHexString(HashUtil.sha256("test".getBytes()));
         assertEquals(expected2, result2);
     }
 
     @Test
     public void testSha256_Multiple() {
         String expected1 = "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014";
-        String result1 = Hex.toHexString(HashUtil.sha256("test1".getBytes()));
+        String result1 = ByteUtil.toHexString(HashUtil.sha256("test1".getBytes()));
         assertEquals(expected1, result1);
 
         String expected2 = "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752";
-        String result2 = Hex.toHexString(HashUtil.sha256("test2".getBytes()));
+        String result2 = ByteUtil.toHexString(HashUtil.sha256("test2".getBytes()));
         assertEquals(expected2, result2);
     }
 
     @Test
     public void testSha3_EmptyString() {
         String expected1 = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
-        String result1 = Hex.toHexString(HashUtil.keccak256(new byte[0]));
+        String result1 = ByteUtil.toHexString(HashUtil.keccak256(new byte[0]));
         assertEquals(expected1, result1);
     }
 
     @Test
     public void testSha3_Test() {
         String expected2 = "9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658";
-        String result2 = Hex.toHexString(HashUtil.keccak256("test".getBytes()));
+        String result2 = ByteUtil.toHexString(HashUtil.keccak256("test".getBytes()));
         assertEquals(expected2, result2);
     }
 
     @Test
     public void testSha3_Multiple() {
         String expected1 = "6d255fc3390ee6b41191da315958b7d6a1e5b17904cc7683558f98acc57977b4";
-        String result1 = Hex.toHexString(HashUtil.keccak256("test1".getBytes()));
+        String result1 = ByteUtil.toHexString(HashUtil.keccak256("test1".getBytes()));
         assertEquals(expected1, result1);
 
         String expected2 = "4da432f1ecd4c0ac028ebde3a3f78510a21d54087b161590a63080d33b702b8d";
-        String result2 = Hex.toHexString(HashUtil.keccak256("test2".getBytes()));
+        String result2 = ByteUtil.toHexString(HashUtil.keccak256("test2".getBytes()));
         assertEquals(expected2, result2);
     }
 
     @Test
     public void testRIPEMD160_EmptyString() {
         String expected1 = "9c1185a5c5e9fc54612808977ee8f548b2258d31";
-        String result1 = Hex.toHexString(HashUtil.ripemd160(new byte[0]));
+        String result1 = ByteUtil.toHexString(HashUtil.ripemd160(new byte[0]));
         assertEquals(expected1, result1);
     }
 
     @Test
     public void testRIPEMD160_Test() {
         String expected2 = "5e52fee47e6b070565f74372468cdc699de89107";
-        String result2 = Hex.toHexString(HashUtil.ripemd160("test".getBytes()));
+        String result2 = ByteUtil.toHexString(HashUtil.ripemd160("test".getBytes()));
         assertEquals(expected2, result2);
     }
 
     @Test
     public void testRIPEMD160_Multiple() {
         String expected1 = "9295fac879006ff44812e43b83b515a06c2950aa";
-        String result1 = Hex.toHexString(HashUtil.ripemd160("test1".getBytes()));
+        String result1 = ByteUtil.toHexString(HashUtil.ripemd160("test1".getBytes()));
         assertEquals(expected1, result1);
 
         String expected2 = "80b85ebf641abccdd26e327c5782353137a0a0af";
-        String result2 = Hex.toHexString(HashUtil.ripemd160("test2".getBytes()));
+        String result2 = ByteUtil.toHexString(HashUtil.ripemd160("test2".getBytes()));
         assertEquals(expected2, result2);
     }
 
@@ -161,12 +159,37 @@ public class HashUtilTest {
                 "E33C0C7F7df4809055C3ebA6c09CFe4BaF1BD9e0");
     }
 
+    @Test
+    public void testToPrintableHash_ProducedHex() {
+        byte[] bHash = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470".getBytes();
+        String expectedResult = ByteUtil.toHexString(bHash);
+
+        String actualResult = HashUtil.toPrintableHash(bHash);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testToPrintableHash_ProducedHexForEmptyByteArray() {
+        byte[] bHash = new byte[0];
+        String expectedResult = ByteUtil.toHexString(bHash);
+
+        String actualResult = HashUtil.toPrintableHash(bHash);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testToPrintableHash_NullPointerExceptionForNull() {
+        HashUtil.toPrintableHash(null);
+    }
+
     private void runTestCalSaltAddr(String address, String saltString, String code, String expected){
         RskAddress r = new RskAddress(address);
         byte[] salt = Hex.decode(saltString);
         byte[] init_code = Hex.decode(code);
 
-        String result = Hex.toHexString(HashUtil.calcSaltAddr(r,init_code,salt));
+        String result = ByteUtil.toHexString(HashUtil.calcSaltAddr(r,init_code,salt));
         assertEquals(expected.toUpperCase(), result.toUpperCase());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/util/RLPDump.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RLPDump.java
@@ -19,9 +19,9 @@
 
 package org.ethereum.util;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 import org.junit.Test;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.util.ArrayList;
 
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 public class RLPDump {
     @Test
     public void dumpTest() {
-        System.out.println(Hex.toHexString(new ECKey().getPubKey()));
+        System.out.println(ByteUtil.toHexString(new ECKey().getPubKey()));
         String hexRlp = "f872f870845609a1ba64c0b8660480136e573eb81ac4a664f8f76e4887ba927f791a053ec5ff580b1037a8633320ca70f8ec0cdea59167acaa1debc07bc0a0b3a5b41bdf0cb4346c18ddbbd2cf222f54fed795dde94417d2e57f85a580d87238efc75394ca4a92cfe6eb9debcc3583c26fee8580";
         System.out.println(dump(RLP.decode2(Hex.decode(hexRlp)), 0));
         hexRlp = "f8d1f8cf845605846c3cc58479a94c49b8c0800b0b2d39d7c59778edb5166bfd0415c5e02417955ef4ef7f7d8c1dfc7f59a0141d97dd798bde6b972090390758b67457e93c2acb11ed4941d4443f87cedbc09c1b0476ca17f4f04da3d69cfb6470969f73d401ee7692293a00a2ff2d7f3fac87d43d85aed19c9e6ecbfe7e5f8268209477ffda58c7a481eec5c50abd313d10b6554e6e04a04fd93b9bf781d600f4ceb3060002ce1eddbbd51a9a902a970d9b41a9627141c0c52742b1179d83e17f1a273adf0a4a1d0346c68686a51428dd9a01";
@@ -57,7 +57,7 @@ public class RLPDump {
             ret += dump((ArrayList<RLPElement>) el, indent);
         } else {
             ret += Utils.repeat("  ", indent) +
-                    (el.getRLPData() == null ? "<null>" : Hex.toHexString(el.getRLPData())) + "\n";
+                    (el.getRLPData() == null ? "<null>" : ByteUtil.toHexString(el.getRLPData())) + "\n";
         }
         return ret;
     }

--- a/rskj-core/src/test/java/org/ethereum/util/RLPTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/RLPTest.java
@@ -19,14 +19,14 @@
 
 package org.ethereum.util;
 
+import org.bouncycastle.util.BigIntegers;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.net.client.Capability;
 import org.ethereum.net.p2p.HelloMessage;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.bouncycastle.util.BigIntegers;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -309,7 +309,7 @@ public class RLPTest {
 
         String expected = "b840" + byteArr;
 
-        assertEquals(expected, Hex.toHexString(encodeElement(byteArray)));
+        assertEquals(expected, ByteUtil.toHexString(encodeElement(byteArray)));
     }
 
     @Test
@@ -371,7 +371,7 @@ public class RLPTest {
                 prevHash, uncleList, coinbase);
 
         assertEquals("f856a000000000000000000000000000000000000000000000000000000000000000001dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000",
-                Hex.toHexString(header));
+                ByteUtil.toHexString(header));
     }
 
     @Test
@@ -608,9 +608,9 @@ public class RLPTest {
         String test = "";
         String expected = "80";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
-        String decodeResult = ByteUtil.toHexString(decode2(encoderesult).get(0).getRLPData());
+        String decodeResult = ByteUtil.toHexStringOrEmpty(decode2(encoderesult).get(0).getRLPData());
         assertEquals(test, decodeResult);
     }
 
@@ -619,7 +619,7 @@ public class RLPTest {
         String test = "dog";
         String expected = "83646f67";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         byte[] decodeResult = decode2(encoderesult).get(0).getRLPData();
         assertEquals(test, bytesToAscii(decodeResult));
@@ -630,7 +630,7 @@ public class RLPTest {
         String test = "d";
         String expected = "64";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         byte[] decodeResult = decode2(encoderesult).get(0).getRLPData();
         assertEquals(test, bytesToAscii(decodeResult));
@@ -641,7 +641,7 @@ public class RLPTest {
         String test = "Lorem ipsum dolor sit amet, consectetur adipisicing elit"; // length = 56
         String expected = "b8384c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e7365637465747572206164697069736963696e6720656c6974";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         byte[] decodeResult = decode2(encoderesult).get(0).getRLPData();
         assertEquals(test, bytesToAscii(decodeResult));
@@ -652,9 +652,9 @@ public class RLPTest {
         Integer test = 0;
         String expected = "80";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
-        String decodeResult = ByteUtil.toHexString(decode2(encoderesult).get(0).getRLPData());
+        String decodeResult = ByteUtil.toHexStringOrEmpty(decode2(encoderesult).get(0).getRLPData());
         assertEquals("", decodeResult);
     }
 
@@ -663,7 +663,7 @@ public class RLPTest {
         Integer test = 15;
         String expected = "0f";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         byte[] decodeResult = decode2(encoderesult).get(0).getRLPData();
         int result = byteArrayToInt(decodeResult);
@@ -675,7 +675,7 @@ public class RLPTest {
         Integer test = 1000;
         String expected = "8203e8";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         byte[] decodeResult = decode2(encoderesult).get(0).getRLPData();
         int result = byteArrayToInt(decodeResult);
@@ -684,7 +684,7 @@ public class RLPTest {
         test = 1024;
         expected = "820400";
         encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         decodeResult = decode2(encoderesult).get(0).getRLPData();
         result = byteArrayToInt(decodeResult);
@@ -696,7 +696,7 @@ public class RLPTest {
         BigInteger test = new BigInteger("100102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", 16);
         String expected = "a0100102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         byte[] decodeResult = decode2(encoderesult).get(0).getRLPData();
         assertEquals(test, BigIntegers.fromUnsignedByteArray(decodeResult));
@@ -707,7 +707,7 @@ public class RLPTest {
         Object[] test = new Object[0];
         String expected = "c0";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         RLPList decodeResult = (RLPList)decode2(encoderesult).get(0);
         assertTrue(decodeResult.size() == 0);
@@ -718,7 +718,7 @@ public class RLPTest {
         String[] test = new String[]{"cat", "dog"};
         String expected = "c88363617483646f67";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         RLPList decodeResult = (RLPList) decode2(encoderesult).get(0);
         assertEquals("cat", bytesToAscii(decodeResult.get(0).getRLPData()));
@@ -727,7 +727,7 @@ public class RLPTest {
         test = new String[]{"dog", "god", "cat"};
         expected = "cc83646f6783676f6483636174";
         encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         decodeResult = (RLPList) decode2(encoderesult).get(0);
         assertEquals("dog", bytesToAscii(decodeResult.get(0).getRLPData()));
@@ -742,7 +742,7 @@ public class RLPTest {
         String[] test = new String[]{element1, element2};
         String expected = "f83e83636174b8384c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e7365637465747572206164697069736963696e6720656c6974";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         RLPList decodeResult = (RLPList) decode2(encoderesult).get(0);
         assertEquals(element1, bytesToAscii(decodeResult.get(0).getRLPData()));
@@ -759,7 +759,7 @@ public class RLPTest {
         Object[] test = new Object[]{1, new Object[]{"cat"}, "dog", new Object[]{2}};
         String expected = "cc01c48363617483646f67c102";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         RLPList decodeResult = (RLPList) decode2(encoderesult).get(0);
         assertEquals(1, byteArrayToInt(decodeResult.get(0).getRLPData()));
@@ -770,7 +770,7 @@ public class RLPTest {
         test = new Object[]{new Object[]{"cat", "dog"}, new Object[]{1, 2}, new Object[]{}};
         expected = "cdc88363617483646f67c20102c0";
         encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         decodeResult = (RLPList) decode2(encoderesult).get(0);
         assertEquals("cat", bytesToAscii((((RLPList) decodeResult.get(0)).get(0).getRLPData())));
@@ -786,7 +786,7 @@ public class RLPTest {
         Object[] test = new Object[]{new Object[]{new Object[]{}, new Object[]{}}, new Object[]{}};
         String expected = "c4c2c0c0c0";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         RLPList decodeResult = (RLPList) decode2(encoderesult).get(0);
         assertTrue(decodeResult.size() == 2);
@@ -803,7 +803,7 @@ public class RLPTest {
         Object[] test = new Object[]{new Object[]{}, new Object[]{new Object[]{}}, new Object[]{new Object[]{}, new Object[]{new Object[]{}}}};
         String expected = "c7c0c1c0c3c0c1c0";
         byte[] encoderesult = encode(test);
-        assertEquals(expected, Hex.toHexString(encoderesult));
+        assertEquals(expected, ByteUtil.toHexString(encoderesult));
 
         RLPList decodeResult = (RLPList) decode2(encoderesult).get(0);
         assertTrue(decodeResult.size() == 3);
@@ -819,22 +819,22 @@ public class RLPTest {
     @Test
     public void testRlpEncode() {
 
-        assertEquals(result01, Hex.toHexString(encode(test01)));
-        assertEquals(result02, Hex.toHexString(encode(test02)));
-        assertEquals(result03, Hex.toHexString(encode(test03)));
-        assertEquals(result04, Hex.toHexString(encode(test04)));
-        assertEquals(result05, Hex.toHexString(encode(test05)));
-        assertEquals(result06, Hex.toHexString(encode(test06)));
-        assertEquals(result07, Hex.toHexString(encode(test07)));
-        assertEquals(result08, Hex.toHexString(encode(test08)));
-        assertEquals(result09, Hex.toHexString(encode(test09)));
-        assertEquals(result10, Hex.toHexString(encode(test10)));
-        assertEquals(result11, Hex.toHexString(encode(test11)));
-        assertEquals(result12, Hex.toHexString(encode(test12)));
-        assertEquals(result13, Hex.toHexString(encode(test13)));
-        assertEquals(result14, Hex.toHexString(encode(test14)));
-        assertEquals(result15, Hex.toHexString(encode(test15)));
-        assertEquals(result16, Hex.toHexString(encode(test16)));
+        assertEquals(result01, ByteUtil.toHexString(encode(test01)));
+        assertEquals(result02, ByteUtil.toHexString(encode(test02)));
+        assertEquals(result03, ByteUtil.toHexString(encode(test03)));
+        assertEquals(result04, ByteUtil.toHexString(encode(test04)));
+        assertEquals(result05, ByteUtil.toHexString(encode(test05)));
+        assertEquals(result06, ByteUtil.toHexString(encode(test06)));
+        assertEquals(result07, ByteUtil.toHexString(encode(test07)));
+        assertEquals(result08, ByteUtil.toHexString(encode(test08)));
+        assertEquals(result09, ByteUtil.toHexString(encode(test09)));
+        assertEquals(result10, ByteUtil.toHexString(encode(test10)));
+        assertEquals(result11, ByteUtil.toHexString(encode(test11)));
+        assertEquals(result12, ByteUtil.toHexString(encode(test12)));
+        assertEquals(result13, ByteUtil.toHexString(encode(test13)));
+        assertEquals(result14, ByteUtil.toHexString(encode(test14)));
+        assertEquals(result15, ByteUtil.toHexString(encode(test15)));
+        assertEquals(result16, ByteUtil.toHexString(encode(test16)));
     }
 
     @Test
@@ -844,10 +844,10 @@ public class RLPTest {
         byte[] decodedData;
         RLPList decodedList;
 
-        emptyString = ByteUtil.toHexString(decode2(Hex.decode(result01)).get(0).getRLPData());
+        emptyString = ByteUtil.toHexStringOrEmpty(decode2(Hex.decode(result01)).get(0).getRLPData());
         assertEquals("", emptyString);
 
-        emptyString = ByteUtil.toHexString(decode2(Hex.decode(result02)).get(0).getRLPData());
+        emptyString = ByteUtil.toHexStringOrEmpty(decode2(Hex.decode(result02)).get(0).getRLPData());
         assertEquals(test02, emptyString);
 
         decodedData = decode2(Hex.decode(result03)).get(0).getRLPData();
@@ -918,14 +918,14 @@ public class RLPTest {
         int offset = 128;
         byte[] encodedLength = encodeLength(length, offset);
         String expected = "81";
-        assertEquals(expected, Hex.toHexString(encodedLength));
+        assertEquals(expected, ByteUtil.toHexString(encodedLength));
 
         // 56 > length < 2^64
         length = 56;
         offset = 192;
         encodedLength = encodeLength(length, offset);
         expected = "f838";
-        assertEquals(expected, Hex.toHexString(encodedLength));
+        assertEquals(expected, ByteUtil.toHexString(encodedLength));
     }
 
     @Test
@@ -953,7 +953,7 @@ public class RLPTest {
 
     // Code from: http://stackoverflow.com/a/4785776/459349
     private String bytesToAscii(byte[] b) {
-        String hex = Hex.toHexString(b);
+        String hex = ByteUtil.toHexString(b);
         StringBuilder output = new StringBuilder();
         for (int i = 0; i < hex.length(); i += 2) {
             String str = hex.substring(i, i + 2);
@@ -981,7 +981,7 @@ public class RLPTest {
         byte[] rlpCode = Hex.decode("b4600160003556601359506301000000600035040f6018590060005660805460016080530160005760003560805760203560003557");
         byte[] output = encodeList(rlpKeysList, rlpValuesList, rlpCode);
 
-        assertEquals(expectedOutput, Hex.toHexString(output));
+        assertEquals(expectedOutput, ByteUtil.toHexString(output));
     }
 
 
@@ -990,7 +990,7 @@ public class RLPTest {
 
         BigInteger integer = new BigInteger("80", 10);
         byte[] encodedData = encodeBigInteger(integer);
-        System.out.println(Hex.toHexString(encodedData));
+        System.out.println(ByteUtil.toHexString(encodedData));
     }
 
     @Test
@@ -998,15 +998,15 @@ public class RLPTest {
 
         byte[] header = encodeListHeader(10);
         String expected_1 = "ca";
-        assertEquals(expected_1, Hex.toHexString(header));
+        assertEquals(expected_1, ByteUtil.toHexString(header));
 
         header = encodeListHeader(1000);
         String expected_2 = "f903e8";
-        assertEquals(expected_2, Hex.toHexString(header));
+        assertEquals(expected_2, ByteUtil.toHexString(header));
 
         header = encodeListHeader(1000000000);
         String expected_3 = "fb3b9aca00";
-        assertEquals(expected_3, Hex.toHexString(header));
+        assertEquals(expected_3, ByteUtil.toHexString(header));
     }
 
 
@@ -1040,19 +1040,19 @@ public class RLPTest {
 
         Set<ByteArrayWrapper> data = new HashSet<>();
         byte[] setEncoded = encodeSet(data);
-        assertEquals("c0", Hex.toHexString(setEncoded));
+        assertEquals("c0", ByteUtil.toHexString(setEncoded));
     }
 
     @Test
     public void testEncodeInt_7f(){
-        String result =  Hex.toHexString(encodeInt(0x7f));
+        String result =  ByteUtil.toHexString(encodeInt(0x7f));
         String expected = "7f";
         assertEquals(expected, result);
     }
 
     @Test
     public void testEncodeInt_80(){
-        String result =  Hex.toHexString(encodeInt(0x80));
+        String result =  ByteUtil.toHexString(encodeInt(0x80));
         String expected = "8180";
         assertEquals(expected, result);
     }
@@ -1060,7 +1060,7 @@ public class RLPTest {
 
     @Test
     public void testEncode_ED(){
-        String result =  Hex.toHexString(encode(0xED));
+        String result =  ByteUtil.toHexString(encode(0xED));
         String expected = "81ed";
         assertEquals(expected, result);
     }

--- a/rskj-core/src/test/java/org/ethereum/util/ValueTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ValueTest.java
@@ -68,10 +68,8 @@ public class ValueTest {
         assertEquals(bigInt.asBigInt(), bigExp);
     }
 
-
     @Test
     public void longListRLPBug_1() {
-
         String testRlp = "f7808080d387206f72726563748a626574656c676575736580d387207870726573738a70726564696361626c658080808080808080808080";
 
         Value val = Value.fromRlpEncoded(Hex.decode(testRlp));
@@ -79,5 +77,60 @@ public class ValueTest {
         assertEquals(testRlp, ByteUtil.toHexString(val.encode()));
     }
 
+    @Test
+    public void toString_Empty() {
+        Value val = new Value(null);
+        String str = val.toString();
+
+        assertEquals("", str);
+    }
+
+    @Test
+    public void toString_SameString() {
+        Value val = new Value("hello");
+        String str = val.toString();
+
+        assertEquals("hello", str);
+    }
+
+    @Test
+    public void toString_Array() {
+        Value val = new Value(new String[] {"hello", "world", "!"});
+        String str = val.toString();
+
+        assertEquals(" ['hello', 'world', '!'] ", str);
+    }
+
+    @Test
+    public void toString_UnsupportedType() {
+        Value val = new Value('a');
+        String str = val.toString();
+
+        assertEquals("Unexpected type", str);
+    }
+
+    @Test
+    public void isEmpty_Null() {
+        Value val = new Value(null);
+        assertTrue(val.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_EmptyString() {
+        Value val = new Value("");
+        assertTrue(val.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_Bytes() {
+        Value val = new Value(new byte[0]);
+        assertTrue(val.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_Array() {
+        Value val = new Value(new String[0]);
+        assertTrue(val.isEmpty());
+    }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/util/ValueTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ValueTest.java
@@ -19,12 +19,10 @@
 
 package org.ethereum.util;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 
-import org.bouncycastle.util.encoders.Hex;
-
 import java.math.BigInteger;
-
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -78,7 +76,7 @@ public class ValueTest {
 
         Value val = Value.fromRlpEncoded(Hex.decode(testRlp));
 
-        assertEquals(testRlp, Hex.toHexString(val.encode()));
+        assertEquals(testRlp, ByteUtil.toHexString(val.encode()));
     }
 
 

--- a/rskj-core/src/test/java/org/ethereum/vm/DataWordTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/DataWordTest.java
@@ -19,18 +19,15 @@
 
 package org.ethereum.vm;
 
-import co.rsk.crypto.Keccak256;
-import org.ethereum.crypto.HashUtil;
-import org.junit.Test;
-
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
+import org.junit.Test;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class DataWordTest {
 
@@ -74,7 +71,7 @@ public class DataWordTest {
         assertArrayEquals(xdata, x.getData());
         assertArrayEquals(ydata, y.getData());
         assertEquals(32, result.getData().length);
-        assertEquals(expected, Hex.toHexString(result.getData()));
+        assertEquals(expected, ByteUtil.toHexString(result.getData()));
     }
 
     @Test
@@ -95,9 +92,9 @@ public class DataWordTest {
         assertArrayEquals(xdata, x.getData());
         assertArrayEquals(ydata, y.getData());
         assertEquals(32, y.getData().length);
-        assertEquals("0000000000000000000000010000000000000000000000000000000000000000", Hex.toHexString(y.getData()));
+        assertEquals("0000000000000000000000010000000000000000000000000000000000000000", ByteUtil.toHexString(y.getData()));
         assertEquals(32, result.getData().length);
-        assertEquals("0000000000000000000000010000000000000000000000000000000000000000", Hex.toHexString(result.getData()));
+        assertEquals("0000000000000000000000010000000000000000000000000000000000000000", ByteUtil.toHexString(result.getData()));
     }
 
     @Test
@@ -118,9 +115,9 @@ public class DataWordTest {
         assertArrayEquals(xdata, x.getData());
         assertArrayEquals(ydata, y.getData());
         assertEquals(32, y.getData().length);
-        assertEquals("0100000000000000000000000000000000000000000000000000000000000000", Hex.toHexString(y.getData()));
+        assertEquals("0100000000000000000000000000000000000000000000000000000000000000", ByteUtil.toHexString(y.getData()));
         assertEquals(32, result.getData().length);
-        assertEquals("0000000000000000000000000000000000000000000000000000000000000000", Hex.toHexString(result.getData()));
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000000", ByteUtil.toHexString(result.getData()));
     }
 
     @Test
@@ -142,7 +139,7 @@ public class DataWordTest {
         assertArrayEquals(xdata, x.getData());
         assertArrayEquals(ydata, y.getData());
         assertEquals(32, result.getData().length);
-        assertEquals("0000000000000000000000000000000000000000000000000000000000000014", Hex.toHexString(result.getData()));
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000014", ByteUtil.toHexString(result.getData()));
     }
 
     @Test
@@ -408,7 +405,7 @@ public class DataWordTest {
         assertArrayEquals(dataw1, w1.getData());
         assertArrayEquals(dataw2, w2.getData());
         assertEquals(32, result.getData().length);
-        assertEquals("0000000000000000000000000000000000000000000000000000000000000001", org.spongycastle.util.encoders.Hex.toHexString(result.getData()));
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000001", ByteUtil.toHexString(result.getData()));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/PrecompiledContractTest.java
@@ -20,11 +20,11 @@
 package org.ethereum.vm;
 
 import co.rsk.config.TestSystemProperties;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.util.BIUtil;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts.PrecompiledContract;
 import org.junit.Test;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
@@ -64,7 +64,7 @@ public class PrecompiledContractTest {
 
         byte[] result = contract.execute(data);
 
-        assertEquals(expected, Hex.toHexString(result));
+        assertEquals(expected, ByteUtil.toHexString(result));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class PrecompiledContractTest {
 
         byte[] result = contract.execute(data);
 
-        assertEquals(expected, Hex.toHexString(result));
+        assertEquals(expected, ByteUtil.toHexString(result));
     }
 
     @Test
@@ -90,7 +90,7 @@ public class PrecompiledContractTest {
 
         byte[] result = contract.execute(data);
 
-        assertEquals(expected, Hex.toHexString(result));
+        assertEquals(expected, ByteUtil.toHexString(result));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class PrecompiledContractTest {
 
         byte[] result = contract.execute(data);
 
-        assertEquals(expected, Hex.toHexString(result));
+        assertEquals(expected, ByteUtil.toHexString(result));
     }
 
     @Test
@@ -116,7 +116,7 @@ public class PrecompiledContractTest {
 
         byte[] result = contract.execute(data);
 
-        System.out.println(Hex.toHexString(result));
+        System.out.println(ByteUtil.toHexString(result));
 
     }
     @Test

--- a/rskj-core/src/test/java/org/ethereum/vm/ProgramTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/ProgramTest.java
@@ -22,13 +22,68 @@ package org.ethereum.vm;
 import co.rsk.util.TestContract;
 import org.ethereum.vm.program.ProgramResult;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
 
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Parameterized.class)
+@PrepareForTest(LoggerFactory.class)
 public class ProgramTest {
 
+    private static Logger logger;
+    private static Logger gasLogger;
+
     private static final String LOREM_IPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> params() {
+        return Arrays.asList(new Object[][] {
+                { true, true },
+                { true, false },
+                { false, true },
+                { false, false }
+        });
+    }
+
+    private final boolean isLogEnabled;
+    private final boolean isGasLogEnabled;
+
+    public ProgramTest(boolean isLogEnabled, boolean isGasLogEnabled) {
+        this.isLogEnabled = isLogEnabled;
+        this.isGasLogEnabled = isGasLogEnabled;
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+        spy(LoggerFactory.class);
+
+        logger = mock(Logger.class);
+        when(LoggerFactory.getLogger("VM")).thenReturn(logger);
+
+        gasLogger = mock(Logger.class);
+        when(LoggerFactory.getLogger("gas")).thenReturn(gasLogger);
+    }
+
+    @Before
+    public void setUp() {
+        when(logger.isInfoEnabled()).thenReturn(isLogEnabled);
+        when(logger.isTraceEnabled()).thenReturn(isLogEnabled);
+        when(gasLogger.isInfoEnabled()).thenReturn(isGasLogEnabled);
+    }
 
     @Test
     public void helloContract() {

--- a/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMCustomTest.java
@@ -26,6 +26,7 @@ import co.rsk.core.RskAddress;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.BlockFactory;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.program.Program;
 import org.ethereum.vm.program.Program.OutOfGasException;
 import org.ethereum.vm.program.Program.StackTooSmallException;
@@ -79,7 +80,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
 
@@ -94,7 +95,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // CALLDATALOAD OP
@@ -108,7 +109,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
 
@@ -123,7 +124,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
 
@@ -138,7 +139,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // CALLDATALOAD OP
@@ -152,7 +153,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = RuntimeException.class) // CALLDATALOAD OP mal
@@ -179,7 +180,7 @@ public class VMCustomTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()).toUpperCase());
     }
 
     @Test // CALLDATACOPY OP
@@ -195,7 +196,7 @@ public class VMCustomTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()).toUpperCase());
     }
 
 
@@ -212,7 +213,7 @@ public class VMCustomTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()).toUpperCase());
     }
 
 
@@ -230,7 +231,7 @@ public class VMCustomTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()).toUpperCase());
     }
 
     @Test // CALLDATACOPY OP
@@ -247,7 +248,7 @@ public class VMCustomTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()).toUpperCase());
     }
 
 
@@ -292,7 +293,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // BALANCE OP
@@ -306,7 +307,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // ORIGIN OP
@@ -319,7 +320,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // CALLER OP
@@ -332,7 +333,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // CALLVALUE OP
@@ -345,7 +346,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // SHA3 OP
@@ -363,7 +364,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // SHA3 OP
@@ -381,7 +382,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // SHA3 OP mal
@@ -411,7 +412,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // COINBASE OP
@@ -424,7 +425,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // TIMESTAMP OP
@@ -437,7 +438,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // NUMBER OP
@@ -450,7 +451,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // DIFFICULTY OP
@@ -463,7 +464,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // GASPRICE OP
@@ -476,7 +477,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Ignore //TODO #POC9
@@ -490,7 +491,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // GASLIMIT OP
@@ -503,7 +504,7 @@ public class VMCustomTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = Program.IllegalOperationException.class) // INVALID OP
@@ -519,7 +520,7 @@ public class VMCustomTest {
         } finally {
             assertTrue(program.isStopped());
             DataWord item1 = program.stackPop();
-            assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+            assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
         }
     }
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -19,7 +19,6 @@
 
 package org.ethereum.vm;
 
-import co.rsk.asm.EVMAssembler;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
@@ -446,7 +445,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH2 OP
@@ -458,7 +457,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH3 OP
@@ -470,7 +469,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH4 OP
@@ -482,7 +481,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH5 OP
@@ -494,7 +493,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH6 OP
@@ -506,7 +505,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH7 OP
@@ -518,7 +517,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH8 OP
@@ -530,7 +529,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH9 OP
@@ -542,7 +541,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
 
@@ -555,7 +554,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH11 OP
@@ -567,7 +566,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH12 OP
@@ -579,7 +578,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH13 OP
@@ -591,7 +590,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH14 OP
@@ -603,7 +602,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH15 OP
@@ -615,7 +614,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH16 OP
@@ -627,7 +626,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH17 OP
@@ -639,7 +638,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH18 OP
@@ -651,7 +650,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH19 OP
@@ -663,7 +662,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH20 OP
@@ -675,7 +674,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH21 OP
@@ -687,7 +686,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH22 OP
@@ -699,7 +698,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH23 OP
@@ -711,7 +710,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH24 OP
@@ -723,7 +722,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH25 OP
@@ -735,7 +734,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH26 OP
@@ -747,7 +746,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH27 OP
@@ -759,7 +758,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH28 OP
@@ -771,7 +770,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH29 OP
@@ -783,7 +782,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH30 OP
@@ -795,7 +794,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH31 OP
@@ -807,7 +806,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // PUSH32 OP
@@ -819,7 +818,7 @@ public class VMTest {
         program.fullTrace();
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test // PUSHN OP not enough data
@@ -833,7 +832,7 @@ public class VMTest {
         vm.step(program);
 
         assertTrue(program.isStopped());
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test // PUSHN OP not enough data
@@ -846,7 +845,7 @@ public class VMTest {
         vm.step(program);
 
         assertTrue(program.isStopped());
-        String result = Hex.toHexString(program.getStack().peek().getData()).toUpperCase();
+        String result = ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase();
         assertEquals(expected,result);
     }
 
@@ -861,7 +860,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // AND OP
@@ -874,7 +873,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = RuntimeException.class)  // AND OP mal data
@@ -900,7 +899,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // OR OP
@@ -913,7 +912,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = RuntimeException.class)  // OR OP mal data
@@ -939,7 +938,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // XOR OP
@@ -952,7 +951,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
 
@@ -979,7 +978,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // BYTE OP
@@ -992,7 +991,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // BYTE OP
@@ -1005,7 +1004,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
 
@@ -1031,7 +1030,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // ISZERO OP
@@ -1043,7 +1042,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class)  // ISZERO OP mal data
@@ -1069,7 +1068,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // EQ OP
@@ -1082,7 +1081,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // EQ OP
@@ -1095,7 +1094,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class)  // EQ OP mal data
@@ -1121,7 +1120,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // GT OP
@@ -1134,7 +1133,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // GT OP
@@ -1147,7 +1146,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class)  // GT OP mal data
@@ -1173,7 +1172,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // SGT OP
@@ -1188,7 +1187,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // SGT OP
@@ -1203,7 +1202,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class)  // SGT OP mal
@@ -1230,7 +1229,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // LT OP
@@ -1243,7 +1242,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // LT OP
@@ -1256,7 +1255,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class)  // LT OP mal data
@@ -1282,7 +1281,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // SLT OP
@@ -1297,7 +1296,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // SLT OP
@@ -1312,7 +1311,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class)  // SLT OP mal
@@ -1338,7 +1337,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test  // NOT OP
@@ -1350,7 +1349,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
 
@@ -1375,7 +1374,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
 
@@ -1390,7 +1389,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test // POP OP
@@ -1405,7 +1404,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class)  // POP OP mal data
@@ -1453,11 +1452,11 @@ public class VMTest {
         }
 
         assertEquals(expectedLen, program.getStack().toArray().length);
-        assertEquals(expected, Hex.toHexString(program.stackPop().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.stackPop().getData()).toUpperCase());
         for (int i = 0; i < expectedLen - 2; i++) {
-            assertNotEquals(expected, Hex.toHexString(program.stackPop().getData()).toUpperCase());
+            assertNotEquals(expected, ByteUtil.toHexString(program.stackPop().getData()).toUpperCase());
         }
-        assertEquals(expected, Hex.toHexString(program.stackPop().getData()).toUpperCase());
+        assertEquals(expected, ByteUtil.toHexString(program.stackPop().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class)  // DUPN OP mal data
@@ -1494,7 +1493,7 @@ public class VMTest {
 
         }
 
-        programCode += Hex.toHexString(new byte[]{   (byte)(OpCode.SWAP1.val() + n - 1)   });
+        programCode += ByteUtil.toHexString(new byte[]{   (byte)(OpCode.SWAP1.val() + n - 1)   });
 
         program = getProgram(ByteUtil.appendByte(Hex.decode(programCode), operation));
 
@@ -1503,7 +1502,7 @@ public class VMTest {
         }
 
         assertEquals(n + 1, program.getStack().toArray().length);
-        assertEquals(top, Hex.toHexString(program.stackPop().getData()));
+        assertEquals(top, ByteUtil.toHexString(program.stackPop().getData()));
     }
 
     @Test(expected = StackTooSmallException.class)  // SWAPN OP mal data
@@ -1528,7 +1527,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getMemory()));
+        assertEquals(expected, ByteUtil.toHexString(program.getMemory()));
     }
 
 
@@ -1547,9 +1546,9 @@ public class VMTest {
         List<LogInfo> logInfoList = program.getResult().getLogInfoList();
         LogInfo logInfo = logInfoList.get(0);
 
-        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", Hex.toHexString(logInfo.getAddress()));
+        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", ByteUtil.toHexString(logInfo.getAddress()));
         assertEquals(0, logInfo.getTopics().size());
-        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", Hex.toHexString(logInfo
+        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", ByteUtil.toHexString(logInfo
                 .getData()));
     }
 
@@ -1569,9 +1568,9 @@ public class VMTest {
         List<LogInfo> logInfoList = program.getResult().getLogInfoList();
         LogInfo logInfo = logInfoList.get(0);
 
-        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", Hex.toHexString(logInfo.getAddress()));
+        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", ByteUtil.toHexString(logInfo.getAddress()));
         assertEquals(1, logInfo.getTopics().size());
-        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", Hex.toHexString(logInfo
+        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", ByteUtil.toHexString(logInfo
                 .getData()));
     }
 
@@ -1592,9 +1591,9 @@ public class VMTest {
         List<LogInfo> logInfoList = program.getResult().getLogInfoList();
         LogInfo logInfo = logInfoList.get(0);
 
-        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", Hex.toHexString(logInfo.getAddress()));
+        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", ByteUtil.toHexString(logInfo.getAddress()));
         assertEquals(2, logInfo.getTopics().size());
-        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", Hex.toHexString(logInfo
+        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", ByteUtil.toHexString(logInfo
                 .getData()));
     }
 
@@ -1616,9 +1615,9 @@ public class VMTest {
         List<LogInfo> logInfoList = program.getResult().getLogInfoList();
         LogInfo logInfo = logInfoList.get(0);
 
-        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", Hex.toHexString(logInfo.getAddress()));
+        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", ByteUtil.toHexString(logInfo.getAddress()));
         assertEquals(3, logInfo.getTopics().size());
-        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", Hex.toHexString(logInfo
+        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", ByteUtil.toHexString(logInfo
                 .getData()));
     }
 
@@ -1642,9 +1641,9 @@ public class VMTest {
         List<LogInfo> logInfoList = program.getResult().getLogInfoList();
         LogInfo logInfo = logInfoList.get(0);
 
-        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", Hex.toHexString(logInfo.getAddress()));
+        assertEquals("cd2a3d9f938e13cd947ec05abc7fe734df8dd826", ByteUtil.toHexString(logInfo.getAddress()));
         assertEquals(4, logInfo.getTopics().size());
-        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", Hex.toHexString(logInfo
+        assertEquals("0000000000000000000000000000000000000000000000000000000000001234", ByteUtil.toHexString(logInfo
                 .getData()));
     }
 
@@ -1663,7 +1662,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getMemory()));
+        assertEquals(expected, ByteUtil.toHexString(program.getMemory()));
     }
 
     @Test // MSTORE OP
@@ -1683,7 +1682,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getMemory()));
+        assertEquals(expected, ByteUtil.toHexString(program.getMemory()));
     }
 
     @Test // MSTORE OP
@@ -1702,7 +1701,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(expected, Hex.toHexString(program.getMemory()));
+        assertEquals(expected, ByteUtil.toHexString(program.getMemory()));
     }
 
     @Test(expected = StackTooSmallException.class) // MSTORE OP
@@ -1727,8 +1726,8 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test // MLOAD OP
@@ -1743,8 +1742,8 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()).toUpperCase());
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
 
@@ -1759,8 +1758,8 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test // MLOAD OP
@@ -1777,8 +1776,8 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test // MLOAD OP
@@ -1795,8 +1794,8 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     // Testes the versioning header, specifying version 0
@@ -1817,8 +1816,8 @@ public class VMTest {
 
         assertEquals(program.getExeVersion(), 1);
         assertEquals(program.getScriptVersion(), 1);
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
     // Test for currectness of extra header length when over 128 (negative byte)
     @Test
@@ -1856,8 +1855,8 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = Program.IllegalOperationException.class)
@@ -1890,7 +1889,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
     }
 
 
@@ -1904,7 +1903,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
     }
 
     @Test // MSTORE8 OP
@@ -1918,7 +1917,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected, Hex.toHexString(program.getMemory()));
+        assertEquals(m_expected, ByteUtil.toHexString(program.getMemory()));
     }
 
     @Test(expected = StackTooSmallException.class) // MSTORE8 OP mal
@@ -1947,7 +1946,7 @@ public class VMTest {
         DataWord key = DataWord.valueOf(Hex.decode(s_expected_key));
         DataWord val = program.getStorage().getStorageValue(new RskAddress(invoke.getOwnerAddress()), key);
 
-        assertEquals(s_expected_val, Hex.toHexString(val.getData()).toUpperCase());
+        assertEquals(s_expected_val, ByteUtil.toHexString(val.getData()).toUpperCase());
     }
 
     @Test // SSTORE OP
@@ -1968,7 +1967,7 @@ public class VMTest {
         DataWord key = DataWord.valueOf(Hex.decode(s_expected_key));
         DataWord val = repository.getStorageValue(new RskAddress(invoke.getOwnerAddress()), key);
 
-        assertEquals(s_expected_val, Hex.toHexString(val.getData()).toUpperCase());
+        assertEquals(s_expected_val, ByteUtil.toHexString(val.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // SSTORE OP
@@ -1992,7 +1991,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test // SLOAD OP
@@ -2007,7 +2006,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test // SLOAD OP
@@ -2025,7 +2024,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // SLOAD OP
@@ -2047,7 +2046,7 @@ public class VMTest {
 
         vm.step(program);
 
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
 
@@ -2064,7 +2063,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
@@ -2079,7 +2078,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
     @Test(expected = BadJumpDestinationException.class) // JUMP OP mal data
@@ -2109,7 +2108,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected, Hex.toHexString(program.getStack().peek().getData()).toUpperCase());
+        assertEquals(s_expected, ByteUtil.toHexString(program.getStack().peek().getData()).toUpperCase());
     }
 
 
@@ -2129,8 +2128,8 @@ public class VMTest {
         DataWord item1 = program.stackPop();
         DataWord item2 = program.stackPop();
 
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
-        assertEquals(s_expected_2, Hex.toHexString(item2.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_2, ByteUtil.toHexString(item2.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // JUMPI OP mal
@@ -2178,7 +2177,7 @@ public class VMTest {
         DataWord val = program.getStorage().getStorageValue(new RskAddress(invoke.getOwnerAddress()), key);
 
         assertTrue(program.isStopped());
-        assertEquals(s_expected_val, Hex.toHexString(val.getData()).toUpperCase());
+        assertEquals(s_expected_val, ByteUtil.toHexString(val.getData()).toUpperCase());
     }
 
     @Test // JUMPDEST OP for JUMPI
@@ -2201,7 +2200,7 @@ public class VMTest {
         DataWord val = program.getStorage().getStorageValue(new RskAddress(invoke.getOwnerAddress()), key);
 
         assertTrue(program.isStopped());
-        assertEquals(s_expected_val, Hex.toHexString(val.getData()).toUpperCase());
+        assertEquals(s_expected_val, ByteUtil.toHexString(val.getData()).toUpperCase());
     }
 
     @Test // ADD OP mal
@@ -2215,7 +2214,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // ADD OP
@@ -2229,7 +2228,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // ADD OP
@@ -2243,7 +2242,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // ADD OP mal
@@ -2270,7 +2269,7 @@ public class VMTest {
 
         DataWord item1 = program.stackPop();
         assertTrue(program.isStopped());
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // ADDMOD OP
@@ -2285,7 +2284,7 @@ public class VMTest {
 
         DataWord item1 = program.stackPop();
         assertFalse(program.isStopped());
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // ADDMOD OP
@@ -2300,7 +2299,7 @@ public class VMTest {
 
         DataWord item1 = program.stackPop();
         assertTrue(program.isStopped());
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // ADDMOD OP mal
@@ -2325,7 +2324,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // MUL OP
@@ -2339,7 +2338,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // MUL OP
@@ -2353,7 +2352,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // MUL OP mal
@@ -2379,7 +2378,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // MULMOD OP
@@ -2393,7 +2392,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // MULMOD OP
@@ -2407,7 +2406,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // MULMOD OP mal
@@ -2432,7 +2431,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // DIV OP
@@ -2446,7 +2445,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
 
@@ -2461,7 +2460,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // DIV OP
@@ -2475,7 +2474,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
 
@@ -2490,7 +2489,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // DIV OP
@@ -2517,7 +2516,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // SDIV OP
@@ -2531,7 +2530,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // SDIV OP
@@ -2546,7 +2545,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // SDIV OP mal
@@ -2573,7 +2572,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // SUB OP
@@ -2587,7 +2586,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // SUB OP
@@ -2601,7 +2600,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // SUB OP mal
@@ -2626,7 +2625,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // MSIZE OP
@@ -2642,7 +2641,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
 
@@ -2676,7 +2675,7 @@ public class VMTest {
         DataWord item1 = program.stackPop();
         long gas = program.getResult().getGasUsed();
 
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
         assertEquals(66, gas);
     }
 
@@ -2694,7 +2693,7 @@ public class VMTest {
         DataWord item1 = program.stackPop();
         long gas = program.getResult().getGasUsed();
 
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
         assertEquals(16, gas);
     }
 
@@ -2712,7 +2711,7 @@ public class VMTest {
         DataWord item1 = program.stackPop();
         long gas = program.getResult().getGasUsed();
 
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
         assertEquals(116, gas);
     }
 
@@ -2744,7 +2743,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected_1, Hex.toHexString(program.getResult().getHReturn()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(program.getResult().getHReturn()).toUpperCase());
         assertTrue(program.isStopped());
     }
 
@@ -2763,7 +2762,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected_1, Hex.toHexString(program.getResult().getHReturn()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(program.getResult().getHReturn()).toUpperCase());
         assertTrue(program.isStopped());
     }
 
@@ -2781,7 +2780,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected_1, Hex.toHexString(program.getResult().getHReturn()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(program.getResult().getHReturn()).toUpperCase());
         assertTrue(program.isStopped());
     }
 
@@ -2800,7 +2799,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(s_expected_1, Hex.toHexString(program.getResult().getHReturn()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(program.getResult().getHReturn()).toUpperCase());
         assertTrue(program.isStopped());
     }
 
@@ -2816,7 +2815,7 @@ public class VMTest {
         vm.step(program);
 
         long gas = program.getResult().getGasUsed();
-        assertEquals(m_expected_1, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected_1, ByteUtil.toHexString(program.getMemory()).toUpperCase());
         assertEquals(6, gas);
     }
 
@@ -2837,7 +2836,7 @@ public class VMTest {
         vm.step(program);
 
         long gas = program.getResult().getGasUsed();
-        assertEquals(m_expected_1, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected_1, ByteUtil.toHexString(program.getMemory()).toUpperCase());
         assertEquals(10, gas);
     }
 
@@ -2924,7 +2923,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected_1, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected_1, ByteUtil.toHexString(program.getMemory()).toUpperCase());
     }
 
     @Test // EXTCODECOPY OP
@@ -2942,7 +2941,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected_1, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected_1, ByteUtil.toHexString(program.getMemory()).toUpperCase());
     }
 
     @Test // EXTCODECOPY OP
@@ -2961,7 +2960,7 @@ public class VMTest {
         vm.step(program);
         vm.step(program);
 
-        assertEquals(m_expected_1, Hex.toHexString(program.getMemory()).toUpperCase());
+        assertEquals(m_expected_1, ByteUtil.toHexString(program.getMemory()).toUpperCase());
     }
 
     @Test // EXTCODECOPY OP
@@ -3013,7 +3012,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Ignore // todo: test is not testing EXTCODESIZE
@@ -3029,7 +3028,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // MOD OP
@@ -3042,7 +3041,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // MOD OP
@@ -3056,7 +3055,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // MOD OP
@@ -3070,7 +3069,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // MOD OP mal
@@ -3099,7 +3098,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // SMOD OP
@@ -3115,7 +3114,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test // SMOD OP
@@ -3130,7 +3129,7 @@ public class VMTest {
         vm.step(program);
 
         DataWord item1 = program.stackPop();
-        assertEquals(s_expected_1, Hex.toHexString(item1.getData()).toUpperCase());
+        assertEquals(s_expected_1, ByteUtil.toHexString(item1.getData()).toUpperCase());
     }
 
     @Test(expected = StackTooSmallException.class) // SMOD OP mal
@@ -3296,7 +3295,7 @@ public class VMTest {
         StringBuilder ret = new StringBuilder();
         for (int i = 0; i < binData.length; i+= 16) {
             ret.append(Utils.align("" + Integer.toHexString(startPC + (i)) + ":", ' ', 8, false));
-            ret.append(Hex.toHexString(binData, i, min(16, binData.length - i))).append('\n');
+            ret.append(ByteUtil.toHexString(binData, i, min(16, binData.length - i))).append('\n');
         }
         return ret.toString();
     }

--- a/rskj-core/src/test/java/org/ethereum/vm/trace/DetailedProgramTraceProcessorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/trace/DetailedProgramTraceProcessorTest.java
@@ -22,9 +22,9 @@ package org.ethereum.vm.trace;
 import co.rsk.config.VmConfig;
 import co.rsk.crypto.Keccak256;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Repository;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
 import org.junit.Assert;
@@ -74,7 +74,7 @@ public class DetailedProgramTraceProcessorTest {
         JsonNode jnode = processor.getProgramTraceAsJsonNode(hash);
 
         Assert.assertNotNull(jnode);
-        Assert.assertEquals(Hex.toHexString(ownerDW.getLast20Bytes()), jnode.get("contractAddress").asText());
+        Assert.assertEquals(ByteUtil.toHexString(ownerDW.getLast20Bytes()), jnode.get("contractAddress").asText());
 
         String jsonText = jnode.toString();
         Assert.assertNotNull(jsonText);


### PR DESCRIPTION
Changes that are done if scope of this pull request:

1. Removed truncation of ids, hashes etc. while logging them.
2. Encapsulated `Hex.toHexString()` method inside the `ByteUtil` class.
3. Improved `Transaction.toString()` method. Now inside the `Transaction.toString()` method the `gasPrice`, `receiveAddress` and `value` fields are printed directly without calling `toString()` on them (which could cause `NullPointerException` when, for instance, `gasPrice` or the other fields are `null`).
4. Added logging of tx hash in Program class

Note: there are a lot of files with changes, but the changes themselves are pretty straightforward. Mostly replacements in logging methods.