### PR TITLE
add control to message queue size by peer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ rskj-core/java/
 #GradleJARS
 rskj-core/libs/gradle-witness.jar
 rskj-core/libs/rsk-gradle-witness.jar
+rskj-core/networkStateExporterTest.json
 gradle/wrapper/gradle-wrapper.jar
 
 #Classes

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -385,4 +385,8 @@ public class RskSystemProperties extends SystemProperties {
     public boolean fastBlockPropagation() {
         return configFromFiles.getBoolean("peer.fastBlockPropagation");
     }
+
+    public Integer getMessageQueueMaxSize() {
+    	return configFromFiles.getInt("peer.messageQueue.maxSizePerPeer");
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
+++ b/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net;
 
 import java.util.Map;
@@ -10,37 +27,38 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class MessageCounter {
 
-	private static final AtomicInteger ZERO = new AtomicInteger(0);
+    private static final AtomicInteger ZERO = new AtomicInteger(0);
 
-	private Map<NodeID, AtomicInteger> messagesPerNode = new ConcurrentHashMap<>();			
-    
+    private Map<NodeID, AtomicInteger> messagesPerNode = new ConcurrentHashMap<>();
+
     public int getValue(Peer sender) {
-    	return Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID())).orElse(ZERO).intValue();
+        return Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID())).orElse(ZERO).intValue();
     }
-    
+
     public void increment(Peer sender) {
-    	messagesPerNode
-    		.computeIfAbsent(sender.getPeerNodeID(), this::createAtomicInteger)
-    		.incrementAndGet();
+        messagesPerNode
+            .computeIfAbsent(sender.getPeerNodeID(), this::createAtomicInteger)
+            .incrementAndGet();
     }
-    
+
     private AtomicInteger createAtomicInteger(NodeID nodeId) {
-    	return new AtomicInteger();
+        return new AtomicInteger();
     }
-    
+
     public void decrement(Peer sender) {
-    	
-    	Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID())).ifPresent(AtomicInteger::decrementAndGet);
-    	
-    	// if this counter is zero or negative: remove key from map
-		Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID()))
-			.filter(counter -> counter.get() < 1)
-			.ifPresent(counter -> messagesPerNode.remove(sender.getPeerNodeID()));
+
+        Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID()))
+            .ifPresent(AtomicInteger::decrementAndGet);
+
+        // if this counter is zero or negative: remove key from map
+        Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID()))
+            .filter(counter -> counter.get() < 1)
+            .ifPresent(counter -> messagesPerNode.remove(sender.getPeerNodeID()));
 
     }
-    
+
     public boolean hasCounter(Peer sender) {
-    	return messagesPerNode.containsKey(sender.getPeerNodeID());
+        return messagesPerNode.containsKey(sender.getPeerNodeID());
     }
-    
+
 }

--- a/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
+++ b/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
@@ -10,10 +10,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class MessageCounter {
 
-    private Map<NodeID, AtomicInteger> messagesPerNode = new ConcurrentHashMap<>();
+	private static final AtomicInteger ZERO = new AtomicInteger(0);
 
-    private static final AtomicInteger ZERO = new AtomicInteger(0);
-			
+	private Map<NodeID, AtomicInteger> messagesPerNode = new ConcurrentHashMap<>();			
     
     public int getValue(Peer sender) {
     	return Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID())).orElse(ZERO).intValue();
@@ -38,6 +37,10 @@ public class MessageCounter {
     		.filter(counter -> counter.get() < 1)
     		.ifPresent(counter -> messagesPerNode.remove(sender.getPeerNodeID()));
 
+    }
+    
+    public boolean hasCounter(Peer sender) {
+    	return messagesPerNode.containsKey(sender.getPeerNodeID());
     }
     
 }

