### PR TITLE
Reused calculated block hash

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -115,7 +115,7 @@ public class BlockHeader {
     private volatile boolean sealed;
 
     /* Holds calculated block hash */
-    private volatile Keccak256 hash;
+    private Keccak256 hash;
 
     /* Indicates if the block was mined according to RSKIP-92 rules */
     private final boolean useRskip92Encoding;

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -50,12 +50,12 @@ public class BlockHeader {
     private static final int UMM_LEAVES_LENGTH = 20;
 
     /* The SHA3 256-bit hash of the parent block, in its entirety */
-    private byte[] parentHash;
+    private final byte[] parentHash;
     /* The SHA3 256-bit hash of the uncles list portion of this block */
-    private byte[] unclesHash;
+    private final byte[] unclesHash;
     /* The 160-bit address to which all fees collected from the
      * successful mining of this block be transferred; formally */
-    private RskAddress coinbase;
+    private final RskAddress coinbase;
     /* The SHA3 256-bit hash of the root node of the state trie,
      * after all transactions are executed and finalisations applied */
     private byte[] stateRoot;
@@ -79,12 +79,12 @@ public class BlockHeader {
     private BlockDifficulty difficulty;
     /* A scalar value equalBytes to the reasonable output of Unix's time()
      * at this block's inception */
-    private long timestamp;
+    private final long timestamp;
     /* A scalar value equalBytes to the number of ancestor blocks.
      * The genesis block has a number of zero */
-    private long number;
+    private final long number;
     /* A scalar value equalBytes to the current limit of gas expenditure per block */
-    private byte[] gasLimit;
+    private final byte[] gasLimit;
     /* A scalar value equalBytes to the total gas used in transactions in this block */
     private long gasUsed;
     /* A scalar value equalBytes to the total paid fees in transactions in this block */
@@ -92,7 +92,7 @@ public class BlockHeader {
 
     /* An arbitrary byte array containing data relevant to this block.
      * With the exception of the genesis block, this must be 32 bytes or fewer */
-    private byte[] extraData;
+    private final byte[] extraData;
 
     /* The 80-byte bitcoin block header for merged mining */
     private byte[] bitcoinMergedMiningHeader;
@@ -103,22 +103,25 @@ public class BlockHeader {
 
     private byte[] miningForkDetectionData;
 
-    private byte[] ummRoot;
+    private final byte[] ummRoot;
 
     /**
      * The mgp for a tx to be included in the block.
      */
-    private Coin minimumGasPrice;
-    private int uncleCount;
+    private final Coin minimumGasPrice;
+    private final int uncleCount;
 
     /* Indicates if this block header cannot be changed */
     private volatile boolean sealed;
 
+    /* Holds calculated block hash */
+    private volatile Keccak256 hash;
+
     /* Indicates if the block was mined according to RSKIP-92 rules */
-    private boolean useRskip92Encoding;
+    private final boolean useRskip92Encoding;
 
     /* Indicates if Block hash for merged mining should have the format described in RSKIP-110 */
-    private boolean includeForkDetectionData;
+    private final boolean includeForkDetectionData;
 
     public BlockHeader(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
                        byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] logsBloom, BlockDifficulty difficulty,
@@ -192,6 +195,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter state root");
         }
+        this.hash = null;
 
         this.stateRoot = stateRoot;
     }
@@ -205,6 +209,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter receipts root");
         }
+        this.hash = null;
 
         this.receiptTrieRoot = receiptTrieRoot;
     }
@@ -218,6 +223,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter transactions root");
         }
+        this.hash = null;
 
         this.txTrieRoot = stateRoot;
     }
@@ -242,6 +248,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter difficulty");
         }
+        this.hash = null;
 
         this.difficulty = difficulty;
     }
@@ -267,6 +274,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter paid fees");
         }
+        this.hash = null;
 
         this.paidFees = paidFees;
     }
@@ -280,6 +288,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter gas used");
         }
+        this.hash = null;
 
         this.gasUsed = gasUsed;
     }
@@ -293,12 +302,17 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter logs bloom");
         }
+        this.hash = null;
 
         this.logsBloom = logsBloom;
     }
 
     public Keccak256 getHash() {
-        return new Keccak256(HashUtil.keccak256(getEncoded()));
+        if (this.hash == null) {
+            this.hash = new Keccak256(HashUtil.keccak256(getEncoded()));
+        }
+
+        return this.hash;
     }
 
     public byte[] getFullEncoded() {
@@ -451,6 +465,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter bitcoin merged mining header");
         }
