### PR TITLE
Removing root field from TransactionReceiptDTO

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -24,7 +24,6 @@ import org.ethereum.core.Block;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.rpc.LogFilterElement;
-import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.LogInfo;
 
 import static org.ethereum.rpc.TypeConverter.*;
@@ -46,7 +45,6 @@ public class TransactionReceiptDTO {
     private LogFilterElement[] logs;     // Array of log objects, which this transaction generated.
     private String from;                 // address of the sender.
     private String to;                   // address of the receiver. null when it's a contract creation transaction.
-    private String root;                 // post-transaction stateroot
     private String status;               // either 1 (success) or 0 (failure)
     private String logsBloom;            // Bloom filter for light clients to quickly retrieve related logs.
 
@@ -73,7 +71,6 @@ public class TransactionReceiptDTO {
                     txInfo.getReceipt().getTransaction(), i);
         }
 
-        root = toUnformattedJsonHex(ByteUtil.toBytesWithLeadingZeros(receipt.getPostTxState(), ROOT_HASH_LEN));
         to = receipt.getTransaction().getReceiveAddress().toJsonString();
         transactionHash = receipt.getTransaction().getHash().toJsonString();
         transactionIndex = toQuantityJsonHex(txInfo.getIndex());
@@ -118,10 +115,6 @@ public class TransactionReceiptDTO {
 
     public String getTo() {
         return to;
-    }
-
-    public String getRoot() {
-        return root;
     }
 
     public String getStatus() {

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -19,7 +19,6 @@
 package org.ethereum.rpc.dto;
 
 import co.rsk.core.RskAddress;
-import co.rsk.crypto.Keccak256;
 import org.ethereum.core.Block;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.db.TransactionInfo;

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -32,9 +32,6 @@ import static org.ethereum.rpc.TypeConverter.*;
  * Created by Ruben on 5/1/2016.
  */
 public class TransactionReceiptDTO {
-
-    private static final int ROOT_HASH_LEN = Keccak256.HASH_LEN;
-
     private String transactionHash;      // hash of the transaction.
     private String transactionIndex;     // integer of the transactions index position in the block.
     private String blockHash;            // hash of the block where this transaction was in.

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionReceiptDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionReceiptDTOTest.java
@@ -39,10 +39,7 @@ import static org.mockito.Mockito.when;
 public class TransactionReceiptDTOTest {
 
     @Test
-    public void testRootField() {
-        byte[] postTxState = new byte[]{0x01};
-        String expectedRoot = toUnformattedJsonHex(ByteUtil.toBytesWithLeadingZeros(postTxState, Keccak256.HASH_LEN));
-
+    public void testOkStatusField() {
         RskAddress rskAddress = RskAddress.nullAddress();
         Keccak256 hash = Keccak256.ZERO_HASH;
         Bloom bloom = new Bloom();
@@ -59,15 +56,105 @@ public class TransactionReceiptDTOTest {
         when(txReceipt.getTransaction()).thenReturn(transaction);
         when(txReceipt.getLogInfoList()).thenReturn(Collections.emptyList());
         when(txReceipt.getBloomFilter()).thenReturn(bloom);
-        when(txReceipt.getPostTxState()).thenReturn(postTxState);
+        when(txReceipt.getStatus()).thenReturn(new byte[] { 0x01 });
 
         TransactionInfo txInfo = new TransactionInfo(txReceipt, hash.getBytes(), 0);
 
         TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo);
 
-        String actualRoot = transactionReceiptDTO.getRoot();
+        String actualStatus = transactionReceiptDTO.getStatus();
 
-        assertNotNull(actualRoot);
-        assertEquals(expectedRoot, actualRoot);
+        assertNotNull(actualStatus);
+        assertEquals("0x1", actualStatus);
+    }
+
+    @Test
+    public void testErrorStatusField() {
+        RskAddress rskAddress = RskAddress.nullAddress();
+        Keccak256 hash = Keccak256.ZERO_HASH;
+        Bloom bloom = new Bloom();
+
+        Block block = mock(Block.class);
+        when(block.getHash()).thenReturn(hash);
+
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getHash()).thenReturn(hash);
+        when(transaction.getSender()).thenReturn(rskAddress);
+        when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+
+        TransactionReceipt txReceipt = mock(TransactionReceipt.class);
+        when(txReceipt.getTransaction()).thenReturn(transaction);
+        when(txReceipt.getLogInfoList()).thenReturn(Collections.emptyList());
+        when(txReceipt.getBloomFilter()).thenReturn(bloom);
+        when(txReceipt.getStatus()).thenReturn(new byte[] { 0x00 });
+
+        TransactionInfo txInfo = new TransactionInfo(txReceipt, hash.getBytes(), 0);
+
+        TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo);
+
+        String actualStatus = transactionReceiptDTO.getStatus();
+
+        assertNotNull(actualStatus);
+        assertEquals("0x0", actualStatus);
+    }
+
+    @Test
+    public void testErrorStatusFieldUsingEmptyByteArray() {
+        RskAddress rskAddress = RskAddress.nullAddress();
+        Keccak256 hash = Keccak256.ZERO_HASH;
+        Bloom bloom = new Bloom();
+
+        Block block = mock(Block.class);
+        when(block.getHash()).thenReturn(hash);
+
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getHash()).thenReturn(hash);
+        when(transaction.getSender()).thenReturn(rskAddress);
+        when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+
+        TransactionReceipt txReceipt = mock(TransactionReceipt.class);
+        when(txReceipt.getTransaction()).thenReturn(transaction);
+        when(txReceipt.getLogInfoList()).thenReturn(Collections.emptyList());
+        when(txReceipt.getBloomFilter()).thenReturn(bloom);
+        when(txReceipt.getStatus()).thenReturn(ByteUtil.EMPTY_BYTE_ARRAY);
+
+        TransactionInfo txInfo = new TransactionInfo(txReceipt, hash.getBytes(), 0);
+
+        TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo);
+
+        String actualStatus = transactionReceiptDTO.getStatus();
+
+        assertNotNull(actualStatus);
+        assertEquals("0x0", actualStatus);
+    }
+
+    @Test
+    public void testErrorStatusFieldUsingNullByteArray() {
+        RskAddress rskAddress = RskAddress.nullAddress();
+        Keccak256 hash = Keccak256.ZERO_HASH;
+        Bloom bloom = new Bloom();
+
+        Block block = mock(Block.class);
+        when(block.getHash()).thenReturn(hash);
+
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getHash()).thenReturn(hash);
+        when(transaction.getSender()).thenReturn(rskAddress);
+        when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+
+        TransactionReceipt txReceipt = mock(TransactionReceipt.class);
+        when(txReceipt.getTransaction()).thenReturn(transaction);
+        when(txReceipt.getLogInfoList()).thenReturn(Collections.emptyList());
+        when(txReceipt.getBloomFilter()).thenReturn(bloom);
+        when(txReceipt.getStatus()).thenReturn(null);
+
+        TransactionInfo txInfo = new TransactionInfo(txReceipt, hash.getBytes(), 0);
+
+        TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo);
+
+        String actualStatus = transactionReceiptDTO.getStatus();
+
+        assertNotNull(actualStatus);
+        assertEquals("0x0", actualStatus);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the `root` field from Transaction Receipt DTO (Data Transfer Object) used in JSON RPC serialization

## Motivation and Context
It should solve #1328 

The `root` field was never used in current RSK testnet and mainnet, so we don't need to implement it as a hard fork.

## How Has This Been Tested?
Some test code was added, testing the result of other field, `status`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
I recommend intergration tests for this feature