### PR TITLE
Creation of receiveHeaders function

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -485,6 +485,17 @@ public enum BridgeMethods {
             ),
             false
     ),
+    RECEIVE_HEADER(
+            CallTransaction.Function.fromSignature(
+                    "receiveHeader",
+                    new String[]{"bytes"},
+                    new String[]{"int256"}
+            ),
+            fixedCost(22_000L),  // TODO: calculate gas cost.
+            (BridgeMethodExecutorTyped) Bridge::receiveHeader,
+            activations -> activations.isActive(RSKIP200),
+            false
+    ),
     REGISTER_BTC_TRANSACTION(
             CallTransaction.Function.fromSignature(
                     "registerBtcTransaction",

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -205,6 +205,14 @@ public class BridgeSupport {
     }
 
     /**
+     * Receives only one header of serialized Bitcoin block headers and adds them to the internal BlockChain structure.
+     * @param header The bitcoin headers
+     */
+    public Integer receiveHeader(BtcBlock header) throws IOException {
+        return 0;
+    }
+
+    /**
      * Get the wallet for the currently active federation
      * @return A BTC wallet for the currently active federation
      *


### PR DESCRIPTION
It includes a new function in bridgeMethods called receiveHeader, which will be public and receives a single header as an input parameter, being able to return errors.
This function can be used from RSKIP200

In turn, receiveHeaders is no longer public with this same RSKIP.
