### PR TITLE
Missing dependency at jar task

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -153,6 +153,7 @@ task javadocJar(type: Jar) {
 }
 
 jar {
+    dependsOn 'generateResources'
     def commitHash = gitCommitHash()
     def currentBranch = gitCurrentBranch()
     manifest {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Missing dependency at `jar` task

## Description
<!--- Describe your changes in detail -->
Now `jar` task dependsOn `generateResources`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR aims to fix this [described issue](https://github.com/rsksmart/rskj/issues/1456) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Builded the project without this dependecy and then sent a JSON RPC request => PAPYRUS-dev
- Builded the project with this dependecy and then sent a JSON RPC request => PAPYRUS-someHash
- Run the entire test suite. 
- An integration test is needed to test it properly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
