### PR TITLE
decupling message command processing from RSKWireProtocol

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/eth/RskMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/eth/RskMessage.java
@@ -19,8 +19,10 @@
 package co.rsk.net.eth;
 
 import co.rsk.net.messages.Message;
+import io.netty.channel.ChannelHandlerContext;
 import org.ethereum.net.eth.message.EthMessage;
 import org.ethereum.net.eth.message.EthMessageCodes;
+import org.ethereum.net.server.Channel;
 import org.ethereum.util.RLP;
 
 /**
@@ -63,6 +65,11 @@ public class RskMessage extends EthMessage {
         this.encoded = RLP.encodeList(msg);
     }
 
+    @Override
+    public void processCommand(ChannelHandlerContext ctx, Channel channel, RskWireProtocol rskWireProtocol) throws InterruptedException {
+        rskWireProtocol.updateSyncStats(this.getMessage());
+        rskWireProtocol.postMessage(channel, this);
+    }
 
     @Override
     public String toString() {

--- a/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
@@ -217,7 +217,6 @@ public class MessageVisitor {
         if (sender == null) {
             return;
         }
-
         this.peerScoringManager.recordEvent(sender.getPeerNodeID(), sender.getAddress(), event);
     }
 

--- a/rskj-core/src/main/java/org/ethereum/net/eth/message/EthMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/eth/message/EthMessage.java
@@ -19,7 +19,9 @@
 
 package org.ethereum.net.eth.message;
 
+import co.rsk.net.eth.RskWireProtocol;import io.netty.channel.ChannelHandlerContext;
 import org.ethereum.net.message.Message;
+import org.ethereum.net.server.Channel;
 
 public abstract class EthMessage extends Message {
 
@@ -31,4 +33,6 @@ public abstract class EthMessage extends Message {
     }
 
     public abstract EthMessageCodes getCommand();
+
+    public abstract void processCommand(ChannelHandlerContext ctx, Channel channel, RskWireProtocol rskWireProtocol) throws InterruptedException;
 }

--- a/rskj-core/src/main/java/org/ethereum/net/eth/message/StatusMessage.java
+++ b/rskj-core/src/main/java/org/ethereum/net/eth/message/StatusMessage.java
@@ -19,6 +19,9 @@
 
 package org.ethereum.net.eth.message;
 
+import co.rsk.net.eth.RskWireProtocol;
+import io.netty.channel.ChannelHandlerContext;
+import org.ethereum.net.server.Channel;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -146,6 +149,10 @@ public class StatusMessage extends EthMessage {
         return EthMessageCodes.STATUS;
     }
 
+    @Override
+    public void processCommand(ChannelHandlerContext ctx, Channel channel, RskWireProtocol rskWireProtocol) {
+        rskWireProtocol.processStatus(this, ctx);
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
Two small refactors

- Extracted updating sync stats logic (do we even use this class or it can be removed?)
- Decoupled command processing from `RskWireProtocol`, in this PR we take polymorphism advantage and now each `EthMessage` knows how to process commands (instead of using a forced type-switch).