### PR TITLE
Implementation of EIP-1898 In RSKj RPC Methods

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -98,6 +98,7 @@ public interface Web3EthModule {
     default String eth_getCode(String address, String blockId) {
         return getEthModule().getCode(address, blockId);
     }
+    String eth_getCode(String address, Map<String, String> blockRef) throws Exception;
 
     default String eth_sendRawTransaction(String rawData) {
         return getEthModule().sendRawTransaction(rawData);

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -75,6 +75,8 @@ public interface Web3EthModule {
 
     String eth_getBalance(String address) throws Exception;
 
+    String eth_getBalance(String address, Map<String, String> block) throws Exception;
+
     String eth_getStorageAt(String address, String storageIdx, String blockId) throws Exception;
 
     String eth_getTransactionCount(String address, String blockId) throws Exception ;

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -79,6 +79,8 @@ public interface Web3EthModule {
 
     String eth_getStorageAt(String address, String storageIdx, String blockId) throws Exception;
 
+    String eth_getTransactionCount(String address, Map<String, String> blockRef) throws Exception ;
+
     String eth_getTransactionCount(String address, String blockId) throws Exception ;
 
     String eth_getBlockTransactionCountByHash(String blockHash)throws Exception;

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -71,11 +71,13 @@ public interface Web3EthModule {
 
     String eth_blockNumber();
 
+    String eth_call(Web3.CallArguments args, Map<String, String> blockRef) throws Exception;
+
     String eth_getBalance(String address, String block) throws Exception;
 
     String eth_getBalance(String address) throws Exception;
 
-    String eth_getBalance(String address, Map<String, String> block) throws Exception;
+    String eth_getBalance(String address, Map<String, String> blockRef) throws Exception;
 
     String eth_getStorageAt(String address, String storageIdx, Map<String, String> blockRef) throws Exception;
 

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -77,6 +77,8 @@ public interface Web3EthModule {
 
     String eth_getBalance(String address, Map<String, String> block) throws Exception;
 
+    String eth_getStorageAt(String address, String storageIdx, Map<String, String> blockRef) throws Exception;
+
     String eth_getStorageAt(String address, String storageIdx, String blockId) throws Exception;
 
     String eth_getTransactionCount(String address, Map<String, String> blockRef) throws Exception ;

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -380,6 +380,11 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
+    public String eth_call(CallArguments args, Map<String, String> inputs) {
+        return invokeByBlockRef(inputs, blockNumber -> this.eth_call(args,blockNumber));
+    }
+
+    @Override
     public String eth_getBalance(String address, String block) {
         /* HEX String  - an integer block number
         *  String "earliest"  for the earliest/genesis block

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -41,7 +41,10 @@ import co.rsk.rpc.modules.trace.TraceModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.*;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.core.*;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Blockchain;
+import org.ethereum.core.Transaction;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.db.BlockInformation;
 import org.ethereum.db.BlockStore;
@@ -389,6 +392,12 @@ public class Web3Impl implements Web3 {
         Coin balance = accountInformationProvider.getBalance(addr);
 
         return toQuantityJsonHex(balance.asBigInteger());
+    }
+
+    @Override
+    public String eth_getBalance(String address, Map<String, String> block) {
+        Optional<String> blockNumber = Optional.ofNullable(block.get("blockNumber"));
+        return this.eth_getBalance(address, blockNumber.get());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -458,7 +458,7 @@ public class Web3Impl implements Web3 {
      * @param toInvokeByBlockNumber a function that returns a string based on the block number
      * @return function invocation result
      */
-    private String invokeByBlockRef(Map<String, String> inputs, Function<String, String> toInvokeByBlockNumber) {
+    protected String invokeByBlockRef(Map<String, String> inputs, Function<String, String> toInvokeByBlockNumber) {
         Function<String, String> getBalanceByBlockHash = hash -> {
             Optional<Block> optBlock = Optional.ofNullable(this.blockchain.getBlockByHash(stringHexToByteArray(hash)));
             Block block = optBlock.orElseThrow(() -> blockNotFound(String.format("Block with hash %s not found", hash)));

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -462,7 +462,8 @@ public class Web3Impl implements Web3 {
 
     @Override
     public String eth_getTransactionCount(String accountAddress, Map<String, String> blockRef) {
-        return applyIfPresent(blockRef,"blockNumber", blockNumber -> this.eth_getTransactionCount(accountAddress,blockNumber)).get();
+        return applyIfPresent(blockRef,"blockNumber", blockNumber -> this.eth_getTransactionCount(accountAddress,blockNumber))
+                .orElseThrow(() -> invalidParamError("Invalid block input"));
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -461,6 +461,11 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
+    public String eth_getTransactionCount(String accountAddress, Map<String, String> blockRef) {
+        return applyIfPresent(blockRef,"blockNumber", blockNumber -> this.eth_getTransactionCount(accountAddress,blockNumber)).get();
+    }
+
+    @Override
     public String eth_getTransactionCount(String address, String blockId) {
         String s = null;
         try {

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -59,6 +59,7 @@ import org.ethereum.rpc.dto.BlockResultDTO;
 import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.util.BuildInfo;
 import org.ethereum.vm.DataWord;
 import org.slf4j.Logger;
@@ -397,7 +398,7 @@ public class Web3Impl implements Web3 {
     @Override
     public String eth_getBalance(String address, Map<String, String> block) {
         Optional<String> blockNumber = Optional.ofNullable(block.get("blockNumber"));
-        return this.eth_getBalance(address, blockNumber.get());
+        return this.eth_getBalance(address, blockNumber.orElseThrow(() -> invalidParamError("invalid block input")));
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -397,6 +397,12 @@ public class Web3Impl implements Web3 {
 
     @Override
     public String eth_getBalance(String address, Map<String, String> block) {
+        Optional<String> blockHash = Optional.ofNullable(block.get("blockHash"));
+        if(blockHash.isPresent()) {
+            Optional<Block> optBlock = Optional.ofNullable(this.blockchain.getBlockByHash(stringHexToByteArray(blockHash.get())));
+            return this.eth_getBalance(address, toQuantityJsonHex(optBlock.get().getNumber()));
+        }
+
         Optional<String> blockNumber = Optional.ofNullable(block.get("blockNumber"));
         return this.eth_getBalance(address, blockNumber.orElseThrow(() -> invalidParamError("invalid block input")));
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -400,7 +400,7 @@ public class Web3Impl implements Web3 {
         Optional<String> blockHash = Optional.ofNullable(block.get("blockHash"));
         if(blockHash.isPresent()) {
             Optional<Block> optBlock = Optional.ofNullable(this.blockchain.getBlockByHash(stringHexToByteArray(blockHash.get())));
-            return this.eth_getBalance(address, toQuantityJsonHex(optBlock.get().getNumber()));
+            return this.eth_getBalance(address, toQuantityJsonHex(optBlock.orElseThrow(()->blockNotFound(String.format("Block with hash %s not found", blockHash))).getNumber()));
         }
 
         Optional<String> blockNumber = Optional.ofNullable(block.get("blockNumber"));

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -418,6 +418,11 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
+    public String eth_getStorageAt(String address, String storageIdx, Map<String, String> blockRef) {
+        return invokeByBlockRef(blockRef, blockNumber -> this.eth_getStorageAt(address,storageIdx, blockNumber));
+    }
+
+    @Override
     public String eth_getStorageAt(String address, String storageIdx, String blockId) {
         String s = null;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -381,7 +381,12 @@ public class Web3Impl implements Web3 {
 
     @Override
     public String eth_call(CallArguments args, Map<String, String> inputs) {
-        return invokeByBlockRef(inputs, blockNumber -> this.eth_call(args,blockNumber));
+        return invokeByBlockRef(inputs, blockNumber -> this.eth_call(args, blockNumber));
+    }
+
+    @Override
+    public String eth_getCode(String address, Map<String, String> inputs) {
+        return invokeByBlockRef(inputs, blockNumber -> this.eth_getCode(address, blockNumber));
     }
 
     @Override

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -793,6 +793,33 @@ public class Web3ImplTest {
     }
 
     @Test
+    //[ "0x<address>", { "blockNumber": "0x0" } -> return tx count at given address in genesis block
+    public void getTransactionCountByBlockNumber() {
+        World world = new World();
+
+
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(100000000)).build();
+        Account acc2 = new AccountBuilder().name("acc2").build();
+        Transaction tx = new TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
+        List<Transaction> txs = new ArrayList<>();
+        txs.add(tx);
+        Block genesis = world.getBlockChain().getBestBlock();
+        Block block1 = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
+                world.getBlockStore()).trieStore(world.getTrieStore()).parent(genesis).transactions(txs).build();
+        assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
+
+
+        String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockNumber", "0x1");
+            }
+        };
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1", web3.eth_getTransactionCount(accountAddress, blockRef));
+    }
+
+    @Test
     public void getBlockByNumber() {
         World world = new World();
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -923,6 +923,43 @@ public class Web3ImplTest {
     }
 
     @Test
+    // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>" } -> return tx count at given address in specified bloc
+    public void getTransactionCountByNonCanonicalBlockHash() {
+        World world = new World();
+
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(100000000)).build();
+        Account acc2 = new AccountBuilder().name("acc2").build();
+        Transaction tx = new TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
+        List<Transaction> txs = new ArrayList<>();
+        txs.add(tx);
+
+        Block genesis = world.getBlockChain().getBestBlock();
+
+        final BlockBuilder blockBuilder = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(), world.getBlockStore());
+
+        Block block1Canonical = blockBuilder.trieStore(world.getTrieStore()).parent(genesis).transactions(txs).build();
+        Block nonCanonicalBlock = blockBuilder.trieStore(world.getTrieStore()).parent(genesis).transactions(txs).build();
+        Block block2Canonical = blockBuilder.parent(block1Canonical).build();
+
+
+        world.getBlockChain().tryToConnect(genesis);
+        world.getBlockChain().tryToConnect(block1Canonical);
+        world.getBlockChain().tryToConnect(nonCanonicalBlock);
+        world.getBlockChain().tryToConnect(block2Canonical);
+
+
+        String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + nonCanonicalBlock.getPrintableHash());
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1", web3.eth_getTransactionCount(accountAddress, blockRef));
+    }
+
+    @Test
     public void getBlockByNumber() {
         World world = new World();
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -431,6 +431,169 @@ public class Web3ImplTest {
     }
 
     @Test
+    public void invokeByBlockNumber() {
+        World world = new World();
+        createChainWithOneBlock(world);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockNumber", "0x1");
+            }
+        };
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1",web3.invokeByBlockRef(blockRef,b -> b));
+    }
+
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    public void invokeByInvalidInputThrowsException() {
+        World world = new World();
+        createChainWithOneBlock(world);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("invalidInput", "0x1");
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        web3.invokeByBlockRef(blockRef,b -> b);
+    }
+
+    @Test
+    public void invokeByBlockHash() {
+        World world = new World();
+        Block block = createChainWithOneBlock(world);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + block.getPrintableHash());
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1",web3.invokeByBlockRef(blockRef,b -> b));
+    }
+
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    public void invokeByNonExistentBlockHash() {
+        World world = new World();
+        createChainWithOneBlock(world);
+        final String nonExistentBlockHash="0x" + String.join("", Collections.nCopies(64, "1")); // "0x1111..."
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", nonExistentBlockHash);
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        web3.invokeByBlockRef(blockRef,b -> b);
+    }
+
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    public void invokeByNonExistentBlockHashWhenCanonicalIsRequired() {
+        World world = new World();
+        createChainWithOneBlock(world);
+        final String nonExistentBlockHash="0x" + String.join("", Collections.nCopies(64, "1")); // "0x1111..."
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", nonExistentBlockHash);
+                put("requireCanonical","true");
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        web3.invokeByBlockRef(blockRef,b -> b);;
+    }
+
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    public void invokeByNonExistentBlockHashWhenCanonicalIsNotRequired() {
+        World world = new World();
+        createChainWithOneBlock(world);
+        final String nonExistentBlockHash="0x" + String.join("", Collections.nCopies(64, "1")); // "0x1111..."
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", nonExistentBlockHash);
+                put("requireCanonical","false");
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        web3.invokeByBlockRef(blockRef,b -> b);
+    }
+
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    public void invokeByNonCanonicalBlockHashWhenCanonicalIsRequired() {
+        World world = new World();
+        String accountAddress = createAccountWith10KBalance(world);
+        Block nonCanonicalBlock = createChainWithNonCanonicalBlock(world);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + nonCanonicalBlock.getPrintableHash());
+                put("requireCanonical","true");
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        web3.invokeByBlockRef(blockRef,b -> b);
+    }
+
+    @Test
+    public void invokeCanonicalBlockHashWhenCanonicalIsRequired() {
+        World world = new World();
+        Block block = createChainWithOneBlock(world);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + block.getPrintableHash());
+                put("requireCanonical","true");
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1",web3.invokeByBlockRef(blockRef,b -> b));
+    }
+
+    @Test
+    public void invokeByCanonicalBlockHashWhenCanonicalIsNotRequired() {
+        World world = new World();
+        Block block = createChainWithOneBlock(world);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + block.getPrintableHash());
+                put("requireCanonical","false");
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1",web3.invokeByBlockRef(blockRef,b -> b));
+    }
+
+    @Test
+    public void invokeByNonCanonicalBlockHashWhenCanonicalIsNotRequired() {
+        World world = new World();
+        Block nonCanonicalBlock = createChainWithNonCanonicalBlock(world);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + nonCanonicalBlock.getPrintableHash());
+                put("requireCanonical","false");
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1",web3.invokeByBlockRef(blockRef,b -> b));
+    }
+
+    @Test
+    public void invokeByNonCanonicalBlockHash() {
+        World world = new World();
+        Block nonCanonicalBlock = createChainWithNonCanonicalBlock(world);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + nonCanonicalBlock.getPrintableHash());
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1",web3.invokeByBlockRef(blockRef,b -> b));
+    }
+
+    @Test
     public void eth_mining()  {
         Ethereum ethMock = Web3Mocks.getMockEthereum();
         Blockchain blockchain = Web3Mocks.getMockBlockchain();

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -250,7 +250,6 @@ public class Web3ImplTest {
         Web3Impl web3 = createWeb3(world);
 
         String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
-        String balanceString = "0x" + ByteUtil.toHexString(BigInteger.valueOf(10000).toByteArray());
         Map<String, String> blockRef = new HashMap<String, String>() {
             {
                 put("invalidInput", "0x1");
@@ -279,6 +278,25 @@ public class Web3ImplTest {
         assertEquals(balanceString, web3.eth_getBalance(accountAddress, blockRef));
     }
 
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    //[ "0x<address>", { "blockHash": "0x<non-existent-block-hash>" } -> raise block-not-found error
+    public void getBalanceWithAccountAndNonExistentBlockHash() {
+        World world = new World();
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(10000)).build();
+
+        createChainWithOneBlock(world);
+        Web3Impl web3 = createWeb3(world);
+
+        String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
+        final String nonExistentBlockHash="0x" + String.join("", Collections.nCopies(64, "1")); // "0x1111..."
+        System.out.println(nonExistentBlockHash);
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", nonExistentBlockHash);
+            }
+        };
+        web3.eth_getBalance(accountAddress, blockRef);
+    }
     @Test
     public void getBalanceWithAccountAndBlockWithTransaction() {
         World world = new World();

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -211,10 +211,7 @@ public class Web3ImplTest {
     public void getBalanceWithAccountAndBlock() {
         World world = new World();
         Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(10000)).build();
-        Block genesis = world.getBlockByName("g00");
-
-        Block block1 = new BlockBuilder(null, null, null).parent(genesis).build();
-        world.getBlockChain().tryToConnect(block1);
+        createChainWithOneBlock(world);
 
         Web3Impl web3 = createWeb3(world);
 
@@ -225,14 +222,11 @@ public class Web3ImplTest {
     }
 
     @Test
-    //[ "0x<address>", { "blockNumber": "0x0" } -> return storage at given address in genesis block
+    //[ "0x<address>", { "blockNumber": "0x0" } -> return balance at given address in genesis block
     public void getBalanceWithAccountAndBlockNumber() {
         World world = new World();
         Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(10000)).build();
-        Block genesis = world.getBlockByName("g00");
-
-        Block block1 = new BlockBuilder(null, null, null).parent(genesis).build();
-        world.getBlockChain().tryToConnect(block1);
+        createChainWithOneBlock(world);
 
         Web3Impl web3 = createWeb3(world);
 
@@ -251,10 +245,7 @@ public class Web3ImplTest {
     public void getBalanceWithAccountAndInvalidInputThrowsException() {
         World world = new World();
         Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(10000)).build();
-        Block genesis = world.getBlockByName("g00");
-
-        Block block1 = new BlockBuilder(null, null, null).parent(genesis).build();
-        world.getBlockChain().tryToConnect(block1);
+        createChainWithOneBlock(world);
 
         Web3Impl web3 = createWeb3(world);
 
@@ -267,6 +258,25 @@ public class Web3ImplTest {
         };
 
         web3.eth_getBalance(accountAddress, blockRef);
+    }
+
+    @Test
+    //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" } -> return balance at given address in genesis block
+    public void getBalanceWithAccountAndBlockHash() {
+        World world = new World();
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(10000)).build();
+
+        Block block1 = createChainWithOneBlock(world);
+        Web3Impl web3 = createWeb3(world);
+
+        String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
+        String balanceString = "0x" + ByteUtil.toHexString(BigInteger.valueOf(10000).toByteArray());
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + block1.getPrintableHash());
+            }
+        };
+        assertEquals(balanceString, web3.eth_getBalance(accountAddress, blockRef));
     }
 
     @Test
@@ -2104,5 +2114,13 @@ public class Web3ImplTest {
                 new ProgramInvokeFactoryImpl(),
                 new PrecompiledContracts(config, null),
                 blockTxSignatureCache);
+    }
+
+    private Block createChainWithOneBlock(World world) {
+        Block genesis = world.getBlockByName("g00");
+
+        Block block1 = new BlockBuilder(null, null, null).parent(genesis).build();
+        world.getBlockChain().tryToConnect(block1);
+        return block1;
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -246,6 +246,29 @@ public class Web3ImplTest {
         assertEquals(balanceString, web3.eth_getBalance(accountAddress, blockRef));
     }
 
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    //[ "0x<address>", { "invalidInput": "0x0" } -> throw RskJsonRpcRequestException
+    public void getBalanceWithAccountAndInvalidInputThrowsException() {
+        World world = new World();
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(10000)).build();
+        Block genesis = world.getBlockByName("g00");
+
+        Block block1 = new BlockBuilder(null, null, null).parent(genesis).build();
+        world.getBlockChain().tryToConnect(block1);
+
+        Web3Impl web3 = createWeb3(world);
+
+        String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
+        String balanceString = "0x" + ByteUtil.toHexString(BigInteger.valueOf(10000).toByteArray());
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("invalidInput", "0x1");
+            }
+        };
+
+        web3.eth_getBalance(accountAddress, blockRef);
+    }
+
     @Test
     public void getBalanceWithAccountAndBlockWithTransaction() {
         World world = new World();

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -53,7 +53,6 @@ import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.util.TestContract;
-import co.rsk.vm.BytecodeCompiler;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.core.*;
@@ -82,10 +81,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.is;
@@ -226,6 +222,28 @@ public class Web3ImplTest {
         String balanceString = "0x" + ByteUtil.toHexString(BigInteger.valueOf(10000).toByteArray());
 
         assertEquals(balanceString, web3.eth_getBalance(accountAddress, "0x1"));
+    }
+
+    @Test
+    //[ "0x<address>", { "blockNumber": "0x0" } -> return storage at given address in genesis block
+    public void getBalanceWithAccountAndBlockNumber() {
+        World world = new World();
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(10000)).build();
+        Block genesis = world.getBlockByName("g00");
+
+        Block block1 = new BlockBuilder(null, null, null).parent(genesis).build();
+        world.getBlockChain().tryToConnect(block1);
+
+        Web3Impl web3 = createWeb3(world);
+
+        String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
+        String balanceString = "0x" + ByteUtil.toHexString(BigInteger.valueOf(10000).toByteArray());
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockNumber", "0x1");
+            }
+        };
+        assertEquals(balanceString, web3.eth_getBalance(accountAddress, blockRef));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -869,6 +869,23 @@ public class Web3ImplTest {
         assertEquals("0x1", web3.eth_getTransactionCount(accountAddress, blockRef));
     }
 
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    //[ "0x<address>", { "blockHash": "0x<non-existent-block-hash>" } -> raise block-not-found error
+    public void getTransactionCountByNonExistentBlockHash() {
+        World world = new World();
+        String accountAddress = createAccountWith10KBalance(world);
+        createChainWithOneBlock(world);
+        final String nonExistentBlockHash="0x" + String.join("", Collections.nCopies(64, "1")); // "0x1111..."
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", nonExistentBlockHash);
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        web3.eth_getTransactionCount(accountAddress, blockRef);
+    }
+
     @Test
     public void getBlockByNumber() {
         World world = new World();

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -846,6 +846,30 @@ public class Web3ImplTest {
     }
 
     @Test
+    //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" } -> return tx count at given address in genesis block
+    public void getTransactionCountByBlockHash() {
+        World world = new World();
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(100000000)).build();
+        Account acc2 = new AccountBuilder().name("acc2").build();
+        Transaction tx = new TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
+        List<Transaction> txs = new ArrayList<>();
+        txs.add(tx);
+        Block genesis = world.getBlockChain().getBestBlock();
+        Block block1 = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
+                world.getBlockStore()).trieStore(world.getTrieStore()).parent(genesis).transactions(txs).build();
+        assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
+        String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x" + block1.getPrintableHash());
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        assertEquals("0x1", web3.eth_getTransactionCount(accountAddress, blockRef));
+    }
+
+    @Test
     public void getBlockByNumber() {
         World world = new World();
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -819,6 +819,32 @@ public class Web3ImplTest {
         assertEquals("0x1", web3.eth_getTransactionCount(accountAddress, blockRef));
     }
 
+    @Test(expected=org.ethereum.rpc.exception.RskJsonRpcRequestException.class)
+    //[ "0x<address>", { "invalidInput": "0x0" } -> throw RskJsonRpcRequestException
+    public void getTransactionCountAndInvalidInputThrowsException() {
+        World world = new World();
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(100000000)).build();
+        Account acc2 = new AccountBuilder().name("acc2").build();
+        Transaction tx = new TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
+        List<Transaction> txs = new ArrayList<>();
+        txs.add(tx);
+        Block genesis = world.getBlockChain().getBestBlock();
+        Block block1 = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
+                world.getBlockStore()).trieStore(world.getTrieStore()).parent(genesis).transactions(txs).build();
+        assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
+
+
+        String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("invalidInput", "0x1");
+            }
+        };
+
+        Web3Impl web3 = createWeb3(world);
+        web3.eth_getTransactionCount(accountAddress, blockRef);
+    }
+
     @Test
     public void getBlockByNumber() {
         World world = new World();

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -203,6 +203,22 @@ public class Web3ImplUnitTest {
     }
 
     @Test
+    //validates invokeByBlockRef call
+    public void  eth_getBlockTransactionCountByBlockRef() {
+        String addr = "0x0011223344556677880011223344556677889900";
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x0011223344556677880011223344556677889900");
+            }
+        };
+        final Web3Impl spyTarget = spy(target);
+        doReturn("0x1").when(spyTarget).invokeByBlockRef(eq(blockRef),any());
+        String result = spyTarget.eth_getTransactionCount(addr, blockRef);
+        assertEquals("0x1", result);
+        verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
+    }
+
+    @Test
     public void eth_getUncleCountByBlockHash_blockNotFound() {
         String hash = "0x4A54";
         byte[] bytesHash = TypeConverter.stringHexToByteArray(hash);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -34,21 +34,21 @@ import org.ethereum.util.BuildInfo;
 import org.ethereum.vm.DataWord;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Spy;
 
 import java.math.BigInteger;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.ethereum.rpc.TypeConverter.stringHexToByteArray;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class Web3ImplUnitTest {
 
     private Blockchain blockchain;
+
     private Web3Impl target;
     private Web3InformationRetriever retriever;
 
@@ -110,6 +110,22 @@ public class Web3ImplUnitTest {
 
         String result = target.eth_getBalance(addr, id);
         assertEquals("0x1", result);
+    }
+
+    @Test
+    //validates invokeByBlockRef call
+    public void eth_getBalanceByBlockRef() {
+        String addr = "0x0011223344556677880011223344556677889900";
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x0011223344556677880011223344556677889900");
+            }
+        };
+        final Web3Impl spyTarget = spy(target);
+        doReturn("0x1").when(spyTarget).invokeByBlockRef(eq(blockRef),any());
+        String result = spyTarget.eth_getBalance(addr, blockRef);
+        assertEquals("0x1", result);
+        verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -34,7 +34,6 @@ import org.ethereum.util.BuildInfo;
 import org.ethereum.vm.DataWord;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Spy;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -218,6 +217,24 @@ public class Web3ImplUnitTest {
         String result = target.eth_getBlockTransactionCountByNumber(id);
 
         assertEquals("0x2", result);
+    }
+
+    @Test
+    //validates invokeByBlockRef call
+    public void  eth_getCode() {
+        final String addr = "0x0011223344556677880011223344556677889900";
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x0011223344556677880011223344556677889900");
+            }
+        };
+        final Web3Impl spyTarget = spy(target);
+        final String expectedData =  "0x010203";
+        System.out.println(expectedData);
+        doReturn(expectedData).when(spyTarget).invokeByBlockRef(eq(blockRef),any());
+        String result = spyTarget.eth_getCode(addr,blockRef);
+        assertEquals(expectedData, result);
+        verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -159,6 +159,24 @@ public class Web3ImplUnitTest {
                 result);
     }
 
