### PR TITLE
Added type arg

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -41,6 +41,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String value;
         public String data; // compiledCode
         public String nonce;
+        public String type;
 
         @Override
         public String toString() {
@@ -52,6 +53,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
                     ", value='" + value + '\'' +
                     ", data='" + data + '\'' +
                     ", nonce='" + nonce + '\'' +
+                    ", type='" + type + '\'' +
                     '}';
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -41,7 +41,7 @@ public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, 
         public String value;
         public String data; // compiledCode
         public String nonce;
-        public String type;
+        public String type; //NOSONAR
 
         @Override
         public String toString() {

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -174,8 +174,9 @@ public class Web3RskImplTest {
         callArguments.value = "1";
         callArguments.data = "data";
         callArguments.nonce = "0";
+        callArguments.type = "0";
 
-        Assert.assertEquals(callArguments.toString(), "CallArguments{from='0x1', to='0x2', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0'}");
+        Assert.assertEquals(callArguments.toString(), "CallArguments{from='0x1', to='0x2', gasLimit='21000', gasPrice='100', value='1', data='data', nonce='0', type='0'}");
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As some js libraries started to send type parameter in JSON-RPC calls that expect call arguments (e.g. eth_sendTransaction or eth_estimateGas), this causes some tests that are using these libraries to fail. This change introduces type as expected, non-required field which is simply being ignored.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Motivation behind this is to prevent failing of those JSON-RPC endpoints when the type field is being provided by a client.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
