### PR TITLE
Upgrade Jackson 2.8 to 2.11 and add missing checksums

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     compile "org.fusesource.leveldbjni:leveldbjni:1.8"
     compile "org.ethereum:leveldbjni-all:1.18.3"
     compile "org.slf4j:slf4j-api:${slf4jVersion}"
-    compile "com.fasterxml.jackson.core:jackson-databind:2.8.7"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.11.3"
     compile "org.apache.commons:commons-lang3:3.5"
     compile "com.typesafe:config:1.3.3"
     compile "org.mapdb:mapdb:2.0-beta13"
@@ -114,9 +114,9 @@ dependencyVerification {
         'ch.qos.logback:logback-core:280be7a9327e7434d214d6b9eb881c083c3e057a22d0ed7663a7ce81a718a494',
         'co.rsk.bitcoinj:bitcoinj-thin:77f2cbf36f4661530160184f48460d4f81b228e39f58fbc2735ad4b511eb5ec2',
         'co.rsk:lll-compiler:a645fdb272f56721761f65dd32caa952453efc07d98d292259d99353b6f647d0',
-        'com.fasterxml.jackson.core:jackson-annotations:4caf3936315439b509b8c3ef494d4e47eaa6d25c3b5299aadb0eafb3944ed32f',
-        'com.fasterxml.jackson.core:jackson-core:256ff34118ab292d1b4f3ee4d2c3e5e5f0f609d8e07c57e8ad1f51c46d4fbb46',
-        'com.fasterxml.jackson.core:jackson-databind:4f74337b6d18664be0f5b15c6664b17aa3972c9c175092328b139b894ff66f19',
+        'com.fasterxml.jackson.core:jackson-annotations:6519b3811cb1c0afbbdab74fd841b0b34f3a489fccb43e9f981da1328d8ec23d',
+        'com.fasterxml.jackson.core:jackson-core:78cd0a6b936232e06dd3e38da8a0345348a09cd1ff9c4d844c6ee72c75cfc402',
+        'com.fasterxml.jackson.core:jackson-databind:5eb2fa8403a077a15391b80f43784fe09f8787863f5c6f53cc9edd710fd3c1ae',
 	    'com.github.briandilley.jsonrpc4j:jsonrpc4j:bb2cde1f554e152e69741353c6630e02e69f217abbd6703f8c038e6ed637c105',
         'com.google.code.findbugs:jsr305:1e7f53fa5b8b5c807e986ba335665da03f18d660802d8bf061823089d1bee468',
         'com.google.guava:guava:d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99',
@@ -130,10 +130,13 @@ dependencyVerification {
         'commons-codec:commons-codec:4241dfa94e711d435f29a4604a3e2de5c4aa3c165e23bd066be6fc1fc4309569',
         'commons-io:commons-io:a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474',
         'io.netty:netty-buffer:055f5ccfd7f9683c5d961fbf4466778d5b91ebf8b1f2ddd2eed539a82352b695',
+        'io.netty:netty-codec:f5921cb7f0f7a9188241321cbab4e208c75d49f4b97fae46eed01e60ef57800f',
         'io.netty:netty-codec-http:73e735f8d73946f860c667bd148be0d25b3e23a85ed62c6178c8bf74c17f9048',
         'io.netty:netty-common:5d50a53f063c6544433951a04099b0eec17ddd5a1c7f5b0c63f38912daef1677',
         'io.netty:netty-handler:b1a634a593bb9d1c3e881817991aa5e5fe34b338295ccc1f464511d0af809c61',
         'io.netty:netty-transport:adec23f7790a138014a15eff4c85939cddec63d49f9ef0810725cb4aa5518199',
+        'net.bytebuddy:byte-buddy:917758b3c651e278a15a029ba1d42dbf802d8b0e1fe2aa4b81c5750c64f461c1',
+        'net.bytebuddy:byte-buddy-agent:c141a2d6809c3eeff4a43d25992826abccebdd4b793af3e7a5f346e88ae73a33',
         'net.iharder:base64:f1a0e359eee29a5939c35e5fdedc574dd7e8ca065b056fc14b2b29e3ed3cd54d',
         'net.jcip:jcip-annotations:be5805392060c71474bf6c9a67a099471274d30b83eef84bfc4e0889a4f1dcc0',
         'org.apache.commons:commons-lang3:8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c',
@@ -142,6 +145,7 @@ dependencyVerification {
         'org.ethereum:leveldbjni-all:18da00444c77080d4422b16c9d4750c4addabda350b702b4a6d628b86658e585',
         'org.fusesource.hawtjni:hawtjni-runtime:74fe9764e1fb1ef20b159dbca2d29abd6de292082ce3fcf538f81ac912390416',
         'org.fusesource.leveldbjni:leveldbjni:05fe3a006d030aaf8d1e43f6c640a85f9f6b967c4499ce1ad5055ac236c3b944',
+        'org.hamcrest:hamcrest-core:66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9',
         'org.hamcrest:hamcrest-library:711d64522f9ec410983bd310934296da134be4254a125080a0416ec178dfad1c',
         'org.iq80.leveldb:leveldb-api:279e3a5649cde0bf0d4e09fd1369ec0e9ee80344ec06527c37148c9a58684140',
         'org.iq80.leveldb:leveldb:0dcc623fcb8450e736b9d2b1b8d91b980e44920d6a22cec8c00f703548b3747f',

--- a/rskj-core/src/main/java/co/rsk/config/RemascConfigFactory.java
+++ b/rskj-core/src/main/java/co/rsk/config/RemascConfigFactory.java
@@ -46,6 +46,9 @@ public class RemascConfigFactory {
         try (InputStream is = RemascConfigFactory.class.getClassLoader().getResourceAsStream(this.configPath)){
             JsonNode node = mapper.readTree(is);
             remascConfig = mapper.treeToValue(node.get(config), RemascConfig.class);
+            if (remascConfig == null) {
+               throw new IllegalArgumentException("Invalid config:" + config);
+            }
         } catch (Exception ex) {
             logger.error("Error reading REMASC configuration[{}]: {}", config, ex);
             throw new RemascException("Error reading REMASC configuration[" + config +"]: ", ex);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Along the journey we missed some checksums to the dependency validator. The aim of this PR is to fill those wholes and since Jackson had an old version, we decided to upgrade it to the last stable version.

## Description
<!--- Describe your changes in detail -->
Upgrade Jackson (core/annotations/databind) from 2.8.7 to 2.11.3
Add checksums for deps: netty-codec / byte-buddy / hamcrest-core

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix alerts regarding old version of Jackson and improve dependency security.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build the project and run unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

*fed: enveloping*