### PR TITLE
Adding error handler for invalid fields

### DIFF
--- a/rskj-core/src/main/java/co/rsk/jsonrpc/JsonRpcError.java
+++ b/rskj-core/src/main/java/co/rsk/jsonrpc/JsonRpcError.java
@@ -23,6 +23,10 @@ import java.util.Objects;
  * The standard JSON-RPC error object for responses.
  */
 public class JsonRpcError implements JsonRpcResultOrError {
+    // Error codes as defined in https://www.jsonrpc.org/specification#error_object
+    public static final int INVALID_PARAMS = -32602;
+    public static final int INTERNAL_ERROR = -32603;
+
     private final int code;
     private final String message;
 

--- a/rskj-core/src/main/java/co/rsk/jsonrpc/JsonRpcInternalError.java
+++ b/rskj-core/src/main/java/co/rsk/jsonrpc/JsonRpcInternalError.java
@@ -22,6 +22,6 @@ package co.rsk.jsonrpc;
  */
 public class JsonRpcInternalError extends JsonRpcError {
     public JsonRpcInternalError() {
-        super(-32603, "Internal error.");
+        super(JsonRpcError.INTERNAL_ERROR, "Internal error.");
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskErrorResolver.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskErrorResolver.java
@@ -2,11 +2,13 @@ package org.ethereum.rpc.exception;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.googlecode.jsonrpc4j.ErrorResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -23,10 +25,21 @@ public class RskErrorResolver implements ErrorResolver {
             error =  new JsonError(((RskJsonRpcRequestException) t).getCode(), t.getMessage(), null);
         } else if (t instanceof InvalidFormatException) {
             error = new JsonError(-32603, "Internal server error, probably due to invalid parameter type", null);
+        } else if (t instanceof UnrecognizedPropertyException) {
+            String message = getExceptionMessage((UnrecognizedPropertyException) t);
+            logger.error("JsonRPC error {} for method {} with arguments {}", message, method, arguments);
+            error = new JsonError(-32603, message, null);
         } else {
             logger.error("JsonRPC error when for method {} with arguments {}", method, arguments, t);
             error = new JsonError(-32603, "Internal server error", null);
         }
         return error;
+    }
+
+    private String getExceptionMessage(UnrecognizedPropertyException ex) {
+        if (ex.getMessage() == null) return "Invalid parameters";
+        return Arrays.stream(ex.getMessage().split("\\n at "))
+                .findFirst()
+                .orElse("Invalid parameters");
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskErrorResolver.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskErrorResolver.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskErrorResolver.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskErrorResolver.java
@@ -38,7 +38,7 @@ public class RskErrorResolver implements ErrorResolver {
         return error;
     }
 
-    private String getExceptionMessage(UnrecognizedPropertyException ex) {
+    private static String getExceptionMessage(UnrecognizedPropertyException ex) {
         if (ex.getPropertyName() == null || ex.getKnownPropertyIds() == null) return "Invalid parameters";
 
         StringBuilder stringBuilder = new StringBuilder("Unrecognized field \"");

--- a/rskj-core/src/test/java/org/ethereum/rpc/exception/RskErrorResolverTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/exception/RskErrorResolverTest.java
@@ -1,0 +1,128 @@
+package org.ethereum.rpc.exception;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by Nazaret García on 26/05/2021
+ */
+
+public class RskErrorResolverTest {
+
+    private RskErrorResolver rskErrorResolver;
+
+    @Before
+    public void setup() {
+        rskErrorResolver = new RskErrorResolver();
+    }
+
+    @Test
+    public void test_resolveError_givenRskJsonRpcRequestException_returnsJsonErrorAsExpected() throws NoSuchMethodException {
+        // Given
+        Integer code = 1;
+        String message = "message";
+        RskJsonRpcRequestException exception = new RskJsonRpcRequestException(code, message);
+
+        Method methodMock = this.getClass().getMethod("mockMethod");
+        List<JsonNode> jsonNodeListMock = new ArrayList<>();
+
+        // When
+        JsonError result = rskErrorResolver.resolveError(exception, methodMock, jsonNodeListMock);
+
+        // Then
+        Assert.assertNotNull(result);
+        Assert.assertEquals(code, (Integer) result.code);
+        Assert.assertEquals(message, result.message);
+        Assert.assertNull(result.data);
+    }
+
+    @Test
+    public void test_resolveError_givenInvalidFormatException_returnsJsonErrorAsExpected() throws NoSuchMethodException {
+        // Given
+        InvalidFormatException exception = mock(InvalidFormatException.class);
+
+        Method methodMock = this.getClass().getMethod("mockMethod");
+        List<JsonNode> jsonNodeListMock = new ArrayList<>();
+
+        // When
+        JsonError result = rskErrorResolver.resolveError(exception, methodMock, jsonNodeListMock);
+
+        // Then
+        Assert.assertNotNull(result);
+        Assert.assertEquals(-32603, result.code);
+        Assert.assertEquals("Internal server error, probably due to invalid parameter type", result.message);
+        Assert.assertNull(result.data);
+    }
+
+    @Test
+    public void test_resolveError_givenUnrecognizedPropertyException_nullExceptionMessage_returnsJsonErrorWithDefaultMessageAsExpected() throws NoSuchMethodException {
+        // Given
+        UnrecognizedPropertyException exception = mock(UnrecognizedPropertyException.class);
+        when(exception.getMessage()).thenReturn(null);
+
+        Method methodMock = this.getClass().getMethod("mockMethod");
+        List<JsonNode> jsonNodeListMock = new ArrayList<>();
+
+        // When
+        JsonError result = rskErrorResolver.resolveError(exception, methodMock, jsonNodeListMock);
+
+        // Then
+        Assert.assertNotNull(result);
+        Assert.assertEquals(-32603, result.code);
+        Assert.assertEquals("Invalid parameters", result.message);
+        Assert.assertNull(result.data);
+    }
+
+    @Test
+    public void test_resolveError_givenUnrecognizedPropertyException_returnsJsonErrorWithDescriptiveMessageAsExpected() throws NoSuchMethodException {
+        // Given
+        String message = "Unrecognized field \"form\" (class org.ethereum.rpc.Web3$CallArguments), not marked as ignorable (8 known properties: \"gasPrice\", \"value\", \"gas\", \"from\", \"to\", \"chainId\", \"nonce\", \"data\"])\n at [Source: N/A; line: -1, column: -1] (through reference chain: org.ethereum.rpc.Web3$CallArguments[\"form\"])";
+        UnrecognizedPropertyException exception = mock(UnrecognizedPropertyException.class);
+        when(exception.getMessage()).thenReturn(message);
+
+        Method methodMock = this.getClass().getMethod("mockMethod");
+        List<JsonNode> jsonNodeListMock = new ArrayList<>();
+
+        // When
+        JsonError result = rskErrorResolver.resolveError(exception, methodMock, jsonNodeListMock);
+
+        // Then
+        Assert.assertNotNull(result);
+        Assert.assertEquals(-32603, result.code);
+        Assert.assertEquals("Unrecognized field \"form\" (class org.ethereum.rpc.Web3$CallArguments), not marked as ignorable (8 known properties: \"gasPrice\", \"value\", \"gas\", \"from\", \"to\", \"chainId\", \"nonce\", \"data\"])", result.message);
+        Assert.assertNull(result.data);
+    }
+
+    @Test
+    public void test_resolveError_givenGenericException_returnsJsonErrorWithDefaultMessageAsExpected() throws NoSuchMethodException {
+        // Given
+        Exception exception = mock(Exception.class);
+
+        Method methodMock = this.getClass().getMethod("mockMethod");
+        List<JsonNode> jsonNodeListMock = new ArrayList<>();
+
+        // When
+        JsonError result = rskErrorResolver.resolveError(exception, methodMock, jsonNodeListMock);
+
+        // Then
+        Assert.assertNotNull(result);
+        Assert.assertEquals(-32603, result.code);
+        Assert.assertEquals("Internal server error", result.message);
+        Assert.assertNull(result.data);
+    }
+
+    public void mockMethod() { }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When doing a JSON RPC request, if an invalid field is sent, then only an internal error is returned.

## Description
<!--- Describe your changes in detail -->

When a field is invalid a description of the problem is returned Instead of returning and Internal Error without description, e.g., when a "form" field is sent instead of "from", the following message is returned:

> Unrecognized field "form" (8 known properties: ["gasPrice", "value", "gas", "from", "to", "chainId", "nonce", "data"])

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/rsksmart/rskj/issues/1531

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

By using Unit Tests and Integration Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
