### PR TITLE
getStorageAt from empty cell now returns 0x0 instead of null

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -402,6 +402,7 @@ public class Web3Impl implements Web3 {
 
         try {
             RskAddress addr = new RskAddress(address);
+            
             AccountInformationProvider accountInformationProvider =
                     web3InformationRetriever.getInformationProvider(blockId);
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -409,7 +409,7 @@ public class Web3Impl implements Web3 {
                     .getStorageValue(addr, DataWord.valueOf(stringHexToByteArray(storageIdx)));
 
             if (sv == null) {
-                s = null;
+                s = "0x0";
             } else {
                 s = toUnformattedJsonHex(sv.getData());
             }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -143,6 +143,25 @@ public class Web3ImplUnitTest {
                 result);
     }
 
+
+    @Test
+    public void eth_getStorageAtEmptyCell() {
+        String id = "id";
+        String addr = "0x0011223344556677880011223344556677889900";
+        RskAddress expectedAddress = new RskAddress(addr);
+        String storageIdx = "0x01";
+        DataWord expectedIdx = DataWord.valueOf(stringHexToByteArray(storageIdx));
+
+        AccountInformationProvider aip = mock(AccountInformationProvider.class);
+        when(retriever.getInformationProvider(eq(id))).thenReturn(aip);
+        when(aip.getStorageValue(eq(expectedAddress), eq(expectedIdx)))
+                .thenReturn(null);
+
+        String result = target.eth_getStorageAt(addr, storageIdx, id);
+        assertEquals("0x0",
+                result);
+    }
+
     @Test
     public void eth_getBlockTransactionCountByNumber_blockNotFound() {
         String id = "id";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
JSON RPC method `eth_getStorageAt` now returns `0x0` instead of null if the storage cell to be retrieved is empty (the default value is then zero)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Returning null riases some issues with the ecosystem, ie `geth` console and other integration tools

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Adding code tests, and manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

Please, we need more info about other `getStorageAt` compatibility. For example, our implementation returns `0x0000000000000000000000000000000000000000000000000000000000000001` when the storage cell contains the value ONE, but `ganache` returns `0x01`. Is it an issue? Which is the value returned by `geth` and other implementations? Maybe they expect `0x1` as in other cases (with leading zeroes removed)