### PR TITLE
Revert reason delegation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionInstant.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionInstant.java
@@ -113,7 +113,7 @@ public class EthModuleTransactionInstant extends EthModuleTransactionBase {
         ProgramResult programResult = this.blockExecutor.getProgramResult(hash);
 
         if (programResult != null && programResult.isRevert()) {
-            Optional<String> revertReason = EthModule.decodeRevertReason(programResult);
+            Optional<String> revertReason = programResult.decodeRevertReason();
 
             if (revertReason.isPresent()) {
                 throw RskJsonRpcRequestException.transactionRevertedExecutionError(revertReason.get());

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -137,11 +137,10 @@ public class EthModuleTest {
                         "0000002000000000000000000000000000000000000000000000000000000000" +
                         "0000000f6465706f73697420746f6f2062696700000000000000000000000000" +
                         "00000000");
-        ProgramResult executorResult = mock(ProgramResult.class);
-        when(executorResult.isRevert()).thenReturn(true);
-        when(executorResult.getHReturn())
-                .thenReturn(hreturn);
-
+        ProgramResult executorResult = new ProgramResult();
+        executorResult.setHReturn(hreturn);
+        executorResult.setRevert();
+        
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
         when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(executorResult);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When you want to call any `eth_` method you'll need to use the `EthModule`, all it's public methods are `eth_` calls, except for `EthModule.decodeRevertReaseon()`, which only uses the program result to decode the revert reason. 

I'm taking out that responsibility from `EthModule` and delegate to `ProgramResult` whenever we want to decode the revert reason


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes this https://github.com/rsksmart/rskj/issues/1560 .
Easy to solve tech debt.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I'll add some tests for programResult.decodeRevertReason

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
