### PR TITLE
Improve Trie Node Retrieve and Save

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/tools/ExecuteBlocks.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ExecuteBlocks.java
@@ -19,9 +19,12 @@ package co.rsk.cli.tools;
 
 import co.rsk.RskContext;
 import co.rsk.core.bc.BlockExecutor;
+import co.rsk.core.bc.BlockResult;
 import co.rsk.trie.TrieStore;
 import org.ethereum.core.Block;
 import org.ethereum.db.BlockStore;
+
+import java.util.Arrays;
 
 /**
  * The entry point for execute blocks CLI tool
@@ -46,7 +49,12 @@ public class ExecuteBlocks {
             Block block = blockStore.getChainBlockByNumber(n);
             Block parent = blockStore.getBlockByHash(block.getParentHash().getBytes());
 
-            blockExecutor.execute(block, parent.getHeader(), false, false);
+            BlockResult blockResult = blockExecutor.execute(block, parent.getHeader(), false, false);
+
+            if (!Arrays.equals(blockResult.getFinalState().getHash().getBytes(), block.getStateRoot())) {
+                System.err.println("Invalid state root block number " + n);
+                break;
+            }
         }
 
         trieStore.flush();

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -35,6 +35,7 @@ import org.ethereum.util.RLPList;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class BootstrapImporter {
 
@@ -76,7 +77,7 @@ public class BootstrapImporter {
 
         for (int k = 0; k < nodesData.size(); k++) {
             RLPElement element = nodesData.get(k);
-            byte[] rlpData = element.getRLPData();
+            byte[] rlpData = Objects.requireNonNull(element.getRLPData());
             Trie trie = Trie.fromMessage(rlpData, fakeStore);
             hashMapDB.put(trie.getHash().getBytes(), rlpData);
             nodes.add(trie);

--- a/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java
+++ b/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java
@@ -81,7 +81,7 @@ public class MultiTrieStore implements TrieStore {
             if (message == null) {
                 continue;
             }
-            return Optional.of(Trie.fromMessage(message, this));
+            return Optional.of(Trie.fromMessage(message, this).markAsSaved());
         }
 
         return Optional.empty();

--- a/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
+++ b/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
@@ -106,6 +106,11 @@ public class NodeReference {
 
     }
 
+    // the referenced node was loaded
+    public boolean wasLoaded() {
+        return lazyNode != null;
+    }
+
     // This method should only be called from save()
     public int serializedLength() {
         if (!isEmpty()) {

--- a/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
+++ b/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 public class NodeReference {
 
+    private static final NodeReference EMPTY = new NodeReference(null, null, null);
 
     private final TrieStore store;
 
@@ -154,6 +155,6 @@ public class NodeReference {
     }
 
     public static NodeReference empty() {
-        return new NodeReference(null, null, null);
+        return EMPTY;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -103,6 +103,9 @@ public class Trie {
     // associated store, to store or retrieve nodes in the trie
     private TrieStore store;
 
+    // already saved in store flag
+    private boolean saved;
+
     // shared Path
     private final TrieKeySlice sharedPath;
 
@@ -151,7 +154,10 @@ public class Trie {
             trie = fromMessageRskip107(ByteBuffer.wrap(message), store);
         }
 
+        trie.saved = true;
+
         profiler.stop(metric);
+
         return trie;
     }
 
@@ -232,7 +238,10 @@ public class Trie {
         }
 
         // it doesn't need to clone value since it's retrieved from store or created from message
-        return new Trie(store, sharedPath, value, left, right, lvalue, valueHash);
+        Trie trie = new Trie(store, sharedPath, value, left, right, lvalue, valueHash);
+        trie.saved = true;
+
+        return trie;
     }
 
     private static Trie fromMessageRskip107(ByteBuffer message, TrieStore store) {
@@ -320,7 +329,10 @@ public class Trie {
             throw new IllegalArgumentException("The message had more data than expected");
         }
 
-        return new Trie(store, sharedPath, value, left, right, lvalue, valueHash, childrenSize);
+        Trie trie = new Trie(store, sharedPath, value, left, right, lvalue, valueHash, childrenSize);
+        trie.saved = true;
+
+        return trie;
     }
 
     /**
@@ -1434,5 +1446,13 @@ public class Trie {
         subnodes.add(this);
 
         return subnodes;
+    }
+
+    public boolean wasSaved() {
+        return this.saved;
+    }
+
+    public void saved() {
+        this.saved = true;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -70,9 +70,9 @@ public class TrieStoreImpl implements TrieStore {
     }
 
     /**
-     * @param forceSaveRoot allows saving the root node even if it's embeddable
+     * @param isRootNode it is the root node of the trie
      */
