### PR TITLE
Create PeginInformation class

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/PeginInformation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PeginInformation.java
@@ -1,0 +1,106 @@
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.core.RskAddress;
+import co.rsk.peg.btcLockSender.BtcLockSender;
+import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
+import co.rsk.peg.pegininstructions.PeginInstructions;
+import co.rsk.peg.pegininstructions.PeginInstructionsException;
+import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
+import co.rsk.peg.pegininstructions.PeginInstructionsVersion1;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PeginInformation {
+
+    private static final Logger logger = LoggerFactory.getLogger(PeginInformation.class);
+
+    private final BtcLockSenderProvider btcLockSenderProvider;
+    private final PeginInstructionsProvider peginInstructionsProvider;
+
+    private int protocolVersion;
+    private RskAddress rskDestinationAddress;
+    private Address btcRefundAddress;
+
+    public PeginInformation(
+        BtcLockSenderProvider btcLockSenderProvider,
+        PeginInstructionsProvider peginInstructionsProvider) {
+        this.btcLockSenderProvider = btcLockSenderProvider;
+        this.peginInstructionsProvider = peginInstructionsProvider;
+    }
+
+    public int getProtocolVersion() {
+        return protocolVersion;
+    }
+
+    public RskAddress getRskDestinationAddress() {
+        return this.rskDestinationAddress;
+    }
+
+    public Address getBtcRefundAddress() {
+        return this.btcRefundAddress;
+    }
+
+    public void parse(BtcTransaction btcTx) throws PeginInstructionsException {
+        logger.trace("[parse] Trying to parse peg-in information from btc tx {}", btcTx.getHash());
+
+        // Get information from tx sender first
+        Optional<BtcLockSender> btcLockSenderOptional = btcLockSenderProvider.tryGetBtcLockSender(btcTx);
+        if (btcLockSenderOptional.isPresent()) {
+            BtcLockSender btcLockSender = btcLockSenderOptional.get();
+            parseFromBtcLockSender(btcLockSender);
+        }
+
+        // If peg-in instructions were provided then override the info obtained from BtcLockSender
+        Optional<PeginInstructions> peginInstructionsOptional = peginInstructionsProvider.buildPeginInstructions(btcTx);
+        if (peginInstructionsOptional.isPresent()) {
+            PeginInstructions peginInstructions = peginInstructionsOptional.get();
+            parseFromPeginInstructions(peginInstructions);
+        }
+
+        // If BtcLockSender could not be parsed and peg-in instructions were not provided, then this tx can't be processed
+        if(!btcLockSenderOptional.isPresent() && !peginInstructionsOptional.isPresent()) {
+            String message = String.format("Could not get peg-in information for tx %s", btcTx.getHash());
+            logger.warn("[parse] {}", message);
+            throw new PeginInstructionsException(message);
+        }
+    }
+
+    private void parseFromBtcLockSender(BtcLockSender btcLockSender) {
+        this.protocolVersion = 0;
+        this.rskDestinationAddress = btcLockSender.getRskAddress();
+        this.btcRefundAddress = btcLockSender.getBTCAddress();
+
+        logger.trace("[parseFromBtcLockSender] Protocol version: {}", this.protocolVersion);
+        logger.trace("[parseFromBtcLockSender] RSK destination address: {}", btcLockSender.getRskAddress());
+        logger.trace("[parseFromBtcLockSender] BTC refund address: {}", btcLockSender.getBTCAddress());
+    }
+
+    private void parseFromPeginInstructions(PeginInstructions peginInstructions)  throws PeginInstructionsException {
+        this.protocolVersion = peginInstructions.getProtocolVersion();
+        this.rskDestinationAddress = peginInstructions.getRskDestinationAddress();
+        logger.trace("[parseFromPeginInstructions] Protocol version: {}", peginInstructions.getProtocolVersion());
+        logger.trace("[parseFromPeginInstructions] RSK destination address: {}", peginInstructions.getRskDestinationAddress());
+
+        switch (protocolVersion) {
+            case 1:
+                PeginInstructionsVersion1 peginInstructionsV1 = (PeginInstructionsVersion1) peginInstructions;
+                parseFromPeginInstructionsVersion1(peginInstructionsV1);
+                break;
+            default:
+                String message = String.format("Invalid protocol version: %d", protocolVersion);
+                logger.warn("[parseFromPeginInstructions] {}", message);
+                throw new PeginInstructionsException(message);
+        }
+    }
+
+    private void parseFromPeginInstructionsVersion1(PeginInstructionsVersion1 peginInstructions) {
+        Optional<Address> btcRefundAddressOptional = peginInstructions.getBtcRefundAddress();
+        if (btcRefundAddressOptional.isPresent()) {
+            this.btcRefundAddress = btcRefundAddressOptional.get();
+            logger.trace("[parseFromPeginInstructionsVersion1] BTC refund address: {}", btcRefundAddressOptional.get());
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/PeginInformationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PeginInformationTest.java
@@ -1,0 +1,286 @@
+package co.rsk.peg;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.config.BridgeConstants;
+import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.core.RskAddress;
+import co.rsk.peg.btcLockSender.BtcLockSender;
+import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
+import co.rsk.peg.btcLockSender.P2pkhBtcLockSender;
+import co.rsk.peg.pegininstructions.PeginInstructionsException;
+import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
+import co.rsk.peg.pegininstructions.PeginInstructionsVersion1;
+import java.util.Optional;
+import org.ethereum.crypto.ECKey;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class PeginInformationTest {
+
+    private static BridgeConstants bridgeConstants;
+    private static NetworkParameters networkParameters;
+
+    @BeforeClass
+    public static void setup() {
+        bridgeConstants = BridgeRegTestConstants.getInstance();
+        networkParameters = bridgeConstants.getBtcParams();
+    }
+
+    @Test
+    public void parse_fromBtcLockSender() throws PeginInstructionsException {
+        // Arrange
+        BtcECKey key = new BtcECKey();
+        RskAddress rskDestinationAddressFromBtcLockSender = new RskAddress(ECKey.fromPublicOnly(key.getPubKey()).getAddress());
+        Address btcRefundAddressFromBtcLockSender = key.toAddress(networkParameters);
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+
+        BtcLockSender btcLockSenderMock = mock(P2pkhBtcLockSender.class);
+        when(btcLockSenderMock.getRskAddress()).thenReturn(rskDestinationAddressFromBtcLockSender);
+        when(btcLockSenderMock.getBTCAddress()).thenReturn(btcRefundAddressFromBtcLockSender);
+
+        BtcLockSenderProvider btcLockSenderProviderMock = mock(BtcLockSenderProvider.class);
+        when(btcLockSenderProviderMock.tryGetBtcLockSender(btcTx))
+            .thenReturn(Optional.of(btcLockSenderMock));
+
+        PeginInstructionsProvider peginInstructionsProviderMock = mock(
+            PeginInstructionsProvider.class);
+
+        // Act
+        PeginInformation peginInformation = new PeginInformation(
+            btcLockSenderProviderMock,
+            peginInstructionsProviderMock
+        );
+        peginInformation.parse(btcTx);
+
+        // Assert
+        Assert.assertEquals(0, peginInformation.getProtocolVersion());
+        Assert.assertEquals(rskDestinationAddressFromBtcLockSender, peginInformation.getRskDestinationAddress());
+        Assert.assertEquals(btcRefundAddressFromBtcLockSender, peginInformation.getBtcRefundAddress());
+    }
+
+    @Test
+    public void parse_fromPeginInstructions() throws PeginInstructionsException {
+        // Arrange
+        BtcECKey address1Key = new BtcECKey();
+        RskAddress rskDestinationAddressFromBtcLockSender = new RskAddress(ECKey.fromPublicOnly(address1Key.getPubKey()).getAddress());
+        Address btcRefundAddressFromBtcLockSender = address1Key.toAddress(networkParameters);
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+
+        BtcLockSender btcLockSenderMock = mock(P2pkhBtcLockSender.class);
+        when(btcLockSenderMock.getRskAddress()).thenReturn(rskDestinationAddressFromBtcLockSender);
+        when(btcLockSenderMock.getBTCAddress()).thenReturn(btcRefundAddressFromBtcLockSender);
+
+        BtcLockSenderProvider btcLockSenderProviderMock = mock(BtcLockSenderProvider.class);
+        when(btcLockSenderProviderMock.tryGetBtcLockSender(btcTx))
+            .thenReturn(Optional.of(btcLockSenderMock));
+
+        BtcECKey address2Key = new BtcECKey();
+        RskAddress rskDestinationAddressFromPeginInstructions = new RskAddress(ECKey.fromPublicOnly(address2Key.getPubKey()).getAddress());
+        Address btcRefundAddressFromPeginInstructions = address2Key.toAddress(networkParameters);
+
+        PeginInstructionsVersion1 peginInstructionsMock = mock(PeginInstructionsVersion1.class);
+        when(peginInstructionsMock.getProtocolVersion()).thenReturn(1);
+        when(peginInstructionsMock.getRskDestinationAddress())
+            .thenReturn(rskDestinationAddressFromPeginInstructions);
+        when(peginInstructionsMock.getBtcRefundAddress())
+            .thenReturn(Optional.of(btcRefundAddressFromPeginInstructions));
+
+        PeginInstructionsProvider peginInstructionsProviderMock = mock(PeginInstructionsProvider.class);
+        when(peginInstructionsProviderMock.buildPeginInstructions(btcTx))
+            .thenReturn(Optional.of(peginInstructionsMock));
+
+        // Act
+        PeginInformation peginInformation = new PeginInformation(
+            btcLockSenderProviderMock,
+            peginInstructionsProviderMock
+        );
+        peginInformation.parse(btcTx);
+
+        // Assert
+        Assert.assertEquals(1, peginInformation.getProtocolVersion());
+        Assert.assertEquals(rskDestinationAddressFromPeginInstructions, peginInformation.getRskDestinationAddress());
+        Assert.assertEquals(btcRefundAddressFromPeginInstructions, peginInformation.getBtcRefundAddress());
+        Assert.assertNotEquals(rskDestinationAddressFromBtcLockSender, peginInformation.getRskDestinationAddress());
+        Assert.assertNotEquals(btcRefundAddressFromBtcLockSender, peginInformation.getBtcRefundAddress());
+    }
+
+    @Test
+    public void parse_fromPeginInstructions_withoutBtcLockSender() throws PeginInstructionsException {
+        // Arrange
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        BtcLockSenderProvider btcLockSenderProviderMock = mock(BtcLockSenderProvider.class);
+        when(btcLockSenderProviderMock.tryGetBtcLockSender(btcTx))
+            .thenReturn(Optional.empty());
+
+        BtcECKey address2Key = new BtcECKey();
+        RskAddress rskDestinationAddressFromPeginInstructions = new RskAddress(ECKey.fromPublicOnly(address2Key.getPubKey()).getAddress());
+        Address btcRefundAddressFromPeginInstructions = address2Key.toAddress(networkParameters);
+
+        PeginInstructionsVersion1 peginInstructionsMock = mock(PeginInstructionsVersion1.class);
+        when(peginInstructionsMock.getProtocolVersion()).thenReturn(1);
+        when(peginInstructionsMock.getRskDestinationAddress())
+            .thenReturn(rskDestinationAddressFromPeginInstructions);
+        when(peginInstructionsMock.getBtcRefundAddress())
+            .thenReturn(Optional.of(btcRefundAddressFromPeginInstructions));
+
+        PeginInstructionsProvider peginInstructionsProviderMock = mock(PeginInstructionsProvider.class);
+        when(peginInstructionsProviderMock.buildPeginInstructions(btcTx))
+            .thenReturn(Optional.of(peginInstructionsMock));
+
+        // Act
+        PeginInformation peginInformation = new PeginInformation(
+            btcLockSenderProviderMock,
+            peginInstructionsProviderMock
+        );
+        peginInformation.parse(btcTx);
+
+        // Assert
+        Assert.assertEquals(1, peginInformation.getProtocolVersion());
+        Assert.assertEquals(rskDestinationAddressFromPeginInstructions, peginInformation.getRskDestinationAddress());
+        Assert.assertEquals(btcRefundAddressFromPeginInstructions, peginInformation.getBtcRefundAddress());
+    }
+
+    @Test
+    public void parse_fromPeginInstructions_withoutBtcRefundAddress() throws PeginInstructionsException {
+        // Arrange
+        BtcECKey address1Key = new BtcECKey();
+        RskAddress rskDestinationAddressFromBtcLockSender = new RskAddress(ECKey.fromPublicOnly(address1Key.getPubKey()).getAddress());
+        Address btcRefundAddressFromBtcLockSender = address1Key.toAddress(networkParameters);
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+
+        BtcLockSender btcLockSenderMock = mock(P2pkhBtcLockSender.class);
+        when(btcLockSenderMock.getRskAddress()).thenReturn(rskDestinationAddressFromBtcLockSender);
+        when(btcLockSenderMock.getBTCAddress()).thenReturn(btcRefundAddressFromBtcLockSender);
+
+        BtcLockSenderProvider btcLockSenderProviderMock = mock(BtcLockSenderProvider.class);
+        when(btcLockSenderProviderMock.tryGetBtcLockSender(btcTx))
+            .thenReturn(Optional.of(btcLockSenderMock));
+
+        BtcECKey address2Key = new BtcECKey();
+        RskAddress rskDestinationAddressFromPeginInstructions = new RskAddress(ECKey.fromPublicOnly(address2Key.getPubKey()).getAddress());
+
+        PeginInstructionsVersion1 peginInstructionsMock = mock(PeginInstructionsVersion1.class);
+        when(peginInstructionsMock.getProtocolVersion()).thenReturn(1);
+        when(peginInstructionsMock.getRskDestinationAddress())
+            .thenReturn(rskDestinationAddressFromPeginInstructions);
+        when(peginInstructionsMock.getBtcRefundAddress()).thenReturn(Optional.empty());
+
+        PeginInstructionsProvider peginInstructionsProviderMock = mock(
+            PeginInstructionsProvider.class);
+        when(peginInstructionsProviderMock.buildPeginInstructions(btcTx))
+            .thenReturn(Optional.of(peginInstructionsMock));
+
+        // Act
+        PeginInformation peginInformation = new PeginInformation(
+            btcLockSenderProviderMock,
+            peginInstructionsProviderMock
+        );
+        peginInformation.parse(btcTx);
+
+        // Assert
+        Assert.assertEquals(1, peginInformation.getProtocolVersion());
+        Assert.assertEquals(rskDestinationAddressFromPeginInstructions, peginInformation.getRskDestinationAddress());
+        Assert.assertEquals(btcRefundAddressFromBtcLockSender, peginInformation.getBtcRefundAddress());
+        Assert.assertNotEquals(rskDestinationAddressFromBtcLockSender, peginInformation.getRskDestinationAddress());
+    }
+
+    @Test
+    public void parse_fromPeginInstructions_withoutBtcLockSender_withoutBtcRefundAddress() throws PeginInstructionsException {
+        // Arrange
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        BtcLockSenderProvider btcLockSenderProviderMock = mock(BtcLockSenderProvider.class);
+        when(btcLockSenderProviderMock.tryGetBtcLockSender(btcTx))
+            .thenReturn(Optional.empty());
+
+        BtcECKey address2Key = new BtcECKey();
+        RskAddress rskDestinationAddressFromPeginInstructions = new RskAddress(ECKey.fromPublicOnly(address2Key.getPubKey()).getAddress());
+
+        PeginInstructionsVersion1 peginInstructionsMock = mock(PeginInstructionsVersion1.class);
+        when(peginInstructionsMock.getProtocolVersion()).thenReturn(1);
+        when(peginInstructionsMock.getRskDestinationAddress())
+            .thenReturn(rskDestinationAddressFromPeginInstructions);
+        when(peginInstructionsMock.getBtcRefundAddress())
+            .thenReturn(Optional.empty());
+
+        PeginInstructionsProvider peginInstructionsProviderMock = mock(PeginInstructionsProvider.class);
+        when(peginInstructionsProviderMock.buildPeginInstructions(btcTx))
+            .thenReturn(Optional.of(peginInstructionsMock));
+
+        // Act
+        PeginInformation peginInformation = new PeginInformation(
+            btcLockSenderProviderMock,
+            peginInstructionsProviderMock
+        );
+        peginInformation.parse(btcTx);
+
+        // Assert
+        Assert.assertEquals(1, peginInformation.getProtocolVersion());
+        Assert.assertEquals(rskDestinationAddressFromPeginInstructions, peginInformation.getRskDestinationAddress());
+        Assert.assertNull(peginInformation.getBtcRefundAddress());
+    }
+
+    @Test(expected = PeginInstructionsException.class)
+    public void parse_fromPeginInstructions_invalidProtocolVersion() throws PeginInstructionsException {
+        // Arrange
+        BtcECKey address1Key = new BtcECKey();
+        RskAddress rskDestinationAddressFromBtcLockSender = new RskAddress(ECKey.fromPublicOnly(address1Key.getPubKey()).getAddress());
+        Address btcRefundAddressFromBtcLockSender = address1Key.toAddress(networkParameters);
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+
+        BtcLockSender btcLockSenderMock = mock(P2pkhBtcLockSender.class);
+        when(btcLockSenderMock.getRskAddress()).thenReturn(rskDestinationAddressFromBtcLockSender);
+        when(btcLockSenderMock.getBTCAddress()).thenReturn(btcRefundAddressFromBtcLockSender);
+
+        BtcLockSenderProvider btcLockSenderProviderMock = mock(BtcLockSenderProvider.class);
+        when(btcLockSenderProviderMock.tryGetBtcLockSender(btcTx))
+            .thenReturn(Optional.of(btcLockSenderMock));
+
+        BtcECKey address2Key = new BtcECKey();
+        RskAddress rskDestinationAddressFromPeginInstructions = new RskAddress(ECKey.fromPublicOnly(address2Key.getPubKey()).getAddress());
+
+        PeginInstructionsVersion1 peginInstructionsMock = mock(PeginInstructionsVersion1.class);
+        when(peginInstructionsMock.getProtocolVersion()).thenReturn(0);
+        when(peginInstructionsMock.getRskDestinationAddress())
+            .thenReturn(rskDestinationAddressFromPeginInstructions);
+
+        PeginInstructionsProvider peginInstructionsProviderMock = mock(
+            PeginInstructionsProvider.class);
+        when(peginInstructionsProviderMock.buildPeginInstructions(btcTx))
+            .thenReturn(Optional.of(peginInstructionsMock));
+
+        // Act
+        PeginInformation peginInformation = new PeginInformation(
+            btcLockSenderProviderMock,
+            peginInstructionsProviderMock
+        );
+        peginInformation.parse(btcTx);
+    }
+
+    @Test(expected = PeginInstructionsException.class)
+    public void parse_withoutBtcLockSender_withoutPeginInstructions() throws PeginInstructionsException {
+        // Arrange
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        BtcLockSenderProvider btcLockSenderProviderMock = mock(BtcLockSenderProvider.class);
+        when(btcLockSenderProviderMock.tryGetBtcLockSender(btcTx))
+            .thenReturn(Optional.empty());
+
+        PeginInstructionsProvider peginInstructionsProviderMock = mock(
+            PeginInstructionsProvider.class);
+        when(peginInstructionsProviderMock.buildPeginInstructions(btcTx))
+            .thenReturn(Optional.empty());
+
+        // Act
+        PeginInformation peginInformation = new PeginInformation(
+            btcLockSenderProviderMock,
+            peginInstructionsProviderMock
+        );
+        peginInformation.parse(btcTx);
+    }
+}


### PR DESCRIPTION
This class is responsible for parsing a btc lock tx and obtaining the RSK address where the funds should be transferred to, and a BTC refund address in case the lock can not be completed. This information is obtained from peg-in instructions included in an output with OP_RETURN in the tx, or from the tx sender using BtcLockSender class.