--- a/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
+++ b/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
@@ -1,0 +1,42 @@
+package co.rsk.net;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Keeps the counter of messages per peer
+ */
+public class MessageCounter {
+
+    private Map<NodeID, AtomicInteger> messagesPerNode = new HashMap<>();
+
+    private static final AtomicInteger ZERO = new AtomicInteger(0);
+			
+    
+    public int getValue(Peer sender) {
+    	return Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID())).orElse(ZERO).intValue();
+    }
+    
+    public void increment(Peer sender) {
+    	messagesPerNode.computeIfAbsent(sender.getPeerNodeID(), this::createAtomicInteger);
+    	messagesPerNode.get(sender.getPeerNodeID()).incrementAndGet();
+    }
+    
+    private AtomicInteger createAtomicInteger(NodeID nodeId) {
+    	return new AtomicInteger();
+    }
+    
+    public void decrement(Peer sender) {
+    	
+    	Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID())).ifPresent(AtomicInteger::decrementAndGet);
+    	
+    	// if this counter is zero or negative: remove key from map
+    	Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID()))
+    		.filter(counter -> counter.get() < 1)
+    		.ifPresent(counter -> messagesPerNode.remove(sender.getPeerNodeID()));
+
+    }
+    
+}

--- a/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
+++ b/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
@@ -1,8 +1,8 @@
 package co.rsk.net;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class MessageCounter {
 
-    private Map<NodeID, AtomicInteger> messagesPerNode = new HashMap<>();
+    private Map<NodeID, AtomicInteger> messagesPerNode = new ConcurrentHashMap<>();
 
     private static final AtomicInteger ZERO = new AtomicInteger(0);
 			
@@ -20,8 +20,9 @@ public class MessageCounter {
     }
     
     public void increment(Peer sender) {
-    	messagesPerNode.computeIfAbsent(sender.getPeerNodeID(), this::createAtomicInteger);
-    	messagesPerNode.get(sender.getPeerNodeID()).incrementAndGet();
+    	messagesPerNode
+    		.computeIfAbsent(sender.getPeerNodeID(), this::createAtomicInteger)
+    		.incrementAndGet();
     }
     
     private AtomicInteger createAtomicInteger(NodeID nodeId) {

--- a/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
+++ b/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
@@ -33,9 +33,9 @@ public class MessageCounter {
     	Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID())).ifPresent(AtomicInteger::decrementAndGet);
     	
     	// if this counter is zero or negative: remove key from map
-    	Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID()))
-    		.filter(counter -> counter.get() < 1)
-    		.ifPresent(counter -> messagesPerNode.remove(sender.getPeerNodeID()));
+		Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID()))
+			.filter(counter -> counter.get() < 1)
+			.ifPresent(counter -> messagesPerNode.remove(sender.getPeerNodeID()));
 
     }
     

--- a/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
+++ b/rskj-core/src/main/java/co/rsk/net/MessageCounter.java
@@ -30,13 +30,14 @@ import org.slf4j.LoggerFactory;
  */
 public class MessageCounter {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MessageCounter.class);
+    private static final Logger logger = LoggerFactory.getLogger(MessageCounter.class);
 
     private static final AtomicInteger ZERO = new AtomicInteger(0);
 
+    private static final String COUNTER_ERROR = "Counter for {} is null or negative: {}.";
+
     private Map<NodeID, AtomicInteger> messagesPerNode = new ConcurrentHashMap<>();
 
