### PR TITLE
Add configure.sh instructions to rskj-core README page

### DIFF
--- a/rskj-core/README.md
+++ b/rskj-core/README.md
@@ -1,9 +1,15 @@
 
 ## rskj-core
 
+#### Configure the RSK-compatible Gradle local installation
+
+Run `sh configure.sh` in the project's root directory.
+
+Now you'll be able to run `./gradlew` commands (while avoiding the `Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain` error).
+
 #### Compile, test and package
 
-Run `$ ../gradlew build`
+Run `$ ./gradlew build`
 
  - find jar artifacts at `build/libs`
  - find unit test and code coverage reports at `build/reports`
@@ -20,7 +26,7 @@ Note that in order to build the project without errors in IDEA, you will need to
 
 #### Install artifacts into your local `~/.m2` repository
 
-Run `../gradlew install`.
+Run `./gradlew install`.
 
 #### Publish rskj-core builds
 

--- a/rskj-core/README.md
+++ b/rskj-core/README.md
@@ -3,9 +3,15 @@
 
 #### Configure the RSK-compatible Gradle local installation
 
+Using a local Gradle installation will be necessary to be able to run `./gradlew` commands while avoiding the `Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain` error.
+
+##### Linux and macOS
+
 Run `sh configure.sh` in the project's root directory.
 
-Now you'll be able to run `./gradlew` commands (while avoiding the `Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain` error).
+##### Windows
+
+Run `./configure.sh` in the project's root directory, using Windows 10's git bash. You could also run `bash configure.sh` under WSL.
 
 #### Compile, test and package
 


### PR DESCRIPTION
## Description
Add a step to the setup instructions (to run the configure.sh script, so that a local Gradle version can be used when developing).

## Motivation and Context
For new devs to know they can use a local Gradle version (which is compatible with the project - 6.5 at the moment of writing this).

## How Has This Been Tested?
By doing a fresh setup of the project and following the instructions.