### PR TITLE
Limit the RSK merged mining merkle proof

### DIFF
--- a/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java
@@ -128,7 +128,8 @@ public class ProofOfWorkRule implements BlockHeaderValidationRule, BlockValidati
         MerkleProofValidator mpValidator;
         try {
             if (activationConfig.isActive(ConsensusRule.RSKIP92, header.getNumber())) {
-                mpValidator = new Rskip92MerkleProofValidator(header.getBitcoinMergedMiningMerkleProof());
+                boolean isRskip180Enabled = activationConfig.isActive(ConsensusRule.RSKIP180, header.getNumber());
+                mpValidator = new Rskip92MerkleProofValidator(header.getBitcoinMergedMiningMerkleProof(), isRskip180Enabled);
             } else {
                 mpValidator = new GenesisMerkleProofValidator(bitcoinNetworkParameters, header.getBitcoinMergedMiningMerkleProof());
             }

--- a/rskj-core/src/main/java/co/rsk/validators/Rskip92MerkleProofValidator.java
+++ b/rskj-core/src/main/java/co/rsk/validators/Rskip92MerkleProofValidator.java
@@ -19,6 +19,7 @@ package co.rsk.validators;
 
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.peg.utils.MerkleTreeUtils;
+import org.ethereum.config.Constants;
 
 import java.util.Arrays;
 import java.util.stream.IntStream;
@@ -31,7 +32,18 @@ public class Rskip92MerkleProofValidator implements MerkleProofValidator {
 
     private final byte[] pmtSerialized;
 
-    public Rskip92MerkleProofValidator(byte[] pmtSerialized) {
+    public Rskip92MerkleProofValidator(byte[] pmtSerialized, boolean isRskip180Enabled) {
+        if (isRskip180Enabled) {
+            if (pmtSerialized == null) {
+                throw new IllegalArgumentException("Partial merkle tree is <null>");
+            }
+
+            int maxMerkleProofLength = Constants.getMaxBitcoinMergedMiningMerkleProofLength();
+            if (pmtSerialized.length > maxMerkleProofLength) {
+                throw new IllegalArgumentException("Partial merkle tree's size is greater than " + maxMerkleProofLength);
+            }
+        }
+
         if ((pmtSerialized.length % Sha256Hash.LENGTH) != 0) {
             throw new IllegalArgumentException("Partial merkle tree does not have the expected format");
         }

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -180,6 +180,10 @@ public class Constants {
         return 20;
     }
 
+    public static int getMaxBitcoinMergedMiningMerkleProofLength() {
+        return 480;
+    }
+
     public static Constants mainnet() {
         return new Constants(
                 MAINNET_CHAIN_ID,

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -54,6 +54,7 @@ public enum ConsensusRule {
     RSKIP171("rskip171"),
     RSKIP172("rskip172"),
     RSKIP174("rskip174"),
+    RSKIP180("rskip180"),
     RSKIPUMM("rskipUMM");
 
     private String configKey;

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -50,6 +50,7 @@ blockchain = {
              rskip171 = <hardforkName>
              rskip172 = <hardforkName>
              rskip174 = <hardforkName>
+             rskip180 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -41,6 +41,7 @@ blockchain = {
             rskip171 = iris300
             rskip172 = iris300
             rskip174 = iris300
+            rskip180 = iris300
         }
     }
     gc = {

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -76,6 +76,7 @@ public class ActivationConfigTest {
             "    rskip171: iris300",
             "    rskip172: iris300",
             "    rskip174: iris300",
+            "    rskip180: iris300",
             "}"
     ));
 

--- a/rskj-core/src/test/java/org/ethereum/validator/Rskip92MerkleProofValidatorTests.java
+++ b/rskj-core/src/test/java/org/ethereum/validator/Rskip92MerkleProofValidatorTests.java
@@ -1,0 +1,116 @@
+package org.ethereum.validator;
+
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.peg.utils.MerkleTreeUtils;
+import co.rsk.validators.Rskip92MerkleProofValidator;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class Rskip92MerkleProofValidatorTests {
+
+    @Test
+    public void isValid_PassValidHashes_ShouldReturnTrue() {
+        List<byte[]> hashList = makeHashList();
+        byte[] pmtSerialized = join(hashList);
+        Sha256Hash coinbaseHash = Sha256Hash.wrap(hashList.get(0));
+        Rskip92MerkleProofValidator rskip92MerkleProofValidator = new Rskip92MerkleProofValidator(pmtSerialized, true);
+        Sha256Hash rootHash = hashList.stream().map(Sha256Hash::wrap).reduce(coinbaseHash, MerkleTreeUtils::combineLeftRight);
+
+        boolean actualResult = rskip92MerkleProofValidator.isValid(rootHash, coinbaseHash);
+
+        assertTrue(actualResult);
+    }
+
+    @Test
+    public void isValid_PassInvalidCoinbaseHash_ShouldReturnFalse() {
+        List<byte[]> hashList = makeHashList();
+        byte[] pmtSerialized = join(hashList);
+        Sha256Hash coinbaseHash = Sha256Hash.wrap(hashList.get(0));
+        Rskip92MerkleProofValidator rskip92MerkleProofValidator = new Rskip92MerkleProofValidator(pmtSerialized, true);
+        Sha256Hash rootHash = hashList.stream().map(Sha256Hash::wrap).reduce(coinbaseHash, MerkleTreeUtils::combineLeftRight);
+
+        boolean actualResult = rskip92MerkleProofValidator.isValid(rootHash, Sha256Hash.wrap(new byte[Sha256Hash.LENGTH]));
+
+        assertFalse(actualResult);
+    }
+
+    @Test
+    public void isValid_PassInvalidRootHash_ShouldReturnFalse() {
+        List<byte[]> hashList = makeHashList();
+        byte[] pmtSerialized = join(hashList);
+        Sha256Hash coinbaseHash = Sha256Hash.wrap(hashList.get(0));
+        Rskip92MerkleProofValidator rskip92MerkleProofValidator = new Rskip92MerkleProofValidator(pmtSerialized, true);
+        Sha256Hash rootHash = Sha256Hash.wrap(new byte[Sha256Hash.LENGTH]);
+
+        boolean actualResult = rskip92MerkleProofValidator.isValid(rootHash, coinbaseHash);
+
+        assertFalse(actualResult);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createInstance_PassNullProofAndRskip180Enabled_ShouldThrowError() {
+        new Rskip92MerkleProofValidator(null, true);
+    }
+
+    @Test
+    public void createInstance_PassNullProofAndRskip180Disabled_ShouldNotThrowError() {
+        byte[] pmtSerialized = new byte[15 * Sha256Hash.LENGTH];
+        Rskip92MerkleProofValidator instance = new Rskip92MerkleProofValidator(pmtSerialized, false);
+        assertNotNull(instance);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createInstance_PassLargeProofAndRskip180Enabled_ShouldThrowError() {
+        byte[] pmtSerialized = new byte[16 * Sha256Hash.LENGTH];
+        new Rskip92MerkleProofValidator(pmtSerialized, true);
+    }
+
+    @Test
+    public void createInstance_PassLargeProofAndRskip180Disabled_ShouldNotThrowError() {
+        byte[] pmtSerialized = new byte[16 * Sha256Hash.LENGTH];
+        Rskip92MerkleProofValidator instance = new Rskip92MerkleProofValidator(pmtSerialized, false);
+        assertNotNull(instance);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createInstance_PassMalformedProofAndRskip180Enabled_ShouldThrowError() {
+        byte[] pmtSerialized = new byte[Sha256Hash.LENGTH + 1];
+        new Rskip92MerkleProofValidator(pmtSerialized, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createInstance_PassMalformedProofAndRskip180Disabled_ShouldThrowError() {
+        byte[] pmtSerialized = new byte[Sha256Hash.LENGTH + 1];
+        new Rskip92MerkleProofValidator(pmtSerialized, false);
+    }
+
+    private static List<byte[]> makeHashList() {
+        final int hashCount = 5;
+        Random rand = new Random(100);
+        List<byte[]> result = new ArrayList<>(hashCount);
+
+        for (int i = 0; i < hashCount; i++) {
+            byte[] hash = new byte[Sha256Hash.LENGTH];
+            rand.nextBytes(hash);
+
+            result.add(hash);
+        }
+
+        return result;
+    }
+
+    private static byte[] join(List<byte[]> hashList) {
+        byte[] result = new byte[hashList.size() * Sha256Hash.LENGTH];
+
+        for (int i = 0; i < result.length; i++) {
+            result[i] = hashList.get(i / Sha256Hash.LENGTH)[i % Sha256Hash.LENGTH];
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
This change limits the RSK merged mining merkle proof length to max of 480 bytes.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
