### PR TITLE
eth_sendTransaction support 'gasLimit' field #961 plus transaction refactory 

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/MiningMainchainViewImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/MiningMainchainViewImpl.java
@@ -161,7 +161,7 @@ public class MiningMainchainViewImpl implements MiningMainchainView {
 
             Block nextBlock = blockStore.getBlockByHash(currentHeader.getParentHash().getBytes());
             if (nextBlock == null) {
-                logger.error("Missing parent for block %s, number %d", currentHeader.getPrintableHash(), currentHeader.getNumber());
+                logger.error("Missing parent for block {}, number {}", currentHeader.getPrintableHash(), currentHeader.getNumber());
                 break;
             }
             currentHeader = nextBlock.getHeader();

--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -277,7 +277,7 @@ public class NodeBlockProcessor implements BlockProcessor {
         List<BlockIdentifier> blockIdentifiers = new ArrayList<>();
         long skeletonNumber = skeletonStartHeight;
         int maxSkeletonChunks = syncConfiguration.getMaxSkeletonChunks();
-        long maxSkeletonNumber = Math.min(this.getBestBlockNumber(), skeletonStartHeight + skeletonStep * maxSkeletonChunks);
+        long maxSkeletonNumber = Math.min(this.getBestBlockNumber(), skeletonStartHeight + skeletonStep * (long) maxSkeletonChunks);
 
         for (; skeletonNumber < maxSkeletonNumber; skeletonNumber += skeletonStep) {
             byte[] skeletonHash = getSkeletonHash(skeletonNumber);

--- a/rskj-core/src/main/java/co/rsk/pcc/NativeMethod.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/NativeMethod.java
@@ -77,7 +77,7 @@ public abstract class NativeMethod {
         // the default can always be used on top.
         // (e.g., "return 23000L + super(parsedArguments, originalData);")
 
-        return originalData == null ? 0 : originalData.length * 2;
+        return originalData == null ? 0 : originalData.length * 2L;
     }
 
     public abstract boolean isEnabled();

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1187,7 +1187,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
             Federation retiringFederation = self.bridgeSupport.getRetiringFederation();
 
             if (!BridgeUtils.isFromFederateMember(self.rskTx, self.bridgeSupport.getActiveFederation())
-                    && ( retiringFederation == null || (retiringFederation != null && !BridgeUtils.isFromFederateMember(self.rskTx, retiringFederation)))) {
+                    && (retiringFederation == null || !BridgeUtils.isFromFederateMember(self.rskTx, retiringFederation))) {
                 String errorMessage = String.format("Sender is not part of the active or retiring federations, so he is not enabled to call the function '%s'",funcName);
                 logger.warn(errorMessage);
                 throw new VMException(errorMessage);

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -18,28 +18,27 @@
 
 package co.rsk.rpc.modules.eth;
 
-import co.rsk.core.RskAddress;
-import co.rsk.core.Wallet;
-import co.rsk.net.TransactionGateway;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.config.Constants;
-import org.ethereum.core.*;
-import org.ethereum.rpc.TypeConverter;
-import org.ethereum.rpc.Web3;
-import org.ethereum.rpc.exception.RskJsonRpcRequestException;
-import org.ethereum.util.ByteUtil;
-import org.ethereum.vm.GasCost;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.math.BigInteger;
-
 import static org.ethereum.rpc.TypeConverter.stringHexToByteArray;
 import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
 
-public class EthModuleTransactionBase implements EthModuleTransaction {
+import org.ethereum.config.Constants;
+import org.ethereum.core.Account;
+import org.ethereum.core.ImmutableTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionArguments;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.core.TransactionPoolAddResult;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.util.TransactionArgumentsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-    private static final String ERR_INVALID_CHAIN_ID = "Invalid chainId: ";
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+import co.rsk.net.TransactionGateway;
+
+public class EthModuleTransactionBase implements EthModuleTransaction {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger("web3");
 
@@ -57,54 +56,37 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
 
     @Override
     public synchronized String sendTransaction(Web3.CallArguments args) {
-        Account account = this.wallet.getAccount(new RskAddress(args.from));
-        String s = null;
+        
+    	Account senderAccount = this.wallet.getAccount(new RskAddress(args.from));
+        String txHash = null;
+        
         try {
-            String toAddress = args.to != null ? ByteUtil.toHexString(stringHexToByteArray(args.to)) : null;
 
-            BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
-            BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
-            BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
+        	synchronized (transactionPool) {
 
-            if (args.data != null && args.data.startsWith("0x")) {
-                args.data = args.data.substring(2);
-            }
-
-            byte txChainId = hexToChainId(args.chainId);
-            if (txChainId == 0) {
-                txChainId = constants.getChainId();
-            }
-
-            synchronized (transactionPool) {
-                BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : transactionPool.getPendingState().getNonce(account.getAddress());
-                Transaction tx = Transaction
-                        .builder()
-                        .nonce(accountNonce)
-                        .gasPrice(gasPrice)
-                        .gasLimit(gasLimit)
-                        .destination(toAddress == null ? null : Hex.decode(toAddress))
-                        .data(args.data == null ? null : Hex.decode(args.data))
-                        .chainId(txChainId)
-                        .value(value)
-                        .build();
-                tx.sign(account.getEcKey().getPrivKeyBytes());
-
+            	TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, transactionPool, senderAccount, constants.getChainId());
+                
+                Transaction tx = Transaction.builder().from(txArgs).build();
+                
+                tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
+                
                 if (!tx.acceptTransactionSignature(constants.getChainId())) {
-                    throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + args.chainId);
+                    throw RskJsonRpcRequestException.invalidParamError(TransactionArgumentsUtil.ERR_INVALID_CHAIN_ID + args.chainId);
                 }
 
                 TransactionPoolAddResult result = transactionGateway.receiveTransaction(tx.toImmutableTransaction());
+                
                 if(!result.transactionsWereAdded()) {
                     throw RskJsonRpcRequestException.transactionError(result.getErrorMessage());
                 }
 
-                s = tx.getHash().toJsonString();
+                txHash = tx.getHash().toJsonString();
             }
 
-            return s;
+            return txHash;
 
         } finally {
-            LOGGER.debug("eth_sendTransaction({}): {}", args, s);
+            LOGGER.debug("eth_sendTransaction({}): {}", args, txHash);
         }
     }
 
@@ -133,19 +115,4 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
         }
     }
 
-    private static byte hexToChainId(String hex) {
-        if (hex == null) {
-            return 0;
-        }
-        try {
-            byte[] bytes = TypeConverter.stringHexToByteArray(hex);
-            if (bytes.length != 1) {
-                throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex);
-            }
-
-            return bytes[0];
-        } catch (Exception e) {
-            throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex, e);
-        }
-    }
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -184,22 +184,22 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
         return wallet.getAccount(new RskAddress(from), passphrase);
     }
 
-    private String sendTransaction(Web3.CallArguments args, Account senderAccount) throws Exception {
-        
-    	if (senderAccount == null) {
-            throw new Exception("From address private key could not be found in this node");
-        }
+	private String sendTransaction(Web3.CallArguments args, Account senderAccount) throws Exception {
 
-    	TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, transactionPool, senderAccount, config.getNetworkConstants().getChainId());
+		if (senderAccount == null) {
+			throw new Exception("From address private key could not be found in this node");
+		}
 
-        Transaction tx = Transaction.builder().from(txArgs).build();
+		TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, transactionPool, senderAccount, config.getNetworkConstants().getChainId());
 
-        tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
+		Transaction tx = Transaction.builder().from(txArgs).build();
 
-        eth.submitTransaction(tx);
+		tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
 
