### PR TITLE
Support eth_getProof JSON RPC method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -19,6 +19,7 @@
 package co.rsk.rpc;
 
 import co.rsk.rpc.modules.eth.EthModule;
+import co.rsk.rpc.modules.eth.getProof.ProofDTO;
 import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.dto.BlockResultDTO;
 import org.ethereum.rpc.dto.CompilationResultDTO;
@@ -26,6 +27,7 @@ import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Map;
 
 public interface Web3EthModule {
@@ -142,4 +144,6 @@ public interface Web3EthModule {
     boolean eth_submitWork(String nonce, String header, String mince);
 
     boolean eth_submitHashrate(String hashrate, String id);
+
+    ProofDTO eth_getProof(String address, List<String> storageKeys, String blockNumber);
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/getProof/ProofDTO.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/getProof/ProofDTO.java
@@ -1,0 +1,61 @@
+package co.rsk.rpc.modules.eth.getProof;
+
+import java.util.List;
+
+public class ProofDTO {
+
+    private String balance;
+    private String codeHash;
+    private String nonce;
+    private String storageHash;
+    private List<String> accountProof;
+    private List<StorageProofDTO> storageProof;
+
+    public String getBalance() {
+        return balance;
+    }
+
+    public void setBalance(String balance) {
+        this.balance = balance;
+    }
+
+    public String getCodeHash() {
+        return codeHash;
+    }
+
+    public void setCodeHash(String codeHash) {
+        this.codeHash = codeHash;
+    }
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public void setNonce(String nonce) {
+        this.nonce = nonce;
+    }
+
+    public String getStorageHash() {
+        return storageHash;
+    }
+
+    public void setStorageHash(String storageHash) {
+        this.storageHash = storageHash;
+    }
+
+    public List<String> getAccountProof() {
+        return accountProof;
+    }
+
+    public void setAccountProof(List<String> accountProof) {
+        this.accountProof = accountProof;
+    }
+
+    public List<StorageProofDTO> getStorageProof() {
+        return storageProof;
+    }
+
+    public void setStorageProof(List<StorageProofDTO> storageProof) {
+        this.storageProof = storageProof;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/getProof/StorageProofDTO.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/getProof/StorageProofDTO.java
@@ -1,0 +1,34 @@
+package co.rsk.rpc.modules.eth.getProof;
+
+import java.util.List;
+
+public class StorageProofDTO {
+
+    private String key;
+    private String value;
+    private List<String> proofs;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public List<String> getProofs() {
+        return proofs;
+    }
+
+    public void setProofs(List<String> proofs) {
+        this.proofs = proofs;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -33,6 +33,7 @@ import co.rsk.rpc.ModuleDescription;
 import co.rsk.rpc.Web3InformationRetriever;
 import co.rsk.rpc.modules.debug.DebugModule;
 import co.rsk.rpc.modules.eth.EthModule;
+import co.rsk.rpc.modules.eth.getProof.ProofDTO;
 import co.rsk.rpc.modules.evm.EvmModule;
 import co.rsk.rpc.modules.mnr.MnrModule;
 import co.rsk.rpc.modules.personal.PersonalModule;
@@ -1085,5 +1086,10 @@ public class Web3Impl implements Web3 {
      */
     public PeerScoringReputationSummary sco_reputationSummary() {
         return PeerScoringReporterUtil.buildReputationSummary(peerScoringManager.getPeersInformation());
+    }
+
+    @Override
+    public ProofDTO eth_getProof(String address, List<String> storageKeys, String blockNumber) {
+        throw new UnsupportedOperationException("Not implemeted yet");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Support eth_getProof JSON RPC method
Adding support to eth_getProof method, this will allow offchain verifications for storage and account values.

## Description
<!--- Describe your changes in detail -->
TBD...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TBD...

Solves https://github.com/rsksmart/rskj/issues/1493

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
TBD... 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
* https://eips.ethereum.org/EIPS/eip-1186
* https://medium.com/coinmonks/spv-proofs-explained-f38f8bb8f580
* https://medium.com/shyft-network-media/understanding-trie-databases-in-ethereum-9f03d2c3325d
* https://blog.rsk.co/es/noticia/hacia-una-mayor-escalabilidad-en-la-cadena-con-la-unitrie/

