### PR TITLE
Depth limit for Receive Header.

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -62,6 +62,8 @@ public class BridgeConstants {
 
     protected long minSecondsBetweenCallsReceiveHeader;  // (seconds)
 
+    protected int maxDepthBlockchainAccepted;
+
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
     }
@@ -121,4 +123,6 @@ public class BridgeConstants {
     public Coin getMaxRbtc() { return Coin.valueOf(21_000_000, 0); }
 
     public long getMinSecondsBetweenCallsToReceiveHeader() { return minSecondsBetweenCallsReceiveHeader; }
+
+    public int getMaxDepthBlockchainAccepted() { return maxDepthBlockchainAccepted; }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -130,5 +130,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
         lockingCapIncrementsMultiplier = 2;
 
         minSecondsBetweenCallsReceiveHeader = 600;  // 10 minutes in Seconds
+        maxDepthBlockchainAccepted = 4000;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -128,6 +128,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
         initialLockingCap = Coin.COIN.multiply(300); // 300 BTC
 
         minSecondsBetweenCallsReceiveHeader = 600;  // 10 minutes in Seconds
+        maxDepthBlockchainAccepted = 4000;
     }
 
     public static BridgeMainNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -123,6 +123,8 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         minSecondsBetweenCallsReceiveHeader = 600;  // 10 minutes in Seconds
 
+        maxDepthBlockchainAccepted = 4000;
+
         // Key generated with GenNodeKey using generator 'auth-increase_locking_cap'
         List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
                 "04450bbaab83ec48b3cb8fbb077c950ee079733041c039a8c4f1539e5181ca1a27589eeaf0fbf430e49d2909f14c767bf6909ad6845831f683416ee12b832e36ed"

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -128,6 +128,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
         initialLockingCap = Coin.COIN.multiply(200); // 200 BTC
 
         minSecondsBetweenCallsReceiveHeader = 600;  // 10 minutes in Seconds
+        maxDepthBlockchainAccepted = 4000;
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -96,6 +96,8 @@ public class BridgeSupport {
     public static final Integer BTC_TRANSACTION_CONFIRMATION_INVALID_MERKLE_BRANCH_ERROR_CODE = -5;
 
     public static final Integer RECEIVE_HEADER_CALLED_TOO_SOON = -1;
+    public static final Integer RECEIVE_HEADER_BLOCK_TOO_OLD = -2;
+    public static final Integer RECEIVE_HEADER_CANT_FOUND_PREVIOUS_BLOCK = -3;
     public static final Integer RECEIVE_HEADER_UNEXPECTED_EXCEPTION = -99;
 
     // Enough depth to be able to search backwards one month worth of blocks
@@ -212,6 +214,8 @@ public class BridgeSupport {
      * @param header The bitcoin headers
      */
     public Integer receiveHeader(BtcBlock header) throws IOException, BlockStoreException {
+        Context.propagate(btcContext);
+        this.ensureBtcBlockChain();
 
         long diffTimeStamp = bridgeConstants.getMinSecondsBetweenCallsToReceiveHeader();
 
@@ -222,8 +226,17 @@ public class BridgeSupport {
             return RECEIVE_HEADER_CALLED_TOO_SOON;
         }
 
-        Context.propagate(btcContext);
-        this.ensureBtcBlockChain();
+        //Depth
+        StoredBlock previousBlock = btcBlockStore.get(header.getPrevBlockHash());
+        if (previousBlock == null) {
+            return RECEIVE_HEADER_CANT_FOUND_PREVIOUS_BLOCK;
+        }
+
+        // height of best chain - height of current header block greater than maximum depth accepted
+        if ((getBtcBlockchainBestChainHeight() - (previousBlock.getHeight() + 1)) > bridgeConstants.getMaxDepthBlockchainAccepted()) {
+            return RECEIVE_HEADER_BLOCK_TOO_OLD;
+        }
+
         try {
             btcBlockChain.add(header);
         } catch (Exception e) {


### PR DESCRIPTION
Check the depth of the block, taking into account the depth in the storage of the previous block.
If the depth of the block is too old, then it returns error. If it can't find the previous block in storage, then it also returns error.
The new errors that are introduced here are:

-2 -> RECEIVE_HEADER_BLOCK_TOO_OLD
-3 -> RECEIVE_HEADER_CANT_FOUND_PREVIUOS_BLOCK


