### PR TITLE
Add NewPendingTransactions To RSKj Eth_subscribe RPC Method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -62,6 +62,7 @@ import co.rsk.rpc.modules.debug.DebugModuleImpl;
 import co.rsk.rpc.modules.eth.*;
 import co.rsk.rpc.modules.eth.subscribe.BlockHeaderNotificationEmitter;
 import co.rsk.rpc.modules.eth.subscribe.LogsNotificationEmitter;
+import co.rsk.rpc.modules.eth.subscribe.PendingTransactionsNotificationEmitter;
 import co.rsk.rpc.modules.evm.EvmModule;
 import co.rsk.rpc.modules.evm.EvmModuleImpl;
 import co.rsk.rpc.modules.mnr.MnrModule;
@@ -1593,8 +1594,8 @@ public class RskContext implements NodeBootstrapper {
                             jsonRpcSerializer,
                             getReceiptStore(),
                             new BlockchainBranchComparator(getBlockStore())
-                    )
-            );
+                    ),
+                    new PendingTransactionsNotificationEmitter(rsk, jsonRpcSerializer));
             RskJsonRpcHandler jsonRpcHandler = new RskJsonRpcHandler(emitter, jsonRpcSerializer);
             web3WebSocketServer = new Web3WebSocketServer(
                     rskSystemProperties.rpcWebSocketBindAddress(),

--- a/rskj-core/src/main/java/co/rsk/rpc/EthSubscriptionNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/EthSubscriptionNotificationEmitter.java
@@ -65,7 +65,8 @@ public class EthSubscriptionNotificationEmitter implements EthSubscribeParamsVis
         // temporal variables avoid short-circuiting behavior
         boolean unsubscribedBlockHeader = blockHeader.unsubscribe(subscriptionId);
         boolean unsubscribedLogs = logs.unsubscribe(subscriptionId);
-        return unsubscribedBlockHeader || unsubscribedLogs;
+        boolean unsubscribedPendingTransactions = pendingTransactions.unsubscribe(subscriptionId);
+        return unsubscribedBlockHeader || unsubscribedLogs || unsubscribedPendingTransactions;
     }
 
     /**
@@ -74,5 +75,6 @@ public class EthSubscriptionNotificationEmitter implements EthSubscribeParamsVis
     public void unsubscribe(Channel channel) {
         blockHeader.unsubscribe(channel);
         logs.unsubscribe(channel);
+        pendingTransactions.unsubscribe(channel);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/EthSubscriptionNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/EthSubscriptionNotificationEmitter.java
@@ -27,12 +27,14 @@ import io.netty.channel.Channel;
 public class EthSubscriptionNotificationEmitter implements EthSubscribeParamsVisitor {
     private final BlockHeaderNotificationEmitter blockHeader;
     private final LogsNotificationEmitter logs;
+    private final PendingTransactionsNotificationEmitter pendingTransactions;
 
     public EthSubscriptionNotificationEmitter(
             BlockHeaderNotificationEmitter blockHeader,
-            LogsNotificationEmitter logs) {
+            LogsNotificationEmitter logs, PendingTransactionsNotificationEmitter pendingTransactions) {
         this.blockHeader = blockHeader;
         this.logs = logs;
+        this.pendingTransactions = pendingTransactions;
     }
 
     @Override
@@ -46,6 +48,13 @@ public class EthSubscriptionNotificationEmitter implements EthSubscribeParamsVis
     public SubscriptionId visit(EthSubscribeLogsParams params, Channel channel) {
         SubscriptionId subscriptionId = new SubscriptionId();
         logs.subscribe(subscriptionId, channel, params);
+        return subscriptionId;
+    }
+
+    @Override
+    public SubscriptionId visit(EthSubscribePendingTransactionsParams params, Channel channel) {
+        SubscriptionId subscriptionId = new SubscriptionId();
+        pendingTransactions.subscribe(subscriptionId, channel);
         return subscriptionId;
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsDeserializer.java
@@ -38,6 +38,7 @@ public class EthSubscribeParamsDeserializer extends JsonDeserializer {
         this.subscriptionTypes = new HashMap<>();
         this.subscriptionTypes.put("newHeads", EthSubscribeNewHeadsParams.class);
         this.subscriptionTypes.put("logs", EthSubscribeLogsParams.class);
+        this.subscriptionTypes.put("newPendingTransactions",EthSubscribePendingTransactionsParams.class);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribeParamsVisitor.java
@@ -36,4 +36,11 @@ public interface EthSubscribeParamsVisitor {
      * @return a subscription id which should be used as an unsubscribe parameter.
      */
     SubscriptionId visit(EthSubscribeLogsParams params, Channel channel);
