### PR TITLE
Fixed length of root field in tx receipt response

### DIFF
--- a/rskj-core/src/main/java/co/rsk/crypto/Keccak256.java
+++ b/rskj-core/src/main/java/co/rsk/crypto/Keccak256.java
@@ -33,16 +33,18 @@ import static com.google.common.base.Preconditions.checkArgument;
  * map. It also checks that the length is correct and provides a bit more type safety.
  */
 public class Keccak256 implements Serializable, Comparable<Keccak256> {
+    public static final int HASH_LEN = 32;
+    public static final Keccak256 ZERO_HASH = new Keccak256(new byte[HASH_LEN]);
+
     private final byte[] bytes;
-    public static final Keccak256 ZERO_HASH = new Keccak256(new byte[32]);
 
     public Keccak256(byte[] rawHashBytes) {
-        checkArgument(rawHashBytes.length == 32);
+        checkArgument(rawHashBytes.length == HASH_LEN);
         this.bytes = rawHashBytes;
     }
 
     public Keccak256(String hexString) {
-        checkArgument(hexString.length() == 64);
+        checkArgument(hexString.length() == 2*HASH_LEN);
         this.bytes = Utils.HEX.decode(hexString);
     }
 
@@ -94,7 +96,7 @@ public class Keccak256 implements Serializable, Comparable<Keccak256> {
 
     @Override
     public int compareTo(Keccak256 o) {
-        for (int i = 32 - 1; i >= 0; i--) {
+        for (int i = HASH_LEN - 1; i >= 0; i--) {
             final int thisByte = this.bytes[i] & 0xff;
             final int otherByte = o.bytes[i] & 0xff;
             if (thisByte > otherByte) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -19,19 +19,22 @@
 package org.ethereum.rpc.dto;
 
 import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.rpc.LogFilterElement;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.LogInfo;
 
 import static org.ethereum.rpc.TypeConverter.*;
-
 
 /**
  * Created by Ruben on 5/1/2016.
  */
 public class TransactionReceiptDTO {
+
+    private static final int ROOT_HASH_LEN = Keccak256.HASH_LEN;
 
     private String transactionHash;      // hash of the transaction.
     private String transactionIndex;     // integer of the transactions index position in the block.
@@ -46,7 +49,6 @@ public class TransactionReceiptDTO {
     private String root;                 // post-transaction stateroot
     private String status;               // either 1 (success) or 0 (failure)
     private String logsBloom;            // Bloom filter for light clients to quickly retrieve related logs.
-
 
     public  TransactionReceiptDTO(Block block, TransactionInfo txInfo) {
 
@@ -72,7 +74,7 @@ public class TransactionReceiptDTO {
                     txInfo.getReceipt().getTransaction(), i);
         }
 
-        root = toUnformattedJsonHex(receipt.getPostTxState());
+        root = toUnformattedJsonHex(ByteUtil.toBytesWithLeadingZeros(receipt.getPostTxState(), ROOT_HASH_LEN));
         to = receipt.getTransaction().getReceiveAddress().toJsonString();
         transactionHash = receipt.getTransaction().getHash().toJsonString();
         transactionIndex = toQuantityJsonHex(txInfo.getIndex());

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -50,8 +50,7 @@ public class TransactionReceiptDTO {
     private String status;               // either 1 (success) or 0 (failure)
     private String logsBloom;            // Bloom filter for light clients to quickly retrieve related logs.
 
-    public  TransactionReceiptDTO(Block block, TransactionInfo txInfo) {
-
+    public TransactionReceiptDTO(Block block, TransactionInfo txInfo) {
         TransactionReceipt receipt = txInfo.getReceipt();
 
         status = toQuantityJsonHex(txInfo.getReceipt().getStatus());

--- a/rskj-core/src/main/java/org/ethereum/util/ByteUtil.java
+++ b/rskj-core/src/main/java/org/ethereum/util/ByteUtil.java
@@ -57,6 +57,29 @@ public class ByteUtil {
     }
 
     /**
+     * Adds leading zeros to a {@code src} byte array to have at least {@code len} length.
+     *
+     * @param src a source byte array
+     * @param len the minimum length of the final byte array with leading zeros.
+     * @return byte array with leading zeros.
+     */
+    public static byte[] toBytesWithLeadingZeros(byte[] src, int len) {
+        if (len < 0) {
+            throw new IllegalArgumentException("len");
+        }
+
+        if (src == null || len <= src.length) {
+            return src;
+        }
+
+        byte[] dest = new byte[len];
+        int start = len - src.length;
+        System.arraycopy(src, 0, dest, start, src.length);
+
+        return dest;
+    }
+
+    /**
      * The regular {@link java.math.BigInteger#toByteArray()} method isn't quite what we often need:
      * it appends a leading zero to indicate that the number is positive and may need padding.
      *

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionReceiptDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionReceiptDTOTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.rpc.dto;
+
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import org.ethereum.core.Block;
+import org.ethereum.core.Bloom;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.db.TransactionInfo;
+import org.ethereum.util.ByteUtil;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.ethereum.rpc.TypeConverter.toUnformattedJsonHex;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransactionReceiptDTOTest {
+
+    @Test
+    public void testRootField() {
+        byte[] postTxState = new byte[]{0x01};
+        String expectedRoot = toUnformattedJsonHex(ByteUtil.toBytesWithLeadingZeros(postTxState, Keccak256.HASH_LEN));
+
+        RskAddress rskAddress = RskAddress.nullAddress();
+        Keccak256 hash = Keccak256.ZERO_HASH;
+        Bloom bloom = new Bloom();
+
+        Block block = mock(Block.class);
+        when(block.getHash()).thenReturn(hash);
+
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getHash()).thenReturn(hash);
+        when(transaction.getSender()).thenReturn(rskAddress);
+        when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+
+        TransactionReceipt txReceipt = mock(TransactionReceipt.class);
+        when(txReceipt.getTransaction()).thenReturn(transaction);
+        when(txReceipt.getLogInfoList()).thenReturn(Collections.emptyList());
+        when(txReceipt.getBloomFilter()).thenReturn(bloom);
+        when(txReceipt.getPostTxState()).thenReturn(postTxState);
+
+        TransactionInfo txInfo = new TransactionInfo(txReceipt, hash.getBytes(), 0);
+
+        TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo);
+
+        String actualRoot = transactionReceiptDTO.getRoot();
+
+        assertNotNull(actualRoot);
+        assertEquals(expectedRoot, actualRoot);
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
@@ -500,13 +500,18 @@ public class ByteUtilTest {
 
     @Test
     public void testToBytesWithLeadingZeros_WithLeadingZeros() {
-        byte[] src = new byte[]{1};
+        byte[] src = new byte[]{1, 2};
 
         byte[] actualResult = ByteUtil.toBytesWithLeadingZeros(src, 10);
 
         assertEquals(10, actualResult.length);
-        for (int i = 0; i < actualResult.length - src.length; i++) {
+
+        int srcStart = actualResult.length - src.length;
+        for (int i = 0; i < srcStart; i++) {
             assertEquals(0, actualResult[i]);
+        }
+        for (int i = srcStart; i < actualResult.length; i++) {
+            assertEquals(src[i - srcStart], actualResult[i]);
         }
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/ByteUtilTest.java
@@ -466,7 +466,47 @@ public class ByteUtilTest {
         for (int i=0; i < b3.length; i++) {
             assertEquals(b3[i],normalByteArrayOffset3LeadingZeroes[i]);
         }
-
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testToBytesWithLeadingZeros_InvalidLen() {
+        ByteUtil.toBytesWithLeadingZeros(new byte[0], -1);
+    }
+
+    @Test
+    public void testToBytesWithLeadingZeros_NullSource() {
+        byte[] actualResult = ByteUtil.toBytesWithLeadingZeros(null, 1);
+
+        assertNull(actualResult);
+    }
+
+    @Test
+    public void testToBytesWithLeadingZeros_EmptySource() {
+        byte[] src = new byte[0];
+
+        byte[] actualResult = ByteUtil.toBytesWithLeadingZeros(src, 0);
+
+        assertEquals(src, actualResult);
+    }
+
+    @Test
+    public void testToBytesWithLeadingZeros_SameSource() {
+        byte[] src = new byte[]{0};
+
+        byte[] actualResult = ByteUtil.toBytesWithLeadingZeros(src, 0);
+
+        assertEquals(src, actualResult);
+    }
+
+    @Test
+    public void testToBytesWithLeadingZeros_WithLeadingZeros() {
+        byte[] src = new byte[]{1};
+
+        byte[] actualResult = ByteUtil.toBytesWithLeadingZeros(src, 10);
+
+        assertEquals(10, actualResult.length);
+        for (int i = 0; i < actualResult.length - src.length; i++) {
+            assertEquals(0, actualResult[i]);
+        }
+    }
 }


### PR DESCRIPTION
This sets the length of the `root` field that's being returned by `eth_getTransactionReceipt` JSON-RPC call to 32 bytes.

## Description
Right now rskj returns 0x00,0x01 instead of 0x0...0 and 0x0...1 (32 bytes) for the `root` field. This makes some js libraries incompatible with rskj.

## Motivation and Context
This change is required for the rskj node to be compatible with client libraries at the JSON-RPC level.

## How Has This Been Tested?
JSON-RPC response of `eth_getTransactionReceipt` has been checked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
