### PR TITLE
Add ability to turn on/off logs file/stdout

### DIFF
--- a/rskj-core/src/main/resources/logback.xml
+++ b/rskj-core/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
             </Pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>OFF</level>
+            <level>${log.stdout:-OFF}</level>
         </filter>
     </appender>
 
@@ -31,6 +31,9 @@
                 %date{yyyy-MM-dd-HH:mm:ss.SSSS} %p [%c{1}] [%thread]%replace( [%mdc{}]){' \[\]', ''}  %m%n
             </Pattern>
         </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${log.file:-ON}</level>
+        </filter>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./logs/rskj-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>


### PR DESCRIPTION
Quick PR to turn on/off logs file/stdout.

It happens frequently when developing the need to turn on/off logs and even testing the node.
With this new feature, we could turn it on and off with JVM parameters.
Parameters:
- log.file
- log.stdout
Values:
- ON
- OFF
Example:
`-Dlog.file=ON`
`-Dlog.stdout=OFF`