### PR TITLE
eth_sendTransaction support 'gasLimit' field #961 plus transaction refactory

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -18,134 +18,100 @@
 
 package co.rsk.rpc.modules.eth;
 
-import co.rsk.core.RskAddress;
-import co.rsk.core.Wallet;
-import co.rsk.net.TransactionGateway;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.config.Constants;
-import org.ethereum.core.*;
-import org.ethereum.rpc.TypeConverter;
-import org.ethereum.rpc.Web3;
-import org.ethereum.rpc.exception.RskJsonRpcRequestException;
-import org.ethereum.util.ByteUtil;
-import org.ethereum.vm.GasCost;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.math.BigInteger;
-
 import static org.ethereum.rpc.TypeConverter.stringHexToByteArray;
 import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
 
+import org.ethereum.config.Constants;
+import org.ethereum.core.Account;
+import org.ethereum.core.ImmutableTransaction;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionArguments;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.core.TransactionPoolAddResult;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.util.TransactionArgumentsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+import co.rsk.net.TransactionGateway;
+
 public class EthModuleTransactionBase implements EthModuleTransaction {
 
-    private static final String ERR_INVALID_CHAIN_ID = "Invalid chainId: ";
+	protected static final Logger LOGGER = LoggerFactory.getLogger("web3");
 
-    protected static final Logger LOGGER = LoggerFactory.getLogger("web3");
+	private final Wallet wallet;
+	private final TransactionPool transactionPool;
+	private final Constants constants;
+	private final TransactionGateway transactionGateway;
 
-    private final Wallet wallet;
-    private final TransactionPool transactionPool;
-    private final Constants constants;
-    private final TransactionGateway transactionGateway;
+	public EthModuleTransactionBase(Constants constants, Wallet wallet, TransactionPool transactionPool, TransactionGateway transactionGateway) {
+		this.wallet = wallet;
+		this.transactionPool = transactionPool;
+		this.constants = constants;
+		this.transactionGateway = transactionGateway;
+	}
 
-    public EthModuleTransactionBase(Constants constants, Wallet wallet, TransactionPool transactionPool, TransactionGateway transactionGateway) {
-        this.wallet = wallet;
-        this.transactionPool = transactionPool;
-        this.constants = constants;
-        this.transactionGateway = transactionGateway;
-    }
+	@Override
+	public synchronized String sendTransaction(Web3.CallArguments args) {
 
-    @Override
-    public synchronized String sendTransaction(Web3.CallArguments args) {
-        Account account = this.wallet.getAccount(new RskAddress(args.from));
-        String s = null;
-        try {
-            String toAddress = args.to != null ? ByteUtil.toHexString(stringHexToByteArray(args.to)) : null;
+		Account senderAccount = this.wallet.getAccount(new RskAddress(args.from));
+		String txHash = null;
 
-            BigInteger value = args.value != null ? TypeConverter.stringNumberAsBigInt(args.value) : BigInteger.ZERO;
-            BigInteger gasPrice = args.gasPrice != null ? TypeConverter.stringNumberAsBigInt(args.gasPrice) : BigInteger.ZERO;
-            BigInteger gasLimit = args.gas != null ? TypeConverter.stringNumberAsBigInt(args.gas) : BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
+		try {
 
-            if (args.data != null && args.data.startsWith("0x")) {
-                args.data = args.data.substring(2);
-            }
+			synchronized (transactionPool) {
 
-            byte txChainId = hexToChainId(args.chainId);
-            if (txChainId == 0) {
-                txChainId = constants.getChainId();
-            }
+				TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, transactionPool, senderAccount, constants.getChainId());
 
-            synchronized (transactionPool) {
-                BigInteger accountNonce = args.nonce != null ? TypeConverter.stringNumberAsBigInt(args.nonce) : transactionPool.getPendingState().getNonce(account.getAddress());
-                Transaction tx = Transaction
-                        .builder()
-                        .nonce(accountNonce)
-                        .gasPrice(gasPrice)
-                        .gasLimit(gasLimit)
-                        .destination(toAddress == null ? null : Hex.decode(toAddress))
-                        .data(args.data == null ? null : Hex.decode(args.data))
-                        .chainId(txChainId)
-                        .value(value)
-                        .build();
-                tx.sign(account.getEcKey().getPrivKeyBytes());
+				Transaction tx = Transaction.builder().from(txArgs).build();
 
-                if (!tx.acceptTransactionSignature(constants.getChainId())) {
-                    throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + args.chainId);
-                }
+				tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
 
-                TransactionPoolAddResult result = transactionGateway.receiveTransaction(tx.toImmutableTransaction());
-                if(!result.transactionsWereAdded()) {
-                    throw RskJsonRpcRequestException.transactionError(result.getErrorMessage());
-                }
+				if (!tx.acceptTransactionSignature(constants.getChainId())) {
+					throw RskJsonRpcRequestException.invalidParamError(TransactionArgumentsUtil.ERR_INVALID_CHAIN_ID + args.chainId);
+				}
 
-                s = tx.getHash().toJsonString();
-            }
+				TransactionPoolAddResult result = transactionGateway.receiveTransaction(tx.toImmutableTransaction());
 
-            return s;
+				if (!result.transactionsWereAdded()) {
+					throw RskJsonRpcRequestException.transactionError(result.getErrorMessage());
+				}
 
-        } finally {
-            LOGGER.debug("eth_sendTransaction({}): {}", args, s);
-        }
-    }
+				txHash = tx.getHash().toJsonString();
+			}
 
-    @Override
-    public String sendRawTransaction(String rawData) {
-        String s = null;
-        try {
-            Transaction tx = new ImmutableTransaction(stringHexToByteArray(rawData));
+			return txHash;
 
-            if (null == tx.getGasLimit()
-                    || null == tx.getGasPrice()
-                    || null == tx.getValue()) {
-                throw invalidParamError("Missing parameter, gasPrice, gas or value");
-            }
+		} finally {
+			LOGGER.debug("eth_sendTransaction({}): {}", args, txHash);
+		}
+	}
 
-            TransactionPoolAddResult result = transactionGateway.receiveTransaction(tx);
-            if(!result.transactionsWereAdded()) {
-                throw RskJsonRpcRequestException.transactionError(result.getErrorMessage());
-            }
+	@Override
+	public String sendRawTransaction(String rawData) {
+		String s = null;
+		try {
+			Transaction tx = new ImmutableTransaction(stringHexToByteArray(rawData));
 
-            return s = tx.getHash().toJsonString();
-        } finally {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("eth_sendRawTransaction({}): {}", rawData, s);
-            }
-        }
-    }
+			if (null == tx.getGasLimit() || null == tx.getGasPrice() || null == tx.getValue()) {
+				throw invalidParamError("Missing parameter, gasPrice, gas or value");
+			}
 
