### PR TITLE
Added logic of new RskLab address activation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RemascConfig.java
+++ b/rskj-core/src/main/java/co/rsk/config/RemascConfig.java
@@ -35,6 +35,11 @@ public class RemascConfig {
     // is deserialized automatically from JSON.
     private String rskLabsAddress;
 
+    // RSK labs address.
+    // Note that his has to be a basic type (such as String) because RemascConfig
+    // is deserialized automatically from JSON.
+    private String rskLabsAddressRskipXyz;
+
     // RSK labs cut. Available reward / rskLabsDivisor is what RSK gets.
     private long rskLabsDivisor = 5;
 
@@ -67,6 +72,10 @@ public class RemascConfig {
 
     public RskAddress getRskLabsAddress() {
         return new RskAddress(this.rskLabsAddress);
+    }
+
+    public RskAddress getRskLabsAddressRskipXyz() {
+        return new RskAddress(this.rskLabsAddressRskipXyz);
     }
 
     public long getRskLabsDivisor() {

--- a/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
@@ -172,8 +172,9 @@ public class Remasc {
         provider.setRewardBalance(rewardBalance);
 
         // Pay RSK labs cut
+        RskAddress rskLabsAddress = getRskLabsAddress();
         Coin payToRskLabs = syntheticReward.divide(BigInteger.valueOf(remascConstants.getRskLabsDivisor()));
-        feesPayer.payMiningFees(processingBlockHeader.getHash().getBytes(), payToRskLabs, remascConstants.getRskLabsAddress(), logs);
+        feesPayer.payMiningFees(processingBlockHeader.getHash().getBytes(), payToRskLabs, rskLabsAddress, logs);
         syntheticReward = syntheticReward.subtract(payToRskLabs);
         Coin payToFederation = payToFederation(constants, isRskip85Enabled, processingBlock, processingBlockHeader, syntheticReward);
         syntheticReward = syntheticReward.subtract(payToFederation);
@@ -190,6 +191,11 @@ public class Remasc {
             }
             feesPayer.payMiningFees(processingBlockHeader.getHash().getBytes(), syntheticReward, processingBlockHeader.getCoinbase(), logs);
         }
+    }
+
+    RskAddress getRskLabsAddress() {
+        boolean isRskipXyzEnabled = activationConfig.isActive(ConsensusRule.RSKIPXYZ, executionBlock.getNumber());
+        return isRskipXyzEnabled ? remascConstants.getRskLabsAddressRskipXyz() : remascConstants.getRskLabsAddress();
     }
 
     private Coin payToFederation(Constants constants, boolean isRskip85Enabled, Block processingBlock, BlockHeader processingBlockHeader, Coin syntheticReward) {

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -54,6 +54,7 @@ public enum ConsensusRule {
     RSKIP171("rskip171"),
     RSKIP172("rskip172"),
     RSKIP174("rskip174"),
+    RSKIPXYZ("rskipXYZ"),
     RSKIPUMM("rskipUMM");
 
     private String configKey;

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -50,6 +50,7 @@ blockchain = {
              rskip171 = <hardforkName>
              rskip172 = <hardforkName>
              rskip174 = <hardforkName>
+             rskipXYZ = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -41,6 +41,7 @@ blockchain = {
             rskip171 = iris300
             rskip172 = iris300
             rskip174 = iris300
+            rskipXYZ = iris300
         }
     }
     gc = {

--- a/rskj-core/src/main/resources/remasc.json
+++ b/rskj-core/src/main/resources/remasc.json
@@ -7,6 +7,7 @@
       "publishersDivisor" : 10,
       "federationDivisor" : 100,
       "rskLabsAddress" : "dabadabadabadabadabadabadabadabadaba0002",
+      "rskLabsAddressRskipXyz" : "dabadabadabadabadabadabadabadabadaba0002",
       "lateUncleInclusionPunishmentDivisor": 20
    },
    "regtest": {
@@ -17,6 +18,7 @@
       "publishersDivisor" : 10,
       "federationDivisor" : 100,
       "rskLabsAddress" : "dabadabadabadabadabadabadabadabadaba0001",
+      "rskLabsAddressRskipXyz" : "dabadabadabadabadabadabadabadabadaba0001",
       "lateUncleInclusionPunishmentDivisor": 20,
       "paidFeesMultiplier": 2,
       "paidFeesDivisor": 1
@@ -29,6 +31,7 @@
       "publishersDivisor" : 10,
       "federationDivisor" : 100,
       "rskLabsAddress" : "14d3065c8Eb89895f4df12450EC6b130049F8034",
+      "rskLabsAddressRskipXyz" : "14d3065c8Eb89895f4df12450EC6b130049F8034",
       "lateUncleInclusionPunishmentDivisor": 20,
       "paidFeesMultiplier": 2,
       "paidFeesDivisor": 1
@@ -41,6 +44,7 @@
       "publishersDivisor" : 10,
       "federationDivisor" : 100,
       "rskLabsAddress" : "14d3065c8Eb89895f4df12450EC6b130049F8034",
+      "rskLabsAddressRskipXyz" : "14d3065c8Eb89895f4df12450EC6b130049F8034",
       "lateUncleInclusionPunishmentDivisor": 20,
       "paidFeesMultiplier": 2,
       "paidFeesDivisor": 1
@@ -53,6 +57,7 @@
       "publishersDivisor" : 10,
       "federationDivisor" : 100,
       "rskLabsAddress" : "dabadabadabadabadabadabadabadabadaba0003",
+      "rskLabsAddressRskipXyz" : "dabadabadabadabadabadabadabadabadaba0003",
       "lateUncleInclusionPunishmentDivisor": 20,
       "paidFeesMultiplier": 2,
       "paidFeesDivisor": 1

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascRskAddressActivationTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascRskAddressActivationTest.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.remasc;
+
+import co.rsk.config.RemascConfig;
+import co.rsk.config.RemascConfigFactory;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
+import org.ethereum.db.BlockStore;
+import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
+public class RemascRskAddressActivationTest {
+
+    private RemascConfig remascConfig;
+    private Block blockMock;
+    private Remasc remasc;
+
+    @Before
+    public void setUp() {
+        RemascTransaction txMock = Mockito.mock(RemascTransaction.class);
+        Repository repositoryMock = Mockito.mock(Repository.class);
+        BlockStore blockStoreMock = Mockito.mock(BlockStore.class);
+        ActivationConfig activationConfig = new TestSystemProperties().getActivationConfig();
+        List<LogInfo> logs = Collections.emptyList();
+
+        blockMock = mock(Block.class);
+        remascConfig = spy(new RemascConfigFactory(RemascContract.REMASC_CONFIG).createRemascConfig("regtest"));
+        remasc = new Remasc(Constants.regtest(), activationConfig, repositoryMock, blockStoreMock, remascConfig, txMock, PrecompiledContracts.REMASC_ADDR, blockMock, logs);
+    }
+
+    @Test
+    public void testActivation() {
+        final RskAddress oldAddress = new RskAddress("0000000000000000000000000000000001000001");
+        final RskAddress newAddress = new RskAddress("0000000000000000000000000000000001000002");
+
+        when(remascConfig.getRskLabsAddress()).thenReturn(oldAddress);
+        when(remascConfig.getRskLabsAddressRskipXyz()).thenReturn(newAddress);
+
+        when(blockMock.getNumber()).thenReturn(4L);
+        RskAddress actualAddress = remasc.getRskLabsAddress();
+        Assert.assertEquals(oldAddress, actualAddress);
+        verify(remascConfig).getRskLabsAddress();
+
+        when(blockMock.getNumber()).thenReturn(5L);
+        actualAddress = remasc.getRskLabsAddress();
+        Assert.assertEquals(newAddress, actualAddress);
+        verify(remascConfig).getRskLabsAddressRskipXyz();
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -76,6 +76,7 @@ public class ActivationConfigTest {
             "    rskip171: iris300",
             "    rskip172: iris300",
             "    rskip174: iris300",
+            "    rskipXYZ: iris300",
             "}"
     ));
 


### PR DESCRIPTION
Added logic for HF activation of a new RskLab address

Note: exact RSKIP number and actual account address will be provided later.