### PR TITLE
Fixing javadoc tags

### DIFF
--- a/rskj-core/src/main/java/co/rsk/scoring/InetAddressUtils.java
+++ b/rskj-core/src/main/java/co/rsk/scoring/InetAddressUtils.java
@@ -37,7 +37,7 @@ public final class InetAddressUtils {
      * Convert a text representation to an InetAddress
      * It supports IPV4 and IPV6 formats
      *
-     * @param   name    the address
+     * @param   hostname    the address
      *
      * @return  the text converted to an InetAddress
      */

--- a/rskj-core/src/main/java/org/ethereum/crypto/signature/Secp256k1.java
+++ b/rskj-core/src/main/java/org/ethereum/crypto/signature/Secp256k1.java
@@ -50,7 +50,7 @@ public final class Secp256k1 {
      *
      * <p> By default it initialize Bouncy Castle impl.</p>
      *
-     * @param {@link Nullable} rskSystemProperties = Could be null in tests.
+     * @param rskSystemProperties {@link Nullable} = Could be null in tests.
      */
     public static synchronized void initialize(@Nullable RskSystemProperties rskSystemProperties) {
         // Just a warning for duplicate initialization.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updating wrong Javadoc tags

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in LGTM [documentation](https://lgtm.com/rules/2049510531/): "The Javadoc comment for a method or constructor should always use non-empty @param values that match actual parameter or type parameter names."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Changes does not require tests since code was not changed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
