### PR TITLE
Update lock_btc event

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
@@ -5,13 +5,22 @@ import org.ethereum.solidity.SolidityType;
 
 public enum BridgeEvents {
 
-    LOCK_BTC("lock_btc",
+    LOCK_BTC_PRE_IRIS("lock_btc",
             new CallTransaction.Param[]{
                     new CallTransaction.Param(true, "receiver", SolidityType.getType("address")),
                     new CallTransaction.Param(false, "btcTxHash", SolidityType.getType("bytes32")),
                     new CallTransaction.Param(false, "senderBtcAddress", SolidityType.getType("string")),
                     new CallTransaction.Param(false, "amount", SolidityType.getType("int"))
-            }),
+            }
+    ),
+    LOCK_BTC_POST_IRIS("lock_btc",
+        new CallTransaction.Param[]{
+            new CallTransaction.Param(true, "receiver", SolidityType.getType("address")),
+            new CallTransaction.Param(true, "btcTxHash", SolidityType.getType("bytes32")),
+            new CallTransaction.Param(false, "amount", SolidityType.getType("int")),
+            new CallTransaction.Param(false, "peginProtocolVersion", SolidityType.getType("int"))
+        }
+    ),
     UPDATE_COLLECTIONS("update_collections",
             new CallTransaction.Param[]{
                     new CallTransaction.Param(false, "sender", SolidityType.getType("address"))

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -439,6 +439,7 @@ public class BridgeSupport {
         RskAddress rskDestinationAddress = peginInformation.getRskDestinationAddress();
         Address senderBtcAddress = peginInformation.getSenderBtcAddress();
         TxSenderAddressType senderBtcAddressType = peginInformation.getSenderBtcAddressType();
+        int protocolVersion = peginInformation.getProtocolVersion();
         co.rsk.core.Coin amountInWeis = co.rsk.core.Coin.fromBitcoin(amount);
 
         logger.debug("[executePegIn] [btcTx:{}] Is a lock from a {} sender", btcTx.getHash(), senderBtcAddressType);
@@ -451,7 +452,7 @@ public class BridgeSupport {
         );
 
         if (activations.isActive(ConsensusRule.RSKIP146)) {
-            eventLogger.logLockBtc(rskDestinationAddress, btcTx, senderBtcAddress, amount);
+            eventLogger.logLockBtc(rskDestinationAddress, btcTx, senderBtcAddress, amount, protocolVersion);
         }
 
         // Save UTXOs from the federation(s) only if we actually locked the funds

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -42,7 +42,7 @@ public interface BridgeEventLogger {
 
     void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation);
 
-    void logLockBtc(RskAddress rskReceiver, BtcTransaction btcTx, Address senderBtcAddress, Coin amount);
+    void logLockBtc(RskAddress rskReceiver, BtcTransaction btcTx, Address senderBtcAddress, Coin amount, int protocolVersion);
 
     void logReleaseBtcRequested(byte[] rskTxHash, BtcTransaction btcTx, Coin amount);
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -593,7 +594,7 @@ public class BridgeSupportTest {
 
         bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), height, pmt.bitcoinSerialize());
 
-        verify(mockedEventLogger, never()).logLockBtc(any(RskAddress.class), any(BtcTransaction.class), any(Address.class), any(Coin.class));
+        verify(mockedEventLogger, never()).logLockBtc(any(RskAddress.class), any(BtcTransaction.class), any(Address.class), any(Coin.class), anyInt());
     }
 
     @Test
@@ -658,7 +659,7 @@ public class BridgeSupportTest {
         );
 
         bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), height, pmt.bitcoinSerialize());
-        verify(mockedEventLogger, atLeastOnce()).logLockBtc(any(RskAddress.class), any(BtcTransaction.class), any(Address.class), any(Coin.class));
+        verify(mockedEventLogger, atLeastOnce()).logLockBtc(any(RskAddress.class), any(BtcTransaction.class), any(Address.class), any(Coin.class), anyInt());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
@@ -3517,7 +3517,7 @@ public class BridgeSupportTestPowerMock {
 
         bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), height, pmt.bitcoinSerialize());
 
-        verify(mockedEventLogger, never()).logLockBtc(any(RskAddress.class), any(BtcTransaction.class), any(Address.class), any(Coin.class));
+        verify(mockedEventLogger, never()).logLockBtc(any(RskAddress.class), any(BtcTransaction.class), any(Address.class), any(Coin.class), anyInt());
     }
 
     @Test
@@ -3582,7 +3582,7 @@ public class BridgeSupportTestPowerMock {
 
         bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), height, pmt.bitcoinSerialize());
 
-        verify(mockedEventLogger, atLeastOnce()).logLockBtc(any(RskAddress.class), any(BtcTransaction.class), any(Address.class), any(Coin.class));
+        verify(mockedEventLogger, atLeastOnce()).logLockBtc(any(RskAddress.class), any(BtcTransaction.class), any(Address.class), any(Coin.class), anyInt());
     }
 
     private BridgeStorageProvider getBridgeStorageProviderMockWithProcessedHashes() throws IOException {


### PR DESCRIPTION
After RSKIP 170 activation sender address is no longer registered and peg-in protocol version is added. Also btc tx hash is now a topic.

Removed logic to put "Undetermined" in sender field when the sender could not be obtained, since after HF activation the new event will be used that does not have this field.