### PR TITLE
Added type arg to CallArguments

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
@@ -28,6 +28,7 @@ public class CallArguments {
     private String data; // compiledCode
     private String nonce;
     private String chainId;
+    private String type;
 
     public String getFrom() {
         return from;
@@ -101,6 +102,14 @@ public class CallArguments {
         this.chainId = chainId;
     }
 
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
     @Override
     public String toString() {
         return "CallArguments{" +
@@ -113,6 +122,7 @@ public class CallArguments {
                 ", data='" + data + '\'' +
                 ", nonce='" + nonce + '\'' +
                 ", chainId='" + chainId + '\'' +
+                ", type='" + type + '\'' +
                 '}';
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
@@ -28,7 +28,7 @@ public class CallArguments {
     private String data; // compiledCode
     private String nonce;
     private String chainId;
-    private String type;
+    private String type; // ignore, see https://github.com/rsksmart/rskj/pull/1601
 
     public String getFrom() {
         return from;

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -174,8 +174,9 @@ public class Web3RskImplTest {
         callArguments.setData("data");
         callArguments.setNonce("0");
         callArguments.setChainId("0x00");
+        callArguments.setType("0x00");
 
-        assertEquals("CallArguments{from='0x1', to='0x2', gas='21000', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0', chainId='0x00'}", callArguments.toString());
+        assertEquals("CallArguments{from='0x1', to='0x2', gas='21000', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0', chainId='0x00', type='0x00'}", callArguments.toString());
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As some js libraries started to send `type` parameter in JSON-RPC calls that expect call arguments (e.g. `eth_sendTransaction` or `eth_estimateGas`), this causes some tests that are using these libraries to fail. This change introduces `type` as expected, non-required field which is simply being ignored.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Motivation behind this is to prevent failing of those JSON-RPC endpoints when the `type` field is being provided by a client.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
