### PR TITLE
Preserve Txn revert reason

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
@@ -22,6 +22,10 @@ public class RskJsonRpcRequestException extends RuntimeException {
         return executionError("transaction reverted");
     }
 
+    public static RskJsonRpcRequestException transactionRevertedExecutionError(String revertReason) {
+        return executionError(revertReason);
+    }
+
     public static RskJsonRpcRequestException unknownError(String message) {
         return new RskJsonRpcRequestException(-32009, message);
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDLSTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDLSTest.java
@@ -47,7 +47,6 @@ import static org.mockito.ArgumentMatchers.anyByte;
 public class EthModuleDLSTest {
     @Test
     public void testCall_getRevertReason() throws FileNotFoundException, DslProcessorException {
-        System.gc();
         DslParser parser = DslParser.fromResource("dsl/eth_module/revert_reason.txt");
         World world = new World();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDLSTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDLSTest.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth;
+
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.ReversibleTransactionExecutor;
+import co.rsk.core.TransactionExecutorFactory;
+import co.rsk.rpc.ExecutionBlockRetriever;
+import co.rsk.test.World;
+import co.rsk.test.dsl.DslParser;
+import co.rsk.test.dsl.DslProcessorException;
+import co.rsk.test.dsl.WorldDslProcessor;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.vm.PrecompiledContracts;
+import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyByte;
+
+/**
+ * Created by patogallaiovlabs on 28/10/2020.
+ */
+public class EthModuleDLSTest {
+    @Test
+    public void testCall_getRevertReason() throws FileNotFoundException, DslProcessorException {
+        System.gc();
+        DslParser parser = DslParser.fromResource("dsl/eth_module/revert_reason.txt");
+        World world = new World();
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        TransactionReceipt transactionReceipt = world.getTransactionReceiptByName("tx02");
+        byte[] status = transactionReceipt.getStatus();
+
+        Assert.assertNotNull(status);
+        Assert.assertEquals(0, status.length);
+
+        EthModule eth = buildEthModule(world);
+        final Transaction tx01 = world.getTransactionByName("tx01");
+        final Web3.CallArguments args = new Web3.CallArguments();
+        args.to = tx01.getContractAddress().toHexString(); //"6252703f5ba322ec64d3ac45e56241b7d9e481ad";
+        args.data = "d96a094a0000000000000000000000000000000000000000000000000000000000000000"; // call to contract with param value = 0
+        args.value = "0";
+        args.nonce = "1";
+        args.gas = "10000000";
+        try {
+            eth.call(args, "0x2");
+            fail();
+        } catch (RskJsonRpcRequestException e) {
+            assertThat(e.getMessage(), Matchers.containsString("Negative value."));
+        }
+
+        args.data = "d96a094a0000000000000000000000000000000000000000000000000000000000000001"; // call to contract with param value = 1
+        final String call = eth.call(args, "0x2");
+        assertEquals("0x00", call);
+    }
+
+    private EthModule buildEthModule(World world) {
+        final TestSystemProperties config = new TestSystemProperties();
+        TransactionExecutorFactory executor = new TransactionExecutorFactory(
+                config,
+                world.getBlockStore(),
+                null,
+                null,
+                new ProgramInvokeFactoryImpl(),
+                new PrecompiledContracts(config, world.getBridgeSupportFactory()),
+                null
+        );
+
+        return new EthModule(
+                null,
+                anyByte(),
+                world.getBlockChain(),
+                null,
+                new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),
+                new ExecutionBlockRetriever(null, world.getBlockChain(), null, null),
+                null,
+                null,
+                null,
+                world.getBridgeSupportFactory());
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDLSTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDLSTest.java
@@ -26,6 +26,7 @@ import co.rsk.test.World;
 import co.rsk.test.dsl.DslParser;
 import co.rsk.test.dsl.DslProcessorException;
 import co.rsk.test.dsl.WorldDslProcessor;
+import org.ethereum.config.Constants;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.rpc.Web3;
@@ -93,7 +94,7 @@ public class EthModuleDLSTest {
 
         return new EthModule(
                 null,
-                anyByte(),
+                Constants.REGTEST_CHAIN_ID,
                 world.getBlockChain(),
                 null,
                 new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),

--- a/rskj-core/src/test/resources/dsl/eth_module/revert_reason.txt
+++ b/rskj-core/src/test/resources/dsl/eth_module/revert_reason.txt
@@ -1,0 +1,69 @@
+
+comment
+
+// Contracts compiled using
+// Truffle v5.1.14 (core: 5.1.14)
+// Solidity v0.5.16 (solc-js)
+// the contract to be deployed is RevertReason
+
+// the contracts source code
+
+pragma solidity >=0.5.0 <0.7.0;
+
+contract RevertReason {
+    function buy(uint amount) public payable {
+        require(
+            amount > 0,
+            "Negative value."
+        );
+    }
+}
+
+end
+
+account_new acc1 20000000
+
+# Deploy RevertReason
+
+transaction_build tx01
+    sender acc1
+    receiverAddress 00
+    value 0
+    data 608060405234801561001057600080fd5b5061010f806100206000396000f3fe6080604052600436106039576000357c010000000000000000000000000000000000000000000000000000000090048063d96a094a14603e575b600080fd5b606760048036036020811015605257600080fd5b81019080803590602001909291905050506069565b005b60008111151560e0576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252600f8152602001807f4e656761746976652076616c75652e000000000000000000000000000000000081525060200191505060405180910390fd5b5056fea165627a7a7230582028a98e792c3f36ab792c10a5bd8d5f46b19e22fbc9c43635c77fec5a5858254e0029
+    gas 2000000
+    build
+
+block_build b01
+    parent g00
+    transactions tx01
+    build
+
+block_connect b01
+
+# Assert best block
+assert_best b01
+
+# invoke increment(350) method
+
+transaction_build tx02
+    sender acc1
+    nonce 1
+    contract tx01   # created in tx01
+    value 0
+    data d96a094a0000000000000000000000000000000000000000000000000000000000000000
+    gas 6400000
+    build
+
+block_build b02
+    parent b01
+    transactions tx02
+    gasLimit 6500000
+    build
+
+block_connect b02
+
+# Assert best block
+assert_best b02
+
+# Back to code test, you must check tx02 result is Error with message = "Negative value."
+


### PR DESCRIPTION
RSK is not notifying the revert reason when a transaction invoked by RPC is reverted. This PR decodes and adds the revert reason to the exception thrown in such case.
