### PR TITLE
[PAPYRUS-2.2.0-rc] Consider MGP in eth_getPrice

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/Coin.java
+++ b/rskj-core/src/main/java/co/rsk/core/Coin.java
@@ -120,4 +120,8 @@ public class Coin implements Comparable<Coin> {
     public static Coin fromBitcoin(co.rsk.bitcoinj.core.Coin val) {
         return new Coin(Denomination.satoshisToWeis(val.getValue()));
     }
+
+    public static Coin max(Coin a, Coin b) {
+        return a.compareTo(b) > 0 ? a : b;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/listener/GasPriceTracker.java
+++ b/rskj-core/src/main/java/org/ethereum/listener/GasPriceTracker.java
@@ -27,8 +27,10 @@ import org.ethereum.core.TransactionReceipt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Calculates a 'reasonable' Gas price based on statistics of the latest transaction's Gas prices
@@ -39,17 +41,29 @@ import java.util.List;
  * Created by Anton Nashatyrev on 22.09.2015.
  */
 public class GasPriceTracker extends EthereumListenerAdapter {
+
     private static final Logger logger = LoggerFactory.getLogger("gaspricetracker");
 
-    private final Coin[] window = new Coin[512];
+    private static final int WINDOW_SIZE = 512;
+
+    private static final BigInteger BI_10 = BigInteger.valueOf(10);
+    private static final BigInteger BI_11 = BigInteger.valueOf(11);
+
+    private final Coin[] window = new Coin[WINDOW_SIZE];
+    private final AtomicReference<Coin> bestBlockPriceRef = new AtomicReference<>();
+
     private Coin defaultPrice = Coin.valueOf(20_000_000_000L);
-    private int idx = window.length - 1;
-    private boolean filled = false;
+    private int idx = WINDOW_SIZE - 1;
 
     private Coin lastVal;
 
     @Override
-    public void onBlock(Block block, List<TransactionReceipt> receipts) {
+    public void onBestBlock(Block block, List<TransactionReceipt> receipts) {
+        bestBlockPriceRef.set(block.getMinimumGasPrice());
+    }
+
+    @Override
+    public synchronized void onBlock(Block block, List<TransactionReceipt> receipts) {
         logger.trace("Start onBlock");
 
         defaultPrice = block.getMinimumGasPrice();
@@ -61,30 +75,39 @@ public class GasPriceTracker extends EthereumListenerAdapter {
         logger.trace("End onBlock");
     }
 
-    public void onTransaction(Transaction tx) {
+    private void onTransaction(Transaction tx) {
         if (tx instanceof RemascTransaction) {
             return;
         }
 
         if (idx == -1) {
-            idx = window.length - 1;
-            filled = true;
+            idx = WINDOW_SIZE - 1;
             lastVal = null;  // recalculate only 'sometimes'
         }
 
         window[idx--] = tx.getGasPrice();
     }
 
-    public Coin getGasPrice() {
-        if (!filled) {
+    public synchronized Coin getGasPrice() {
+        if (window[0] == null) { // not filled yet
             return defaultPrice;
         } else {
             if (lastVal == null) {
-                Coin[] values = Arrays.copyOf(window, window.length);
+                Coin[] values = Arrays.copyOf(window, WINDOW_SIZE);
                 Arrays.sort(values);
                 lastVal = values[values.length / 4];  // 25% percentile
             }
-            return lastVal;
+
+            Coin bestBlockPrice = bestBlockPriceRef.get();
+            if (bestBlockPrice == null) {
+                return lastVal;
+            } else {
+                return max(lastVal, bestBlockPrice.multiply(BI_11).divide(BI_10));
+            }
         }
+    }
+
+    private static Coin max(Coin a, Coin b) {
+        return a.compareTo(b) > 0 ? a : b;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/listener/GasPriceTracker.java
+++ b/rskj-core/src/main/java/org/ethereum/listener/GasPriceTracker.java
@@ -102,12 +102,8 @@ public class GasPriceTracker extends EthereumListenerAdapter {
             if (bestBlockPrice == null) {
                 return lastVal;
             } else {
-                return max(lastVal, bestBlockPrice.multiply(BI_11).divide(BI_10));
+                return Coin.max(lastVal, bestBlockPrice.multiply(BI_11).divide(BI_10));
             }
         }
-    }
-
-    private static Coin max(Coin a, Coin b) {
-        return a.compareTo(b) > 0 ? a : b;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/CoinTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CoinTest.java
@@ -3,12 +3,28 @@ package co.rsk.core;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class CoinTest {
+
+    private static final Coin ONE_COIN = Coin.valueOf(1L);
+    private static final Coin TWO_COINS = Coin.valueOf(2L);
+
     @Test
     public void zeroGetBytes() {
         assertThat(Coin.ZERO.getBytes(), is(new byte[]{0}));
     }
 
+    @Test
+    public void maxOfTwoCoins() {
+        Coin actualResult = Coin.max(TWO_COINS, ONE_COIN);
+        assertEquals(TWO_COINS, actualResult);
+
+        actualResult = Coin.max(ONE_COIN, TWO_COINS);
+        assertEquals(TWO_COINS, actualResult);
+
+        actualResult = Coin.max(ONE_COIN, ONE_COIN);
+        assertEquals(ONE_COIN, actualResult);
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/listener/GasPriceTrackerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/listener/GasPriceTrackerTest.java
@@ -1,0 +1,105 @@
+package org.ethereum.listener;
+
+import co.rsk.core.Coin;
+import co.rsk.peg.simples.SimpleRskTransaction;
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GasPriceTrackerTest {
+
+    private final GasPriceTracker gasPriceTracker = new GasPriceTracker();
+
+    @Test
+    public void getGasPrice_TrackerNotTriggered_ReturnsDefaultPrice() {
+        Coin actualResult = gasPriceTracker.getGasPrice();
+
+        assertEquals(Coin.valueOf(20_000_000_000L), actualResult);
+    }
+
+    @Test
+    public void getGasPrice_PriceWindowNotFilled_ReturnsBlockPrice() {
+        Block block = makeBlock(Coin.valueOf(30_000_000_000L), 511, i -> makeTx(Coin.valueOf(40_000_000_000L)));
+
+        gasPriceTracker.onBlock(block, Collections.emptyList());
+
+        Coin actualResult = gasPriceTracker.getGasPrice();
+
+        assertEquals(Coin.valueOf(30_000_000_000L), actualResult);
+    }
+
+    @Test
+    public void getGasPrice_PriceWindowFilledAndNoBestBlock_ReturnsCalculatedPrice() {
+        Block block = makeBlock(Coin.valueOf(30_000_000_000L), 512, i -> makeTx(Coin.valueOf(i * 1_000_000_000L)));
+
+        gasPriceTracker.onBlock(block, Collections.emptyList());
+
+        Coin actualResult = gasPriceTracker.getGasPrice();
+
+        assertEquals(Coin.valueOf(128_000_000_000L), actualResult);
+    }
+
+    @Test
+    public void getGasPrice_PriceWindowFilledAndBestBlockWithLowerPrice_ReturnsCalculatedPrice() {
+        Block bestBlock = makeBlock(Coin.valueOf(1_000_000_000L), 0, i -> null);
+        Block block = makeBlock(Coin.valueOf(1_000_000_000L), 512, i -> makeTx(Coin.valueOf(i * 1_000_000_000L)));
+
+        gasPriceTracker.onBestBlock(bestBlock, Collections.emptyList());
+        gasPriceTracker.onBlock(block, Collections.emptyList());
+        Coin actualResult = gasPriceTracker.getGasPrice();
+        assertEquals(Coin.valueOf(128_000_000_000L), actualResult); // calculated value has been returned
+
+        block = makeBlock(Coin.valueOf(1_000_000_000L), 513, i -> makeTx(Coin.valueOf(2_000_000_000L)));
+        gasPriceTracker.onBlock(block, Collections.emptyList());
+        actualResult = gasPriceTracker.getGasPrice();
+        assertEquals(Coin.valueOf(2_000_000_000L), actualResult); // re-calculated value has been returned
+
+        block = makeBlock(Coin.valueOf(1_000_000_000L), 511, i -> makeTx(Coin.valueOf(10_000_000_000L)));
+        gasPriceTracker.onBlock(block, Collections.emptyList());
+        actualResult = gasPriceTracker.getGasPrice();
+        assertEquals(Coin.valueOf(2_000_000_000L), actualResult); // cached value has been returned
+    }
+
+    @Test
+    public void getGasPrice_PriceWindowFilledAndBestBlockWithGreaterPrice_ReturnsBestBlockAdjustedPrice() {
+        Block bestBlock = makeBlock(Coin.valueOf(50_000_000_000L), 0, i -> null);
+        Block block = makeBlock(Coin.valueOf(30_000_000_000L), 512, i -> makeTx(Coin.valueOf(40_000_000_000L)));
+
+        gasPriceTracker.onBestBlock(bestBlock, Collections.emptyList());
+        gasPriceTracker.onBlock(block, Collections.emptyList());
+
+        Coin actualResult = gasPriceTracker.getGasPrice();
+
+        assertEquals(Coin.valueOf(55_000_000_000L), actualResult);
+    }
+
+    private static Block makeBlock(Coin mgp, int txCount, Function<Integer, Transaction> txMaker) {
+        Block block = mock(Block.class);
+
+        when(block.getMinimumGasPrice()).thenReturn(mgp);
+
+        List<Transaction> txs = IntStream.range(0, txCount).mapToObj(txMaker::apply).collect(Collectors.toList());
+        when(block.getTransactionsList()).thenReturn(txs);
+
+        return block;
+    }
+
+    private static Transaction makeTx(Coin gasPrice) {
+        return new SimpleRskTransaction(null) {
+            @Override
+            public Coin getGasPrice() {
+                return gasPrice;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Considering best block's MGP in `eth_getPrice`.

## Description
This change takes into account best block's MGP while calculating gas price in the `eth_getPrice` JSON-RPC method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Using unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


*fit: 2.2-rc*