### PR TITLE
Add new check for peg-out minimum considering fees 

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -76,6 +76,8 @@ public class BridgeConstants {
 
     protected String oldFederationAddress;
 
+    protected int percentageAboveFeeForPegouts;
+
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
     }
@@ -157,4 +159,8 @@ public class BridgeConstants {
     public long getMinSecondsBetweenCallsToReceiveHeader() { return minSecondsBetweenCallsReceiveHeader; }
 
     public int getMaxDepthBlockchainAccepted() { return maxDepthBlockchainAccepted; }
+
+    public int getPercentageAboveFeeForPegouts() {
+        return percentageAboveFeeForPegouts;
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -76,7 +76,7 @@ public class BridgeConstants {
 
     protected String oldFederationAddress;
 
-    protected int percentageAboveFeeForPegouts;
+    protected int minimumPegoutValuePercentageToReceiveAfterFee;
 
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
@@ -160,7 +160,7 @@ public class BridgeConstants {
 
     public int getMaxDepthBlockchainAccepted() { return maxDepthBlockchainAccepted; }
 
-    public int getPercentageAboveFeeForPegouts() {
-        return percentageAboveFeeForPegouts;
+    public int getMinimumPegoutValuePercentageToReceiveAfterFee() {
+        return minimumPegoutValuePercentageToReceiveAfterFee;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -158,6 +158,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
         maxDepthBlockchainAccepted = 25;
 
-        percentageAboveFeeForPegouts = 20;
+        minimumPegoutValuePercentageToReceiveAfterFee = 20;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -157,5 +157,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes in Seconds
 
         maxDepthBlockchainAccepted = 25;
+
+        percentageAboveFeeForPegouts = 20;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -144,6 +144,8 @@ public class BridgeMainNetConstants extends BridgeConstants {
 
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes in Seconds
         maxDepthBlockchainAccepted = 25;
+
+        percentageAboveFeeForPegouts = 20;
     }
 
     public static BridgeMainNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -145,7 +145,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes in Seconds
         maxDepthBlockchainAccepted = 25;
 
-        percentageAboveFeeForPegouts = 20;
+        minimumPegoutValuePercentageToReceiveAfterFee = 20;
     }
 
     public static BridgeMainNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -158,6 +158,8 @@ public class BridgeRegTestConstants extends BridgeConstants {
         // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
         // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
+
+        percentageAboveFeeForPegouts = 20;
     }
 
     public static BridgeRegTestConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -159,7 +159,7 @@ public class BridgeRegTestConstants extends BridgeConstants {
         // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
 
-        percentageAboveFeeForPegouts = 20;
+        minimumPegoutValuePercentageToReceiveAfterFee = 20;
     }
 
     public static BridgeRegTestConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -148,7 +148,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes in Seconds
         maxDepthBlockchainAccepted = 25;
 
-        percentageAboveFeeForPegouts = 20;
+        minimumPegoutValuePercentageToReceiveAfterFee = 20;
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -147,6 +147,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes in Seconds
         maxDepthBlockchainAccepted = 25;
+
+        percentageAboveFeeForPegouts = 20;
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -504,6 +504,10 @@ public class BridgeUtils {
     }
 
     public static int getRegularPegoutTxSize(@Nonnull Federation federation) {
+        // A regular peg-out transaction has two inputs and two outputs
+        // Each input has M/N signatures and each signature is around 71 bytes long (signed sighash)
+        // The outputs are composed of the scriptPubkeyHas(or publicKeyHash)
+        // and the op_codes for the corresponding script
         final int INPUT_MULTIPLIER = 2;
         final int SIGNATURE_MULTIPLIER = 71;
         final int OUTPUT_MULTIPLIER = 2;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -507,7 +507,7 @@ public class BridgeUtils {
         final int INPUT_MULTIPLIER = 2;
         final int SIGNATURE_MULTIPLIER = 71;
         final int OUTPUT_MULTIPLIER = 2;
-        final int OUTPUT_SIZE = 67;
+        final int OUTPUT_SIZE = 25;
 
         return calculatePegoutTxSize(
             federation,
@@ -525,11 +525,17 @@ public class BridgeUtils {
         int outputMultiplier,
         int outputSize
     ) {
-        return (
-            federation.getNumberOfSignaturesRequired() * signatureMultiplier +
-                federation.getRedeemScript().getProgram().length
-        ) * inputMultiplier +
-            outputMultiplier * outputSize;
-
+        // This data accounts for txid+vout+sequence
+        int INPUT_ADDITIONAL_DATA_SIZE = 40;
+        // This data accounts for the value+index
+        int OUTPUT_ADDITIONAL_DATA_SIZE = 9;
+        // This data accounts for the version field
+        int TX_ADDITIONAL_DATA_SIZE = 4;
+        // The added ones are to account for the data size
+        int scriptSigChunk = federation.getNumberOfSignaturesRequired() * (signatureMultiplier + 1) +
+                federation.getRedeemScript().getProgram().length + 1;
+        return TX_ADDITIONAL_DATA_SIZE +
+            (scriptSigChunk + INPUT_ADDITIONAL_DATA_SIZE) * inputMultiplier +
+            (outputSize + 1 + OUTPUT_ADDITIONAL_DATA_SIZE) * outputMultiplier;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -31,6 +31,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.utils.BtcTransactionFormatUtils;
+import javax.annotation.Nonnull;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -500,5 +501,35 @@ public class BridgeUtils {
         byte[] hashBytes = new byte[20];
         System.arraycopy(addressBytes, 1, hashBytes, 0, 20);
         return hashBytes;
+    }
+
+    public static int getRegularPegoutTxSize(@Nonnull Federation federation) {
+        final int INPUT_MULTIPLIER = 2;
+        final int SIGNATURE_MULTIPLIER = 71;
+        final int OUTPUT_MULTIPLIER = 2;
+        final int OUTPUT_SIZE = 67;
+
+        return calculatePegoutTxSize(
+            federation,
+            INPUT_MULTIPLIER,
+            SIGNATURE_MULTIPLIER,
+            OUTPUT_MULTIPLIER,
+            OUTPUT_SIZE
+        );
+    }
+
+    public static int calculatePegoutTxSize(
+        Federation federation,
+        int inputMultiplier,
+        int signatureMultiplier,
+        int outputMultiplier,
+        int outputSize
+    ) {
+        return (
+            federation.getNumberOfSignaturesRequired() * signatureMultiplier +
+                federation.getRedeemScript().getProgram().length
+        ) * inputMultiplier +
+            outputMultiplier * outputSize;
+
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/RejectedPegoutReason.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/RejectedPegoutReason.java
@@ -20,7 +20,8 @@ package co.rsk.peg.utils;
 public enum RejectedPegoutReason {
 
     LOW_AMOUNT(1),
-    CALLER_CONTRACT(2);
+    CALLER_CONTRACT(2),
+    FEE_ABOVE_VALUE(3);
 
     private final int value;
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1349,6 +1349,21 @@ public class BridgeUtilsTest {
         Assert.assertArrayEquals(hash160, obtainedHash160);
     }
 
+    @Test
+    public void calculatePegoutTxSize() {
+        Federation fed = new Federation(
+            Arrays.asList(FederationMember.getFederationMemberFromKey(new BtcECKey())),
+            Instant.now(),
+            0,
+            BridgeRegTestConstants.getInstance().getBtcParams()
+        );
+
+        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(fed, 1, 1, 1, 1);
+
+        int calculation = 1 + fed.getRedeemScript().getProgram().length + 1;
+        assertEquals(calculation, pegoutTxSize);
+    }
+
     private void test_getSpendWallet(boolean isFastBridgeCompatible) throws UTXOProviderException {
         Federation federation = new Federation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(
             BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),


### PR DESCRIPTION
A peg-out transaction has a minimum established in the Bridge constants.
This value doesn't take into account the changing nature of the fees.
Ths commit adds a validation to calculate the approximated cost of a peg-out with the current fees per KB of the network.
The cost is calculated considering a transaction with two inputs and two outputs, which is the most common situation ATM.

A peg-out transaction should also generate value for the user, this is, if a peg-out tx costs 400k satoshis and the user is attempting to peg-out 450k, the remainder (50k) won't be of much use for the user. In order to avoid this situation the Bridge now includes a percentage above the fee cost that the peg-out should include, if this is amount is not attained, the peg-out is rejected and funds returned.