### PR TITLE
Skip REMASC Transaction (Configurable)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -216,6 +216,10 @@ public class RskSystemProperties extends SystemProperties {
         this.remascEnabled = remascEnabled;
     }
 
+    public boolean skipRemasc() {
+            return getBoolean("rpc.skipRemasc", false);
+    }
+
     public long peerDiscoveryMessageTimeOut() {
         return getLong("peer.discovery.msg.timeout", PD_DEFAULT_TIMEOUT_MESSAGE);
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -66,7 +66,7 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
 
 				TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, transactionPool, senderAccount, constants.getChainId());
 
-				Transaction tx = Transaction.builder().from(txArgs).build();
+				Transaction tx = Transaction.builder().withTransactionArguments(txArgs).build();
 
 				tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/personal/PersonalModuleWalletEnabled.java
@@ -194,7 +194,7 @@ public class PersonalModuleWalletEnabled implements PersonalModule {
 
 		TransactionArguments txArgs = TransactionArgumentsUtil.processArguments(args, transactionPool, senderAccount, config.getNetworkConstants().getChainId());
 
-		Transaction tx = Transaction.builder().from(txArgs).build();
+		Transaction tx = Transaction.builder().withTransactionArguments(txArgs).build();
 
 		tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
 

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionBuilder.java
@@ -131,7 +131,7 @@ public final class TransactionBuilder {
 		return this.data(data == null ? null : Hex.decode(data));
 	}
 
-	public TransactionBuilder from(TransactionArguments args) {
+	public TransactionBuilder withTransactionArguments(TransactionArguments args) {
 
 		nonce(args.getNonce());
 		gasPrice(args.getGasPrice());

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -532,7 +532,7 @@ public class Web3Impl implements Web3 {
     }
 
     public BlockResultDTO getBlockResult(Block b, boolean fullTx) {
-        return BlockResultDTO.fromBlock(b, fullTx, this.blockStore);
+        return BlockResultDTO.fromBlock(b, fullTx, this.blockStore, config.skipRemasc());
     }
 
     public BlockInformationResult[] eth_getBlocksByNumber(String number) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.ethereum.crypto.HashUtil.EMPTY_TRIE_HASH;
+
 
 public class BlockResultDTO {
     private final String number; // QUANTITY - the block number. null when its pending block.
@@ -143,13 +145,20 @@ public class BlockResultDTO {
             uncles.add(header.getHash().toJsonString());
         }
 
+        // Useful for geth integration
+        byte[] transactionsRoot = skipRemasc &&
+                b.getTransactionsList().size() == 1 &&
+                b.getTransactionsList().get(0).isRemascTransaction(0,1) ?
+                    EMPTY_TRIE_HASH :
+                    b.getTxTrieRoot();
+
         return new BlockResultDTO(
                 isPending ? null : b.getNumber(),
                 isPending ? null : b.getHash(),
                 b.getParentHash(),
                 b.getUnclesHash(),
                 isPending ? null : b.getLogBloom(),
-                b.getTxTrieRoot(),
+                transactionsRoot,
                 b.getStateRoot(),
                 b.getReceiptsRoot(),
                 isPending ? null : b.getCoinbase(),

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
@@ -31,6 +31,7 @@ import org.ethereum.rpc.TypeConverter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -133,7 +134,7 @@ public class BlockResultDTO {
         // For full tx will present as TransactionResultDTO otherwise just as transaction hash
         List<Object> transactions = IntStream.range(0, blockTransactions.size())
                 .mapToObj(txIndex -> toTransactionResult(txIndex, b, fullTx, skipRemasc))
-                .filter(o -> o != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
         List<String> uncles = new ArrayList<>();

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
@@ -65,7 +65,7 @@ public class BlockResultDTO {
     private final String paidFees;
     private final String cumulativeDifficulty;
 
-    public BlockResultDTO(
+    private BlockResultDTO(
             Long number,
             Keccak256 hash,
             Keccak256 parentHash,

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java
@@ -22,6 +22,7 @@ import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
+import co.rsk.remasc.RemascTransaction;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Transaction;
@@ -117,7 +118,7 @@ public class BlockResultDTO {
         this.paidFees = paidFees != null ? TypeConverter.toQuantityJsonHex(paidFees.getBytes()) : null;
     }
 
-    public static BlockResultDTO fromBlock(Block b, boolean fullTx, BlockStore blockStore) {
+    public static BlockResultDTO fromBlock(Block b, boolean fullTx, BlockStore blockStore, boolean skipRemasc) {
         if (b == null) {
             return null;
         }
@@ -131,10 +132,22 @@ public class BlockResultDTO {
         List<Transaction> blockTransactions = b.getTransactionsList();
         if (fullTx) {
             for (int i = 0; i < blockTransactions.size(); i++) {
+                Transaction tx = blockTransactions.get(i);
+
+                if (skipRemasc && tx.isRemascTransaction(i, blockTransactions.size())) {
+                    continue;
+                }
+
                 transactions.add(new TransactionResultDTO(b, i, blockTransactions.get(i)));
             }
         } else {
-            for (Transaction tx : blockTransactions) {
+            for (int i = 0; i < blockTransactions.size(); i++) {
+                Transaction tx = blockTransactions.get(i);
+
+                if (skipRemasc && tx.isRemascTransaction(i, blockTransactions.size())) {
+                    continue;
+                }
+
                 transactions.add(tx.getHash().toJsonString());
             }
         }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -82,112 +82,56 @@ public class TransactionResultDTO {
         return hash;
     }
 
-    public void setHash(String hash) {
-        this.hash = hash;
-    }
-
     public String getNonce() {
         return nonce;
-    }
-
-    public void setNonce(String nonce) {
-        this.nonce = nonce;
     }
 
     public String getBlockHash() {
         return blockHash;
     }
 
-    public void setBlockHash(String blockHash) {
-        this.blockHash = blockHash;
-    }
-
     public String getBlockNumber() {
         return blockNumber;
-    }
-
-    public void setBlockNumber(String blockNumber) {
-        this.blockNumber = blockNumber;
     }
 
     public String getTransactionIndex() {
         return transactionIndex;
     }
 
-    public void setTransactionIndex(String transactionIndex) {
-        this.transactionIndex = transactionIndex;
-    }
-
     public String getFrom() {
         return from;
-    }
-
-    public void setFrom(String from) {
-        this.from = from;
     }
 
     public String getTo() {
         return to;
     }
 
-    public void setTo(String to) {
-        this.to = to;
-    }
-
     public String getGas() {
         return gas;
-    }
-
-    public void setGas(String gas) {
-        this.gas = gas;
     }
 
     public String getGasPrice() {
         return gasPrice;
     }
 
-    public void setGasPrice(String gasPrice) {
-        this.gasPrice = gasPrice;
-    }
-
     public String getValue() {
         return value;
-    }
-
-    public void setValue(String value) {
-        this.value = value;
     }
 
     public String getInput() {
         return input;
     }
 
-    public void setInput(String input) {
-        this.input = input;
-    }
-
     public String getV() {
         return v;
-    }
-
-    public void setV(String v) {
-        this.v = v;
     }
 
     public String getR() {
         return r;
     }
 
-    public void setR(String r) {
-        this.r = r;
-    }
-
     public String getS() {
         return s;
-    }
-
-    public void setS(String s) {
-        this.s = s;
     }
 
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -30,22 +30,20 @@ import org.ethereum.rpc.TypeConverter;
  */
 public class TransactionResultDTO {
 
-    public String hash;
-    public String nonce;
-    public String blockHash;
-    public String blockNumber;
-    public String transactionIndex;
-
-    public String from;
-    public String to;
-    public String gas;
-    public String gasPrice;
-    public String value;
-    public String input;
-
-    public String v;
-    public String r;
-    public String s;
+    private String hash;
+    private String nonce;
+    private String blockHash;
+    private String blockNumber;
+    private String transactionIndex;
+    private String from;
+    private String to;
+    private String gas;
+    private String gasPrice;
+    private String value;
+    private String input;
+    private String v;
+    private String r;
+    private String s;
 
     public TransactionResultDTO(Block b, Integer index, Transaction tx) {
         hash = tx.getHash().toJsonString();
@@ -59,7 +57,7 @@ public class TransactionResultDTO {
         from = tx.getSender().toJsonString();
         to = tx.getReceiveAddress().toJsonString();
         gas = TypeConverter.toQuantityJsonHex(tx.getGasLimit());
-        
+
         gasPrice = TypeConverter.toQuantityJsonHex(tx.getGasPrice().getBytes());
 
         if (Coin.ZERO.equals(tx.getValue())) {
@@ -79,4 +77,117 @@ public class TransactionResultDTO {
             s = TypeConverter.toQuantityJsonHex(signature.getS());
         }
     }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public void setNonce(String nonce) {
+        this.nonce = nonce;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public void setBlockHash(String blockHash) {
+        this.blockHash = blockHash;
+    }
+
+    public String getBlockNumber() {
+        return blockNumber;
+    }
+
+    public void setBlockNumber(String blockNumber) {
+        this.blockNumber = blockNumber;
+    }
+
+    public String getTransactionIndex() {
+        return transactionIndex;
+    }
+
+    public void setTransactionIndex(String transactionIndex) {
+        this.transactionIndex = transactionIndex;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public String getGas() {
+        return gas;
+    }
+
+    public void setGas(String gas) {
+        this.gas = gas;
+    }
+
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    public void setGasPrice(String gasPrice) {
+        this.gasPrice = gasPrice;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getInput() {
+        return input;
+    }
+
+    public void setInput(String input) {
+        this.input = input;
+    }
+
+    public String getV() {
+        return v;
+    }
+
+    public void setV(String v) {
+        this.v = v;
+    }
+
+    public String getR() {
+        return r;
+    }
+
+    public void setR(String r) {
+        this.r = r;
+    }
+
+    public String getS() {
+        return s;
+    }
+
+    public void setS(String s) {
+        this.s = s;
+    }
+
 }

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -236,6 +236,8 @@ rpc = {
             }
         }
     ]
+
+    skipRemasc: <enabled>
 }
 wire = {
     protocol = <protocol>

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -236,7 +236,6 @@ rpc = {
             }
         }
     ]
-
     skipRemasc: <enabled>
 }
 wire = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -356,7 +356,6 @@ rpc {
              enabled: "true"
          }
     ]
-
     skipRemasc: false
 }
 

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -356,6 +356,8 @@ rpc {
              enabled: "true"
          }
     ]
+
+    skipRemasc: false
 }
 
 wire {

--- a/rskj-core/src/test/java/co/rsk/core/CallTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/CallTransactionTest.java
@@ -18,8 +18,6 @@
 
 package co.rsk.core;
 
-import co.rsk.peg.BridgeEvents;
-import jdk.nashorn.internal.codegen.CompilerConstants;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.solidity.SolidityType;

--- a/rskj-core/src/test/java/co/rsk/test/builderstest/TransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/builderstest/TransactionBuilderTest.java
@@ -26,6 +26,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Created by ajlopez on 08/08/2016.
@@ -52,5 +57,16 @@ public class TransactionBuilderTest {
         Assert.assertEquals(BigInteger.valueOf(21000), new BigInteger(1, tx.getGasLimit()));
         Assert.assertNotNull(tx.getData());
         Assert.assertEquals(0, tx.getData().length);
+    }
+
+    @Test
+    public void buildValidRandomTransactions() {
+        List<String> randomTxsHashes = IntStream.range(0, 100)
+                .mapToObj(i -> new TransactionBuilder().buildRandomTransaction().getHash().toJsonString())
+                .collect(Collectors.toList());
+
+        Set<String> hashesWithoutDuplicates = randomTxsHashes.stream().collect(Collectors.toSet());
+
+        Assert.assertEquals(randomTxsHashes.size(), hashesWithoutDuplicates.size());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -421,20 +421,20 @@ public class Web3ImplTest {
         TransactionResultDTO tr = web3.eth_getTransactionByHash(hashString);
 
         assertNotNull(tr);
-        assertEquals("0x" + hashString, tr.hash);
+        assertEquals("0x" + hashString, tr.getHash());
 
         String blockHashString = "0x" + block1.getHash();
-        assertEquals(blockHashString, tr.blockHash);
+        assertEquals(blockHashString, tr.getBlockHash());
 
-        assertEquals("0x", tr.input);
-        assertEquals("0x" + ByteUtil.toHexString(tx.getReceiveAddress().getBytes()), tr.to);
+        assertEquals("0x", tr.getInput());
+        assertEquals("0x" + ByteUtil.toHexString(tx.getReceiveAddress().getBytes()), tr.getTo());
 
         // Check the v value used to encode the transaction
         // NOT the v value used in signature
         // the encoded value includes chain id
-        Assert.assertArrayEquals(new byte[] {tx.getEncodedV()}, TypeConverter.stringHexToByteArray(tr.v));
-        Assert.assertThat(TypeConverter.stringHexToBigInteger(tr.s), is(tx.getSignature().getS()));
-        Assert.assertThat(TypeConverter.stringHexToBigInteger(tr.r), is(tx.getSignature().getR()));
+        Assert.assertArrayEquals(new byte[] {tx.getEncodedV()}, TypeConverter.stringHexToByteArray(tr.getV()));
+        Assert.assertThat(TypeConverter.stringHexToBigInteger(tr.getS()), is(tx.getSignature().getS()));
+        Assert.assertThat(TypeConverter.stringHexToBigInteger(tr.getR()), is(tx.getSignature().getR()));
     }
 
     @Test
@@ -460,12 +460,12 @@ public class Web3ImplTest {
 
         assertNotNull(tr);
 
-        assertEquals("0x" + hashString, tr.hash);
-        assertEquals("0x0", tr.nonce);
-        assertEquals(null, tr.blockHash);
-        assertEquals(null, tr.transactionIndex);
-        assertEquals("0x", tr.input);
-        assertEquals("0x" + ByteUtil.toHexString(tx.getReceiveAddress().getBytes()), tr.to);
+        assertEquals("0x" + hashString, tr.getHash());
+        assertEquals("0x0", tr.getNonce());
+        assertEquals(null, tr.getBlockHash());
+        assertEquals(null, tr.getTransactionIndex());
+        assertEquals("0x", tr.getInput());
+        assertEquals("0x" + ByteUtil.toHexString(tx.getReceiveAddress().getBytes()), tr.getTo());
     }
 
     @Test
@@ -520,9 +520,9 @@ public class Web3ImplTest {
         TransactionResultDTO tr = web3.eth_getTransactionByBlockHashAndIndex(blockHashString, "0x0");
 
         assertNotNull(tr);
-        assertEquals("0x" + hashString, tr.hash);
+        assertEquals("0x" + hashString, tr.getHash());
 
-        assertEquals("0x" + blockHashString, tr.blockHash);
+        assertEquals("0x" + blockHashString, tr.getBlockHash());
     }
 
     @Test
@@ -565,9 +565,9 @@ public class Web3ImplTest {
         TransactionResultDTO tr = web3.eth_getTransactionByBlockNumberAndIndex("0x01", "0x0");
 
         assertNotNull(tr);
-        assertEquals("0x" + hashString, tr.hash);
+        assertEquals("0x" + hashString, tr.getHash());
 
-        assertEquals("0x" + blockHashString, tr.blockHash);
+        assertEquals("0x" + blockHashString, tr.getBlockHash());
     }
 
     @Test
@@ -832,9 +832,9 @@ public class Web3ImplTest {
         assertNotNull(bresult);
         assertEquals(block1HashString, bresult.getHash());
         assertEquals(1, bresult.getTransactions().size());
-        assertEquals(block1HashString, ((TransactionResultDTO) bresult.getTransactions().get(0)).blockHash);
+        assertEquals(block1HashString, ((TransactionResultDTO) bresult.getTransactions().get(0)).getBlockHash());
         assertEquals(0, bresult.getUncles().size());
-        assertEquals("0x0", ((TransactionResultDTO) bresult.getTransactions().get(0)).value);
+        assertEquals("0x0", ((TransactionResultDTO) bresult.getTransactions().get(0)).getValue());
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/BlockResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/BlockResultDTOTest.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.rpc.dto;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.core.genesis.TestGenesisLoader;
+import co.rsk.remasc.RemascTransaction;
+import co.rsk.test.builders.BlockBuilder;
+import org.ethereum.core.Block;
+import org.ethereum.core.Blockchain;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.genesis.GenesisLoader;
+import org.ethereum.db.BlockStore;
+import org.ethereum.util.RskTestFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class BlockResultDTOTest {
+    private Block block;
+    private BlockStore blockStore;
+
+    @Before
+    public void setup() {
+        RskTestFactory objects = new RskTestFactory() {
+            @Override
+            protected GenesisLoader buildGenesisLoader() {
+                return new TestGenesisLoader(getTrieStore(), "rsk-unittests.json", BigInteger.ZERO, true, true, true);
+            }
+        };
+        Blockchain blockChain = objects.getBlockchain();
+
+        BlockBuilder builder = new BlockBuilder(null, null, null).parent(blockChain.getBestBlock());
+        List<Transaction> transactions = new ArrayList<>();
+        RemascTransaction remascTransaction = spy(new RemascTransaction(1));
+        when(remascTransaction.isRemascTransaction(1, 2)).thenReturn(true);
+        Transaction transaction = spy(new RemascTransaction(1));
+        when(transaction.isRemascTransaction(0, 2)).thenReturn(false);
+        transactions.add(transaction);
+        transactions.add(remascTransaction);
+
+        block = builder.transactions(transactions).build();
+        blockStore = mock(BlockStore.class);
+        when(blockStore.getTotalDifficultyForHash(any())).thenReturn(BlockDifficulty.ONE);
+    }
+
+    @Test
+    public void getBlockResultDTOWithRemascAndTransactionHashes() {
+        BlockResultDTO blockResultDTO = BlockResultDTO.fromBlock(block, false, blockStore, false);
+
+        Assert.assertNotNull(blockResultDTO);
+        Assert.assertEquals(2, blockResultDTO.getTransactions().size());
+    }
+
+    @Test
+    public void getBlockResultDTOWithoutRemascAndTransactionHashes() {
+        BlockResultDTO blockResultDTO = BlockResultDTO.fromBlock(block, false, blockStore, true);
+
+        Assert.assertNotNull(blockResultDTO);
+        Assert.assertEquals(1, blockResultDTO.getTransactions().size());
+    }
+
+    @Test
+    public void getBlockResultDTOWithRemascAndFullTransactions() {
+        BlockResultDTO blockResultDTO = BlockResultDTO.fromBlock(block, true, blockStore, false);
+
+        Assert.assertNotNull(blockResultDTO);
+        Assert.assertEquals(2, blockResultDTO.getTransactions().size());
+    }
+
+    @Test
+    public void getBlockResultDTOWithoutRemascAndFullTransactions() {
+        BlockResultDTO blockResultDTO = BlockResultDTO.fromBlock(block, true, blockStore, true);
+
+        Assert.assertNotNull(blockResultDTO);
+        Assert.assertEquals(1, blockResultDTO.getTransactions().size());
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
@@ -43,10 +43,10 @@ public class TransactionResultDTOTest {
         RemascTransaction remascTransaction = new RemascTransaction(new Random().nextLong());
 
         TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, remascTransaction);
-        assertThat(dto.from, is("0x0000000000000000000000000000000000000000"));
-        assertThat(dto.r, is(nullValue()));
-        assertThat(dto.s, is(nullValue()));
-        assertThat(dto.v, is(nullValue()));
+        assertThat(dto.getFrom(), is("0x0000000000000000000000000000000000000000"));
+        assertThat(dto.getR(), is(nullValue()));
+        assertThat(dto.getS(), is(nullValue()));
+        assertThat(dto.getV(), is(nullValue()));
     }
 
     @Test
@@ -60,13 +60,13 @@ public class TransactionResultDTOTest {
 
         TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction);
 
-        Assert.assertNotNull(dto.r);
-        Assert.assertNotNull(dto.s);
-        Assert.assertNotNull(dto.v);
+        Assert.assertNotNull(dto.getR());
+        Assert.assertNotNull(dto.getS());
+        Assert.assertNotNull(dto.getV());
 
         String expectedV = String.format("0x%02x", originalTransaction.getSignature().getV() - Transaction.LOWER_REAL_V + Transaction.CHAIN_ID_INC + chainId * 2);
 
-        Assert.assertEquals(expectedV, dto.v);
+        Assert.assertEquals(expectedV, dto.getV());
     }
 
     @Test
@@ -80,8 +80,8 @@ public class TransactionResultDTOTest {
 
         TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction);
 
-        Assert.assertNotNull(dto.nonce);
-        Assert.assertEquals("0x0", dto.nonce);
+        Assert.assertNotNull(dto.getNonce());
+        Assert.assertEquals("0x0", dto.getNonce());
     }
 
     @Test
@@ -95,8 +95,8 @@ public class TransactionResultDTOTest {
 
         TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction);
 
-        Assert.assertNotNull(dto.nonce);
-        Assert.assertEquals("0x1", dto.nonce);
+        Assert.assertNotNull(dto.getNonce());
+        Assert.assertEquals("0x1", dto.getNonce());
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Continuing this [previous PR](https://github.com/rsksmart/rskj/pull/1490) from @ajlopez, adds support to skip REMASC transaction from blocks on JSON RPC requests. This feature it's disabled by default

Use `-Drpc.skipRemasc=true`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are some Ethereum's ecosystem tools that relies on transactions with gasUsed > 0 (since there are no transactions with gasUsed > 0 on eth). Checkout this example https://github.com/rsksmart/rskj/issues/1484

In RSK every block has a tranaction, which is part of the consensus, named REMASC. This special case differs from other ones beacause it has `gasUsed == 0`.

In order to provide a better UX and compatibility we provide a mechanism to filter this Transaction from the returned block/s on JSON RPC requests (IE `eth_getBlockByNumber` or `eth_getBlockByHash`).

DISCLAIMER: even though we provide this mechanisim the user must take care and notice that there is a hidden REMASC transaction contained in the block.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests coming form the angel's PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


**Other information**:
* https://developers.rsk.co/rsk/architecture/mining/remasc/
