### PR TITLE
Testing remaining bytes after merged mining hash.

### DIFF
--- a/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerServerImpl.java
@@ -320,10 +320,6 @@ public class MinerServerImpl implements MinerServer {
             rskTagPosition = Collections.indexOfSubList(coinBaseTransactionSerializedAsList, tagAsList);
         }
 
-        int remainingByteCount = bitcoinMergedMiningCoinbaseTransactionSerialized.length - rskTagPosition - RskMiningConstants.RSK_TAG.length - RskMiningConstants.BLOCK_HEADER_HASH_SIZE;
-        if (remainingByteCount > RskMiningConstants.MAX_BYTES_AFTER_MERGED_MINING_HASH) {
-            throw new IllegalArgumentException("More than 128 bytes after RSK tag");
-        }
         int sha256Blocks = rskTagPosition / 64;
         int bytesToHash = sha256Blocks * 64;
         SHA256Digest digest = new SHA256Digest();

--- a/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
+++ b/rskj-core/src/main/java/co/rsk/mine/MinerUtils.java
@@ -55,15 +55,22 @@ public class MinerUtils {
     }
 
     public static co.rsk.bitcoinj.core.BtcTransaction getBitcoinMergedMiningCoinbaseTransaction(co.rsk.bitcoinj.core.NetworkParameters params, byte[] blockHashForMergedMining) {
-        co.rsk.bitcoinj.core.BtcTransaction coinbaseTransaction = new co.rsk.bitcoinj.core.BtcTransaction(params);
-        //Add a random number of random bytes before the RSK tag
         SecureRandom random = new SecureRandom();
         byte[] prefix = new byte[random.nextInt(1000)];
         random.nextBytes(prefix);
         byte[] bytes = Arrays.concatenate(prefix, RskMiningConstants.RSK_TAG, blockHashForMergedMining);
-        // Add the Tag to the scriptSig of first input
-        co.rsk.bitcoinj.core.TransactionInput ti = new co.rsk.bitcoinj.core.TransactionInput(params, coinbaseTransaction, bytes);
+
+        return getBitcoinCoinbaseTransaction(params, bytes);
+    }
+
+    public static co.rsk.bitcoinj.core.BtcTransaction getBitcoinCoinbaseTransaction(co.rsk.bitcoinj.core.NetworkParameters params, byte[] additionalData) {
+
+        co.rsk.bitcoinj.core.BtcTransaction coinbaseTransaction = new co.rsk.bitcoinj.core.BtcTransaction(params);
+
+        // Add the data to the scriptSig of first input
+        co.rsk.bitcoinj.core.TransactionInput ti = new co.rsk.bitcoinj.core.TransactionInput(params, coinbaseTransaction, new byte[0]);
         coinbaseTransaction.addInput(ti);
+
         ByteArrayOutputStream scriptPubKeyBytes = new ByteArrayOutputStream();
         co.rsk.bitcoinj.core.BtcECKey key = new co.rsk.bitcoinj.core.BtcECKey();
         try {
@@ -73,6 +80,9 @@ public class MinerUtils {
         }
         scriptPubKeyBytes.write(co.rsk.bitcoinj.script.ScriptOpCodes.OP_CHECKSIG);
         coinbaseTransaction.addOutput(new co.rsk.bitcoinj.core.TransactionOutput(params, coinbaseTransaction, co.rsk.bitcoinj.core.Coin.valueOf(50, 0), scriptPubKeyBytes.toByteArray()));
+
+        coinbaseTransaction.addOutput(new co.rsk.bitcoinj.core.TransactionOutput(params, coinbaseTransaction, co.rsk.bitcoinj.core.Coin.valueOf(0), additionalData));
+
         return coinbaseTransaction;
     }
 


### PR DESCRIPTION
## Description
New test validations for remaining bytes after merged mining hash.

## Motivation and Context
More than 2 outputs placed after merged mining hash (36 bytes each) make a solution invalid. 
A test with 2 outputs is needed in order to be alert that the condition for remaining bytes after merged mining tag should trigger some test alarm, otherwise, if is changed MAX_BYTES_AFTER_MERGED_MINING_HASH  for a value smaller than 128 could make miner solutions invalid.
Nowadays, existing miners have 1 or 2 outputs. 