-    private void save(Trie trie, boolean forceSaveRoot, int level) {
+    private void save(Trie trie, boolean isRootNode, int level) {
         if (trie.wasSaved()) {
             return;
         }
@@ -83,7 +83,7 @@ public class TrieStoreImpl implements TrieStore {
 
         byte[] trieKeyBytes = trie.getHash().getBytes();
 
-        if (forceSaveRoot && this.store.get(trieKeyBytes) != null) {
+        if (isRootNode && this.store.get(trieKeyBytes) != null) {
             // the full trie is already saved
             logger.trace("End saving trie, level : {}, already saved.", level);
             return;
@@ -118,7 +118,7 @@ public class TrieStoreImpl implements TrieStore {
             logger.trace("End Putting in store, hasLongValue. Level: {}", level);
         }
 
-        if (trie.isEmbeddable() && !forceSaveRoot) {
+        if (trie.isEmbeddable() && !isRootNode) {
             logger.trace("End Saving. Level: {}", level);
             return;
         }

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -55,9 +55,9 @@ public class TrieStoreImpl implements TrieStore {
         TraceInfo traceInfo = null;
         if (logger.isTraceEnabled()) {
             traceInfo = traceInfoLocal.get();
-            traceInfo.noRetrievesInSaveTrie = 0;
-            traceInfo.noSavesInSaveTrie = 0;
-            traceInfo.noNoSavesInSaveTrie = 0;
+            traceInfo.numOfRetrievesInSaveTrie = 0;
+            traceInfo.numOfSavesInSaveTrie = 0;
+            traceInfo.numOfNoSavesInSaveTrie = 0;
 
             logger.trace("Start saving trie root.");
         }
@@ -67,13 +67,13 @@ public class TrieStoreImpl implements TrieStore {
 
         if (traceInfo != null) {
             logger.trace("End saving trie root. No. Retrieves: {}. No. Saves: {}. No. No Saves: {}",
-                    traceInfo.noRetrievesInSaveTrie, traceInfo.noSavesInSaveTrie, traceInfo.noNoSavesInSaveTrie);
+                    traceInfo.numOfRetrievesInSaveTrie, traceInfo.numOfSavesInSaveTrie, traceInfo.numOfNoSavesInSaveTrie);
             logger.trace("End process block. No. Retrieves: {}. No. Saves: {}. No. No Saves: {}",
-                    traceInfo.noRetrievesInBlockProcess, traceInfo.noSavesInBlockProcess, traceInfo.noNoSavesInBlockProcess);
+                    traceInfo.numOfRetrievesInBlockProcess, traceInfo.numOfSavesInBlockProcess, traceInfo.numOfNoSavesInBlockProcess);
 
-            traceInfo.noRetrievesInBlockProcess = 0;
-            traceInfo.noSavesInBlockProcess = 0;
-            traceInfo.noNoSavesInBlockProcess = 0;
+            traceInfo.numOfRetrievesInBlockProcess = 0;
+            traceInfo.numOfSavesInBlockProcess = 0;
+            traceInfo.numOfNoSavesInBlockProcess = 0;
 
             if (store instanceof DataSourceWithCache) {
                 ((DataSourceWithCache) store).emitLogs();
@@ -98,16 +98,16 @@ public class TrieStoreImpl implements TrieStore {
             logger.trace("End saving trie, level : {}, already saved.", level);
 
             if (traceInfo != null) {
-                traceInfo.noNoSavesInSaveTrie++;
-                traceInfo.noNoSavesInBlockProcess++;
+                traceInfo.numOfNoSavesInSaveTrie++;
+                traceInfo.numOfNoSavesInBlockProcess++;
             }
 
             return;
         }
 
         if (traceInfo != null) {
-            traceInfo.noSavesInSaveTrie++;
-            traceInfo.noSavesInBlockProcess++;
+            traceInfo.numOfSavesInSaveTrie++;
+            traceInfo.numOfSavesInBlockProcess++;
         }
 
         NodeReference leftNodeReference = trie.getLeft();
@@ -166,8 +166,8 @@ public class TrieStoreImpl implements TrieStore {
 
         if (logger.isTraceEnabled()) {
             TraceInfo traceInfo = traceInfoLocal.get();
-            traceInfo.noRetrievesInSaveTrie++;
-            traceInfo.noRetrievesInBlockProcess++;
+            traceInfo.numOfRetrievesInSaveTrie++;
+            traceInfo.numOfRetrievesInBlockProcess++;
         }
 
         Trie trie = Trie.fromMessage(message, this).markAsSaved();
@@ -178,8 +178,8 @@ public class TrieStoreImpl implements TrieStore {
     public byte[] retrieveValue(byte[] hash) {
         if (logger.isTraceEnabled()) {
             TraceInfo traceInfo = traceInfoLocal.get();
-            traceInfo.noRetrievesInSaveTrie++;
-            traceInfo.noRetrievesInBlockProcess++;
+            traceInfo.numOfRetrievesInSaveTrie++;
+            traceInfo.numOfRetrievesInBlockProcess++;
         }
 
         return this.store.get(hash);
@@ -195,12 +195,12 @@ public class TrieStoreImpl implements TrieStore {
      * Should not be used when logger tracing is disabled ({@link Logger#isTraceEnabled()} is {@code false}).
      */
     private static final class TraceInfo {
-        int noRetrievesInBlockProcess;
-        int noSavesInBlockProcess;
-        int noNoSavesInBlockProcess;
+        int numOfRetrievesInBlockProcess;
+        int numOfSavesInBlockProcess;
+        int numOfNoSavesInBlockProcess;
 
-        int noRetrievesInSaveTrie;
-        int noSavesInSaveTrie;
-        int noNoSavesInSaveTrie;
+        int numOfRetrievesInSaveTrie;
+        int numOfSavesInSaveTrie;
+        int numOfNoSavesInSaveTrie;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -78,6 +78,8 @@ public class TrieStoreImpl implements TrieStore {
             if (store instanceof DataSourceWithCache) {
                 ((DataSourceWithCache) store).emitLogs();
             }
+
+            traceInfoLocal.remove();
         }
     }
 
@@ -195,12 +197,12 @@ public class TrieStoreImpl implements TrieStore {
      * Should not be used when logger tracing is disabled ({@link Logger#isTraceEnabled()} is {@code false}).
      */
     private static final class TraceInfo {
-        int numOfRetrievesInBlockProcess;
-        int numOfSavesInBlockProcess;
-        int numOfNoSavesInBlockProcess;
+        private int numOfRetrievesInBlockProcess;
+        private int numOfSavesInBlockProcess;
+        private int numOfNoSavesInBlockProcess;
 
-        int numOfRetrievesInSaveTrie;
-        int numOfSavesInSaveTrie;
-        int numOfNoSavesInSaveTrie;
+        private int numOfRetrievesInSaveTrie;
+        private int numOfSavesInSaveTrie;
+        private int numOfNoSavesInSaveTrie;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -41,9 +41,9 @@ public class DataSourceWithCache implements KeyValueDataSource {
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
-    private final AtomicInteger noPuts = new AtomicInteger();
-    private final AtomicInteger noGets = new AtomicInteger();
-    private final AtomicInteger noGetsFromStore = new AtomicInteger();
+    private final AtomicInteger numOfPuts = new AtomicInteger();
+    private final AtomicInteger numOfGets = new AtomicInteger();
+    private final AtomicInteger numOfGetsFromStore = new AtomicInteger();
 
     public DataSourceWithCache(KeyValueDataSource base, int cacheSize) {
         this.cacheSize = cacheSize;
@@ -74,7 +74,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
             value = base.get(key);
 
             if (traceEnabled) {
-                noGetsFromStore.incrementAndGet();
+                numOfGetsFromStore.incrementAndGet();
             }
 
             //null value, as expected, is allowed here to be stored in committedCache
@@ -82,7 +82,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
         }
         finally {
             if (traceEnabled) {
-                noGets.incrementAndGet();
+                numOfGets.incrementAndGet();
             }
 
             this.lock.readLock().unlock();
@@ -116,7 +116,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
         }
         finally {
             if (logger.isTraceEnabled()) {
-                noPuts.incrementAndGet();
+                numOfPuts.incrementAndGet();
             }
 
             this.lock.writeLock().unlock();
@@ -283,9 +283,9 @@ public class DataSourceWithCache implements KeyValueDataSource {
 
         try {
             logger.trace("Activity: No. Gets: {}. No. Puts: {}. No. Gets from Store: {}",
-                    noGets.getAndSet(0),
-                    noPuts.getAndSet(0),
-                    noGetsFromStore.getAndSet(0));
+                    numOfGets.getAndSet(0),
+                    numOfPuts.getAndSet(0),
+                    numOfGetsFromStore.getAndSet(0));
         }
         finally {
             this.lock.writeLock().unlock();

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -160,7 +160,8 @@ public class CliToolsTest {
 
         String[] args = new String[] { "1", "2" };
 
-        ExecuteBlocks.execute(args, world.getBlockExecutor(), world.getBlockStore(), world.getTrieStore());
+        ExecuteBlocks.execute(args, world.getBlockExecutor(), world.getBlockStore(), world.getTrieStore(),
+                world.getStateRootHandler());
 
         Assert.assertEquals(2, world.getBlockChain().getBestBlock().getNumber());
     }

--- a/rskj-core/src/test/resources/logback.xml
+++ b/rskj-core/src/test/resources/logback.xml
@@ -70,6 +70,7 @@
     <logger name="co.rsk.db.migration.MissingOrchidStorageKeysProvider" level="INFO"/>
     <logger name="co.rsk.core.bc.BlockChainFlusher" level="TRACE"/>
     <logger name="blooms" level="INFO"/>
+    <logger name="triestore" level="TRACE" />
 
     <root level="DEBUG">
         <appender-ref ref="stdout"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It removes a trie node set, add an internal boolean flag to each trie node to knows if the node was already saved, improve the retrieval of the node (no get hash calculation is needed for adding the retrieved node to the removed set), improve save trie without visiting unloaded child nodes

Originated from https://github.com/rsksmart/rskj/pull/1526

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It solves #1509 and #1510

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Additionally to the usual code tests, the execution of blocks from a testnet node was executed:

java -cp rskj-core-3.0.0-triefix-all.jar -Dlogback.configurationFile=<logbackfile> -Dblockchain.flushNumberOfBlocks=1000 -Dcache.states.max-elements=1000000 co.rsk.cli.tools.ExecuteBlocks 1672391 1673139 --testnet
There are new logs, to obtain some additional information from TrieStoreImpl and DataSourceWithCache. The above command was executed with

    <logger name="triestore" level="TRACE"/>
    <logger name="datasourcewithcache" level="TRACE"/>
    <logger name="execute" level="TRACE"/>
    <logger name="blockvalidator" level="TRACE"/>
    <logger name="blocksyncservice" level="TRACE"/>
    <logger name="blockexecutor" level="TRACE"/>
Only for testing purpose.

Some additional logs obtained:

2021-05-07-16:52:33.317 TRACE [triestore]  Start saving trie root.
2021-05-07-16:52:33.318 TRACE [triestore]  Start saving trie, level : 0
2021-05-07-16:52:57.923 TRACE [triestore]  End saving trie, level : 0, already saved.
2021-05-07-16:52:57.924 TRACE [triestore]  End saving trie root. No. Retrieves: 396. No. Saves: 0. No. No Saves: 1
2021-05-07-16:52:57.924 TRACE [triestore]  End process block. No. Retrieves: 968. No. Saves: 0. No. No Saves: 1
2021-05-07-16:52:57.925 TRACE [datasourcewithcache]  Activity: No. Gets: 969. No. Puts: 0. No. Gets from Store: 967

With this additional logs we have more information about the effectivity of having a cache (and the Trie getHash issue #1511 was discovered using these logs)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
