### PR TITLE
Modify the signature and the way the derivationHash is saved.

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -2154,13 +2154,16 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_afterRSKIP176_returnTrue() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
 
-        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromLongString("fastBridgeScriptHash-" + hash.toString())))
-                .thenReturn(new byte[]{FAST_BRIDGE_FEDERATION_SCRIPT_HASH_TRUE_VALUE_TEST});
+        when(repository.getStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromLongString("fastBridgeHashUsedInBtcTx-" + btcTxHash.toString() + derivationHash.toString()))
+        ).thenReturn(new byte[]{FAST_BRIDGE_FEDERATION_SCRIPT_HASH_TRUE_VALUE_TEST});
 
         BridgeStorageProvider provider = new BridgeStorageProvider(
                 repository,
@@ -2169,7 +2172,7 @@ public class BridgeStorageProviderTest {
                 activations
         );
 
-        boolean result = provider.isFastBridgeFederationDerivationHashUsed(hash);
+        boolean result = provider.isFastBridgeFederationDerivationHashUsed(btcTxHash, derivationHash);
         Assert.assertTrue(result);
     }
 
@@ -2177,13 +2180,16 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_beforeRSKIP176_returnFalse() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(false);
 
-        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromLongString("fastBridgeScriptHash-" + hash.toString())))
-                .thenReturn(new byte[]{FAST_BRIDGE_FEDERATION_SCRIPT_HASH_TRUE_VALUE_TEST});
+        when(repository.getStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromLongString("fastBridgeHashUsedInBtcTx-" + btcTxHash.toString() + derivationHash.toString()))
+        ).thenReturn(new byte[]{FAST_BRIDGE_FEDERATION_SCRIPT_HASH_TRUE_VALUE_TEST});
 
         BridgeStorageProvider provider = new BridgeStorageProvider(
                 repository,
@@ -2192,7 +2198,7 @@ public class BridgeStorageProviderTest {
                 activations
         );
 
-        boolean result = provider.isFastBridgeFederationDerivationHashUsed(hash);
+        boolean result = provider.isFastBridgeFederationDerivationHashUsed(btcTxHash, derivationHash);
         Assert.assertFalse(result);
     }
 
@@ -2200,10 +2206,13 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_storageReturnsNull_returnFalse() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
-        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromLongString("fastBridgeScriptHash-" + hash.toString())))
-                .thenReturn(null);
+        when(repository.getStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromLongString("fastBridgeHashUsedInBtcTx-" + btcTxHash.toString() + derivationHash.toString()))
+        ).thenReturn(null);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
@@ -2215,7 +2224,7 @@ public class BridgeStorageProviderTest {
                 activations
         );
 
-        boolean result = provider.isFastBridgeFederationDerivationHashUsed(hash);
+        boolean result = provider.isFastBridgeFederationDerivationHashUsed(btcTxHash, derivationHash);
         Assert.assertFalse(result);
     }
 
@@ -2223,10 +2232,13 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_storageReturnsEmpty_returnFalse() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
-        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromLongString("fastBridgeScriptHash-" + hash.toString())))
-                .thenReturn(new byte[]{});
+        when(repository.getStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromLongString("fastBridgeHashUsedInBtcTx-" + btcTxHash.toString() + derivationHash.toString()))
+        ).thenReturn(new byte[]{});
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
@@ -2238,7 +2250,7 @@ public class BridgeStorageProviderTest {
                 activations
         );
 
-        boolean result = provider.isFastBridgeFederationDerivationHashUsed(hash);
+        boolean result = provider.isFastBridgeFederationDerivationHashUsed(btcTxHash, derivationHash);
         Assert.assertFalse(result);
     }
 
@@ -2246,10 +2258,13 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_storageReturnsWrongValue_returnFalse() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
-        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromLongString("fastBridgeScriptHash-" + hash.toString())))
-                .thenReturn(new byte[]{(byte) 0});
+        when(repository.getStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromLongString("fastBridgeHashUsedInBtcTx-" + btcTxHash.toString() + derivationHash.toString()))
+        ).thenReturn(new byte[]{(byte) 0});
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
@@ -2261,7 +2276,7 @@ public class BridgeStorageProviderTest {
                 activations
         );
 
