### PR TITLE
Fix JSON RPC trace_transaction and trace_block

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -388,7 +388,7 @@ public class BridgeSupport {
 
         TransferInvoke invoke = new TransferInvoke(from, to, gas, value);
         ProgramResult result     = ProgramResult.empty();
-        ProgramSubtrace subtrace = ProgramSubtrace.newCallSubtrace(CallType.CALL, invoke, result, Collections.emptyList());
+        ProgramSubtrace subtrace = ProgramSubtrace.newCallSubtrace(CallType.CALL, invoke, result, null, Collections.emptyList());
 
         this.subtraces.add(subtrace);
     }

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascFeesPayer.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascFeesPayer.java
@@ -68,7 +68,7 @@ class RemascFeesPayer {
 
         TransferInvoke invoke = new TransferInvoke(from, to, gas, amount);
         ProgramResult result     = new ProgramResult();
-        ProgramSubtrace subtrace = ProgramSubtrace.newCallSubtrace(CallType.CALL, invoke, result, Collections.emptyList());
+        ProgramSubtrace subtrace = ProgramSubtrace.newCallSubtrace(CallType.CALL, invoke, result, null, Collections.emptyList());
 
         this.subtraces.add(subtrace);
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/CallType.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/CallType.java
@@ -25,7 +25,7 @@ public enum CallType {
     NONE,
     CALL,
     CALLCODE,
-    DELEGATECODE,
+    DELEGATECALL,
     STATICCALL;
 
     public static CallType fromMsgType(MessageCall.MsgType msgType) {
@@ -35,7 +35,7 @@ public enum CallType {
             case CALLCODE:
                 return CALLCODE;
             case DELEGATECALL:
-                return DELEGATECODE;
+                return DELEGATECALL;
             case STATICCALL:
                 return STATICCALL;
             default:

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/ProgramSubtrace.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/ProgramSubtrace.java
@@ -29,26 +29,28 @@ public class ProgramSubtrace {
     private final TraceType traceType;
     private final CallType callType;
     private final CreationData creationData;
+    private final String creationMethod;
     private final InvokeData invokeData;
     private final ProgramResult programResult;
     private final List<ProgramSubtrace> subtraces;
 
     public static ProgramSubtrace newSuicideSubtrace(InvokeData invokeData) {
-        return new ProgramSubtrace(TraceType.SUICIDE, CallType.NONE, null, invokeData, null, Collections.emptyList());
+        return new ProgramSubtrace(TraceType.SUICIDE, CallType.NONE, null, null, invokeData, null, Collections.emptyList());
     }
 
-    public static ProgramSubtrace newCreateSubtrace(CreationData creationData, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces) {
-        return new ProgramSubtrace(TraceType.CREATE, CallType.NONE, creationData, invokeData, programResult, subtraces);
+    public static ProgramSubtrace newCreateSubtrace(CreationData creationData, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces, boolean isCreate2) {
+        return new ProgramSubtrace(TraceType.CREATE, CallType.NONE, creationData, isCreate2 ? "create2" : null, invokeData, programResult, subtraces);
     }
 
     public static ProgramSubtrace newCallSubtrace(CallType callType, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces) {
-        return new ProgramSubtrace(TraceType.CALL, callType, null, invokeData, programResult, subtraces);
+        return new ProgramSubtrace(TraceType.CALL, callType, null, null, invokeData, programResult, subtraces);
     }
 
-    private ProgramSubtrace(TraceType traceType, CallType callType, CreationData creationData, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces) {
+    private ProgramSubtrace(TraceType traceType, CallType callType, CreationData creationData, String creationMethod, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces) {
         this.traceType = traceType;
         this.callType = callType;
         this.creationData = creationData;
+        this.creationMethod = creationMethod;
         this.invokeData = invokeData;
         this.programResult = programResult;
         this.subtraces = subtraces == null ? null : Collections.unmodifiableList(subtraces);
@@ -59,6 +61,8 @@ public class ProgramSubtrace {
     public CallType getCallType() { return this.callType; }
 
     public CreationData getCreationData() { return this.creationData; }
+
+    public String getCreationMethod() { return this.creationMethod; }
 
     public InvokeData getInvokeData() {
         return this.invokeData;

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/ProgramSubtrace.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/ProgramSubtrace.java
@@ -41,7 +41,7 @@ public class ProgramSubtrace {
     }
 
     public static ProgramSubtrace newCreateSubtrace(CreationData creationData, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces, boolean isCreate2) {
-        return new ProgramSubtrace(TraceType.CREATE, CallType.NONE, creationData, isCreate2 ? "create2" : null, invokeData, programResult, null, subtraces);
+        return new ProgramSubtrace(TraceType.CREATE, CallType.NONE, creationData, isCreate2 ? "create2" : "create", invokeData, programResult, null, subtraces);
     }
 
     public static ProgramSubtrace newCallSubtrace(CallType callType, InvokeData invokeData, ProgramResult programResult, DataWord codeAddress, List<ProgramSubtrace> subtraces) {

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/ProgramSubtrace.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/ProgramSubtrace.java
@@ -19,6 +19,7 @@
 
 package co.rsk.rpc.modules.trace;
 
+import org.ethereum.vm.DataWord;
 import org.ethereum.vm.program.ProgramResult;
 import org.ethereum.vm.program.invoke.InvokeData;
 
@@ -32,27 +33,29 @@ public class ProgramSubtrace {
     private final String creationMethod;
     private final InvokeData invokeData;
     private final ProgramResult programResult;
+    private final DataWord codeAddress;
     private final List<ProgramSubtrace> subtraces;
 
     public static ProgramSubtrace newSuicideSubtrace(InvokeData invokeData) {
-        return new ProgramSubtrace(TraceType.SUICIDE, CallType.NONE, null, null, invokeData, null, Collections.emptyList());
+        return new ProgramSubtrace(TraceType.SUICIDE, CallType.NONE, null, null, invokeData, null, null, Collections.emptyList());
     }
 
     public static ProgramSubtrace newCreateSubtrace(CreationData creationData, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces, boolean isCreate2) {
-        return new ProgramSubtrace(TraceType.CREATE, CallType.NONE, creationData, isCreate2 ? "create2" : null, invokeData, programResult, subtraces);
+        return new ProgramSubtrace(TraceType.CREATE, CallType.NONE, creationData, isCreate2 ? "create2" : null, invokeData, programResult, null, subtraces);
     }
 
-    public static ProgramSubtrace newCallSubtrace(CallType callType, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces) {
-        return new ProgramSubtrace(TraceType.CALL, callType, null, null, invokeData, programResult, subtraces);
+    public static ProgramSubtrace newCallSubtrace(CallType callType, InvokeData invokeData, ProgramResult programResult, DataWord codeAddress, List<ProgramSubtrace> subtraces) {
+        return new ProgramSubtrace(TraceType.CALL, callType, null, null, invokeData, programResult, codeAddress, subtraces);
     }
 
-    private ProgramSubtrace(TraceType traceType, CallType callType, CreationData creationData, String creationMethod, InvokeData invokeData, ProgramResult programResult, List<ProgramSubtrace> subtraces) {
+    private ProgramSubtrace(TraceType traceType, CallType callType, CreationData creationData, String creationMethod, InvokeData invokeData, ProgramResult programResult, DataWord codeAddress, List<ProgramSubtrace> subtraces) {
         this.traceType = traceType;
         this.callType = callType;
         this.creationData = creationData;
         this.creationMethod = creationMethod;
         this.invokeData = invokeData;
         this.programResult = programResult;
+        this.codeAddress = codeAddress;
         this.subtraces = subtraces == null ? null : Collections.unmodifiableList(subtraces);
     }
 
@@ -71,6 +74,8 @@ public class ProgramSubtrace {
     public ProgramResult getProgramResult() {
         return this.programResult;
     }
+
+    public DataWord getCodeAddress() { return this.codeAddress; }
 
     public List<ProgramSubtrace> getSubtraces() { return this.subtraces == null ? null : Collections.unmodifiableList(this.subtraces); }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceAction.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceAction.java
@@ -33,6 +33,7 @@ public class TraceAction {
     private final String address;
     private final String refundAddress;
     private final String balance;
+    private final String creationMethod;
 
     public TraceAction(
             CallType callType,
@@ -41,6 +42,7 @@ public class TraceAction {
             String gas,
             String input,
             String init,
+            String creationMethod,
             String value,
             String address,
             String refundAddress,
@@ -51,6 +53,7 @@ public class TraceAction {
         this.gas = gas;
         this.input = input;
         this.init = init;
+        this.creationMethod = creationMethod;
         this.value = value;
         this.address = address;
         this.refundAddress = refundAddress;
@@ -84,6 +87,11 @@ public class TraceAction {
     @JsonGetter("input")
     public String getInput() {
         return this.input;
+    }
+
+    @JsonGetter("creationMethod")
+    public String getCreationMethod() {
+        return this.creationMethod;
     }
 
     @JsonGetter("init")

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceTransformer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceTransformer.java
@@ -70,7 +70,7 @@ public class TraceTransformer {
 
         int nsubtraces = trace.getSubtraces().size();
 
-        traces.add(toTrace(traceType, trace.getInvokeData(), programResult, txInfo, blockNumber, traceAddress, callType, creationData, trace.getError(), nsubtraces));
+        traces.add(toTrace(traceType, trace.getInvokeData(), programResult, txInfo, blockNumber, traceAddress, callType, creationData, null, trace.getError(), nsubtraces));
 
         for (int k = 0; k < nsubtraces; k++) {
             addTrace(traces, trace.getSubtraces().get(k), txInfo, blockNumber, new TraceAddress(traceAddress, k));
@@ -78,7 +78,7 @@ public class TraceTransformer {
     }
 
     private static void addTrace(List<TransactionTrace> traces, ProgramSubtrace subtrace, TransactionInfo txInfo, long blockNumber, TraceAddress traceAddress) {
-        traces.add(toTrace(subtrace.getTraceType(), subtrace.getInvokeData(), subtrace.getProgramResult(), txInfo, blockNumber, traceAddress, subtrace.getCallType(), subtrace.getCreationData(), null, subtrace.getSubtraces().size()));
+        traces.add(toTrace(subtrace.getTraceType(), subtrace.getInvokeData(), subtrace.getProgramResult(), txInfo, blockNumber, traceAddress, subtrace.getCallType(), subtrace.getCreationData(), subtrace.getCreationMethod(), null, subtrace.getSubtraces().size()));
 
         int nsubtraces = subtrace.getSubtraces().size();
 
@@ -87,8 +87,8 @@ public class TraceTransformer {
         }
     }
 
-    public static TransactionTrace toTrace(TraceType traceType, InvokeData invoke, ProgramResult programResult, TransactionInfo txInfo, long blockNumber, TraceAddress traceAddress, CallType callType, CreationData creationData, String err, int nsubtraces) {
-        TraceAction action = toAction(traceType, invoke, callType, creationData == null ? null : creationData.getCreationInput());
+    public static TransactionTrace toTrace(TraceType traceType, InvokeData invoke, ProgramResult programResult, TransactionInfo txInfo, long blockNumber, TraceAddress traceAddress, CallType callType, CreationData creationData, String creationMethod, String err, int nsubtraces) {
+        TraceAction action = toAction(traceType, invoke, callType, creationData == null ? null : creationData.getCreationInput(), creationMethod);
         TraceResult result = null;
         String error = null;
 
@@ -145,7 +145,7 @@ public class TraceTransformer {
         return new TraceResult(gasUsed, output, code, address);
     }
 
-    public static TraceAction toAction(TraceType traceType, InvokeData invoke, CallType callType, byte[] creationInput) {
+    public static TraceAction toAction(TraceType traceType, InvokeData invoke, CallType callType, byte[] creationInput, String creationMethod) {
         String from = new RskAddress(invoke.getCallerAddress().getLast20Bytes()).toJsonString();
         String to = null;
         String gas = null;
@@ -186,6 +186,7 @@ public class TraceTransformer {
                 gas,
                 input,
                 init,
+                creationMethod,
                 value,
                 address,
                 refundAddress,

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceTransformer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceTransformer.java
@@ -178,7 +178,11 @@ public class TraceTransformer {
             value = TypeConverter.toQuantityJsonHex(callValue.getData());
 
             if (callType == CallType.DELEGATECALL) {
-                to = new RskAddress(codeAddress.getLast20Bytes()).toJsonString();
+                // The code address should not be null in a DELEGATECALL case
+                // but handling the case here
+                if (codeAddress != null) {
+                    to = new RskAddress(codeAddress.getLast20Bytes()).toJsonString();
+                }
             }
             else {
                 to = new RskAddress(invoke.getOwnerAddress().getLast20Bytes()).toJsonString();

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -777,7 +777,7 @@ public class Program {
             TransferInvoke invoke = new TransferInvoke(callerAddress, ownerAddress, msg.getGas().longValue(), transferValue);
             ProgramResult result = new ProgramResult();
 
-            ProgramSubtrace subtrace = ProgramSubtrace.newCallSubtrace(CallType.fromMsgType(msg.getType()), invoke, result, Collections.emptyList());
+            ProgramSubtrace subtrace = ProgramSubtrace.newCallSubtrace(CallType.fromMsgType(msg.getType()), invoke, result, null, Collections.emptyList());
 
             getTrace().addSubTrace(subtrace);
         }
@@ -821,7 +821,7 @@ public class Program {
         vm.play(program);
         childResult  = program.getResult();
 
-        getTrace().addSubTrace(ProgramSubtrace.newCallSubtrace(CallType.fromMsgType(msg.getType()), program.getProgramInvoke(), program.getResult(), program.getTrace().getSubtraces()));
+        getTrace().addSubTrace(ProgramSubtrace.newCallSubtrace(CallType.fromMsgType(msg.getType()), program.getProgramInvoke(), program.getResult(), msg.getCodeAddress(), program.getTrace().getSubtraces()));
 
         getTrace().merge(program.getTrace());
         getResult().merge(childResult);

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -433,7 +433,7 @@ public class Program {
         byte[] newAddressBytes = HashUtil.calcNewAddr(getOwnerAddress().getLast20Bytes(), nonce);
         RskAddress newAddress = new RskAddress(newAddressBytes);
 
-        createContract(senderAddress, nonce, value, memStart, memSize, newAddress);
+        createContract(senderAddress, nonce, value, memStart, memSize, newAddress, false);
     }
 
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
@@ -445,10 +445,10 @@ public class Program {
         byte[] nonce = getStorage().getNonce(senderAddress).toByteArray();
         RskAddress newAddress = new RskAddress(newAddressBytes);
 
-        createContract(senderAddress, nonce, value, memStart, memSize, newAddress);
+        createContract(senderAddress, nonce, value, memStart, memSize, newAddress, true);
     }
 
-    private void createContract( RskAddress senderAddress, byte[] nonce, DataWord value, DataWord memStart, DataWord memSize, RskAddress contractAddress) {
+    private void createContract( RskAddress senderAddress, byte[] nonce, DataWord value, DataWord memStart, DataWord memSize, RskAddress contractAddress, boolean isCreate2) {
         if (getCallDeep() == getMaxDepth()) {
             logger.debug("max depth reached creating a new contract inside contract run: [{}]", senderAddress);
             stackPushZero();
@@ -564,7 +564,7 @@ public class Program {
 
 
         // [5] COOK THE INVOKE AND EXECUTE
-        programResult = getProgramResult(senderAddress, nonce, value, contractAddress, endowment, programCode, gasLimit, track, newBalance, programResult);
+        programResult = getProgramResult(senderAddress, nonce, value, contractAddress, endowment, programCode, gasLimit, track, newBalance, programResult, isCreate2);
         if (programResult == null) {
             return;
         }
@@ -589,7 +589,7 @@ public class Program {
 
     private ProgramResult getProgramResult(RskAddress senderAddress, byte[] nonce, DataWord value,
                                            RskAddress contractAddress, Coin endowment, byte[] programCode,
-                                           long gasLimit, Repository track, Coin newBalance, ProgramResult programResult) {
+                                           long gasLimit, Repository track, Coin newBalance, ProgramResult programResult, boolean isCreate2) {
 
 
         InternalTransaction internalTx = addInternalTx(nonce, getGasLimit(), senderAddress, RskAddress.nullAddress(), endowment, programCode, "create");
@@ -606,7 +606,7 @@ public class Program {
             programResult = program.getResult();
 
             if (programResult.getException() == null && !programResult.isRevert()) {
-                getTrace().addSubTrace(ProgramSubtrace.newCreateSubtrace(new CreationData(programCode, programResult.getHReturn(), contractAddress), program.getProgramInvoke(), program.getResult(), program.getTrace().getSubtraces()));
+                getTrace().addSubTrace(ProgramSubtrace.newCreateSubtrace(new CreationData(programCode, programResult.getHReturn(), contractAddress), program.getProgramInvoke(), program.getResult(), program.getTrace().getSubtraces(), isCreate2));
             }
         }
 

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
@@ -397,6 +397,36 @@ public class TraceModuleImplTest {
         Assert.assertEquals("\"delegatecall\"", oresult.get("action").get("callType").toString());
     }
 
+    @Test
+    public void executeContractWithCreate2() throws Exception {
+        DslParser parser = DslParser.fromResource("dsl/create201.txt");
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = new World(receiptStore);
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        Transaction transaction = world.getTransactionByName("tx01");
+
+        TraceModuleImpl traceModule = new TraceModuleImpl(world.getBlockChain(), world.getBlockStore(), receiptStore, world.getBlockExecutor());
+
+        JsonNode result = traceModule.traceTransaction(transaction.getHash().toJsonString());
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray());
+
+        ArrayNode aresult = (ArrayNode)result;
+
+        Assert.assertEquals(2, aresult.size());
+        Assert.assertTrue(result.get(0).isObject());
+
+        ObjectNode oresult = (ObjectNode)result.get(1);
+
+        Assert.assertNotNull(oresult.get("action"));
+        Assert.assertNotNull(oresult.get("action").get("creationMethod"));
+        Assert.assertEquals("\"create2\"", oresult.get("action").get("creationMethod").toString());
+    }
+
     private static World executeMultiContract(ReceiptStore receiptStore) throws DslProcessorException, FileNotFoundException {
         DslParser parser = DslParser.fromResource("dsl/contracts08.txt");
         World world = new World(receiptStore);

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
@@ -90,6 +90,7 @@ public class TraceModuleImplTest {
         Assert.assertEquals("\"create\"", oresult.get("type").toString());
 
         Assert.assertNotNull(oresult.get("action"));
+        Assert.assertNull(oresult.get("action").get("creationMethod"));
         Assert.assertNotNull(oresult.get("action").get("init"));
         Assert.assertNull(oresult.get("action").get("input"));
     }
@@ -179,6 +180,12 @@ public class TraceModuleImplTest {
             Assert.assertEquals("\"create\"", oresult.get("type").toString());
 
             Assert.assertNotNull(oresult.get("action"));
+
+            if (k > 0) {
+                Assert.assertNotNull(oresult.get("action").get("creationMethod"));
+                Assert.assertEquals("\"create\"", oresult.get("action").get("creationMethod").toString());
+            }
+
             Assert.assertNotNull(oresult.get("action").get("init"));
             Assert.assertNull(oresult.get("action").get("input"));
         }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
@@ -367,6 +367,36 @@ public class TraceModuleImplTest {
         Assert.assertEquals("\"call\"", oresult.get("type").toString());
     }
 
+    @Test
+    public void executeContractWithDelegateCall() throws Exception {
+        DslParser parser = DslParser.fromResource("dsl/delegatecall01.txt");
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = new World(receiptStore);
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        Transaction transaction = world.getTransactionByName("tx01");
+
+        TraceModuleImpl traceModule = new TraceModuleImpl(world.getBlockChain(), world.getBlockStore(), receiptStore, world.getBlockExecutor());
+
+        JsonNode result = traceModule.traceTransaction(transaction.getHash().toJsonString());
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray());
+
+        ArrayNode aresult = (ArrayNode)result;
+
+        Assert.assertEquals(2, aresult.size());
+        Assert.assertTrue(result.get(0).isObject());
+
+        ObjectNode oresult = (ObjectNode)result.get(1);
+
+        Assert.assertNotNull(oresult.get("action"));
+        Assert.assertNotNull(oresult.get("action").get("callType"));
+        Assert.assertEquals("\"delegatecall\"", oresult.get("action").get("callType").toString());
+    }
+
     private static World executeMultiContract(ReceiptStore receiptStore) throws DslProcessorException, FileNotFoundException {
         DslParser parser = DslParser.fromResource("dsl/contracts08.txt");
         World world = new World(receiptStore);

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
@@ -46,7 +46,7 @@ public class TraceTransformerTest {
                 null, null, null, null, null, null,
                 null, null, 0, null, false, false);
 
-        TraceAction action = TraceTransformer.toAction(TraceType.CALL, invoke, CallType.CALL, null, null);
+        TraceAction action = TraceTransformer.toAction(TraceType.CALL, invoke, CallType.CALL, null, null, null);
 
         Assert.assertNotNull(action);
 
@@ -79,7 +79,7 @@ public class TraceTransformerTest {
                 null, null, null, null, null, null,
                 null, null, 0, null, false, false);
 
-        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, null);
+        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, null, null);
 
         Assert.assertNotNull(action);
 
@@ -113,7 +113,7 @@ public class TraceTransformerTest {
                 null, null, null, null, null, null,
                 null, null, 0, null, false, false);
 
-        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, "create2");
+        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, "create2", null);
 
         Assert.assertNotNull(action);
 

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
@@ -46,7 +46,7 @@ public class TraceTransformerTest {
                 null, null, null, null, null, null,
                 null, null, 0, null, false, false);
 
-        TraceAction action = TraceTransformer.toAction(TraceType.CALL, invoke, CallType.CALL, null);
+        TraceAction action = TraceTransformer.toAction(TraceType.CALL, invoke, CallType.CALL, null, null);
 
         Assert.assertNotNull(action);
 
@@ -79,7 +79,7 @@ public class TraceTransformerTest {
                 null, null, null, null, null, null,
                 null, null, 0, null, false, false);
 
-        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data);
+        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, null);
 
         Assert.assertNotNull(action);
 
@@ -87,6 +87,41 @@ public class TraceTransformerTest {
         Assert.assertNull(action.getTo());
         Assert.assertEquals("0x0000000000000000000000000000000000000003", action.getFrom());
         Assert.assertEquals("0x01020304", action.getInit());
+        Assert.assertNull(action.getCreationMethod());
+        Assert.assertEquals("0xf4240", action.getGas());
+        Assert.assertEquals("0x186a0", action.getValue());
+    }
+
+    @Test
+    public void getActionFromInvokeDataWithCreationDataUsingCreationMethod() {
+        DataWord address = DataWord.valueOf(1);
+        DataWord origin = DataWord.valueOf(2);
+        DataWord caller = DataWord.valueOf(3);
+        long gas = 1000000;
+        DataWord callValue = DataWord.valueOf(100000);
+        byte[] data = new byte[]{0x01, 0x02, 0x03, 0x04};
+
+        ProgramInvoke invoke = new ProgramInvokeImpl(
+                address,
+                origin,
+                caller,
+                null,
+                null,
+                gas,
+                callValue,
+                null,
+                null, null, null, null, null, null,
+                null, null, 0, null, false, false);
+
+        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, "create2");
+
+        Assert.assertNotNull(action);
+
+        Assert.assertNull(action.getCallType());
+        Assert.assertNull(action.getTo());
+        Assert.assertEquals("0x0000000000000000000000000000000000000003", action.getFrom());
+        Assert.assertEquals("0x01020304", action.getInit());
+        Assert.assertEquals("create2", action.getCreationMethod());
         Assert.assertEquals("0xf4240", action.getGas());
         Assert.assertEquals("0x186a0", action.getValue());
     }

--- a/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsltest/WorldDslProcessorTest.java
@@ -18,6 +18,7 @@
 
 package co.rsk.test.dsltest;
 
+import co.rsk.bitcoinj.core.Address;
 import co.rsk.db.RepositorySnapshot;
 import co.rsk.test.World;
 import co.rsk.test.dsl.DslParser;
@@ -296,6 +297,61 @@ public class WorldDslProcessorTest {
         Assert.assertNotNull(account);
         RepositorySnapshot repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
         Assert.assertEquals(new BigInteger("1000000"), repository.getBalance(account.getAddress()).asBigInteger());
+    }
+
+    @Test
+    public void processAccountNewCommandWithBalanceAndCode() throws DslProcessorException {
+        World world = new World();
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+
+        DslParser parser = new DslParser("account_new acc1 1000000 01020304");
+
+        processor.processCommands(parser);
+
+        Account account = world.getAccountByName("acc1");
+
+        Assert.assertNotNull(account);
+        RepositorySnapshot repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        Assert.assertEquals(new BigInteger("1000000"), repository.getBalance(account.getAddress()).asBigInteger());
+
+        byte[] code = repository.getCode(account.getAddress());
+
+        Assert.assertNotNull(code);
+        Assert.assertArrayEquals(new byte[] { 0x01, 0x02, 0x03, 0x04 }, code);
+    }
+
+    @Test
+    public void processAccountNewCommandWithBalanceAndCodeWithOtherAccountAddress() throws DslProcessorException {
+        World world = new World();
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+
+        DslParser parser0 = new DslParser("account_new acc0");
+
+        processor.processCommands(parser0);
+
+        DslParser parser = new DslParser("account_new acc1 1000000 0102[acc0]0304");
+
+        processor.processCommands(parser);
+
+        Account account0 = world.getAccountByName("acc0");
+        Account account = world.getAccountByName("acc1");
+
+        Assert.assertNotNull(account);
+        RepositorySnapshot repository = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        Assert.assertEquals(new BigInteger("1000000"), repository.getBalance(account.getAddress()).asBigInteger());
+
+        byte[] code = repository.getCode(account.getAddress());
+        byte[] expected = new byte[4 + 20];
+        expected[0] = 0x01;
+        expected[1] = 0x02;
+        System.arraycopy(account0.getAddress().getBytes(), 0, expected, 2, Address.LENGTH);
+        expected[22] = 0x03;
+        expected[23] = 0x04;
+
+        Assert.assertNotNull(code);
+        Assert.assertArrayEquals(expected, code);
     }
 
     @Test

--- a/rskj-core/src/test/resources/dsl/call01.txt
+++ b/rskj-core/src/test/resources/dsl/call01.txt
@@ -1,0 +1,46 @@
+
+account_new acc1 10000000
+
+# contract account with simple return
+
+# code
+# PUSH1 0x00
+# PUSH1 0x00
+# RETURN
+
+account_new called 0 60006000f3
+
+# contract account with call
+
+# code
+# PUSH1 0x00    (output data size)
+# PUSH1 0x00    (output data offset)
+# PUSH1 0x00    (input data size)
+# PUSH1 0x00    (input data offset)
+# PUSH1 0x00    (value to transfer)
+# PUSH20 <called contract address>
+# PUSH2 0x1000   (gas to use)
+# CALL
+# STOP
+
+account_new call 0 6000600060006000600073[called]611000f100
+
+# invoke call contract
+
+transaction_build tx01
+    sender acc1
+    receiver call
+    value 0
+    gas 1200000
+    build
+
+block_build b01
+    parent g00
+    transactions tx01
+    build
+
+block_connect b01
+
+# Assert best block
+assert_best b01
+

--- a/rskj-core/src/test/resources/dsl/create201.txt
+++ b/rskj-core/src/test/resources/dsl/create201.txt
@@ -1,0 +1,34 @@
+
+account_new acc1 10000000
+
+# contract account with create2 call
+
+# code
+# PUSH1 0x00    (salt)
+# PUSH1 0x01    (code memory length)
+# PUSH1 0x00    (code memory offset)
+# PUSH1 0x00   (value to use)
+# CREATE2
+# STOP
+
+account_new creator 0 6000600160006000f500
+
+# invoke creator contract
+
+transaction_build tx01
+    sender acc1
+    receiver creator
+    value 0
+    gas 1200000
+    build
+
+block_build b01
+    parent g00
+    transactions tx01
+    build
+
+block_connect b01
+
+# Assert best block
+assert_best b01
+

--- a/rskj-core/src/test/resources/dsl/delegatecall01.txt
+++ b/rskj-core/src/test/resources/dsl/delegatecall01.txt
@@ -1,0 +1,45 @@
+
+account_new acc1 10000000
+
+# contract account with simple return
+
+# code
+# PUSH1 0x00
+# PUSH1 0x00
+# RETURN
+
+account_new delegated 0 60006000f3
+
+# contract account with delegate call
+
+# code
+# PUSH1 0x00    (output data size)
+# PUSH1 0x00    (output data offset)
+# PUSH1 0x00    (input data size)
+# PUSH1 0x00    (input data offset)
+# PUSH20 <delegated contract address>
+# PUSH2 0x1000   (gas to use)
+# DELEGATECALL
+# STOP
+
+account_new delegatecall 0 600060006000600073[delegated]611000f400
+
+# invoke delegatecall contract
+
+transaction_build tx01
+    sender acc1
+    receiver delegatecall
+    value 0
+    gas 1200000
+    build
+
+block_build b01
+    parent g00
+    transactions tx01
+    build
+
+block_connect b01
+
+# Assert best block
+assert_best b01
+


### PR DESCRIPTION
This  code fix two issues in current JSON RPC output for `trace_transaction` and `trace_block`:

- `callType` value should be `delegatecall` when the call from contract A to contract B was executed via a DELEGATECALL opcode

```
  {
    "action": {
      "callType": "delegatecall",         //   <-------------- this value
      "from": "0x9653f73cbf95b738a44019aeb1efc4e1b5632d71",
      "gas": "0x3fd19",
      "input": "0xb63e800d0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000180000000000000000000000000d5d82b6addc9027b22dca772aa68d5d74cdbdf4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023fe3a2cefb32800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000140f54704b9b5d6d4158501f0aed48474ddc0529000000000000000000000000150d407e066f079fbbdce728fac8b51d2c56f26800000000000000000000000086425fba06faaf4353e275b925af0aa13a2af99100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      "to": "0x34cfac646f301356faa8b21e94227e3583fe3f5f",
      "value": "0x0"
    },
    "blockHash": "0x17162e1eae50987a63bcd3e046d3f370a28125c9735b6624b32333df2d765c69",
    "blockNumber": 10356397,
    "result": {
      "gasUsed": "0x30fb8",
      "output": "0x"
    },
    "subtraces": 1,
    "traceAddress": [
      1,
      0
    ],
    "transactionHash": "0xabf3f349e585a728441ce9a45c06897fb4d15fd4cc7bfdbdd0c449d0096fe79a",
    "transactionPosition": 21,
    "type": "call"
  },
```

This new code also solves #1291 

.- the `creationMethod` value should be `create2` when a contract is created from another contract using the CREATE2 opcode (this code also adds this field with value `create` when a CREATE opcode is used):

```
  {
    "action": {
      "creationMethod": "create2",     //   <-------------- this value
      "from": "0x76e2cfc1f5fa8f6a5b3fc4c8f4788f0116861f9b",
      "gas": "0x4eaea",
      "init": "0x608060405234801561001057600080fd5b506040516101e73803806101e78339818101604052602081101561003357600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100ca576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260248152602001806101c36024913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505060aa806101196000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea265627a7a72315820d8a00dc4fe6bf675a9d7416fc2d00bb3433362aa8186b750f76c4027269667ff64736f6c634300050e0032496e76616c6964206d617374657220636f707920616464726573732070726f766964656400000000000000000000000034cfac646f301356faa8b21e94227e3583fe3f5f",
      "value": "0x0"
    },
    "blockHash": "0x17162e1eae50987a63bcd3e046d3f370a28125c9735b6624b32333df2d765c69",
    "blockNumber": 10356397,
    "result": {
      "address": "0x9653f73cbf95b738a44019aeb1efc4e1b5632d71",
      "code": "0x608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea265627a7a72315820d8a00dc4fe6bf675a9d7416fc2d00bb3433362aa8186b750f76c4027269667ff64736f6c634300050e0032",
      "gasUsed": "0xd745"
    },
    "subtraces": 0,
    "traceAddress": [
      0
    ],
    "transactionHash": "0xabf3f349e585a728441ce9a45c06897fb4d15fd4cc7bfdbdd0c449d0096fe79a",
    "transactionPosition": 21,
    "type": "create"
  },
  {
    "action": {
      "callType": "call",
      "from": "0x76e2cfc1f5fa8f6a5b3fc4c8f4788f0116861f9b",
      "gas": "0x413ce",
      "input": "0xb63e800d0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000180000000000000000000000000d5d82b6addc9027b22dca772aa68d5d74cdbdf4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023fe3a2cefb32800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000140f54704b9b5d6d4158501f0aed48474ddc0529000000000000000000000000150d407e066f079fbbdce728fac8b51d2c56f26800000000000000000000000086425fba06faaf4353e275b925af0aa13a2af99100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      "to": "0x9653f73cbf95b738a44019aeb1efc4e1b5632d71",
      "value": "0x0"
    },
    "blockHash": "0x17162e1eae50987a63bcd3e046d3f370a28125c9735b6624b32333df2d765c69",
    "blockNumber": 10356397,
    "result": {
      "gasUsed": "0x31662",
      "output": "0x"
    },
    "subtraces": 1,
    "traceAddress": [
      1
    ],
    "transactionHash": "0xabf3f349e585a728441ce9a45c06897fb4d15fd4cc7bfdbdd0c449d0096fe79a",
    "transactionPosition": 21,
    "type": "call"
  },

```



