### PR TITLE
Set flushNumberOfBlocks to 1000

### DIFF
--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -44,6 +44,7 @@ blockchain = {
         epochs = 3
         blocksPerEpoch = 20000
     }
+    flushNumberOfBlocks = 1000
 }
 
 peer {


### PR DESCRIPTION
With this pull request the config property `flushNumberOfBlocks` is set to `1000`. Previously default value of it was `20`.

Reason for this is a result of some benchmarking tests that were made.