### PR TITLE
Fast bridge burning utxos fix

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -104,7 +104,7 @@ public class BridgeConstants {
 
     public int getMaxBtcHeadersPerRskBlock() { return maxBtcHeadersPerRskBlock; }
 
-    public Coin getlegacyMinimumPeginTxValueInSatoshis() { return legacyMinimumPeginTxValueInSatoshis; }
+    public Coin getLegacyMinimumPeginTxValueInSatoshis() { return legacyMinimumPeginTxValueInSatoshis; }
 
     public Coin getMinimumPeginTxValueInSatoshis() { return minimumPeginTxValueInSatoshis; }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2286,7 +2286,7 @@ public class BridgeSupport {
      * @return the minimum amount of satoshis a user should send to the federation.
      */
     public Coin getMinimumPeginTxValue() {
-        return activations.isActive(RSKIP219) ? bridgeConstants.getMinimumPeginTxValueInSatoshis() : bridgeConstants.getlegacyMinimumPeginTxValueInSatoshis();
+        return activations.isActive(RSKIP219) ? bridgeConstants.getMinimumPeginTxValueInSatoshis() : bridgeConstants.getLegacyMinimumPeginTxValueInSatoshis();
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -452,7 +452,7 @@ public class BridgeSupport {
             return TxType.MIGRATION;
         }
 
-        if (BridgeUtils.isPegOutTx(btcTx, getLiveFederations())) {
+        if (BridgeUtils.isPegOutTx(btcTx, getLiveFederations(), activations)) {
             return TxType.PEGOUT;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -198,7 +198,7 @@ public class BridgeUtils {
         Coin valueSentToMe = tx.getValueSentToMe(federationsWallet);
         Coin minimumPegInTxValue = activations.isActive(ConsensusRule.RSKIP219) ?
             bridgeConstants.getMinimumPeginTxValueInSatoshis() :
-            bridgeConstants.getlegacyMinimumPeginTxValueInSatoshis();
+            bridgeConstants.getLegacyMinimumPeginTxValueInSatoshis();
 
         if (valueSentToMe.isLessThan(minimumPegInTxValue)) {
             logger.warn("[btctx:{}] Someone sent to the federation less than {} satoshis", tx.getHash(), minimumPegInTxValue);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -604,7 +604,7 @@ public class BridgeUtils {
         } catch (ScriptException e) {
             logger.debug(
                 "[extractRedeemScriptFromInput] Failed to extract redeem script from tx input {}. {}",
-                txInput.getHash(),
+                txInput,
                 e.getMessage()
             );
             return Optional.empty();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -7634,7 +7634,7 @@ public class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP134)).thenReturn(isLockingCapEnabled);
 
         BridgeConstants bridgeConstants = mock(BridgeConstants.class);
-        when(bridgeConstants.getlegacyMinimumPeginTxValueInSatoshis()).thenReturn(Coin.SATOSHI);
+        when(bridgeConstants.getLegacyMinimumPeginTxValueInSatoshis()).thenReturn(Coin.SATOSHI);
         when(bridgeConstants.getBtcParams()).thenReturn(BridgeRegTestConstants.getInstance().getBtcParams());
         when(bridgeConstants.getBtc2RskMinimumAcceptableConfirmations()).thenReturn(1);
         when(bridgeConstants.getGenesisFeePerKb()).thenReturn(BridgeRegTestConstants.getInstance().getGenesisFeePerKb());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestPowerMock.java
@@ -1005,7 +1005,7 @@ public class BridgeTestPowerMock {
 
         byte[] data = Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode();
 
-        Assert.assertArrayEquals(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encodeOutputs(bridgeConstants.getlegacyMinimumPeginTxValueInSatoshis().value), bridge.execute(data));
+        Assert.assertArrayEquals(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encodeOutputs(bridgeConstants.getLegacyMinimumPeginTxValueInSatoshis().value), bridge.execute(data));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -127,7 +127,7 @@ public class BridgeUtilsTest {
         when(actForBlock.isActive(any(ConsensusRule.class))).thenReturn(false);
 
         // Tx sending less than the minimum allowed, not a peg-in tx
-        Coin minimumLockValue = bridgeConstants.getlegacyMinimumPeginTxValueInSatoshis();
+        Coin minimumLockValue = bridgeConstants.getLegacyMinimumPeginTxValueInSatoshis();
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addOutput(minimumLockValue.subtract(Coin.CENT), federationAddress);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
@@ -230,7 +230,7 @@ public class BridgeUtilsTest {
         BtcTransaction tx = new BtcTransaction(networkParameters);
 
         // Get a value in between pre and post iris minimum
-        Coin minimumPegInValueBeforeIris = bridgeConstants.getlegacyMinimumPeginTxValueInSatoshis();
+        Coin minimumPegInValueBeforeIris = bridgeConstants.getLegacyMinimumPeginTxValueInSatoshis();
         Coin minimumPegInValueAfterIris = bridgeConstants.getMinimumPeginTxValueInSatoshis();
         Coin valueLock = minimumPegInValueAfterIris.plus((minimumPegInValueBeforeIris.subtract(minimumPegInValueAfterIris)).div(2));
         assertTrue(valueLock.isLessThan(minimumPegInValueBeforeIris));
@@ -254,7 +254,7 @@ public class BridgeUtilsTest {
         BtcTransaction tx = new BtcTransaction(networkParameters);
 
         // Get a value in between pre and post iris minimum
-        Coin minimumPegInValueBeforeIris = bridgeConstants.getlegacyMinimumPeginTxValueInSatoshis();
+        Coin minimumPegInValueBeforeIris = bridgeConstants.getLegacyMinimumPeginTxValueInSatoshis();
         Coin minimumPegInValueAfterIris = bridgeConstants.getMinimumPeginTxValueInSatoshis();
         Coin valueLock = minimumPegInValueAfterIris.plus((minimumPegInValueBeforeIris.subtract(minimumPegInValueAfterIris)).div(2));
         assertTrue(valueLock.isGreaterThan(minimumPegInValueAfterIris));

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -19,10 +19,11 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
-import co.rsk.bitcoinj.script.ScriptOpCodes;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -152,5 +153,10 @@ public class PegTestUtils {
         System.arraycopy(customPayload, 0, payloadBytes, index, customPayload.length);
 
         return ScriptBuilder.createOpReturnScript(payloadBytes);
+    }
+
+    public static Address createRandomBtcAddress() {
+        BtcECKey key = new BtcECKey();
+        return key.toAddress(RegTestParams.get());
     }
 }


### PR DESCRIPTION
When a fast bridge Federation UTXO is spent, it probably generates a change UTXO, this change UTXO is then registered via registerBtcTransaction, but the logic in this method detects the transaction as an attempted peg-in, which will be rejected because the FB Federation is a multisig. This will burn the funds because the FB Federation won't register those funds.

Fix:
Extract the standard redeem script from the input using the existing bitcoinj logic, and compare it against the active federations redeem script. If it matches, then don't process the tx as a peg-in

*fed:fb-burning-utxos-fix*