### PR TITLE
Change Sha256Hash to Keccak256 type

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.config.BridgeConstants;
 import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
 import co.rsk.panic.PanicProcessor;
 import co.rsk.peg.bitcoin.MerkleBranch;
 import co.rsk.peg.utils.BtcTransactionFormatUtils;
@@ -1102,7 +1103,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
             byte[] btcTxSerialized = (byte[]) args[0];
             int height = ((BigInteger) args[1]).intValue();
             byte[] pmtSerialized = (byte[]) args[2];
-            Sha256Hash derivationArgumentsHash = Sha256Hash.wrap((byte[]) args[3]);
+            Keccak256 derivationArgumentsHash = new Keccak256((byte[]) args[3]);
             Address userRefundAddress = new Address(bridgeConstants.getBtcParams(), (byte[]) args[4]);
             // A DataWord cast is used because a SolidityType "address" is decoded using this specific type.
             RskAddress lbcAddress = new RskAddress((DataWord) args[5]);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -754,7 +754,7 @@ public class BridgeSerializationUtils {
         if (rlpList.size() != 2) {
             throw new RuntimeException(String.format("Invalid serialized Fast Bridge Federation: expected 2 value but got %d", rlpList.size()));
         }
-        Sha256Hash derivationHash = Sha256Hash.wrap(rlpList.get(0).getRLPData());
+        Keccak256 derivationHash = new Keccak256(rlpList.get(0).getRLPData());
         byte[] federationP2SH = rlpList.get(1).getRLPData();
 
         return new FastBridgeFederationInformation(derivationHash, federationP2SH, fastBridgeScriptHash);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -114,7 +114,7 @@ public class BridgeStorageProvider {
 
     private Map<Sha256Hash, CoinbaseInformation> coinbaseInformationMap;
 
-    private Sha256Hash fastBridgeDerivationArgumentsHashToSave = null;
+    private Keccak256 fastBridgeDerivationArgumentsHashToSave = null;
     private Sha256Hash fastBridgeBtcTxHashToSave = null;
 
     private FastBridgeFederationInformation fastBridgeFederationInformationsToSave = null;
@@ -601,7 +601,7 @@ public class BridgeStorageProvider {
             safeSaveToRepository(getStorageKeyForCoinbaseInformation(blockHash), data, BridgeSerializationUtils::serializeCoinbaseInformation));
     }
 
-    public boolean isFastBridgeFederationDerivationHashUsed(Sha256Hash btcTxHash, Sha256Hash derivationArgsHash) {
+    public boolean isFastBridgeFederationDerivationHashUsed(Sha256Hash btcTxHash, Keccak256 derivationArgsHash) {
         if (!activations.isActive(RSKIP176)) {
             return false;
         }
@@ -618,7 +618,7 @@ public class BridgeStorageProvider {
         return ((data != null) && (data.length == 1) && (data[0] == FAST_BRIDGE_FEDERATION_DERIVATION_ARGUMENTS_HASH_TRUE_VALUE));
     }
 
-    public void markFastBridgeFederationDerivationHashAsUsed(Sha256Hash btcTxHashToSave, Sha256Hash derivationArgsHash) {
+    public void markFastBridgeFederationDerivationHashAsUsed(Sha256Hash btcTxHashToSave, Keccak256 derivationArgsHash) {
         if (activations.isActive(RSKIP176)) {
             fastBridgeBtcTxHashToSave = btcTxHashToSave;
             fastBridgeDerivationArgumentsHashToSave = derivationArgsHash;
@@ -717,7 +717,7 @@ public class BridgeStorageProvider {
         return DataWord.fromLongString("coinbaseInformation-" + btcTxHash.toString());
     }
 
-    private DataWord getStorageKeyForDerivationArgumentsHash(Sha256Hash btcTxHash, Sha256Hash derivationHash) {
+    private DataWord getStorageKeyForDerivationArgumentsHash(Sha256Hash btcTxHash, Keccak256 derivationHash) {
         return DataWord.fromLongString("fastBridgeHashUsedInBtcTx-" + btcTxHash.toString() + derivationHash.toString());
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -55,6 +55,8 @@ import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
@@ -2075,7 +2077,7 @@ public class BridgeSupport {
         byte[] btcTxSerialized,
         int height,
         byte[] pmtSerialized,
-        Sha256Hash derivationArgumentsHash,
+        Keccak256 derivationArgumentsHash,
         Address userRefundAddress,
         RskAddress lbcAddress,
         Address lpBtcAddress,
@@ -2102,7 +2104,7 @@ public class BridgeSupport {
         Context.propagate(btcContext);
         Sha256Hash btcTxHash = BtcTransactionFormatUtils.calculateBtcTxHash(btcTxSerialized);
 
-        Sha256Hash fastBridgeDerivationHash = getFastBridgeDerivationHash(
+        Keccak256 fastBridgeDerivationHash = getFastBridgeDerivationHash(
                 derivationArgumentsHash,
                 userRefundAddress,
                 lpBtcAddress,
@@ -2166,11 +2168,10 @@ public class BridgeSupport {
         return totalAmount.getValue();
     }
 
-    protected FastBridgeFederationInformation createFastBridgeFederationInformation(
-        Sha256Hash fastBridgeDerivationHash) {
+    protected FastBridgeFederationInformation createFastBridgeFederationInformation(Keccak256 fastBridgeDerivationHash) {
         Script fastBridgeScript = RedeemScriptParser.createMultiSigFastBridgeRedeemScript(
             getActiveFederation().getRedeemScript(),
-            fastBridgeDerivationHash
+            Sha256Hash.wrap(fastBridgeDerivationHash.getBytes())
         );
 
         Script fastBridgeScriptHash = ScriptBuilder.createP2SHOutputScript(fastBridgeScript);
@@ -2218,8 +2219,8 @@ public class BridgeSupport {
         return wallet;
     }
 
-    protected Sha256Hash getFastBridgeDerivationHash(
-        Sha256Hash derivationArgumentsHash,
+    protected Keccak256 getFastBridgeDerivationHash(
+        Keccak256 derivationArgumentsHash,
         Address userRefundAddress,
         Address lpBtcAddress,
         RskAddress lbcAddress
@@ -2271,8 +2272,7 @@ public class BridgeSupport {
             dstPosition,
             lpBtcAddressBytes.length
         );
-
-        return Sha256Hash.of(result);
+        return new Keccak256(HashUtil.keccak256(result));
     }
 
     protected Coin getAmountToLiveFederations(BtcTransaction btcTx) throws IOException{
@@ -2299,7 +2299,7 @@ public class BridgeSupport {
    // and will look like.
     protected void saveFastBridgeDataInStorage(
             Sha256Hash btcTxHash,
-            Sha256Hash derivationHash,
+            Keccak256 derivationHash,
             FastBridgeFederationInformation fastBridgeFederationInformation,
             List<UTXO> utxosList) throws IOException {
         provider.markFastBridgeFederationDerivationHashAsUsed(btcTxHash, derivationHash);

--- a/rskj-core/src/main/java/co/rsk/peg/FastBridgeCompatibleBtcWallet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FastBridgeCompatibleBtcWallet.java
@@ -1,6 +1,7 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.Context;
+import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.script.RedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.RedeemData;
@@ -41,7 +42,7 @@ public abstract class FastBridgeCompatibleBtcWallet extends BridgeBtcWallet {
             Script fedRedeemScript = destinationFederationInstance.getRedeemScript();
             Script fastBridgeRedeemScript = RedeemScriptParser
                 .createMultiSigFastBridgeRedeemScript(fedRedeemScript,
-                    fastBridgeFederationInformationInstance.getDerivationHash());
+                    Sha256Hash.wrap(fastBridgeFederationInformationInstance.getDerivationHash().getBytes()));
 
             return RedeemData.of(destinationFederationInstance.getBtcPublicKeys(), fastBridgeRedeemScript);
         }

--- a/rskj-core/src/main/java/co/rsk/peg/fastbridge/FastBridgeFederationInformation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/fastbridge/FastBridgeFederationInformation.java
@@ -2,15 +2,15 @@ package co.rsk.peg.fastbridge;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.crypto.Keccak256;
 
 public class FastBridgeFederationInformation {
-    private final Sha256Hash derivationHash;
+    private final Keccak256 derivationHash;
     private final byte[] federationScriptHash;
     private final byte[] fastBridgeScriptHash;
 
     public FastBridgeFederationInformation(
-        Sha256Hash derivationHash,
+        Keccak256 derivationHash,
         byte[] federationScriptHash,
         byte[] fastBridgeScriptHash
     ) {
@@ -19,7 +19,7 @@ public class FastBridgeFederationInformation {
         this.fastBridgeScriptHash = fastBridgeScriptHash;
     }
 
-    public Sha256Hash getDerivationHash() {
+    public Keccak256 getDerivationHash() {
         return derivationHash;
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1059,7 +1059,7 @@ public class BridgeSerializationUtilsTest {
     public void serializeFastBridgeInformation_Ok() {
         byte[] fastBridgeScriptHash = new byte[]{(byte)0x23};
         FastBridgeFederationInformation fastBridge = new FastBridgeFederationInformation(
-                Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000002"),
+                PegTestUtils.createHash3(2),
                 new byte[]{(byte)0x22},
                 fastBridgeScriptHash
         );

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -2154,7 +2154,7 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_afterRSKIP176_returnTrue() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -2180,7 +2180,7 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_beforeRSKIP176_returnFalse() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -2206,7 +2206,7 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_storageReturnsNull_returnFalse() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         when(repository.getStorageBytes(
@@ -2232,7 +2232,7 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_storageReturnsEmpty_returnFalse() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         when(repository.getStorageBytes(
@@ -2258,7 +2258,7 @@ public class BridgeStorageProviderTest {
     public void isFastBridgeFederationDerivationHashUsed_storageReturnsWrongValue_returnFalse() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         when(repository.getStorageBytes(
@@ -2284,7 +2284,7 @@ public class BridgeStorageProviderTest {
     public void saveDerivationArgumentsScriptHash_afterRSKIP176_Ok() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -2313,7 +2313,7 @@ public class BridgeStorageProviderTest {
     public void saveDerivationArgumentsScriptHash_afterRSKIP176_nullBtcTxHash_notSaved() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         Sha256Hash btcTxHash = null;
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -2337,7 +2337,7 @@ public class BridgeStorageProviderTest {
     public void saveDerivationArgumentsScriptHash_afterRSKIP176_nullDerivationHash_notSaved() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = null;
+        Keccak256 derivationHash = null;
         Sha256Hash btcTxHash = PegTestUtils.createHash(1);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -2361,7 +2361,7 @@ public class BridgeStorageProviderTest {
     public void saveDerivationArgumentsScriptHash_beforeRSKIP176_Ok() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = PegTestUtils.createHash(1);
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         Sha256Hash btcTxHash = PegTestUtils.createHash(2);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -2390,7 +2390,7 @@ public class BridgeStorageProviderTest {
         Repository repository = mock(Repository.class);
 
         byte[] fastBridgeScriptHash = new byte[]{(byte) 0xbb};
-        Sha256Hash derivationHash = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000001");
+        Keccak256 derivationHash = PegTestUtils.createHash3(1);
         byte[] federationScriptHash = new byte[]{(byte) 0xaa};
         FastBridgeFederationInformation fastBridgeValue =
             new FastBridgeFederationInformation(derivationHash, federationScriptHash, fastBridgeScriptHash);
@@ -2422,7 +2422,7 @@ public class BridgeStorageProviderTest {
     public void getFastBridgeFederationInformation_beforeRSKIP176_Ok() {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000002");
+        Keccak256 derivationHash = PegTestUtils.createHash3(2);
         byte[] federationP2SH = new byte[]{(byte) 0xaa};
         byte[] fastBridgeFederationP2SH = new byte[]{(byte) 0xaa};
         byte[] fastBridgeScriptHash = new byte[]{(byte)0x22};
@@ -2512,7 +2512,7 @@ public class BridgeStorageProviderTest {
     public void saveFastBridgeFederationInformation_afterRSKIP176_Ok() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000002");
+        Keccak256 derivationHash = PegTestUtils.createHash3(2);
         byte[] federationP2SH = new byte[]{(byte) 0xaa};
         byte[] fastBridgeScriptHash = new byte[]{(byte)0x22};
         FastBridgeFederationInformation fastBridgeValue =
@@ -2542,7 +2542,7 @@ public class BridgeStorageProviderTest {
     public void saveFastBridgeFederationInformation_beforeRSKIP176_Ok() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000002");
+        Keccak256 derivationHash = PegTestUtils.createHash3(2);
         byte[] federationP2SH = new byte[]{(byte) 0xaa};
         byte[] fastBridgeScriptHash = new byte[]{(byte)0x22};
         FastBridgeFederationInformation fastBridgeValue =
@@ -2573,7 +2573,7 @@ public class BridgeStorageProviderTest {
     public void saveFastBridgeFederationInformation_alreadySet_dont_set_again() throws IOException {
         Repository repository = mock(Repository.class);
 
-        Sha256Hash derivationHash = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000002");
+        Keccak256 derivationHash = PegTestUtils.createHash3(2);
         byte[] federationP2SH = new byte[]{(byte) 0xaa};
         byte[] fastBridgeScriptHash = new byte[]{(byte)0x22};
         FastBridgeFederationInformation fastBridgeValue =

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -9,6 +9,7 @@ import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -235,7 +236,7 @@ public class BridgeTest {
                 any(byte[].class),
                 anyInt(),
                 any(byte[].class),
-                any(Sha256Hash.class),
+                any(Keccak256.class),
                 any(Address.class),
                 any(RskAddress.class),
                 any(Address.class),
@@ -275,7 +276,7 @@ public class BridgeTest {
                 eq(value),
                 eq(1),
                 eq(value),
-                eq(Sha256Hash.wrap(value)),
+                eq(new Keccak256(value)),
                 eq(refundBtcAddress),
                 eq(rskAddress),
                 eq(lpBtcAddress),
@@ -296,7 +297,7 @@ public class BridgeTest {
                 any(byte[].class),
                 anyInt(),
                 any(byte[].class),
-                any(Sha256Hash.class),
+                any(Keccak256.class),
                 any(Address.class),
                 any(RskAddress.class),
                 any(Address.class),

--- a/rskj-core/src/test/java/co/rsk/peg/FastBridgeCompatibleBtcWalletWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FastBridgeCompatibleBtcWalletWithSingleScriptTest.java
@@ -8,6 +8,7 @@ import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.script.RedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.RedeemData;
+import co.rsk.crypto.Keccak256;
 import co.rsk.peg.fastbridge.FastBridgeFederationInformation;
 import java.time.Instant;
 import java.util.Collections;
@@ -44,7 +45,7 @@ public class FastBridgeCompatibleBtcWalletWithSingleScriptTest {
         byte[] fastBridgeScriptHash = new byte[]{(byte)0x22};
         FastBridgeFederationInformation fastBridgeFederationInformation =
             new FastBridgeFederationInformation(
-                Sha256Hash.of(new byte[]{2}),
+                PegTestUtils.createHash3(2),
                 federation.getP2SHScript().getPubKeyHash(),
                 fastBridgeScriptHash);
 
@@ -58,7 +59,7 @@ public class FastBridgeCompatibleBtcWalletWithSingleScriptTest {
             federation.getP2SHScript().getPubKeyHash());
 
         Script fastBridgeRedeemScript = RedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            federation.getRedeemScript(), fastBridgeFederationInformation.getDerivationHash()
+            federation.getRedeemScript(), Sha256Hash.wrap(fastBridgeFederationInformation.getDerivationHash().getBytes())
         );
 
         Assert.assertNotNull(redeemData);

--- a/rskj-core/src/test/java/co/rsk/peg/FastBridgeCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FastBridgeCompatibleBtcWalletWithStorageTest.java
@@ -11,6 +11,7 @@ import co.rsk.bitcoinj.script.RedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.wallet.RedeemData;
+import co.rsk.crypto.Keccak256;
 import co.rsk.peg.fastbridge.FastBridgeFederationInformation;
 import java.time.Instant;
 import java.util.Collections;
@@ -47,10 +48,10 @@ public class FastBridgeCompatibleBtcWalletWithStorageTest {
     @Test
     public void findRedeemDataFromScriptHash_with_fastBridgeInformation_in_storage() {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Keccak256 derivationArgumentsHash = PegTestUtils.createHash3(1);
 
         Script fastBridgeRedeemScript = RedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            federation.getRedeemScript(), derivationArgumentsHash);
+            federation.getRedeemScript(), Sha256Hash.wrap(derivationArgumentsHash.getBytes()));
 
         Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(fastBridgeRedeemScript);
         byte[] fastBridgeFederationP2SH = p2SHOutputScript.getPubKeyHash();
@@ -76,7 +77,7 @@ public class FastBridgeCompatibleBtcWalletWithStorageTest {
 
     @Test
     public void findRedeemDataFromScriptHash_null_destination_federation() {
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{2});
+        Keccak256 derivationArgumentsHash = PegTestUtils.createHash3(2);
         FastBridgeFederationInformation fastBridgeFederationInformation =
             new FastBridgeFederationInformation(
                 derivationArgumentsHash,
@@ -99,7 +100,7 @@ public class FastBridgeCompatibleBtcWalletWithStorageTest {
         byte[] fastBridgeScriptHash = new byte[1];
         FastBridgeFederationInformation fastBridgeFederationInformation =
             new FastBridgeFederationInformation(
-                Sha256Hash.of(new byte[]{2}),
+                PegTestUtils.createHash3(2),
                 new byte[0],
                 fastBridgeScriptHash);
 


### PR DESCRIPTION
Change Sha256Hash to Keccak256 type for parameter DerivationArgumentsHash in getFastBridgeDerivationHash, createFastBridgeFederationInformation, BridgeStorageProvider, etc and related test cases.

