### PR TITLE
Fixing multiplication cast to wider type

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -277,7 +277,7 @@ public class NodeBlockProcessor implements BlockProcessor {
         List<BlockIdentifier> blockIdentifiers = new ArrayList<>();
         long skeletonNumber = skeletonStartHeight;
         int maxSkeletonChunks = syncConfiguration.getMaxSkeletonChunks();
-        long maxSkeletonNumber = Math.min(this.getBestBlockNumber(), skeletonStartHeight + skeletonStep * maxSkeletonChunks);
+        long maxSkeletonNumber = Math.min(this.getBestBlockNumber(), skeletonStartHeight + skeletonStep * (long) maxSkeletonChunks);
 
         for (; skeletonNumber < maxSkeletonNumber; skeletonNumber += skeletonStep) {
             byte[] skeletonHash = getSkeletonHash(skeletonNumber);

--- a/rskj-core/src/main/java/co/rsk/pcc/NativeMethod.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/NativeMethod.java
@@ -77,7 +77,7 @@ public abstract class NativeMethod {
         // the default can always be used on top.
         // (e.g., "return 23000L + super(parsedArguments, originalData);")
 
-        return originalData == null ? 0 : originalData.length * 2;
+        return originalData == null ? 0 : originalData.length * 2L;
     }
 
     public abstract boolean isEnabled();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updating multiplications to avoid casting the result to a wider type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in LGTM [documentation](https://lgtm.com/rules/7900075/): "An integer multiplication that is assigned to a variable of type long or returned from a method with return type long may cause unexpected arithmetic overflow."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Using Unit Test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
