### PR TITLE
Adding Support for Raw Keys containing Hex Prefix (0x)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -125,6 +125,9 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
     public String importRawKey(String key, String passphrase) {
         String s = null;
         try {
+            if (key.startsWith("0x")) {
+                key = key.substring(2);
+            }
             RskAddress address = this.wallet.addAccountWithPrivateKey(Hex.decode(key), passphrase);
             unlockAccount(address, passphrase, null);
             return s = address.toJsonString();

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -125,7 +125,7 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
     public String importRawKey(String key, String passphrase) {
         String s = null;
         try {
-            if (key.startsWith("0x")) {
+            if (key != null && key.startsWith("0x")) {
                 key = key.substring(2);
             }
             RskAddress address = this.wallet.addAccountWithPrivateKey(Hex.decode(key), passphrase);

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabledTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabledTest.java
@@ -1,0 +1,81 @@
+package co.rsk.rpc.modules.personal;
+
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+import org.bouncycastle.util.encoders.DecoderException;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by Nazaret García on 15/01/2021
+ */
+
+public class PersonalModuleWalletEnabledTest {
+
+    @Test(expected = DecoderException.class)
+    public void importRawKey_KeyIsNull_ThrowsNullPointerException() {
+        PersonalModuleWalletEnabled personalModuleWalletEnabled = createPersonalModuleWalletEnabled(null);
+
+        personalModuleWalletEnabled.importRawKey(null, "passphrase1");
+    }
+
+    @Test
+    public void importRawKey_KeyContains0xPrefix_OK() {
+        ECKey eckey = new ECKey();
+        String rawKey = ByteUtil.toHexString(eckey.getPrivKeyBytes());
+        String passphrase = "passphrase1";
+        byte[] hexDecodedKey = Hex.decode(rawKey);
+
+        RskAddress addressMock = mock(RskAddress.class);
+        doReturn("{}").when(addressMock).toJsonString();
+
+        Wallet walletMock = mock(Wallet.class);
+        doReturn(addressMock).when(walletMock).addAccountWithPrivateKey(hexDecodedKey, passphrase);
+        doReturn(true).when(walletMock).unlockAccount(eq(addressMock), eq(passphrase), any(Long.class));
+
+        PersonalModuleWalletEnabled personalModuleWalletEnabled = createPersonalModuleWalletEnabled(walletMock);
+        String result = personalModuleWalletEnabled.importRawKey(String.format("0x%s", rawKey), passphrase);
+
+        verify(walletMock, times(1)).addAccountWithPrivateKey(hexDecodedKey, passphrase);
+        verify(walletMock, times(1)).unlockAccount(addressMock, passphrase, 1800000L);
+        verify(addressMock, times(1)).toJsonString();
+
+        assertEquals("{}", result);
+    }
+
+    @Test
+    public void importRawKey_KeyDoesNotContains0xPrefix_OK() {
+        ECKey eckey = new ECKey();
+        String rawKey = ByteUtil.toHexString(eckey.getPrivKeyBytes());
+        String passphrase = "passphrase1";
+        byte[] hexDecodedKey = Hex.decode(rawKey);
+
+        RskAddress addressMock = mock(RskAddress.class);
+        doReturn("{}").when(addressMock).toJsonString();
+
+        Wallet walletMock = mock(Wallet.class);
+        doReturn(addressMock).when(walletMock).addAccountWithPrivateKey(hexDecodedKey, passphrase);
+        doReturn(true).when(walletMock).unlockAccount(eq(addressMock), eq(passphrase), any(Long.class));
+
+        PersonalModuleWalletEnabled personalModuleWalletEnabled = createPersonalModuleWalletEnabled(walletMock);
+        String result = personalModuleWalletEnabled.importRawKey(rawKey, passphrase);
+
+        verify(walletMock, times(1)).addAccountWithPrivateKey(hexDecodedKey, passphrase);
+        verify(walletMock, times(1)).unlockAccount(addressMock, passphrase, 1800000L);
+        verify(addressMock, times(1)).toJsonString();
+
+        assertEquals("{}", result);
+    }
+
+    private PersonalModuleWalletEnabled createPersonalModuleWalletEnabled(Wallet wallet) {
+        return new PersonalModuleWalletEnabled(null, null, wallet, null);
+    }
+
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -1577,6 +1577,33 @@ public class Web3ImplTest {
     }
 
     @Test
+    public void importAccountUsingRawKeyContaining0xPrefix() {
+        Web3Impl web3 = createWeb3();
+
+        ECKey eckey = new ECKey();
+
+        byte[] privKeyBytes = eckey.getPrivKeyBytes();
+
+        ECKey privKey = ECKey.fromPrivate(privKeyBytes);
+
+        RskAddress addr = new RskAddress(privKey.getAddress());
+
+        Account account = wallet.getAccount(addr);
+
+        assertNull(account);
+
+        String address = web3.personal_importRawKey(String.format("0x%s", ByteUtil.toHexString(privKeyBytes)), "passphrase1");
+
+        assertNotNull(address);
+
+        account = wallet.getAccount(addr);
+
+        assertNotNull(account);
+        assertEquals(address, "0x" + ByteUtil.toHexString(account.getAddress().getBytes()));
+        assertArrayEquals(privKeyBytes, account.getEcKey().getPrivKeyBytes());
+    }
+
+    @Test
     public void dumpRawKey() throws Exception {
         Web3Impl web3 = createWeb3();
 
@@ -1590,6 +1617,19 @@ public class Web3ImplTest {
         assertArrayEquals(eckey.getPrivKeyBytes(), Hex.decode(rawKey));
     }
 
+    @Test
+    public void dumpRawKeyContaining0xPrefix() throws Exception {
+        Web3Impl web3 = createWeb3();
+
+        ECKey eckey = new ECKey();
+
+        String address = web3.personal_importRawKey(String.format("0x%s", ByteUtil.toHexString(eckey.getPrivKeyBytes())), "passphrase1");
+        assertTrue(web3.personal_unlockAccount(address, "passphrase1", ""));
+
+        String rawKey = web3.personal_dumpRawKey(address).substring(2);
+
+        assertArrayEquals(eckey.getPrivKeyBytes(), Hex.decode(rawKey));
+    }
 
     @Test
     public void sendPersonalTransaction()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

A new check was added to look for Raw Key Strings containing the "hex prefix' (0x). If the string contains this prefix, then it is removed and the execution continues.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Solves issue #1340.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Using Unit Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
