### PR TITLE
Implemented timestamp linking validation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1208,7 +1208,8 @@ public class RskContext implements NodeBootstrapper {
             RskSystemProperties rskSystemProperties = getRskSystemProperties();
             Constants commonConstants = rskSystemProperties.getNetworkConstants();
             BlockTimeStampValidationRule blockTimeStampValidationRule = new BlockTimeStampValidationRule(
-                    commonConstants.getNewBlockMaxSecondsInTheFuture()
+                    commonConstants.getNewBlockMaxSecondsInTheFuture(),
+                    rskSystemProperties.getActivationConfig()
             );
             blockValidationRule = new BlockValidatorRule(
                     new TxsMinGasPriceRule(),
@@ -1253,7 +1254,7 @@ public class RskContext implements NodeBootstrapper {
                     commonConstants.getUncleGenerationLimit(),
                     new BlockHeaderCompositeRule(
                             getProofOfWorkRule(),
-                            new BlockTimeStampValidationRule(commonConstants.getNewBlockMaxSecondsInTheFuture()),
+                            new BlockTimeStampValidationRule(commonConstants.getNewBlockMaxSecondsInTheFuture(), rskSystemProperties.getActivationConfig()),
                             new ValidGasUsedRule()
                     ),
                     new BlockHeaderParentCompositeRule(

--- a/rskj-core/src/main/java/co/rsk/util/TimeProvider.java
+++ b/rskj-core/src/main/java/co/rsk/util/TimeProvider.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.util;
+
+public interface TimeProvider {
+
+    long currentTimeMillis();
+
+}

--- a/rskj-core/src/main/java/co/rsk/util/TimeProvider.java
+++ b/rskj-core/src/main/java/co/rsk/util/TimeProvider.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of RskJ
- * Copyright (C) 2017 RSK Labs Ltd.
+ * Copyright (C) 2020 RSK Labs Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -180,6 +180,10 @@ public class Constants {
         return 20;
     }
 
+    public static long getMaxTimestampsDiffInSecs() {
+        return 300;
+    }
+
     public static int getMaxBitcoinMergedMiningMerkleProofLength() {
         return 480;
     }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -54,7 +54,7 @@ public enum ConsensusRule {
     RSKIP171("rskip171"),
     RSKIP172("rskip172"),
     RSKIP174("rskip174"),
-    RSKIP179("rskip179"),
+    RSKIP179("rskip179"), // BTC-RSK timestamp linking
     RSKIP180("rskip180"),
     RSKIP191("rskip191"),
     RSKIPUMM("rskipUMM");

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -54,6 +54,7 @@ public enum ConsensusRule {
     RSKIP171("rskip171"),
     RSKIP172("rskip172"),
     RSKIP174("rskip174"),
+    RSKIP179("rskip179"),
     RSKIP180("rskip180"),
     RSKIP191("rskip191"),
     RSKIPUMM("rskipUMM");

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -50,6 +50,7 @@ blockchain = {
              rskip171 = <hardforkName>
              rskip172 = <hardforkName>
              rskip174 = <hardforkName>
+             rskip179 = <hardforkName>
              rskip180 = <hardforkName>
              rskip191 = <hardforkName>
          }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -41,6 +41,7 @@ blockchain = {
             rskip171 = iris300
             rskip172 = iris300
             rskip174 = iris300
+            rskip179 = iris300
             rskip180 = iris300
             rskip191 = iris300
         }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
@@ -111,7 +111,7 @@ public class BlockValidatorBuilder {
     }
 
     public BlockValidatorBuilder addBlockTimeStampValidationRule(int validPeriod) {
-        this.blockTimeStampValidationRule = new BlockTimeStampValidationRule(validPeriod);
+        this.blockTimeStampValidationRule = new BlockTimeStampValidationRule(validPeriod, config.getActivationConfig());
         return this;
     }
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -76,6 +76,7 @@ public class ActivationConfigTest {
             "    rskip171: iris300",
             "    rskip172: iris300",
             "    rskip174: iris300",
+            "    rskip179: iris300",
             "    rskip180: iris300",
             "    rskip191: iris300",
             "}"


### PR DESCRIPTION
This implementation checks if BTC and RSK block timestamps are close enough.

## Description
This extends `BlockTimeStampValidationRule` class with the timestamps validation logic and its activation in the next HF.

## Motivation and Context
This aims to prevent a merge-miner attacker from mining old RSK blocks with the current Bitcoin hashrate. 

## How Has This Been Tested?
Using unit tests and running the node locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)


* **Other information**:
