### PR TITLE
Configurable write timeout for websocket server

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1600,7 +1600,8 @@ public class RskContext implements NodeBootstrapper {
                     rskSystemProperties.rpcWebSocketBindAddress(),
                     rskSystemProperties.rpcWebSocketPort(),
                     jsonRpcHandler,
-                    getJsonRpcWeb3ServerHandler()
+                    getJsonRpcWeb3ServerHandler(),
+                    rskSystemProperties.rpcWebSocketServerWriteTimeout()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1595,7 +1595,7 @@ public class RskContext implements NodeBootstrapper {
                             new BlockchainBranchComparator(getBlockStore())
                     )
             );
-            RskJsonRpcHandler jsonRpcHandler = new RskJsonRpcHandler(emitter, jsonRpcSerializer);
+            RskWebSocketJsonRpcHandler jsonRpcHandler = new RskWebSocketJsonRpcHandler(emitter, jsonRpcSerializer);
             web3WebSocketServer = new Web3WebSocketServer(
                     rskSystemProperties.rpcWebSocketBindAddress(),
                     rskSystemProperties.rpcWebSocketPort(),

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1601,7 +1601,7 @@ public class RskContext implements NodeBootstrapper {
                     rskSystemProperties.rpcWebSocketPort(),
                     jsonRpcHandler,
                     getJsonRpcWeb3ServerHandler(),
-                    rskSystemProperties.rpcWebSocketServerWriteTimeout()
+                    rskSystemProperties.rpcWebSocketServerWriteTimeoutSeconds()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
@@ -28,10 +28,13 @@ import co.rsk.rpc.modules.eth.subscribe.EthSubscribeRequest;
 import co.rsk.rpc.modules.eth.subscribe.EthUnsubscribeRequest;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.ByteBufInputStream;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.timeout.WriteTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,15 +51,15 @@ import java.io.IOException;
  */
 
 @Sharable
-public class RskJsonRpcHandler
+public class RskWebSocketJsonRpcHandler
         extends SimpleChannelInboundHandler<ByteBufHolder>
         implements RskJsonRpcRequestVisitor {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RskJsonRpcHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RskWebSocketJsonRpcHandler.class);
 
     private final EthSubscriptionNotificationEmitter emitter;
     private final JsonRpcSerializer serializer;
 
-    public RskJsonRpcHandler(EthSubscriptionNotificationEmitter emitter, JsonRpcSerializer serializer) {
+    public RskWebSocketJsonRpcHandler(EthSubscriptionNotificationEmitter emitter, JsonRpcSerializer serializer) {
         this.emitter = emitter;
         this.serializer = serializer;
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
@@ -67,12 +67,9 @@ public class RskWebSocketJsonRpcHandler
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) throws IOException {
-        ByteBuf content = null;
-        ByteBufInputStream source = null;
+        ByteBuf content = msg.content().copy();
 
-        try {
-            content = msg.content().copy();
-            source = new ByteBufInputStream(content);
+        try (ByteBufInputStream source = new ByteBufInputStream(content)){
             RskJsonRpcRequest request = serializer.deserializeRequest(source);
 
             // TODO(mc) we should support the ModuleDescription method filters
@@ -85,10 +82,6 @@ public class RskWebSocketJsonRpcHandler
 
             // We need to release this resource, netty only takes care about 'ByteBufHolder msg'
             content.release(content.refCnt());
-        } finally {
-            if(source != null) {
-                source.close();
-            }
         }
 
         // delegate to the next handler if the message can't be matched to a known JSON-RPC request

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
@@ -64,7 +64,7 @@ public class RskWebSocketJsonRpcHandler
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) throws IOException {
-        ByteBuf content = msg.content().copy();
+        ByteBuf content = msg.copy().content();
 
         try (ByteBufInputStream source = new ByteBufInputStream(content)){
             RskJsonRpcRequest request = serializer.deserializeRequest(source);

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
@@ -63,7 +63,7 @@ public class RskWebSocketJsonRpcHandler
     }
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) throws IOException {
+    protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) {
         ByteBuf content = msg.copy().content();
 
         try (ByteBufInputStream source = new ByteBufInputStream(content)){

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
@@ -29,13 +29,10 @@ import co.rsk.rpc.modules.eth.subscribe.EthUnsubscribeRequest;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.ByteBufInputStream;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
-import io.netty.handler.timeout.WriteTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandler.java
@@ -66,12 +66,14 @@ public class RskWebSocketJsonRpcHandler
     }
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) {
+    protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) throws IOException {
         ByteBuf content = null;
+        ByteBufInputStream source = null;
 
         try {
             content = msg.content().copy();
-            RskJsonRpcRequest request = serializer.deserializeRequest(new ByteBufInputStream(content));
+            source = new ByteBufInputStream(content);
+            RskJsonRpcRequest request = serializer.deserializeRequest(source);
 
             // TODO(mc) we should support the ModuleDescription method filters
             JsonRpcResultOrError resultOrError = request.accept(this, ctx);
@@ -83,6 +85,10 @@ public class RskWebSocketJsonRpcHandler
 
             // We need to release this resource, netty only takes care about 'ByteBufHolder msg'
             content.release(content.refCnt());
+        } finally {
+            if(source != null) {
+                source.close();
+            }
         }
 
         // delegate to the next handler if the message can't be matched to a known JSON-RPC request

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
@@ -1,0 +1,27 @@
+package co.rsk.rpc.netty;
+
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.timeout.WriteTimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RskWebSocketServerProtocolHandler extends WebSocketServerProtocolHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RskWebSocketServerProtocolHandler.class);
+
+    public RskWebSocketServerProtocolHandler(String websocketPath) {
+        super(websocketPath);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        if(cause instanceof WriteTimeoutException) {
+            ctx.writeAndFlush(new CloseWebSocketFrame(1000, "Exceeded write timout")).addListener(ChannelFutureListener.CLOSE);
+            LOGGER.error("Write timout exceeded, closing web socket channel", cause);
+        } else {
+            super.exceptionCaught(ctx, cause);
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
 
 public class RskWebSocketServerProtocolHandler extends WebSocketServerProtocolHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(RskWebSocketServerProtocolHandler.class);
+    public static final String WRITE_TIMEOUT_REASON = "Exceeded write timout";
+    public static final int NORMAL_CLOSE_WEBSOCKET_STATUS = 1000;
 
     public RskWebSocketServerProtocolHandler(String websocketPath) {
         super(websocketPath);
@@ -18,8 +20,8 @@ public class RskWebSocketServerProtocolHandler extends WebSocketServerProtocolHa
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if(cause instanceof WriteTimeoutException) {
-            ctx.writeAndFlush(new CloseWebSocketFrame(1000, "Exceeded write timout")).addListener(ChannelFutureListener.CLOSE);
-            LOGGER.error("Write timout exceeded, closing web socket channel", cause);
+            ctx.writeAndFlush(new CloseWebSocketFrame(NORMAL_CLOSE_WEBSOCKET_STATUS, WRITE_TIMEOUT_REASON)).addListener(ChannelFutureListener.CLOSE);
+            LOGGER.error("Write timeout exceeded, closing web socket channel", cause);
         } else {
             super.exceptionCaught(ctx, cause);
         }

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
@@ -28,7 +28,6 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
-import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Web3WebSocketServer implements InternalService {
     private static final Logger logger = LoggerFactory.getLogger(Web3WebSocketServer.class);
-    public static final int WRITE_TIMEOUT_SECONDS = 5;
+    public static final int WRITE_TIMEOUT_SECONDS = 30;
 
     private final InetAddress host;
     private final int port;

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
@@ -46,21 +46,21 @@ public class Web3WebSocketServer implements InternalService {
     private final EventLoopGroup bossGroup;
     private final EventLoopGroup workerGroup;
     private @Nullable ChannelFuture webSocketChannel;
-    private final int serverWriteTimeout;
+    private final int serverWriteTimeoutSeconds;
 
     public Web3WebSocketServer(
             InetAddress host,
             int port,
             RskWebSocketJsonRpcHandler webSocketJsonRpcHandler,
             JsonRpcWeb3ServerHandler web3ServerHandler,
-            int serverWriteTimeout) {
+            int serverWriteTimeoutSeconds) {
         this.host = host;
         this.port = port;
         this.webSocketJsonRpcHandler = webSocketJsonRpcHandler;
         this.web3ServerHandler = web3ServerHandler;
         this.bossGroup = new NioEventLoopGroup();
         this.workerGroup = new NioEventLoopGroup();
-        this.serverWriteTimeout = serverWriteTimeout;
+        this.serverWriteTimeoutSeconds = serverWriteTimeoutSeconds;
     }
 
     @Override
@@ -75,7 +75,7 @@ public class Web3WebSocketServer implements InternalService {
                     ChannelPipeline p = ch.pipeline();
                     p.addLast(new HttpServerCodec());
                     p.addLast(new HttpObjectAggregator(1024 * 1024 * 5));
-                    p.addLast(new WriteTimeoutHandler(serverWriteTimeout, TimeUnit.SECONDS));
+                    p.addLast(new WriteTimeoutHandler(serverWriteTimeoutSeconds, TimeUnit.SECONDS));
                     p.addLast(new RskWebSocketServerProtocolHandler("/websocket"));
                     p.addLast(webSocketJsonRpcHandler);
                     p.addLast(web3ServerHandler);

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Web3WebSocketServer implements InternalService {
     private static final Logger logger = LoggerFactory.getLogger(Web3WebSocketServer.class);
+    private static final int HTTP_MAX_CONTENT_LENGTH = 1024 * 1024 * 5;
 
     private final InetAddress host;
     private final int port;
@@ -74,7 +75,7 @@ public class Web3WebSocketServer implements InternalService {
                 protected void initChannel(SocketChannel ch) throws Exception {
                     ChannelPipeline p = ch.pipeline();
                     p.addLast(new HttpServerCodec());
-                    p.addLast(new HttpObjectAggregator(1024 * 1024 * 5));
+                    p.addLast(new HttpObjectAggregator(HTTP_MAX_CONTENT_LENGTH));
                     p.addLast(new WriteTimeoutHandler(serverWriteTimeoutSeconds, TimeUnit.SECONDS));
                     p.addLast(new RskWebSocketServerProtocolHandler("/websocket"));
                     p.addLast(webSocketJsonRpcHandler);

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -82,6 +82,7 @@ public abstract class SystemProperties {
     private static final String PROPERTY_RPC_WEBSOCKET_ENABLED = "rpc.providers.web.ws.enabled";
     private static final String PROPERTY_RPC_WEBSOCKET_ADDRESS = "rpc.providers.web.ws.bind_address";
     private static final String PROPERTY_RPC_WEBSOCKET_PORT = "rpc.providers.web.ws.port";
+    private static final String PROPERTY_RPC_WEBSOCKET_SERVER_WRITE_TIMEOUT = "rpc.providers.web.ws.server_write_timeout";
 
     public static final String PROPERTY_PUBLIC_IP = "public.ip";
     public static final String PROPERTY_BIND_ADDRESS = "bind_address";
@@ -610,6 +611,10 @@ public abstract class SystemProperties {
 
     public int rpcWebSocketPort() {
         return configFromFiles.getInt(PROPERTY_RPC_WEBSOCKET_PORT);
+    }
+
+    public int rpcWebSocketServerWriteTimeout() {
+        return configFromFiles.getInt(PROPERTY_RPC_WEBSOCKET_SERVER_WRITE_TIMEOUT);
     }
 
     public InetAddress rpcHttpBindAddress() {

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -82,7 +82,7 @@ public abstract class SystemProperties {
     private static final String PROPERTY_RPC_WEBSOCKET_ENABLED = "rpc.providers.web.ws.enabled";
     private static final String PROPERTY_RPC_WEBSOCKET_ADDRESS = "rpc.providers.web.ws.bind_address";
     private static final String PROPERTY_RPC_WEBSOCKET_PORT = "rpc.providers.web.ws.port";
-    private static final String PROPERTY_RPC_WEBSOCKET_SERVER_WRITE_TIMEOUT = "rpc.providers.web.ws.server_write_timeout";
+    private static final String PROPERTY_RPC_WEBSOCKET_SERVER_WRITE_TIMEOUT_SECONDS = "rpc.providers.web.ws.server_write_timeout_seconds";
 
     public static final String PROPERTY_PUBLIC_IP = "public.ip";
     public static final String PROPERTY_BIND_ADDRESS = "bind_address";
@@ -613,8 +613,8 @@ public abstract class SystemProperties {
         return configFromFiles.getInt(PROPERTY_RPC_WEBSOCKET_PORT);
     }
 
-    public int rpcWebSocketServerWriteTimeout() {
-        return configFromFiles.getInt(PROPERTY_RPC_WEBSOCKET_SERVER_WRITE_TIMEOUT);
+    public int rpcWebSocketServerWriteTimeoutSeconds() {
+        return configFromFiles.getInt(PROPERTY_RPC_WEBSOCKET_SERVER_WRITE_TIMEOUT_SECONDS);
     }
 
     public InetAddress rpcHttpBindAddress() {

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -220,6 +220,7 @@ rpc = {
                 enabled = <enabled>
                 bind_address = <bind_address>
                 port = <port>
+                server_write_timeout = <timeout>
             }
         }
     }

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -220,7 +220,7 @@ rpc = {
                 enabled = <enabled>
                 bind_address = <bind_address>
                 port = <port>
-                server_write_timeout = <timeout>
+                server_write_timeout_seconds = <timeout>
             }
         }
     }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -282,6 +282,8 @@ rpc {
                 enabled = false
                 bind_address = localhost
                 port = 4445
+                # Shuts down the server when it's not able to write a response after a certain period (expressed in seconds)
+                server_write_timeout = 30
             }
         }
     }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -283,7 +283,7 @@ rpc {
                 bind_address = localhost
                 port = 4445
                 # Shuts down the server when it's not able to write a response after a certain period (expressed in seconds)
-                server_write_timeout = 30
+                server_write_timeout_seconds = 30
             }
         }
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/RskWebSocketJsonRpcHandlerTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
-public class RskJsonRpcHandlerTest {
+public class RskWebSocketJsonRpcHandlerTest {
     private static final SubscriptionId SAMPLE_SUBSCRIPTION_ID = new SubscriptionId("0x3075");
     private static final EthSubscribeRequest SAMPLE_SUBSCRIBE_REQUEST = new EthSubscribeRequest(
             JsonRpcVersion.V2_0,
@@ -47,7 +47,7 @@ public class RskJsonRpcHandlerTest {
 
     );
 
-    private RskJsonRpcHandler handler;
+    private RskWebSocketJsonRpcHandler handler;
     private EthSubscriptionNotificationEmitter emitter;
     private JsonRpcSerializer serializer;
 
@@ -55,7 +55,7 @@ public class RskJsonRpcHandlerTest {
     public void setUp() {
         emitter = mock(EthSubscriptionNotificationEmitter.class);
         serializer = mock(JsonRpcSerializer.class);
-        handler = new RskJsonRpcHandler(emitter, serializer);
+        handler = new RskWebSocketJsonRpcHandler(emitter, serializer);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
@@ -71,7 +71,7 @@ public class Web3WebSocketServerTest {
         int randomPort = 9998;//new ServerSocket(0).getLocalPort();
 
         List<ModuleDescription> filteredModules = Collections.singletonList(new ModuleDescription("web3", "1.0", true, Collections.emptyList(), Collections.emptyList()));
-        RskJsonRpcHandler handler = new RskJsonRpcHandler(null, new JacksonBasedRpcSerializer());
+        RskWebSocketJsonRpcHandler handler = new RskWebSocketJsonRpcHandler(null, new JacksonBasedRpcSerializer());
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Mock, filteredModules);
 
         Web3WebSocketServer websocketServer = new Web3WebSocketServer(InetAddress.getLoopbackAddress(), randomPort, handler, serverHandler);

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
@@ -31,7 +31,6 @@ import com.squareup.okhttp.ws.WebSocketListener;
 import okio.Buffer;
 import org.ethereum.rpc.Web3;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -55,7 +54,7 @@ public class Web3WebSocketServerTest {
 
     private static JsonNodeFactory JSON_NODE_FACTORY = JsonNodeFactory.instance;
     private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final int DEFAULT_WRITE_TIMEOUT = 30;
+    private static final int DEFAULT_WRITE_TIMEOUT_SECONDS = 30;
 
     private ExecutorService wsExecutor;
 
@@ -77,16 +76,16 @@ public class Web3WebSocketServerTest {
         List<ModuleDescription> filteredModules = Collections.singletonList(new ModuleDescription("web3", "1.0", true, Collections.emptyList(), Collections.emptyList()));
         RskWebSocketJsonRpcHandler handler = new RskWebSocketJsonRpcHandler(null, new JacksonBasedRpcSerializer());
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Mock, filteredModules);
-        int serverWriteTimout = testSystemProperties.rpcWebSocketServerWriteTimeout();
+        int serverWriteTimeoutSeconds = testSystemProperties.rpcWebSocketServerWriteTimeoutSeconds();
 
-        assertEquals(DEFAULT_WRITE_TIMEOUT, serverWriteTimout);
+        assertEquals(DEFAULT_WRITE_TIMEOUT_SECONDS, serverWriteTimeoutSeconds);
 
         Web3WebSocketServer websocketServer = new Web3WebSocketServer(
                 InetAddress.getLoopbackAddress(),
                 randomPort,
                 handler,
                 serverHandler,
-                serverWriteTimout
+                serverWriteTimeoutSeconds
         );
         websocketServer.start();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Any websocket connection will be closed after a certain write timeout. Currently set to 30 seconds but it can be less (I think it should be less).

This implied 

- in adding a `WriteTimeoutHandler` to the `Web3WebSocketServer`
- And creating an `RskWebSocketJsonRpcHandler` to close a connection after exceding the timeout.
- Also renamed `RskJsonRpcHandler` to `RskWebSocketJsonRpcHandler`, since it was only used for the websocket server.

Also take account that I had to modify the `RskWebSocketJsonRpcHandler`, there where two reference counted objects that are producing memory leaks when the connection is closed due to exceding the timeout:

```java

class RskWebSocketJsonRpcHandler {
    protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) {
      ... 
      RskJsonRpcRequest request = serializer.deserializeRequest(new ByteBufInputStream(msg.copy().content()));
      ...
      ctx.fireChannelRead(msg.retain());
    }
}
```
This last one is also unnecesary, there's no need to retain a `msg` that will be passed anyway to the next handler.

## Unit Testing

This should be covered by an integration test, I've only added one assertion to make sure that the timeout has properly been set.

Also if you want to verify netty is not producing any other buffer leak, you can activate the leak decector by adding

```java
java -Dio.netty.leakDetection.level=advanced 
```

## Useful links

- [Netty's reference counted objects](https://netty.io/wiki/reference-counted-objects.html)