### PR TITLE
Clean returnDataBuffer for call-like opcodes

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorMinimuGasPriceValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorMinimuGasPriceValidator.java
@@ -39,5 +39,4 @@ public class TxValidatorMinimuGasPriceValidator implements TxValidatorStep {
 
         return TransactionValidationResult.withError("transaction's gas price lower than block's minimum");
     }
-
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -51,6 +51,7 @@ public enum ConsensusRule {
     RSKIP152("rskip152"),
     RSKIP156("rskip156"),
     RSKIP169("rskip169"),
+    RSKIP171("rskip171"),
     RSKIPUMM("rskipUMM");
 
     private String configKey;

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1482,12 +1482,12 @@ public class VM {
 
         MessageCall msg = getMessageCall(gas, codeAddress, activations);
 
-        PrecompiledContracts.PrecompiledContract contract = precompiledContracts.getContractForAddress(activations, codeAddress);
+        PrecompiledContracts.PrecompiledContract precompiledContract = precompiledContracts.getContractForAddress(activations, codeAddress);
 
-        if (contract != null) {
-            program.callToPrecompiledAddress(msg, contract);
+        if (precompiledContract != null) {
+            program.callToPrecompiledAddress(msg, precompiledContract);
         } else {
-            program.callToAddress(msg);
+            program.callToAddress(msg, activations);
         }
 
         program.step();

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1485,7 +1485,7 @@ public class VM {
         PrecompiledContracts.PrecompiledContract precompiledContract = precompiledContracts.getContractForAddress(activations, codeAddress);
 
         if (precompiledContract != null) {
-            program.callToPrecompiledAddress(msg, precompiledContract);
+            program.callToPrecompiledAddress(msg, precompiledContract, activations);
         } else {
             program.callToAddress(msg, activations);
         }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -733,6 +733,9 @@ public class Program {
         Coin endowment = new Coin(msg.getEndowment().getData());
         Coin senderBalance = track.getBalance(senderAddress);
         if (isNotCovers(senderBalance, endowment)) {
+            // reset return data buffer when call did not create a new call frame
+            // *TODO*: set check to activate only after a certain release
+            returnDataBuffer = null;
             stackPushZero();
             refundGas(msg.getGas().longValue(), "refund gas from message call");
             return;
@@ -769,6 +772,7 @@ public class Program {
             track.commit();
             callResult = true;
             refundGas(GasCost.toGas(msg.getGas().longValue()), "remaining gas from the internal call");
+            returnDataBuffer = null;            
 
             DataWord callerAddress = DataWord.valueOf(senderAddress.getBytes());
             DataWord ownerAddress = DataWord.valueOf(contextAddress.getBytes());
@@ -851,6 +855,7 @@ public class Program {
             // 4. THE FLAG OF SUCCESS IS ONE PUSHED INTO THE STACK
             track.commit();
         }
+
 
 
         // 3. APPLY RESULTS: childResult.getHReturn() into out_memory allocated

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -796,7 +796,7 @@ public class Program {
     }
 
     private void cleanReturnDataBuffer(ActivationConfig.ForBlock activations) {
-        if(activations.isActive(ConsensusRule.EIP_211_COMPATIBILITY)) {
+        if(activations.isActive(ConsensusRule.RSKIP171)) {
             // reset return data buffer when call did not create a new call frame
             returnDataBuffer = null;
         }

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1332,11 +1332,12 @@ public class Program {
         return ret;
     }
 
-    public void callToPrecompiledAddress(MessageCall msg, PrecompiledContract contract) {
+    public void callToPrecompiledAddress(MessageCall msg, PrecompiledContract contract, ActivationConfig.ForBlock activations) {
 
         if (getCallDeep() == getMaxDepth()) {
             stackPushZero();
             this.refundGas(msg.getGas().longValue(), " call deep limit reach");
+
             return;
         }
 
@@ -1351,6 +1352,8 @@ public class Program {
         if (senderBalance.compareTo(endowment) < 0) {
             stackPushZero();
             this.refundGas(msg.getGas().longValue(), "refund gas from message call");
+            this.cleanReturnDataBuffer(activations);
+
             return;
         }
 
@@ -1402,10 +1405,10 @@ public class Program {
 
         long requiredGas = contract.getGasForData(data);
         if (requiredGas > msg.getGas().longValue()) {
-
             this.refundGas(0, "call pre-compiled"); //matches cpp logic
             this.stackPushZero();
             track.rollback();
+            this.cleanReturnDataBuffer(activations);
         } else {
 
             this.refundGas(msg.getGas().longValue() - requiredGas, "call pre-compiled");

--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -7,7 +7,8 @@ blockchain.config {
         orchid060 = 0,
         wasabi100 = 0,
         twoToThree = 0,
-        papyrus200 = 0
+        papyrus200 = 0,
+        iris300 = 0
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -47,6 +47,7 @@ blockchain = {
              rskip156 = <hardforkName>
              rskipUMM = <hardforkName>
              rskip169 = <hardforkName>
+             rskip171 = <height>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -38,6 +38,7 @@ blockchain = {
             rskip156 = papyrus200
             rskipUMM = papyrus200
             rskip169 = iris300
+            rskip171 = iris300
         }
     }
     gc = {

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -73,7 +73,7 @@ public class ActivationConfigTest {
             "    rskip156: papyrus200",
             "    rskipUMM: papyrus200",
             "    rskip169: iris300",
-
+            "    rskip171: iris300",
             "}"
     ));
 

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -257,7 +257,7 @@ public class VMTest {
                 " RETURN"  // the return value of the contract should be zero (as last call failed)
         ));
         vm.steps(program, Long.MAX_VALUE);
-        assertEquals(program.getResult().getHReturn(), new byte[0]);
+        assertEquals(program.getResult().getHReturn(), new byte[32]);
     }
 
     @Test
@@ -293,7 +293,7 @@ public class VMTest {
                " RETURN"  // the return value of the return data size (should be zero)
        ));
        vm.steps(program, Long.MAX_VALUE);
-       assertEquals(program.getResult().getHReturn(), new byte[0]);
+       assertEquals(program.getResult().getHReturn(), new byte[32]);
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -248,13 +248,13 @@ public class VMTest {
                 " PUSH1 0x00" + // but call a non-existent contract
                 " PUSH4 0x005B8D80" +
                 " STATICCALL" +
-                " PUSH1 0x20 " +
-                " PUSH1 0x00 " +
-                " PUSH1 0x40" +
-                " RETURNDATACOPY" +
-                " PUSH1 0x20" +
-                " PUSH1 0x40" +
-                " RETURN"  // the return value of the contract should be 0x15 (0x40 not overwritten)
+                " PUSH1 0x20 " + // now put the 32 bytes
+                " PUSH1 0x00 " + // from the beginning of the return databuffer
+                " PUSH1 0x40" + //  to the 0x40 position on memory
+                " RETURNDATACOPY" + // do it!
+                " PUSH1 0x20" +  // and return 32 bytes
+                " PUSH1 0x40" +  // from the 0x40 position on memory
+                " RETURN"  // the return value of the contract should be zero (as last call failed)
         ));
         vm.steps(program, Long.MAX_VALUE);
         assertEquals(program.getResult().getHReturn(), new byte[0]);
@@ -285,12 +285,12 @@ public class VMTest {
                " PUSH1 0x00" + // but call a non-existent contract
                " PUSH4 0x005B8D80" +
                " STATICCALL" +
-               " RETURNDATASIZE" +
+               " RETURNDATASIZE" + // push the return data size to the stack
                " PUSH1 0x40" +
-               " MSTORE" +
+               " MSTORE" +  // and store the value in the 0x40 position
                " PUSH1 0x20" +
                " PUSH1 0x40" +
-               " RETURN"  // the return value of the contract should be 0x15 (0x40 not overwritten)
+               " RETURN"  // the return value of the return data size (should be zero)
        ));
        vm.steps(program, Long.MAX_VALUE);
        assertEquals(program.getResult().getHReturn(), new byte[0]);

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -275,7 +275,7 @@ public class VMTest {
                 " PUSH1 0x40" +     // from the 0x40 position on memory
                 " RETURN"           // the return value of the contract should be zero (as last call failed)
         ));
-        when(program.getActivations().isActive(ConsensusRule.EIP_211_COMPATIBILITY)).thenReturn(active);
+        when(program.getActivations().isActive(ConsensusRule.RSKIP171)).thenReturn(active);
         vm.steps(program, Long.MAX_VALUE);
         byte[] result = program.getResult().getHReturn();
         assertArrayEquals(expected, result);
@@ -319,7 +319,7 @@ public class VMTest {
                 " STATICCALL" +
                 " RETURNDATASIZE" // push the return data size to the stack
         ));
-        when(program.getActivations().isActive(ConsensusRule.EIP_211_COMPATIBILITY)).thenReturn(active);
+        when(program.getActivations().isActive(ConsensusRule.RSKIP171)).thenReturn(active);
         vm.steps(program, Long.MAX_VALUE);
         assertEquals(expectedReturnDataSize, program.stackPop().intValue());
     }
@@ -377,7 +377,7 @@ public class VMTest {
                         " CALL" +       // call it! result should be 0x15
                         " RETURNDATASIZE" // push the return data size to the stack
         ));
-        when(program.getActivations().isActive(ConsensusRule.EIP_211_COMPATIBILITY)).thenReturn(irisHardForkActive);
+        when(program.getActivations().isActive(ConsensusRule.RSKIP171)).thenReturn(irisHardForkActive);
         when(program.getActivations().isActive(ConsensusRule.RSKIP119)).thenReturn(true);
         vm.steps(program, Long.MAX_VALUE);
         assertEquals(expectedReturnDataSize, program.stackPop().intValue());
@@ -422,7 +422,7 @@ public class VMTest {
                         " CALL" +
                         " RETURNDATASIZE" // push the return data size to the stack
         ), TransactionUtils.createTransaction());
-        when(program.getActivations().isActive(ConsensusRule.EIP_211_COMPATIBILITY)).thenReturn(irisHardForkActive);
+        when(program.getActivations().isActive(ConsensusRule.RSKIP171)).thenReturn(irisHardForkActive);
         when(program.getActivations().isActive(ConsensusRule.RSKIP119)).thenReturn(true);
         vm.steps(program, Long.MAX_VALUE);
         assertEquals(expectedReturnDataSize, program.stackPop().intValue());

--- a/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/VMTest.java
@@ -22,6 +22,7 @@ package org.ethereum.vm;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.config.VmConfig;
 import co.rsk.core.RskAddress;
+import co.rsk.net.utils.TransactionUtils;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.vm.BitSet;
@@ -226,10 +227,10 @@ public class VMTest {
     // This test should throw an exception because we are reading from the RETURNDATABUFFER
     // in a non-existent position. This results in an error according to EIP 211
     @Test(expected = RuntimeException.class)
-    public void cleanReturnDataBufferAfterCallToNonExistentContract() {
+    public void returnDataBufferAfterCallToNonExistentContract() {
         byte[] expected = new byte[32];
         Arrays.fill(expected, (byte) 0);
-        doCallAfterCallToNonExistentContract(expected, true);
+        doCallToNonExistentContractAndReturnValue(expected, true);
     }
 
     @Test
@@ -237,10 +238,10 @@ public class VMTest {
         byte[] expected = new byte[32];
         Arrays.fill(expected, (byte) 0);
         expected[31] = (byte) 21;
-        doCallAfterCallToNonExistentContract(expected, false);
+        doCallToNonExistentContractAndReturnValue(expected, false);
     }
 
-    private void doCallAfterCallToNonExistentContract(byte[] expected, boolean active) {
+    private void doCallToNonExistentContractAndReturnValue(byte[] expected, boolean active) {
         invoke = new ProgramInvokeMockImpl(compile(
                 "PUSH1 0x10" +
                 " PUSH1 0x05 " +
@@ -281,16 +282,16 @@ public class VMTest {
     }
 
     @Test
-    public void cleanReturnDataBufferAfterCallToNonExistent() {
-        doCallToNonExistent(true, 0);
+    public void returnDataSizeAfterCallToNonExistentContract() {
+        doCallToNonExistentContractAndReturnDataSize(true, 0);
     }
 
     @Test
-    public void beforeIrisReturnDataBufferAfterCallToNonExistent() {
-        doCallToNonExistent(false, 32);
+    public void beforeIrisReturnDataSizeAfterCallToNonExistentContract() {
+        doCallToNonExistentContractAndReturnDataSize(false, 32);
     }
 
-    private void doCallToNonExistent(boolean active, int expectedReturnDataSize) {
+    private void doCallToNonExistentContractAndReturnDataSize(boolean active, int expectedReturnDataSize) {
         invoke = new ProgramInvokeMockImpl(compile(
                  "PUSH1 0x10" +
                  " PUSH1 0x05 " +
@@ -324,16 +325,30 @@ public class VMTest {
     }
 
     @Test
-    public void cleanReturnDataBufferAfterInsufficientFunds() {
-        doCallInsufficientFunds(true, 0);
+    public void returnDataBufferAfterInsufficientFunds() {
+        String contract = "471fd3ad3e9eeadeec4608b92d16ce6b500704cc"; // in the mock contract specified above
+        doCallInsufficientFunds(true, 0, contract);
     }
 
     @Test
-    public void beforeIrisReturnDataBufferCallWithInsufficientFunds() {
-        doCallInsufficientFunds(false, 32);
+    public void returnDataBufferAfterInsufficientFundsAtPrecompiled() {
+        String precompiled = "0000000000000000000000000000000001000010";
+        doCallInsufficientFunds(true, 0, precompiled);
     }
 
-    private void doCallInsufficientFunds(boolean consensusRuleActive, int expectedReturnDataSize) {
+    @Test
+    public void beforeIrisReturnDataBufferWithInsufficientFunds() {
+        String contract = "471fd3ad3e9eeadeec4608b92d16ce6b500704cc"; // in the mock contract specified above
+        doCallInsufficientFunds(false, 32, contract);
+    }
+
+    @Test
+    public void beforeIrisReturnDataBufferWithInsufficientFundsAtPrecompiled() {
+        String precompiled = "0000000000000000000000000000000001000010";
+        doCallInsufficientFunds(false, 32, precompiled);
+    }
+
+    private void doCallInsufficientFunds(boolean irisHardForkActive, int expectedReturnDataSize, String contract) {
         invoke = new ProgramInvokeMockImpl(compile(
                 "PUSH1 0x10" +
                         " PUSH1 0x05 " +
@@ -356,13 +371,59 @@ public class VMTest {
                         " PUSH1 0x40" +       // on free memory pointer
                         " PUSH1 0x00" +       // no argument
                         " PUSH1 0x00" +       // no argument size
-                        " PUSH4 0x00002710" +       // with a high value
-                        " PUSH20 0x" + invoke.getContractAddress() + // in the mock contract specified above
+                        " PUSH4 0xffffffff" +       // with a high value
+                        " PUSH20 0x" + contract +
                         " PUSH4 0x005B8D80" + // with some gas
                         " CALL" +       // call it! result should be 0x15
                         " RETURNDATASIZE" // push the return data size to the stack
         ));
-        when(program.getActivations().isActive(ConsensusRule.EIP_211_COMPATIBILITY)).thenReturn(consensusRuleActive);
+        when(program.getActivations().isActive(ConsensusRule.EIP_211_COMPATIBILITY)).thenReturn(irisHardForkActive);
+        when(program.getActivations().isActive(ConsensusRule.RSKIP119)).thenReturn(true);
+        vm.steps(program, Long.MAX_VALUE);
+        assertEquals(expectedReturnDataSize, program.stackPop().intValue());
+    }
+
+    @Test
+    public void returnDataBufferAfterEnoughGasAtPrecompiled() {
+        doCallToPrecompiledEnoughGas(true, 0);
+    }
+
+    @Test
+    public void beforeIrisReturnDataBufferAfterEnoughGasAtPrecompiled() {
+        doCallToPrecompiledEnoughGas(false, 32);
+    }
+
+    private void doCallToPrecompiledEnoughGas(boolean irisHardForkActive, int expectedReturnDataSize) {
+        invoke = new ProgramInvokeMockImpl(compile(
+                "PUSH1 0x10" +
+                        " PUSH1 0x05 " +
+                        " ADD" +
+                        " PUSH1 0x40" +
+                        " MSTORE " +
+                        " PUSH1 0x20 " +
+                        " PUSH1 0x40" +
+                        " RETURN"
+        ), null);
+        program = getProgramWithTransaction(compile(
+                " PUSH1 0x20" +  // return size is 32 bytes
+                        " PUSH1 0x40" +       // on free memory pointer
+                        " PUSH1 0x00" +       // no argument
+                        " PUSH1 0x00" +       // no argument size
+                        " PUSH20 0x" + invoke.getContractAddress() + // in the mock contract specified above
+                        " PUSH4 0x005B8D80" + // with some gas
+                        " STATICCALL" +       // call it! result should be 0x15
+                        " PUSH1 0x20" + // return size is 32 bytes
+                        " PUSH1 0x40" + // on free memory pointer
+                        " PUSH1 0x00" + // no argument
+                        " PUSH1 0x00" + // no argument size
+                        " PUSH1 0x00" + // with no value
+                        " PUSH20 0x" + PrecompiledContracts.IDENTITY_ADDR_STR +
+                        " PUSH1 0x00" + // without gas!
+                        " CALL" +
+                        " RETURNDATASIZE" // push the return data size to the stack
+        ), TransactionUtils.createTransaction());
+        when(program.getActivations().isActive(ConsensusRule.EIP_211_COMPATIBILITY)).thenReturn(irisHardForkActive);
+        when(program.getActivations().isActive(ConsensusRule.RSKIP119)).thenReturn(true);
         vm.steps(program, Long.MAX_VALUE);
         assertEquals(expectedReturnDataSize, program.stackPop().intValue());
     }
@@ -3418,6 +3479,10 @@ public class VMTest {
 
     private Program getProgram(byte[] code) {
         return getProgram(code, null);
+    }
+
+    private Program getProgramWithTransaction(byte[] code, Transaction transaction) {
+        return getProgram(code, transaction);
     }
 
     private ActivationConfig.ForBlock getBlockchainConfig(boolean preFixStaticCall) {


### PR DESCRIPTION
This PR aims 
- to move [this](https://github.com/rsksmart/rskj/pull/991) other PR into "hardfork mode"
- Fix [this](https://github.com/rsksmart/rskj/issues/1272) issue

According to the [EIP-211](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-211.md)

```
If the call-like opcode is executed but does not really instantiate a call frame (for example 
due to insufficient funds for a value transfer or if the called contract does not exist), 
the return data buffer is empty.
```

Since VM code it's critical, we've decided to implement it as part of hardfork.

I've also added elements to `ConsensusRule` & `NetworkUpgrade` enums to be used in the future network upgrade

NOTE: `ConsensusRule` name (eip211Compatibility) will be changed