-        boolean result = provider.isFastBridgeFederationDerivationHashUsed(hash);
+        boolean result = provider.isFastBridgeFederationDerivationHashUsed(btcTxHash, derivationHash);
         Assert.assertFalse(result);
     }
 
@@ -2269,7 +2284,8 @@ public class BridgeStorageProviderTest {
     public void saveDerivationArgumentsScriptHash_afterRSKIP176_Ok() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
@@ -2281,24 +2297,72 @@ public class BridgeStorageProviderTest {
                 activations
         );
 
-        provider.markFastBridgeFederationDerivationHashAsUsed(hash);
+        provider.markFastBridgeFederationDerivationHashAsUsed(btcTxHash, derivationHash);
 
         provider.save();
 
         verify(repository, times(1)).addStorageBytes(
                 PrecompiledContracts.BRIDGE_ADDR,
-                DataWord.fromLongString("fastBridgeScriptHash-" + hash.toString()),
+                DataWord.fromLongString("fastBridgeHashUsedInBtcTx-" + btcTxHash.toString() + derivationHash.toString()),
                 new byte[]{FAST_BRIDGE_FEDERATION_SCRIPT_HASH_TRUE_VALUE_TEST}
         );
         verifyNoMoreInteractions(repository);
     }
 
     @Test
+    public void saveDerivationArgumentsScriptHash_afterRSKIP176_nullBtcTxHash_notSaved() throws IOException {
+        Repository repository = mock(Repository.class);
+
+        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Sha256Hash btcTxHash = null;
+
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+                repository,
+                PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(),
+                activations
+        );
+
+        provider.markFastBridgeFederationDerivationHashAsUsed(btcTxHash, derivationHash);
+
+        provider.save();
+
+        verifyZeroInteractions(repository);
+    }
+
+    @Test
+    public void saveDerivationArgumentsScriptHash_afterRSKIP176_nullDerivationHash_notSaved() throws IOException {
+        Repository repository = mock(Repository.class);
+
+        Sha256Hash derivationHash = null;
+        Sha256Hash btcTxHash = PegTestUtils.createHash(1);
+
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+                repository,
+                PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(),
+                activations
+        );
+
+        provider.markFastBridgeFederationDerivationHashAsUsed(btcTxHash, derivationHash);
+
+        provider.save();
+
+        verifyZeroInteractions(repository);
+    }
+
+    @Test
     public void saveDerivationArgumentsScriptHash_beforeRSKIP176_Ok() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
-        byte[] fastBridgeFedP2SH = new byte[]{(byte) 0xaa};
+        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(false);
@@ -2310,13 +2374,13 @@ public class BridgeStorageProviderTest {
                 activations
         );
 
-        provider.markFastBridgeFederationDerivationHashAsUsed(hash);
+        provider.markFastBridgeFederationDerivationHashAsUsed(btcTxHash, derivationHash);
 
         provider.save();
 
         verify(repository, never()).addStorageBytes(
                 PrecompiledContracts.BRIDGE_ADDR,
-                DataWord.fromLongString("fastBridgeScriptHash-" + hash.toString()),
+                DataWord.fromLongString("fastBridgeHashUsedInBtcTx-" + btcTxHash.toString() + derivationHash.toString()),
                 new byte[]{FAST_BRIDGE_FEDERATION_SCRIPT_HASH_TRUE_VALUE_TEST}
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -5142,6 +5142,8 @@ public class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP134)).thenReturn(true);
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.isFastBridgeFederationDerivationHashUsed(any(Sha256Hash.class), any(Sha256Hash.class))).thenReturn(true);
+
         ReleaseTransactionSet releaseTransactionSet = new ReleaseTransactionSet(new HashSet<>());
         when(provider.getReleaseTransactionSet()).thenReturn(releaseTransactionSet);
 


### PR DESCRIPTION
Previously only the derivationHash was saved, now the hash of the original bitcoin transaction is added as a joint key.

