### PR TITLE
Send Transaction and Send Raw Transaction returns an error message when automine is enabled

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1486,7 +1486,8 @@ public class RskContext implements NodeBootstrapper {
                         getMinerServer(),
                         getMinerClient(),
                         getBlockchain(),
-                        getTransactionGateway()
+                        getTransactionGateway(),
+                        getBlockExecutor()
                 );
             } else {
                 ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, getTransactionGateway());

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -62,6 +62,7 @@ public class BlockExecutor {
     private final ActivationConfig activationConfig;
 
     private Map<Keccak256, ProgramResult> transactionResults;
+    private boolean registerProgramResults;
 
     public BlockExecutor(
             ActivationConfig activationConfig,
@@ -281,8 +282,6 @@ public class BlockExecutor {
 
         int txindex = 0;
 
-        this.transactionResults = new HashMap<>();
-
         for (Transaction tx : block.getTransactionsList()) {
             logger.trace("apply block: [{}] tx: [{}] ", block.getNumber(), i);
 
@@ -311,7 +310,10 @@ public class BlockExecutor {
             }
 
             executedTransactions.add(tx);
-            this.transactionResults.put(tx.getHash(), txExecutor.getResult());
+
+            if (this.registerProgramResults) {
+                this.transactionResults.put(tx.getHash(), txExecutor.getResult());
+            }
 
             if (vmTrace) {
                 txExecutor.extractTrace(programTraceProcessor);
@@ -411,5 +413,10 @@ public class BlockExecutor {
 
     public ProgramResult getProgramResult(Keccak256 txhash) {
         return this.transactionResults.get(txhash);
+    }
+
+    public void setRegisterProgramResults(boolean value) {
+        this.registerProgramResults = value;
+        this.transactionResults = new HashMap<>();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -61,7 +61,7 @@ public class BlockExecutor {
     private final StateRootHandler stateRootHandler;
     private final ActivationConfig activationConfig;
 
-    private Map<Keccak256, ProgramResult> transactionResults;
+    private final Map<Keccak256, ProgramResult> transactionResults = new HashMap<>();
     private boolean registerProgramResults;
 
     public BlockExecutor(
@@ -417,6 +417,6 @@ public class BlockExecutor {
 
     public void setRegisterProgramResults(boolean value) {
         this.registerProgramResults = value;
-        this.transactionResults = new HashMap<>();
+        this.transactionResults.clear();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -245,7 +245,7 @@ public class EthModule
      * @param res
      * @return revert reason, empty if didnt match.
      */
-    private Optional<String> decodeRevertReason(ProgramResult res) {
+    public static Optional<String> decodeRevertReason(ProgramResult res) {
         byte[] bytes = res.getHReturn();
         if (bytes == null || bytes.length < 4) {
             return Optional.empty();

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
@@ -23,7 +23,7 @@ public class RskJsonRpcRequestException extends RuntimeException {
     }
 
     public static RskJsonRpcRequestException transactionRevertedExecutionError(String revertReason) {
-        return executionError(revertReason);
+        return executionError("revert " + revertReason);
     }
 
     public static RskJsonRpcRequestException unknownError(String message) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
@@ -31,7 +31,7 @@ public class RskJsonRpcRequestException extends RuntimeException {
     }
 
     private static RskJsonRpcRequestException executionError(String message) {
-        return new RskJsonRpcRequestException(-32015, String.format("VM execution error: %s", message));
+        return new RskJsonRpcRequestException(-32015, String.format("VM Exception while processing transaction: %s", message));
     }
 
     public static RskJsonRpcRequestException transactionError(String message) {

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -113,6 +113,8 @@ public class BlockExecutorTest {
         Assert.assertFalse(result.getTransactionReceipts().isEmpty());
         Assert.assertEquals(1, result.getTransactionReceipts().size());
 
+        Assert.assertNotNull(executor.getProgramResult(tx.getHash()));
+
         TransactionReceipt receipt = result.getTransactionReceipts().get(0);
         Assert.assertEquals(tx, receipt.getTransaction());
         Assert.assertEquals(21000, new BigInteger(1, receipt.getGasUsed()).longValue());

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -48,7 +48,6 @@ import org.ethereum.net.message.Message;
 import org.ethereum.net.p2p.HelloMessage;
 import org.ethereum.net.rlpx.Node;
 import org.ethereum.net.server.Channel;
-import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RskTestFactory;
 import org.ethereum.vm.PrecompiledContracts;

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -332,6 +332,13 @@ public class TransactionModuleTest {
         MinerClock minerClock = new MinerClock(true, Clock.systemUTC());
         transactionExecutorFactory = buildTransactionExecutorFactory(blockStore, receiptStore, signatureCache);
         MiningConfig miningConfig = ConfigUtils.getDefaultMiningConfig();
+        BlockExecutor blockExecutor = new BlockExecutor(
+                config.getActivationConfig(),
+                repositoryLocator,
+                stateRootHandler,
+                transactionExecutorFactory
+        );
+
         MinerServer minerServer = new MinerServerImpl(
                 config,
                 eth,
@@ -350,12 +357,7 @@ public class TransactionModuleTest {
                         Mockito.mock(BlockUnclesValidationRule.class),
                         minerClock,
                         blockFactory,
-                        new BlockExecutor(
-                                config.getActivationConfig(),
-                                repositoryLocator,
-                                stateRootHandler,
-                                transactionExecutorFactory
-                        ),
+                        blockExecutor,
                         new MinimumGasPriceCalculator(Coin.valueOf(miningConfig.getMinGasPriceTarget())),
                         new MinerUtils()
                 ),
@@ -376,7 +378,7 @@ public class TransactionModuleTest {
         );
 
         if (mineInstant) {
-            transactionModule = new EthModuleTransactionInstant(config.getNetworkConstants(), wallet, transactionPool, minerServer, minerClient, blockchain, transactionGateway);
+            transactionModule = new EthModuleTransactionInstant(config.getNetworkConstants(), wallet, transactionPool, minerServer, minerClient, blockchain, transactionGateway, blockExecutor);
         } else {
             transactionModule = new EthModuleTransactionBase(config.getNetworkConstants(), wallet, transactionPool, transactionGateway);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Descriptio
When a transaction is mined immediately (when the automine is enabled, ie using `-Dminer.client.autoMine=true`, if an error occurs (ie out of gas, revert) a message describing the problem is returned

## Motivation and Context
Some node implementation used for testing (like ganache and hardhat) have a node that executes immediately a transaction (like our autominer) but also they return a message in case an error occurs. If the error was raised by a unsatisfied require (in Solidity) with an associated description message, that message is included in the returned JSON object.

## How Has This Been Tested?
It was tested manually, maybe a better code test could be implemented

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The message added to `eth_sendTransaction` and `eth_sendRawTransaction` was taken from `eth_call` implementation. But it should be changed for compatibility with the ecosystem. Then, the returned message by `eth_call` was changed, too. In this case, the change was only the prefix of the message: the rest of the description is the same as before. But we should check if that change breaks something with our integration tests using tools like Truffle or OpenZeppelin tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

We should research why the previous prefix in `eth_call` returned message was chosen.