-    private static final String COUNTER_ERROR = "Counter for {} is null or negative: {}.";
 
     public int getValue(Peer sender) {
         return Optional.ofNullable(messagesPerNode.get(sender.getPeerNodeID())).orElse(ZERO).intValue();
@@ -58,7 +59,7 @@ public class MessageCounter {
         AtomicInteger cnt = messagesPerNode.get(peerNodeID);
 
         if(cnt == null || cnt.get() < 0) {
-            LOG.error(COUNTER_ERROR, peerNodeID, cnt);
+            logger.error(COUNTER_ERROR, peerNodeID, cnt);
             return;
         }
 

--- a/rskj-core/src/main/java/co/rsk/net/NodeMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeMessageHandler.java
@@ -227,7 +227,7 @@ public class NodeMessageHandler implements MessageHandler, InternalService, Runn
 			logger.trace("Received message already known, not added to the queue");
 		}
 
-		return (contains == false);
+		return !contains;
 	}
 
 	private void addMessage(Peer sender, Message message, double score) {

--- a/rskj-core/src/main/java/co/rsk/net/NodeMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeMessageHandler.java
@@ -111,6 +111,9 @@ public class NodeMessageHandler implements MessageHandler, InternalService, Runn
      * @param message the message to be processed.
      */
     public synchronized void processMessage(final Peer sender, @Nonnull final Message message) {
+
+        messageCounter.decrement(sender);
+
         long start = System.nanoTime();
         MessageType messageType = message.getMessageType();
         logger.trace("Process message type: {}", messageType);
@@ -127,7 +130,6 @@ public class NodeMessageHandler implements MessageHandler, InternalService, Runn
             loggerMessageProcess.debug("Message[{}] processed after [{}] seconds.", message.getMessageType(), timeInSeconds);
         }
 
-        messageCounter.decrement(sender);
     }
 
     @Override

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -118,6 +118,7 @@ peer = {
     bannedPeerIPs = []
     bannedPeerIDs = []
     bannedMiners = []
+    messageQueue.maxSizePerPeer = <mazSize>
 }
 genesis = <genesis>
 genesis_constants.federationPublicKeys = []

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -118,7 +118,7 @@ peer = {
     bannedPeerIPs = []
     bannedPeerIDs = []
     bannedMiners = []
-    messageQueue.maxSizePerPeer = <mazSize>
+    messageQueue.maxSizePerPeer = <maxSize>
 }
 genesis = <genesis>
 genesis_constants.federationPublicKeys = []

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -130,6 +130,10 @@ peer {
 
     # list of banned miners
     bannedMiners = []
+
+    # Max number of pending messages that will be allowed per peer 
+    messageQueue.maxSizePerPeer = 2000
+
 }
 
 miner {

--- a/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
@@ -1,0 +1,26 @@
+package co.rsk.net;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import co.rsk.net.simples.SimplePeer;
+
+
+public class MessageCounterTest {
+
+	
+	@Test
+	public void decrement_toBelowOne_thenRemoveKey() {
+	
+		SimplePeer sender = new SimplePeer(new NodeID(new byte[] {1}));
+		
+		MessageCounter counter = new MessageCounter();
+		
+		counter.increment(sender);
+		counter.decrement(sender);
+		
+		Assert.assertFalse(counter.hasCounter(sender));
+		
+	}
+	
+}

--- a/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
@@ -1,5 +1,11 @@
 package co.rsk.net;
 
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,5 +43,97 @@ public class MessageCounterTest {
 		
 		Assert.assertEquals(1, counter.getValue(sender));
 	}
+
+	@Test
+	public void givenConcurrentCalls_then_expectCorrectCount() throws InterruptedException {
+
+		/**
+		 *  this queue will be added with a '+' when the counter is incremented
+		 *  and added with a '-' when the counter is decremented
+		 */
+		ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
+
+		ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(3);
+
+		SimplePeer sender = new SimplePeer(new NodeID(new byte[] {1}));
+
+		MessageCounter counter = new MessageCounter();
+
+		Thread inc1 = new Thread(new Incrementer(counter, sender, executor, queue));
+		Thread inc2 = new Thread(new Incrementer(counter, sender, executor, queue));
+		Thread inc3 = new Thread(new Incrementer(counter, sender, executor, queue));
+
+		inc1.start();
+		inc2.start();
+		inc3.start();
+
+		inc1.join();
+		inc2.join();
+		inc3.join();
+
+		executor.shutdown();
+
+		executor.awaitTermination(30, TimeUnit.SECONDS);
+
+		int changeCount = countConcurrency(queue);
+
+		// assert we had more than a 100 proofs of concurrency
+		Assert.assertThat(changeCount, greaterThan(100));
+		
+		// counter must be zero at this point
+		Assert.assertEquals(0, counter.getValue(sender));
+	}
+
+	/**
+	 * process the queue to count how many times we had a change in signal which means
+	 * that increment and decrement are been called concurrently
+	 * 
+	 * ++++++++------+++++-----
+	 */
+	private int countConcurrency(ConcurrentLinkedQueue<String> queue) {
+		int changeCount = 0;
+		String lastSignal = null;
+		while(!queue.isEmpty()) {
+			String signal = queue.poll();
+			// skip the first and last interactions
+			if(lastSignal != null && signal != null && !signal.equals(lastSignal)) {
+				changeCount++;
+			}
+			lastSignal = signal;
+		}
+		return changeCount;
+	}
 	
+	private static class Incrementer implements Runnable {
+
+		private MessageCounter counter;
+		private SimplePeer sender;
+		private ScheduledThreadPoolExecutor executor;
+		private ConcurrentLinkedQueue<String> queue;
+
+		public Incrementer(MessageCounter counter, SimplePeer sender, ScheduledThreadPoolExecutor executor, ConcurrentLinkedQueue<String> queue) {
+			this.counter = counter;
+			this.sender = sender;
+			this.executor = executor;
+			this.queue = queue;
+		}
+
+		@Override
+		public void run() {
+			
+			for(int i = 0; i < 100_000; i++) {
+				counter.increment(sender);
+				queue.add("+");
+				executor.schedule(() -> {
+					counter.decrement(sender);
+					queue.add("-");
+				}, 5, TimeUnit.MILLISECONDS);
+			}
+
+		}
+
+	}
+
+
+
 }

--- a/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
@@ -22,5 +22,20 @@ public class MessageCounterTest {
 		Assert.assertFalse(counter.hasCounter(sender));
 		
 	}
+
+	@Test
+	public void decrement() {
+
+		SimplePeer sender = new SimplePeer(new NodeID(new byte[] {1}));
+		
+		MessageCounter counter = new MessageCounter();
+		
+		counter.increment(sender);
+		counter.increment(sender);
+		
+		counter.decrement(sender);
+		
+		Assert.assertTrue(counter.getValue(sender) == 1);
+	}
 	
 }

--- a/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
@@ -35,7 +35,7 @@ public class MessageCounterTest {
 		
 		counter.decrement(sender);
 		
-		Assert.assertTrue(counter.getValue(sender) == 1);
+		Assert.assertEquals(1, counter.getValue(sender));
 	}
 	
 }

--- a/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/MessageCounterTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net;
 
 import static org.hamcrest.number.OrderingComparison.greaterThan;
@@ -11,129 +28,125 @@ import org.junit.Test;
 
 import co.rsk.net.simples.SimplePeer;
 
-
 public class MessageCounterTest {
 
-	
-	@Test
-	public void decrement_toBelowOne_thenRemoveKey() {
-	
-		SimplePeer sender = new SimplePeer(new NodeID(new byte[] {1}));
-		
-		MessageCounter counter = new MessageCounter();
-		
-		counter.increment(sender);
-		counter.decrement(sender);
-		
-		Assert.assertFalse(counter.hasCounter(sender));
-		
-	}
+    @Test
+    public void decrement_toBelowOne_thenRemoveKey() {
 
-	@Test
-	public void decrement() {
+        SimplePeer sender = new SimplePeer(new NodeID(new byte[] { 1 }));
 
-		SimplePeer sender = new SimplePeer(new NodeID(new byte[] {1}));
-		
-		MessageCounter counter = new MessageCounter();
-		
-		counter.increment(sender);
-		counter.increment(sender);
-		
-		counter.decrement(sender);
-		
-		Assert.assertEquals(1, counter.getValue(sender));
-	}
+        MessageCounter counter = new MessageCounter();
 
-	@Test
-	public void givenConcurrentCalls_then_expectCorrectCount() throws InterruptedException {
+        counter.increment(sender);
+        counter.decrement(sender);
 
-		/**
-		 *  this queue will be added with a '+' when the counter is incremented
-		 *  and added with a '-' when the counter is decremented
-		 */
-		ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
+        Assert.assertFalse(counter.hasCounter(sender));
 
-		ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(3);
+    }
 
-		SimplePeer sender = new SimplePeer(new NodeID(new byte[] {1}));
+    @Test
+    public void decrement() {
 
-		MessageCounter counter = new MessageCounter();
+        SimplePeer sender = new SimplePeer(new NodeID(new byte[] { 1 }));
 
-		Thread inc1 = new Thread(new Incrementer(counter, sender, executor, queue));
-		Thread inc2 = new Thread(new Incrementer(counter, sender, executor, queue));
-		Thread inc3 = new Thread(new Incrementer(counter, sender, executor, queue));
+        MessageCounter counter = new MessageCounter();
 
-		inc1.start();
-		inc2.start();
-		inc3.start();
+        counter.increment(sender);
+        counter.increment(sender);
 
-		inc1.join();
-		inc2.join();
-		inc3.join();
+        counter.decrement(sender);
 
-		executor.shutdown();
+        Assert.assertEquals(1, counter.getValue(sender));
+    }
 
-		executor.awaitTermination(30, TimeUnit.SECONDS);
+    @Test
+    public void givenConcurrentCalls_then_expectCorrectCount() throws InterruptedException {
 
-		int changeCount = countConcurrency(queue);
+        /**
+         *  this queue will be added with a '+' when the counter is incremented
+         *  and added with a '-' when the counter is decremented
+         */
+        ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>();
 
-		// assert we had more than a 100 proofs of concurrency
-		Assert.assertThat(changeCount, greaterThan(100));
-		
-		// counter must be zero at this point
-		Assert.assertEquals(0, counter.getValue(sender));
-	}
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(3);
 
-	/**
-	 * process the queue to count how many times we had a change in signal which means
-	 * that increment and decrement are been called concurrently
-	 * 
-	 * ++++++++------+++++-----
-	 */
-	private int countConcurrency(ConcurrentLinkedQueue<String> queue) {
-		int changeCount = 0;
-		String lastSignal = null;
-		while(!queue.isEmpty()) {
-			String signal = queue.poll();
-			// skip the first and last interactions
-			if(lastSignal != null && signal != null && !signal.equals(lastSignal)) {
-				changeCount++;
-			}
-			lastSignal = signal;
-		}
-		return changeCount;
-	}
-	
-	private static class Incrementer implements Runnable {
+        SimplePeer sender = new SimplePeer(new NodeID(new byte[] { 1 }));
 
-		private MessageCounter counter;
-		private SimplePeer sender;
-		private ScheduledThreadPoolExecutor executor;
-		private ConcurrentLinkedQueue<String> queue;
+        MessageCounter counter = new MessageCounter();
 
-		public Incrementer(MessageCounter counter, SimplePeer sender, ScheduledThreadPoolExecutor executor, ConcurrentLinkedQueue<String> queue) {
-			this.counter = counter;
-			this.sender = sender;
-			this.executor = executor;
-			this.queue = queue;
-		}
+        Thread inc1 = new Thread(new Incrementer(counter, sender, executor, queue));
+        Thread inc2 = new Thread(new Incrementer(counter, sender, executor, queue));
+        Thread inc3 = new Thread(new Incrementer(counter, sender, executor, queue));
 
-		@Override
-		public void run() {
-			
-			for(int i = 0; i < 100_000; i++) {
-				counter.increment(sender);
-				queue.add("+");
-				executor.schedule(() -> {
-					counter.decrement(sender);
-					queue.add("-");
-				}, 5, TimeUnit.MILLISECONDS);
-			}
+        inc1.start();
+        inc2.start();
+        inc3.start();
 
-		}
+        inc1.join();
+        inc2.join();
+        inc3.join();
 
-	}
+        executor.shutdown();
 
+        executor.awaitTermination(30, TimeUnit.SECONDS);
 
+        int changeCount = countConcurrency(queue);
+
+        // assert we had more than a 100 proofs of concurrency
+        Assert.assertThat(changeCount, greaterThan(100));
+
+        // counter must be zero at this point
+        Assert.assertEquals(0, counter.getValue(sender));
+    }
+
+    /**
+     * process the queue to count how many times we had a change in signal which means
+     * that increment and decrement are been called concurrently
+     * 
+     * ++++++++------+++++-----
+     */
+    private int countConcurrency(ConcurrentLinkedQueue<String> queue) {
+        int changeCount = 0;
+        String lastSignal = null;
+        while (!queue.isEmpty()) {
+            String signal = queue.poll();
+            // skip the first and last interactions
+            if (lastSignal != null && signal != null && !signal.equals(lastSignal)) {
+                changeCount++;
+            }
+            lastSignal = signal;
+        }
+        return changeCount;
+    }
+
+    private static class Incrementer implements Runnable {
+
+        private MessageCounter counter;
+        private SimplePeer sender;
+        private ScheduledThreadPoolExecutor executor;
+        private ConcurrentLinkedQueue<String> queue;
+
+        public Incrementer(MessageCounter counter, SimplePeer sender, ScheduledThreadPoolExecutor executor, ConcurrentLinkedQueue<String> queue) {
+            this.counter = counter;
+            this.sender = sender;
+            this.executor = executor;
+            this.queue = queue;
+        }
+
+        @Override
+        public void run() {
+
+            for (int i = 0; i < 100_000; i++) {
+                counter.increment(sender);
+                queue.add("+");
+                executor.schedule(() -> {
+                    counter.decrement(sender);
+                    queue.add("-");
+                }, 5, TimeUnit.MILLISECONDS);
+            }
+
+        }
+
+    }
 
 }

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -678,7 +678,9 @@ public class NodeMessageHandlerTest {
         Message message = mock(Message.class);
         Mockito.when(message.getMessageType()).thenReturn(MessageType.NEW_BLOCK_HASHES);
 
-        handler.processMessage(null, message);
+        final SimplePeer sender = new SimplePeer(new NodeID(new byte[] {1}));
+        
+        handler.processMessage(sender, message);
 
         verify(blockProcessor, never()).processNewBlockHashesMessage(any(), any());
     }
@@ -854,6 +856,33 @@ public class NodeMessageHandlerTest {
                 Collections.emptyList(),
                 Collections.emptyList()
         );
+    }
+    
+    @Test
+    public void fillMessageQueue_thenBlockNewMessages() throws UnknownHostException {
+     
+    	TransactionGateway transactionGateway = mock(TransactionGateway.class);
+        BlockProcessor blockProcessor = mock(BlockProcessor.class);
+        Mockito.when(blockProcessor.hasBetterBlockToSync()).thenReturn(false);
+
+        final NodeMessageHandler handler = new NodeMessageHandler(config, blockProcessor, null, null, transactionGateway, RskMockFactory.getPeerScoringManager(),
+                mock(StatusResolver.class));
+
+        final SimplePeer sender = new SimplePeer(new NodeID(new byte[] {1}));
+    
+        // Add more than the queue supports
+        int numMsgToAdd = config.getMessageQueueMaxSize() + 50;
+        for(int i = 0; i < numMsgToAdd; i++) {
+        	
+        	final TransactionsMessage message = new TransactionsMessage(TransactionUtils.getTransactions(1));
+        
+        	handler.postMessage(sender, message);
+        	
+        }
+        
+        // assert that the surplus was not added
+        Assert.assertEquals(config.getMessageQueueMaxSize(), handler.getMessageQueueSize(sender));
+        
     }
 }
 

