### PR TITLE
Fix index DB shutdown NPE

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1674,7 +1674,6 @@ public class RskContext implements NodeBootstrapper {
         }
 
         DB indexDB = DBMaker.fileDB(dbFile)
-                .closeOnJvmShutdown()
                 .make();
 
         KeyValueDataSource blocksDB = LevelDbDataSource.makeDataSource(Paths.get(databaseDir, "blocks"));

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainFlusher.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainFlusher.java
@@ -72,6 +72,13 @@ public class BlockChainFlusher implements InternalService {
     public void stop() {
         emitter.removeListener(listener);
         flushAll();
+        closeAll();
+    }
+
+    private void closeAll() {
+        logger.trace("closing blockStore.");
+        blockStore.close();
+        logger.trace("blockStore closed.");
     }
 
     private void flush() {

--- a/rskj-core/src/main/java/co/rsk/db/BlocksIndex.java
+++ b/rskj-core/src/main/java/co/rsk/db/BlocksIndex.java
@@ -84,4 +84,6 @@ public interface BlocksIndex {
      * Commits the changes to the underlying permanent storage.
      */
     void flush();
+
+    void close();
 }

--- a/rskj-core/src/main/java/co/rsk/db/MapDBBlocksIndex.java
+++ b/rskj-core/src/main/java/co/rsk/db/MapDBBlocksIndex.java
@@ -135,4 +135,9 @@ public class MapDBBlocksIndex implements BlocksIndex {
     public void flush() {
         indexDB.commit();
     }
+
+    @Override
+    public void close() {
+        indexDB.close();
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/db/BlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/BlockStore.java
@@ -79,4 +79,6 @@ public interface BlockStore extends RemascCache {
     List<BlockInformation> getBlocksInformationByNumber(long number);
 
     boolean isEmpty();
+
+    void close();
 }

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -183,6 +183,10 @@ public class IndexedBlockStore implements BlockStore {
         profiler.stop(metric);
     }
 
+    public void close() {
+        this.index.close();
+    }
+
     @Override
     public synchronized void saveBlock(Block block, BlockDifficulty cummDifficulty, boolean mainChain) {
         List<BlockInfo> blockInfos = index.getBlocksByNumber(block.getNumber());

--- a/rskj-core/src/main/resources/logback.xml
+++ b/rskj-core/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
             </Pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ON</level>
+            <level>OFF</level>
         </filter>
     </appender>
 
@@ -31,9 +31,6 @@
                 %date{yyyy-MM-dd-HH:mm:ss.SSSS} %p [%c{1}] [%thread]%replace( [%mdc{}]){' \[\]', ''}  %m%n
             </Pattern>
         </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>OFF</level>
-        </filter>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./logs/rskj-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>

--- a/rskj-core/src/main/resources/logback.xml
+++ b/rskj-core/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
             </Pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>OFF</level>
+            <level>ON</level>
         </filter>
     </appender>
 
@@ -31,6 +31,9 @@
                 %date{yyyy-MM-dd-HH:mm:ss.SSSS} %p [%c{1}] [%thread]%replace( [%mdc{}]){' \[\]', ''}  %m%n
             </Pattern>
         </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>OFF</level>
+        </filter>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./logs/rskj-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>

--- a/rskj-core/src/test/java/co/rsk/db/HashMapBlocksIndex.java
+++ b/rskj-core/src/test/java/co/rsk/db/HashMapBlocksIndex.java
@@ -62,4 +62,9 @@ public class HashMapBlocksIndex implements BlocksIndex {
     @Override
     public void flush() {
     }
+
+    @Override
+    public void close() {
+
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/db/BlockStoreDummy.java
+++ b/rskj-core/src/test/java/org/ethereum/db/BlockStoreDummy.java
@@ -122,6 +122,11 @@ public class BlockStoreDummy implements BlockStore {
     }
 
     @Override
+    public void close() {
+
+    }
+
+    @Override
     public Map<Long, List<Sibling>> getSiblingsFromBlockByHash(Keccak256 hash) {
         return null;
     }


### PR DESCRIPTION
- Issue

When we a halt of the JVM (on purpose or not), we have a NPE trying to commit the changes on the indexDB. So last blocks were lost. 
The problem was that the DB was initialised with a property of closeOnShutdown, so when we try to flush it's already closed (shouldn't throw a NPE, but thats because we use an older version of mapdb).

- Solution

What i did was just remove the option of automatically closing the db when shutdown, and do it "manually" after flushing.

- Test

Dont know how to properly test it, i just run a node -> stop it by halting the jvm -> start it again (checking that the last block number its the same as when starts).

- Exception thrown

```
Exception in thread "Thread-3" java.lang.NullPointerException
	at org.mapdb.StoreDirect.indexValGet(StoreDirect.java:1575)
	at org.mapdb.StoreWAL.indexValGet(StoreWAL.java:307)
	at org.mapdb.StoreDirect.update2(StoreDirect.java:378)
	at org.mapdb.StoreCached.flushWriteCacheSegment(StoreCached.java:454)
	at org.mapdb.StoreCached.flushWriteCache(StoreCached.java:429)
	at org.mapdb.StoreWAL.commit(StoreWAL.java:613)
	at org.mapdb.Engine$CloseOnJVMShutdown.commit(Engine.java:489)
	at org.mapdb.DB.commit(DB.java:2638)
	at co.rsk.db.MapDBBlocksIndex.flush(MapDBBlocksIndex.java:136)
	at org.ethereum.db.IndexedBlockStore.flush(IndexedBlockStore.java:182)
	at co.rsk.core.bc.BlockChainFlusher.flushAll(BlockChainFlusher.java:87)
	at co.rsk.core.bc.BlockChainFlusher.stop(BlockChainFlusher.java:69)
	at co.rsk.FullNodeRunner.stop(FullNodeRunner.java:76)
	at java.lang.Thread.run(Thread.java:748)
```