### PR TITLE
Trie cache optimization provides 10x performane boost in ExecuteBlocks

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/tools/ExecuteBlocks.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ExecuteBlocks.java
@@ -37,19 +37,43 @@ public class ExecuteBlocks {
         
         execute(args, blockExecutor, blockStore, trieStore);
     }
-    
+
     public static void execute(String[] args, BlockExecutor blockExecutor, BlockStore blockStore, TrieStore trieStore) {
         long fromBlockNumber = Long.parseLong(args[0]);
         long toBlockNumber = Long.parseLong(args[1]);
-
+        long started = System.currentTimeMillis();
+        long lastTime = started;
+        int printInterval = 10;
+        int bcount = 0;
         for (long n = fromBlockNumber; n <= toBlockNumber; n++) {
             Block block = blockStore.getChainBlockByNumber(n);
+            //System.out.println("Block: "+n+" ("+(n*100/toBlockNumber)+"%)");
             Block parent = blockStore.getBlockByHash(block.getParentHash().getBytes());
+            bcount++;
+            if (bcount>=printInterval) {
+                System.out.println("Block: "+n+" ("+(n*100/toBlockNumber)+"%)");
 
-            blockExecutor.execute(block, parent.getHeader(), false, false);
+            }
+            if (!blockExecutor.executeAndValidate(block,parent.getHeader())) {
+                System.out.println("out of consensus at block: "+n);
+                break;
+            }
+            if (bcount >=printInterval) {
+                long currentTime = System.currentTimeMillis();
+                long deltaTime = (currentTime - started);
+                long deltaBlock = (n-fromBlockNumber);
+                System.out.println("Time[s]: " + (deltaTime / 1000));
+                if (currentTime>started)
+                    System.out.println("total blocks/sec: " +deltaBlock*1000/(currentTime-started));
+                if (currentTime>lastTime) {
+                    System.out.println("current blocks/sec: " +bcount*1000/(currentTime-lastTime));
+                    lastTime = currentTime;
+                }
+                bcount =0;
+            }
         }
 
         trieStore.flush();
-        blockStore.flush();
+        //blockStore.flush();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -19,13 +19,11 @@
 package co.rsk.trie;
 
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.db.ByteArrayWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.*;
 
 /**
  * TrieStoreImpl store and retrieve Trie node by hash
@@ -43,8 +41,8 @@ public class TrieStoreImpl implements TrieStore {
     private KeyValueDataSource store;
 
     /** Weak references are removed once the tries are garbage collected */
-    private Set<Trie> savedTries = Collections
-            .newSetFromMap(Collections.synchronizedMap(new WeakHashMap<>()));
+    private Map<ByteArrayWrapper,Trie> savedTries = Collections.synchronizedMap(
+            new WeakHashMap<>());
 
     public TrieStoreImpl(KeyValueDataSource store) {
         this.store = store;
@@ -65,13 +63,13 @@ public class TrieStoreImpl implements TrieStore {
      */
     private void save(Trie trie, boolean forceSaveRoot, int level) {
         logger.trace("Start saving trie, level : {}", level);
-        if (savedTries.contains(trie)) {
+        if (savedTries.get(new ByteArrayWrapper(trie.getHash().getBytes()))!=null) {
             // it is guaranteed that the children of a saved node are also saved
             return;
         }
 
         byte[] trieKeyBytes = trie.getHash().getBytes();
-
+        savedTries.put(new ByteArrayWrapper(trieKeyBytes),trie);
         if (forceSaveRoot && this.store.get(trieKeyBytes) != null) {
             // the full trie is already saved
             logger.trace("End saving trie, level : {}, already saved.", level);
@@ -106,7 +104,6 @@ public class TrieStoreImpl implements TrieStore {
         logger.trace("Putting in store trie root.");
         this.store.put(trieKeyBytes, trie.toMessage());
         logger.trace("End putting in store trie root.");
-        savedTries.add(trie);
         logger.trace("End Saving trie, level: {}.", level);
     }
 
@@ -123,7 +120,7 @@ public class TrieStoreImpl implements TrieStore {
         }
 
         Trie trie = Trie.fromMessage(message, this);
-        savedTries.add(trie);
+        savedTries.put(new ByteArrayWrapper(trie.getHash().getBytes()),trie);
         return Optional.of(trie);
     }
 

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -114,6 +114,11 @@ public class TrieStoreImpl implements TrieStore {
 
     @Override
     public Optional<Trie> retrieve(byte[] hash) {
+
+        Trie e =savedTries.get(new ByteArrayWrapper(hash));
+        if (e!=null)
+            return Optional.of(e);
+
         byte[] message = this.store.get(hash);
         if (message == null) {
             return Optional.empty();


### PR DESCRIPTION
The current cache (savesTrie) is filled but not used. This change makes use of an existing cache. This leads to a 10x performance boost in a controlled environment but it should translate also to increased performance in node synchronization (although slow networking code may prevent this performance gain to reach 10X in a networked node)

## Description

See summary .

## Motivation and Context

Node is slow. 

## How Has This Been Tested?
Only performance was tested using ExecuteBlocks over blocks near 2_000_000.

## Types of changes

WeakHashSet converted to WeakHashMap.

Tries stored on save().

It's not a bug fix, not a new feature nor a breaking change. It's a performance improvement.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
