### PR TITLE
Pegout transactions improvement

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2773,6 +2773,9 @@ public class BridgeSupport {
         for(;;) {
             BtcTransaction migrationBtcTx = new BtcTransaction(originWallet.getParams());
             migrationBtcTx.addOutput(expectedMigrationValue, destinationAddress);
+            if (activations.isActive(ConsensusRule.RSKIP201)) {
+                migrationBtcTx.addOutput(Coin.ZERO, OpReturnUtils.createPegOutOpReturnScriptForRsk());
+            }
 
             SendRequest sr = SendRequest.forTx(migrationBtcTx);
             sr.changeAddress = destinationAddress;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -432,7 +432,6 @@ public class BridgeSupport {
         if (BridgeUtils.isValidPegInTx(
             btcTx,
             getLiveFederations(),
-            retiredFederationP2SHScript,
             btcContext,
             bridgeConstants,
             activations

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -228,9 +228,16 @@ public class BridgeUtils {
     }
 
     public static boolean isPegOutTx(BtcTransaction tx, ActivationConfig.ForBlock activations, Script... p2shScript) {
-        return activations.isActive(ConsensusRule.RSKIP201) ?
-            isPegOutTxPostIris(tx) :
-            isPegOutTxPreIris(tx, p2shScript);
+        // If a peg-out is made just before Iris activation and registered afterwards
+        // it won't have the identifying OP_RETURN output
+        // So for a period of time after Iris HF activation we need to perform both checks
+        if (activations.isActive(ConsensusRule.PEGOUT_IDENTIFIER)) {
+            return isPegOutTxPostIris(tx);
+        } else if (activations.isActive(ConsensusRule.RSKIP201)) {
+            return isPegOutTxPostIris(tx) || isPegOutTxPreIris(tx, p2shScript);
+        } else {
+            return isPegOutTxPreIris(tx, p2shScript);
+        }
     }
 
     public static boolean isMigrationTx(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -161,7 +161,6 @@ public class BridgeUtils {
      * the minimum ({@see BridgeConstants::getMinimumLockTxValue}) to any of the federations
      * @param tx the BTC transaction to check
      * @param activeFederations the active federations
-     * @param retiredFederationP2SHScript the retired federation P2SHScript. Could be {@code null}.
      * @param btcContext the BTC Context
      * @param bridgeConstants the Bridge constants
      * @param activations the network HF activations configuration
@@ -170,7 +169,6 @@ public class BridgeUtils {
     public static boolean isValidPegInTx(
         BtcTransaction tx,
         List<Federation> activeFederations,
-        Script retiredFederationP2SHScript,
         Context btcContext,
         BridgeConstants bridgeConstants,
         ActivationConfig.ForBlock activations) {
@@ -189,11 +187,6 @@ public class BridgeUtils {
                 final int index = i;
                 if (activeFederations.stream().anyMatch(
                     federation -> scriptCorrectlySpendsTx(tx, index, federation.getP2SHScript()))) {
-                    return false;
-                }
-
-                if (retiredFederationP2SHScript != null && scriptCorrectlySpendsTx(tx, index,
-                    retiredFederationP2SHScript)) {
                     return false;
                 }
             }
@@ -215,33 +208,6 @@ public class BridgeUtils {
         }
 
         return valueSentToMe.isPositive() && !valueSentToMe.isLessThan(minimumPegInTxValue);
-    }
-
-    /**
-     * It checks if the tx doesn't spend any of the federations' funds and if it sends more than
-     * the minimum ({@see BridgeConstants::getMinimumLockTxValue}) to any of the federations
-     * @param tx the BTC transaction to check
-     * @param federation the active federation
-     * @param btcContext the BTC Context
-     * @param bridgeConstants the Bridge constants
-     * @param activations the network HF activations configuration
-     * @return true if this is a valid peg-in transaction
-     */
-    public static boolean isValidPegInTx(
-        BtcTransaction tx,
-        Federation federation,
-        Context btcContext,
-        BridgeConstants bridgeConstants,
-        ActivationConfig.ForBlock activations) {
-
-        return isValidPegInTx(
-            tx,
-            Collections.singletonList(federation),
-            null,
-            btcContext,
-            bridgeConstants,
-            activations
-        );
     }
 
     /**
@@ -281,7 +247,7 @@ public class BridgeUtils {
         }
         boolean moveFromRetired = retiredFederationP2SHScript != null && isPegOutTx(btcTx, activations, retiredFederationP2SHScript);
         boolean moveFromRetiring = retiringFederation != null && isPegOutTx(btcTx, retiringFederation, activations);
-        boolean moveToActive = isValidPegInTx(btcTx, activeFederation, btcContext, bridgeConstants, activations);
+        boolean moveToActive = isValidPegInTx(btcTx, Collections.singletonList(activeFederation), btcContext, bridgeConstants, activations);
 
         return (moveFromRetired || moveFromRetiring) && moveToActive;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -96,6 +96,13 @@ public class ReleaseTransactionBuilder {
         return feePerKb;
     }
 
+    /***
+     * Generates a peg-out transaction sending the specified amount to the destination address.
+     * If RSKIP201 is active will generate an additional output with OP_RETURN
+     * @param to
+     * @param amount
+     * @return
+     */
     public Optional<BuildResult> buildAmountTo(Address to, Coin amount) {
         return buildWithConfiguration((SendRequest sr) -> {
             sr.tx.addOutput(amount, to);
@@ -107,15 +114,18 @@ public class ReleaseTransactionBuilder {
         }, String.format("sending %s to %s", amount, to));
     }
 
+    /***
+     * Generates a peg-out transaction spending all the available UTXOs.
+     * Won't generate an additional output with OP_RETURN!!!
+     * @param to
+     * @return
+     */
     public Optional<BuildResult> buildEmptyWalletTo(Address to) {
         return buildWithConfiguration((SendRequest sr) -> {
             sr.tx.addOutput(Coin.ZERO, to);
             sr.changeAddress = to;
             sr.emptyWallet = true;
 
-            if (activations.isActive(ConsensusRule.RSKIP201)) {
-                sr.tx.addOutput(Coin.ZERO, OpReturnUtils.createPegOutOpReturnScriptForRsk());
-            }
         }, String.format("emptying wallet to %s", to));
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -21,6 +21,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.wallet.SendRequest;
 import co.rsk.bitcoinj.wallet.Wallet;
+import co.rsk.peg.utils.OpReturnUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.slf4j.Logger;
@@ -99,6 +100,10 @@ public class ReleaseTransactionBuilder {
         return buildWithConfiguration((SendRequest sr) -> {
             sr.tx.addOutput(amount, to);
             sr.changeAddress = changeAddress;
+
+            if (activations.isActive(ConsensusRule.RSKIP201)) {
+                sr.tx.addOutput(Coin.ZERO, OpReturnUtils.createPegOutOpReturnScriptForRsk());
+            }
         }, String.format("sending %s to %s", amount, to));
     }
 
@@ -107,6 +112,10 @@ public class ReleaseTransactionBuilder {
             sr.tx.addOutput(Coin.ZERO, to);
             sr.changeAddress = to;
             sr.emptyWallet = true;
+
+            if (activations.isActive(ConsensusRule.RSKIP201)) {
+                sr.tx.addOutput(Coin.ZERO, OpReturnUtils.createPegOutOpReturnScriptForRsk());
+            }
         }, String.format("emptying wallet to %s", to));
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/pegininstructions/PeginInstructionsBase.java
+++ b/rskj-core/src/main/java/co/rsk/peg/pegininstructions/PeginInstructionsBase.java
@@ -1,6 +1,7 @@
 package co.rsk.peg.pegininstructions;
 
 import co.rsk.core.RskAddress;
+import co.rsk.peg.utils.OpReturnUtils;
 import java.util.Arrays;
 import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
@@ -26,21 +27,27 @@ public abstract class PeginInstructionsBase implements PeginInstructions {
     protected abstract void parseAdditionalData(byte[] data) throws PeginInstructionsParseException;
 
     public static int extractProtocolVersion(byte[] data) throws PeginInstructionsParseException {
-        if (data == null || data.length < 5) {
+        byte[] prefix = OpReturnUtils.PEGIN_OUTPUT_IDENTIFIER;
+        int minimumExpectedLength = prefix.length + 1; // 1 extra byte after the prefix for the protocol version
+
+        if (data == null || data.length < minimumExpectedLength) {
             String message;
 
             if (data == null) {
                 message = "Provided data is null";
             } else {
-                message = String.format("Invalid data given. Expected at least 5 bytes, " +
-                    "received %d", data.length);
+                message = String.format(
+                    "Invalid data given. Expected at least %d bytes, received %d",
+                    minimumExpectedLength,
+                    data.length
+                );
             }
 
             logger.debug("[extractProtocolVersion] {}", message);
             throw new PeginInstructionsParseException(message);
         }
 
-        byte[] protocolVersionBytes = Arrays.copyOfRange(data, 4, 5);
+        byte[] protocolVersionBytes = Arrays.copyOfRange(data, prefix.length, prefix.length + 1);
         return ByteUtil.byteArrayToInt(protocolVersionBytes);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/OpReturnUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/OpReturnUtils.java
@@ -1,0 +1,79 @@
+package co.rsk.peg.utils;
+
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.TransactionOutput;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.bitcoinj.script.ScriptChunk;
+import co.rsk.peg.pegininstructions.NoOpReturnException;
+import co.rsk.peg.pegininstructions.PeginInstructionsException;
+import java.util.Arrays;
+import java.util.List;
+import org.bouncycastle.util.encoders.Hex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpReturnUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(OpReturnUtils.class);
+    public static final byte[] PEGIN_OUTPUT_IDENTIFIER = Hex.decode("52534b54"); // 'RSKT' in hexa
+    public static final byte[] PEGOUT_OUTPUT_IDENTIFIER = Hex.decode("52534b4f"); // 'RSKO' in hexa
+
+    public static byte[] extractPegInOpReturnData(BtcTransaction btcTx) throws PeginInstructionsException {
+        return extractOpReturnData(btcTx, PEGIN_OUTPUT_IDENTIFIER);
+    }
+
+    public static byte[] extractPegOutOpReturnData(BtcTransaction btcTx) throws PeginInstructionsException {
+        return extractOpReturnData(btcTx, PEGOUT_OUTPUT_IDENTIFIER);
+    }
+
+    public static Script createPegOutOpReturnScriptForRsk() {
+        return ScriptBuilder.createOpReturnScript(PEGOUT_OUTPUT_IDENTIFIER);
+    }
+
+    private static byte[] extractOpReturnData(BtcTransaction btcTx, byte[] outputIdentifier) throws PeginInstructionsException {
+        logger.trace("[extractOpReturnData] Getting OP_RETURN data for btc tx: {}", btcTx.getHash());
+
+        byte[] data = new byte[]{};
+        int opReturnForRskOccurrences = 0;
+
+        for (int i = 0; i < btcTx.getOutputs().size(); i++) {
+            TransactionOutput txOutput = btcTx.getOutput(i);
+            if(hasOpReturnForRsk(txOutput, outputIdentifier)) {
+                data = txOutput.getScriptPubKey().getChunks().get(1).data;
+                opReturnForRskOccurrences++;
+            }
+        }
+
+        if (opReturnForRskOccurrences == 0) {
+            String message = String.format("No OP_RETURN output found for tx %s", btcTx.getHash());
+            throw new NoOpReturnException(message);
+        }
+
+        if (opReturnForRskOccurrences > 1) {
+            String message = String.format("Only one output with OP_RETURN for RSK is allowed. Found %d",
+                opReturnForRskOccurrences);
+            logger.debug("[extractOpReturnData] {}", message);
+            throw new PeginInstructionsException(message);
+        }
+
+        return data;
+    }
+
+    private static boolean hasOpReturnForRsk(TransactionOutput txOutput, byte[] outputIdentifier) {
+        if(txOutput.getScriptPubKey().isOpReturn()) {
+            // Check if it has data with the output identifier
+            List<ScriptChunk> chunksByOutput = txOutput.getScriptPubKey().getChunks();
+            if (chunksByOutput.size() > 1 &&
+                chunksByOutput.get(1).data != null &&
+                chunksByOutput.get(1).data.length >= outputIdentifier.length) {
+                byte[] prefix = Arrays.copyOfRange(chunksByOutput.get(1).data, 0, outputIdentifier.length);
+                if (Arrays.equals(prefix, outputIdentifier)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -69,7 +69,8 @@ public enum ConsensusRule {
     RSKIP201("rskip201"),
     RSKIP218("rskip218"), // New rewards fee adddress
     RSKIP219("rskip219"),
-    RSKIP220("rskip220");
+    RSKIP220("rskip220"),
+    PEGOUT_IDENTIFIER("pegoutIdentifier");
 
     private String configKey;
 

--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -11,7 +11,11 @@ blockchain.config {
         iris300 = 0
     },
     consensusRules = {
-        rskip97 = -1 # disable orchid difficulty drop
+        rskip97 = -1, # disable orchid difficulty drop
+        pegoutIdentifier = 1  # between iris activation height and this block height,
+                              # we will be using both pre and post iris mechanisms to identify peg-outs
+                              # in case a peg-out transaction is created just before iris activation
+                              # and registered post activation
     }
 }
 

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -9,6 +9,13 @@ blockchain.config {
         twoToThree = 2018000,
         papyrus200 = 2392700
         iris300 = -1
+    },
+    consensusRules = {
+        # TODO: Set this value to iris activation height + 86_400 (1 month aprox in rsk blocks)
+        pegoutIdentifier = -1  # between iris activation height and this block height,
+                               # we will be using both pre and post iris mechanisms to identify peg-outs
+                               # in case a peg-out transaction is created just before iris activation
+                               # and registered post activation
     }
 }
 

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -11,7 +11,11 @@ blockchain.config {
         iris300 = -1
     },
     consensusRules = {
-        rskip97 = -1 # disable orchid difficulty drop
+        rskip97 = -1, # disable orchid difficulty drop
+        pegoutIdentifier = 99 # between iris activation height and this block height,
+                              # we will be using both pre and post iris mechanisms to identify peg-outs
+                              # in case a peg-out transaction is created just before iris activation
+                              # and registered post activation
     }
 }
 

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -12,7 +12,12 @@ blockchain.config {
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop
-        rskip132 = 43550 # enable recalculted receive headers cost
+        rskip132 = 43550, # enable recalculted receive headers cost
+        # TODO: Set this value to iris activation height + 86_400 (1 month aprox in rsk blocks)
+        pegoutIdentifier = 99 # between iris activation height and this block height,
+                              # we will be using both pre and post iris mechanisms to identify peg-outs
+                              # in case a peg-out transaction is created just before iris activation
+                              # and registered post activation
     }
 }
 

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -65,6 +65,7 @@ blockchain = {
              rskip218 = <hardforkName>
              rskip219 = <hardforkName>
              rskip220 = <hardforkName>
+             pegoutIdentifier = <activationHeight>
          }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -5848,10 +5848,6 @@ public class BridgeSupportTest {
         }
         migrationTxInput.setScriptSig(inputScript);
         Assert.assertEquals(TxType.MIGRATION, bridgeSupport.getTransactionType(migrationTx));
-
-        when(mockFederationSupport.getRetiringFederation()).thenReturn(null);
-        when(provider.getLastRetiredFederationP2SHScript()).thenReturn(Optional.of(retiringFederation.getP2SHScript()));
-        Assert.assertEquals(TxType.MIGRATION, bridgeSupport.getTransactionType(migrationTx));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
@@ -1512,7 +1512,6 @@ public class BridgeSupportTestPowerMock {
             "isValidPegInTx",
             any(BtcTransaction.class),
             anyList(),
-            nullable(Script.class),
             any(Context.class),
             any(BridgeConstants.class),
             any(ActivationConfig.ForBlock.class)

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -132,7 +132,7 @@ public class BridgeUtilsTest {
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addOutput(minimumLockValue.subtract(Coin.CENT), federationAddress);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertFalse(BridgeUtils.isValidPegInTx(tx, federation, btcContext, bridgeConstants, actForBlock));
+        assertFalse(BridgeUtils.isValidPegInTx(tx, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
 
         // Tx sending 1 btc to the federation, but also spending from the federation address,
         // the typical peg-out tx, not a peg-in tx.
@@ -146,19 +146,19 @@ public class BridgeUtilsTest {
         );
         tx2.addInput(txIn);
         signWithNecessaryKeys(bridgeConstants.getGenesisFederation(), BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx2);
-        assertFalse(BridgeUtils.isValidPegInTx(tx2, federation, btcContext, bridgeConstants, actForBlock));
+        assertFalse(BridgeUtils.isValidPegInTx(tx2, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
 
         // Tx sending 1 btc to the federation, is a peg-in tx
         BtcTransaction tx3 = new BtcTransaction(networkParameters);
         tx3.addOutput(Coin.COIN, federationAddress);
         tx3.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isValidPegInTx(tx3, federation, btcContext, bridgeConstants, actForBlock));
+        assertTrue(BridgeUtils.isValidPegInTx(tx3, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
 
         // Tx sending 50 btc to the federation, is a peg-in tx
         BtcTransaction tx4 = new BtcTransaction(networkParameters);
         tx4.addOutput(Coin.FIFTY_COINS, federationAddress);
         tx4.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(BridgeUtils.isValidPegInTx(tx4, federation, btcContext, bridgeConstants, actForBlock));
+        assertTrue(BridgeUtils.isValidPegInTx(tx4, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
     }
 
     @Test
@@ -176,7 +176,7 @@ public class BridgeUtilsTest {
         tx.addOutput(minimumPegInValueAfterIris.subtract(Coin.CENT), federation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        assertFalse(BridgeUtils.isValidPegInTx(tx, federation, btcContext, bridgeConstants, actForBlock));
+        assertFalse(BridgeUtils.isValidPegInTx(tx, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
     }
 
     @Test
@@ -199,7 +199,7 @@ public class BridgeUtilsTest {
         tx.addInput(txIn);
         signWithNecessaryKeys(bridgeConstants.getGenesisFederation(), BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx);
 
-        assertFalse(BridgeUtils.isValidPegInTx(tx, federation, btcContext, bridgeConstants, actForBlock));
+        assertFalse(BridgeUtils.isValidPegInTx(tx, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
     }
 
     @Test
@@ -216,7 +216,7 @@ public class BridgeUtilsTest {
         tx.addOutput(Coin.FIFTY_COINS, federation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        assertTrue(BridgeUtils.isValidPegInTx(tx, federation, btcContext, bridgeConstants, actForBlock));
+        assertTrue(BridgeUtils.isValidPegInTx(tx, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
     }
 
     @Test
@@ -241,7 +241,7 @@ public class BridgeUtilsTest {
         tx.addOutput(valueLock, federation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        assertFalse(BridgeUtils.isValidPegInTx(tx, federation, btcContext, bridgeConstants, actForBlock));
+        assertFalse(BridgeUtils.isValidPegInTx(tx, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
     }
 
     @Test
@@ -266,7 +266,7 @@ public class BridgeUtilsTest {
         tx.addOutput(valueLock, federation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        assertTrue(BridgeUtils.isValidPegInTx(tx, federation, btcContext, bridgeConstants, actForBlock));
+        assertTrue(BridgeUtils.isValidPegInTx(tx, Collections.singletonList(federation), btcContext, bridgeConstants, actForBlock));
     }
 
     @Test
@@ -312,7 +312,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -325,7 +324,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -339,7 +337,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -360,7 +357,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx2,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -381,7 +377,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx2,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -403,7 +398,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx2,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -425,7 +419,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx2,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -445,7 +438,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx2,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -465,8 +457,7 @@ public class BridgeUtilsTest {
         signWithNecessaryKeys(federation1, federation1Keys, txIn, tx2);
         assertFalse(BridgeUtils.isValidPegInTx(
             tx2,
-            Collections.singletonList(federation2),
-            federation1.getP2SHScript(),
+            Arrays.asList(federation1, federation2),
             btcContext,
             bridgeConstants,
             actForBlock
@@ -479,7 +470,6 @@ public class BridgeUtilsTest {
         assertTrue(BridgeUtils.isValidPegInTx(
             tx3,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -492,7 +482,6 @@ public class BridgeUtilsTest {
         assertTrue(BridgeUtils.isValidPegInTx(
             tx3,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -506,7 +495,6 @@ public class BridgeUtilsTest {
         assertTrue(BridgeUtils.isValidPegInTx(
             tx3,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -519,7 +507,6 @@ public class BridgeUtilsTest {
         assertTrue(BridgeUtils.isValidPegInTx(
             tx4,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -532,7 +519,6 @@ public class BridgeUtilsTest {
         assertTrue(BridgeUtils.isValidPegInTx(
             tx4,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -546,7 +532,6 @@ public class BridgeUtilsTest {
         assertTrue(BridgeUtils.isValidPegInTx(
             tx4,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -606,7 +591,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -628,7 +612,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -651,7 +634,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -674,7 +656,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -695,7 +676,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -716,8 +696,7 @@ public class BridgeUtilsTest {
         signWithNecessaryKeys(federation1, federation1Keys, txIn, tx);
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
-            Collections.singletonList(federation2),
-            federation1.getP2SHScript(),
+            Arrays.asList(federation1, federation2),
             btcContext,
             bridgeConstants,
             actForBlock
@@ -732,7 +711,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -747,7 +725,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             tx,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             actForBlock
@@ -1135,7 +1112,6 @@ public class BridgeUtilsTest {
         assertFalse(BridgeUtils.isValidPegInTx(
             pegOutWithChange,
             federations,
-            null,
             btcContext,
             bridgeConstants,
             mock(ActivationConfig.ForBlock.class)

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -27,8 +27,8 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
+import co.rsk.peg.utils.OpReturnUtils;
 import java.util.Optional;
-import org.bouncycastle.util.encoders.Hex;
 
 /**
  * Created by oscar on 05/08/2016.
@@ -86,21 +86,22 @@ public class PegTestUtils {
         return redeemScript;
     }
 
-    public static Script createOpReturnScriptForRsk(
+    public static Script createPegInOpReturnScriptForRsk(
         int protocolVersion,
         RskAddress rskDestinationAddress,
         Optional<Address> btcRefundAddressOptional
     ) {
+        byte[] prefix = OpReturnUtils.PEGIN_OUTPUT_IDENTIFIER;
+
         int index = 0;
-        int payloadLength;
+        int payloadLength = prefix.length;
         if (btcRefundAddressOptional.isPresent()) {
-            payloadLength = 46;
+            payloadLength += 42;
         } else {
-            payloadLength = 25;
+            payloadLength += 21;
         }
         byte[] payloadBytes = new byte[payloadLength];
 
-        byte[] prefix = Hex.decode("52534b54"); // 'RSKT' in hexa
         System.arraycopy(prefix, 0, payloadBytes, index, prefix.length);
         index += prefix.length;
 
@@ -137,13 +138,12 @@ public class PegTestUtils {
         return ScriptBuilder.createOpReturnScript(payloadBytes);
     }
 
-    public static Script createOpReturnScriptForRskWithCustomPayload(int protocolVersion, byte[] customPayload) {
+    public static Script createPegInOpReturnScriptForRskWithCustomPayload(int protocolVersion, byte[] customPayload) {
         int index = 0;
-        int payloadLength = customPayload.length;
+        byte[] prefix = OpReturnUtils.PEGIN_OUTPUT_IDENTIFIER;
 
-        byte[] payloadBytes = new byte[payloadLength + 5]; // Add 4 bytes for the prefix, and another for the protocol version
+        byte[] payloadBytes = new byte[prefix.length + customPayload.length + 1]; // Add 1 extra byte for the protocol version
 
-        byte[] prefix = Hex.decode("52534b54"); // 'RSKT' in hexa
         System.arraycopy(prefix, 0, payloadBytes, index, prefix.length);
         index += prefix.length;
 

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -57,6 +57,7 @@ public class ReleaseTransactionBuilderTest {
         wallet = mock(Wallet.class);
         changeAddress = mockAddress(1000);
         activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
         builder = new ReleaseTransactionBuilder(
             networkParameters,
             wallet,
@@ -423,13 +424,8 @@ public class ReleaseTransactionBuilderTest {
 
             BtcTransaction tx = sr.tx;
 
-            if (isRSKIPActive) {
-                Assert.assertEquals(2, tx.getOutputs().size());
-                Assert.assertEquals(Coin.ZERO, tx.getOutput(1).getValue());
-                Assert.assertEquals(OpReturnUtils.createPegOutOpReturnScriptForRsk(), tx.getOutput(1).getScriptPubKey());
-            } else {
-                Assert.assertEquals(1, tx.getOutputs().size());
-            }
+            // buildEmptyWallet generates a regular peg-out with no OP_RETURN output
+            Assert.assertEquals(1, tx.getOutputs().size());
 
             Assert.assertEquals(Coin.ZERO, tx.getOutput(0).getValue());
             Assert.assertEquals(to, tx.getOutput(0).getAddressFromP2PKHScript(networkParameters));
@@ -450,13 +446,9 @@ public class ReleaseTransactionBuilderTest {
         BtcTransaction tx = result.get().getBtcTx();
         List<UTXO> selectedUTXOs = result.get().getSelectedUTXOs();
 
-        if (isRSKIPActive) {
-            Assert.assertEquals(2, tx.getOutputs().size());
-            Assert.assertEquals(Coin.ZERO, tx.getOutput(1).getValue());
-            Assert.assertEquals(OpReturnUtils.createPegOutOpReturnScriptForRsk(), tx.getOutput(1).getScriptPubKey());
-        } else {
-            Assert.assertEquals(1, tx.getOutputs().size());
-        }
+        // buildEmptyWallet generates a regular peg-out with no OP_RETURN output
+        Assert.assertEquals(1, tx.getOutputs().size());
+
         Assert.assertEquals(Coin.FIFTY_COINS, tx.getOutput(0).getValue());
         Assert.assertEquals(to, tx.getOutput(0).getAddressFromP2PKHScript(networkParameters));
 

--- a/rskj-core/src/test/java/co/rsk/peg/pegininstructions/PeginInstructionsBaseTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/pegininstructions/PeginInstructionsBaseTest.java
@@ -1,5 +1,6 @@
 package co.rsk.peg.pegininstructions;
 
+import co.rsk.peg.utils.OpReturnUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Assert;
 import org.junit.Test;
@@ -8,16 +9,24 @@ public class PeginInstructionsBaseTest {
 
     @Test
     public void extractProtocolVersion() throws PeginInstructionsParseException {
-        int protocolVersion = PeginInstructionsBase.extractProtocolVersion(
-                Hex.decode("52534b54010e537aad84447a2c2a7590d5f2665ef5cf9b667a"));
+        StringBuilder opReturnData = new StringBuilder();
+        opReturnData.append(Hex.toHexString(OpReturnUtils.PEGIN_OUTPUT_IDENTIFIER))
+            .append("01") // protocol version
+            .append("0e537aad84447a2c2a7590d5f2665ef5cf9b667a"); // data
+
+        int protocolVersion = PeginInstructionsBase.extractProtocolVersion(Hex.decode(opReturnData.toString()));
 
         Assert.assertEquals(1, protocolVersion);
     }
 
     @Test
     public void extractProtocolVersion_version_bigger_than_9() throws PeginInstructionsParseException {
-        int protocolVersion = PeginInstructionsBase.extractProtocolVersion(
-            Hex.decode("52534b540a0e537aad84447a2c2a7590d5f2665ef5cf9b667a"));
+        StringBuilder opReturnData = new StringBuilder();
+        opReturnData.append(Hex.toHexString(OpReturnUtils.PEGIN_OUTPUT_IDENTIFIER))
+            .append("0a") // protocol version
+            .append("0e537aad84447a2c2a7590d5f2665ef5cf9b667a"); // data
+
+        int protocolVersion = PeginInstructionsBase.extractProtocolVersion(Hex.decode(opReturnData.toString()));
 
         Assert.assertEquals(10, protocolVersion);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/pegininstructions/PeginInstructionsVersion1Test.java
+++ b/rskj-core/src/test/java/co/rsk/peg/pegininstructions/PeginInstructionsVersion1Test.java
@@ -10,7 +10,6 @@ import co.rsk.core.RskAddress;
 import co.rsk.peg.PegTestUtils;
 import java.util.Arrays;
 import java.util.Optional;
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -44,7 +43,7 @@ public class PeginInstructionsVersion1Test {
     @Test
     public void parseAdditionalData_noBtcRefundAddress() throws PeginInstructionsException {
         // Arrange
-        Script opReturnScript = PegTestUtils.createOpReturnScriptForRsk(1, new RskAddress(new byte[20]), Optional.empty());
+        Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(1, new RskAddress(new byte[20]), Optional.empty());
 
         // Act
         PeginInstructionsVersion1 peginInstructionsVersion1 = new PeginInstructionsVersion1(params);
@@ -60,7 +59,7 @@ public class PeginInstructionsVersion1Test {
         // Arrange
         BtcECKey key = new BtcECKey();
         Address btcRefundAddress = key.toAddress(params);
-        Script opReturnScript = PegTestUtils.createOpReturnScriptForRsk(
+        Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(
             1,
             new RskAddress(new byte[20]),
             Optional.of(btcRefundAddress)
@@ -85,7 +84,7 @@ public class PeginInstructionsVersion1Test {
             Arrays.asList(new BtcECKey(), new BtcECKey(), new BtcECKey())
         );
         Address btcRefundAddress = Address.fromP2SHScript(params, p2shScript);
-        Script opReturnScript = PegTestUtils.createOpReturnScriptForRsk(
+        Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(
             1,
             new RskAddress(new byte[20]),
             Optional.of(btcRefundAddress)
@@ -107,7 +106,7 @@ public class PeginInstructionsVersion1Test {
         // Arrange
         BtcECKey key = new BtcECKey();
         Address btcRefundAddress = key.toAddress(params);
-        Script opReturnScript = PegTestUtils.createOpReturnScriptForRsk(
+        Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(
             1,
             new RskAddress(new byte[20]),
             Optional.of(btcRefundAddress)

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
@@ -247,7 +247,7 @@ public class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
 
             ECKey ecKey = new ECKey();
             if (isVersion1) {
-                Script opReturnScript = PegTestUtils.createOpReturnScriptForRsk(1, new RskAddress(ecKey.getAddress()), Optional.empty());
+                Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(1, new RskAddress(ecKey.getAddress()), Optional.empty());
                 txToLock.addOutput(Coin.ZERO, opReturnScript);
             }
 

--- a/rskj-core/src/test/java/co/rsk/peg/utils/OpReturnUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/OpReturnUtilsTest.java
@@ -1,0 +1,279 @@
+package co.rsk.peg.utils;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.bitcoinj.script.ScriptOpCodes;
+import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.core.RskAddress;
+import co.rsk.peg.PegTestUtils;
+import co.rsk.peg.pegininstructions.NoOpReturnException;
+import co.rsk.peg.pegininstructions.PeginInstructionsException;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OpReturnUtilsTest {
+    private final NetworkParameters params = BridgeRegTestConstants.getInstance().getBtcParams();
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegInOpReturnData_noOpReturn() throws PeginInstructionsException {
+        // Arrange
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.COIN, new BtcECKey().toAddress(params));
+
+        // Act
+        OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegOutOpReturnData_noOpReturn() throws PeginInstructionsException {
+        // Arrange
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.COIN, new BtcECKey().toAddress(params));
+
+        // Act
+        OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegInOpReturnData_noOpReturnForRsk() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = ScriptBuilder.createOpReturnScript("some-payload".getBytes());
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegOutOpReturnData_noOpReturnForRsk() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = ScriptBuilder.createOpReturnScript("some-payload".getBytes());
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegInOpReturnData_opReturnWithDataLengthShorterThanExpected() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = ScriptBuilder.createOpReturnScript("1".getBytes());
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegOutOpReturnData_opReturnWithDataLengthShorterThanExpected() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = ScriptBuilder.createOpReturnScript("1".getBytes());
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = PeginInstructionsException.class)
+    public void extractPegInOpReturnData_twoOpReturnOutputsForRsk() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(
+            1,
+            new RskAddress(new byte[20]),
+            Optional.empty()
+        );
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = PeginInstructionsException.class)
+    public void extractPegOutOpReturnData_twoOpReturnOutputsForRsk() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = ScriptBuilder.createOpReturnScript(OpReturnUtils.PEGOUT_OUTPUT_IDENTIFIER);
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+    }
+
+    @Test
+    public void extractPegInOpReturnData_oneOpReturnForRsk() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(
+            1,
+            new RskAddress(new byte[20]),
+            Optional.empty()
+        );
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        byte[] data = OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+
+        // Assert
+        Assert.assertArrayEquals(opReturnScript.getChunks().get(1).data, data);
+    }
+
+    @Test
+    public void extractPegOutOpReturnData_oneOpReturnForRsk() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = ScriptBuilder.createOpReturnScript(OpReturnUtils.PEGOUT_OUTPUT_IDENTIFIER);
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        byte[] data = OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+
+        // Assert
+        Assert.assertArrayEquals(opReturnScript.getChunks().get(1).data, data);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegInOpReturnData_oneOpReturnForRskWithPegOutIdentifier() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = ScriptBuilder.createOpReturnScript(OpReturnUtils.PEGOUT_OUTPUT_IDENTIFIER);
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegOutOpReturnData_oneOpReturnForRskWithPegInIdentifier() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(
+            1,
+            new RskAddress(new byte[20]),
+            Optional.empty()
+        );
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript);
+
+        // Act
+        OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+    }
+
+    @Test
+    public void extractPegInOpReturnData_oneOpReturnForRskWithValue() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = PegTestUtils.createPegInOpReturnScriptForRsk(
+            1,
+            new RskAddress(new byte[20]),
+            Optional.empty()
+        );
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.FIFTY_COINS, opReturnScript);
+
+        // Act
+        byte[] data = OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+
+        // Assert
+        Assert.assertArrayEquals(opReturnScript.getChunks().get(1).data, data);
+    }
+
+    @Test
+    public void extractPegOutOpReturnData_oneOpReturnForRskWithValue() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnScript = ScriptBuilder.createOpReturnScript(OpReturnUtils.PEGOUT_OUTPUT_IDENTIFIER);
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.FIFTY_COINS, opReturnScript);
+
+        // Act
+        byte[] data = OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+
+        // Assert
+        Assert.assertArrayEquals(opReturnScript.getChunks().get(1).data, data);
+    }
+
+    @Test
+    public void extractPegInOpReturnData_multipleOpReturnOutputs_oneForRsk() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnForRskScript = PegTestUtils.createPegInOpReturnScriptForRsk(1, new RskAddress(new byte[20]), Optional.empty());
+        Script opReturnScript1 = ScriptBuilder.createOpReturnScript("1".getBytes());
+        Script opReturnScript2 = ScriptBuilder.createOpReturnScript("some-payload".getBytes());
+        Script opReturnScript3 = ScriptBuilder.createOpReturnScript("another-output".getBytes());
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript1);
+        btcTransaction.addOutput(Coin.ZERO, opReturnForRskScript);
+        btcTransaction.addOutput(Coin.COIN, opReturnScript2);
+        btcTransaction.addOutput(Coin.FIFTY_COINS, opReturnScript3);
+
+        // Act
+        byte[] data = OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+
+        // Assert
+        Assert.assertArrayEquals(opReturnForRskScript.getChunks().get(1).data, data);
+    }
+
+    @Test
+    public void extractPegOutOpReturnData_multipleOpReturnOutputs_oneForRsk() throws PeginInstructionsException {
+        // Arrange
+        Script opReturnForRskScript = ScriptBuilder.createOpReturnScript(OpReturnUtils.PEGOUT_OUTPUT_IDENTIFIER);
+        Script opReturnScript1 = ScriptBuilder.createOpReturnScript("1".getBytes());
+        Script opReturnScript2 = ScriptBuilder.createOpReturnScript("some-payload".getBytes());
+        Script opReturnScript3 = ScriptBuilder.createOpReturnScript("another-output".getBytes());
+
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        btcTransaction.addOutput(Coin.ZERO, opReturnScript1);
+        btcTransaction.addOutput(Coin.ZERO, opReturnForRskScript);
+        btcTransaction.addOutput(Coin.COIN, opReturnScript2);
+        btcTransaction.addOutput(Coin.FIFTY_COINS, opReturnScript3);
+
+        // Act
+        byte[] data = OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+
+        // Assert
+        Assert.assertArrayEquals(opReturnForRskScript.getChunks().get(1).data, data);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegInOpReturnData_nullOpReturnData() throws PeginInstructionsException {
+        // Arrange
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        // Add OP_RETURN output with empty data
+        btcTransaction.addOutput(Coin.ZERO, new Script(new byte[] { ScriptOpCodes.OP_RETURN }));
+
+        // Act
+        OpReturnUtils.extractPegInOpReturnData(btcTransaction);
+    }
+
+    @Test(expected = NoOpReturnException.class)
+    public void extractPegOutOpReturnData_nullOpReturnData() throws PeginInstructionsException {
+        // Arrange
+        BtcTransaction btcTransaction = new BtcTransaction(params);
+        // Add OP_RETURN output with empty data
+        btcTransaction.addOutput(Coin.ZERO, new Script(new byte[] { ScriptOpCodes.OP_RETURN }));
+
+        // Act
+        OpReturnUtils.extractPegOutOpReturnData(btcTransaction);
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -91,6 +91,7 @@ public class ActivationConfigTest {
             "    rskip218: iris300",
             "    rskip219: iris300",
             "    rskip220: iris300",
+            "    pegoutIdentifier: 1",
             "}"
     ));
 


### PR DESCRIPTION
Include an output with OP_RETURN code and value zero to pegout transactions, in order to be easily identified by the Bridge. This output will have '52534b4f' (hexadecimal representation of 'RSKO') as its only content, for the purpose of distinguishing this output from other possible outputs with OP_RETURN op code.


*fed:pegout-improvement*