--- a/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/NodeMessageHandlerTest.java
@@ -881,7 +881,7 @@ public class NodeMessageHandlerTest {
         }
         
         // assert that the surplus was not added
-        Assert.assertEquals(config.getMessageQueueMaxSize(), handler.getMessageQueueSize(sender));
+        Assert.assertEquals(config.getMessageQueueMaxSize(), (Integer) handler.getMessageQueueSize(sender));
         
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
@@ -18,6 +18,10 @@
 
 package co.rsk.net.utils;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
 import org.ethereum.core.Account;
@@ -27,20 +31,16 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.Utils;
 
-import java.math.BigInteger;
-import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Created by ajlopez on 7/22/2016.
  */
 public class TransactionUtils {
+	
     public static List<Transaction> getTransactions(int n) {
         List<Transaction> txs = new ArrayList<>();
 
         for (long k = 0; k < n; k++)
-            txs.add(createTransaction(getPrivateKeyBytes(), getAddress(), BigInteger.valueOf(Utils.getRandom().nextInt(2000)), BigInteger.valueOf(k)));
+            txs.add(createTransaction(getPrivateKeyBytes(k), getAddress(), BigInteger.valueOf(k + 1), BigInteger.valueOf(k)));
 
         return txs;
     }
@@ -51,7 +51,12 @@ public class TransactionUtils {
     }
 
     public static byte[] getPrivateKeyBytes() {
-        return HashUtil.keccak256(SecureRandom.getSeed(15));
+    	return getPrivateKeyBytes(0L);
+    }
+    
+    public static byte[] getPrivateKeyBytes(long salt) {
+    	String seed = "this is a seed" + Long.toString(salt);
+        return HashUtil.keccak256(seed.getBytes());
     }
 
     public static Transaction createTransaction(byte[] privateKey, String toAddress, BigInteger value, BigInteger nonce) {

--- a/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
+++ b/rskj-core/src/test/java/co/rsk/net/utils/TransactionUtils.java
@@ -28,6 +28,7 @@ import org.ethereum.util.ByteUtil;
 import org.ethereum.util.Utils;
 
 import java.math.BigInteger;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class TransactionUtils {
         List<Transaction> txs = new ArrayList<>();
 
         for (long k = 0; k < n; k++)
-            txs.add(createTransaction(getPrivateKeyBytes(), getAddress(), BigInteger.valueOf(k + 1), BigInteger.valueOf(k)));
+            txs.add(createTransaction(getPrivateKeyBytes(), getAddress(), BigInteger.valueOf(Utils.getRandom().nextInt(2000)), BigInteger.valueOf(k)));
 
         return txs;
     }
@@ -50,7 +51,7 @@ public class TransactionUtils {
     }
 
     public static byte[] getPrivateKeyBytes() {
-        return HashUtil.keccak256("this is a seed".getBytes());
+        return HashUtil.keccak256(SecureRandom.getSeed(15));
     }
 
     public static Transaction createTransaction(byte[] privateKey, String toAddress, BigInteger value, BigInteger nonce) {

--- a/rskj-core/src/test/java/co/rsk/util/CacheElementTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/CacheElementTest.java
@@ -15,7 +15,7 @@ public class CacheElementTest {
         CacheElement<String> cacheElement1 = new CacheElement<>("value.1", 1L);
         CacheElement<String> cacheElement2 = new CacheElement<>("value.2", 10000L);
 
-        await().atMost(200L, TimeUnit.MILLISECONDS).untilAsserted(() -> assertTrue(cacheElement1.hasExpired()));
+        await().atMost(500L, TimeUnit.MILLISECONDS).untilAsserted(() -> assertTrue(cacheElement1.hasExpired()));
         assertFalse(cacheElement2.hasExpired());
     }
 


### PR DESCRIPTION
add control to message queue size by peer

## Description

## Motivation and Context
To avoid overflow of messages if the local node is to busy processing

## How Has This Been Tested?
unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