+
+    /**
+     * @param params newPendingTransactions subscription request parameters.
+     * @param channel a Netty channel to subscribe notifications to.
+     * @return a subscription id which should be used as an unsubscribe parameter.
+     */
+    SubscriptionId visit(EthSubscribePendingTransactionsParams params, Channel channel);
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribePendingTransactionsParams.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscribePendingTransactionsParams.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2019 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.eth.subscribe;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.netty.channel.Channel;
+
+@JsonDeserialize
+public class EthSubscribePendingTransactionsParams implements EthSubscribeParams {
+    @Override
+    public SubscriptionId accept(EthSubscribeParamsVisitor visitor, Channel channel) {
+        return visitor.visit(this, channel);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscriptionParams.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/EthSubscriptionParams.java
@@ -24,11 +24,11 @@ import java.util.Objects;
 /**
  * The subscription params DTO for JSON serialization purposes.
  */
-public class EthSubscriptionParams {
+public class EthSubscriptionParams<T> {
     private final SubscriptionId subscription;
-    private final EthSubscriptionNotificationDTO result;
+    private final T result;
 
-    public EthSubscriptionParams(SubscriptionId subscription, EthSubscriptionNotificationDTO result) {
+    public EthSubscriptionParams(SubscriptionId subscription, T result) {
         this.subscription = Objects.requireNonNull(subscription);
         this.result = Objects.requireNonNull(result);
     }
@@ -39,7 +39,7 @@ public class EthSubscriptionParams {
     }
 
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    public EthSubscriptionNotificationDTO getResult() {
+    public T getResult() {
         return result;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
@@ -1,0 +1,41 @@
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.rpc.JsonRpcSerializer;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.ethereum.core.Transaction;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.listener.EthereumListenerAdapter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PendingTransactionsNotificationEmitter {
+
+    private final JsonRpcSerializer jsonRpcSerializer;
+
+    private final Map<SubscriptionId, Channel> subscriptions = new ConcurrentHashMap<>();
+
+    public PendingTransactionsNotificationEmitter(Ethereum ethereum, JsonRpcSerializer jsonRpcSerializer) {
+        this.jsonRpcSerializer = jsonRpcSerializer;
+        ethereum.addListener(new EthereumListenerAdapter() {
+            @Override
+            public void onPendingTransactionsReceived(List<Transaction> transactions) {
+                emit();
+            }
+        });
+    }
+
+    private void emit() {
+        subscriptions.forEach((SubscriptionId id, Channel channel) -> {
+            //TODO: HARDCODED FOR TDD
+            String msg = "serialized";
+            channel.writeAndFlush(new TextWebSocketFrame(msg));
+        });
+    }
+
+    public void subscribe(SubscriptionId subscriptionId, Channel channel) {
+        subscriptions.put(subscriptionId, channel);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
@@ -1,17 +1,21 @@
 package co.rsk.rpc.modules.eth.subscribe;
 
 import co.rsk.rpc.JsonRpcSerializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import org.ethereum.core.Transaction;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.listener.EthereumListenerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class PendingTransactionsNotificationEmitter {
+    private static final Logger logger = LoggerFactory.getLogger(PendingTransactionsNotificationEmitter.class);
 
     private final JsonRpcSerializer jsonRpcSerializer;
 
@@ -22,16 +26,24 @@ public class PendingTransactionsNotificationEmitter {
         ethereum.addListener(new EthereumListenerAdapter() {
             @Override
             public void onPendingTransactionsReceived(List<Transaction> transactions) {
-                emit();
+                emit(transactions);
             }
         });
     }
 
-    private void emit() {
+    private void emit(List<Transaction> transactions) {
         subscriptions.forEach((SubscriptionId id, Channel channel) -> {
             //TODO: HARDCODED FOR TDD
-            String msg = "serialized";
-            channel.writeAndFlush(new TextWebSocketFrame(msg));
+            EthSubscriptionNotification request = new EthSubscriptionNotification(
+                    new EthSubscriptionParams(id, new EthSubscriptionNotificationDTO() {
+                    })
+            );
+            try {
+                String msg = jsonRpcSerializer.serializeMessage(request);
+                channel.writeAndFlush(new TextWebSocketFrame(msg));
+            } catch (JsonProcessingException e) {
+                logger.error("Couldn't serialize block header result for notification", e);
+            }
         });
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
@@ -33,11 +33,9 @@ public class PendingTransactionsNotificationEmitter {
 
     private void emit(List<Transaction> transactions) {
         subscriptions.forEach((SubscriptionId id, Channel channel) -> {
-            //TODO: HARDCODED FOR TDD
-            EthSubscriptionNotification request = new EthSubscriptionNotification(
-                    new EthSubscriptionParams(id, new EthSubscriptionNotificationDTO() {
-                    })
-            );
+            String txHash = transactions.get(0).getHash().toJsonString();
+            EthSubscriptionParams params = new EthSubscriptionParams(id, txHash);
+            EthSubscriptionNotification request = new EthSubscriptionNotification(params);
             try {
                 String msg = jsonRpcSerializer.serializeMessage(request);
                 channel.writeAndFlush(new TextWebSocketFrame(msg));

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
@@ -39,6 +39,10 @@ public class PendingTransactionsNotificationEmitter {
         return subscriptions.remove(subscriptionId) != null;
     }
 
+    public void unsubscribe(Channel channel) {
+        subscriptions.values().removeIf(channel::equals);
+    }
+
     private void emit(List<Transaction> transactions) {
         subscriptions.forEach((SubscriptionId id, Channel channel) -> {
             transactions.forEach(t -> emit(id, channel, t.getHash().toJsonString()));

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitter.java
@@ -35,6 +35,10 @@ public class PendingTransactionsNotificationEmitter {
         subscriptions.put(subscriptionId, channel);
     }
 
+    public boolean unsubscribe(SubscriptionId subscriptionId) {
+        return subscriptions.remove(subscriptionId) != null;
+    }
+
     private void emit(List<Transaction> transactions) {
         subscriptions.forEach((SubscriptionId id, Channel channel) -> {
             transactions.forEach(t -> emit(id, channel, t.getHash().toJsonString()));

--- a/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
@@ -84,6 +84,7 @@ public class EthSubscriptionNotificationEmitterTest {
         assertThat(unsubscribed, is(false));
         verify(newHeads).unsubscribe(subscriptionId);
         verify(logs).unsubscribe(subscriptionId);
+        verify(pendingTransactions).unsubscribe(subscriptionId);
     }
 
     @Test
@@ -96,6 +97,7 @@ public class EthSubscriptionNotificationEmitterTest {
         assertThat(unsubscribed, is(true));
         verify(newHeads).unsubscribe(subscriptionId);
         verify(logs).unsubscribe(subscriptionId);
+        verify(pendingTransactions).unsubscribe(subscriptionId);
     }
 
     @Test
@@ -108,6 +110,20 @@ public class EthSubscriptionNotificationEmitterTest {
         assertThat(unsubscribed, is(true));
         verify(newHeads).unsubscribe(subscriptionId);
         verify(logs).unsubscribe(subscriptionId);
+        verify(pendingTransactions).unsubscribe(subscriptionId);
+    }
+
+    @Test
+    public void unsubscribeSuccessfullyFromPendingTransactions() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        when(pendingTransactions.unsubscribe(subscriptionId)).thenReturn(true);
+
+        boolean unsubscribed = emitter.unsubscribe(subscriptionId);
+
+        assertThat(unsubscribed, is(true));
+        verify(newHeads).unsubscribe(subscriptionId);
+        verify(logs).unsubscribe(subscriptionId);
+        verify(pendingTransactions).unsubscribe(subscriptionId);
     }
 
     @Test
@@ -118,5 +134,6 @@ public class EthSubscriptionNotificationEmitterTest {
 
         verify(newHeads).unsubscribe(channel);
         verify(logs).unsubscribe(channel);
+        verify(pendingTransactions).unsubscribe(channel);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/EthSubscriptionNotificationEmitterTest.java
@@ -30,13 +30,16 @@ import static org.mockito.Mockito.*;
 public class EthSubscriptionNotificationEmitterTest {
     private BlockHeaderNotificationEmitter newHeads;
     private LogsNotificationEmitter logs;
+    private PendingTransactionsNotificationEmitter pendingTransactions;
+
     private EthSubscriptionNotificationEmitter emitter;
 
     @Before
     public void setUp() {
         newHeads = mock(BlockHeaderNotificationEmitter.class);
         logs = mock(LogsNotificationEmitter.class);
-        emitter = new EthSubscriptionNotificationEmitter(newHeads, logs);
+        pendingTransactions = mock(PendingTransactionsNotificationEmitter.class);
+        emitter = new EthSubscriptionNotificationEmitter(newHeads, logs, pendingTransactions);
     }
 
     @Test
@@ -59,6 +62,17 @@ public class EthSubscriptionNotificationEmitterTest {
 
         assertThat(subscriptionId, notNullValue());
         verify(logs).subscribe(subscriptionId, channel, params);
+    }
+
+    @Test
+    public void subscribeToPendingTransactions() {
+        Channel channel = mock(Channel.class);
+
+        EthSubscribePendingTransactionsParams params = mock(EthSubscribePendingTransactionsParams.class);
+        SubscriptionId subscriptionId = emitter.visit(params, channel);
+
+        assertThat(subscriptionId, notNullValue());
+        verify(pendingTransactions).subscribe(subscriptionId, channel);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitterTest.java
@@ -13,9 +13,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class PendingTransactionsNotificationEmitterTest {
@@ -49,5 +52,48 @@ public class PendingTransactionsNotificationEmitterTest {
 
         String result = "{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{\"subscription\":\"0xc3b33aa549fb9a60e95d21862596617c\",\"result\":\"0xd6fdc5cc41a9959e922f30cb772a9aef46f4daea279307bc5f7024edc4ccd7fa\"}}";
         verify(channel).writeAndFlush(new TextWebSocketFrame(result));
+    }
+
+    @Test
+    public void onNonPendingTransactionsReceivedMessageIsNotTrigger() throws JsonProcessingException {
+        SubscriptionId subscriptionId = new SubscriptionId("0xc3b33aa549fb9a60e95d21862596617c");
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+
+        listener.onPendingTransactionsReceived(new ArrayList<Transaction>());
+
+        verify(channel,never()).writeAndFlush(any());
+    }
+
+    @Test
+    public void onTwoPendingTransactionsReceivedTriggersTwoMessageToChannel() throws JsonProcessingException {
+        SubscriptionId subscriptionId = new SubscriptionId("0xc3b33aa549fb9a60e95d21862596617c");
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+
+        Transaction tx1 = mock(Transaction.class);
+        when(tx1.getHash()).thenReturn(new Keccak256("d6fdc5cc41a9959e922f30cb772a9aef46f4daea279307bc5f7024edc4ccd7fa"));
+        Transaction tx2 = mock(Transaction.class);
+        when(tx2.getHash()).thenReturn(new Keccak256("a6fdc5cc41a9959e922f30cb772a9aef46f4daea279307bc5f7024edc4ccd7fb"));
+
+        List<Transaction> transactions = Arrays.asList(tx1,tx2);
+
+        listener.onPendingTransactionsReceived(transactions);
+
+        String result1 = "{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{\"subscription\":\"0xc3b33aa549fb9a60e95d21862596617c\",\"result\":\"0xd6fdc5cc41a9959e922f30cb772a9aef46f4daea279307bc5f7024edc4ccd7fa\"}}";
+        String result2 = "{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{\"subscription\":\"0xc3b33aa549fb9a60e95d21862596617c\",\"result\":\"0xa6fdc5cc41a9959e922f30cb772a9aef46f4daea279307bc5f7024edc4ccd7fb\"}}";
+
+        verify(channel).writeAndFlush(new TextWebSocketFrame(result1));
+        verify(channel).writeAndFlush(new TextWebSocketFrame(result2));
+    }
+
+    @Test
+    public void unsubscribeSucceedsForExistingSubscriptionId() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+
+        assertThat(emitter.unsubscribe(new SubscriptionId()), is(false));
+        assertThat(emitter.unsubscribe(subscriptionId), is(true));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitterTest.java
@@ -1,0 +1,48 @@
+package co.rsk.rpc.modules.eth.subscribe;
+
+import co.rsk.rpc.JsonRpcSerializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.ethereum.core.Transaction;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.listener.EthereumListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class PendingTransactionsNotificationEmitterTest {
+    private PendingTransactionsNotificationEmitter emitter;
+    private EthereumListener listener;
+    private JsonRpcSerializer serializer;
+
+    @Before
+    public void setUp() {
+        Ethereum ethereum = mock(Ethereum.class);
+        serializer = mock(JsonRpcSerializer.class);
+        emitter = new PendingTransactionsNotificationEmitter(ethereum, serializer);
+
+        ArgumentCaptor<EthereumListener> listenerCaptor = ArgumentCaptor.forClass(EthereumListener.class);
+        verify(ethereum).addListener(listenerCaptor.capture());
+        listener = listenerCaptor.getValue();
+    }
+
+    @Test
+    public void onPendingTransactionsReceivedTriggersMessageToChannel() throws JsonProcessingException {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+        when(serializer.serializeMessage(any()))
+                .thenReturn("serialized");
+
+        List<Transaction> transactions = new ArrayList<>();
+        listener.onPendingTransactionsReceived(transactions);
+
+        verify(channel).writeAndFlush(new TextWebSocketFrame("serialized"));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitterTest.java
@@ -96,4 +96,21 @@ public class PendingTransactionsNotificationEmitterTest {
         assertThat(emitter.unsubscribe(new SubscriptionId()), is(false));
         assertThat(emitter.unsubscribe(subscriptionId), is(true));
     }
+
+    @Test
+    public void unsubscribeChannelThenNothingIsEmitted() {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+
+        emitter.unsubscribe(channel);
+
+        Transaction tx = mock(Transaction.class);
+        Keccak256 txHash = new Keccak256("d6fdc5cc41a9959e922f30cb772a9aef46f4daea279307bc5f7024edc4ccd7fa");
+        when(tx.getHash()).thenReturn(txHash);
+        List<Transaction> transactions = Arrays.asList(tx);
+        listener.onPendingTransactionsReceived(transactions);
+
+        verifyNoMoreInteractions(channel);
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitterTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/PendingTransactionsNotificationEmitterTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.Mockito.*;
@@ -44,5 +45,29 @@ public class PendingTransactionsNotificationEmitterTest {
         listener.onPendingTransactionsReceived(transactions);
 
         verify(channel).writeAndFlush(new TextWebSocketFrame("serialized"));
+    }
+
+    @Test
+    public void onPendingTransactionsReceivedTriggersMessageToChannelWithTxHash() throws JsonProcessingException {
+        SubscriptionId subscriptionId = mock(SubscriptionId.class);
+
+        String result = "{\n" +
+                "        \"jsonrpc\":\"2.0\",\n" +
+                "        \"method\":\"eth_subscription\",\n" +
+                "        \"params\":{\n" +
+                "            \"subscription\":\"0xc3b33aa549fb9a60e95d21862596617c\",\n" +
+                "            \"result\":\"0xd6fdc5cc41a9959e922f30cb772a9aef46f4daea279307bc5f7024edc4ccd7fa\"\n" +
+                "        }\n" +
+                "   }";
+
+        Channel channel = mock(Channel.class);
+        emitter.subscribe(subscriptionId, channel);
+        Transaction tx = mock(Transaction.class);
+        when(serializer.serializeMessage(any())).thenReturn(result);
+        List<Transaction> transactions = Arrays.asList(tx);
+
+        listener.onPendingTransactionsReceived(transactions);
+
+        verify(channel).writeAndFlush(new TextWebSocketFrame(result));
     }
 }


### PR DESCRIPTION
## Add NewPendingTransactions To RSKj Eth_subscribe RPC Method
According to  [ rsk-gitcoin-hackathon-2021 - Add NewPendingTransactions To RSKj Eth_subscribe RPC Method ](https://github.com/rsksmart/rsk-gitcoin-hackathon-2021/issues/15) , I worked on newPendingTransactions subscription event

## Code Coverage

Attached [coverage.zip](https://github.com/rsksmart/rskj/files/6408867/coverage.zip) you can find all the code coverage reports.

You can find the main change in coverage/ns-33/sources/source-e.html in the attached coverage reports.

## Demonstration

Here you can see a demonstration about a new pending transactions notification.
![demostration](https://user-images.githubusercontent.com/5402004/116770900-6a5a2c00-aa1d-11eb-8df2-ac5436f0f878.gif)

new transaction created
![tx-done](https://user-images.githubusercontent.com/5402004/116770712-01be7f80-aa1c-11eb-8cb1-3381805710ad.png)

rskj-node initialization
![rskj-node-init](https://user-images.githubusercontent.com/5402004/116770687-dc317600-aa1b-11eb-9d7f-d74a87a44b0f.gif)

The following code was used for the demo.
``` var Web3 = require("web3");

const urlRSK = "ws://localhost:4445/websocket";

// Using web3js
const web3 = new Web3(urlRSK);

web3.eth.getBlockNumber().then((result) => {
  console.log("Latest Ethereum Block is ", result);
});

console.log("newPendingTxs...");

var subscription = web3.eth
  .subscribe("pendingTransactions", function (error, result) {
    if (!error) {
      console.log(result);
    } 
});

setTimeout(() => {
  console.log("unsubscribe");
  // unsubscribes the subscription
  subscription.unsubscribe(function (error, success) {
    if (success) console.log("Successfully unsubscribed!");
  });
}, 60000);


setTimeout(() => {
  console.log("GoodBye!");
  process.exit();
}, 61000); 
```
