### PR TITLE
Added chainId to list of valid call args

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -45,8 +45,6 @@ public interface Web3EthModule {
         return getEthModule().estimateGas(args);
     }
 
-
-
     default Map<String, Object> eth_bridgeState() throws Exception {
         return getEthModule().bridgeState();
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -39,6 +39,8 @@ import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParam
 
 public class EthModuleTransactionBase implements EthModuleTransaction {
 
+    private static final String ERR_INVALID_CHAIN_ID = "Invalid chainId: ";
+
     protected static final Logger LOGGER = LoggerFactory.getLogger("web3");
 
     private final Wallet wallet;
@@ -88,7 +90,7 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
                 tx.sign(account.getEcKey().getPrivKeyBytes());
 
                 if (!tx.acceptTransactionSignature(constants.getChainId())) {
-                    throw RskJsonRpcRequestException.invalidParamError("Invalid chainId: " + args.chainId);
+                    throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + args.chainId);
                 }
 
                 TransactionPoolAddResult result = transactionGateway.receiveTransaction(tx.toImmutableTransaction());
@@ -138,12 +140,12 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
         try {
             byte[] bytes = TypeConverter.stringHexToByteArray(hex);
             if (bytes.length != 1) {
-                throw RskJsonRpcRequestException.invalidParamError("Invalid chainId: " + hex);
+                throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex);
             }
 
             return bytes[0];
         } catch (Exception e) {
-            throw RskJsonRpcRequestException.invalidParamError("Invalid chainId: " + hex, e);
+            throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex, e);
         }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -22,6 +22,7 @@ import co.rsk.config.InternalService;
 import co.rsk.rpc.*;
 import co.rsk.scoring.PeerScoringReputationSummary;
 import co.rsk.scoring.PeerScoringInformation;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -33,6 +34,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String highestBlock;
     }
 
+    @JsonIgnoreProperties("chainId")
     class CallArguments {
         public String from;
         public String to;

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -20,9 +20,8 @@ package org.ethereum.rpc;
 
 import co.rsk.config.InternalService;
 import co.rsk.rpc.*;
-import co.rsk.scoring.PeerScoringReputationSummary;
 import co.rsk.scoring.PeerScoringInformation;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import co.rsk.scoring.PeerScoringReputationSummary;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -34,7 +33,6 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String highestBlock;
     }
 
-    @JsonIgnoreProperties("chainId")
     class CallArguments {
         public String from;
         public String to;
@@ -43,6 +41,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String value;
         public String data; // compiledCode
         public String nonce;
+        public String chainId;
 
         @Override
         public String toString() {
@@ -54,6 +53,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
                     ", value='" + value + '\'' +
                     ", data='" + data + '\'' +
                     ", nonce='" + nonce + '\'' +
+                    ", chainId='" + chainId + '\'' +
                     '}';
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -41,7 +41,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String value;
         public String data; // compiledCode
         public String nonce;
-        public String chainId;
+        public String chainId; //NOSONAR
 
         @Override
         public String toString() {

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -141,7 +141,6 @@ public class TransactionModuleTest {
      */
     @Test
     public void sendSeveralTransactionsWithAutoMining() {
-
         ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
         World world = new World(receiptStore);
         BlockChainImpl blockchain = world.getBlockChain();
@@ -256,7 +255,6 @@ public class TransactionModuleTest {
     }
 
     private String sendTransaction(Web3Impl web3, RepositorySnapshot repository) {
-
         Web3.CallArguments args = getTransactionParameters(web3, repository);
 
         return web3.eth_sendTransaction(args);
@@ -269,6 +267,7 @@ public class TransactionModuleTest {
         BigInteger gasPrice = BigInteger.valueOf(8);
         BigInteger gasLimit = BigInteger.valueOf(50000);
         String data = "0xff";
+        byte chainId = config.getNetworkConstants().getChainId();
 
         Web3.CallArguments args = new Web3.CallArguments();
         args.from = TypeConverter.toJsonHex(addr1.getBytes());
@@ -278,6 +277,7 @@ public class TransactionModuleTest {
         args.gasPrice = TypeConverter.toQuantityJsonHex(gasPrice);
         args.value = value.toString();
         args.nonce = repository.getAccountState(addr1).getNonce().toString();
+        args.chainId = TypeConverter.toJsonHex(new byte[] { chainId });
 
         return args;
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -174,8 +174,9 @@ public class Web3RskImplTest {
         callArguments.value = "1";
         callArguments.data = "data";
         callArguments.nonce = "0";
+        callArguments.chainId = "0x00";
 
-        Assert.assertEquals(callArguments.toString(), "CallArguments{from='0x1', to='0x2', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0'}");
+        Assert.assertEquals(callArguments.toString(), "CallArguments{from='0x1', to='0x2', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0', chainId='0x00'}");
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -176,7 +176,7 @@ public class Web3RskImplTest {
         callArguments.nonce = "0";
         callArguments.chainId = "0x00";
 
-        Assert.assertEquals(callArguments.toString(), "CallArguments{from='0x1', to='0x2', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0', chainId='0x00'}");
+        Assert.assertEquals("CallArguments{from='0x1', to='0x2', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0', chainId='0x00'}", callArguments.toString());
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change makes `chainId` a valid call argument at the JSON-RPC level.

## Motivation and Context
Since Truffle version 5.2.5, `chainId` is included as a transaction parameter. The change allows to properly handle JSON-RPC requests from this client. As of now, `chainId` argument is being ignored.

## How Has This Been Tested?
Via JSON-RPC calls.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


Fixes #1485
