### PR TITLE
Properly handle chunked requests on WebsocketServer

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1601,7 +1601,9 @@ public class RskContext implements NodeBootstrapper {
                     rskSystemProperties.rpcWebSocketPort(),
                     jsonRpcHandler,
                     getJsonRpcWeb3ServerHandler(),
-                    rskSystemProperties.rpcWebSocketServerWriteTimeoutSeconds()
+                    rskSystemProperties.rpcWebSocketServerWriteTimeoutSeconds(),
+                    rskSystemProperties.rpcWebSocketMaxFrameSize(),
+                    rskSystemProperties.rpcWebSocketMaxAggregatedFrameSize()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
@@ -13,14 +13,16 @@ public class RskWebSocketServerProtocolHandler extends WebSocketServerProtocolHa
     public static final String WRITE_TIMEOUT_REASON = "Exceeded write timout";
     public static final int NORMAL_CLOSE_WEBSOCKET_STATUS = 1000;
 
-    public RskWebSocketServerProtocolHandler(String websocketPath) {
-        super(websocketPath);
+    public RskWebSocketServerProtocolHandler(String websocketPath, int maxFrameSize) {
+        // there are no subprotocols nor extensions
+        super(websocketPath, null, false, maxFrameSize);
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if(cause instanceof WriteTimeoutException) {
-            ctx.writeAndFlush(new CloseWebSocketFrame(NORMAL_CLOSE_WEBSOCKET_STATUS, WRITE_TIMEOUT_REASON)).addListener(ChannelFutureListener.CLOSE);
+            ctx.writeAndFlush(new CloseWebSocketFrame(NORMAL_CLOSE_WEBSOCKET_STATUS, WRITE_TIMEOUT_REASON))
+                    .addListener(ChannelFutureListener.CLOSE);
             LOGGER.error("Write timeout exceeded, closing web socket channel", cause);
         } else {
             super.exceptionCaught(ctx, cause);

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
@@ -30,7 +30,6 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
-import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
@@ -29,6 +29,8 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +80,7 @@ public class Web3WebSocketServer implements InternalService {
                     p.addLast(new HttpObjectAggregator(HTTP_MAX_CONTENT_LENGTH));
                     p.addLast(new WriteTimeoutHandler(serverWriteTimeoutSeconds, TimeUnit.SECONDS));
                     p.addLast(new RskWebSocketServerProtocolHandler("/websocket"));
+                    p.addLast(new WebSocketFrameAggregator(1024 * 1024 * 5));
                     p.addLast(webSocketJsonRpcHandler);
                     p.addLast(web3ServerHandler);
                     p.addLast(new Web3ResultWebSocketResponseHandler());

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -83,6 +83,8 @@ public abstract class SystemProperties {
     private static final String PROPERTY_RPC_WEBSOCKET_ADDRESS = "rpc.providers.web.ws.bind_address";
     private static final String PROPERTY_RPC_WEBSOCKET_PORT = "rpc.providers.web.ws.port";
     private static final String PROPERTY_RPC_WEBSOCKET_SERVER_WRITE_TIMEOUT_SECONDS = "rpc.providers.web.ws.server_write_timeout_seconds";
+    private static final String PROPERTY_RPC_WEBSOCKET_SERVER_MAX_FRAME_SIZE = "rpc.providers.web.ws.max_frame_size";
+    private static final String PROPERTY_RPC_WEBSOCKET_SERVER_MAX_AGGREGATED_FRAME_SIZE = "rpc.providers.web.ws.max_aggregated_frame_size";
 
     public static final String PROPERTY_PUBLIC_IP = "public.ip";
     public static final String PROPERTY_BIND_ADDRESS = "bind_address";
@@ -615,6 +617,14 @@ public abstract class SystemProperties {
 
     public int rpcWebSocketServerWriteTimeoutSeconds() {
         return configFromFiles.getInt(PROPERTY_RPC_WEBSOCKET_SERVER_WRITE_TIMEOUT_SECONDS);
+    }
+
+    public int rpcWebSocketMaxFrameSize() {
+        return configFromFiles.getInt(PROPERTY_RPC_WEBSOCKET_SERVER_MAX_FRAME_SIZE);
+    }
+
+    public int rpcWebSocketMaxAggregatedFrameSize() {
+        return configFromFiles.getInt(PROPERTY_RPC_WEBSOCKET_SERVER_MAX_AGGREGATED_FRAME_SIZE);
     }
 
     public InetAddress rpcHttpBindAddress() {

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -221,6 +221,8 @@ rpc = {
                 bind_address = <bind_address>
                 port = <port>
                 server_write_timeout_seconds = <timeout>
+                max_aggregated_frame_size = <frame_size_bytes>
+                max_frame_size = <frame_size_bytes>
             }
         }
     }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -284,6 +284,8 @@ rpc {
                 port = 4445
                 # Shuts down the server when it's not able to write a response after a certain period (expressed in seconds)
                 server_write_timeout_seconds = 30
+                max_aggregated_frame_size = 5242880 # 5 mb, a chunked request can accumulate data up to this frame size
+                max_frame_size = 65536 # 64 kb, maximum supported frame size
             }
         }
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
@@ -55,6 +55,8 @@ public class Web3WebSocketServerTest {
     private static JsonNodeFactory JSON_NODE_FACTORY = JsonNodeFactory.instance;
     private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final int DEFAULT_WRITE_TIMEOUT_SECONDS = 30;
+    private static final int DEFAULT_MAX_FRAME_SIZE = 65536; // 64 kb
+    private static final int DEFAULT_MAX_AGGREGATED_FRAME_SIZE = 5242880; // 5 mb
 
     private ExecutorService wsExecutor;
 
@@ -91,15 +93,21 @@ public class Web3WebSocketServerTest {
         RskWebSocketJsonRpcHandler handler = new RskWebSocketJsonRpcHandler(null, new JacksonBasedRpcSerializer());
         JsonRpcWeb3ServerHandler serverHandler = new JsonRpcWeb3ServerHandler(web3Mock, filteredModules);
         int serverWriteTimeoutSeconds = testSystemProperties.rpcWebSocketServerWriteTimeoutSeconds();
+        int maxFrameSize = testSystemProperties.rpcWebSocketMaxFrameSize();
+        int maxAggregatedFrameSize = testSystemProperties.rpcWebSocketMaxAggregatedFrameSize();
 
         assertEquals(DEFAULT_WRITE_TIMEOUT_SECONDS, serverWriteTimeoutSeconds);
+        assertEquals(DEFAULT_MAX_FRAME_SIZE, maxFrameSize);
+        assertEquals(DEFAULT_MAX_AGGREGATED_FRAME_SIZE, maxAggregatedFrameSize);
 
         Web3WebSocketServer websocketServer = new Web3WebSocketServer(
                 InetAddress.getLoopbackAddress(),
                 randomPort,
                 handler,
                 serverHandler,
-                serverWriteTimeoutSeconds
+                serverWriteTimeoutSeconds,
+                maxFrameSize,
+                maxAggregatedFrameSize
         );
         websocketServer.start();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
@@ -65,6 +65,20 @@ public class Web3WebSocketServerTest {
 
     @Test
     public void smokeTest() throws Exception {
+        smokeTest(getJsonRpcDummyMessage("value"));
+    }
+
+    @Test
+    public void smokeTestWithBigJson() throws Exception {
+        smokeTest(getJsonRpcBigMessage());
+    }
+
+    @After
+    public void tearDown() {
+        wsExecutor.shutdown();
+    }
+
+    private void smokeTest(byte [] msg) throws Exception {
         Web3 web3Mock = mock(Web3.class);
         String mockResult = "output";
         when(web3Mock.web3_sha3(anyString())).thenReturn(mockResult);
@@ -103,7 +117,7 @@ public class Web3WebSocketServerTest {
             @Override
             public void onOpen(WebSocket webSocket, Response response) {
                 wsExecutor.submit(() -> {
-                    RequestBody body = RequestBody.create(WebSocket.TEXT, getJsonRpcDummyMessage());
+                    RequestBody body = RequestBody.create(WebSocket.TEXT, msg);
                     try {
                         this.webSocket = webSocket;
                         this.webSocket.sendMessage(body);
@@ -154,17 +168,12 @@ public class Web3WebSocketServerTest {
         }
     }
 
-    @After
-    public void tearDown() {
-        wsExecutor.shutdown();
-    }
-
-    private byte[] getJsonRpcDummyMessage() {
+    private byte[] getJsonRpcDummyMessage(String value) {
         Map<String, JsonNode> jsonRpcRequestProperties = new HashMap<>();
         jsonRpcRequestProperties.put("jsonrpc", JSON_NODE_FACTORY.textNode("2.0"));
         jsonRpcRequestProperties.put("id", JSON_NODE_FACTORY.numberNode(13));
         jsonRpcRequestProperties.put("method", JSON_NODE_FACTORY.textNode("web3_sha3"));
-        jsonRpcRequestProperties.put("params", JSON_NODE_FACTORY.arrayNode().add("value"));
+        jsonRpcRequestProperties.put("params", JSON_NODE_FACTORY.arrayNode().add(value));
 
         byte[] request = new byte[0];
         try {
@@ -175,5 +184,13 @@ public class Web3WebSocketServerTest {
         }
         return request;
 
+    }
+
+    private byte[] getJsonRpcBigMessage() {
+        StringBuilder s = new StringBuilder();
+        for (int i = 0; i < 55; i++) {
+            s.append("thisisabigmessagethatwillbesentchunked");
+        }
+        return getJsonRpcDummyMessage(s.toString());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR intends to solve a bug when processing incomplete or chunked requests received through the Websocket endpoint.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR aims to provide a solution to a bug causing chunked requests sent to the Rskj WebSocket Endpoint to be treated as separate requests.

This bug was discovered when using the official Ethereum Go client to send a transaction. The geth client sends data > 1024 bytes in chunks. That caused the Web3WebSocketServer to read every chunk of 1024 bytes as a new request, failing in consequence to process it as a valid json.

Adding the WebsocketFrameAggregator handler to the pipeline provides a way to properly handle those chunked requests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This patch was tested using geth client with successful results

A new test was added in Web3WebSocketServerTest.java called smokeTestWithBigJson that uses the same logic that the original smokeTest, but generates a JSON message that exceeds 2048 bytes (OkHttpClient buffer) so it gets sent chunked to the WebSocket Server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
https://netty.io/4.0/api/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.html