### PR TITLE
Disable Iris network upgrade in regtest

### DIFF
--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -8,7 +8,7 @@ blockchain.config {
         wasabi100 = 0,
         twoToThree = 0,
         papyrus200 = 0
-        iris300 = 0
+        iris300 = -1
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop


### PR DESCRIPTION
Iris should not be enabled even in regtest until we actually release that network upgrade