### PR TITLE
Make BtcBlockStore cache configurable

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -350,6 +350,14 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getInt("cache.receipts.max-elements");
     }
 
+    public int getBtcBlockStoreCacheSize() {
+        return configFromFiles.getInt("cache.btcBlockStore.size");
+    }
+
+    public int getBtcBlockStoreCacheDepth() {
+        return configFromFiles.getInt("cache.btcBlockStore.depth");
+    }
+
     public long getVmExecutionStackSize() {
         return configFromFiles.getBytes("vm.executionStackSize");
     }

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -248,6 +248,7 @@ public class BlockExecutor {
             boolean discardInvalidTxs,
             boolean acceptInvalidTransactions) {
         boolean vmTrace = programTraceProcessor != null;
+        logger.trace("Start executeInternal.");
         logger.trace("applyBlock: block: [{}] tx.list: [{}]", block.getNumber(), block.getTransactionsList().size());
 
         // Forks the repo, does not change "repository". It will have a completely different
@@ -344,10 +345,14 @@ public class BlockExecutor {
             logger.trace("tx done");
         }
 
+        logger.trace("End txs executions.");
         if (!vmTrace) {
+            logger.trace("Saving track.");
             track.save();
+            logger.trace("End saving track.");
         }
 
+        logger.trace("Building execution results.");
         BlockResult result = new BlockResult(
                 block,
                 executedTransactions,
@@ -357,6 +362,7 @@ public class BlockExecutor {
                 vmTrace ? null : track.getTrie()
         );
         profiler.stop(metric);
+        logger.trace("End executeInternal.");
         return result;
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2424,7 +2424,9 @@ public class BridgeSupport {
 
         // Check the the merkle root equals merkle root of btc block at specified height in the btc best chain
         // BTC blockstore is available since we've already queried the best chain height
+        logger.trace("Getting btc block at height: {}", height);
         BtcBlock blockHeader = btcBlockStore.getStoredBlockAtMainChainHeight(height).getHeader();
+        logger.trace("Validating block merkle root at height: {}", height);
         if (!isBlockMerkleRootValid(merkleRoot, blockHeader)){
             String panicMessage = String.format(
                     "Btc Tx %s Supplied merkle root %s does not match block's merkle root %s",

--- a/rskj-core/src/main/java/co/rsk/peg/RepositoryBtcBlockStoreWithCache.java
+++ b/rskj-core/src/main/java/co/rsk/peg/RepositoryBtcBlockStoreWithCache.java
@@ -25,6 +25,7 @@ import co.rsk.bitcoinj.core.StoredBlock;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.core.RskAddress;
 import co.rsk.util.MaxSizeHashMap;
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
@@ -37,25 +38,33 @@ import java.util.Map;
 
 /**
  * Implementation of a bitcoinj blockstore that persists to RSK's Repository
+ *
  * @author Oscar Guindzberg
  */
 public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache {
 
     private static final Logger logger = LoggerFactory.getLogger("btcBlockStore");
 
-    public static final String BLOCK_STORE_CHAIN_HEAD_KEY = "blockStoreChainHead";
+    private static final String BLOCK_STORE_CHAIN_HEAD_KEY = "blockStoreChainHead";
+    private static final int DEFAULT_MAX_DEPTH_BLOCK_CACHE = 5_000;
+    private static final int DEFAULT_MAX_SIZE_BLOCK_CACHE = 10_000;
+
     private final Repository repository;
     private final RskAddress contractAddress;
     private final NetworkParameters btcNetworkParams;
-    public static final int MAX_DEPTH_STORED_BLOCKS = 50_000;
-    public static final int MAX_SIZE_MAP_STORED_BLOCKS = 100_000;
+    private final int maxDepthBlockCache;
     private final Map<Sha256Hash, StoredBlock> cacheBlocks;
 
     public RepositoryBtcBlockStoreWithCache(NetworkParameters btcNetworkParams, Repository repository, Map<Sha256Hash, StoredBlock> cacheBlocks, RskAddress contractAddress) {
+        this(btcNetworkParams, repository, cacheBlocks, contractAddress, DEFAULT_MAX_DEPTH_BLOCK_CACHE);
+    }
+
+    public RepositoryBtcBlockStoreWithCache(NetworkParameters btcNetworkParams, Repository repository, Map<Sha256Hash, StoredBlock> cacheBlocks, RskAddress contractAddress, int maxDepthBlockCache) {
         this.cacheBlocks = cacheBlocks;
         this.repository = repository;
         this.contractAddress = contractAddress;
         this.btcNetworkParams = btcNetworkParams;
+        this.maxDepthBlockCache = maxDepthBlockCache;
         checkIfInitialized();
     }
 
@@ -66,7 +75,7 @@ public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache 
         repository.addStorageBytes(contractAddress, DataWord.valueFromHex(hash.toString()), ba);
         if (cacheBlocks != null) {
             StoredBlock chainHead = getChainHead();
-            if (chainHead == null || chainHead.getHeight() - storedBlock.getHeight() < MAX_DEPTH_STORED_BLOCKS) {
+            if (chainHead == null || chainHead.getHeight() - storedBlock.getHeight() < this.maxDepthBlockCache) {
                 cacheBlocks.put(storedBlock.getHeader().getHash(), storedBlock);
             }
         }
@@ -79,14 +88,14 @@ public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache 
             return null;
         }
         StoredBlock storedBlock = byteArrayToStoredBlock(ba);
-        return  storedBlock;
+        return storedBlock;
     }
 
     @Override
     public synchronized StoredBlock getChainHead() {
         byte[] ba = repository.getStorageBytes(contractAddress, DataWord.fromString(BLOCK_STORE_CHAIN_HEAD_KEY));
         if (ba == null) {
-           return null;
+            return null;
         }
         return byteArrayToStoredBlock(ba);
     }
@@ -95,8 +104,10 @@ public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache 
     public synchronized void setChainHead(StoredBlock newChainHead) {
         byte[] ba = storedBlockToByteArray(newChainHead);
         repository.addStorageBytes(contractAddress, DataWord.fromString(BLOCK_STORE_CHAIN_HEAD_KEY), ba);
-        if(cacheBlocks != null) {
+        if (cacheBlocks != null) {
+            logger.info("Populating BTC Block Store Cache.");
             populateCache(newChainHead);
+            logger.info("END Populating BTC Block Store Cache.");
         }
     }
 
@@ -111,7 +122,7 @@ public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache 
 
     @Override
     public StoredBlock getFromCache(Sha256Hash branchBlockHash) {
-        if(cacheBlocks == null) {
+        if (cacheBlocks == null) {
             return null;
         }
         return cacheBlocks.get(branchBlockHash);
@@ -119,21 +130,21 @@ public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache 
 
     @Override
     public StoredBlock getStoredBlockAtMainChainHeight(int height) throws BlockStoreException {
-        StoredBlock chainHead =  getChainHead();
+        StoredBlock chainHead = getChainHead();
         int depth = chainHead.getHeight() - height;
         logger.trace("Getting btc block at depth: {}", depth);
         return getStoredBlockAtMainChainDepth(depth);
     }
 
     private synchronized void populateCache(StoredBlock chainHead) {
-        if(this.btcNetworkParams.getGenesisBlock().equals(chainHead.getHeader())) {
+        if (this.btcNetworkParams.getGenesisBlock().equals(chainHead.getHeader())) {
             return;
         }
         cacheBlocks.put(chainHead.getHeader().getHash(), chainHead);
         Sha256Hash blockHash = chainHead.getHeader().getPrevBlockHash();
-        int depth = MAX_DEPTH_STORED_BLOCKS-1;
+        int depth = this.maxDepthBlockCache - 1;
         while (blockHash != null && depth > 0) {
-            if(cacheBlocks.get(blockHash) != null) {
+            if (cacheBlocks.get(blockHash) != null) {
                 break;
             }
             StoredBlock currentBlock = get(blockHash);
@@ -148,13 +159,13 @@ public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache 
 
     @Override
     public StoredBlock getStoredBlockAtMainChainDepth(int depth) throws BlockStoreException {
-        StoredBlock chainHead =  getChainHead();
+        StoredBlock chainHead = getChainHead();
         Sha256Hash blockHash = chainHead.getHeader().getHash();
 
         for (int i = 0; i < depth && blockHash != null; i++) {
             //If its older than cache go to disk
             StoredBlock currentBlock = getFromCache(blockHash);
-            if(currentBlock == null) {
+            if (currentBlock == null) {
                 logger.trace("Missing cache (depth={}/{}), getting from store.", i, depth);
                 currentBlock = get(blockHash);
                 if (currentBlock == null) {
@@ -168,7 +179,7 @@ public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache 
             return null;
         }
         StoredBlock block = getFromCache(blockHash);
-        if(block == null) {
+        if (block == null) {
             block = get(blockHash);
         }
         int expectedHeight = chainHead.getHeight() - depth;
@@ -208,19 +219,31 @@ public class RepositoryBtcBlockStoreWithCache implements BtcBlockStoreWithCache 
     }
 
     public static class Factory implements BtcBlockStoreWithCache.Factory {
+
+        private final int maxSizeBlockCache;
         //This is ok as we don't have parallel execution, in the feature we should move to a concurrentHashMap
-        private final Map<Sha256Hash, StoredBlock> cacheBlocks = new MaxSizeHashMap<>(MAX_SIZE_MAP_STORED_BLOCKS, true);
+        private final Map<Sha256Hash, StoredBlock> cacheBlocks;
         private final RskAddress contractAddress;
         private final NetworkParameters btcNetworkParams;
+        private final int maxDepthBlockCache;
 
+        @Deprecated
+        @VisibleForTesting
         public Factory(NetworkParameters btcNetworkParams) {
+            this(btcNetworkParams, DEFAULT_MAX_DEPTH_BLOCK_CACHE, DEFAULT_MAX_SIZE_BLOCK_CACHE);
+        }
+
+        public Factory(NetworkParameters btcNetworkParams, int maxDepthBlockCache, int maxSizeBlockCache) {
             this.contractAddress = PrecompiledContracts.BRIDGE_ADDR;
             this.btcNetworkParams = btcNetworkParams;
+            this.maxDepthBlockCache = maxDepthBlockCache;
+            this.maxSizeBlockCache = maxSizeBlockCache;
+            this.cacheBlocks = new MaxSizeHashMap<>(this.maxSizeBlockCache, true);
         }
 
         @Override
         public BtcBlockStoreWithCache newInstance(Repository track) {
-            return new RepositoryBtcBlockStoreWithCache(btcNetworkParams, track, cacheBlocks, contractAddress);
+            return new RepositoryBtcBlockStoreWithCache(btcNetworkParams, track, cacheBlocks, contractAddress, this.maxDepthBlockCache);
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/crypto/ECKey.java
+++ b/rskj-core/src/main/java/org/ethereum/crypto/ECKey.java
@@ -265,6 +265,12 @@ public class ECKey {
     /**
      * Gets the hash160 form of the public key (as seen in addresses).
      *
+     * When we hash the PK to get the address -> Keccak256(PK),
+     * Some things are important:
+     *  - 12 bytes are omitted, to get 20bytes for the address.
+     *  - first byte of the public key is omitted (generally that byte is the format of the PK - 2/3/4)
+     *  - In case of PoI when PK = [0], as the first byte is omitted, we hash an empty byte array.
+     *
      * @return -
      */
     public byte[] getAddress() {

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -71,3 +71,10 @@ wallet {
     enabled = false
     accounts = []
 }
+
+cache {
+    btcBlockStore {
+        depth: 50000,
+        size: 100000
+    }
+}

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -74,7 +74,7 @@ wallet {
 
 cache {
     btcBlockStore {
-        depth: 50000,
-        size: 100000
+        depth: 15000,
+        size: 20000
     }
 }

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -72,9 +72,10 @@ wallet {
     accounts = []
 }
 
-cache {
-    btcBlockStore {
-        depth: 15000,
-        size: 20000
-    }
-}
+#This is a suggested configuration for Full Sync in testnet, for block range 900k-1100k.
+#cache {
+#    btcBlockStore {
+#        depth: 10000,
+#        size: 20000
+#    }
+#}

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -254,6 +254,10 @@ cache = {
   },
   receipts {
     max-elements = <max-elements>
+  },
+  btcBlockStore {
+    depth = <depth-elements>
+    size = <cache-max-elements>
   }
 }
 

--- a/rskj-core/src/main/resources/logback.xml
+++ b/rskj-core/src/main/resources/logback.xml
@@ -86,6 +86,8 @@
     <logger name="co.rsk.db.migration.OrchidToUnitrieMigrator" level="INFO"/>
     <logger name="co.rsk.db.migration.MissingOrchidStorageKeysProvider" level="INFO"/>
     <logger name="blooms" level="INFO"/>
+    <logger name="triestore" level="INFO" />
+    <logger name="btcBlockStore" level="INFO" />
 
     <!-- Use INFO or upper levels for productive environments. -->
     <logger name="com.googlecode.jsonrpc4j" level="INFO"></logger>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -402,6 +402,10 @@ cache {
     # initial estimated capacity: 4000 transactions
     # ie 200 transactions in 20 blocks
     max-elements: 4000
+  },
+  btcBlockStore {
+    depth: 5000,
+    size: 10000
   }
 }
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/LockWhitelistTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/LockWhitelistTest.java
@@ -126,9 +126,7 @@ public class LockWhitelistTest extends BridgePerformanceTestCase {
         final int maxBtcBlocks = 1000;
 
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBtcBlockStoreWithCache(BridgeRegTestConstants.getInstance().getBtcParams(),
-                    repository.startTracking(), new MaxSizeHashMap<>(RepositoryBtcBlockStoreWithCache.MAX_SIZE_MAP_STORED_BLOCKS, true),
-                    PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBtcBlockStoreWithCache.Factory(BridgeRegTestConstants.getInstance().getBtcParams()).newInstance(repository.startTracking());
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/LockingCapTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/LockingCapTest.java
@@ -112,9 +112,7 @@ public class LockingCapTest extends BridgePerformanceTestCase {
         final int maxBtcBlocks = 1000;
 
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
-            BtcBlockStore btcBlockStore = new RepositoryBtcBlockStoreWithCache(BridgeRegTestConstants.getInstance().getBtcParams(),
-                    repository.startTracking(), new MaxSizeHashMap<>(RepositoryBtcBlockStoreWithCache.MAX_SIZE_MAP_STORED_BLOCKS, true),
-                    PrecompiledContracts.BRIDGE_ADDR);
+            BtcBlockStore btcBlockStore = new RepositoryBtcBlockStoreWithCache.Factory(BridgeRegTestConstants.getInstance().getBtcParams()).newInstance(repository.startTracking());
             Context btcContext = new Context(networkParameters);
             BtcBlockChain btcBlockChain;
             try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make BtcBlockStore cache configurable, with 2 options: depth and size.
Add more logs, to identify possible issues in long sync.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When making a long-sync in testnet, I found some range of blocks with a lot of BTC blocks, which makes it really hard to process. Increasing the cache, would make it faster and would take more advantage of this cache. As the configuration of this cache are now static fields, I made this change so we could configure it depending on the chain we are. 
For the purpose of this PR, we wanted to change only testnet params.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Syncing with Boton instance on testnet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

Properties:
- cache.btcBlockStore.size: default to 10k
- cache.btcBlockStore.depth: default to 5k (depth is calculated by the height of the block)