### PR TITLE
JVM version preflight check

### DIFF
--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -17,6 +17,7 @@
  */
 package co.rsk;
 
+import co.rsk.util.PreflightChecksUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,8 +30,10 @@ public class Start {
     public static void main(String[] args) {
         Thread.currentThread().setName("main");
         RskContext ctx = new RskContext(args);
+        PreflightChecksUtils preflightChecks = new PreflightChecksUtils(ctx);
         NodeRunner runner = ctx.getNodeRunner();
         try {
+            preflightChecks.runChecks();
             runner.run();
             Runtime.getRuntime().addShutdownHook(new Thread(runner::stop, "stopper"));
         } catch (Exception e) {

--- a/rskj-core/src/main/java/co/rsk/config/NodeCliFlags.java
+++ b/rskj-core/src/main/java/co/rsk/config/NodeCliFlags.java
@@ -31,6 +31,7 @@ public enum NodeCliFlags implements CliArg {
     DB_IMPORT("import", SystemProperties.PROPERTY_DB_IMPORT, true),
     VERIFY_CONFIG("verify-config", SystemProperties.PROPERTY_BC_VERIFY, true),
     PRINT_SYSTEM_INFO("print-system-info", SystemProperties.PROPERTY_PRINT_SYSTEM_INFO, true),
+    SKIP_JAVA_CHECK("skip-java-check", SystemProperties.PROPERTY_SKIP_JAVA_VERSION_CHECK, false),
     NETWORK_TESTNET("testnet", SystemProperties.PROPERTY_BC_CONFIG_NAME, "testnet"),
     NETWORK_REGTEST("regtest", SystemProperties.PROPERTY_BC_CONFIG_NAME, "regtest"),
     NETWORK_DEVNET("devnet", SystemProperties.PROPERTY_BC_CONFIG_NAME, "devnet"),

--- a/rskj-core/src/main/java/co/rsk/util/PreflightCheckException.java
+++ b/rskj-core/src/main/java/co/rsk/util/PreflightCheckException.java
@@ -1,0 +1,11 @@
+package co.rsk.util;
+
+/**
+ * Created by Nazaret García on 25/01/2021
+ */
+
+public class PreflightCheckException extends Exception {
+    public PreflightCheckException(String message) {
+        super(message);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/util/PreflightChecksUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/PreflightChecksUtils.java
@@ -1,0 +1,91 @@
+package co.rsk.util;
+
+import co.rsk.RskContext;
+import co.rsk.config.NodeCliFlags;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * Created by Nazaret García on 21/01/2021
+ *
+ * This class exposes a method to run a variety of checks.
+ * If any given check fails, then a PreflightCheckException exception is thrown.
+ *
+ * Flags, as command-line arguments, can be used to skip or configure any available check.
+ *
+ * Current Supported Checks:
+ *
+ * - Supported Java Version Check: (can be skipped by setting the --skip-java-check flag)
+ */
+
+public class PreflightChecksUtils {
+    private static final Logger logger = LoggerFactory.getLogger(PreflightChecksUtils.class);
+
+    private static final int[] SUPPORTED_JAVA_VERSIONS = {8, 11};
+
+    private final RskContext rskContext;
+
+    public PreflightChecksUtils(RskContext rskContext) {
+        this.rskContext = rskContext;
+    }
+
+    /**
+     * Checks if current Java Version is supported
+     * @throws PreflightCheckException if current Java Version is not supported
+     */
+    @VisibleForTesting
+    void checkSupportedJavaVersion() throws PreflightCheckException {
+        String javaVersion = getJavaVersion();
+
+        int intJavaVersion = getIntJavaVersion(javaVersion);
+
+        if (Arrays.stream(SUPPORTED_JAVA_VERSIONS).noneMatch(v -> intJavaVersion == v)) {
+            String errorMessage = String.format("Invalid Java Version '%s'. Supported versions: %s", intJavaVersion, StringUtils.join(SUPPORTED_JAVA_VERSIONS, ' '));
+            logger.error(errorMessage);
+            throw new PreflightCheckException(errorMessage);
+        }
+    }
+
+    @VisibleForTesting
+    String getJavaVersion() {
+        return System.getProperty("java.version");
+    }
+
+    /**
+     * Returns the Java version as an int value.
+     * Formats allowed: 1.8.0_72-ea, 9-ea, 9, 9.0.1, 11, 11.0, etc.
+     * Based on @link https://stackoverflow.com/a/49512420
+     * @param version The java version as String
+     * @return the Java version as an int value (8, 9, etc.)
+     */
+    @VisibleForTesting
+    int getIntJavaVersion(String version) {
+        if (version.startsWith("1.")) {
+            version = version.substring(2);
+        }
+
+        int dotPos = version.indexOf('.');
+        int dashPos = version.indexOf('-');
+
+        int endIndex;
+
+        if (dotPos > -1) {
+            endIndex = dotPos;
+        } else {
+            endIndex = dashPos > -1 ? dashPos : version.length();
+        }
+
+        return Integer.parseInt(version.substring(0, endIndex));
+    }
+
+    public void runChecks() throws PreflightCheckException {
+        if (!rskContext.getCliArgs().getFlags().contains(NodeCliFlags.SKIP_JAVA_CHECK)) {
+            checkSupportedJavaVersion();
+        }
+    }
+
+}

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -88,6 +88,8 @@ public abstract class SystemProperties {
 
     public static final String PROPERTY_PRINT_SYSTEM_INFO = "system.printInfo";
 
+    public static final String PROPERTY_SKIP_JAVA_VERSION_CHECK = "system.checkJavaVersion";
+
     /* Testing */
     private static final Boolean DEFAULT_VMTEST_LOAD_LOCAL = false;
 
@@ -550,6 +552,10 @@ public abstract class SystemProperties {
 
     public boolean shouldPrintSystemInfo() {
         return getBoolean(PROPERTY_PRINT_SYSTEM_INFO, false);
+    }
+
+    public boolean shouldSkipJavaVersionCheck() {
+        return getBoolean(PROPERTY_SKIP_JAVA_VERSION_CHECK, false);
     }
 
     protected int getInt(String path, int val) {

--- a/rskj-core/src/test/java/co/rsk/util/PreflightChecksUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/PreflightChecksUtilsTest.java
@@ -1,0 +1,103 @@
+package co.rsk.util;
+
+import co.rsk.RskContext;
+import org.ethereum.util.RskTestContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by Nazaret García on 22/01/2021
+ */
+
+public class PreflightChecksUtilsTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void runChecks_receivesSkipJavaCheck_skipsJavaChecks() throws Exception {
+        String[] args = {"--skip-java-check"};
+
+        RskContext rskContext = new RskTestContext(args);
+        PreflightChecksUtils preflightChecksUtilsSpy = spy(new PreflightChecksUtils(rskContext));
+
+        when(preflightChecksUtilsSpy.getJavaVersion()).thenReturn(null);
+
+        preflightChecksUtilsSpy.runChecks();
+
+        verify(preflightChecksUtilsSpy, times(0)).getJavaVersion();
+    }
+
+    @Test
+    public void getIntJavaVersion_OK() {
+        RskContext rskContext = new RskContext(new String[0]);
+        PreflightChecksUtils preflightChecksUtils = new PreflightChecksUtils(rskContext);
+
+        assertEquals(preflightChecksUtils.getIntJavaVersion("1.8.0_275"), 8);
+        assertEquals(preflightChecksUtils.getIntJavaVersion("1.8.0_72-ea"), 8);
+        assertEquals(preflightChecksUtils.getIntJavaVersion("11.8.0_71-ea"), 11);
+        assertEquals(preflightChecksUtils.getIntJavaVersion("11.0"), 11);
+        assertEquals(preflightChecksUtils.getIntJavaVersion("9"), 9);
+        assertEquals(preflightChecksUtils.getIntJavaVersion("11"), 11);
+        assertEquals(preflightChecksUtils.getIntJavaVersion("333"), 333);
+        assertEquals(preflightChecksUtils.getIntJavaVersion("9-ea"), 9);
+    }
+
+    @Test
+    public void runChecks_invalidJavaVersion_exceptionIsThrown() throws Exception {
+        expectedException.expect(PreflightCheckException.class);
+        expectedException.expectMessage("Invalid Java Version '16'. Supported versions: 8 11");
+
+        RskContext rskContext = new RskTestContext(new String[0]);
+        PreflightChecksUtils preflightChecksUtilsSpy = spy(new PreflightChecksUtils(rskContext));
+
+        when(preflightChecksUtilsSpy.getJavaVersion()).thenReturn("16");
+
+        preflightChecksUtilsSpy.runChecks();
+    }
+
+    @Test
+    public void runChecks_currentJavaVersionIs1dot8_OK() throws Exception {
+        RskContext rskContext = new RskTestContext(new String[0]);
+        PreflightChecksUtils preflightChecksUtilsSpy = spy(new PreflightChecksUtils(rskContext));
+
+        when(preflightChecksUtilsSpy.getJavaVersion()).thenReturn("1.8");
+
+        preflightChecksUtilsSpy.runChecks();
+
+        verify(preflightChecksUtilsSpy, times(1)).getJavaVersion();
+        verify(preflightChecksUtilsSpy, times(1)).getIntJavaVersion("1.8");
+    }
+
+    @Test
+    public void runChecks_currentJavaVersionIs11_OK() throws Exception {
+        RskContext rskContext = new RskTestContext(new String[0]);
+        PreflightChecksUtils preflightChecksUtilsSpy = spy(new PreflightChecksUtils(rskContext));
+
+        when(preflightChecksUtilsSpy.getJavaVersion()).thenReturn("11");
+
+        preflightChecksUtilsSpy.runChecks();
+
+        verify(preflightChecksUtilsSpy, times(1)).getJavaVersion();
+        verify(preflightChecksUtilsSpy, times(1)).getIntJavaVersion("11");
+    }
+
+    @Test
+    public void runChecks_runAllChecks_OK() throws Exception {
+        RskContext rskContext = new RskTestContext(new String[0]);
+        PreflightChecksUtils preflightChecksUtilsSpy = spy(new PreflightChecksUtils(rskContext));
+
+        when(preflightChecksUtilsSpy.getJavaVersion()).thenReturn("1.8.0_275");
+
+        preflightChecksUtilsSpy.runChecks();
+
+        verify(preflightChecksUtilsSpy, times(1)).getJavaVersion();
+        verify(preflightChecksUtilsSpy, times(1)).getIntJavaVersion("1.8.0_275");
+        verify(preflightChecksUtilsSpy, times(1)).checkSupportedJavaVersion();
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Added preflight checks to stop node from running when Java Version is not supported.

Java version check can be avoided if the `--skip-java-check` flag is set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some people use jre16 or alike for running rskj node. We only support LTS versions 8 and 11, so we should restrict in the code versions of java we support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Using Unit Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
