### PR TITLE
Fixing potential resource leak

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1735,8 +1735,14 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             String fullFilename = filePath.toString();
             MessageFilter filter = new MessageFilter(rskSystemProperties.getMessageRecorderCommands());
 
-            try (FileOutputStream fos = new FileOutputStream(fullFilename); OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
-                writerMessageRecorder = new WriterMessageRecorder(new BufferedWriter(osw), filter);
+            try {
+                // This resource needs to remain open when method returns, so LGTM warning is disabled.
+                writerMessageRecorder = new WriterMessageRecorder(
+                        new BufferedWriter(
+                                new OutputStreamWriter(new FileOutputStream(fullFilename), StandardCharsets.UTF_8) // lgtm [java/output-resource-leak]
+                        ),
+                        filter
+                );
             } catch (IOException ex) {
                 throw new IllegalArgumentException("Can't use this path to record messages", ex);
             }

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1735,13 +1735,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             String fullFilename = filePath.toString();
             MessageFilter filter = new MessageFilter(rskSystemProperties.getMessageRecorderCommands());
 
-            try {
-                writerMessageRecorder = new WriterMessageRecorder(
-                        new BufferedWriter(
-                                new OutputStreamWriter(new FileOutputStream(fullFilename), StandardCharsets.UTF_8)
-                        ),
-                        filter
-                );
+            try (FileOutputStream fos = new FileOutputStream(fullFilename); OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
+                writerMessageRecorder = new WriterMessageRecorder(new BufferedWriter(osw), filter);
             } catch (IOException ex) {
                 throw new IllegalArgumentException("Can't use this path to record messages", ex);
             }

--- a/rskj-core/src/main/java/org/ethereum/net/rlpx/FrameCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/net/rlpx/FrameCodec.java
@@ -107,7 +107,9 @@ public class FrameCodec {
     }
 
     public void writeFrame(Frame frame, ByteBuf buf) throws IOException {
-        writeFrame(frame, new ByteBufOutputStream(buf));
+        try (ByteBufOutputStream bos = new ByteBufOutputStream(buf)) {
+            writeFrame(frame, bos);
+        }
     }
 
     public void writeFrame(Frame frame, OutputStream out) throws IOException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

**Try** blocks were replaced by **Try With Resources** blocks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in LGTM [documentation](https://lgtm.com/rules/2980072/): "Ensure that the resource is always closed to avoid a resource leak. Note that, because of exceptions, it is safest to close a resource properly in a finally block. (However, this is unnecessary for subclasses of StringWriter and ByteArrayOutputStream.) For Java 7 or later, the recommended way to close resources that implement java.lang.AutoCloseable is to declare them within a try-with-resources statement, so that they are closed implicitly." 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Using Unit Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
