### PR TITLE
[RSKIP186] Active Federation creation block height registration

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1066,6 +1066,12 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return bridgeSupport.hasBtcBlockCoinbaseTransactionInformation(blockHash);
     }
 
+    public long getActiveFederationCreationBlockHeight(Object[] args) {
+        logger.trace("getActiveFederationCreationBlockHeight");
+
+        return bridgeSupport.getActiveFederationCreationBlockHeight();
+    }
+
     public static BridgeMethods.BridgeMethodExecutor activeAndRetiringFederationOnly(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {
         return (self, args) -> {
             Federation retiringFederation = self.bridgeSupport.getRetiringFederation();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -450,6 +450,17 @@ public enum BridgeMethods {
             activations -> activations.isActive(RSKIP134),
             true
     ),
+    GET_ACTIVE_FEDERATION_CREATION_BLOCK_HEIGHT(
+            CallTransaction.Function.fromSignature(
+                    "getActiveFederationCreationBlockHeight",
+                    new String[]{},
+                    new String[]{"uint256"}
+            ),
+            fixedCost(3_000L),
+            (BridgeMethodExecutorTyped) Bridge::getActiveFederationCreationBlockHeight,
+            activations -> activations.isActive(RSKIP186),
+            true
+    ),
     INCREASE_LOCKING_CAP(
             CallTransaction.Function.fromSignature(
                     "increaseLockingCap",

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -459,7 +459,7 @@ public enum BridgeMethods {
             fixedCost(3_000L),
             (BridgeMethodExecutorTyped) Bridge::getActiveFederationCreationBlockHeight,
             activations -> activations.isActive(RSKIP186),
-            true
+            false
     ),
     INCREASE_LOCKING_CAP(
             CallTransaction.Function.fromSignature(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -19,6 +19,7 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.script.Script;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.bitcoin.CoinbaseInformation;
@@ -741,6 +742,27 @@ public class BridgeSerializationUtils {
         byte[][] rlpElements = new byte[1][];
         rlpElements[0] = RLP.encodeElement(coinbaseInformation.getWitnessMerkleRoot().getBytes());
         return RLP.encodeList(rlpElements);
+    }
+
+    public static byte[] serializeScript(Script script) {
+        byte[][] rlpElements = new byte[1][];
+        rlpElements[0] = RLP.encodeElement(script.getProgram());
+
+        return RLP.encodeList(rlpElements);
+    }
+
+    @Nullable
+    public static Script deserializeScript(byte[] data) {
+        if (data == null) {
+            return null;
+        }
+
+        RLPList rlpList = (RLPList) RLP.decode2(data).get(0);
+        if (rlpList.size() != 1) {
+            throw new RuntimeException(String.format("Invalid serialized script. Expected 1 element, but got %d", rlpList.size()));
+        }
+
+        return new Script(rlpList.get(0).getRLPData());
     }
 
     // An ABI call spec is serialized as:

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -745,10 +745,7 @@ public class BridgeSerializationUtils {
     }
 
     public static byte[] serializeScript(Script script) {
-        byte[][] rlpElements = new byte[1][];
-        rlpElements[0] = RLP.encodeElement(script.getProgram());
-
-        return RLP.encodeList(rlpElements);
+        return RLP.encodeList(RLP.encodeElement(script.getProgram()));
     }
 
     @Nullable
@@ -762,7 +759,7 @@ public class BridgeSerializationUtils {
             throw new RuntimeException(String.format("Invalid serialized script. Expected 1 element, but got %d", rlpList.size()));
         }
 
-        return new Script(rlpList.get(0).getRLPData());
+        return new Script(rlpList.get(0).getRLPRawData());
     }
 
     // An ABI call spec is serialized as:

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -602,17 +602,17 @@ public class BridgeStorageProvider {
             safeSaveToRepository(getStorageKeyForCoinbaseInformation(blockHash), data, BridgeSerializationUtils::serializeCoinbaseInformation));
     }
 
-    public Long getActiveFederationCreationBlockHeight() {
+    public Optional<Long> getActiveFederationCreationBlockHeight() {
         if (!activations.isActive(RSKIP186)) {
-            return null;
+            return Optional.empty();
         }
 
         if (activeFederationCreationBlockHeight != null) {
-            return activeFederationCreationBlockHeight;
+            return Optional.of(activeFederationCreationBlockHeight);
         }
 
         activeFederationCreationBlockHeight = safeGetFromRepository(ACTIVE_FEDERATION_CREATION_BLOCK_HEIGHT_KEY, BridgeSerializationUtils::deserializeOptionalLong).orElse(null);
-        return activeFederationCreationBlockHeight;
+        return Optional.ofNullable(activeFederationCreationBlockHeight);
     }
 
     public void setActiveFederationCreationBlockHeight(long activeFederationCreationBlockHeight) {
@@ -627,17 +627,17 @@ public class BridgeStorageProvider {
         safeSaveToRepository(ACTIVE_FEDERATION_CREATION_BLOCK_HEIGHT_KEY, activeFederationCreationBlockHeight, BridgeSerializationUtils::serializeLong);
     }
 
-    public Long getNextFederationCreationBlockHeight() {
+    public Optional<Long> getNextFederationCreationBlockHeight() {
         if (!activations.isActive(RSKIP186)) {
-            return null;
+            return Optional.empty();
         }
 
         if (nextFederationCreationBlockHeight != null) {
-            return nextFederationCreationBlockHeight;
+            return Optional.of(nextFederationCreationBlockHeight);
         }
 
         nextFederationCreationBlockHeight = safeGetFromRepository(NEXT_FEDERATION_CREATION_BLOCK_HEIGHT_KEY, BridgeSerializationUtils::deserializeOptionalLong).orElse(null);
-        return nextFederationCreationBlockHeight;
+        return Optional.ofNullable(nextFederationCreationBlockHeight);
     }
 
     public void setNextFederationCreationBlockHeight(long nextFederationCreationBlockHeight) {
@@ -660,17 +660,17 @@ public class BridgeStorageProvider {
         }
     }
 
-    public Script getLastRetiredFederationP2SHScript() {
+    public Optional<Script> getLastRetiredFederationP2SHScript() {
         if (!activations.isActive(RSKIP186)) {
-            return null;
+            return Optional.empty();
         }
 
         if (lastRetiredFederationP2SHScript != null) {
-            return lastRetiredFederationP2SHScript;
+            return Optional.of(lastRetiredFederationP2SHScript);
         }
 
         lastRetiredFederationP2SHScript = safeGetFromRepository(LAST_RETIRED_FEDERATION_P2SH_SCRIPT_KEY, BridgeSerializationUtils::deserializeScript);
-        return lastRetiredFederationP2SHScript;
+        return Optional.ofNullable(lastRetiredFederationP2SHScript);
     }
 
     public void setLastRetiredFederationP2SHScript(Script lastRetiredFederationP2SHScript) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -70,6 +70,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP186;
+
 /**
  * Helper class to move funds from btc to rsk and rsk to btc
  * @author Oscar Guindzberg
@@ -316,7 +318,9 @@ public class BridgeSupport {
     }
 
     protected TxType getTransactionType(BtcTransaction btcTx) {
-        if (BridgeUtils.isLockTx(btcTx, getLiveFederations(), btcContext, bridgeConstants)) {
+        Script retiredFederationP2SHScript = provider.getLastRetiredFederationP2SHScript();
+
+        if (BridgeUtils.isLockTx(btcTx, getLiveFederations(), retiredFederationP2SHScript, btcContext, bridgeConstants)) {
             return TxType.PEGIN;
         }
 
@@ -324,6 +328,7 @@ public class BridgeSupport {
             btcTx,
             getActiveFederation(),
             getRetiringFederation(),
+            retiredFederationP2SHScript,
             btcContext,
             bridgeConstants
         )) {
@@ -728,6 +733,8 @@ public class BridgeSupport {
         processReleaseRequests();
 
         processReleaseTransactions(rskTx);
+
+        updateFederationCreationBlockHeights();
     }
 
     private boolean federationIsInMigrationAge(Federation federation) {
@@ -973,6 +980,16 @@ public class BridgeSupport {
                 txsWaitingForSignatures.put(rskTx.getHash(), entry.getTransaction());
             }
         }
+    }
+
+    private void updateFederationCreationBlockHeights() {
+        if (!activations.isActive(RSKIP186)) {
+            return;
+        }
+
+        Long nextFederationCreationBlockHeight = provider.getNextFederationCreationBlockHeight();
+        provider.setActiveFederationCreationBlockHeight(nextFederationCreationBlockHeight);
+        provider.clearNextFederationCreationBlockHeight();
     }
 
     /**
@@ -1656,7 +1673,7 @@ public class BridgeSupport {
      * @return 1 upon success, -1 if there was no pending federation, -2 if the pending federation was incomplete,
      * -3 if the given hash doesn't match the current pending federation's hash.
      */
-    private Integer commitFederation(boolean dryRun, Keccak256 hash) throws IOException {
+    protected Integer commitFederation(boolean dryRun, Keccak256 hash) throws IOException {
         PendingFederation currentPendingFederation = provider.getPendingFederation();
 
         if (currentPendingFederation == null) {
@@ -1686,12 +1703,21 @@ public class BridgeSupport {
         // Network parameters for the new federation are taken from the bridge constants.
         // Creation time is the block's timestamp.
         Instant creationTime = Instant.ofEpochMilli(rskExecutionBlock.getTimestamp());
-        provider.setOldFederation(getActiveFederation());
+        Federation oldFederation = getActiveFederation();
+        provider.setOldFederation(oldFederation);
         provider.setNewFederation(currentPendingFederation.buildFederation(creationTime, rskExecutionBlock.getNumber(), bridgeConstants.getBtcParams()));
         provider.setPendingFederation(null);
 
         // Clear votes on election
         provider.getFederationElection(bridgeConstants.getFederationChangeAuthorizer()).clear();
+
+        if (activations.isActive(RSKIP186)) {
+            // Preserve federation change info
+            long nextFederationCreationBlockHeight = rskExecutionBlock.getNumber();
+            provider.setNextFederationCreationBlockHeight(nextFederationCreationBlockHeight);
+            Script oldFederationP2SHScript = oldFederation.getP2SHScript();
+            provider.setLastRetiredFederationP2SHScript(oldFederationP2SHScript);
+        }
 
         eventLogger.logCommitFederation(rskExecutionBlock, provider.getOldFederation(), provider.getNewFederation());
 
@@ -2231,6 +2257,27 @@ public class BridgeSupport {
     public boolean hasBtcBlockCoinbaseTransactionInformation(Sha256Hash blockHash) {
         CoinbaseInformation coinbaseInformation = provider.getCoinbaseInformation(blockHash);
         return coinbaseInformation != null;
+    }
+
+    public long getActiveFederationCreationBlockHeight() {
+        if (!activations.isActive(RSKIP186)) {
+            return 0L;
+        }
+
+        Long nextFederationCreationBlockHeight = provider.getNextFederationCreationBlockHeight();
+        if (nextFederationCreationBlockHeight != null) {
+            long curBlockHeight = rskExecutionBlock.getNumber();
+            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge()) {
+                return nextFederationCreationBlockHeight;
+            }
+        }
+
+        Long activeFederationCreationBlockHeight = provider.getActiveFederationCreationBlockHeight();
+        if (activeFederationCreationBlockHeight != null) {
+            return activeFederationCreationBlockHeight;
+        }
+
+        return 0L;
     }
 
     private StoredBlock getBtcBlockchainChainHead() throws IOException, BlockStoreException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -335,7 +335,7 @@ public class BridgeSupport {
             return TxType.MIGRATION;
         }
 
-        if (BridgeUtils.isReleaseTx(btcTx, getLiveFederations())) {
+        if (BridgeUtils.isPegOutTx(btcTx, getLiveFederations())) {
             return TxType.PEGOUT;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -988,8 +988,10 @@ public class BridgeSupport {
         }
 
         Long nextFederationCreationBlockHeight = provider.getNextFederationCreationBlockHeight();
-        provider.setActiveFederationCreationBlockHeight(nextFederationCreationBlockHeight);
-        provider.clearNextFederationCreationBlockHeight();
+        if (nextFederationCreationBlockHeight != null) {
+            provider.setActiveFederationCreationBlockHeight(nextFederationCreationBlockHeight);
+            provider.clearNextFederationCreationBlockHeight();
+        }
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -320,7 +320,7 @@ public class BridgeSupport {
     protected TxType getTransactionType(BtcTransaction btcTx) {
         Script retiredFederationP2SHScript = provider.getLastRetiredFederationP2SHScript();
 
-        if (BridgeUtils.isLockTx(btcTx, getLiveFederations(), retiredFederationP2SHScript, btcContext, bridgeConstants)) {
+        if (BridgeUtils.isPegInTx(btcTx, getLiveFederations(), retiredFederationP2SHScript, btcContext, bridgeConstants)) {
             return TxType.PEGIN;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -118,8 +118,8 @@ public class BridgeUtils {
      * @param bridgeConstants the Bridge constants
      * @return true if this is a valid lock transaction
      */
-    public static boolean isLockTx(BtcTransaction tx, List<Federation> activeFederations, Script retiredFederationP2SHScript,
-                                   Context btcContext, BridgeConstants bridgeConstants) {
+    public static boolean isPegInTx(BtcTransaction tx, List<Federation> activeFederations, Script retiredFederationP2SHScript,
+                                    Context btcContext, BridgeConstants bridgeConstants) {
         // First, check tx is not a typical release tx (tx spending from the any of the federation addresses and
         // optionally sending some change to any of the federation addresses)
         for (int i = 0; i < tx.getInputs().size(); i++) {
@@ -143,8 +143,8 @@ public class BridgeUtils {
         return (valueSentToMeSignum > 0 && !valueSentToMe.isLessThan(bridgeConstants.getMinimumLockTxValue()));
     }
 
-    public static boolean isLockTx(BtcTransaction tx, Federation federation, Context btcContext, BridgeConstants bridgeConstants) {
-        return isLockTx(tx, Collections.singletonList(federation), null, btcContext, bridgeConstants);
+    public static boolean isPegInTx(BtcTransaction tx, Federation federation, Context btcContext, BridgeConstants bridgeConstants) {
+        return isPegInTx(tx, Collections.singletonList(federation), null, btcContext, bridgeConstants);
     }
 
     /**
@@ -187,7 +187,7 @@ public class BridgeUtils {
         }
         boolean moveFromRetired = retiredFederationP2SHScript != null && isReleaseTx(btcTx, retiredFederationP2SHScript);
         boolean moveFromRetiring = retiringFederation != null && isReleaseTx(btcTx, retiringFederation);
-        boolean moveToActive = isLockTx(btcTx, activeFederation, btcContext, bridgeConstants);
+        boolean moveToActive = isPegInTx(btcTx, activeFederation, btcContext, bridgeConstants);
 
         return (moveFromRetired || moveFromRetiring) && moveToActive;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -160,15 +160,15 @@ public class BridgeUtils {
             (activations.isActive(ConsensusRule.RSKIP143) && txSenderAddressType != TxSenderAddressType.UNKNOWN);
     }
 
-    private static boolean isReleaseTx(BtcTransaction tx, Federation federation) {
-        return isReleaseTx(tx, Collections.singletonList(federation));
+    private static boolean isPegOutTx(BtcTransaction tx, Federation federation) {
+        return isPegOutTx(tx, Collections.singletonList(federation));
     }
 
-    public static boolean isReleaseTx(BtcTransaction tx, List<Federation> federations) {
-        return isReleaseTx(tx, federations.stream().filter(Objects::nonNull).map(Federation::getP2SHScript).toArray(Script[]::new));
+    public static boolean isPegOutTx(BtcTransaction tx, List<Federation> federations) {
+        return isPegOutTx(tx, federations.stream().filter(Objects::nonNull).map(Federation::getP2SHScript).toArray(Script[]::new));
     }
 
-    public static boolean isReleaseTx(BtcTransaction tx, Script... p2shScript) {
+    public static boolean isPegOutTx(BtcTransaction tx, Script... p2shScript) {
         int inputsSize = tx.getInputs().size();
         for (int i = 0; i < inputsSize; i++) {
             final int inputIndex = i;
@@ -185,8 +185,8 @@ public class BridgeUtils {
         if (retiredFederationP2SHScript == null && retiringFederation == null) {
             return false;
         }
-        boolean moveFromRetired = retiredFederationP2SHScript != null && isReleaseTx(btcTx, retiredFederationP2SHScript);
-        boolean moveFromRetiring = retiringFederation != null && isReleaseTx(btcTx, retiringFederation);
+        boolean moveFromRetired = retiredFederationP2SHScript != null && isPegOutTx(btcTx, retiredFederationP2SHScript);
+        boolean moveFromRetiring = retiringFederation != null && isPegOutTx(btcTx, retiringFederation);
         boolean moveToActive = isPegInTx(btcTx, activeFederation, btcContext, bridgeConstants);
 
         return (moveFromRetired || moveFromRetiring) && moveToActive;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -37,10 +37,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * @author Oscar Guindzberg
@@ -114,22 +112,28 @@ public class BridgeUtils {
      * It checks if the tx doesn't spend any of the federations' funds and if it sends more than
      * the minimum ({@see BridgeConstants::getMinimumLockTxValue}) to any of the federations
      * @param tx the BTC transaction to check
-     * @param federations the active federations
+     * @param activeFederations the active federations
+     * @param retiredFederationP2SHScript the retired federation P2SHScript. Could be {@code null}.
      * @param btcContext the BTC Context
      * @param bridgeConstants the Bridge constants
      * @return true if this is a valid lock transaction
      */
-    public static boolean isLockTx(BtcTransaction tx, List<Federation> federations, Context btcContext, BridgeConstants bridgeConstants) {
+    public static boolean isLockTx(BtcTransaction tx, List<Federation> activeFederations, Script retiredFederationP2SHScript,
+                                   Context btcContext, BridgeConstants bridgeConstants) {
         // First, check tx is not a typical release tx (tx spending from the any of the federation addresses and
         // optionally sending some change to any of the federation addresses)
         for (int i = 0; i < tx.getInputs().size(); i++) {
             final int index = i;
-            if (federations.stream().anyMatch(federation -> scriptCorrectlySpendsTx(tx, index, federation.getP2SHScript()))) {
+            if (activeFederations.stream().anyMatch(federation -> scriptCorrectlySpendsTx(tx, index, federation.getP2SHScript()))) {
+                return false;
+            }
+
+            if (retiredFederationP2SHScript != null && scriptCorrectlySpendsTx(tx, index, retiredFederationP2SHScript)) {
                 return false;
             }
         }
 
-        Wallet federationsWallet = BridgeUtils.getFederationsNoSpendWallet(btcContext, federations);
+        Wallet federationsWallet = BridgeUtils.getFederationsNoSpendWallet(btcContext, activeFederations);
         Coin valueSentToMe = tx.getValueSentToMe(federationsWallet);
 
         int valueSentToMeSignum = valueSentToMe.signum();
@@ -140,7 +144,7 @@ public class BridgeUtils {
     }
 
     public static boolean isLockTx(BtcTransaction tx, Federation federation, Context btcContext, BridgeConstants bridgeConstants) {
-        return isLockTx(tx, Collections.singletonList(federation), btcContext, bridgeConstants);
+        return isLockTx(tx, Collections.singletonList(federation), null, btcContext, bridgeConstants);
     }
 
     /**
@@ -161,24 +165,31 @@ public class BridgeUtils {
     }
 
     public static boolean isReleaseTx(BtcTransaction tx, List<Federation> federations) {
+        return isReleaseTx(tx, federations.stream().filter(Objects::nonNull).map(Federation::getP2SHScript).toArray(Script[]::new));
+    }
+
+    public static boolean isReleaseTx(BtcTransaction tx, Script... p2shScript) {
         int inputsSize = tx.getInputs().size();
         for (int i = 0; i < inputsSize; i++) {
             final int inputIndex = i;
-            if (federations.stream().map(Federation::getP2SHScript).anyMatch(federationPayScript -> scriptCorrectlySpendsTx(tx, inputIndex, federationPayScript))) {
+            if (Stream.of(p2shScript).anyMatch(federationPayScript -> scriptCorrectlySpendsTx(tx, inputIndex, federationPayScript))) {
                 return true;
             }
         }
         return false;
     }
 
-    public static boolean isMigrationTx(BtcTransaction btcTx, Federation activeFederation, Federation retiringFederation, Context btcContext, BridgeConstants bridgeConstants) {
-        if (retiringFederation == null) {
+    public static boolean isMigrationTx(BtcTransaction btcTx,
+                                        Federation activeFederation, Federation retiringFederation, Script retiredFederationP2SHScript,
+                                        Context btcContext, BridgeConstants bridgeConstants) {
+        if (retiredFederationP2SHScript == null && retiringFederation == null) {
             return false;
         }
-        boolean moveFromRetiring = isReleaseTx(btcTx, retiringFederation);
+        boolean moveFromRetired = retiredFederationP2SHScript != null && isReleaseTx(btcTx, retiredFederationP2SHScript);
+        boolean moveFromRetiring = retiringFederation != null && isReleaseTx(btcTx, retiringFederation);
         boolean moveToActive = isLockTx(btcTx, activeFederation, btcContext, bridgeConstants);
 
-        return moveFromRetiring && moveToActive;
+        return (moveFromRetired || moveFromRetiring) && moveToActive;
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -59,6 +59,7 @@ public enum ConsensusRule {
     RSKIP179("rskip179"), // BTC-RSK timestamp linking
     RSKIP180("rskip180"), // Limit RSK merged mining merkle proof
     RSKIP181("rskip181"), // Peg-in rejection events
+    RSKIP186("rskip186"), // Active Federation creation block height registration
     RSKIPUMM("rskipUMM"),
     RSKIP185("rskip185"), // Peg-out refund and events
     RSKIP191("rskip191"),

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -56,6 +56,7 @@ blockchain = {
              rskip180 = <hardforkName>
              rskip181 = <hardforkName>
              rskip185 = <hardforkName>
+             rskip186 = <hardforkName>
              rskip191 = <hardforkName>
              rskip197 = <hardforkName>
          }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -47,6 +47,7 @@ blockchain = {
             rskip180 = iris300
             rskip181 = iris300
             rskip185 = iris300
+            rskip186 = iris300
             rskip191 = iris300
             rskip197 = iris300
         }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -19,10 +19,13 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.whitelist.LockWhitelist;
 import co.rsk.peg.whitelist.LockWhitelistEntry;
 import co.rsk.peg.whitelist.OneOffWhiteListEntry;
+import com.google.common.collect.Lists;
 import com.google.common.primitives.UnsignedBytes;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bouncycastle.util.encoders.Hex;
@@ -1007,6 +1010,27 @@ public class BridgeSerializationUtilsTest {
     public void deserializeInteger() {
         Assert.assertEquals(123, BridgeSerializationUtils.deserializeInteger(RLP.encodeBigInteger(BigInteger.valueOf(123))).intValue());
         Assert.assertEquals(1200, BridgeSerializationUtils.deserializeInteger(RLP.encodeBigInteger(BigInteger.valueOf(1200))).intValue());
+    }
+
+    @Test
+    public void serializeScript() {
+        Script expectedScript = ScriptBuilder.createP2SHOutputScript(2, Lists.newArrayList(new BtcECKey(), new BtcECKey(), new BtcECKey()));
+
+        byte[] actualData = BridgeSerializationUtils.serializeScript(expectedScript);
+
+        Assert.assertEquals(expectedScript, new Script(((RLPList) RLP.decode2(actualData).get(0)).get(0).getRLPData()));
+    }
+
+    @Test
+    public void deserializeScript() {
+        Script expectedScript = ScriptBuilder.createP2SHOutputScript(2, Lists.newArrayList(new BtcECKey(), new BtcECKey(), new BtcECKey()));
+        byte[][] rlpElements = new byte[1][];
+        rlpElements[0] = RLP.encodeElement(expectedScript.getProgram());
+        byte[] data = RLP.encodeList(rlpElements);
+
+        Script actualScript = BridgeSerializationUtils.deserializeScript(data);
+
+        Assert.assertEquals(expectedScript, actualScript);
     }
 
     private Address mockAddressHash160(String hash160) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1024,9 +1024,7 @@ public class BridgeSerializationUtilsTest {
     @Test
     public void deserializeScript() {
         Script expectedScript = ScriptBuilder.createP2SHOutputScript(2, Lists.newArrayList(new BtcECKey(), new BtcECKey(), new BtcECKey()));
-        byte[][] rlpElements = new byte[1][];
-        rlpElements[0] = RLP.encodeElement(expectedScript.getProgram());
-        byte[] data = RLP.encodeList(rlpElements);
+        byte[] data = RLP.encodeList(RLP.encodeElement(expectedScript.getProgram()));
 
         Script actualScript = BridgeSerializationUtils.deserializeScript(data);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -20,6 +20,7 @@ package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
+import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
@@ -2147,6 +2148,138 @@ public class BridgeStorageProviderTest {
                 DataWord.fromLongString("coinbaseInformation-" + hash.toString()),
                 BridgeSerializationUtils.serializeCoinbaseInformation(coinbaseInformation)
         );
+    }
+
+    @Test
+    public void saveActiveFederationCreationBlockHeight_after_RSKIP186() {
+        Repository repository = mock(Repository.class);
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        provider0.setActiveFederationCreationBlockHeight(10L);
+        provider0.saveActiveFederationCreationBlockHeight();
+
+        // Once the network upgrade is active, we will store it in the repository
+        verify(repository, times(1)).addStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromString("activeFedCreationBlockHeight"),
+                BridgeSerializationUtils.serializeLong(10L)
+        );
+    }
+
+    @Test
+    public void saveActiveFederationCreationBlockHeight_before_RSKIP186() {
+        Repository repository = mock(Repository.class);
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"))).thenReturn(new byte[] { 1 });
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        assertNull(provider0.getActiveFederationCreationBlockHeight());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"));
+    }
+
+    @Test
+    public void saveNextFederationCreationBlockHeight_after_RSKIP186() {
+        Repository repository1 = mock(Repository.class);
+
+        BridgeStorageProvider provider1 = new BridgeStorageProvider(
+                repository1, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        provider1.setNextFederationCreationBlockHeight(10L);
+        provider1.saveNextFederationCreationBlockHeight();
+
+        // Once the network upgrade is active, we will store it in the repository
+        verify(repository1, times(1)).addStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromString("nextFedCreationBlockHeight"),
+                BridgeSerializationUtils.serializeLong(10L)
+        );
+
+        Repository repository2 = mock(Repository.class);
+
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(
+                repository2, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        provider2.clearNextFederationCreationBlockHeight();
+        provider2.saveNextFederationCreationBlockHeight();
+
+        // Once the network upgrade is active, we will store it in the repository
+        verify(repository2, times(1)).addStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromString("nextFedCreationBlockHeight"),
+                null
+        );
+    }
+
+    @Test
+    public void saveNextFederationCreationBlockHeight_before_RSKIP186() {
+        Repository repository = mock(Repository.class);
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"))).thenReturn(new byte[] { 1 });
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        assertNull(provider0.getNextFederationCreationBlockHeight());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"));
+    }
+
+    //
+
+    @Test
+    public void saveLastRetiredFederationP2SHScript_after_RSKIP186() {
+        Repository repository = mock(Repository.class);
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        Script script = new Script(new byte[]{});
+
+        provider0.setLastRetiredFederationP2SHScript(script);
+        provider0.saveLastRetiredFederationP2SHScript();
+
+        // Once the network upgrade is active, we will store it in the repository
+        verify(repository, times(1)).addStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromString("lastRetiredFedP2SHScript"),
+                BridgeSerializationUtils.serializeScript(script)
+        );
+    }
+
+    @Test
+    public void saveLastRetiredFederationP2SHScript_before_RSKIP186() {
+        Repository repository = mock(Repository.class);
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"))).thenReturn(new byte[] { 1 });
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        assertNull(provider0.getLastRetiredFederationP2SHScript());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"));
     }
 
     private BtcTransaction createTransaction() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -2151,42 +2151,6 @@ public class BridgeStorageProviderTest {
     }
 
     @Test
-    public void setActiveFederationCreationBlockHeight_before_fork() {
-        Repository repository = mock(Repository.class);
-
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(
-                repository, PrecompiledContracts.BRIDGE_ADDR,
-                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
-        );
-
-        provider0.setActiveFederationCreationBlockHeight(1L);
-        provider0.saveActiveFederationCreationBlockHeight();
-
-        // If the network upgrade is not enabled we shouldn't be writing in the repository
-        verify(repository, never()).addStorageBytes(any(), any(), any());
-    }
-
-    @Test
-    public void setActiveFederationCreationBlockHeight_after_fork() {
-        Repository repository = mock(Repository.class);
-
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(
-                repository, PrecompiledContracts.BRIDGE_ADDR,
-                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
-        );
-
-        provider0.setActiveFederationCreationBlockHeight(1L);
-        provider0.saveActiveFederationCreationBlockHeight();;
-
-        // Once the network upgrade is active, we will store the value in the repository
-        verify(repository, times(1)).addStorageBytes(
-                PrecompiledContracts.BRIDGE_ADDR,
-                DataWord.fromString("activeFedCreationBlockHeight"),
-                BridgeSerializationUtils.serializeLong(1L)
-        );
-    }
-
-    @Test
     public void getActiveFederationCreationBlockHeight_before_fork() {
         Repository repository = mock(Repository.class);
         // If by chance the repository is called I want to force the tests to fail
@@ -2197,7 +2161,7 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertNull(provider0.getActiveFederationCreationBlockHeight());
+        assertEquals(Optional.empty(), provider0.getActiveFederationCreationBlockHeight());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"));
@@ -2214,7 +2178,7 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsAllForks
         );
 
-        assertEquals(Long.valueOf(1L), provider0.getActiveFederationCreationBlockHeight());
+        assertEquals(Optional.of(1L), provider0.getActiveFederationCreationBlockHeight());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, atLeastOnce()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"));
@@ -2243,7 +2207,7 @@ public class BridgeStorageProviderTest {
         );
 
         // And then we get it back
-        assertThat(provider.getActiveFederationCreationBlockHeight(), is(1L));
+        assertThat(provider.getActiveFederationCreationBlockHeight(), is(Optional.of(1L)));
     }
 
     @Test
@@ -2277,46 +2241,10 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertNull(provider0.getActiveFederationCreationBlockHeight());
+        assertEquals(Optional.empty(), provider0.getActiveFederationCreationBlockHeight());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"));
-    }
-
-    @Test
-    public void setNextFederationCreationBlockHeight_before_fork() {
-        Repository repository = mock(Repository.class);
-
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(
-                repository, PrecompiledContracts.BRIDGE_ADDR,
-                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
-        );
-
-        provider0.setNextFederationCreationBlockHeight(1L);
-        provider0.saveNextFederationCreationBlockHeight();
-
-        // If the network upgrade is not enabled we shouldn't be writing in the repository
-        verify(repository, never()).addStorageBytes(any(), any(), any());
-    }
-
-    @Test
-    public void setNextFederationCreationBlockHeight_after_fork() {
-        Repository repository = mock(Repository.class);
-
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(
-                repository, PrecompiledContracts.BRIDGE_ADDR,
-                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
-        );
-
-        provider0.setNextFederationCreationBlockHeight(1L);
-        provider0.saveNextFederationCreationBlockHeight();
-
-        // Once the network upgrade is active, we will store the value in the repository
-        verify(repository, times(1)).addStorageBytes(
-                PrecompiledContracts.BRIDGE_ADDR,
-                DataWord.fromString("nextFedCreationBlockHeight"),
-                BridgeSerializationUtils.serializeLong(1L)
-        );
     }
 
     @Test
@@ -2330,7 +2258,7 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertNull(provider0.getNextFederationCreationBlockHeight());
+        assertEquals(Optional.empty(), provider0.getNextFederationCreationBlockHeight());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"));
@@ -2347,7 +2275,7 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsAllForks
         );
 
-        assertEquals(Long.valueOf(1L), provider0.getNextFederationCreationBlockHeight());
+        assertEquals(Optional.of(1L), provider0.getNextFederationCreationBlockHeight());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, atLeastOnce()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"));
@@ -2376,7 +2304,7 @@ public class BridgeStorageProviderTest {
         );
 
         // And then we get it back
-        assertThat(provider.getNextFederationCreationBlockHeight(), is(1L));
+        assertThat(provider.getNextFederationCreationBlockHeight(), is(Optional.of(1L)));
     }
 
     @Test
@@ -2427,50 +2355,10 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertNull(provider0.getNextFederationCreationBlockHeight());
+        assertEquals(Optional.empty(), provider0.getNextFederationCreationBlockHeight());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"));
-    }
-
-    //
-
-    @Test
-    public void setLastRetiredFederationP2SHScript_before_fork() {
-        Repository repository = mock(Repository.class);
-        Script script = new Script(new byte[] {});
-
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(
-                repository, PrecompiledContracts.BRIDGE_ADDR,
-                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
-        );
-
-        provider0.setLastRetiredFederationP2SHScript(script);
-        provider0.saveLastRetiredFederationP2SHScript();
-
-        // If the network upgrade is not enabled we shouldn't be writing in the repository
-        verify(repository, never()).addStorageBytes(any(), any(), any());
-    }
-
-    @Test
-    public void setLastRetiredFederationP2SHScript_after_fork() {
-        Repository repository = mock(Repository.class);
-        Script script = new Script(new byte[] {});
-
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(
-                repository, PrecompiledContracts.BRIDGE_ADDR,
-                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
-        );
-
-        provider0.setLastRetiredFederationP2SHScript(script);
-        provider0.saveLastRetiredFederationP2SHScript();
-
-        // Once the network upgrade is active, we will store the value in the repository
-        verify(repository, times(1)).addStorageBytes(
-                PrecompiledContracts.BRIDGE_ADDR,
-                DataWord.fromString("lastRetiredFedP2SHScript"),
-                BridgeSerializationUtils.serializeScript(script)
-        );
     }
 
     @Test
@@ -2486,7 +2374,7 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertNull(provider0.getLastRetiredFederationP2SHScript());
+        assertEquals(Optional.empty(), provider0.getLastRetiredFederationP2SHScript());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"));
@@ -2505,7 +2393,7 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsAllForks
         );
 
-        assertEquals(script, provider0.getLastRetiredFederationP2SHScript());
+        assertEquals(Optional.of(script), provider0.getLastRetiredFederationP2SHScript());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, atLeastOnce()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"));
@@ -2535,10 +2423,8 @@ public class BridgeStorageProviderTest {
         );
 
         // And then we get it back
-        assertThat(provider.getLastRetiredFederationP2SHScript(), is(script));
+        assertThat(provider.getLastRetiredFederationP2SHScript(), is(Optional.of(script)));
     }
-
-    //
 
     @Test
     public void saveLastRetiredFederationP2SHScript_after_RSKIP186() {
@@ -2573,7 +2459,7 @@ public class BridgeStorageProviderTest {
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertNull(provider0.getLastRetiredFederationP2SHScript());
+        assertEquals(Optional.empty(), provider0.getLastRetiredFederationP2SHScript());
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -2233,18 +2233,21 @@ public class BridgeStorageProviderTest {
     @Test
     public void saveActiveFederationCreationBlockHeight_before_RSKIP186() {
         Repository repository = mock(Repository.class);
-        // If by chance the repository is called I want to force the tests to fail
-        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"))).thenReturn(new byte[] { 1 });
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(
                 repository, PrecompiledContracts.BRIDGE_ADDR,
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertEquals(Optional.empty(), provider0.getActiveFederationCreationBlockHeight());
+        provider0.setActiveFederationCreationBlockHeight(10L);
+        provider0.saveActiveFederationCreationBlockHeight();
 
-        // If the network upgrade is not enabled we shouldn't be reading the repository
-        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"));
+        // If the network upgrade is not enabled we shouldn't be saving to the repository
+        verify(repository, never()).addStorageBytes(
+                eq(PrecompiledContracts.BRIDGE_ADDR),
+                eq(DataWord.fromString("activeFedCreationBlockHeight")),
+                any()
+        );
     }
 
     @Test
@@ -2346,19 +2349,39 @@ public class BridgeStorageProviderTest {
 
     @Test
     public void saveNextFederationCreationBlockHeight_before_RSKIP186() {
-        Repository repository = mock(Repository.class);
-        // If by chance the repository is called I want to force the tests to fail
-        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"))).thenReturn(new byte[] { 1 });
+        Repository repository1 = mock(Repository.class);
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(
-                repository, PrecompiledContracts.BRIDGE_ADDR,
+        BridgeStorageProvider provider1 = new BridgeStorageProvider(
+                repository1, PrecompiledContracts.BRIDGE_ADDR,
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertEquals(Optional.empty(), provider0.getNextFederationCreationBlockHeight());
+        provider1.setNextFederationCreationBlockHeight(10L);
+        provider1.saveNextFederationCreationBlockHeight();
 
-        // If the network upgrade is not enabled we shouldn't be reading the repository
-        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"));
+        // If the network upgrade is not enabled we shouldn't be saving to the repository
+        verify(repository1, never()).addStorageBytes(
+                eq(PrecompiledContracts.BRIDGE_ADDR),
+                eq(DataWord.fromString("nextFedCreationBlockHeight")),
+                any()
+        );
+
+        Repository repository2 = mock(Repository.class);
+
+        BridgeStorageProvider provider2 = new BridgeStorageProvider(
+                repository2, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        provider2.clearNextFederationCreationBlockHeight();
+        provider2.saveNextFederationCreationBlockHeight();
+
+        // If the network upgrade is not enabled we shouldn't be saving to the repository
+        verify(repository2, never()).addStorageBytes(
+                eq(PrecompiledContracts.BRIDGE_ADDR),
+                eq(DataWord.fromString("nextFedCreationBlockHeight")),
+                any()
+        );
     }
 
     @Test
@@ -2451,18 +2474,23 @@ public class BridgeStorageProviderTest {
     @Test
     public void saveLastRetiredFederationP2SHScript_before_RSKIP186() {
         Repository repository = mock(Repository.class);
-        // If by chance the repository is called I want to force the tests to fail
-        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"))).thenReturn(new byte[] { 1 });
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(
                 repository, PrecompiledContracts.BRIDGE_ADDR,
                 config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        assertEquals(Optional.empty(), provider0.getLastRetiredFederationP2SHScript());
+        Script script = new Script(new byte[]{});
 
-        // If the network upgrade is not enabled we shouldn't be reading the repository
-        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"));
+        provider0.setLastRetiredFederationP2SHScript(script);
+        provider0.saveLastRetiredFederationP2SHScript();
+
+        // If the network upgrade is not enabled we shouldn't be saving to the repository
+        verify(repository, never()).addStorageBytes(
+                eq(PrecompiledContracts.BRIDGE_ADDR),
+                eq(DataWord.fromString("lastRetiredFedP2SHScript")),
+                any()
+        );
     }
 
     private BtcTransaction createTransaction() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -2151,6 +2151,102 @@ public class BridgeStorageProviderTest {
     }
 
     @Test
+    public void setActiveFederationCreationBlockHeight_before_fork() {
+        Repository repository = mock(Repository.class);
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        provider0.setActiveFederationCreationBlockHeight(1L);
+        provider0.saveActiveFederationCreationBlockHeight();
+
+        // If the network upgrade is not enabled we shouldn't be writing in the repository
+        verify(repository, never()).addStorageBytes(any(), any(), any());
+    }
+
+    @Test
+    public void setActiveFederationCreationBlockHeight_after_fork() {
+        Repository repository = mock(Repository.class);
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        provider0.setActiveFederationCreationBlockHeight(1L);
+        provider0.saveActiveFederationCreationBlockHeight();;
+
+        // Once the network upgrade is active, we will store the value in the repository
+        verify(repository, times(1)).addStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromString("activeFedCreationBlockHeight"),
+                BridgeSerializationUtils.serializeLong(1L)
+        );
+    }
+
+    @Test
+    public void getActiveFederationCreationBlockHeight_before_fork() {
+        Repository repository = mock(Repository.class);
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"))).thenReturn(new byte[] { 1 });
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        assertNull(provider0.getActiveFederationCreationBlockHeight());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"));
+    }
+
+    @Test
+    public void getActiveFederationCreationBlockHeight_after_fork() {
+        Repository repository = mock(Repository.class);
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"))).thenReturn(new byte[] { 1 });
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        assertEquals(Long.valueOf(1L), provider0.getActiveFederationCreationBlockHeight());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, atLeastOnce()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"));
+    }
+
+    @Test
+    public void setActiveFederationCreationBlockHeightAndGetActiveFederationCreationBlockHeight() {
+        Repository repository = createRepository();
+        Repository track = repository.startTracking();
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        // We store the value
+        provider0.setActiveFederationCreationBlockHeight(1L);
+        provider0.saveActiveFederationCreationBlockHeight();
+        track.commit();
+
+        track = repository.startTracking();
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+                track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        // And then we get it back
+        assertThat(provider.getActiveFederationCreationBlockHeight(), is(1L));
+    }
+
+    @Test
     public void saveActiveFederationCreationBlockHeight_after_RSKIP186() {
         Repository repository = mock(Repository.class);
 
@@ -2185,6 +2281,102 @@ public class BridgeStorageProviderTest {
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("activeFedCreationBlockHeight"));
+    }
+
+    @Test
+    public void setNextFederationCreationBlockHeight_before_fork() {
+        Repository repository = mock(Repository.class);
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        provider0.setNextFederationCreationBlockHeight(1L);
+        provider0.saveNextFederationCreationBlockHeight();
+
+        // If the network upgrade is not enabled we shouldn't be writing in the repository
+        verify(repository, never()).addStorageBytes(any(), any(), any());
+    }
+
+    @Test
+    public void setNextFederationCreationBlockHeight_after_fork() {
+        Repository repository = mock(Repository.class);
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        provider0.setNextFederationCreationBlockHeight(1L);
+        provider0.saveNextFederationCreationBlockHeight();
+
+        // Once the network upgrade is active, we will store the value in the repository
+        verify(repository, times(1)).addStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromString("nextFedCreationBlockHeight"),
+                BridgeSerializationUtils.serializeLong(1L)
+        );
+    }
+
+    @Test
+    public void getNextFederationCreationBlockHeight_before_fork() {
+        Repository repository = mock(Repository.class);
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"))).thenReturn(new byte[] { 1 });
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        assertNull(provider0.getNextFederationCreationBlockHeight());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"));
+    }
+
+    @Test
+    public void getNextFederationCreationBlockHeight_after_fork() {
+        Repository repository = mock(Repository.class);
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"))).thenReturn(new byte[] { 1 });
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        assertEquals(Long.valueOf(1L), provider0.getNextFederationCreationBlockHeight());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, atLeastOnce()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"));
+    }
+
+    @Test
+    public void setNextFederationCreationBlockHeightAndGetNextFederationCreationBlockHeight() {
+        Repository repository = createRepository();
+        Repository track = repository.startTracking();
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        // We store the value
+        provider0.setNextFederationCreationBlockHeight(1L);
+        provider0.saveNextFederationCreationBlockHeight();
+        track.commit();
+
+        track = repository.startTracking();
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+                track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        // And then we get it back
+        assertThat(provider.getNextFederationCreationBlockHeight(), is(1L));
     }
 
     @Test
@@ -2239,6 +2431,111 @@ public class BridgeStorageProviderTest {
 
         // If the network upgrade is not enabled we shouldn't be reading the repository
         verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("nextFedCreationBlockHeight"));
+    }
+
+    //
+
+    @Test
+    public void setLastRetiredFederationP2SHScript_before_fork() {
+        Repository repository = mock(Repository.class);
+        Script script = new Script(new byte[] {});
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        provider0.setLastRetiredFederationP2SHScript(script);
+        provider0.saveLastRetiredFederationP2SHScript();
+
+        // If the network upgrade is not enabled we shouldn't be writing in the repository
+        verify(repository, never()).addStorageBytes(any(), any(), any());
+    }
+
+    @Test
+    public void setLastRetiredFederationP2SHScript_after_fork() {
+        Repository repository = mock(Repository.class);
+        Script script = new Script(new byte[] {});
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        provider0.setLastRetiredFederationP2SHScript(script);
+        provider0.saveLastRetiredFederationP2SHScript();
+
+        // Once the network upgrade is active, we will store the value in the repository
+        verify(repository, times(1)).addStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                DataWord.fromString("lastRetiredFedP2SHScript"),
+                BridgeSerializationUtils.serializeScript(script)
+        );
+    }
+
+    @Test
+    public void getLastRetiredFederationP2SHScript_before_fork() {
+        Repository repository = mock(Repository.class);
+        Script script = new Script(new byte[] {});
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript")))
+                .thenReturn(BridgeSerializationUtils.serializeScript(script));
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        assertNull(provider0.getLastRetiredFederationP2SHScript());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"));
+    }
+
+    @Test
+    public void getLastRetiredFederationP2SHScript_after_fork() {
+        Repository repository = mock(Repository.class);
+        Script script = new Script(new byte[] {});
+        // If by chance the repository is called I want to force the tests to fail
+        when(repository.getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript")))
+                .thenReturn(BridgeSerializationUtils.serializeScript(script));
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                repository, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        assertEquals(script, provider0.getLastRetiredFederationP2SHScript());
+
+        // If the network upgrade is not enabled we shouldn't be reading the repository
+        verify(repository, atLeastOnce()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, DataWord.fromString("lastRetiredFedP2SHScript"));
+    }
+
+    @Test
+    public void setLastRetiredFederationP2SHScriptAndGetLastRetiredFederationP2SHScript() {
+        Repository repository = createRepository();
+        Repository track = repository.startTracking();
+        Script script = new Script(new byte[] {});
+
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(
+                track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        // We store the value
+        provider0.setLastRetiredFederationP2SHScript(script);
+        provider0.saveLastRetiredFederationP2SHScript();
+        track.commit();
+
+        track = repository.startTracking();
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+                track, PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        // And then we get it back
+        assertThat(provider.getLastRetiredFederationP2SHScript(), is(script));
     }
 
     //

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1601,6 +1601,133 @@ public class BridgeSupportTest {
     }
 
     @Test
+    public void updateFederationCreationBlockHeights_before_rskip_186_activation() throws IOException {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP186)).thenReturn(false);
+
+        BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
+
+        Federation oldFederation = bridgeConstants.getGenesisFederation();
+
+        Federation newFederation = new Federation(
+                FederationTestUtils.getFederationMembers(1),
+                Instant.EPOCH,
+                5L,
+                bridgeConstants.getBtcParams()
+        );
+
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.getFeePerKb())
+                .thenReturn(Coin.MILLICOIN);
+        when(provider.getReleaseRequestQueue())
+                .thenReturn(new ReleaseRequestQueue(Collections.emptyList()));
+        when(provider.getReleaseTransactionSet())
+                .thenReturn(new ReleaseTransactionSet(Collections.emptySet()));
+        when(provider.getOldFederation())
+                .thenReturn(oldFederation);
+        when(provider.getNewFederation())
+                .thenReturn(newFederation);
+
+        BlockGenerator blockGenerator = new BlockGenerator();
+        // Old federation will be in migration age at block 35
+        org.ethereum.core.Block rskCurrentBlock = blockGenerator.createBlock(180, 1);
+        Transaction tx = Transaction
+                .builder()
+                .nonce(NONCE)
+                .gasPrice(GAS_PRICE)
+                .gasLimit(GAS_LIMIT)
+                .destination(Hex.decode(TO_ADDRESS))
+                .data(Hex.decode(DATA))
+                .chainId(Constants.REGTEST_CHAIN_ID)
+                .value(DUST_AMOUNT)
+                .build();
+
+        BridgeSupport bridgeSupport = getBridgeSupport(
+                bridgeConstants, provider, mock(Repository.class), bridgeEventLogger, rskCurrentBlock, null, activations
+        );
+
+        List<UTXO> sufficientUTXOsForMigration1 = new ArrayList<>();
+        sufficientUTXOsForMigration1.add(createUTXO(Coin.COIN, oldFederation.getAddress()));
+        when(provider.getOldFederationBtcUTXOs()).thenReturn(sufficientUTXOsForMigration1);
+
+        when(provider.getNextFederationCreationBlockHeight()).thenReturn(1L);
+
+        bridgeSupport.updateCollections(tx);
+
+        verify(provider, never()).getNextFederationCreationBlockHeight();
+        verify(provider, never()).setActiveFederationCreationBlockHeight(any(Long.class));
+        verify(provider, never()).clearNextFederationCreationBlockHeight();
+    }
+
+    @Test
+    public void updateFederationCreationBlockHeights_after_rskip_186_activation() throws IOException {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP186)).thenReturn(true);
+
+        BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
+
+        Federation oldFederation = bridgeConstants.getGenesisFederation();
+
+        Federation newFederation = new Federation(
+                FederationTestUtils.getFederationMembers(1),
+                Instant.EPOCH,
+                5L,
+                bridgeConstants.getBtcParams()
+        );
+
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.getFeePerKb())
+                .thenReturn(Coin.MILLICOIN);
+        when(provider.getReleaseRequestQueue())
+                .thenReturn(new ReleaseRequestQueue(Collections.emptyList()));
+        when(provider.getReleaseTransactionSet())
+                .thenReturn(new ReleaseTransactionSet(Collections.emptySet()));
+        when(provider.getOldFederation())
+                .thenReturn(oldFederation);
+        when(provider.getNewFederation())
+                .thenReturn(newFederation);
+
+        BlockGenerator blockGenerator = new BlockGenerator();
+        // Old federation will be in migration age at block 35
+        org.ethereum.core.Block rskCurrentBlock = blockGenerator.createBlock(180, 1);
+        Transaction tx = Transaction
+                .builder()
+                .nonce(NONCE)
+                .gasPrice(GAS_PRICE)
+                .gasLimit(GAS_LIMIT)
+                .destination(Hex.decode(TO_ADDRESS))
+                .data(Hex.decode(DATA))
+                .chainId(Constants.REGTEST_CHAIN_ID)
+                .value(DUST_AMOUNT)
+                .build();
+
+        BridgeSupport bridgeSupport = getBridgeSupport(
+                bridgeConstants, provider, mock(Repository.class), bridgeEventLogger, rskCurrentBlock, null, activations
+        );
+
+        List<UTXO> sufficientUTXOsForMigration1 = new ArrayList<>();
+        sufficientUTXOsForMigration1.add(createUTXO(Coin.COIN, oldFederation.getAddress()));
+        when(provider.getOldFederationBtcUTXOs())
+                .thenReturn(sufficientUTXOsForMigration1);
+
+        when(provider.getNextFederationCreationBlockHeight()).thenReturn(null);
+
+        bridgeSupport.updateCollections(tx);
+
+        verify(provider, times(1)).getNextFederationCreationBlockHeight();
+        verify(provider, never()).setActiveFederationCreationBlockHeight(any(Long.class));
+        verify(provider, never()).clearNextFederationCreationBlockHeight();
+
+        when(provider.getNextFederationCreationBlockHeight()).thenReturn(1L);
+
+        bridgeSupport.updateCollections(tx);
+
+        verify(provider, times(2)).getNextFederationCreationBlockHeight();
+        verify(provider, times(1)).setActiveFederationCreationBlockHeight(1L);
+        verify(provider, times(1)).clearNextFederationCreationBlockHeight();
+    }
+
+    @Test
     public void rskTxWaitingForSignature_uses_updateCollection_rskTxHash_before_rskip_146_activation() throws IOException {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1650,7 +1650,7 @@ public class BridgeSupportTest {
         sufficientUTXOsForMigration1.add(createUTXO(Coin.COIN, oldFederation.getAddress()));
         when(provider.getOldFederationBtcUTXOs()).thenReturn(sufficientUTXOsForMigration1);
 
-        when(provider.getNextFederationCreationBlockHeight()).thenReturn(1L);
+        when(provider.getNextFederationCreationBlockHeight()).thenReturn(Optional.of(1L));
 
         bridgeSupport.updateCollections(tx);
 
@@ -1710,7 +1710,7 @@ public class BridgeSupportTest {
         when(provider.getOldFederationBtcUTXOs())
                 .thenReturn(sufficientUTXOsForMigration1);
 
-        when(provider.getNextFederationCreationBlockHeight()).thenReturn(null);
+        when(provider.getNextFederationCreationBlockHeight()).thenReturn(Optional.empty());
 
         bridgeSupport.updateCollections(tx);
 
@@ -1718,7 +1718,7 @@ public class BridgeSupportTest {
         verify(provider, never()).setActiveFederationCreationBlockHeight(any(Long.class));
         verify(provider, never()).clearNextFederationCreationBlockHeight();
 
-        when(provider.getNextFederationCreationBlockHeight()).thenReturn(1L);
+        when(provider.getNextFederationCreationBlockHeight()).thenReturn(Optional.of(1L));
 
         bridgeSupport.updateCollections(tx);
 
@@ -5616,7 +5616,7 @@ public class BridgeSupportTest {
         Assert.assertEquals(BridgeSupport.TxType.MIGRATION, bridgeSupport.getTransactionType(migrationTx));
 
         when(mockFederationSupport.getRetiringFederation()).thenReturn(null);
-        when(provider.getLastRetiredFederationP2SHScript()).thenReturn(retiringFederation.getP2SHScript());
+        when(provider.getLastRetiredFederationP2SHScript()).thenReturn(Optional.of(retiringFederation.getP2SHScript()));
         Assert.assertEquals(BridgeSupport.TxType.MIGRATION, bridgeSupport.getTransactionType(migrationTx));
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -5363,7 +5363,7 @@ public class BridgeSupportTest {
 
     @Test
     public void getTransactionType_release_tx() {
-        BridgeSupport bridgeSupport = getBridgeSupport(bridgeConstants, mock(BridgeStorageProvider.class));
+        BridgeSupport bridgeSupport = getBridgeSupport(bridgeConstants, mock(BridgeStorageProvider.class), mock(ActivationConfig.ForBlock.class));
         Federation federation = bridgeConstants.getGenesisFederation();
         List<BtcECKey> federationPrivateKeys = BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS;
         co.rsk.bitcoinj.core.Address randomAddress =
@@ -5430,7 +5430,7 @@ public class BridgeSupportTest {
                 new Context(bridgeConstants.getBtcParams()),
                 mockFederationSupport,
                 null,
-                null
+                mock(ActivationConfig.ForBlock.class)
         );
 
         Federation retiringFederation = bridgeConstants.getGenesisFederation();
@@ -5487,11 +5487,15 @@ public class BridgeSupportTest {
         }
         migrationTxInput.setScriptSig(inputScript);
         Assert.assertEquals(BridgeSupport.TxType.MIGRATION, bridgeSupport.getTransactionType(migrationTx));
+
+        when(mockFederationSupport.getRetiringFederation()).thenReturn(null);
+        when(provider.getLastRetiredFederationP2SHScript()).thenReturn(retiringFederation.getP2SHScript());
+        Assert.assertEquals(BridgeSupport.TxType.MIGRATION, bridgeSupport.getTransactionType(migrationTx));
     }
 
     @Test
     public void getTransactionType_unknown_tx() {
-        BridgeSupport bridgeSupport = getBridgeSupport(bridgeConstants, mock(BridgeStorageProvider.class));
+        BridgeSupport bridgeSupport = getBridgeSupport(bridgeConstants, mock(BridgeStorageProvider.class), mock(ActivationConfig.ForBlock.class));
         BtcTransaction btcTx = new BtcTransaction(btcParams);
         Assert.assertEquals(BridgeSupport.TxType.UNKNOWN, bridgeSupport.getTransactionType(btcTx));
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
@@ -1393,7 +1393,7 @@ public class BridgeSupportTestPowerMock {
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class, Mockito.RETURNS_DEEP_STUBS);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
-        when(mockBridgeStorageProvider.getLastRetiredFederationP2SHScript()).thenReturn(null);
+        when(mockBridgeStorageProvider.getLastRetiredFederationP2SHScript()).thenReturn(Optional.empty());
 
         List<UTXO> retiringFederationUtxos = new ArrayList<>();
         FederationSupport mockFederationSupport = mock(FederationSupport.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
@@ -1393,6 +1393,7 @@ public class BridgeSupportTestPowerMock {
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class, Mockito.RETURNS_DEEP_STUBS);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
+        when(mockBridgeStorageProvider.getLastRetiredFederationP2SHScript()).thenReturn(null);
 
         List<UTXO> retiringFederationUtxos = new ArrayList<>();
         FederationSupport mockFederationSupport = mock(FederationSupport.class);
@@ -1424,8 +1425,8 @@ public class BridgeSupportTestPowerMock {
         when(mockFactory.newInstance(any())).thenReturn(mockBtcBlockStore);
 
         PowerMockito.spy(BridgeUtils.class);
-        PowerMockito.doReturn(false).when(BridgeUtils.class, "isLockTx", any(BtcTransaction.class), anyList(), any(Context.class), any(BridgeConstants.class));
-        PowerMockito.doReturn(true).when(BridgeUtils.class, "isMigrationTx", any(BtcTransaction.class), any(Federation.class), any(Federation.class), any(Context.class), any(BridgeConstants.class));
+        PowerMockito.doReturn(false).when(BridgeUtils.class, "isLockTx", any(BtcTransaction.class), anyList(), nullable(Script.class), any(Context.class), any(BridgeConstants.class));
+        PowerMockito.doReturn(true).when(BridgeUtils.class, "isMigrationTx", any(BtcTransaction.class), any(Federation.class), any(Federation.class), isNull(), any(Context.class), any(BridgeConstants.class));
 
         BridgeSupport bridgeSupport = new BridgeSupport(
                 bridgeConstants,
@@ -1449,7 +1450,7 @@ public class BridgeSupportTestPowerMock {
         assertThat(changeUtxo.getScript().getToAddress(params), is(retiringFederationAddress));
 
         PowerMockito.verifyStatic(BridgeUtils.class);
-        BridgeUtils.isMigrationTx(releaseWithChangeTx, activeFederation, retiringFederation, btcContext, bridgeConstants);
+        BridgeUtils.isMigrationTx(releaseWithChangeTx, activeFederation, retiringFederation, null, btcContext, bridgeConstants);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
@@ -1425,7 +1425,7 @@ public class BridgeSupportTestPowerMock {
         when(mockFactory.newInstance(any())).thenReturn(mockBtcBlockStore);
 
         PowerMockito.spy(BridgeUtils.class);
-        PowerMockito.doReturn(false).when(BridgeUtils.class, "isLockTx", any(BtcTransaction.class), anyList(), nullable(Script.class), any(Context.class), any(BridgeConstants.class));
+        PowerMockito.doReturn(false).when(BridgeUtils.class, "isPegInTx", any(BtcTransaction.class), anyList(), nullable(Script.class), any(Context.class), any(BridgeConstants.class));
         PowerMockito.doReturn(true).when(BridgeUtils.class, "isMigrationTx", any(BtcTransaction.class), any(Federation.class), any(Federation.class), isNull(), any(Context.class), any(BridgeConstants.class));
 
         BridgeSupport bridgeSupport = new BridgeSupport(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestPowerMock.java
@@ -3145,6 +3145,7 @@ public class BridgeTestPowerMock {
                 BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY,
                 BridgeMethods.GET_STATE_FOR_BTC_RELEASE_CLIENT,
                 BridgeMethods.GET_STATE_FOR_DEBUGGING,
+                BridgeMethods.GET_ACTIVE_FEDERATION_CREATION_BLOCK_HEIGHT,
                 BridgeMethods.IS_BTC_TX_HASH_ALREADY_PROCESSED
         ).stream().forEach(m -> {
             Assert.assertTrue(m.onlyAllowsLocalCalls());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestPowerMock.java
@@ -3145,7 +3145,6 @@ public class BridgeTestPowerMock {
                 BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY,
                 BridgeMethods.GET_STATE_FOR_BTC_RELEASE_CLIENT,
                 BridgeMethods.GET_STATE_FOR_DEBUGGING,
-                BridgeMethods.GET_ACTIVE_FEDERATION_CREATION_BLOCK_HEIGHT,
                 BridgeMethods.IS_BTC_TX_HASH_ALREADY_PROCESSED
         ).stream().forEach(m -> {
             Assert.assertTrue(m.onlyAllowsLocalCalls());
@@ -3173,7 +3172,8 @@ public class BridgeTestPowerMock {
                 BridgeMethods.ROLLBACK_FEDERATION,
                 BridgeMethods.SET_LOCK_WHITELIST_DISABLE_BLOCK_DELAY,
                 BridgeMethods.UPDATE_COLLECTIONS,
-                BridgeMethods.VOTE_FEE_PER_KB
+                BridgeMethods.VOTE_FEE_PER_KB,
+                BridgeMethods.GET_ACTIVE_FEDERATION_CREATION_BLOCK_HEIGHT
         ).stream().forEach(m -> {
             Assert.assertFalse(m.onlyAllowsLocalCalls());
         });

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -660,20 +660,20 @@ public class BridgeUtilsTest {
         releaseTx1.addInput(releaseInput1);
         signWithNecessaryKeys(federation, federationPrivateKeys, releaseInput1, releaseTx1, bridgeConstants);
 
-        assertThat(BridgeUtils.isReleaseTx(releaseTx1, Collections.singletonList(federation)), is(true));
-        assertThat(BridgeUtils.isReleaseTx(releaseTx1, Arrays.asList(federation, federation2)), is(true));
-        assertThat(BridgeUtils.isReleaseTx(releaseTx1, Collections.singletonList(federation2)), is(false));
+        assertThat(BridgeUtils.isPegOutTx(releaseTx1, Collections.singletonList(federation)), is(true));
+        assertThat(BridgeUtils.isPegOutTx(releaseTx1, Arrays.asList(federation, federation2)), is(true));
+        assertThat(BridgeUtils.isPegOutTx(releaseTx1, Collections.singletonList(federation2)), is(false));
 
-        assertThat(BridgeUtils.isReleaseTx(releaseTx1, federation.getP2SHScript()), is(true));
-        assertThat(BridgeUtils.isReleaseTx(releaseTx1, federation.getP2SHScript(), federation2.getP2SHScript()), is(true));
-        assertThat(BridgeUtils.isReleaseTx(releaseTx1, federation2.getP2SHScript()), is(false));
+        assertThat(BridgeUtils.isPegOutTx(releaseTx1, federation.getP2SHScript()), is(true));
+        assertThat(BridgeUtils.isPegOutTx(releaseTx1, federation.getP2SHScript(), federation2.getP2SHScript()), is(true));
+        assertThat(BridgeUtils.isPegOutTx(releaseTx1, federation2.getP2SHScript()), is(false));
 
         BtcTransaction releaseTx2 = new BtcTransaction(params);
         releaseTx2.addOutput(Coin.COIN, randomAddress);
         TransactionInput releaseInput2 = new TransactionInput(params, releaseTx2, new byte[]{}, new TransactionOutPoint(params, 0, Sha256Hash.ZERO_HASH));
         releaseTx2.addInput(releaseInput2);
         signWithNKeys(federation, federationPrivateKeys, releaseInput2, releaseTx2, bridgeConstants, 1);
-        assertThat(BridgeUtils.isReleaseTx(releaseTx2, Collections.singletonList(federation)), is(false));
+        assertThat(BridgeUtils.isPegOutTx(releaseTx2, Collections.singletonList(federation)), is(false));
     }
 
     @Test
@@ -714,7 +714,7 @@ public class BridgeUtilsTest {
         releaseWithChange.addInput(releaseFromFederation2);
         signWithNecessaryKeys(federation2, federation2Keys, releaseFromFederation2, releaseWithChange, bridgeConstants);
         assertThat(BridgeUtils.isPegInTx(releaseWithChange, federations, null, btcContext, bridgeConstants), is(false));
-        assertThat(BridgeUtils.isReleaseTx(releaseWithChange, federations), is(true));
+        assertThat(BridgeUtils.isPegOutTx(releaseWithChange, federations), is(true));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -124,7 +124,7 @@ public class BridgeUtilsTest {
         BtcTransaction tx = new BtcTransaction(params);
         tx.addOutput(minimumLockValue.subtract(Coin.CENT), federationAddress);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertFalse(BridgeUtils.isLockTx(tx, federation, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx, federation, btcContext, bridgeConstants));
 
         // Tx sending 1 btc to the federation, but also spending from the federation addres, the typical release tx, not a lock tx.
         BtcTransaction tx2 = new BtcTransaction(params);
@@ -132,19 +132,19 @@ public class BridgeUtilsTest {
         TransactionInput txIn = new TransactionInput(params, tx2, new byte[]{}, new TransactionOutPoint(params, 0, Sha256Hash.ZERO_HASH));
         tx2.addInput(txIn);
         signWithNecessaryKeys(bridgeConstants.getGenesisFederation(), BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx2, bridgeConstants);
-        assertFalse(BridgeUtils.isLockTx(tx2, federation, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx2, federation, btcContext, bridgeConstants));
 
         // Tx sending 1 btc to the federation, is a lock tx
         BtcTransaction tx3 = new BtcTransaction(params);
         tx3.addOutput(Coin.COIN, federationAddress);
         tx3.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isLockTx(tx3, federation, btcContext, bridgeConstants));
+        assertTrue(BridgeUtils.isPegInTx(tx3, federation, btcContext, bridgeConstants));
 
         // Tx sending 50 btc to the federation, is a lock tx
         BtcTransaction tx4 = new BtcTransaction(params);
         tx4.addOutput(Coin.FIFTY_COINS, federationAddress);
         tx4.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isLockTx(tx4, federation, btcContext, bridgeConstants));
+        assertTrue(BridgeUtils.isPegInTx(tx4, federation, btcContext, bridgeConstants));
     }
 
     @Test
@@ -175,20 +175,20 @@ public class BridgeUtilsTest {
         BtcTransaction tx = new BtcTransaction(parameters);
         tx.addOutput(Coin.CENT, address1);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertFalse(BridgeUtils.isLockTx(tx, federations, null, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx, federations, null, btcContext, bridgeConstants));
 
         // Tx sending less than 1 btc to the second federation, not a lock tx
         tx = new BtcTransaction(parameters);
         tx.addOutput(Coin.CENT, address2);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertFalse(BridgeUtils.isLockTx(tx, federations, null, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx, federations, null, btcContext, bridgeConstants));
 
         // Tx sending less than 1 btc to both federations, not a lock tx
         tx = new BtcTransaction(parameters);
         tx.addOutput(Coin.CENT, address1);
         tx.addOutput(Coin.CENT, address2);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertFalse(BridgeUtils.isLockTx(tx, federations, null, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 1 btc to the first federation, but also spending from the first federation address, the typical release tx, not a lock tx.
         BtcTransaction tx2 = new BtcTransaction(parameters);
@@ -196,7 +196,7 @@ public class BridgeUtilsTest {
         TransactionInput txIn = new TransactionInput(parameters, tx2, new byte[]{}, new TransactionOutPoint(parameters, 0, Sha256Hash.ZERO_HASH));
         tx2.addInput(txIn);
         signWithNecessaryKeys(federation1, federation1Keys, txIn, tx2, bridgeConstants);
-        assertFalse(BridgeUtils.isLockTx(tx2, federations, null, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx2, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 1 btc to the second federation, but also spending from the second federation address, the typical release tx, not a lock tx.
         tx2 = new BtcTransaction(parameters);
@@ -204,7 +204,7 @@ public class BridgeUtilsTest {
         txIn = new TransactionInput(parameters, tx2, new byte[]{}, new TransactionOutPoint(parameters, 0, Sha256Hash.ZERO_HASH));
         tx2.addInput(txIn);
         signWithNecessaryKeys(federation2, federation2Keys, txIn, tx2, bridgeConstants);
-        assertFalse(BridgeUtils.isLockTx(tx2, federations, null, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx2, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 1 btc to both federations, but also spending from the first federation address, the typical release tx, not a lock tx.
         tx2 = new BtcTransaction(parameters);
@@ -213,7 +213,7 @@ public class BridgeUtilsTest {
         txIn = new TransactionInput(parameters, tx2, new byte[]{}, new TransactionOutPoint(parameters, 0, Sha256Hash.ZERO_HASH));
         tx2.addInput(txIn);
         signWithNecessaryKeys(federation1, federation1Keys, txIn, tx2, bridgeConstants);
-        assertFalse(BridgeUtils.isLockTx(tx2, federations, null, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx2, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 1 btc to both federations, but also spending from the second federation address, the typical release tx, not a lock tx.
         tx2 = new BtcTransaction(parameters);
@@ -222,7 +222,7 @@ public class BridgeUtilsTest {
         txIn = new TransactionInput(parameters, tx2, new byte[]{}, new TransactionOutPoint(parameters, 0, Sha256Hash.ZERO_HASH));
         tx2.addInput(txIn);
         signWithNecessaryKeys(federation2, federation2Keys, txIn, tx2, bridgeConstants);
-        assertFalse(BridgeUtils.isLockTx(tx2, federations, null, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx2, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 1 btc from federation1 to federation2, the typical migration tx, not a lock tx.
         tx2 = new BtcTransaction(parameters);
@@ -230,7 +230,7 @@ public class BridgeUtilsTest {
         txIn = new TransactionInput(parameters, tx2, new byte[]{}, new TransactionOutPoint(parameters, 0, Sha256Hash.ZERO_HASH));
         tx2.addInput(txIn);
         signWithNecessaryKeys(federation1, federation1Keys, txIn, tx2, bridgeConstants);
-        assertFalse(BridgeUtils.isLockTx(tx2, federations, null, btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx2, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 1 btc from federation1 to federation2, the typical migration tx from the retired federation, not a lock tx.
         tx2 = new BtcTransaction(parameters);
@@ -238,45 +238,45 @@ public class BridgeUtilsTest {
         txIn = new TransactionInput(parameters, tx2, new byte[]{}, new TransactionOutPoint(parameters, 0, Sha256Hash.ZERO_HASH));
         tx2.addInput(txIn);
         signWithNecessaryKeys(federation1, federation1Keys, txIn, tx2, bridgeConstants);
-        assertFalse(BridgeUtils.isLockTx(tx2, Collections.singletonList(federation2), federation1.getP2SHScript(), btcContext, bridgeConstants));
+        assertFalse(BridgeUtils.isPegInTx(tx2, Collections.singletonList(federation2), federation1.getP2SHScript(), btcContext, bridgeConstants));
 
         // Tx sending 1 btc to the first federation, is a lock tx
         BtcTransaction tx3 = new BtcTransaction(parameters);
         tx3.addOutput(Coin.COIN, address1);
         tx3.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isLockTx(tx3, federations, null, btcContext, bridgeConstants));
+        assertTrue(BridgeUtils.isPegInTx(tx3, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 1 btc to the second federation, is a lock tx
         tx3 = new BtcTransaction(parameters);
         tx3.addOutput(Coin.COIN, address2);
         tx3.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isLockTx(tx3, federations, null, btcContext, bridgeConstants));
+        assertTrue(BridgeUtils.isPegInTx(tx3, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 1 btc to the both federations, is a lock tx
         tx3 = new BtcTransaction(parameters);
         tx3.addOutput(Coin.COIN, address1);
         tx3.addOutput(Coin.COIN, address2);
         tx3.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isLockTx(tx3, federations, null, btcContext, bridgeConstants));
+        assertTrue(BridgeUtils.isPegInTx(tx3, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 50 btc to the first federation, is a lock tx
         BtcTransaction tx4 = new BtcTransaction(parameters);
         tx4.addOutput(Coin.FIFTY_COINS, address1);
         tx4.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isLockTx(tx4, federations, null, btcContext, bridgeConstants));
+        assertTrue(BridgeUtils.isPegInTx(tx4, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 50 btc to the second federation, is a lock tx
         tx4 = new BtcTransaction(parameters);
         tx4.addOutput(Coin.FIFTY_COINS, address2);
         tx4.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isLockTx(tx4, federations, null, btcContext, bridgeConstants));
+        assertTrue(BridgeUtils.isPegInTx(tx4, federations, null, btcContext, bridgeConstants));
 
         // Tx sending 50 btc to the both federations, is a lock tx
         tx4 = new BtcTransaction(parameters);
         tx4.addOutput(Coin.FIFTY_COINS, address1);
         tx4.addOutput(Coin.FIFTY_COINS, address2);
         tx4.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isLockTx(tx4, federations, null, btcContext, bridgeConstants));
+        assertTrue(BridgeUtils.isPegInTx(tx4, federations, null, btcContext, bridgeConstants));
     }
 
     @Test
@@ -713,7 +713,7 @@ public class BridgeUtilsTest {
         TransactionInput releaseFromFederation2 = new TransactionInput(params, releaseWithChange, new byte[]{}, new TransactionOutPoint(params, 0, Sha256Hash.ZERO_HASH));
         releaseWithChange.addInput(releaseFromFederation2);
         signWithNecessaryKeys(federation2, federation2Keys, releaseFromFederation2, releaseWithChange, bridgeConstants);
-        assertThat(BridgeUtils.isLockTx(releaseWithChange, federations, null, btcContext, bridgeConstants), is(false));
+        assertThat(BridgeUtils.isPegInTx(releaseWithChange, federations, null, btcContext, bridgeConstants), is(false));
         assertThat(BridgeUtils.isReleaseTx(releaseWithChange, federations), is(true));
     }
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -82,6 +82,7 @@ public class ActivationConfigTest {
             "    rskip180: iris300",
             "    rskip181: iris300",
             "    rskip185: iris300",
+            "    rskip186: iris300",
             "    rskip191: iris300",
             "    rskip197: iris300",
             "}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the Federation change voting process finishes, the Bridge emmits a commit_federation event. This event can be used to provide a blockchain proof of the Federation address when requested. Nowadays doing this would imply navigating the blockchain to determine when it was emmited, or constantly monitoring said events.

This RSKIP proposes adding on-chain information to easily fetch the block where the Federation was changed for the last time. With the block, a system could provide proof that it belongs to the mainchain.

Additionally, once a Federation migration process finishes, the retiring Federation is removed. This RSKIP proposes to keep the last retiring Federation address in storage, to be used in case there are outstanding funds to migrate after the retiring age.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a user gets the Federation address they usually interact with a node/service and have to trust this information. This exposes a risk where a man-in-the-middle kind of attack could lead users to send their funds to an invalid address thus losing them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)


*fed:active-block-reg*
