### PR TITLE
Fixing semantic confusion

### DIFF
--- a/rskj-core/src/main/java/co/rsk/util/NodeStopper.java
+++ b/rskj-core/src/main/java/co/rsk/util/NodeStopper.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2021 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.util;
+
+public interface NodeStopper {
+
+    void stop(int exitStatus);
+
+}

--- a/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/MinerUtilsTest.java
@@ -28,15 +28,27 @@ import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.util.*;
 
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+
 public class MinerUtilsTest {
 
+    private static final Coin ONE_COIN = Coin.valueOf(1L);
+
     private final TestSystemProperties config = new TestSystemProperties();
+    private MinerUtils minerUtils;
+
+    @Before
+    public void setup() {
+        minerUtils = new MinerUtils();
+    }
 
     @Test
     public void getAllTransactionsTest() {
@@ -69,7 +81,7 @@ public class MinerUtilsTest {
 
         Mockito.when(transactionPool.getPendingTransactions()).thenReturn(txs);
 
-        List<Transaction> res = new MinerUtils().getAllTransactions(transactionPool);
+        List<Transaction> res = minerUtils.getAllTransactions(transactionPool);
 
         Assert.assertEquals(2, res.size());
     }
@@ -83,9 +95,8 @@ public class MinerUtilsTest {
         Map<RskAddress, BigInteger> accountNounces = new HashMap();
         Repository repository = Mockito.mock(Repository.class);
         Mockito.when(repository.getNonce(tx.getSender())).thenReturn(BigInteger.valueOf(0));
-        Coin minGasPrice = Coin.valueOf(1L);
 
-        List<Transaction> res = new MinerUtils().filterTransactions(new LinkedList<>(), txs, accountNounces, repository, minGasPrice);
+        List<Transaction> res = minerUtils.filterTransactions(new LinkedList<>(), txs, accountNounces, repository, ONE_COIN);
         Assert.assertEquals(1, res.size());
     }
 
@@ -98,9 +109,8 @@ public class MinerUtilsTest {
         Map<RskAddress, BigInteger> accountNounces = new HashMap();
         accountNounces.put(tx.getSender(), BigInteger.valueOf(0));
         Repository repository = Mockito.mock(Repository.class);
-        Coin minGasPrice = Coin.valueOf(1L);
 
-        List<Transaction> res = new MinerUtils().filterTransactions(new LinkedList<>(), txs, accountNounces, repository, minGasPrice);
+        List<Transaction> res = minerUtils.filterTransactions(new LinkedList<>(), txs, accountNounces, repository, ONE_COIN);
         Assert.assertEquals(1, res.size());
     }
 
@@ -112,10 +122,9 @@ public class MinerUtilsTest {
         Map<RskAddress, BigInteger> accountNounces = new HashMap();
         accountNounces.put(tx.getSender(), BigInteger.valueOf(0));
         Repository repository = Mockito.mock(Repository.class);
-        Coin minGasPrice = Coin.valueOf(1L);
 
         List<Transaction> txsToRemove = new LinkedList<>();
-        List<Transaction> res = new MinerUtils().filterTransactions(txsToRemove, txs, accountNounces, repository, minGasPrice);
+        List<Transaction> res = minerUtils.filterTransactions(txsToRemove, txs, accountNounces, repository, ONE_COIN);
         Assert.assertEquals(0, res.size());
         Assert.assertEquals(0, txsToRemove.size());
     }
@@ -132,7 +141,7 @@ public class MinerUtilsTest {
         Coin minGasPrice = Coin.valueOf(2L);
 
         LinkedList<Transaction> txsToRemove = new LinkedList<>();
-        List<Transaction> res = new MinerUtils().filterTransactions(txsToRemove, txs, accountNounces, repository, minGasPrice);
+        List<Transaction> res = minerUtils.filterTransactions(txsToRemove, txs, accountNounces, repository, minGasPrice);
         Assert.assertEquals(0, res.size());
         Assert.assertEquals(1, txsToRemove.size());
     }
@@ -150,7 +159,7 @@ public class MinerUtilsTest {
         Coin minGasPrice = Coin.valueOf(2L);
 
         LinkedList<Transaction> txsToRemove = new LinkedList<>();
-        List<Transaction> res = new MinerUtils().filterTransactions(txsToRemove, txs, accountNounces, repository, minGasPrice);
+        List<Transaction> res = minerUtils.filterTransactions(txsToRemove, txs, accountNounces, repository, minGasPrice);
         Assert.assertEquals(0, res.size());
         Assert.assertEquals(1, txsToRemove.size());
     }
@@ -193,7 +202,7 @@ public class MinerUtilsTest {
 
         Mockito.when(transactionPool.getPendingTransactions()).thenReturn(txs);
 
-        List<Transaction> res = new MinerUtils().getAllTransactions(transactionPool);
+        List<Transaction> res = minerUtils.getAllTransactions(transactionPool);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals(res.get(0).getGasPrice(), Coin.valueOf(10));
@@ -207,7 +216,7 @@ public class MinerUtilsTest {
 
         Mockito.when(transactionPool.getPendingTransactions()).thenReturn(txs);
 
-        res = new MinerUtils().getAllTransactions(transactionPool);
+        res = minerUtils.getAllTransactions(transactionPool);
 
         Assert.assertEquals(3, res.size());
         Assert.assertEquals(res.get(0).getNonce(), tx1.getNonce());
@@ -242,7 +251,7 @@ public class MinerUtilsTest {
 
         Mockito.when(transactionPool.getPendingTransactions()).thenReturn(txs);
 
-        res = new MinerUtils().getAllTransactions(transactionPool);
+        res = minerUtils.getAllTransactions(transactionPool);
 
         Assert.assertEquals(6, res.size());
         Assert.assertEquals(res.get(0).getGasPrice(), Coin.valueOf(50));
@@ -275,7 +284,7 @@ public class MinerUtilsTest {
 
         Mockito.when(transactionPool.getPendingTransactions()).thenReturn(txs);
 
-        res = new MinerUtils().getAllTransactions(transactionPool);
+        res = minerUtils.getAllTransactions(transactionPool);
 
         Assert.assertEquals(9, res.size());
         Assert.assertEquals(res.get(0).getGasPrice(), Coin.valueOf(500));
@@ -288,4 +297,5 @@ public class MinerUtilsTest {
         Assert.assertEquals(res.get(7).getGasPrice(), Coin.valueOf(100));
         Assert.assertEquals(res.get(8).getGasPrice(), Coin.valueOf(1));
     }
+
 }

--- a/rskj-core/src/test/java/co/rsk/trie/NodeReferenceTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/NodeReferenceTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2021 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.trie;
+
+import co.rsk.crypto.Keccak256;
+import co.rsk.util.NodeStopper;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class NodeReferenceTest {
+
+    @Test
+    public void testGetNode_lazyNodeIsNotNull_returnsOptionalOfLazyNode() {
+        // Given
+        Trie lazyNodeMock = mock(Trie.class);
+
+        NodeReference nodeReference = new NodeReference(null, lazyNodeMock, null);
+
+        // When
+        Optional<Trie> result = nodeReference.getNode();
+
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(lazyNodeMock, result.get());
+    }
+
+    @Test
+    public void testGetNode_lazyNodeIsNullAndLazyHashIsNull_returnsOptionalEmpty() {
+        // Given
+        NodeReference nodeReference = new NodeReference(null, null, null);
+
+        // When
+        Optional<Trie> result = nodeReference.getNode();
+
+        // Then
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testGetNode_lazyNodeIsNullLazyHashIsNotNullAndTrieStoreCanRetrieveNode_returnsNode() {
+        // Given
+        Keccak256 lazyHashMock = mock(Keccak256.class);
+        byte[] bytesMock = new byte[0];
+        doReturn(bytesMock).when(lazyHashMock).getBytes();
+
+        Trie trieMock = mock(Trie.class);
+
+        TrieStoreImpl trieStoreMock = mock(TrieStoreImpl.class);
+        doReturn(Optional.of(trieMock)).when(trieStoreMock).retrieve(bytesMock);
+
+        NodeReference nodeReference = new NodeReference(trieStoreMock, null, lazyHashMock);
+
+        // When
+        Optional<Trie> result = nodeReference.getNode();
+
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(trieMock, result.get());
+
+        verify(lazyHashMock, times(1)).getBytes();
+        verify(trieStoreMock, times(1)).retrieve(bytesMock);
+    }
+
+    @Test
+    public void testGetNode_brokenDatabase_stopMethodIsCalled() {
+        // Given
+        Keccak256 lazyHashMock = mock(Keccak256.class);
+        byte[] bytesMock = new byte[0];
+        doReturn(bytesMock).when(lazyHashMock).getBytes();
+
+        int exitStatus = 1;
+        NodeStopper nodeStopperMock = mock(NodeStopper.class);
+        doNothing().when(nodeStopperMock).stop(exitStatus);
+
+        TrieStoreImpl trieStoreMock = mock(TrieStoreImpl.class);
+        doReturn(Optional.empty()).when(trieStoreMock).retrieve(bytesMock);
+
+        NodeReference nodeReference = new NodeReference(trieStoreMock, null, lazyHashMock, nodeStopperMock);
+
+        // When
+        nodeReference.getNode();
+
+        // Then
+        verify(nodeStopperMock, times(1)).stop(exitStatus);
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Now we throw and exception when a node can not be retrieved from database.

## Description
<!--- Describe your changes in detail -->

Fixing the bug reported by @SergioDemianLerner  on issue [#1549](https://github.com/rsksmart/rskj/issues/1549).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Extracted from the issue "When the node cannot be retrieved from storage, it returns an optional empty trie.
However, the inexistence of a node in the database is NOT a a normal situation, but a fatal exception that should shutdown the node as soon as possible. Anything you do in this situation can be used to fork the network."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

fixes https://github.com/rsksmart/rskj/issues/1549