+    @Test
+    //validates invokeByBlockRef call
+    public void  eth_getStorageAtByBlockRef() {
+        final String addr = "0x0011223344556677880011223344556677889900";
+        final String storageIdx = "0x01";
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x0011223344556677880011223344556677889900");
+            }
+        };
+        final Web3Impl spyTarget = spy(target);
+        final String expecteData = "0x0000000000000000000000000000000000000000000000000000000000000001";
+        doReturn(expecteData).when(spyTarget).invokeByBlockRef(eq(blockRef),any());
+        String result = spyTarget.eth_getStorageAt(addr, storageIdx, blockRef);
+        assertEquals(expecteData, result);
+        verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
+    }
+
 
     @Test
     public void eth_getStorageAtEmptyCell() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -170,10 +170,10 @@ public class Web3ImplUnitTest {
             }
         };
         final Web3Impl spyTarget = spy(target);
-        final String expecteData = "0x0000000000000000000000000000000000000000000000000000000000000001";
-        doReturn(expecteData).when(spyTarget).invokeByBlockRef(eq(blockRef),any());
+        final String expectedData = "0x0000000000000000000000000000000000000000000000000000000000000001";
+        doReturn(expectedData).when(spyTarget).invokeByBlockRef(eq(blockRef),any());
         String result = spyTarget.eth_getStorageAt(addr, storageIdx, blockRef);
