### PR TITLE
Adapt expected failing tests from release candidate

### DIFF
--- a/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
@@ -22,7 +22,6 @@ import co.rsk.bitcoinj.core.BtcBlock;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.util.TimeProvider;
-import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcBlock;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.util.TimeProvider;
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
@@ -18,6 +18,7 @@
 
 package co.rsk.core.bc;
 
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.StateRootHandler;
@@ -35,7 +36,7 @@ import java.util.HashMap;
  */
 public class BlockValidatorBuilder {
 
-    private final TestSystemProperties config = new TestSystemProperties();
+    private final TestSystemProperties config;
 
     private BlockTxsValidationRule blockTxsValidationRule;
 
@@ -58,6 +59,14 @@ public class BlockValidatorBuilder {
     private BlockParentCompositeRule blockParentCompositeRule;
 
     private BlockStore blockStore;
+
+    public BlockValidatorBuilder(TestSystemProperties customConfig) {
+        this.config = customConfig;
+    }
+
+    public BlockValidatorBuilder() {
+        this.config = new TestSystemProperties();
+    }
 
     public BlockValidatorBuilder addBlockTxsFieldsValidationRule() {
         this.blockTxsFieldsValidationRule = new BlockTxsFieldsValidationRule();
@@ -130,5 +139,12 @@ public class BlockValidatorBuilder {
         }
 
         return new BlockValidatorImpl(this.blockStore, this.blockParentCompositeRule, this.blockCompositeRule);
+    }
+
+    public BlockValidatorBuilder addBlockTimeStampValidationWithNetworkParameters(int validPeriod, NetworkParameters bitcoinNetworkParameters) {
+        BlockTimeStampValidationRule blockTimeStampValidationRule = new BlockTimeStampValidationRule(
+                validPeriod, config.getActivationConfig(), System::currentTimeMillis, bitcoinNetworkParameters);
+        this.blockTimeStampValidationRule = blockTimeStampValidationRule;
+        return this;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -685,7 +685,7 @@ public class BlockValidatorTest {
         Block genesis = blockGenerator.getGenesisBlock();
         byte[] bitcoinMergedMiningHeader = new byte[0];
         int validPeriod = 6000;
-        long baseTimeStamp = System.currentTimeMillis() / 1000;
+        long baseTimeStamp = 1627932722; // some random timestamp (taken from Sys.currentTimeMills())
 
         BlockHeader header = mock(BlockHeader.class);
         when(header.getBitcoinMergedMiningHeader()).thenReturn(bitcoinMergedMiningHeader);

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -18,6 +18,10 @@
 
 package co.rsk.core.bc;
 
+import co.rsk.bitcoinj.core.BitcoinSerializer;
+import co.rsk.bitcoinj.core.BtcBlock;
+import co.rsk.bitcoinj.core.MessageSerializer;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.BlockDifficulty;
@@ -29,6 +33,7 @@ import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.validators.BlockHeaderParentDependantValidationRule;
 import co.rsk.validators.ProofOfWorkRule;
+import com.typesafe.config.ConfigValueFactory;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.core.*;
@@ -43,8 +48,8 @@ import org.powermock.reflect.Whitebox;
 import java.math.BigInteger;
 import java.util.*;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by ajlopez on 04/08/2016.
@@ -679,25 +684,59 @@ public class BlockValidatorTest {
     public void blockInTheFuture() {
         BlockGenerator blockGenerator = new BlockGenerator();
         Block genesis = blockGenerator.getGenesisBlock();
-
+        byte[] bitcoinMergedMiningHeader = new byte[0];
         int validPeriod = 6000;
+        long baseTimeStamp = System.currentTimeMillis() / 1000;
 
         BlockHeader header = mock(BlockHeader.class);
-        Block block = mock(Block.class);
-        when(block.getHeader()).thenReturn(header);
+        when(header.getBitcoinMergedMiningHeader()).thenReturn(bitcoinMergedMiningHeader);
         when(header.getTimestamp())
-                .thenReturn((System.currentTimeMillis() / 1000) + 2*validPeriod);
-
+                .thenReturn(baseTimeStamp + 2 * validPeriod);
         when(header.getParentHash()).thenReturn(genesis.getHash());
 
-        BlockValidatorImpl validator = new BlockValidatorBuilder()
-                .addBlockTimeStampValidationRule(validPeriod)
+        Block block = mock(Block.class);
+        when(block.getHeader()).thenReturn(header);
+
+        BtcBlock btcBlock = mock(BtcBlock.class);
+        when(btcBlock.getTimeSeconds()).thenReturn(baseTimeStamp + validPeriod - 100); // a close enough block
+
+        MessageSerializer messageSerializer = mock(BitcoinSerializer.class);
+        when(messageSerializer.makeBlock(bitcoinMergedMiningHeader)).thenReturn(btcBlock);
+
+        NetworkParameters bitcoinNetworkParameters = mock(NetworkParameters.class);
+        when(bitcoinNetworkParameters.getDefaultSerializer()).thenReturn(messageSerializer);
+
+        // Before Iris
+        blockTimeStampValidation(validPeriod, baseTimeStamp, header,
+                block, bitcoinNetworkParameters, false);
+
+        //After Iris
+        blockTimeStampValidation(validPeriod, baseTimeStamp, header,
+                block, bitcoinNetworkParameters, true);
+    }
+
+    private TestSystemProperties blockTimeStampValidationProperties(boolean activateIris) {
+        return new TestSystemProperties(rawConfig ->
+                rawConfig.withValue("blockchain.config.hardforkActivationHeights.iris300",
+                        ConfigValueFactory.fromAnyRef(activateIris ? 0 : -1))
+        );
+    }
+
+    private void blockTimeStampValidation(int validPeriod, long baseTimeStamp, BlockHeader header, Block block,
+                                          NetworkParameters bitcoinNetworkParameters, boolean irisEnabled) {
+        TestSystemProperties testSystemProperties = blockTimeStampValidationProperties(irisEnabled);
+
+        BlockValidatorImpl validator = new BlockValidatorBuilder(testSystemProperties)
+                .addBlockTimeStampValidationWithNetworkParameters(validPeriod, bitcoinNetworkParameters)
                 .build();
+
+        when(header.getTimestamp())
+                .thenReturn(baseTimeStamp + 2 * validPeriod);
 
         Assert.assertFalse(validator.isValid(block));
 
         when(header.getTimestamp())
-                .thenReturn((System.currentTimeMillis() / 1000) + validPeriod);
+                .thenReturn(baseTimeStamp + validPeriod);
 
         Assert.assertTrue(validator.isValid(block));
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorTest.java
@@ -48,7 +48,6 @@ import org.powermock.reflect.Whitebox;
 import java.math.BigInteger;
 import java.util.*;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**

--- a/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
@@ -159,10 +159,10 @@ public class DslFilesTest {
     public void runCreateContractAndPreserveBalance() throws FileNotFoundException, DslProcessorException {
         // after rskip174 activation
         DslParser parser = DslParser.fromResource("dsl/create_and_preserve_balance.txt");
-        TestSystemProperties rskip174Active = new TestSystemProperties(rawConfig ->
+        TestSystemProperties rskip174Enabled = new TestSystemProperties(rawConfig ->
                 rawConfig.withValue("blockchain.config.hardforkActivationHeights.iris300", ConfigValueFactory.fromAnyRef(0))
         );
-        World world = new World(rskip174Active);
+        World world = new World(rskip174Enabled);
         WorldDslProcessor processor = new WorldDslProcessor(world);
         processor.processCommands(parser);
 
@@ -171,9 +171,11 @@ public class DslFilesTest {
     @Test
     public void runCreateContractAndPreserveNoBalance() throws FileNotFoundException, DslProcessorException {
         // before rskip174 activation
-        // todo(fedejinich) this test will change when iris300 == 0
+        TestSystemProperties rskip174Disabled = new TestSystemProperties(rawConfig ->
+                rawConfig.withValue("blockchain.config.hardforkActivationHeights.iris300", ConfigValueFactory.fromAnyRef(-1))
+        );
         DslParser parser = DslParser.fromResource("dsl/create_and_preserve_no_balance.txt");
-        World world = new World();
+        World world = new World(rskip174Disabled);
 
         WorldDslProcessor processor = new WorldDslProcessor(world);
         processor.processCommands(parser);

--- a/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
+++ b/rskj-core/src/test/java/co/rsk/test/DslFilesTest.java
@@ -157,20 +157,20 @@ public class DslFilesTest {
 
     @Test
     public void runCreateContractAndPreserveBalance() throws FileNotFoundException, DslProcessorException {
-        // after rskip174 activation
         DslParser parser = DslParser.fromResource("dsl/create_and_preserve_balance.txt");
-        TestSystemProperties rskip174Enabled = new TestSystemProperties(rawConfig ->
-                rawConfig.withValue("blockchain.config.hardforkActivationHeights.iris300", ConfigValueFactory.fromAnyRef(0))
-        );
-        World world = new World(rskip174Enabled);
+        World world = new World();
         WorldDslProcessor processor = new WorldDslProcessor(world);
         processor.processCommands(parser);
 
         Assert.assertEquals(Coin.valueOf(100L), getBalance(world, "6252703f5ba322ec64d3ac45e56241b7d9e481ad"));
     }
+
+    /**
+     * This test covers the expected behavior BEFORE implementing the RSKIP174
+     * https://github.com/rsksmart/RSKIPs/pull/260
+     * */
     @Test
     public void runCreateContractAndPreserveNoBalance() throws FileNotFoundException, DslProcessorException {
-        // before rskip174 activation
         TestSystemProperties rskip174Disabled = new TestSystemProperties(rawConfig ->
                 rawConfig.withValue("blockchain.config.hardforkActivationHeights.iris300", ConfigValueFactory.fromAnyRef(-1))
         );


### PR DESCRIPTION
This PR tries to adapt failing tests from Iris3.0, they came up when we tried to merge the `3.0.0-rc` branch into the master branch, by setting the iris activation as default for the entire test suite:

1. `runCreateContractAndPreserveBalance`: activated Iris by default, no need to provide any custom activations
2. `runCreateContractAndPreserveNoBalance`: as mentioned in the TODO comment, added custom activations to disable Iris network upgrade
3. `blockInTheFuture`: refactored to test the previous and current behavior, providing a valid `bitcoinTimestamp` according to the `validPeriod`