### PR TITLE
Return Transaction Nonce as Quantity Value in JSON RPC methods

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -24,9 +24,6 @@ import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.rpc.TypeConverter;
-import org.ethereum.util.ByteUtil;
-
-import java.util.Arrays;
 
 /**
  * Created by Ruben on 8/1/2016.

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -53,11 +53,7 @@ public class TransactionResultDTO {
     public TransactionResultDTO(Block b, Integer index, Transaction tx) {
         hash = tx.getHash().toJsonString();
 
-        if (Arrays.equals(tx.getNonce(), ByteUtil.EMPTY_BYTE_ARRAY)) {
-            nonce = "0";
-        } else {
-            nonce = TypeConverter.toJsonHex(tx.getNonce());
-        }
+        nonce = TypeConverter.toQuantityJsonHex(tx.getNonce());
 
         blockHash = b != null ? b.getHashJsonString() : null;
         blockNumber = b != null ? TypeConverter.toQuantityJsonHex(b.getNumber()) : null;

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -461,7 +461,7 @@ public class Web3ImplTest {
         assertNotNull(tr);
 
         assertEquals("0x" + hashString, tr.hash);
-        assertEquals("0", tr.nonce);
+        assertEquals("0x0", tr.nonce);
         assertEquals(null, tr.blockHash);
         assertEquals(null, tr.transactionIndex);
         assertEquals("0x", tr.input);

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/TypeConverterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/TypeConverterTest.java
@@ -91,7 +91,13 @@ public class TypeConverterTest {
         byte[] toEncode = new byte[]{0x00, 0x00};
         Assert.assertEquals("0x0", TypeConverter.toQuantityJsonHex(toEncode));
     }
-    
+
+    @Test
+    public void toQuantityJsonHex_EmptyByteArray() {
+        byte[] toEncode = new byte[0];
+        Assert.assertEquals("0x0", TypeConverter.toQuantityJsonHex(toEncode));
+    }
+
     @Test
     public void toJsonHexCoin() {
         Assert.assertEquals("1234", TypeConverter.toJsonHex(new Coin(new BigInteger("1234"))));

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
@@ -68,5 +68,35 @@ public class TransactionResultDTOTest {
 
         Assert.assertEquals(expectedV, dto.v);
     }
+
+    @Test
+    public void transactionWithZeroNonce() {
+        Transaction originalTransaction = CallTransaction.createCallTransaction(
+                0, 0, 100000000000000L,
+                new RskAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), 0,
+                CallTransaction.Function.fromSignature("get"), chainId);
+
+        originalTransaction.sign(new byte[]{});
+
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction);
+
+        Assert.assertNotNull(dto.nonce);
+        Assert.assertEquals("0x0", dto.nonce);
+    }
+
+    @Test
+    public void transactionWithOneNonceWithoutLeadingZeroes() {
+        Transaction originalTransaction = CallTransaction.createCallTransaction(
+                1, 0, 100000000000000L,
+                new RskAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), 0,
+                CallTransaction.Function.fromSignature("get"), chainId);
+
+        originalTransaction.sign(new byte[]{});
+
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction);
+
+        Assert.assertNotNull(dto.nonce);
+        Assert.assertEquals("0x1", dto.nonce);
+    }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The nonce of a transaction now it is returned WITHOUT leading zeroes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The main motivation is to fix issues with ecosystem tools, like `geth`. In previous changes, other JSON RPC values were adapted to be returned WITHOU leading zeroes, but transaction nonce was not fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
With code tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
