### PR TITLE
Add custom HttpStatusCodeProvider to adjust to JSON-RPC 2.0 conventions

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpServer.java
@@ -81,7 +81,7 @@ public class Web3HttpServer implements InternalService {
                     p.addLast(jsonRpcWeb3FilterHandler);
                     p.addLast(new Web3HttpMethodFilterHandler());
                     p.addLast(jsonRpcWeb3ServerHandler);
-                    p.addLast(new Web3ResultHttpResponseHandler());
+                    p.addLast(buildWeb3ResultHttpResponseHandler());
                 }
             });
         try {
@@ -90,6 +90,11 @@ public class Web3HttpServer implements InternalService {
             logger.error("The RPC HTTP server couldn't be started", e);
             Thread.currentThread().interrupt();
         }
+    }
+
+    private Web3ResultHttpResponseHandler buildWeb3ResultHttpResponseHandler() {
+        Web3HttpStatusCodeProvider web3HttpStatusCodeProvider = new Web3HttpStatusCodeProvider();
+        return new Web3ResultHttpResponseHandler(web3HttpStatusCodeProvider);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpStatusCodeProvider.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpStatusCodeProvider.java
@@ -27,7 +27,7 @@ public class Web3HttpStatusCodeProvider implements HttpStatusCodeProvider {
                 HttpResponseStatus.OK.code();
     }
 
-    private boolean isBadRequestResultCode(int resultCode) {
+    private static boolean isBadRequestResultCode(int resultCode) {
         return BAD_REQUEST_JSON_ERRORS.contains(resultCode);
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpStatusCodeProvider.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpStatusCodeProvider.java
@@ -1,0 +1,48 @@
+package co.rsk.rpc.netty;
+
+import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.*;
+
+public class Web3HttpStatusCodeProvider implements HttpStatusCodeProvider {
+
+    private static final List<JsonError> BAD_REQUEST_JSON_ERRORS = Arrays.asList(
+            METHOD_PARAMS_INVALID, INVALID_REQUEST, PARSE_ERROR
+    );
+
+    /**
+     * Only invalid JSON-RPC requests (e.g. a malformed JSON) qualify for a Bad Request HTTP status.
+     * In any other case, the HTTP protocol remains entirely independent from JSON-RPC (since its 2.0 version).
+     * Reference: https://www.jsonrpc.org/
+     */
+    @Override
+    public int getHttpStatusCode(int resultCode) {
+        return isBadRequestResultCode(resultCode) ?
+                HttpResponseStatus.BAD_REQUEST.code() :
+                HttpResponseStatus.OK.code();
+    }
+
+    private boolean isBadRequestResultCode(int resultCode) {
+        Optional<JsonError> optionalJsonError = BAD_REQUEST_JSON_ERRORS
+                .stream()
+                .filter(jsonError -> jsonError.code == resultCode)
+                .findFirst();
+        return optionalJsonError.isPresent();
+    }
+
+    /**
+     * The default implementation wrongly assumes that an HTTP status code is mapped to a single JSON RPC error - this
+     * is not always the case. Either way, this is not used in the current project.
+     */
+    @Override
+    public Integer getJsonRpcCode(int httpStatusCode) {
+        throw new UnsupportedOperationException("Cannot possibly determine a single JSON RPC from an HTTP status code");
+    }
+
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpStatusCodeProvider.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3HttpStatusCodeProvider.java
@@ -3,18 +3,17 @@ package co.rsk.rpc.netty;
 import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
 import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.*;
 
 public class Web3HttpStatusCodeProvider implements HttpStatusCodeProvider {
 
-    private static final List<JsonError> BAD_REQUEST_JSON_ERRORS = Arrays.asList(
-            METHOD_PARAMS_INVALID, INVALID_REQUEST, PARSE_ERROR
-    );
+    private static final List<Integer> BAD_REQUEST_JSON_ERRORS = Stream.of(METHOD_PARAMS_INVALID, INVALID_REQUEST, PARSE_ERROR)
+            .map(jsonError -> jsonError.code)
+            .collect(Collectors.toList());
 
     /**
      * Only invalid JSON-RPC requests (e.g. a malformed JSON) qualify for a Bad Request HTTP status.
@@ -29,11 +28,7 @@ public class Web3HttpStatusCodeProvider implements HttpStatusCodeProvider {
     }
 
     private boolean isBadRequestResultCode(int resultCode) {
-        Optional<JsonError> optionalJsonError = BAD_REQUEST_JSON_ERRORS
-                .stream()
-                .filter(jsonError -> jsonError.code == resultCode)
-                .findFirst();
-        return optionalJsonError.isPresent();
+        return BAD_REQUEST_JSON_ERRORS.contains(resultCode);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
@@ -17,23 +17,30 @@
  */
 package co.rsk.rpc.netty;
 
-import com.googlecode.jsonrpc4j.DefaultHttpStatusCodeProvider;
+import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_JSON;
 
 public class Web3ResultHttpResponseHandler extends SimpleChannelInboundHandler<Web3Result> {
 
+    private HttpStatusCodeProvider httpStatusCodeProvider;
+
+    public Web3ResultHttpResponseHandler(HttpStatusCodeProvider httpStatusCodeProvider) {
+        this.httpStatusCodeProvider = httpStatusCodeProvider;
+    }
+
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, Web3Result msg) {
         DefaultFullHttpResponse response = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1,
-                HttpResponseStatus.valueOf(DefaultHttpStatusCodeProvider.INSTANCE.getHttpStatusCode(msg.getCode())),
+                HttpResponseStatus.valueOf(httpStatusCodeProvider.getHttpStatusCode(msg.getCode())),
                 msg.getContent()
         );
 

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
@@ -30,7 +30,7 @@ import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_JSON;
 
 public class Web3ResultHttpResponseHandler extends SimpleChannelInboundHandler<Web3Result> {
 
-    private HttpStatusCodeProvider httpStatusCodeProvider;
+    private final HttpStatusCodeProvider httpStatusCodeProvider;
 
     public Web3ResultHttpResponseHandler(HttpStatusCodeProvider httpStatusCodeProvider) {
         this.httpStatusCodeProvider = httpStatusCodeProvider;

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpStatusCodeProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpStatusCodeProviderTest.java
@@ -1,0 +1,50 @@
+package co.rsk.rpc.netty;
+
+import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.*;
+import static org.junit.Assert.assertEquals;
+
+public class Web3HttpStatusCodeProviderTest {
+
+    private HttpStatusCodeProvider httpStatusCodeProvider;
+
+    @Before
+    public void setup() throws Exception {
+        httpStatusCodeProvider = new Web3HttpStatusCodeProvider();
+    }
+
+    @Test
+    public void getHttpStatusCodeReturnsExpectedHttpStatusCodes() {
+        assertThatOkHttpStatusIsReturnedWhenExpected(httpStatusCodeProvider);
+        assertThatBadRequestHttpStatusIsReturnedWhenExpected(httpStatusCodeProvider);
+    }
+
+    private void assertThatBadRequestHttpStatusIsReturnedWhenExpected(HttpStatusCodeProvider httpStatusCodeProvider) {
+        assertReturnedHttpStatusCodeIsExpected(httpStatusCodeProvider, OK.code, HttpResponseStatus.OK.code());
+        assertReturnedHttpStatusCodeIsExpected(httpStatusCodeProvider, METHOD_NOT_FOUND.code, HttpResponseStatus.OK.code());
+        assertReturnedHttpStatusCodeIsExpected(httpStatusCodeProvider, INTERNAL_ERROR.code, HttpResponseStatus.OK.code());
+        assertReturnedHttpStatusCodeIsExpected(httpStatusCodeProvider, ERROR_NOT_HANDLED.code, HttpResponseStatus.OK.code());
+        assertReturnedHttpStatusCodeIsExpected(httpStatusCodeProvider, BULK_ERROR.code, HttpResponseStatus.OK.code());
+    }
+
+    private void assertThatOkHttpStatusIsReturnedWhenExpected(HttpStatusCodeProvider httpStatusCodeProvider) {
+        assertReturnedHttpStatusCodeIsExpected(httpStatusCodeProvider, METHOD_PARAMS_INVALID.code, HttpResponseStatus.BAD_REQUEST.code());
+        assertReturnedHttpStatusCodeIsExpected(httpStatusCodeProvider, INVALID_REQUEST.code, HttpResponseStatus.BAD_REQUEST.code());
+        assertReturnedHttpStatusCodeIsExpected(httpStatusCodeProvider, PARSE_ERROR.code, HttpResponseStatus.BAD_REQUEST.code());
+    }
+
+    private void assertReturnedHttpStatusCodeIsExpected(HttpStatusCodeProvider httpStatusCodeProvider,
+                                                        int jsonRpcResultCode, int expectedHttpStatusCode) {
+        int httpStatusCode = httpStatusCodeProvider.getHttpStatusCode(jsonRpcResultCode);
+        assertEquals(expectedHttpStatusCode, httpStatusCode);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getJsonRpcCodeThrowsUnsupportedOperationException() {
+        httpStatusCodeProvider.getJsonRpcCode(INVALID_REQUEST.code);
+    }
+}


### PR DESCRIPTION
## Description
Since the jsonrpc4j keeps on returning internal error HTTP status codes upon JSON-RPC errors (it shouldn't, since the transport layer protocol should be agnostic to JSON-RPC), we add custom logic to handle them.

Inspired on [this](https://github.com/hyperledger/besu/issues/549), any valid JSON-RPC request should generate a JSON-RPC response, the HTTP status code should be 200. No matter if the response is a success or error response.
Calling a method that hasn't been enabled or a method that doesn't exist are valid JSON-RPC requests, therefore the expected response is a JSON-RPC error (and status code = 200)
Any invalid JSON-RPC request (malformed JSON, etc.) should generate a 400 status code.

## Motivation and Context
Issue #1387 

## How Has This Been Tested?
Unit testing

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)