-    private static byte hexToChainId(String hex) {
-        if (hex == null) {
-            return 0;
-        }
-        try {
-            byte[] bytes = TypeConverter.stringHexToByteArray(hex);
-            if (bytes.length != 1) {
-                throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex);
-            }
+			TransactionPoolAddResult result = transactionGateway.receiveTransaction(tx);
+			if (!result.transactionsWereAdded()) {
+				throw RskJsonRpcRequestException.transactionError(result.getErrorMessage());
+			}
 
-            return bytes[0];
-        } catch (Exception e) {
-            throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex, e);
-        }
-    }
+			return s = tx.getHash().toJsonString();
+		} finally {
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug("eth_sendRawTransaction({}): {}", rawData, s);
+			}
+		}
+	}
+
+
 }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionArguments.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionArguments.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.core;
+
+import java.math.BigInteger;
+
+import java.util.Arrays;
+
+
+public class TransactionArguments {
+
+	private String from;
+	private byte[] to;
+	private BigInteger gas;
+	private BigInteger gasLimit;
+	private BigInteger gasPrice;
+	private BigInteger value;
+	private String data; // compiledCode
+	private BigInteger nonce;
+	private byte chainId; // NOSONAR
+
+	public String getFrom() {
+		return from;
+	}
+
+	public void setFrom(String from) {
+		this.from = from;
+	}
+
+	public byte[] getTo() {
+		return to;
+	}
+
+	public void setTo(byte[] to) {
+		this.to = to;
+	}
+
+	public BigInteger getGas() {
+		return gas;
+	}
+
+	public void setGas(BigInteger gas) {
+		this.gas = gas;
+	}
+
+	public BigInteger getGasLimit() {
+		return gasLimit;
+	}
+
+	public void setGasLimit(BigInteger gasLimit) {
+		this.gasLimit = gasLimit;
+	}
+
+	public BigInteger getGasPrice() {
+		return gasPrice;
+	}
+
+	public void setGasPrice(BigInteger gasPrice) {
+		this.gasPrice = gasPrice;
+	}
+
+	public BigInteger getValue() {
+		return value;
+	}
+
+	public void setValue(BigInteger value) {
+		this.value = value;
+	}
+
+	public String getData() {
+		return data;
+	}
+
+	public void setData(String data) {
+		this.data = data;
+	}
+
+	public BigInteger getNonce() {
+		return nonce;
+	}
+
+	public void setNonce(BigInteger nonce) {
+		this.nonce = nonce;
+	}
+
+	public byte getChainId() {
+		return chainId;
+	}
+
+	public void setChainId(byte chainId) {
+		this.chainId = chainId;
+	}
+
+	@Override
+	public String toString() {
+		return "TransactionArguments{" +
+			"from='" + from + '\'' +
+			", to='" + Arrays.toString(to) + '\'' +
+			", gasLimit='" + ((gas != null)?gas:gasLimit) + '\'' +
+			", gasPrice='" + gasPrice + '\'' +
+			", value='" + value + '\'' +
+			", data='" + data + '\'' +
+			", nonce='" + nonce + '\'' +
+			", chainId='" + chainId + '\'' +
+			"}";
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionBuilder.java
@@ -28,105 +28,120 @@ import org.ethereum.util.RLP;
 import java.math.BigInteger;
 
 public final class TransactionBuilder {
-    private boolean isLocalCall = false;
-    private byte[] nonce = ByteUtil.cloneBytes(null);
-    private Coin value = Coin.ZERO;
-    private RskAddress receiveAddress = RskAddress.nullAddress();
-    private Coin gasPrice = Coin.ZERO;
-    private byte[] gasLimit = ByteUtil.cloneBytes(null);
-    private byte[] data = ByteUtil.cloneBytes(null);
-    private byte chainId = 0;
 
-    TransactionBuilder() {
-    }
+	private boolean isLocalCall = false;
+	private byte[] nonce = ByteUtil.cloneBytes(null);
+	private Coin value = Coin.ZERO;
+	private RskAddress receiveAddress = RskAddress.nullAddress();
+	private Coin gasPrice = Coin.ZERO;
+	private byte[] gasLimit = ByteUtil.cloneBytes(null);
+	private byte[] data = ByteUtil.cloneBytes(null);
+	private byte chainId = 0;
 
-    public TransactionBuilder value(BigInteger value) {
-        return this.value(BigIntegers.asUnsignedByteArray(value));
-    }
+	TransactionBuilder() {
+	}
 
-    public TransactionBuilder gasLimit(BigInteger limit) {
-        return this.gasLimit(BigIntegers.asUnsignedByteArray(limit));
-    }
+	public TransactionBuilder value(BigInteger value) {
+		return this.value(BigIntegers.asUnsignedByteArray(value));
+	}
 
-    public TransactionBuilder gasPrice(BigInteger price) {
-        return this.gasPrice(price.toByteArray());
-    }
+	public TransactionBuilder gasLimit(BigInteger limit) {
+		return this.gasLimit(BigIntegers.asUnsignedByteArray(limit));
+	}
 
-    public TransactionBuilder nonce(BigInteger nonce) {
-        return this.nonce(BigIntegers.asUnsignedByteArray(nonce));
-    }
+	public TransactionBuilder gasPrice(BigInteger price) {
+		return this.gasPrice(price.toByteArray());
+	}
 
-    public TransactionBuilder isLocalCall(boolean isLocalCall) {
-        this.isLocalCall = isLocalCall;
-        return this;
-    }
+	public TransactionBuilder nonce(BigInteger nonce) {
+		return this.nonce(BigIntegers.asUnsignedByteArray(nonce));
+	}
 
-    public TransactionBuilder nonce(byte[] nonce) {
-        this.nonce = ByteUtil.cloneBytes(nonce);
-        return this;
-    }
+	public TransactionBuilder isLocalCall(boolean isLocalCall) {
+		this.isLocalCall = isLocalCall;
+		return this;
+	}
 
-    public TransactionBuilder value(Coin value) {
-        this.value = value;
-        return this;
-    }
+	public TransactionBuilder nonce(byte[] nonce) {
+		this.nonce = ByteUtil.cloneBytes(nonce);
+		return this;
+	}
 
-    public TransactionBuilder value(byte[] value) {
-        this.value(RLP.parseCoinNullZero(ByteUtil.cloneBytes(value)));
-        return this;
-    }
+	public TransactionBuilder value(Coin value) {
+		this.value = value;
+		return this;
+	}
 
-    public TransactionBuilder destination(RskAddress receiveAddress) {
-        this.receiveAddress = receiveAddress;
-        return this;
-    }
+	public TransactionBuilder value(byte[] value) {
+		this.value(RLP.parseCoinNullZero(ByteUtil.cloneBytes(value)));
+		return this;
+	}
 
-    public TransactionBuilder destination(byte[] receiveAddress) {
-        return this.destination(RLP.parseRskAddress(ByteUtil.cloneBytes(receiveAddress)));
-    }
+	public TransactionBuilder destination(RskAddress receiveAddress) {
+		this.receiveAddress = receiveAddress;
+		return this;
+	}
 
-    public TransactionBuilder gasPrice(Coin gasPrice) {
-        this.gasPrice = gasPrice;
-        return this;
-    }
+	public TransactionBuilder destination(byte[] receiveAddress) {
+		return this.destination(RLP.parseRskAddress(ByteUtil.cloneBytes(receiveAddress)));
+	}
 
-    public TransactionBuilder gasPrice(byte[] gasPrice) {
-        this.gasPrice(RLP.parseCoinNonNullZero(ByteUtil.cloneBytes(gasPrice)));
-        return this;
-    }
+	public TransactionBuilder gasPrice(Coin gasPrice) {
+		this.gasPrice = gasPrice;
+		return this;
+	}
 
-    public TransactionBuilder gasLimit(byte[] gasLimit) {
-        this.gasLimit = ByteUtil.cloneBytes(gasLimit);
-        return this;
-    }
+	public TransactionBuilder gasPrice(byte[] gasPrice) {
+		this.gasPrice(RLP.parseCoinNonNullZero(ByteUtil.cloneBytes(gasPrice)));
+		return this;
+	}
 
-    public TransactionBuilder data(byte[] data) {
-        this.data = ByteUtil.cloneBytes(data);
-        return this;
-    }
+	public TransactionBuilder gasLimit(byte[] gasLimit) {
+		this.gasLimit = ByteUtil.cloneBytes(gasLimit);
+		return this;
+	}
 
-    public TransactionBuilder chainId(byte chainId) {
-        this.chainId = chainId;
-        return this;
-    }
+	public TransactionBuilder data(byte[] data) {
+		this.data = ByteUtil.cloneBytes(data);
+		return this;
+	}
 
-    public TransactionBuilder destination(String to) {
-        return this.destination(to == null ? null : Hex.decode(to));
-    }
+	public TransactionBuilder chainId(byte chainId) {
+		this.chainId = chainId;
+		return this;
+	}
 
-    public TransactionBuilder gasLimit(Coin value) {
-        return this.gasLimit(value.getBytes());
-    }
+	public TransactionBuilder destination(String to) {
+		return this.destination(to == null ? null : Hex.decode(to));
+	}
 
-    public TransactionBuilder nonce(Coin value) {
-        return this.nonce(value.getBytes());
-    }
+	public TransactionBuilder gasLimit(Coin value) {
+		return this.gasLimit(value.getBytes());
+	}
 
-    public Transaction build() {
-        return new Transaction(this.nonce, this.gasPrice, this.gasLimit, this.receiveAddress, this.value, this.data, this.chainId, this.isLocalCall);
-    }
+	public TransactionBuilder nonce(Coin value) {
+		return this.nonce(value.getBytes());
+	}
 
-    public TransactionBuilder data(String data) {
-        return this.data(data == null ? null: Hex.decode(data));
-    }
+	public Transaction build() {
+		return new Transaction(this.nonce, this.gasPrice, this.gasLimit, this.receiveAddress, this.value, this.data, this.chainId, this.isLocalCall);
+	}
+
+	public TransactionBuilder data(String data) {
+		return this.data(data == null ? null : Hex.decode(data));
+	}
+
+	public TransactionBuilder from(TransactionArguments args) {
+
+		nonce(args.getNonce());
+		gasPrice(args.getGasPrice());
+		gasLimit(args.getGasLimit());
+		destination(args.getTo());
+		data(args.getData());
+		chainId(args.getChainId());
+		value(BigIntegers.asUnsignedByteArray(args.getValue()));
+
+		return this;
+	}
+
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -37,6 +37,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String from;
         public String to;
         public String gas;
+        public String gasLimit;
         public String gasPrice;
         public String value;
         public String data; // compiledCode
@@ -48,7 +49,8 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
             return "CallArguments{" +
                     "from='" + from + '\'' +
                     ", to='" + to + '\'' +
-                    ", gasLimit='" + gas + '\'' +
+                    ", gas='" + gas + '\'' +
+                    ", gasLimit='" + gasLimit + '\'' +
                     ", gasPrice='" + gasPrice + '\'' +
                     ", value='" + value + '\'' +
                     ", data='" + data + '\'' +

--- a/rskj-core/src/main/java/org/ethereum/util/TransactionArgumentsUtil.java
+++ b/rskj-core/src/main/java/org/ethereum/util/TransactionArgumentsUtil.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.util;
+
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.ethereum.core.Account;
+import org.ethereum.core.TransactionArguments;
+import org.ethereum.core.TransactionPool;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.Web3;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.vm.GasCost;
+
+public class TransactionArgumentsUtil {
+
+	private static final BigInteger DEFAULT_GAS_LIMIT = BigInteger.valueOf(GasCost.TRANSACTION_DEFAULT);
+
+	public static final String ERR_INVALID_CHAIN_ID = "Invalid chainId: ";
+
+	/**
+	 * transform the Web3.CallArguments in TransactionArguments that can be used in
+	 * the TransactionBuilder
+	 */
+	public static TransactionArguments processArguments(Web3.CallArguments argsParam, TransactionPool transactionPool, Account senderAccount, byte defaultChainId) {
+
+		TransactionArguments argsRet = new TransactionArguments();
+
+		argsRet.setFrom(argsParam.from);
+
+		argsRet.setTo(stringHexToByteArray(argsParam.to));
+
+		argsRet.setNonce(stringNumberAsBigInt(argsParam.nonce, () -> transactionPool.getPendingState().getNonce(senderAccount.getAddress())));
+
+		argsRet.setValue(stringNumberAsBigInt(argsParam.value, () -> BigInteger.ZERO));
+
+		argsRet.setGasPrice(stringNumberAsBigInt(argsParam.gasPrice, () -> BigInteger.ZERO));
+
+		argsRet.setGasLimit(stringNumberAsBigInt(argsParam.gas, () -> null));
+
+		if (argsRet.getGasLimit() == null) {
+			argsRet.setGasLimit(stringNumberAsBigInt(argsParam.gasLimit, () -> DEFAULT_GAS_LIMIT));
+		}
+
+		if (argsParam.data != null && argsParam.data.startsWith("0x")) {
+			argsRet.setData(argsParam.data.substring(2));
+			argsParam.data = argsRet.getData(); // needs to change the parameter because some places expect the changed value after sendTransaction call
+		}
+
+		argsRet.setChainId(hexToChainId(argsParam.chainId));
+		if (argsRet.getChainId() == 0) {
+			argsRet.setChainId(defaultChainId);
+		}
+
+		return argsRet;
+	}
+
+	private static BigInteger stringNumberAsBigInt(String number, Supplier<BigInteger> getDefaultValue) {
+
+		BigInteger ret = Optional.ofNullable(number).map(TypeConverter::stringNumberAsBigInt).orElseGet(getDefaultValue);
+
+		return ret;
+	}
+
+	private static byte[] stringHexToByteArray(String value) {
+
+		byte[] ret = Optional.ofNullable(value).map(TypeConverter::stringHexToByteArray).orElse(null);
+
+		return ret;
+	}
+
+	private static byte hexToChainId(String hex) {
+		if (hex == null) {
+			return 0;
+		}
+		try {
+			byte[] bytes = TypeConverter.stringHexToByteArray(hex);
+			if (bytes.length != 1) {
+				throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex);
+			}
+
+			return bytes[0];
+		} catch (Exception e) {
+			throw RskJsonRpcRequestException.invalidParamError(ERR_INVALID_CHAIN_ID + hex, e);
+		}
+	}
+
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -170,13 +170,14 @@ public class Web3RskImplTest {
         callArguments.from = "0x1";
         callArguments.to = "0x2";
         callArguments.gas = "21000";
+        callArguments.gasLimit = "21000";
         callArguments.gasPrice = "100";
         callArguments.value = "1";
         callArguments.data = "data";
         callArguments.nonce = "0";
         callArguments.chainId = "0x00";
 
-        assertEquals("CallArguments{from='0x1', to='0x2', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0', chainId='0x00'}", callArguments.toString());
+        assertEquals("CallArguments{from='0x1', to='0x2', gas='21000', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0', chainId='0x00'}", callArguments.toString());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.rpc.modules.personal;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionPoolAddResult;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.rpc.Web3;
+import org.ethereum.util.TransactionTestHelper;
+import org.junit.Test;
+
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+
+public class PersonalModuleTest {
+
+	private static final String PASS_FRASE = "passfrase";
+
+	@Test
+	public void sendTransactionWithGasLimitTest() throws Exception {
+
+		TestSystemProperties props = new TestSystemProperties();
+
+		Wallet wallet = new Wallet(new HashMapDB());
+		RskAddress sender = wallet.addAccount(PASS_FRASE);
+		RskAddress receiver = wallet.addAccount();
+
+		// Hash of the expected transaction
+		Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
+		Transaction tx = TransactionTestHelper.createTransaction(args, props.getNetworkConstants().getChainId(), wallet.getAccount(sender, PASS_FRASE));
+		String txExpectedResult = tx.getHash().toJsonString();
+
+		TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+		when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+
+		Ethereum ethereum = mock(Ethereum.class);
+
+		PersonalModuleWalletEnabled personalModuleWalletEnabled = new PersonalModuleWalletEnabled(props, ethereum, wallet, null);
+
+		// Hash of the actual transaction builded inside the sendTransaction
+		String txResult = personalModuleWalletEnabled.sendTransaction(args, PASS_FRASE);
+
+		assertEquals(txExpectedResult, txResult);
+	}
+
+}

--- a/rskj-core/src/test/java/org/ethereum/util/TransactionArgumentsUtilTest.java
+++ b/rskj-core/src/test/java/org/ethereum/util/TransactionArgumentsUtilTest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.util;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.ethereum.config.Constants;
+import org.ethereum.core.TransactionArguments;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.rpc.Web3;
+import org.junit.Test;
+
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+
+public class TransactionArgumentsUtilTest {
+
+	@Test
+	public void processArguments() {
+
+		Constants constants = Constants.regtest();
+		
+		Wallet wallet = new Wallet(new HashMapDB());
+		RskAddress sender = wallet.addAccount();
+		RskAddress receiver = wallet.addAccount();
+		
+		Web3.CallArguments args = TransactionTestHelper.createArguments(sender, receiver);
+		
+		TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, null, wallet.getAccount(sender), constants.getChainId());
+		
+		assertEquals(txArgs.getValue(), BigInteger.valueOf(100000L));
+		assertEquals(txArgs.getGasPrice(), BigInteger.valueOf(10000000000000L));
+		assertEquals(txArgs.getGasLimit(), BigInteger.valueOf(30400L));
+		assertEquals(txArgs.getChainId(), 33);
+		assertEquals(txArgs.getNonce(), BigInteger.ONE);
+		assertEquals(txArgs.getData(), null);
+		assertArrayEquals(txArgs.getTo(), receiver.getBytes());
+
+	}
+
+}

--- a/rskj-core/src/test/java/org/ethereum/util/TransactionTestHelper.java
+++ b/rskj-core/src/test/java/org/ethereum/util/TransactionTestHelper.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.util;
+
+import org.ethereum.core.Account;
+import org.ethereum.core.Transaction;
+import org.ethereum.rpc.TypeConverter;
+import org.ethereum.rpc.Web3;
+
+import co.rsk.core.RskAddress;
+
+public class TransactionTestHelper {
+
+	public static Web3.CallArguments createArguments(RskAddress sender, RskAddress receiver) {
+
+		// Simulation of the args handled in the sendTransaction call
+		Web3.CallArguments args = new Web3.CallArguments();
+		args.from = sender.toJsonString();
+		args.to = receiver.toJsonString();
+		args.gasLimit = "0x76c0";
+		args.gasPrice = "0x9184e72a000";
+		args.value = "0x186A0";
+		args.nonce = "0x01";
+
+		return args;
+	}
+
+	public static Transaction createTransaction(Web3.CallArguments args, byte chainId, Account senderAccount) {
+
+		// Transaction that is expected to be constructed WITH the gasLimit
+		Transaction tx = Transaction.builder()
+			.nonce(TypeConverter.stringNumberAsBigInt(args.nonce))
+			.gasPrice(TypeConverter.stringNumberAsBigInt(args.gasPrice))
+			.gasLimit(TypeConverter.stringNumberAsBigInt(args.gasLimit))
+			.destination(TypeConverter.stringHexToByteArray(args.to))
+			.chainId(chainId)
+			.value(TypeConverter.stringNumberAsBigInt(args.value))
+			.build();
+		tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
+
+		return tx;
+	}
+
+}


### PR DESCRIPTION
eth_sendTransaction support 'gasLimit' field #961

## Description
Added gasLimit field to Web3.CallArguments and make the necessary treatments in the EthModuleTransactionBase.sendTransaction and PersonalModuleWalletEnabled.sendTransaction. Making 'gas' param overwrite 'gasLimit' if both are provided

## Motivation and Context
https://github.com/rsksmart/rskj/issues/961

## How Has This Been Tested?
Tested on regtest with sendTransaction rpc API:
`{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from": "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826", "to": "0x7986b3df570230288501eea3d890bd66948c9b79", "gasLimit": "0x76c0", "gasPrice": "0x9184e72a000", "value": "0x186A0"}],"id":73}`

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [ X ] My change requires a change to the documentat