### PR TITLE
Remove non-standard opcodes TXINDEX; DUPN, SWAPN

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -56,6 +56,7 @@ public enum ConsensusRule {
     RSKIP174("rskip174"),
     RSKIP180("rskip180"),
     RSKIPREMOPCODES("rskipremopcodes"),
+    RSKIP191("rskip191"),
     RSKIPUMM("rskipUMM");
 
     private String configKey;

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -55,6 +55,7 @@ public enum ConsensusRule {
     RSKIP172("rskip172"),
     RSKIP174("rskip174"),
     RSKIP180("rskip180"),
+    RSKIPREMOPCODES("rskipremopcodes"),
     RSKIPUMM("rskipUMM");
 
     private String configKey;

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -55,7 +55,6 @@ public enum ConsensusRule {
     RSKIP172("rskip172"),
     RSKIP174("rskip174"),
     RSKIP180("rskip180"),
-    RSKIPREMOPCODES("rskipremopcodes"),
     RSKIP191("rskip191"),
     RSKIPUMM("rskipUMM");
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1858,7 +1858,7 @@ public class VM {
                 doSELFBALANCE();
             break;
             case OpCodes.OP_TXINDEX:
-                if (activations.isActive(RSKIPREMOPCODES)) {
+                if (activations.isActive(RSKIP191)) {
                     throw Program.ExceptionHelper.invalidOpCode(program);
                 }
 
@@ -1903,7 +1903,7 @@ public class VM {
             case OpCodes.OP_SWAP_16: doSWAP();
             break;
             case OpCodes.OP_SWAPN:
-                if (activations.isActive(RSKIPREMOPCODES)) {
+                if (activations.isActive(RSKIP191)) {
                     throw Program.ExceptionHelper.invalidOpCode(program);
                 }
 
@@ -1999,7 +1999,7 @@ public class VM {
             case OpCodes.OP_SUICIDE: doSUICIDE();
             break;
             case OpCodes.OP_DUPN:
-                if (activations.isActive(RSKIPREMOPCODES)) {
+                if (activations.isActive(RSKIP191)) {
                     throw Program.ExceptionHelper.invalidOpCode(program);
                 }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -1857,8 +1857,15 @@ public class VM {
                 }
                 doSELFBALANCE();
             break;
-            case OpCodes.OP_TXINDEX: doTXINDEX();
-            break;
+            case OpCodes.OP_TXINDEX:
+                if (activations.isActive(RSKIPREMOPCODES)) {
+                    throw Program.ExceptionHelper.invalidOpCode(program);
+                }
+
+                doTXINDEX();
+
+                break;
+
             case OpCodes.OP_POP: doPOP();
             break;
             case OpCodes.OP_DUP_1:
@@ -1895,8 +1902,15 @@ public class VM {
             case OpCodes.OP_SWAP_15:
             case OpCodes.OP_SWAP_16: doSWAP();
             break;
-            case OpCodes.OP_SWAPN: doSWAPN();
+            case OpCodes.OP_SWAPN:
+                if (activations.isActive(RSKIPREMOPCODES)) {
+                    throw Program.ExceptionHelper.invalidOpCode(program);
+                }
+
+                doSWAPN();
+
                 break;
+
             case OpCodes.OP_LOG_0:
             case OpCodes.OP_LOG_1:
             case OpCodes.OP_LOG_2:
@@ -1984,7 +1998,13 @@ public class VM {
             break;
             case OpCodes.OP_SUICIDE: doSUICIDE();
             break;
-            case OpCodes.OP_DUPN: doDUPN();
+            case OpCodes.OP_DUPN:
+                if (activations.isActive(RSKIPREMOPCODES)) {
+                    throw Program.ExceptionHelper.invalidOpCode(program);
+                }
+
+                doDUPN();
+
                 break;
 
             /**

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -51,6 +51,7 @@ blockchain = {
              rskip172 = <hardforkName>
              rskip174 = <hardforkName>
              rskip180 = <hardforkName>
+             rskipremopcodes = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -52,6 +52,7 @@ blockchain = {
              rskip174 = <hardforkName>
              rskip180 = <hardforkName>
              rskipremopcodes = <hardforkName>
+             rskip191 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -51,7 +51,6 @@ blockchain = {
              rskip172 = <hardforkName>
              rskip174 = <hardforkName>
              rskip180 = <hardforkName>
-             rskipremopcodes = <hardforkName>
              rskip191 = <hardforkName>
          }
     }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -42,7 +42,6 @@ blockchain = {
             rskip172 = iris300
             rskip174 = iris300
             rskip180 = iris300
-            rskipremopcodes = iris300
             rskip191 = iris300
         }
     }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -42,6 +42,7 @@ blockchain = {
             rskip172 = iris300
             rskip174 = iris300
             rskip180 = iris300
+            rskipremopcodes = iris300
         }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -43,6 +43,7 @@ blockchain = {
             rskip174 = iris300
             rskip180 = iris300
             rskipremopcodes = iris300
+            rskip191 = iris300
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -465,6 +465,20 @@ public class VMExecutionTest {
     }
 
     @Test
+    public void dupnAsInvalidOpcodeWhenDeactivated() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(RSKIPREMOPCODES)).thenReturn(true);
+
+        Program program = playCode("PUSH1 0x01 PUSH1 0x00 DUPN", activations);
+        ProgramResult result = program.getResult();
+
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getException());
+        Assert.assertTrue(result.getException() instanceof Program.IllegalOperationException);
+        Assert.assertEquals("Invalid operation code: opcode[a8], tx[<null>]", result.getException().getMessage());
+    }
+
+    @Test
     public void swapnSecondItem() {
         Program program = executeCode("PUSH1 0x01 PUSH1 0x02 PUSH1 0x00 SWAPN", 4);
         Stack stack = program.getStack();
@@ -509,6 +523,21 @@ public class VMExecutionTest {
         executeCode("PUSH1 0x01 PUSH1 0x02 PUSH1 0x03 PUSH1 0x04 PUSH1 0x05 PUSH1 0x06 PUSH1 0x07 PUSH1 0x08 PUSH1 0x09 PUSH1 0x0a PUSH1 0x0b PUSH1 0x0c PUSH1 0x0d PUSH1 0x0e PUSH1 0x0f PUSH1 0x10 PUSH1 0x11 PUSH1 0x12 PUSH1 0x13 PUSH1 0x12 SWAPN", 22);
     }
 
+
+    @Test
+    public void swapnAsInvalidOpcodeWhenDeactivated() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(RSKIPREMOPCODES)).thenReturn(true);
+
+        Program program = playCode("PUSH1 0x01 PUSH1 0x02 PUSH1 0x00 SWAPN", activations);
+        ProgramResult result = program.getResult();
+
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getException());
+        Assert.assertTrue(result.getException() instanceof Program.IllegalOperationException);
+        Assert.assertEquals("Invalid operation code: opcode[a9], tx[<null>]", result.getException().getMessage());
+    }
+
     @Test
     public void txIndexExecution() {
         invoke.setTransactionIndex(DataWord.valueOf(42));
@@ -517,6 +546,21 @@ public class VMExecutionTest {
 
         Assert.assertEquals(1, stack.size());
         Assert.assertEquals(DataWord.valueOf(42), stack.peek());
+    }
+
+    @Test
+    public void txIndexAsInvalidOpcodeWhenDeactivated() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(RSKIPREMOPCODES)).thenReturn(true);
+
+        invoke.setTransactionIndex(DataWord.valueOf(42));
+        Program program = playCode("TXINDEX", activations);
+        ProgramResult result = program.getResult();
+
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getException());
+        Assert.assertTrue(result.getException() instanceof Program.IllegalOperationException);
+        Assert.assertEquals("Invalid operation code: opcode[aa], tx[<null>]", result.getException().getMessage());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/vm/VMExecutionTest.java
@@ -467,7 +467,7 @@ public class VMExecutionTest {
     @Test
     public void dupnAsInvalidOpcodeWhenDeactivated() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(RSKIPREMOPCODES)).thenReturn(true);
+        when(activations.isActive(RSKIP191)).thenReturn(true);
 
         Program program = playCode("PUSH1 0x01 PUSH1 0x00 DUPN", activations);
         ProgramResult result = program.getResult();
@@ -527,7 +527,7 @@ public class VMExecutionTest {
     @Test
     public void swapnAsInvalidOpcodeWhenDeactivated() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(RSKIPREMOPCODES)).thenReturn(true);
+        when(activations.isActive(RSKIP191)).thenReturn(true);
 
         Program program = playCode("PUSH1 0x01 PUSH1 0x02 PUSH1 0x00 SWAPN", activations);
         ProgramResult result = program.getResult();
@@ -551,7 +551,7 @@ public class VMExecutionTest {
     @Test
     public void txIndexAsInvalidOpcodeWhenDeactivated() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(RSKIPREMOPCODES)).thenReturn(true);
+        when(activations.isActive(RSKIP191)).thenReturn(true);
 
         invoke.setTransactionIndex(DataWord.valueOf(42));
         Program program = playCode("TXINDEX", activations);

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -77,6 +77,7 @@ public class ActivationConfigTest {
             "    rskip172: iris300",
             "    rskip174: iris300",
             "    rskip180: iris300",
+            "    rskip191: iris300",
             "}"
     ));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove virtual machine opcodes execution `TXINDEX`, `DUPN`, `SWAPN`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to keep compatibility with any  future Ethereum virtual machine (evolution of opcodes), we remove the mentioned ones.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Using code tests, with fork activation and without activation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Requires Activation Code (Hard Fork)


* **Other information**:
This opcodes where never used or described in documentation, AFAIR