### PR TITLE
[PAPYRUS-2.2.0-rc]  Content type in JSON RPC response

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
@@ -24,6 +24,8 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_JSON;
 
 public class Web3ResultHttpResponseHandler extends SimpleChannelInboundHandler<Web3Result> {
 
@@ -35,7 +37,7 @@ public class Web3ResultHttpResponseHandler extends SimpleChannelInboundHandler<W
                 msg.getContent()
         );
 
-        response.headers().add("Content-Type", "application/json");
+        response.headers().add(CONTENT_TYPE, APPLICATION_JSON);
 
         ctx.write(response).addListener(ChannelFutureListener.CLOSE);
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
@@ -29,11 +29,15 @@ public class Web3ResultHttpResponseHandler extends SimpleChannelInboundHandler<W
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, Web3Result msg) {
-        ctx.write(new DefaultFullHttpResponse(
-            HttpVersion.HTTP_1_1,
-            HttpResponseStatus.valueOf(DefaultHttpStatusCodeProvider.INSTANCE.getHttpStatusCode(msg.getCode())),
-            msg.getContent()
-        )).addListener(ChannelFutureListener.CLOSE);
+        DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                HttpResponseStatus.valueOf(DefaultHttpStatusCodeProvider.INSTANCE.getHttpStatusCode(msg.getCode())),
+                msg.getContent()
+        );
+
+        response.headers().add("Content-Type", "application/json");
+
+        ctx.write(response).addListener(ChannelFutureListener.CLOSE);
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

*fit: 2.2-rc*

## Description
Add a `Content-Type` header to JSON RPC responses, with value `application/json` to solve #1365 1365

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current code does not returns the content type header in the responses to JSON RPC invocations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

It was tested using `curl`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

