### PR TITLE
Receive headers calculate period time

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -60,6 +60,8 @@ public class BridgeConstants {
 
     protected int lockingCapIncrementsMultiplier;
 
+    protected long minSecondsBetweenCallsReceiveHeader;  // (seconds)
+
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
     }
@@ -117,4 +119,6 @@ public class BridgeConstants {
     public Coin getMaxFeePerKb() { return maxFeePerKb; }
 
     public Coin getMaxRbtc() { return Coin.valueOf(21_000_000, 0); }
+
+    public long getMinSecondsBetweenCallsToReceiveHeader() { return minSecondsBetweenCallsReceiveHeader; }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -128,5 +128,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
         initialLockingCap = Coin.COIN.multiply(1_000L); // 1_000 BTC
 
         lockingCapIncrementsMultiplier = 2;
+
+        minSecondsBetweenCallsReceiveHeader = 600;  // 10 minutes in Seconds
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -126,6 +126,8 @@ public class BridgeMainNetConstants extends BridgeConstants {
 
         lockingCapIncrementsMultiplier = 2;
         initialLockingCap = Coin.COIN.multiply(300); // 300 BTC
+
+        minSecondsBetweenCallsReceiveHeader = 600;  // 10 minutes in Seconds
     }
 
     public static BridgeMainNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -120,7 +120,9 @@ public class BridgeRegTestConstants extends BridgeConstants {
         initialLockingCap = Coin.COIN.multiply(1_000L); // 1_000 BTC
 
         lockingCapIncrementsMultiplier = 2;
-        
+
+        minSecondsBetweenCallsReceiveHeader = 600;  // 10 minutes in Seconds
+
         // Key generated with GenNodeKey using generator 'auth-increase_locking_cap'
         List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
                 "04450bbaab83ec48b3cb8fbb077c950ee079733041c039a8c4f1539e5181ca1a27589eeaf0fbf430e49d2909f14c767bf6909ad6845831f683416ee12b832e36ed"

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -126,6 +126,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         lockingCapIncrementsMultiplier = 2;
         initialLockingCap = Coin.COIN.multiply(200); // 200 BTC
+
+        minSecondsBetweenCallsReceiveHeader = 600;  // 10 minutes in Seconds
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -5134,6 +5134,167 @@ public class BridgeSupportTest {
                 ConsensusRule.RSKIP134);
     }
 
+    @Test
+    public void receiveHeader_time_not_present_in_storage() throws IOException, BlockStoreException {
+
+        Repository repository = mock(Repository.class);
+        StoredBlock storedBlock = mock(StoredBlock.class);
+        BtcBlockStoreWithCache btcBlockStore = mock(BtcBlockStoreWithCache.class);
+
+        BtcBlock btcBlock2 = mock(BtcBlock.class);
+        when(btcBlock2.getPrevBlockHash()).thenReturn(Sha256Hash.ZERO_HASH);
+        when(btcBlockStore.get(Sha256Hash.ZERO_HASH)).thenReturn(storedBlock);
+
+        BridgeStorageProvider provider = spy(new BridgeStorageProvider(
+                        repository,
+                        contractAddress,
+                        bridgeConstants,
+                        activationsAfterForks
+                )
+        );
+
+        BridgeSupport bridgeSupport = getBridgeSupportConfiguredToTestReceiveHeader(
+                btcBlock2,
+                btcBlockStore,
+                provider,
+                storedBlock,
+                activationsBeforeForks
+        );
+
+        StoredBlock storedBlock2 = mock(StoredBlock.class);
+        when(storedBlock.build(btcBlock2)).thenReturn(storedBlock2);
+
+        bridgeSupport.receiveHeader(btcBlock2);
+
+        // Calls put when is adding the block header. (Saves his storedBlock)
+        verify(btcBlockStore, times(1)).put(storedBlock2);
+        verify(provider, times(1)).getReceiveHeadersLastTimestamp();
+        verify(provider, times(1)).setReceiveHeadersLastTimestamp(anyLong());
+    }
+
+    @Test
+    public void receiveHeader_time_exceed_X() throws IOException, BlockStoreException {
+
+        Repository repository = mock(Repository.class);
+        StoredBlock storedBlock = mock(StoredBlock.class);
+        BtcBlockStoreWithCache btcBlockStore = mock(BtcBlockStoreWithCache.class);
+
+        BtcBlock btcBlock2 = mock(BtcBlock.class);
+        when(btcBlock2.getPrevBlockHash()).thenReturn(Sha256Hash.ZERO_HASH);
+        when(btcBlockStore.get(Sha256Hash.ZERO_HASH)).thenReturn(storedBlock);
+
+        Block executionBlockMock = mock(Block.class);
+
+        BridgeStorageProvider provider = spy(new BridgeStorageProvider(
+                repository,
+                contractAddress,
+                bridgeConstants,
+                activationsAfterForks
+                )
+        );
+
+        BridgeSupport bridgeSupport = getBridgeSupportConfiguredToTestReceiveHeader(
+                btcBlock2,
+                btcBlockStore,
+                provider,
+                storedBlock,
+                executionBlockMock,
+                activationsAfterForks
+        );
+
+        long timeStamp_old = executionBlockMock.getTimestamp() - (bridgeConstants.getMinSecondsBetweenCallsToReceiveHeader() * 2L);
+        doReturn(Optional.of(timeStamp_old)).when(provider).getReceiveHeadersLastTimestamp();
+
+        StoredBlock storedBlock2 = mock(StoredBlock.class);
+        when(storedBlock.build(btcBlock2)).thenReturn(storedBlock2);
+
+        bridgeSupport.receiveHeader(btcBlock2);
+
+        // Calls put when is adding the block header. (Saves his storedBlock)
+        verify(btcBlockStore, times(1)).put(storedBlock2);
+        verify(provider, times(1)).setReceiveHeadersLastTimestamp(anyLong());
+    }
+
+    @Test
+    public void receiveHeader_time_less_than_X() throws IOException, BlockStoreException {
+
+        Repository repository = mock(Repository.class);
+        StoredBlock storedBlock = mock(StoredBlock.class);
+        BtcBlockStoreWithCache btcBlockStore = mock(BtcBlockStoreWithCache.class);
+
+        BtcBlock btcBlock2 = mock(BtcBlock.class);
+        when(btcBlock2.getPrevBlockHash()).thenReturn(Sha256Hash.ZERO_HASH);
+        when(btcBlockStore.get(Sha256Hash.ZERO_HASH)).thenReturn(storedBlock);
+
+        Block executionBlockMock = mock(Block.class);
+
+        BridgeStorageProvider provider = spy(new BridgeStorageProvider(
+                        repository,
+                        contractAddress,
+                        bridgeConstants,
+                        activationsAfterForks
+                )
+        );
+
+        BridgeSupport bridgeSupport = getBridgeSupportConfiguredToTestReceiveHeader(
+                btcBlock2,
+                btcBlockStore,
+                provider,
+                storedBlock,
+                executionBlockMock,
+                activationsAfterForks
+        );
+
+        long timeStamp_old = executionBlockMock.getTimestamp() - (bridgeConstants.getMinSecondsBetweenCallsToReceiveHeader() / 2L);
+        doReturn(Optional.of(timeStamp_old)).when(provider).getReceiveHeadersLastTimestamp();
+
+        int result = bridgeSupport.receiveHeader(btcBlock2);
+
+        StoredBlock storedBlock2 = storedBlock.build(btcBlock2);
+
+        // Calls put when is adding the block header. (Saves his storedBlock)
+        verify(btcBlockStore, never()).put(storedBlock2);
+        verify(provider, never()).setReceiveHeadersLastTimestamp(anyLong());
+        Assert.assertEquals(-1, result);
+    }
+
+    @Test
+    public void receiveHeader_unexpected_exception() throws IOException, BlockStoreException {
+
+        Repository repository = mock(Repository.class);
+        StoredBlock storedBlock = mock(StoredBlock.class);
+        BtcBlockStoreWithCache btcBlockStore = mock(BtcBlockStoreWithCache.class);
+
+        BtcBlock btcBlock2 = mock(BtcBlock.class);
+        when(btcBlock2.getPrevBlockHash()).thenReturn(Sha256Hash.ZERO_HASH);
+        when(btcBlockStore.get(Sha256Hash.ZERO_HASH)).thenReturn(storedBlock);
+
+        BridgeStorageProvider provider = spy(new BridgeStorageProvider(
+                        repository,
+                        contractAddress,
+                        bridgeConstants,
+                        activationsAfterForks
+                )
+        );
+
+        BridgeSupport bridgeSupport = getBridgeSupportConfiguredToTestReceiveHeader(
+                btcBlock2,
+                btcBlockStore,
+                provider,
+                storedBlock,
+                activationsAfterForks
+        );
+        // Returns NullPointerException
+        doReturn(null).when(btcBlock2).getHash();
+
+        int result = bridgeSupport.receiveHeader(btcBlock2);
+
+        // Calls put when is adding the block header. (Saves his storedBlock)
+        verify(provider, times(1)).getReceiveHeadersLastTimestamp();
+        verify(provider, never()).setReceiveHeadersLastTimestamp(anyLong());
+        Assert.assertEquals(-99, result);
+    }
+
     private void assertRefundInProcessPegIn(boolean isWhitelisted, boolean mockLockingCap,
                                             BtcLockSender.TxType lockSender, @Nullable ConsensusRule consensusRule)
             throws IOException, RegisterBtcTransactionException {
@@ -5625,4 +5786,60 @@ public class BridgeSupportTest {
         byte[] hash = Keccak256Helper.keccak256(s);
         return new SimpleRskTransaction(hash);
     }
+
+    private BridgeSupport getBridgeSupportConfiguredToTestReceiveHeader(
+            BtcBlock btcBlock,
+            BtcBlockStoreWithCache btcBlockStore,
+            BridgeStorageProvider provider,
+            StoredBlock storedBlock,
+            ActivationConfig.ForBlock activation
+    ) throws BlockStoreException {
+        return getBridgeSupportConfiguredToTestReceiveHeader(
+                btcBlock,
+                btcBlockStore,
+                provider,
+                storedBlock,
+                mock(Block.class),
+                activation
+        );
+    }
+
+    private BridgeSupport getBridgeSupportConfiguredToTestReceiveHeader(
+            BtcBlock btcBlock,
+            BtcBlockStoreWithCache btcBlockStore,
+            BridgeStorageProvider provider,
+            StoredBlock storedBlock,
+            Block rskBlock,
+            ActivationConfig.ForBlock activation
+    ) throws BlockStoreException {
+
+        Repository repository = mock(Repository.class);
+
+        doReturn(1).when(storedBlock).getHeight();
+
+        BtcBlock btcBlock2 = mock(BtcBlock.class);
+        doReturn(PegTestUtils.createHash(1)).when(btcBlock2).getHash();
+        doReturn(btcBlock2).when(storedBlock).getHeader();
+
+        doReturn(storedBlock).when(btcBlockStore).getChainHead();
+
+        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
+        when(mockFactory.newInstance(any())).thenReturn(btcBlockStore);
+
+        when(btcBlock.getPrevBlockHash()).thenReturn(Sha256Hash.ZERO_HASH);
+        when(btcBlockStore.get(Sha256Hash.ZERO_HASH)).thenReturn(storedBlock);
+
+        when(rskBlock.getTimestamp()).thenReturn(1611169584L);
+
+        return getBridgeSupport(
+                bridgeConstants,
+                provider,
+                repository,
+                mock(BridgeEventLogger.class),
+                rskBlock,
+                mockFactory,
+                activation
+        );
+    }
+
 }


### PR DESCRIPTION
Time limit control between calls for receiveHeader

It includes a time limit between calls to receiveHeaders and control of some errors:
-1 -> time in calls is less than defined by constant
- 99 -> exception during add method

