### PR TITLE
Fix v value in JSON RPC transaction result (2.2.0)

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -70,9 +70,9 @@ public class Transaction {
     /**
      * Since EIP-155, we could encode chainId in V
      */
-    private static final byte CHAIN_ID_INC = 35;
+    public static final byte CHAIN_ID_INC = 35;
+    public static final byte LOWER_REAL_V = 27;
 
-    private static final byte LOWER_REAL_V = 27;
     protected RskAddress sender;
     /* whether this is a local call transaction */
     private boolean isLocalCall;
@@ -424,6 +424,12 @@ public class Transaction {
 
     public byte getChainId() {
         return chainId;
+    }
+
+    public byte getEncodedV() {
+        return this.chainId == 0
+            ? this.signature.getV()
+            : (byte)(this.signature.getV() - LOWER_REAL_V + CHAIN_ID_INC + this.chainId * 2);
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -79,7 +79,9 @@ public class TransactionResultDTO {
 
         if (!(tx instanceof RemascTransaction)) {
             ECDSASignature signature = tx.getSignature();
-            v = String.format("0x%02x", signature.getV());
+
+            v = String.format("0x%02x", tx.getEncodedV());
+
             r = TypeConverter.toQuantityJsonHex(signature.getR());
             s = TypeConverter.toQuantityJsonHex(signature.getS());
         }

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -351,4 +351,20 @@ public class TransactionTest {
         Assert.assertFalse(tx.isContractCreation());
     }
 
+    @Test
+    public void createEncodeAndDecodeTransactionWithChainId() {
+        Transaction originalTransaction = CallTransaction.createCallTransaction(
+                0, 0, 100000000000000L,
+                new RskAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), 0,
+                CallTransaction.Function.fromSignature("get"), chainId);
+
+        originalTransaction.sign(new byte[]{});
+
+        byte[] encoded = originalTransaction.getEncoded();
+
+        Transaction transaction = new ImmutableTransaction(encoded);
+
+        Assert.assertEquals(chainId, transaction.getChainId());
+        Assert.assertEquals(27, transaction.getSignature().getV());
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -31,6 +31,8 @@ import org.ethereum.db.BlockStoreDummy;
 import org.ethereum.jsontestsuite.StateTestSuite;
 import org.ethereum.jsontestsuite.runners.StateTestRunner;
 import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
 import org.junit.Assert;
@@ -362,9 +364,18 @@ public class TransactionTest {
 
         byte[] encoded = originalTransaction.getEncoded();
 
+        RLPList rlpList = RLP.decodeList(encoded);
+
+        byte[] vData = rlpList.get(6).getRLPData();
+
+        Assert.assertEquals (Transaction.CHAIN_ID_INC + chainId * 2, vData[0]);
+        Assert.assertEquals (Transaction.CHAIN_ID_INC + chainId * 2, originalTransaction.getEncodedV());
+
         Transaction transaction = new ImmutableTransaction(encoded);
 
         Assert.assertEquals(chainId, transaction.getChainId());
-        Assert.assertEquals(27, transaction.getSignature().getV());
+        Assert.assertEquals(Transaction.LOWER_REAL_V, transaction.getSignature().getV());
+        Assert.assertEquals (Transaction.CHAIN_ID_INC + chainId * 2, transaction.getEncodedV());
     }
 }
+

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -429,7 +429,10 @@ public class Web3ImplTest {
         org.junit.Assert.assertEquals("0x", tr.input);
         org.junit.Assert.assertEquals("0x" + ByteUtil.toHexString(tx.getReceiveAddress().getBytes()), tr.to);
 
-        Assert.assertArrayEquals(new byte[] {tx.getSignature().getV()}, TypeConverter.stringHexToByteArray(tr.v));
+        // Check the v value used to encode the transaction
+        // NOT the v value used in signature
+        // the encoded value includes chain id
+        Assert.assertArrayEquals(new byte[] {tx.getEncodedV()}, TypeConverter.stringHexToByteArray(tr.v));
         Assert.assertThat(TypeConverter.stringHexToBigInteger(tr.s), is(tx.getSignature().getS()));
         Assert.assertThat(TypeConverter.stringHexToBigInteger(tr.r), is(tx.getSignature().getR()));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

*fit: 2.2-rc*

## Description
<!--- Describe your changes in detail -->
Fix #1380 JSON/RPC API returns incorrect v value for EIP155 transactions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Compatibility with Ethereum ecosystem

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Using new test code exercising `TransactionResultDTO`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

New integration tests are recommended

