### PR TITLE
Fix Trie getHash

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -117,7 +117,7 @@ public class Trie {
     }
 
     private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value) {
-        this(store, sharedPath, value, NodeReference.empty(), NodeReference.empty(), getDataLength(value), null);
+        this(store, sharedPath, value, NodeReference.empty(), NodeReference.empty(), getDataLength(value), null, new VarInt(0));
     }
 
     public Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash) {

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -880,7 +880,7 @@ public class Trie {
     private Trie split(TrieKeySlice commonPath) {
         int commonPathLength = commonPath.length();
         TrieKeySlice newChildSharedPath = sharedPath.slice(commonPathLength + 1, sharedPath.length());
-        Trie newChildTrie = new Trie(this.store, newChildSharedPath, this.value, this.left, this.right, this.valueLength, this.valueHash);
+        Trie newChildTrie = new Trie(this.store, newChildSharedPath, this.value, this.left, this.right, this.valueLength, this.valueHash, this.childrenSize);
         NodeReference newChildReference = new NodeReference(this.store, newChildTrie, null);
 
         // this bit will be implicit and not present in a shared path

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -833,7 +833,8 @@ public class Trie {
                     this.left,
                     this.right,
                     getDataLength(value),
-                    null
+                    null,
+                    this.childrenSize
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -787,7 +787,8 @@ public class Trie {
         }
 
         TrieKeySlice newSharedPath = trie.sharedPath.rebuildSharedPath(childImplicitByte, child.sharedPath);
-        return new Trie(child.store, newSharedPath, child.value, child.left, child.right, child.valueLength, child.valueHash);
+
+        return new Trie(child.store, newSharedPath, child.value, child.left, child.right, child.valueLength, child.valueHash, child.childrenSize);
     }
 
     private static Uint24 getDataLength(byte[] value) {

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -859,22 +859,32 @@ public class Trie {
             return this;
         }
 
+        VarInt childrenSize = this.childrenSize;
+
         NodeReference newNodeReference = new NodeReference(this.store, newNode, null);
         NodeReference newLeft;
         NodeReference newRight;
         if (pos == 0) {
             newLeft = newNodeReference;
             newRight = this.right;
+
+            if (childrenSize != null) {
+                childrenSize = new VarInt(childrenSize.value - this.left.referenceSize() + newLeft.referenceSize());
+            }
         } else {
             newLeft = this.left;
             newRight = newNodeReference;
+
+            if (childrenSize != null) {
+                childrenSize = new VarInt(childrenSize.value - this.right.referenceSize() + newRight.referenceSize());
+            }
         }
 
         if (isEmptyTrie(this.valueLength, newLeft, newRight)) {
             return null;
         }
 
-        return new Trie(this.store, this.sharedPath, this.value, newLeft, newRight, this.valueLength, this.valueHash);
+        return new Trie(this.store, this.sharedPath, this.value, newLeft, newRight, this.valueLength, this.valueHash, childrenSize);
     }
 
     private Trie split(TrieKeySlice commonPath) {
@@ -886,6 +896,7 @@ public class Trie {
         // this bit will be implicit and not present in a shared path
         byte pos = sharedPath.get(commonPathLength);
 
+        VarInt childrenSize = new VarInt(newChildReference.referenceSize());
         NodeReference newLeft;
         NodeReference newRight;
         if (pos == 0) {
@@ -896,7 +907,7 @@ public class Trie {
             newRight = newChildReference;
         }
 
-        return new Trie(this.store, commonPath, null, newLeft, newRight, Uint24.ZERO, null);
+        return new Trie(this.store, commonPath, null, newLeft, newRight, Uint24.ZERO, null, childrenSize);
     }
 
     public boolean isTerminal() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Calculate Trie.getHash without additional storage access

Originated from https://github.com/rsksmart/rskj/pull/1545

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix issue #1511

Changes from #1526 are also include, please don't review those lines (not related with children size calculation)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