-        assertEquals(expecteData, result);
+        assertEquals(expectedData, result);
         verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
     }
 
@@ -218,6 +218,27 @@ public class Web3ImplUnitTest {
         String result = target.eth_getBlockTransactionCountByNumber(id);
 
         assertEquals("0x2", result);
+    }
+
+    @Test
+    //validates invokeByBlockRef call
+    public void  eth_callAtByBlockRef() {
+
+        Web3.CallArguments argsForCall = new Web3.CallArguments();
+        argsForCall.to = "0x0011223344556677880011223344556677889900";
+        argsForCall.data = "ead710c40000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000";
+        Map<String, String> blockRef = new HashMap<String, String>() {
+            {
+                put("blockHash", "0x0011223344556677880011223344556677889900");
+            }
+        };
+        final Web3Impl spyTarget = spy(target);
+        final String expectedData = "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000";
+
+        doReturn(expectedData).when(spyTarget).invokeByBlockRef(eq(blockRef),any());
+        String result = spyTarget.eth_call(argsForCall,blockRef);
+        assertEquals(expectedData, result);
+        verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
     }
 
     @Test


### PR DESCRIPTION
## Implement EIP-1898 In RSKj RPC Methods

According to  [rsk-gitcoin-hackathon-2021 - Implement EIP-1898 In RSKj RPC Methods Issue]( https://github.com/rsksmart/rsk-gitcoin-hackathon-2021/issues/17) work on the following methods was done to support EIP-1898 

- eth_getBalance
- eth_getStorageAt
- eth_getTransactionCount
- eth_getCode
- eth_call


## Code Coverage

Attached  [coverage.zip](https://github.com/rsksmart/rskj/files/6398823/coverage.zip) you can find all the code coverage reports but you can see that the changes done are 100% covered, as the following image shows.
 
![coverage](https://user-images.githubusercontent.com/5402004/116557251-a766d700-a8d4-11eb-8533-eaf8bacd3239.png)
![coverage-2](https://user-images.githubusercontent.com/5402004/116558286-a5e9de80-a8d5-11eb-9db0-edd1049fd229.png)
![coverage-3](https://user-images.githubusercontent.com/5402004/116558303-a97d6580-a8d5-11eb-9743-3b601278bc98.png)


You can find it in file:///store/documents/personal/blockchain/rsk/hackaton/coverage/ns-57/sources/source-c.html in the attached coverage reports.

## Demonstration

Here you can see a demonstration about some methods supporting EIP-1898.

![requests](https://user-images.githubusercontent.com/5402004/116559590-fc0b5180-a8d6-11eb-9c7c-d34855534321.gif)

_rskj-node initialization_
![rskj-node-init](https://user-images.githubusercontent.com/5402004/116560250-9370a480-a8d7-11eb-8c50-c54a31edd893.gif)

Also you can find it in the attached [requests.txt](https://github.com/rsksmart/rskj/files/6398974/requests.txt)

## Improvements

In case of search by blockHash, 2 searches are done (one for blockHash and other by blockNumber), this could be avoided by adding blockHash search logic in Web3InformationRetriever.


