### PR TITLE
eth_sendTransaction support 'gasLimit' field #961

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -46,6 +46,8 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
     private final Constants constants;
     private final TransactionGateway transactionGateway;
 
+    private final BigInteger DEFAULT_GAS_LIMIT = BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
+    
     public EthModuleTransactionBase(Constants constants, Wallet wallet, TransactionPool transactionPool, TransactionGateway transactionGateway) {
         this.wallet = wallet;
         this.transactionPool = transactionPool;
@@ -62,8 +64,15 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
 
             BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
             BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
-            BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
 
+            BigInteger gasLimit = DEFAULT_GAS_LIMIT;
+            if(args.gasLimit != null) {
+            	gasLimit = TypeConverter.stringNumberAsBigInt(args.gasLimit);
+            }
+            if(args.gas != null) {
+            	gasLimit = TypeConverter.stringNumberAsBigInt(args.gas);
+            }
+            
             if (args.data != null && args.data.startsWith("0x")) {
                 args.data = args.data.substring(2);
             }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -48,6 +48,8 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
     private final TransactionPool transactionPool;
     private final RskSystemProperties config;
 
+    private final BigInteger DEFAULT_GAS_LIMIT = BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
+    
     public PersonalModuleWalletEnabled(RskSystemProperties config, Ethereum eth, Wallet wallet, TransactionPool transactionPool) {
         this.config = config;
         this.eth = eth;
@@ -193,7 +195,14 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
         BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : transactionPool.getPendingState().getNonce(account.getAddress());
         BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
         BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
-        BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION);
+
+        BigInteger gasLimit = DEFAULT_GAS_LIMIT;
+        if(args.gasLimit != null) {
+        	gasLimit = TypeConverter.stringNumberAsBigInt(args.gasLimit);
+        }
+        if(args.gas != null) {
+        	gasLimit = TypeConverter.stringNumberAsBigInt(args.gas);
+        }
 
         if (args.data != null && args.data.startsWith("0x")) {
             args.data = args.data.substring(2);

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -37,6 +37,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String from;
         public String to;
         public String gas;
+        public String gasLimit;
         public String gasPrice;
         public String value;
         public String data; // compiledCode
@@ -47,7 +48,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
             return "CallArguments{" +
                     "from='" + from + '\'' +
                     ", to='" + to + '\'' +
-                    ", gasLimit='" + gas + '\'' +
+                    ", gasLimit='" + ((gas != null)?gas:gasLimit) + '\'' +
                     ", gasPrice='" + gasPrice + '\'' +
                     ", value='" + value + '\'' +
                     ", data='" + data + '\'' +


### PR DESCRIPTION
eth_sendTransaction support 'gasLimit' field #961

## Description
Added gasLimit field to Web3.CallArguments and make the necessary treatments in the EthModuleTransactionBase.sendTransaction and PersonalModuleWalletEnabled.sendTransaction. Making 'gas' param overwrite 'gasLimit' if both are provided

## Motivation and Context
https://github.com/rsksmart/rskj/issues/961

## How Has This Been Tested?
Tested on regtest with sendTransaction rpc API:
`{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from": "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826", "to": "0x7986b3df570230288501eea3d890bd66948c9b79", "gasLimit": "0x76c0", "gasPrice": "0x9184e72a000", "value": "0x186A0"}],"id":73}`

## Types of changes
- New feature (non-breaking change which adds functionality)