+        this.hash = null;
 
         this.bitcoinMergedMiningHeader = bitcoinMergedMiningHeader;
     }
@@ -464,6 +479,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter bitcoin merged mining merkle proof");
         }
+        this.hash = null;
 
         this.bitcoinMergedMiningMerkleProof = bitcoinMergedMiningMerkleProof;
     }
@@ -477,6 +493,7 @@ public class BlockHeader {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter bitcoin merged mining coinbase transaction");
         }
+        this.hash = null;
 
         this.bitcoinMergedMiningCoinbaseTransaction = bitcoinMergedMiningCoinbaseTransaction;
     }

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
@@ -35,11 +35,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static java.lang.System.arraycopy;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.*;
 
@@ -294,6 +295,35 @@ public class BlockHeaderTest {
         HashUtil.keccak256(headerEncoded);
     }
 
+    @Test
+    public void verifyRecalculatedHashForAmendedBlocks() {
+        BlockHeader header = createBlockHeader(new byte[80], new byte[32], new byte[128], new byte[0],
+                false, new byte[0], false, false);
+
+        assertArrayEquals(HashUtil.keccak256(header.getEncoded()), header.getHash().getBytes());
+
+        List<Consumer<BlockHeader>> stateModifiers = Arrays.asList(
+                h -> h.setBitcoinMergedMiningCoinbaseTransaction(HashUtil.keccak256("BitcoinMergedMiningCoinbaseTransaction".getBytes())),
+                h -> h.setBitcoinMergedMiningHeader(HashUtil.keccak256("BitcoinMergedMiningHeader".getBytes())),
+                h -> h.setBitcoinMergedMiningMerkleProof(HashUtil.keccak256("BitcoinMergedMiningMerkleProof".getBytes())),
+                h -> h.setDifficulty(header.getDifficulty().add(BlockDifficulty.ONE)),
+                h -> h.setGasUsed(header.getGasUsed() + 10),
+                h -> h.setLogsBloom(HashUtil.keccak256("LogsBloom".getBytes())),
+                h -> h.setPaidFees(header.getPaidFees().add(Coin.valueOf(10))),
+                h -> h.setReceiptsRoot(HashUtil.keccak256("ReceiptsRoot".getBytes())),
+                h -> h.setStateRoot(HashUtil.keccak256("StateRoot".getBytes())),
+                h -> h.setTransactionsRoot(HashUtil.keccak256("TransactionsRoot".getBytes())),
+                BlockHeader::seal
+        );
+
+        stateModifiers.forEach(sm -> {
+            sm.accept(header);
+            assertArrayEquals("Block header returned invalid hash after modification",
+                    HashUtil.keccak256(header.getEncoded()),
+                    header.getHash().getBytes());
+        });
+    }
+
     private BlockHeader createBlockHeaderWithMergedMiningFields(
             byte[] forkDetectionData,
             boolean includeForkDetectionData, byte[] ummRoot){
@@ -321,6 +351,14 @@ public class BlockHeaderTest {
     private BlockHeader createBlockHeader(byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
                                           byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] forkDetectionData,
                                           boolean includeForkDetectionData, byte[] ummRoot, boolean sealed) {
+        return createBlockHeader(bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
+                forkDetectionData, includeForkDetectionData, ummRoot, true, sealed);
+    }
+
+    private BlockHeader createBlockHeader(byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
+                                          byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] forkDetectionData,
+                                          boolean includeForkDetectionData, byte[] ummRoot, boolean useRskip92Encoding,
+                                          boolean sealed) {
         BlockDifficulty difficulty = new BlockDifficulty(BigInteger.ONE);
         long number = 1;
         BigInteger gasLimit = BigInteger.valueOf(6800000);
@@ -348,7 +386,7 @@ public class BlockHeaderTest {
                 Coin.valueOf(10L),
                 0,
                 sealed,
-                true,
+                useRskip92Encoding,
                 includeForkDetectionData,
                 ummRoot);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change allows to cache a block hash after first call to `BlockHeader.getHash()` and reuse cached value in next calls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/rsksmart/rskj/issues/1584

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit tests / running node in local env.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
