### PR TITLE
Subroutines in EVM

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -52,6 +52,7 @@ public enum ConsensusRule {
     RSKIP156("rskip156"),
     RSKIP169("rskip169"),
     RSKIP171("rskip171"),
+    EIP2315("eip2315"),
     RSKIPUMM("rskipUMM");
 
     private String configKey;

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -52,7 +52,7 @@ public enum ConsensusRule {
     RSKIP156("rskip156"),
     RSKIP169("rskip169"),
     RSKIP171("rskip171"),
-    EIP2315("eip2315"),
+    RSKIP172("rskip172"),
     RSKIPUMM("rskipUMM");
 
     private String configKey;

--- a/rskj-core/src/main/java/org/ethereum/vm/OpCode.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/OpCode.java
@@ -324,6 +324,21 @@ public enum OpCode {
      */
     JUMPDEST(0x5b, 0, 0, SPECIAL_TIER),
 
+    /*  Subroutines Operations */
+
+    /**
+     * (0x5c)
+     */
+    BEGINSUB(0x5c, 0, 0, BASE_TIER),
+    /**
+     * (0x5d)
+     */
+    RETURNSUB(0x5d, 0, 0, LOW_TIER),
+    /**
+     * (0x5e)
+     */
+    JUMPSUB(0x5e, 1, 0, HIGH_TIER),
+
     /*  Push Operations */
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/vm/OpCodes.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/OpCodes.java
@@ -326,15 +326,15 @@ public class OpCodes {
     /**
      * (0x5c)
      */
-    static final byte OP_BEGINSUB =0x5c ;
+    public static final byte OP_BEGINSUB =0x5c ;
     /**
      * (0x5d)
      */
-    static final byte OP_RETURNSUB =0x5d ;
+    public static final byte OP_RETURNSUB =0x5d ;
     /**
      * (0x5e)
      */
-    static final byte OP_JUMPSUB =0x5e ;
+    public static final byte OP_JUMPSUB =0x5e ;
 
     /*  Push Operations */
 

--- a/rskj-core/src/main/java/org/ethereum/vm/OpCodes.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/OpCodes.java
@@ -321,6 +321,21 @@ public class OpCodes {
      */
     static final byte OP_JUMPDEST =0x5b ;
 
+    /*  Subroutines Operations */
+
+    /**
+     * (0x5c)
+     */
+    static final byte OP_BEGINSUB =0x5c ;
+    /**
+     * (0x5d)
+     */
+    static final byte OP_RETURNSUB =0x5d ;
+    /**
+     * (0x5e)
+     */
+    static final byte OP_JUMPSUB =0x5e ;
+
     /*  Push Operations */
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -88,7 +88,7 @@ public class VM {
     private static final String logString = "{}    Op: [{}]  Gas: [{}] Deep: [{}]  Hint: [{}]";
     private static final boolean computeGas = true; // for performance comp
 
-    private static final int MAX_RETURN_STACK_SIZE = 1024;
+    private static final int MAX_RETURN_STACK_SIZE = 1023;
 
     /* Keeps track of the number of steps performed in this VM */
     private int vmCounter = 0;

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1985,14 +1985,28 @@ public class VM {
              * Subroutines
              */
             case OpCodes.OP_JUMPSUB:
+                if (!activations.isActive(EIP2315)) {
+                    throw Program.ExceptionHelper.invalidOpCode(program);
+                }
+
                 doJUMPSUB();
+
                 break;
 
             case OpCodes.OP_RETURNSUB:
+                if (!activations.isActive(EIP2315)) {
+                    throw Program.ExceptionHelper.invalidOpCode(program);
+                }
+
                 doRETURNSUB();
+
                 break;
 
             case OpCodes.OP_BEGINSUB:
+                if (!activations.isActive(EIP2315)) {
+                    throw Program.ExceptionHelper.invalidOpCode(program);
+                }
+
                 throw Program.ExceptionHelper.invalidBeginSub(program, program.getPC());
 
             case OpCodes.OP_HEADER:

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -88,6 +88,8 @@ public class VM {
     private static final String logString = "{}    Op: [{}]  Gas: [{}] Deep: [{}]  Hint: [{}]";
     private static final boolean computeGas = true; // for performance comp
 
+    private static final int MAX_RETURN_STACK_SIZE = 1024;
+
     /* Keeps track of the number of steps performed in this VM */
     private int vmCounter = 0;
 
@@ -1680,6 +1682,10 @@ public class VM {
 
         if (isLogEnabled) {
             hint = "~> " + nextPC;
+        }
+
+        if (this.returnStack.size() >= MAX_RETURN_STACK_SIZE) {
+            throw Program.ExceptionHelper.returnStackOverflow(program, program.getPC());
         }
 
         this.returnStack.push(program.getPC() + 1);

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1676,7 +1676,7 @@ public class VM {
         spendOpCodeGas();
         // EXECUTION PHASE
         DataWord pos = program.stackPop();
-        int nextPC = program.verifyJumpSub(pos) + 1;
+        int nextPC = program.verifyBeginSub(pos) + 1;
 
         if (isLogEnabled) {
             hint = "~> " + nextPC;

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1985,7 +1985,7 @@ public class VM {
              * Subroutines
              */
             case OpCodes.OP_JUMPSUB:
-                if (!activations.isActive(EIP2315)) {
+                if (!activations.isActive(RSKIP172)) {
                     throw Program.ExceptionHelper.invalidOpCode(program);
                 }
 
@@ -1994,7 +1994,7 @@ public class VM {
                 break;
 
             case OpCodes.OP_RETURNSUB:
-                if (!activations.isActive(EIP2315)) {
+                if (!activations.isActive(RSKIP172)) {
                     throw Program.ExceptionHelper.invalidOpCode(program);
                 }
 
@@ -2003,7 +2003,7 @@ public class VM {
                 break;
 
             case OpCodes.OP_BEGINSUB:
-                if (!activations.isActive(EIP2315)) {
+                if (!activations.isActive(RSKIP172)) {
                     throw Program.ExceptionHelper.invalidOpCode(program);
                 }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1689,6 +1689,11 @@ public class VM {
 
     protected void doRETURNSUB(){
         spendOpCodeGas();
+
+        if (this.returnStack.isEmpty()) {
+            throw Program.ExceptionHelper.invalidReturnSub(program, program.getPC());
+        }
+
         // EXECUTION PHASE
         int nextPC = this.returnStack.pop();
 
@@ -1986,6 +1991,9 @@ public class VM {
             case OpCodes.OP_RETURNSUB:
                 doRETURNSUB();
                 break;
+
+            case OpCodes.OP_BEGINSUB:
+                throw Program.ExceptionHelper.invalidBeginSub(program, program.getPC());
 
             case OpCodes.OP_HEADER:
                 //fallthrough to default case until implementation's ready

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1332,6 +1332,20 @@ public class Program {
         return ret;
     }
 
+    public int verifyJumpSub(DataWord nextPC) {
+        if (nextPC.occupyMoreThan(4)) {
+            throw ExceptionHelper.badJumpDestination(this, -1);
+        }
+
+        int ret = nextPC.intValue(); // could be negative
+
+        if (ret < 0 || ret >= ops.length || ops[ret] != OpCodes.OP_BEGINSUB) {
+            throw ExceptionHelper.badJumpDestination(this, ret);
+        }
+
+        return ret;
+    }
+
     public void callToPrecompiledAddress(MessageCall msg, PrecompiledContract contract, ActivationConfig.ForBlock activations) {
 
         if (getCallDeep() == getMaxDepth()) {

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1334,13 +1334,13 @@ public class Program {
 
     public int verifyJumpSub(DataWord nextPC) {
         if (nextPC.occupyMoreThan(4)) {
-            throw ExceptionHelper.badJumpDestination(this, -1);
+            throw ExceptionHelper.badJumpSubDestination(this, -1);
         }
 
         int ret = nextPC.intValue(); // could be negative
 
         if (ret < 0 || ret >= ops.length || ops[ret] != OpCodes.OP_BEGINSUB) {
-            throw ExceptionHelper.badJumpDestination(this, ret);
+            throw ExceptionHelper.badJumpSubDestination(this, ret);
         }
 
         return ret;
@@ -1477,6 +1477,22 @@ public class Program {
     }
 
     @SuppressWarnings("serial")
+    public static class InvalidReturnSubException extends RuntimeException {
+
+        public InvalidReturnSubException(String message, Object... args) {
+            super(format(message, args));
+        }
+    }
+
+    @SuppressWarnings("serial")
+    public static class InvalidBeginSubException extends RuntimeException {
+
+        public InvalidBeginSubException(String message, Object... args) {
+            super(format(message, args));
+        }
+    }
+
+    @SuppressWarnings("serial")
     public static class StackTooSmallException extends RuntimeException {
 
         public StackTooSmallException(String message, Object... args) {
@@ -1534,6 +1550,18 @@ public class Program {
 
         public static BadJumpDestinationException badJumpDestination(@Nonnull Program program, int pc) {
             return new BadJumpDestinationException("Operation with pc isn't 'JUMPDEST': PC[%d], tx[%s]", pc, extractTxHash(program));
+        }
+
+        public static BadJumpDestinationException badJumpSubDestination(@Nonnull Program program, int pc) {
+            return new BadJumpDestinationException("Operation with pc isn't 'BEGINSUB': PC[%d], tx[%s]", pc, extractTxHash(program));
+        }
+
+        public static InvalidReturnSubException invalidReturnSub(@Nonnull Program program, int pc) {
+            return new InvalidReturnSubException("Invalid 'RETURNSUB': PC[%d], tx[%s]", pc, extractTxHash(program));
+        }
+
+        public static InvalidBeginSubException invalidBeginSub(@Nonnull Program program, int pc) {
+            return new InvalidBeginSubException("Invalid 'BEGINSUB': PC[%d], tx[%s]", pc, extractTxHash(program));
         }
 
         public static StackTooSmallException tooSmallStack(@Nonnull Program program, int expectedSize, int actualSize) {

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1509,6 +1509,14 @@ public class Program {
     }
 
     @SuppressWarnings("serial")
+    public static class ReturnStackOverflowException extends RuntimeException {
+
+        public ReturnStackOverflowException(String message, Object... args) {
+            super(format(message, args));
+        }
+    }
+
+    @SuppressWarnings("serial")
     public static class StaticCallModificationException extends RuntimeException {
         public StaticCallModificationException(String message, Object... args) {
             super(format(message, args));
@@ -1574,6 +1582,10 @@ public class Program {
 
         public static StackTooSmallException tooSmallStack(@Nonnull Program program, int expectedSize, int actualSize) {
             return new StackTooSmallException("Expected stack size %d but actual %d, tx: %s", expectedSize, actualSize, extractTxHash(program));
+        }
+
+        public static ReturnStackOverflowException returnStackOverflow(@Nonnull Program program, int pc) {
+            return new ReturnStackOverflowException("Return stack overflow: PC[%d], tx[%s]", pc, extractTxHash(program));
         }
 
         public static RuntimeException tooLargeContractSize(@Nonnull Program program, int maxSize, int actualSize) {

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -48,6 +48,7 @@ blockchain = {
              rskipUMM = <hardforkName>
              rskip169 = <hardforkName>
              rskip171 = <height>
+             eip2315 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -47,8 +47,8 @@ blockchain = {
              rskip156 = <hardforkName>
              rskipUMM = <hardforkName>
              rskip169 = <hardforkName>
-             rskip171 = <height>
-             eip2315 = <hardforkName>
+             rskip171 = <hardforkName>
+             rskip172 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -39,7 +39,7 @@ blockchain = {
             rskipUMM = papyrus200
             rskip169 = iris300
             rskip171 = iris300
-            eip2315 = iris300
+            rskip172 = iris300
         }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -39,6 +39,7 @@ blockchain = {
             rskipUMM = papyrus200
             rskip169 = iris300
             rskip171 = iris300
+            eip2315 = iris300
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -800,6 +800,26 @@ public class VMExecutionTest {
     }
 
     @Test
+    public void pushArgumentIsNotBeginsub() {
+        byte[] code = compiler.compile("PUSH1 0x04 JUMPSUB STOP BEGINSUB PUSH1 0x5c RETURNSUB");
+        Program program = new Program(vmConfig, precompiledContracts, blockFactory, mock(ActivationConfig.ForBlock.class), code, invoke, null, new HashSet<>());
+
+        BitSet beginsubSet = program.getBeginsubSet();
+
+        Assert.assertNotNull(beginsubSet);
+        Assert.assertEquals(8, beginsubSet.size());
+
+        for (int k = 0; k < beginsubSet.size(); k++) {
+            if (k == 4) {
+                Assert.assertTrue(beginsubSet.get(k));
+            }
+            else {
+                Assert.assertFalse(beginsubSet.get(k));
+            }
+        }
+    }
+
+    @Test
     public void executeTwoLevelsOfSubroutine() {
         Program program = playCode("PUSH9 0x00000000000000000c JUMPSUB STOP BEGINSUB PUSH1 0x11 JUMPSUB RETURNSUB BEGINSUB RETURNSUB");
         Stack stack = program.getStack();

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -901,6 +901,21 @@ public class VMExecutionTest {
     }
 
     @Test
+    public void executeInvalidJumpToSubroutineWhenStackIsEmpty() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
+
+        Program program = playCode("JUMPSUB", activations);
+        Stack stack = program.getStack();
+
+        Assert.assertEquals(0, stack.size());
+        Assert.assertEquals(invoke.getGas(), program.getResult().getGasUsed());
+        Assert.assertNotNull(program.getResult().getException());
+        Assert.assertTrue(program.getResult().getException() instanceof Program.StackTooSmallException);
+        Assert.assertEquals("Expected stack size 1 but actual 0, tx: <null>", program.getResult().getException().getMessage());
+    }
+
+    @Test
     public void executeInvalidShallowReturnStack() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(RSKIP172)).thenReturn(true);

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -874,6 +874,32 @@ public class VMExecutionTest {
     }
 
     @Test
+    public void execute1024LevelsOfSubroutine() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
+
+        Program program = playCode("PUSH2 0x0400 PUSH1 0x07 JUMP BEGINSUB JUMPDEST DUP1 PUSH1 0x0d JUMPI STOP JUMPDEST PUSH1 0x01 SWAP1 SUB PUSH1 0x06 JUMPSUB", activations);
+        Stack stack = program.getStack();
+
+        Assert.assertEquals(1, stack.size());
+        Assert.assertEquals(DataWord.ZERO, stack.pop());
+        Assert.assertFalse(program.getResult().isRevert());
+    }
+
+    @Test
+    public void revertWhenExecute1025LevelsOfSubroutine() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
+
+        Program program = playCode("PUSH2 0x0401 PUSH1 0x07 JUMP BEGINSUB JUMPDEST DUP1 PUSH1 0x0d JUMPI STOP JUMPDEST PUSH1 0x01 SWAP1 SUB PUSH1 0x06 JUMPSUB", activations);
+
+        Assert.assertEquals(invoke.getGas(), program.getResult().getGasUsed());
+        Assert.assertNotNull(program.getResult().getException());
+        Assert.assertTrue(program.getResult().getException() instanceof Program.ReturnStackOverflowException);
+        Assert.assertEquals("Return stack overflow: PC[20], tx[<null>]", program.getResult().getException().getMessage());
+    }
+
+    @Test
     public void executeSubroutineAtEndOfCode() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(RSKIP172)).thenReturn(true);

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -776,6 +776,24 @@ public class VMExecutionTest {
         Assert.assertEquals(balance, selfBalance);
     }
 
+    @Test
+    public void executeSimpleSubroutine() {
+        Program program = executeCode("PUSH1 0x04 JUMPSUB STOP BEGINSUB RETURNSUB", 4);
+        Stack stack = program.getStack();
+
+        Assert.assertEquals(0, stack.size());
+        Assert.assertEquals(18, program.getResult().getGasUsed());
+    }
+
+    @Test
+    public void executeTwoLevelsOfSubroutine() {
+        Program program = executeCode("PUSH9 0x00000000000000000c JUMPSUB STOP BEGINSUB PUSH1 0x11 JUMPSUB RETURNSUB BEGINSUB RETURNSUB", 7);
+        Stack stack = program.getStack();
+
+        Assert.assertEquals(0, stack.size());
+        Assert.assertEquals(36, program.getResult().getGasUsed());
+    }
+
     private Program executeCode(String code, int nsteps) {
         return executeCodeWithActivationConfig(compiler.compile(code), nsteps, mock(ActivationConfig.ForBlock.class));
     }

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -819,7 +819,7 @@ public class VMExecutionTest {
     @Test
     public void executeSimpleSubroutine() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(EIP2315)).thenReturn(true);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
 
         Program program = playCode("PUSH1 0x04 JUMPSUB STOP BEGINSUB RETURNSUB", activations);
         Stack stack = program.getStack();
@@ -831,7 +831,7 @@ public class VMExecutionTest {
     @Test
     public void executeSimpleSubroutineWithStackOperation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(EIP2315)).thenReturn(true);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
 
         Program program = playCode("PUSH1 0x04 JUMPSUB STOP BEGINSUB PUSH1 0x2a RETURNSUB", activations);
         Stack stack = program.getStack();
@@ -864,7 +864,7 @@ public class VMExecutionTest {
     @Test
     public void executeTwoLevelsOfSubroutine() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(EIP2315)).thenReturn(true);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
 
         Program program = playCode("PUSH9 0x00000000000000000c JUMPSUB STOP BEGINSUB PUSH1 0x11 JUMPSUB RETURNSUB BEGINSUB RETURNSUB", activations);
         Stack stack = program.getStack();
@@ -876,7 +876,7 @@ public class VMExecutionTest {
     @Test
     public void executeSubroutineAtEndOfCode() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(EIP2315)).thenReturn(true);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
 
         Program program = playCode("PUSH1 0x05 JUMP BEGINSUB RETURNSUB JUMPDEST PUSH1 0x03 JUMPSUB", activations);
         Stack stack = program.getStack();
@@ -888,7 +888,7 @@ public class VMExecutionTest {
     @Test
     public void executeInvalidJumpToSubroutine() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(EIP2315)).thenReturn(true);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
 
         Program program = playCode("PUSH9 0x01000000000000000c JUMPSUB STOP BEGINSUB RETURNSUB", activations);
         Stack stack = program.getStack();
@@ -903,7 +903,7 @@ public class VMExecutionTest {
     @Test
     public void executeInvalidShallowReturnStack() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(EIP2315)).thenReturn(true);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
 
         Program program = playCode("RETURNSUB PC PC", activations);
         Stack stack = program.getStack();
@@ -918,7 +918,7 @@ public class VMExecutionTest {
     @Test
     public void executeInvalidWalkIntoSubroutine() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(EIP2315)).thenReturn(true);
+        when(activations.isActive(RSKIP172)).thenReturn(true);
 
         Program program = playCode("BEGINSUB RETURNSUB STOP", activations);
         Stack stack = program.getStack();

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -874,24 +874,24 @@ public class VMExecutionTest {
     }
 
     @Test
-    public void execute1024LevelsOfSubroutine() {
+    public void execute1023LevelsOfSubroutine() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(RSKIP172)).thenReturn(true);
 
-        Program program = playCode("PUSH2 0x0400 PUSH1 0x07 JUMP BEGINSUB JUMPDEST DUP1 PUSH1 0x0d JUMPI STOP JUMPDEST PUSH1 0x01 SWAP1 SUB PUSH1 0x06 JUMPSUB", activations);
+        Program program = playCode("PUSH2 0x03ff PUSH1 0x07 JUMP BEGINSUB JUMPDEST DUP1 PUSH1 0x0d JUMPI STOP JUMPDEST PUSH1 0x01 SWAP1 SUB PUSH1 0x06 JUMPSUB", activations);
         Stack stack = program.getStack();
 
         Assert.assertEquals(1, stack.size());
         Assert.assertEquals(DataWord.ZERO, stack.pop());
-        Assert.assertFalse(program.getResult().isRevert());
+        Assert.assertNull(program.getResult().getException());
     }
 
     @Test
-    public void revertWhenExecute1025LevelsOfSubroutine() {
+    public void revertWhenExecute1024LevelsOfSubroutine() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(RSKIP172)).thenReturn(true);
 
-        Program program = playCode("PUSH2 0x0401 PUSH1 0x07 JUMP BEGINSUB JUMPDEST DUP1 PUSH1 0x0d JUMPI STOP JUMPDEST PUSH1 0x01 SWAP1 SUB PUSH1 0x06 JUMPSUB", activations);
+        Program program = playCode("PUSH2 0x0400 PUSH1 0x07 JUMP BEGINSUB JUMPDEST DUP1 PUSH1 0x0d JUMPI STOP JUMPDEST PUSH1 0x01 SWAP1 SUB PUSH1 0x06 JUMPSUB", activations);
 
         Assert.assertEquals(invoke.getGas(), program.getResult().getGasUsed());
         Assert.assertNotNull(program.getResult().getException());

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -74,6 +74,7 @@ public class ActivationConfigTest {
             "    rskipUMM: papyrus200",
             "    rskip169: iris300",
             "    rskip171: iris300",
+            "    eip2315: iris300",
             "}"
     ));
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -74,7 +74,7 @@ public class ActivationConfigTest {
             "    rskipUMM: papyrus200",
             "    rskip169: iris300",
             "    rskip171: iris300",
-            "    eip2315: iris300",
+            "    rskip172: iris300",
             "}"
     ));
 


### PR DESCRIPTION
This code implements the original Ethereum Improvement Proposal 2315: [Simple Subroutines for the EVM](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2315.md)

It adds three new opcodes to the virtual machine: BEGINSUB, RETURNSUB, JUMPSUB, and a return stack to keep the return program counters.

Many of the tests described in the original IP were implemented in code.

As with JUMPDEST, at the beginning of the execution of a contract, the valid BEGINSUB are scanned, in order to reject any spurius BEGINSUB.

