### PR TITLE
[PAPYRUS-2.2.0-rc] Make num of account slots for pending txs configurable

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -326,6 +326,10 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getInt("transaction.gasPriceBump");
     }
 
+    public Integer getNumOfAccountSlots() {
+        return configFromFiles.getInt("transaction.accountSlots");
+    }
+
     public int getStatesCacheSize() {
         return configFromFiles.getInt("cache.states.max-elements");
     }

--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -93,7 +93,7 @@ public class TransactionPoolImpl implements TransactionPool {
         this.outdatedThreshold = outdatedThreshold;
         this.outdatedTimeout = outdatedTimeout;
 
-        this.validator = new TxPendingValidator(config.getNetworkConstants(), config.getActivationConfig());
+        this.validator = new TxPendingValidator(config.getNetworkConstants(), config.getActivationConfig(), config.getNumOfAccountSlots());
 
         if (this.outdatedTimeout > 0) {
             this.cleanerTimer = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "TransactionPoolCleanerTimer"));

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
@@ -46,7 +46,7 @@ public class TxPendingValidator {
     private final Constants constants;
     private final ActivationConfig activationConfig;
 
-    public TxPendingValidator(Constants constants, ActivationConfig activationConfig) {
+    public TxPendingValidator(Constants constants, ActivationConfig activationConfig, int accountSlots) {
         this.constants = constants;
         this.activationConfig = activationConfig;
 
@@ -54,7 +54,7 @@ public class TxPendingValidator {
         validatorSteps.add(new TxValidatorNotRemascTxValidator());
         validatorSteps.add(new TxValidatorGasLimitValidator());
         validatorSteps.add(new TxValidatorAccountStateValidator());
-        validatorSteps.add(new TxValidatorNonceRangeValidator());
+        validatorSteps.add(new TxValidatorNonceRangeValidator(accountSlots));
         validatorSteps.add(new TxValidatorAccountBalanceValidator());
         validatorSteps.add(new TxValidatorMinimuGasPriceValidator());
         validatorSteps.add(new TxValidatorIntrinsicGasLimitValidator(constants, activationConfig));

--- a/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidator.java
@@ -30,18 +30,26 @@ import java.math.BigInteger;
  * Checks that the transaction nonce is not too higher than the account
  * nonce. This helps limiting the in memory transactions for a given address
  */
-public class TxValidatorNonceRangeValidator implements  TxValidatorStep {
+public class TxValidatorNonceRangeValidator implements TxValidatorStep {
+
+    private final BigInteger accountSlots;
+
+    public TxValidatorNonceRangeValidator(int accountSlots) {
+        if (accountSlots < 1) {
+            throw new IllegalArgumentException("accountSlots");
+        }
+        this.accountSlots = BigInteger.valueOf(accountSlots);
+    }
 
     @Override
     public TransactionValidationResult validate(Transaction tx, @Nullable AccountState state, BigInteger gasLimit, Coin minimumGasPrice, long bestBlockNumber, boolean isFreeTx) {
         BigInteger nonce = tx.getNonceAsInteger();
         BigInteger stateNonce = state == null ? BigInteger.ZERO : state.getNonce();
-        BigInteger maxNumberOfTxsPerAddress = BigInteger.valueOf(4);
 
         if (stateNonce.compareTo(nonce) > 0) {
             return TransactionValidationResult.withError("transaction nonce too low");
         }
-        if (stateNonce.add(maxNumberOfTxsPerAddress).compareTo(nonce) < 0) {
+        if (stateNonce.add(accountSlots).compareTo(nonce) <= 0) {
             return TransactionValidationResult.withError("transaction nonce too high");
         }
 

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -148,6 +148,7 @@ transaction = {
         timeout = <timeout>
     }
     gasPriceBump = <gasPriceBump>
+    accountSlots = <numOfAccountSlots>
 }
 dump = {
     full = <full>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -164,6 +164,9 @@ transaction.outdated.timeout = 650
 # with same nonce and sender while the previous one is not yet processed
 transaction.gasPriceBump = 40
 
+# number of slots for pending txs guaranteed per account in a tx pool
+transaction.accountSlots = 5
+
 
 dump {
     # for testing purposes all the state will be dumped in JSON form to [dump.dir] if [dump.full] = true

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidatorTest.java
@@ -48,23 +48,23 @@ public class TxValidatorNonceRangeValidatorTest {
 
     @Test
     public void fiveSlotsRange() {
-        Transaction tx1 = Mockito.mock(Transaction.class);
-        Transaction tx2 = Mockito.mock(Transaction.class);
-        Transaction tx3 = Mockito.mock(Transaction.class);
-        Transaction tx4 = Mockito.mock(Transaction.class);
-        AccountState as = Mockito.mock(AccountState.class);
+        Transaction[] txs = new Transaction[7];
+        for (int i = 0; i < 7; i++) {
+            txs[i] = Mockito.mock(Transaction.class);
+            Mockito.when(txs[i].getNonceAsInteger()).thenReturn(BigInteger.valueOf(i));
+        }
 
-        Mockito.when(tx1.getNonceAsInteger()).thenReturn(BigInteger.valueOf(0));
-        Mockito.when(tx2.getNonceAsInteger()).thenReturn(BigInteger.valueOf(1));
-        Mockito.when(tx3.getNonceAsInteger()).thenReturn(BigInteger.valueOf(5));
-        Mockito.when(tx4.getNonceAsInteger()).thenReturn(BigInteger.valueOf(6));
+        AccountState as = Mockito.mock(AccountState.class);
         Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(1));
 
         TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator(5);
-        Assert.assertFalse(tvnrv.validate(tx1, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
-        Assert.assertTrue(tvnrv.validate(tx2, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
-        Assert.assertTrue(tvnrv.validate(tx3, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
-        Assert.assertFalse(tvnrv.validate(tx4, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+
+        for (int i = 0; i < 7; i++) {
+            Transaction tx = txs[i];
+            long txNonce = tx.getNonceAsInteger().longValue();
+            boolean isValid = tvnrv.validate(tx, as, null, null, Long.MAX_VALUE, false).transactionIsValid();
+            Assert.assertEquals(isValid, txNonce >= 1 && txNonce <= 5); // only valid if tx nonce is in the range [1; 5]
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorNonceRangeValidatorTest.java
@@ -29,32 +29,51 @@ import java.math.BigInteger;
 public class TxValidatorNonceRangeValidatorTest {
 
     @Test
-    public void nonceInRange() {
+    public void oneSlotRange() {
         Transaction tx1 = Mockito.mock(Transaction.class);
         Transaction tx2 = Mockito.mock(Transaction.class);
+        Transaction tx3 = Mockito.mock(Transaction.class);
         AccountState as = Mockito.mock(AccountState.class);
 
         Mockito.when(tx1.getNonceAsInteger()).thenReturn(BigInteger.valueOf(0));
-        Mockito.when(tx2.getNonceAsInteger()).thenReturn(BigInteger.valueOf(3));
-        Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(0));
+        Mockito.when(tx2.getNonceAsInteger()).thenReturn(BigInteger.valueOf(1));
+        Mockito.when(tx3.getNonceAsInteger()).thenReturn(BigInteger.valueOf(2));
+        Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(1));
 
-        TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator();
-        Assert.assertTrue(tvnrv.validate(tx1, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator(1);
+        Assert.assertFalse(tvnrv.validate(tx1, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
         Assert.assertTrue(tvnrv.validate(tx2, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvnrv.validate(tx3, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
     }
 
     @Test
-    public void nonceOutOfRange() {
+    public void fiveSlotsRange() {
         Transaction tx1 = Mockito.mock(Transaction.class);
         Transaction tx2 = Mockito.mock(Transaction.class);
+        Transaction tx3 = Mockito.mock(Transaction.class);
+        Transaction tx4 = Mockito.mock(Transaction.class);
         AccountState as = Mockito.mock(AccountState.class);
 
         Mockito.when(tx1.getNonceAsInteger()).thenReturn(BigInteger.valueOf(0));
-        Mockito.when(tx2.getNonceAsInteger()).thenReturn(BigInteger.valueOf(6));
+        Mockito.when(tx2.getNonceAsInteger()).thenReturn(BigInteger.valueOf(1));
+        Mockito.when(tx3.getNonceAsInteger()).thenReturn(BigInteger.valueOf(5));
+        Mockito.when(tx4.getNonceAsInteger()).thenReturn(BigInteger.valueOf(6));
         Mockito.when(as.getNonce()).thenReturn(BigInteger.valueOf(1));
 
-        TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator();
+        TxValidatorNonceRangeValidator tvnrv = new TxValidatorNonceRangeValidator(5);
         Assert.assertFalse(tvnrv.validate(tx1, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
-        Assert.assertFalse(tvnrv.validate(tx2, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvnrv.validate(tx2, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertTrue(tvnrv.validate(tx3, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+        Assert.assertFalse(tvnrv.validate(tx4, as, null, null, Long.MAX_VALUE, false).transactionIsValid());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void illegalAccountSlotsValue_Zero() {
+        new TxValidatorNonceRangeValidator(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void illegalAccountSlotsValue_Negative() {
+        new TxValidatorNonceRangeValidator(-1);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change makes the number of account slots for pending transactions in a tx pool configurable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Instead of using hardcoded value, this allows us to configure it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit tests and running the node locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


*fit: 2.2-rc*