-        return tx.getHash().toJsonString();
-    }
+		eth.submitTransaction(tx);
+
+		return tx.getHash().toJsonString();
+	}
 
     private String convertFromJsonHexToHex(String x) throws Exception {
         if (!x.startsWith("0x")) {

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -18,26 +18,27 @@
 
 package co.rsk.rpc.modules.personal;
 
-import co.rsk.config.RskSystemProperties;
-import co.rsk.config.WalletAccount;
-import co.rsk.core.RskAddress;
-import co.rsk.core.Wallet;
+import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
+
+import java.util.Arrays;
+
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionArguments;
 import org.ethereum.core.TransactionPool;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.Web3;
 import org.ethereum.util.ByteUtil;
-import org.ethereum.vm.GasCost;
+import org.ethereum.util.TransactionArgumentsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigInteger;
-import java.util.Arrays;
-
-import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.config.WalletAccount;
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
 
 public class PersonalModuleWalletEnabled implements PersonalModule {
 
@@ -183,34 +184,17 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
         return wallet.getAccount(new RskAddress(from), passphrase);
     }
 
-    private String sendTransaction(Web3.CallArguments args, Account account) throws Exception {
-        if (account == null) {
+    private String sendTransaction(Web3.CallArguments args, Account senderAccount) throws Exception {
+        
+    	if (senderAccount == null) {
             throw new Exception("From address private key could not be found in this node");
         }
 
-        String toAddress = args.to != null ? ByteUtil.toHexString(TypeConverter.stringHexToByteArray(args.to)) : null;
+    	TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, transactionPool, senderAccount, config.getNetworkConstants().getChainId());
 
-        BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : transactionPool.getPendingState().getNonce(account.getAddress());
-        BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
-        BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
-        BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION);
+        Transaction tx = Transaction.builder().from(txArgs).build();
 
-        if (args.data != null && args.data.startsWith("0x")) {
-            args.data = args.data.substring(2);
-        }
-
-        Transaction tx = Transaction
-                .builder()
-                .nonce(accountNonce)
-                .gasPrice(gasPrice)
-                .gasLimit(gasLimit)
-                .destination(toAddress == null ? null : Hex.decode(toAddress))
-                .data(args.data == null ? null : Hex.decode(args.data))
-                .chainId(config.getNetworkConstants().getChainId())
-                .value(value)
-                .build();
-
-        tx.sign(account.getEcKey().getPrivKeyBytes());
+        tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
 
         eth.submitTransaction(tx);
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/txpool/TxPoolModuleImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/txpool/TxPoolModuleImpl.java
@@ -102,11 +102,10 @@ public class TxPoolModuleImpl implements TxPoolModule {
     }
 
     private JsonNode summarySerializer(Transaction tx) {
-        String summary = "{}: {} wei + {} x {} gas";
-        String summaryFormatted = String.format(summary,
+        String summaryFormatted = String.format("%s: %s wei + %d x %s gas",
                 tx.getReceiveAddress().toString(),
                 tx.getValue().toString(),
-                tx.getGasLimitAsInteger().toString(),
+                tx.getGasLimitAsInteger(),
                 tx.getGasPrice().toString());
         return jsonNodeFactory.textNode(summaryFormatted);
     }

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -240,7 +240,7 @@ public abstract class SystemProperties {
                     return new Node(nodeId, ip, port);
                 }
 
-                throw new RuntimeException("Invalid config nodeId '" + nodeId + "' at " + configObject);
+                throw new RuntimeException("Invalid config nodeId '" + Arrays.toString(nodeId) + "' at " + configObject);
             }
 
             if (configObject.toConfig().hasPath("nodeName")) {

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionArguments.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionArguments.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.core;
+
+import java.math.BigInteger;
+
+import java.util.Arrays;
+
+
+public class TransactionArguments {
+
+    public String from;
+    public byte[] to;
+    public BigInteger gas;
+    public BigInteger gasLimit;
+    public BigInteger gasPrice;
+    public BigInteger value;
+    public String data; // compiledCode
+    public BigInteger nonce;
+    public byte chainId;  //NOSONAR
+
+    @Override
+    public String toString() {
+        return "TransactionArguments{" +
+                "from='" + from + '\'' +
+                ", to='" + Arrays.toString(to) + '\'' +
+                ", gasLimit='" + ((gas != null)?gas:gasLimit) + '\'' +
+                ", gasPrice='" + gasPrice + '\'' +
+                ", value='" + value + '\'' +
+                ", data='" + data + '\'' +
+                ", nonce='" + nonce + '\'' +
+                ", chainId='" + chainId + '\'' +
+                '}';
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionArguments.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionArguments.java
@@ -25,17 +25,89 @@ import java.util.Arrays;
 
 public class TransactionArguments {
 
-    public String from;
-    public byte[] to;
-    public BigInteger gas;
-    public BigInteger gasLimit;
-    public BigInteger gasPrice;
-    public BigInteger value;
-    public String data; // compiledCode
-    public BigInteger nonce;
-    public byte chainId;  //NOSONAR
+    private String from;
+    private byte[] to;
+    private BigInteger gas;
+    private BigInteger gasLimit;
+    private BigInteger gasPrice;
+    private BigInteger value;
+    private String data; // compiledCode
+    private BigInteger nonce;
+    private byte chainId;  //NOSONAR
 
-    @Override
+    public String getFrom() {
+		return from;
+	}
+
+	public void setFrom(String from) {
+		this.from = from;
+	}
+
+	public byte[] getTo() {
+		return to;
+	}
+
+	public void setTo(byte[] to) {
+		this.to = to;
+	}
+
+	public BigInteger getGas() {
+		return gas;
+	}
+
+	public void setGas(BigInteger gas) {
+		this.gas = gas;
+	}
+
+	public BigInteger getGasLimit() {
+		return gasLimit;
+	}
+
+	public void setGasLimit(BigInteger gasLimit) {
+		this.gasLimit = gasLimit;
+	}
+
+	public BigInteger getGasPrice() {
+		return gasPrice;
+	}
+
+	public void setGasPrice(BigInteger gasPrice) {
+		this.gasPrice = gasPrice;
+	}
+
+	public BigInteger getValue() {
+		return value;
+	}
+
+	public void setValue(BigInteger value) {
+		this.value = value;
+	}
+
+	public String getData() {
+		return data;
+	}
+
+	public void setData(String data) {
+		this.data = data;
+	}
+
+	public BigInteger getNonce() {
+		return nonce;
+	}
+
+	public void setNonce(BigInteger nonce) {
+		this.nonce = nonce;
+	}
+
+	public byte getChainId() {
+		return chainId;
+	}
+
+	public void setChainId(byte chainId) {
+		this.chainId = chainId;
+	}
+
+	@Override
     public String toString() {
         return "TransactionArguments{" +
                 "from='" + from + '\'' +

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionBuilder.java
@@ -132,13 +132,13 @@ public final class TransactionBuilder {
     
     public TransactionBuilder from(TransactionArguments args) {
     	
-        nonce(args.nonce);
-        gasPrice(args.gasPrice);
-        gasLimit(args.gasLimit);
-        destination(args.to);
-        data(args.data);
-        chainId(args.chainId);
-        value(BigIntegers.asUnsignedByteArray(args.value));
+        nonce(args.getNonce());
+        gasPrice(args.getGasPrice());
+        gasLimit(args.getGasLimit());
+        destination(args.getTo());
+        data(args.getData());
+        chainId(args.getChainId());
+        value(BigIntegers.asUnsignedByteArray(args.getValue()));
     	
         return this;
     }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionBuilder.java
@@ -129,4 +129,18 @@ public final class TransactionBuilder {
     public TransactionBuilder data(String data) {
         return this.data(data == null ? null: Hex.decode(data));
     }
+    
+    public TransactionBuilder from(TransactionArguments args) {
+    	
+        nonce(args.nonce);
+        gasPrice(args.gasPrice);
+        gasLimit(args.gasLimit);
+        destination(args.to);
+        data(args.data);
+        chainId(args.chainId);
+        value(BigIntegers.asUnsignedByteArray(args.value));
+    	
+        return this;
+    }
+    
 }

--- a/rskj-core/src/main/java/org/ethereum/net/p2p/P2pHandler.java
+++ b/rskj-core/src/main/java/org/ethereum/net/p2p/P2pHandler.java
@@ -123,7 +123,7 @@ public class P2pHandler extends SimpleChannelInboundHandler<P2pMessage> {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        logger.info("channel inactive: ", ctx);
+        logger.info("channel inactive: {}", ctx);
         this.killTimers();
     }
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/PendingTransactionFilter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/PendingTransactionFilter.java
@@ -20,8 +20,6 @@ package org.ethereum.rpc;
 
 import org.ethereum.core.Transaction;
 
-import static org.ethereum.rpc.TypeConverter.toJsonHex;
-
 /**
  * Created by ajlopez on 17/01/2018.
  */

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -37,6 +37,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String from;
         public String to;
         public String gas;
+        public String gasLimit;
         public String gasPrice;
         public String value;
         public String data; // compiledCode
@@ -48,7 +49,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
             return "CallArguments{" +
                     "from='" + from + '\'' +
                     ", to='" + to + '\'' +
-                    ", gasLimit='" + gas + '\'' +
+                    ", gasLimit='" + ((gas != null)?gas:gasLimit) + '\'' +
                     ", gasPrice='" + gasPrice + '\'' +
                     ", value='" + value + '\'' +
                     ", data='" + data + '\'' +

--- a/rskj-core/src/main/java/org/ethereum/util/TransactionArgumentsUtil.java
+++ b/rskj-core/src/main/java/org/ethereum/util/TransactionArgumentsUtil.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.util;
+
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.ethereum.core.Account;
+import org.ethereum.core.TransactionArguments;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.vm.GasCost;
+
+public class TransactionArgumentsUtil {
+
+	private static final BigInteger DEFAULT_GAS_LIMIT = BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
+
+	public static final String ERR_INVALID_CHAIN_ID = "Invalid chainId: ";
+	
+	/**
+	 * transform the Web3.CallArguments in TransactionArguments that can be used in the TransactionBuilder
+	 */
+	public static TransactionArguments processArguments(Web3.CallArguments argsParam, TransactionPool transactionPool, Account senderAccount, byte defaultChainId) {
+		
+		TransactionArguments argsRet = new TransactionArguments();
+		
+		argsRet.from = argsParam.from;
+		
+		argsRet.to = stringHexToByteArray(argsParam.to);
+
+        argsRet.nonce = stringNumberAsBigInt(argsParam.nonce, () -> transactionPool.getPendingState().getNonce(senderAccount.getAddress()));
+        
+        argsRet.value = stringNumberAsBigInt(argsParam.value, () -> BigInteger.ZERO);
+        
+        argsRet.gasPrice = stringNumberAsBigInt(argsParam.gasPrice, () -> BigInteger.ZERO);
+        
+        argsRet.gasLimit = stringNumberAsBigInt(argsParam.gas, () -> null);
+        
+        if(argsRet.gasLimit == null) {
+        	argsRet.gasLimit = stringNumberAsBigInt(argsParam.gasLimit, () -> DEFAULT_GAS_LIMIT);
+        }
+
+        if (argsParam.data != null && argsParam.data.startsWith("0x")) {
+        	argsRet.data = argsParam.data.substring(2);
+        	argsParam.data = argsRet.data; // needs to change the parameter because some places expect the changed value after sendTransaction call  
+        }
+        
+        argsRet.chainId = hexToChainId(argsParam.chainId);
+        if (argsRet.chainId == 0) {
+        	argsRet.chainId = defaultChainId;
+        }
+
+		return argsRet;
+	} 
+		
+	private static BigInteger stringNumberAsBigInt(String number, Supplier<BigInteger> getDefaultValue) {
+		
+		BigInteger ret = Optional.ofNullable(number).map(TypeConverter::stringNumberAsBigInt).orElseGet(getDefaultValue);
+		
+		return ret;
+	}
+	
+	private static byte[] stringHexToByteArray(String value) {
+		
+		byte[] ret = Optional.ofNullable(value).map(TypeConverter::stringHexToByteArray).orElse(null);
+		
+		return ret;
+	}
+
+    private static byte hexToChainId(String hex) {
+        if (hex == null) {
+            return 0;
+        }
+        try {
+            byte[] bytes = TypeConverter.stringHexToByteArray(hex);
+            if (bytes.length != 1) {
+                throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex);
+            }
+
+            return bytes[0];
+        } catch (Exception e) {
+            throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex, e);
+        }
+    }
+
+}

--- a/rskj-core/src/main/java/org/ethereum/util/TransactionArgumentsUtil.java
+++ b/rskj-core/src/main/java/org/ethereum/util/TransactionArgumentsUtil.java
@@ -44,30 +44,30 @@ public class TransactionArgumentsUtil {
 
 		TransactionArguments argsRet = new TransactionArguments();
 
-		argsRet.from = argsParam.from;
+		argsRet.setFrom(argsParam.from);
 
-		argsRet.to = stringHexToByteArray(argsParam.to);
+		argsRet.setTo(stringHexToByteArray(argsParam.to));
 
-		argsRet.nonce = stringNumberAsBigInt(argsParam.nonce, () -> transactionPool.getPendingState().getNonce(senderAccount.getAddress()));
+		argsRet.setNonce(stringNumberAsBigInt(argsParam.nonce, () -> transactionPool.getPendingState().getNonce(senderAccount.getAddress())));
 
-		argsRet.value = stringNumberAsBigInt(argsParam.value, () -> BigInteger.ZERO);
+		argsRet.setValue(stringNumberAsBigInt(argsParam.value, () -> BigInteger.ZERO));
 
-		argsRet.gasPrice = stringNumberAsBigInt(argsParam.gasPrice, () -> BigInteger.ZERO);
+		argsRet.setGasPrice(stringNumberAsBigInt(argsParam.gasPrice, () -> BigInteger.ZERO));
 
-		argsRet.gasLimit = stringNumberAsBigInt(argsParam.gas, () -> null);
+		argsRet.setGasLimit(stringNumberAsBigInt(argsParam.gas, () -> null));
 
-		if (argsRet.gasLimit == null) {
-			argsRet.gasLimit = stringNumberAsBigInt(argsParam.gasLimit, () -> DEFAULT_GAS_LIMIT);
+		if (argsRet.getGasLimit() == null) {
+			argsRet.setGasLimit(stringNumberAsBigInt(argsParam.gasLimit, () -> DEFAULT_GAS_LIMIT));
 		}
 
 		if (argsParam.data != null && argsParam.data.startsWith("0x")) {
-			argsRet.data = argsParam.data.substring(2);
-			argsParam.data = argsRet.data; // needs to change the parameter because some places expect the changed value after sendTransaction call
+			argsRet.setData(argsParam.data.substring(2));
+			argsParam.data = argsRet.getData(); // needs to change the parameter because some places expect the changed value after sendTransaction call
 		}
 
-		argsRet.chainId = hexToChainId(argsParam.chainId);
-		if (argsRet.chainId == 0) {
-			argsRet.chainId = defaultChainId;
+		argsRet.setChainId(hexToChainId(argsParam.chainId));
+		if (argsRet.getChainId() == 0) {
+			argsRet.setChainId(defaultChainId);
 		}
 
 		return argsRet;

--- a/rskj-core/src/main/java/org/ethereum/util/TransactionArgumentsUtil.java
+++ b/rskj-core/src/main/java/org/ethereum/util/TransactionArgumentsUtil.java
@@ -35,71 +35,72 @@ public class TransactionArgumentsUtil {
 	private static final BigInteger DEFAULT_GAS_LIMIT = BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
 
 	public static final String ERR_INVALID_CHAIN_ID = "Invalid chainId: ";
-	
+
 	/**
-	 * transform the Web3.CallArguments in TransactionArguments that can be used in the TransactionBuilder
+	 * transform the Web3.CallArguments in TransactionArguments that can be used in
+	 * the TransactionBuilder
 	 */
 	public static TransactionArguments processArguments(Web3.CallArguments argsParam, TransactionPool transactionPool, Account senderAccount, byte defaultChainId) {
-		
+
 		TransactionArguments argsRet = new TransactionArguments();
-		
+
 		argsRet.from = argsParam.from;
-		
+
 		argsRet.to = stringHexToByteArray(argsParam.to);
 
-        argsRet.nonce = stringNumberAsBigInt(argsParam.nonce, () -> transactionPool.getPendingState().getNonce(senderAccount.getAddress()));
-        
-        argsRet.value = stringNumberAsBigInt(argsParam.value, () -> BigInteger.ZERO);
-        
-        argsRet.gasPrice = stringNumberAsBigInt(argsParam.gasPrice, () -> BigInteger.ZERO);
-        
-        argsRet.gasLimit = stringNumberAsBigInt(argsParam.gas, () -> null);
-        
-        if(argsRet.gasLimit == null) {
-        	argsRet.gasLimit = stringNumberAsBigInt(argsParam.gasLimit, () -> DEFAULT_GAS_LIMIT);
-        }
+		argsRet.nonce = stringNumberAsBigInt(argsParam.nonce, () -> transactionPool.getPendingState().getNonce(senderAccount.getAddress()));
 
-        if (argsParam.data != null && argsParam.data.startsWith("0x")) {
-        	argsRet.data = argsParam.data.substring(2);
-        	argsParam.data = argsRet.data; // needs to change the parameter because some places expect the changed value after sendTransaction call  
-        }
-        
-        argsRet.chainId = hexToChainId(argsParam.chainId);
-        if (argsRet.chainId == 0) {
-        	argsRet.chainId = defaultChainId;
-        }
+		argsRet.value = stringNumberAsBigInt(argsParam.value, () -> BigInteger.ZERO);
+
+		argsRet.gasPrice = stringNumberAsBigInt(argsParam.gasPrice, () -> BigInteger.ZERO);
+
+		argsRet.gasLimit = stringNumberAsBigInt(argsParam.gas, () -> null);
+
+		if (argsRet.gasLimit == null) {
+			argsRet.gasLimit = stringNumberAsBigInt(argsParam.gasLimit, () -> DEFAULT_GAS_LIMIT);
+		}
+
+		if (argsParam.data != null && argsParam.data.startsWith("0x")) {
+			argsRet.data = argsParam.data.substring(2);
+			argsParam.data = argsRet.data; // needs to change the parameter because some places expect the changed value after sendTransaction call
+		}
+
+		argsRet.chainId = hexToChainId(argsParam.chainId);
+		if (argsRet.chainId == 0) {
+			argsRet.chainId = defaultChainId;
+		}
 
 		return argsRet;
-	} 
-		
+	}
+
 	private static BigInteger stringNumberAsBigInt(String number, Supplier<BigInteger> getDefaultValue) {
-		
+
 		BigInteger ret = Optional.ofNullable(number).map(TypeConverter::stringNumberAsBigInt).orElseGet(getDefaultValue);
-		
+
 		return ret;
 	}
-	
+
 	private static byte[] stringHexToByteArray(String value) {
-		
+
 		byte[] ret = Optional.ofNullable(value).map(TypeConverter::stringHexToByteArray).orElse(null);
-		
+
 		return ret;
 	}
 
-    private static byte hexToChainId(String hex) {
-        if (hex == null) {
-            return 0;
-        }
-        try {
-            byte[] bytes = TypeConverter.stringHexToByteArray(hex);
-            if (bytes.length != 1) {
-                throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex);
-            }
+	private static byte hexToChainId(String hex) {
+		if (hex == null) {
+			return 0;
+		}
+		try {
+			byte[] bytes = TypeConverter.stringHexToByteArray(hex);
+			if (bytes.length != 1) {
+				throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex);
+			}
 
-            return bytes[0];
-        } catch (Exception e) {
-            throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex, e);
-        }
-    }
+			return bytes[0];
+		} catch (Exception e) {
+			throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex, e);
+		}
+	}
 
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -24,6 +24,8 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.core.RskAddress;
+import co.rsk.peg.bitcoin.CoinbaseInformation;
+import co.rsk.peg.utils.MerkleTreeUtils;
 import co.rsk.peg.fastbridge.FastBridgeFederationInformation;
 import co.rsk.peg.whitelist.LockWhitelist;
 import co.rsk.peg.whitelist.LockWhitelistEntry;
@@ -1170,6 +1172,37 @@ public class BridgeSerializationUtilsTest {
 
             Assert.assertEquals(testFederation, deserializedTestFederation);
         }
+    }
+
+    @Test
+    public void deserializeCoinbaseInformation_dataIsNull_returnsNull() {
+        Assert.assertNull(BridgeSerializationUtils.deserializeCoinbaseInformation(null));
+    }
+
+    @Test
+    public void deserializeCoinbaseInformation_dataContainsInvalidList_throwsRuntimeException() {
+        byte[] firstItem = RLP.encodeElement(Hex.decode("010101"));
+        byte[] secondItem = RLP.encodeElement(Hex.decode("010102"));
+        byte[] thirdItem = RLP.encodeElement(Hex.decode("010103"));
+        byte[] data = RLP.encodeList(firstItem, secondItem, thirdItem);
+
+        try {
+            BridgeSerializationUtils.deserializeCoinbaseInformation(data);
+            Assert.fail("Runtime exception should be thrown!");
+        } catch (RuntimeException e) {
+            Assert.assertEquals("Invalid serialized coinbase information, expected 1 value but got 3", e.getMessage());
+        }
+    }
+
+    @Test
+    public void deserializeCoinbaseInformation_dataIsValid_returnsValidCoinbaseInformation() {
+        Sha256Hash secondHashTx = Sha256Hash.wrap(Hex.decode("e3d0840a0825fb7d880e5cb8306745352920a8c7e8a30fac882b275e26c6bb65"));
+        Sha256Hash witnessRoot = MerkleTreeUtils.combineLeftRight(Sha256Hash.ZERO_HASH, secondHashTx);
+
+        CoinbaseInformation coinbaseInformation = new CoinbaseInformation(witnessRoot);
+        byte[] serializedCoinbaseInformation = BridgeSerializationUtils.serializeCoinbaseInformation(coinbaseInformation);
+
+        Assert.assertEquals(witnessRoot, BridgeSerializationUtils.deserializeCoinbaseInformation(serializedCoinbaseInformation).getWitnessMerkleRoot());
     }
 
     private Address mockAddressHash160(String hash160) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -29,7 +29,6 @@ import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.exception.VMException;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,6 +36,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.*;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -67,7 +67,7 @@ public class BridgeTest {
 
         byte[] data = BridgeMethods.GET_LOCKING_CAP.getFunction().encode(new Object[]{});
 
-        Assert.assertNull(bridge.execute(data));
+        assertNull(bridge.execute(data));
     }
 
     @Test
@@ -82,9 +82,9 @@ public class BridgeTest {
 
         byte[] data = Bridge.GET_LOCKING_CAP.encode(new Object[]{});
         byte[] result = bridge.execute(data);
-        Assert.assertEquals(Coin.COIN.getValue(), ((BigInteger) Bridge.GET_LOCKING_CAP.decodeResult(result)[0]).longValue());
+        assertEquals(Coin.COIN.getValue(), ((BigInteger) Bridge.GET_LOCKING_CAP.decodeResult(result)[0]).longValue());
         // Also test the method itself
-        Assert.assertEquals(Coin.COIN.getValue(), bridge.getLockingCap(new Object[]{}));
+        assertEquals(Coin.COIN.getValue(), bridge.getLockingCap(new Object[]{}));
     }
 
     @Test
@@ -96,7 +96,7 @@ public class BridgeTest {
 
         byte[] data = BridgeMethods.INCREASE_LOCKING_CAP.getFunction().encode(new Object[]{});
 
-        Assert.assertNull(bridge.execute(data));
+        assertNull(bridge.execute(data));
     }
 
     @Test
@@ -111,15 +111,15 @@ public class BridgeTest {
 
         byte[] data = Bridge.INCREASE_LOCKING_CAP.encode(new Object[]{1});
         byte[] result = bridge.execute(data);
-        Assert.assertTrue((boolean) Bridge.INCREASE_LOCKING_CAP.decodeResult(result)[0]);
+        assertTrue((boolean) Bridge.INCREASE_LOCKING_CAP.decodeResult(result)[0]);
         // Also test the method itself
-        Assert.assertEquals(true, bridge.increaseLockingCap(new Object[]{BigInteger.valueOf(1)}));
+        assertEquals(true, bridge.increaseLockingCap(new Object[]{BigInteger.valueOf(1)}));
 
         data = Bridge.INCREASE_LOCKING_CAP.encode(new Object[]{21_000_000});
         result = bridge.execute(data);
-        Assert.assertTrue((boolean) Bridge.INCREASE_LOCKING_CAP.decodeResult(result)[0]);
+        assertTrue((boolean) Bridge.INCREASE_LOCKING_CAP.decodeResult(result)[0]);
         // Also test the method itself
-        Assert.assertEquals(true, bridge.increaseLockingCap(new Object[]{BigInteger.valueOf(21_000_000)}));
+        assertEquals(true, bridge.increaseLockingCap(new Object[]{BigInteger.valueOf(21_000_000)}));
     }
 
     @Test
@@ -133,24 +133,24 @@ public class BridgeTest {
         // The solidity decoder in the Bridge will convert the undefined argument as 0, but the initial validation in the method will reject said value
         byte[] data = Bridge.INCREASE_LOCKING_CAP.encodeSignature();
         byte[] result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
 
         // Uses the proper signature but appends invalid data type
         // This will be rejected by the solidity decoder in the Bridge directly
         data = ByteUtil.merge(Bridge.INCREASE_LOCKING_CAP.encodeSignature(), Hex.decode("ab"));
         result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
 
         // Uses the proper signature and data type, but with an invalid value
         // This will be rejected by the initial validation in the method
         data = Bridge.INCREASE_LOCKING_CAP.encode(new Object[]{-1});
         result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
 
         // Uses the proper signature and data type, but with a value that exceeds the long max value
         data = ByteUtil.merge(Bridge.INCREASE_LOCKING_CAP.encodeSignature(), Hex.decode("0000000000000000000000000000000000000000000000080000000000000000"));
         result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
     }
 
     @Test
@@ -166,7 +166,7 @@ public class BridgeTest {
 
         byte[] data = Bridge.REGISTER_BTC_COINBASE_TRANSACTION.encode(new Object[]{value, zero, value, zero, zero});
 
-        Assert.assertNull(bridge.execute(data));
+        assertNull(bridge.execute(data));
     }
 
     @Test
@@ -196,15 +196,15 @@ public class BridgeTest {
 
         byte[] data = Bridge.REGISTER_BTC_COINBASE_TRANSACTION.encodeSignature();
         byte[] result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
 
         data = ByteUtil.merge(Bridge.REGISTER_BTC_COINBASE_TRANSACTION.encodeSignature(), Hex.decode("ab"));
         result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
 
         data = ByteUtil.merge(Bridge.REGISTER_BTC_COINBASE_TRANSACTION.encodeSignature(), Hex.decode("0000000000000000000000000000000000000000000000080000000000000000"));
         result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
     }
 
     @Test
@@ -235,9 +235,9 @@ public class BridgeTest {
 
         try {
             bridge.execute(data);
-            Assert.fail();
+            fail();
         } catch (VMException e) {
-            Assert.assertEquals("Exception executing bridge: Sender is not part of the active or retiring federations, so he is not enabled to call the function 'registerBtcTransaction'", e.getMessage());
+            assertEquals("Exception executing bridge: Sender is not part of the active or retiring federations, so he is not enabled to call the function 'registerBtcTransaction'", e.getMessage());
         }
 
         verify(bridgeSupportMock, never()).registerBtcTransaction(
@@ -322,7 +322,7 @@ public class BridgeTest {
 
         byte[] data = BridgeMethods.GET_ACTIVE_FEDERATION_CREATION_BLOCK_HEIGHT.getFunction().encode(new Object[]{});
 
-        Assert.assertNull(bridge.execute(data));
+        assertNull(bridge.execute(data));
     }
 
     @Test
@@ -338,9 +338,9 @@ public class BridgeTest {
         CallTransaction.Function function = BridgeMethods.GET_ACTIVE_FEDERATION_CREATION_BLOCK_HEIGHT.getFunction();
         byte[] data = function.encode(new Object[]{ });
         byte[] result = bridge.execute(data);
-        Assert.assertEquals(1L, ((BigInteger)function.decodeResult(result)[0]).longValue());
+        assertEquals(1L, ((BigInteger)function.decodeResult(result)[0]).longValue());
         // Also test the method itself
-        Assert.assertEquals(1L, bridge.getActiveFederationCreationBlockHeight(new Object[]{ }));
+        assertEquals(1L, bridge.getActiveFederationCreationBlockHeight(new Object[]{ }));
     }
 
     @Test
@@ -365,7 +365,7 @@ public class BridgeTest {
         );
 
         //Assert
-        Assert.assertNull(bridge.execute(data));
+        assertNull(bridge.execute(data));
     }
 
     @Test
@@ -416,7 +416,7 @@ public class BridgeTest {
         byte[] result = bridge.execute(data);
 
         //Assert
-        Assert.assertEquals(BigInteger.valueOf(2), Bridge.REGISTER_FAST_BRIDGE_BTC_TRANSACTION.decodeResult(result)[0]);
+        assertEquals(BigInteger.valueOf(2), Bridge.REGISTER_FAST_BRIDGE_BTC_TRANSACTION.decodeResult(result)[0]);
         verify(bridgeSupportMock, times(1)).registerFastBridgeBtcTransaction(
                 any(Transaction.class),
                 eq(value),
@@ -469,8 +469,8 @@ public class BridgeTest {
             true
         );
         byte[] result = bridge.execute(data);
-        
-        Assert.assertEquals(BridgeSupport.FAST_BRIDGE_GENERIC_ERROR, 
+
+        assertEquals(BridgeSupport.FAST_BRIDGE_GENERIC_ERROR,
             ((BigInteger)Bridge.REGISTER_FAST_BRIDGE_BTC_TRANSACTION.decodeResult(result)[0]).longValue());
     }
 
@@ -485,11 +485,11 @@ public class BridgeTest {
 
         byte[] data = Bridge.REGISTER_FAST_BRIDGE_BTC_TRANSACTION.encodeSignature();
         byte[] result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
 
         data = ByteUtil.merge(Bridge.REGISTER_FAST_BRIDGE_BTC_TRANSACTION.encodeSignature(), value);
         result = bridge.execute(data);
-        Assert.assertNull(result);
+        assertNull(result);
     }
 
     public void receiveHeader_before_RSKIP200() throws VMException {
@@ -513,7 +513,7 @@ public class BridgeTest {
         byte[] data = Bridge.RECEIVE_HEADER.encode(parameters);
 
         bridge.execute(data);
-        Assert.assertNull(bridge.execute(data));
+        assertNull(bridge.execute(data));
         verify(bridge, never()).receiveHeader(any(Object[].class));
     }
 
@@ -527,7 +527,7 @@ public class BridgeTest {
 
         byte[] data = Bridge.RECEIVE_HEADER.encode(new Object[]{});
 
-        Assert.assertNull(bridge.execute(data));
+        assertNull(bridge.execute(data));
         verify(bridge, never()).receiveHeader(any(Object[].class));
         verifyZeroInteractions(bridgeSupportMock);
     }
@@ -554,7 +554,7 @@ public class BridgeTest {
 
         byte[] result = bridge.execute(data);
         verify(bridge, times(1)).receiveHeader(eq(parameters));
-        Assert.assertEquals(BigInteger.valueOf(0), Bridge.RECEIVE_HEADER.decodeResult(result)[0]);
+        assertEquals(BigInteger.valueOf(0), Bridge.RECEIVE_HEADER.decodeResult(result)[0]);
     }
 
     @Test(expected = VMException.class)
@@ -598,9 +598,9 @@ public class BridgeTest {
 
         try {
             bridge.execute(Bridge.RECEIVE_HEADERS.encode());
-            Assert.fail();
+            fail();
         } catch (Exception ex) {
-            Assert.assertTrue(ex.getMessage().contains("Sender is not part of the active or retiring federation"));
+            assertTrue(ex.getMessage().contains("Sender is not part of the active or retiring federation"));
         }
     }
 
@@ -617,7 +617,7 @@ public class BridgeTest {
         byte[] data = Bridge.RECEIVE_HEADER.encode(parameters);
 
         byte[] result = bridge.execute(data);
-        Assert.assertEquals(BigInteger.valueOf(-20), Bridge.RECEIVE_HEADER.decodeResult(result)[0]);
+        assertEquals(BigInteger.valueOf(-20), Bridge.RECEIVE_HEADER.decodeResult(result)[0]);
     }
 
     @Test
@@ -627,7 +627,7 @@ public class BridgeTest {
 
         Bridge bridge = getBridgeInstance(mock(BridgeSupport.class), activations);
 
-        Assert.assertFalse(bridge.getBtcBlockchainBestChainHeightOnlyAllowsLocalCalls(new Object[0]));
+        assertFalse(bridge.getBtcBlockchainBestChainHeightOnlyAllowsLocalCalls(new Object[0]));
     }
 
     @Test
@@ -637,13 +637,158 @@ public class BridgeTest {
 
         Bridge bridge = getBridgeInstance(mock(BridgeSupport.class), activations);
 
-        Assert.assertTrue(bridge.getBtcBlockchainBestChainHeightOnlyAllowsLocalCalls(new Object[0]));
+        assertTrue(bridge.getBtcBlockchainBestChainHeightOnlyAllowsLocalCalls(new Object[0]));
+    }
+
+    @Test
+    public void activeAndRetiringFederationOnly_activeFederationIsNotFromFederateMember_retiringFederationIsNull_throwsVMException() throws Exception {
+        // Given
+        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeAndRetiringFederationOnly(
+                null,
+                null
+        );
+
+        int senderPK = 999; // Sender PK does not belong to Member PKs
+        Integer[] memberPKs = new Integer[]{100, 200, 300, 400, 500, 600};
+        Federation activeFederation = FederationTestUtils.getFederation(memberPKs);
+
+        Bridge bridge = getBridgeInstance(activeFederation, null, senderPK);
+
+        // Then
+        try {
+            executor.execute(bridge, null);
+            fail("VMException should be thrown!");
+        } catch (VMException vme) {
+            assertEquals(
+                    "Sender is not part of the active or retiring federations, so he is not enabled to call the function 'null'",
+                    vme.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void activeAndRetiringFederationOnly_activeFederationIsNotFromFederateMember_retiringFederationIsNotNull_retiringFederationIsNotFromFederateMember_throwsVMException() throws Exception {
+        // Given
+        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeAndRetiringFederationOnly(
+                null,
+                null
+        );
+
+        int senderPK = 999; // Sender PK does not belong to Member PKs of active nor retiring fed
+        Integer[] activeMemberPKs = new Integer[]{100, 200, 300, 400, 500, 600};
+        Integer[] retiringMemberPKs = new Integer[]{101, 202, 303, 404, 505, 606};
+
+        Federation activeFederation = FederationTestUtils.getFederation(activeMemberPKs);
+        Federation retiringFederation = FederationTestUtils.getFederation(retiringMemberPKs);
+
+        Bridge bridge = getBridgeInstance(activeFederation, retiringFederation, senderPK);
+
+        // Then
+        try {
+            executor.execute(bridge, null);
+            fail("VMException should be thrown!");
+        } catch (VMException vme) {
+            assertEquals(
+                    "Sender is not part of the active or retiring federations, so he is not enabled to call the function 'null'",
+                    vme.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void activeAndRetiringFederationOnly_activeFederationIsFromFederateMember_OK() throws Exception {
+        // Given
+        BridgeMethods.BridgeMethodExecutor decorate = mock(
+                BridgeMethods.BridgeMethodExecutor.class
+        );
+        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeAndRetiringFederationOnly(
+                decorate,
+                null
+        );
+
+        int senderPK = 101; // Sender PK belongs to active federation member PKs
+        Integer[] memberPKs = new Integer[]{100, 200, 300, 400, 500, 600};
+
+        Federation activeFederation = FederationTestUtils.getFederation(memberPKs);
+
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Bridge bridge = getBridgeInstance(activeFederation, null, senderPK, bridgeSupportMock);
+
+        // When
+        executor.execute(bridge, null);
+
+        // Then
+        verify(bridgeSupportMock, times(1)).getActiveFederation();
+        verify(bridgeSupportMock, times(1)).getRetiringFederation();
+        verify(decorate, times(1)).execute(any(), any());
+    }
+
+    @Test
+    public void activeAndRetiringFederationOnly_activeFederationIsNotFromFederateMember_retiringFederationIsNotNull_retiringFederationIsFromFederateMember_OK() throws Exception {
+        // Given
+        BridgeMethods.BridgeMethodExecutor decorate = mock(
+                BridgeMethods.BridgeMethodExecutor.class
+        );
+        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeAndRetiringFederationOnly(
+                decorate,
+                null
+        );
+
+        int senderPK = 405; // Sender PK belongs to retiring federation member PKs
+        Integer[] activeMemberPKs = new Integer[]{100, 200, 300, 400, 500, 600};
+        Integer[] retiringMemberPKs = new Integer[]{101, 202, 303, 404, 505, 606};
+
+        Federation activeFederation = FederationTestUtils.getFederation(activeMemberPKs);
+        Federation retiringFederation = FederationTestUtils.getFederation(retiringMemberPKs);
+
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Bridge bridge = getBridgeInstance(activeFederation, retiringFederation, senderPK, bridgeSupportMock);
+
+        // When
+        executor.execute(bridge, null);
+
+        // Then
+        verify(bridgeSupportMock, times(1)).getActiveFederation();
+        verify(bridgeSupportMock, times(1)).getRetiringFederation();
+        verify(decorate, times(1)).execute(any(), any());
+    }
+
+    private Bridge getBridgeInstance(Federation activeFederation, Federation retiringFederation, int senderPK) {
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        doReturn(activeFederation).when(bridgeSupportMock).getActiveFederation();
+        doReturn(retiringFederation).when(bridgeSupportMock).getRetiringFederation();
+
+        ECKey key = ECKey.fromPrivate(BigInteger.valueOf(senderPK));
+        Transaction rskTxMock = mock(Transaction.class);
+        doReturn(new RskAddress(key.getAddress())).when(rskTxMock).getSender();
+
+        ActivationConfig activations = spy(ActivationConfigsForTest.genesis());
+        doReturn(true).when(activations).isActive(eq(RSKIP143), anyLong());
+
+        return getBridgeInstance(rskTxMock, bridgeSupportMock, activations);
+    }
+
+    private Bridge getBridgeInstance(Federation activeFederation, Federation retiringFederation, int senderPK, BridgeSupport bridgeSupportMock) {
+        doReturn(activeFederation).when(bridgeSupportMock).getActiveFederation();
+        doReturn(retiringFederation).when(bridgeSupportMock).getRetiringFederation();
+
+        ECKey key = ECKey.fromPrivate(BigInteger.valueOf(senderPK));
+        Transaction rskTxMock = mock(Transaction.class);
+        doReturn(new RskAddress(key.getAddress())).when(rskTxMock).getSender();
+
+        ActivationConfig activations = spy(ActivationConfigsForTest.genesis());
+        doReturn(true).when(activations).isActive(eq(RSKIP143), anyLong());
+
+        return getBridgeInstance(rskTxMock, bridgeSupportMock, activations);
     }
 
     /**
-     * Gets a bride instance mocking the transaction and BridgeSupportFactory
+     * Gets a bridge instance mocking the transaction and BridgeSupportFactory
+     *
+     * @param txMock                Provide the transaction to be used
      * @param bridgeSupportInstance Provide the bridgeSupport to be used
-     * @return
+     * @param activationConfig      Provide the activationConfig to be used
+     * @return Bridge instance
      */
     private Bridge getBridgeInstance(Transaction txMock, BridgeSupport bridgeSupportInstance, ActivationConfig activationConfig) {
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
@@ -19,15 +19,27 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import org.ethereum.crypto.ECKey;
 
 import java.math.BigInteger;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class FederationTestUtils {
+
+    public static Federation getFederation(Integer... federationMemberPks) {
+        return new Federation(
+                getFederationMembersFromPks(federationMemberPks),
+                ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
+                0L,
+                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
+    }
+
     public static List<FederationMember> getFederationMembers(int memberCount) {
         List<FederationMember> result = new ArrayList<>();
         for (int i = 1; i <= memberCount; i++) {

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -21,19 +21,26 @@ package co.rsk.rpc.modules.eth;
 import co.rsk.config.BridgeConstants;
 import co.rsk.core.ReversibleTransactionExecutor;
 import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
 import co.rsk.core.bc.BlockResult;
 import co.rsk.core.bc.PendingState;
 import co.rsk.db.RepositoryLocator;
+import co.rsk.net.TransactionGateway;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.rpc.ExecutionBlockRetriever;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
+import org.ethereum.config.Constants;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
+import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionPool;
+import org.ethereum.core.TransactionPoolAddResult;
+import org.ethereum.datasource.HashMapDB;
 import org.ethereum.rpc.TypeConverter;
 import org.ethereum.rpc.Web3;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.util.TransactionTestHelper;
 import org.ethereum.vm.program.ProgramResult;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -122,6 +129,37 @@ public class EthModuleTest {
         assertEquals(expectedResult, actualResult);
     }
 
+    @Test
+    public void sendTransactionWithGasLimitTest() {
+    	
+    	Constants constants = Constants.regtest();
+    	
+    	Wallet wallet = new Wallet(new HashMapDB());
+    	RskAddress sender = wallet.addAccount();
+    	RskAddress receiver = wallet.addAccount();
+    	
+        // Hash of the expected transaction
+    	Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
+        Transaction tx = TransactionTestHelper.createTransaction(args, constants.getChainId(), wallet.getAccount(sender));
+        String txExpectedResult = tx.getHash().toJsonString();
+    	
+    	TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+    	when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+    	
+    	TransactionGateway transactionGateway = mock(TransactionGateway.class); 
+    	when(transactionGateway.receiveTransaction(any(Transaction.class)))
+    		.thenReturn(transactionPoolAddResult);
+    	
+    	TransactionPool transactionPool = mock(TransactionPool.class);
+    	
+    	EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
+    	
+    	// Hash of the actual transaction builded inside the sendTransaction
+    	String txResult = ethModuleTransaction.sendTransaction(args);
+
+    	assertEquals(txExpectedResult, txResult);
+    }
+    
     @Test
     public void test_revertedTransaction() {
         Web3.CallArguments args = new Web3.CallArguments();

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -129,37 +129,36 @@ public class EthModuleTest {
         assertEquals(expectedResult, actualResult);
     }
 
-    @Test
-    public void sendTransactionWithGasLimitTest() {
-    	
-    	Constants constants = Constants.regtest();
-    	
-    	Wallet wallet = new Wallet(new HashMapDB());
-    	RskAddress sender = wallet.addAccount();
-    	RskAddress receiver = wallet.addAccount();
-    	
-        // Hash of the expected transaction
-    	Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
-        Transaction tx = TransactionTestHelper.createTransaction(args, constants.getChainId(), wallet.getAccount(sender));
-        String txExpectedResult = tx.getHash().toJsonString();
-    	
-    	TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
-    	when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
-    	
-    	TransactionGateway transactionGateway = mock(TransactionGateway.class); 
-    	when(transactionGateway.receiveTransaction(any(Transaction.class)))
-    		.thenReturn(transactionPoolAddResult);
-    	
-    	TransactionPool transactionPool = mock(TransactionPool.class);
-    	
-    	EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
-    	
-    	// Hash of the actual transaction builded inside the sendTransaction
-    	String txResult = ethModuleTransaction.sendTransaction(args);
+	@Test
+	public void sendTransactionWithGasLimitTest() {
 
-    	assertEquals(txExpectedResult, txResult);
-    }
-    
+		Constants constants = Constants.regtest();
+
+		Wallet wallet = new Wallet(new HashMapDB());
+		RskAddress sender = wallet.addAccount();
+		RskAddress receiver = wallet.addAccount();
+
+		// Hash of the expected transaction
+		Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
+		Transaction tx = TransactionTestHelper.createTransaction(args, constants.getChainId(), wallet.getAccount(sender));
+		String txExpectedResult = tx.getHash().toJsonString();
+
+		TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+		when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+
+		TransactionGateway transactionGateway = mock(TransactionGateway.class);
+		when(transactionGateway.receiveTransaction(any(Transaction.class))).thenReturn(transactionPoolAddResult);
+
+		TransactionPool transactionPool = mock(TransactionPool.class);
+
+		EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
+
+		// Hash of the actual transaction builded inside the sendTransaction
+		String txResult = ethModuleTransaction.sendTransaction(args);
+
+		assertEquals(txExpectedResult, txResult);
+	}
+
     @Test
     public void test_revertedTransaction() {
         Web3.CallArguments args = new Web3.CallArguments();

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
@@ -36,32 +36,32 @@ import co.rsk.core.Wallet;
 public class PersonalModuleTest {
 
 	private static final String PASS_FRASE = "passfrase";
-	
-    @Test
-    public void sendTransactionWithGasLimitTest() throws Exception {
-    	
-    	TestSystemProperties props = new TestSystemProperties();
-    	
-    	Wallet wallet = new Wallet(new HashMapDB());
-    	RskAddress sender = wallet.addAccount(PASS_FRASE);
-    	RskAddress receiver = wallet.addAccount();
 
-        // Hash of the expected transaction
-    	Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
-        Transaction tx = TransactionTestHelper.createTransaction(args, props.getNetworkConstants().getChainId(), wallet.getAccount(sender, PASS_FRASE));
-        String txExpectedResult = tx.getHash().toJsonString();
-    	
-    	TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
-    	when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
-    	
-    	Ethereum ethereum = mock(Ethereum.class);
-    	
-    	PersonalModuleWalletEnabled personalModuleWalletEnabled = new PersonalModuleWalletEnabled(props, ethereum, wallet, null);
-    	
-    	// Hash of the actual transaction builded inside the sendTransaction
-    	String txResult = personalModuleWalletEnabled.sendTransaction(args, PASS_FRASE);
+	@Test
+	public void sendTransactionWithGasLimitTest() throws Exception {
 
-    	assertEquals(txExpectedResult, txResult);
-    }
-	
+		TestSystemProperties props = new TestSystemProperties();
+
+		Wallet wallet = new Wallet(new HashMapDB());
+		RskAddress sender = wallet.addAccount(PASS_FRASE);
+		RskAddress receiver = wallet.addAccount();
+
+		// Hash of the expected transaction
+		Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
+		Transaction tx = TransactionTestHelper.createTransaction(args, props.getNetworkConstants().getChainId(), wallet.getAccount(sender, PASS_FRASE));
+		String txExpectedResult = tx.getHash().toJsonString();
+
+		TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+		when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+
+		Ethereum ethereum = mock(Ethereum.class);
+
+		PersonalModuleWalletEnabled personalModuleWalletEnabled = new PersonalModuleWalletEnabled(props, ethereum, wallet, null);
+
+		// Hash of the actual transaction builded inside the sendTransaction
+		String txResult = personalModuleWalletEnabled.sendTransaction(args, PASS_FRASE);
+
+		assertEquals(txExpectedResult, txResult);
+	}
+
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.personal;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionPoolAddResult;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.rpc.Web3;
+import org.ethereum.util.TransactionTestHelper;
+import org.junit.Test;
+
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+
+public class PersonalModuleTest {
+
+	private static final String PASS_FRASE = "passfrase";
+	
+    @Test
+    public void sendTransactionWithGasLimitTest() throws Exception {
+    	
+    	TestSystemProperties props = new TestSystemProperties();
+    	
+    	Wallet wallet = new Wallet(new HashMapDB());
+    	RskAddress sender = wallet.addAccount(PASS_FRASE);
+    	RskAddress receiver = wallet.addAccount();
+
+        // Hash of the expected transaction
+    	Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
+        Transaction tx = TransactionTestHelper.createTransaction(args, props.getNetworkConstants().getChainId(), wallet.getAccount(sender, PASS_FRASE));
+        String txExpectedResult = tx.getHash().toJsonString();
+    	
+    	TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+    	when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+    	
+    	Ethereum ethereum = mock(Ethereum.class);
+    	
+    	PersonalModuleWalletEnabled personalModuleWalletEnabled = new PersonalModuleWalletEnabled(props, ethereum, wallet, null);
+    	
+    	// Hash of the actual transaction builded inside the sendTransaction
+    	String txResult = personalModuleWalletEnabled.sendTransaction(args, PASS_FRASE);
+
+    	assertEquals(txExpectedResult, txResult);
+    }
+	
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/txpool/TxPoolModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/txpool/TxPoolModuleImplTest.java
@@ -425,13 +425,6 @@ public class TxPoolModuleImplTest {
     }
 
     private void assertSummaryTransaction(Transaction tx, JsonNode summaryNode) {
-        String summary = "{}: {} wei + {} x {} gas";
-        String summaryFormatted = String.format(summary,
-                tx.getReceiveAddress().toString(),
-                tx.getValue().toString(),
-                tx.getGasLimitAsInteger().toString(),
-                tx.getGasPrice().toString());
-
-        Assert.assertEquals(summaryFormatted, summaryNode.asText());
+        Assert.assertEquals(tx.getReceiveAddress().toString() + ": " + tx.getValue().toString() + " wei + " + tx.getGasLimitAsInteger().toString() + " x " + tx.getGasPrice().toString() + " gas", summaryNode.asText());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/net/p2p/P2pHandlerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/net/p2p/P2pHandlerTest.java
@@ -47,4 +47,16 @@ public class P2pHandlerTest {
 
         verify(msgQueue, times(1)).disconnect();
     }
+
+    @Test
+    public void channelInactive_shouldCallKillTimers() throws Exception {
+        EthereumListener ethereumListener = mock(EthereumListener.class);
+        P2pHandler p2pHandlerSpy = spy(new P2pHandler(ethereumListener, msgQueue, 1000));
+
+        doNothing().when(p2pHandlerSpy).killTimers();
+
+        p2pHandlerSpy.channelInactive(null);
+
+        verify(p2pHandlerSpy, times(1)).killTimers();
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/util/TransactionArgumentsUtilTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/TransactionArgumentsUtilTest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.util;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.ethereum.config.Constants;
+import org.ethereum.core.TransactionArguments;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.rpc.Web3;
+import org.junit.Test;
+
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+
+public class TransactionArgumentsUtilTest {
+
+	@Test
+	public void processArguments() {
+
+		Constants constants = Constants.regtest();
+		
+		Wallet wallet = new Wallet(new HashMapDB());
+		RskAddress sender = wallet.addAccount();
+		RskAddress receiver = wallet.addAccount();
+		
+		Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
+		
+		TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, null, wallet.getAccount(sender), constants.getChainId());
+		
+		assertEquals(txArgs.value, BigInteger.valueOf(100000L));
+		assertEquals(txArgs.gasPrice, BigInteger.valueOf(10000000000000L));
+		assertEquals(txArgs.gasLimit, BigInteger.valueOf(30400L));
+		assertEquals(txArgs.chainId, 33);
+		assertEquals(txArgs.nonce, BigInteger.ONE);
+		assertEquals(txArgs.data, null);
+		assertArrayEquals(txArgs.to, receiver.getBytes());
+
+	}
+
+}

--- a/rskj-core/src/test/java/org/ethereum/util/TransactionArgumentsUtilTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/TransactionArgumentsUtilTest.java
@@ -46,13 +46,13 @@ public class TransactionArgumentsUtilTest {
 		
 		TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, null, wallet.getAccount(sender), constants.getChainId());
 		
-		assertEquals(txArgs.value, BigInteger.valueOf(100000L));
-		assertEquals(txArgs.gasPrice, BigInteger.valueOf(10000000000000L));
-		assertEquals(txArgs.gasLimit, BigInteger.valueOf(30400L));
-		assertEquals(txArgs.chainId, 33);
-		assertEquals(txArgs.nonce, BigInteger.ONE);
-		assertEquals(txArgs.data, null);
-		assertArrayEquals(txArgs.to, receiver.getBytes());
+		assertEquals(txArgs.getValue(), BigInteger.valueOf(100000L));
+		assertEquals(txArgs.getGasPrice(), BigInteger.valueOf(10000000000000L));
+		assertEquals(txArgs.getGasLimit(), BigInteger.valueOf(30400L));
+		assertEquals(txArgs.getChainId(), 33);
+		assertEquals(txArgs.getNonce(), BigInteger.ONE);
+		assertEquals(txArgs.getData(), null);
+		assertArrayEquals(txArgs.getTo(), receiver.getBytes());
 
 	}
 

--- a/rskj-core/src/test/java/org/ethereum/util/TransactionTestHelper.java
+++ b/rskj-core/src/test/java/org/ethereum/util/TransactionTestHelper.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.util;
+import org.ethereum.core.Account;
+import org.ethereum.core.Transaction;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.Web3;
+
+import co.rsk.core.RskAddress;
+
+public class TransactionTestHelper {
+	
+	public static Web3.CallArguments createArguments(RskAddress sender, RskAddress receiver) {
+		
+    	// Simulation of the args handled in the sendTransaction call
+    	Web3.CallArguments args = new Web3.CallArguments();
+    	args.from = sender.toJsonString();
+    	args.to = receiver.toJsonString();
+    	args.gasLimit = "0x76c0";
+    	args.gasPrice = "0x9184e72a000";
+    	args.value = "0x186A0";
+    	args.nonce = "0x01";
+		
+    	return args;
+	}
+	
+	public static Transaction createTransaction(Web3.CallArguments args, byte chainId, Account senderAccount) {
+
+    	// Transaction that is expected to be constructed WITH the gasLimit
+        Transaction tx = Transaction
+            .builder()
+            .nonce(TypeConverter.stringNumberAsBigInt(args.nonce))
+            .gasPrice(TypeConverter.stringNumberAsBigInt(args.gasPrice))
+            .gasLimit(TypeConverter.stringNumberAsBigInt(args.gasLimit))
+            .destination(TypeConverter.stringHexToByteArray(args.to))
+            .chainId(chainId)
+            .value(TypeConverter.stringNumberAsBigInt(args.value))
+            .build();
+        tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
+		
+        return tx;
+	}
+	
+}

--- a/rskj-core/src/test/java/org/ethereum/util/TransactionTestHelper.java
+++ b/rskj-core/src/test/java/org/ethereum/util/TransactionTestHelper.java
@@ -17,6 +17,7 @@
  */
 
 package org.ethereum.util;
+
 import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
 import org.ethereum.rpc.TypeConverter;
@@ -25,36 +26,35 @@ import org.ethereum.rpc.Web3;
 import co.rsk.core.RskAddress;
 
 public class TransactionTestHelper {
-	
+
 	public static Web3.CallArguments createArguments(RskAddress sender, RskAddress receiver) {
-		
-    	// Simulation of the args handled in the sendTransaction call
-    	Web3.CallArguments args = new Web3.CallArguments();
-    	args.from = sender.toJsonString();
-    	args.to = receiver.toJsonString();
-    	args.gasLimit = "0x76c0";
-    	args.gasPrice = "0x9184e72a000";
-    	args.value = "0x186A0";
-    	args.nonce = "0x01";
-		
-    	return args;
+
+		// Simulation of the args handled in the sendTransaction call
+		Web3.CallArguments args = new Web3.CallArguments();
+		args.from = sender.toJsonString();
+		args.to = receiver.toJsonString();
+		args.gasLimit = "0x76c0";
+		args.gasPrice = "0x9184e72a000";
+		args.value = "0x186A0";
+		args.nonce = "0x01";
+
+		return args;
 	}
-	
+
 	public static Transaction createTransaction(Web3.CallArguments args, byte chainId, Account senderAccount) {
 
-    	// Transaction that is expected to be constructed WITH the gasLimit
-        Transaction tx = Transaction
-            .builder()
-            .nonce(TypeConverter.stringNumberAsBigInt(args.nonce))
-            .gasPrice(TypeConverter.stringNumberAsBigInt(args.gasPrice))
-            .gasLimit(TypeConverter.stringNumberAsBigInt(args.gasLimit))
-            .destination(TypeConverter.stringHexToByteArray(args.to))
-            .chainId(chainId)
-            .value(TypeConverter.stringNumberAsBigInt(args.value))
-            .build();
-        tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
-		
-        return tx;
+		// Transaction that is expected to be constructed WITH the gasLimit
+		Transaction tx = Transaction.builder()
+			.nonce(TypeConverter.stringNumberAsBigInt(args.nonce))
+			.gasPrice(TypeConverter.stringNumberAsBigInt(args.gasPrice))
+			.gasLimit(TypeConverter.stringNumberAsBigInt(args.gasLimit))
+			.destination(TypeConverter.stringHexToByteArray(args.to))
+			.chainId(chainId)
+			.value(TypeConverter.stringNumberAsBigInt(args.value))
+			.build();
+		tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
+
+		return tx;
 	}
-	
+
 }


### PR DESCRIPTION
eth_sendTransaction support 'gasLimit' field #961

## Description
Added gasLimit field to Web3.CallArguments and make the necessary treatments in the EthModuleTransactionBase.sendTransaction and PersonalModuleWalletEnabled.sendTransaction. Making 'gas' param overwrite 'gasLimit' if both are provided

## Motivation and Context
https://github.com/rsksmart/rskj/issues/961

## How Has This Been Tested?
Tested on regtest with sendTransaction rpc API:
`{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from": "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826", "to": "0x7986b3df570230288501eea3d890bd66948c9b79", "gasLimit": "0x76c0", "gasPrice": "0x9184e72a000", "value": "0x186A0"}],"id":73}`

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [ X ] My change requires a change to the documentation.
