### PR TITLE
Removed Jcenter() from gradle repositories

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -31,7 +31,6 @@ tasks.withType(Javadoc) {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://deps.rsklabs.io"
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`Jcenter()` repository was removed from gradle dependencies

## Motivation and Context
On February 3 2021, JFrog announced that they will be shutting down Bintray and JCenter. 

Based on the current timeline, builds that use JCenter will be able to resolve dependencies until February 1, 2022 without changes. After that date, there are no guarantees that you will be able to build your software if you continue to use JCenter.

Some details are here, here and here.

The place where it’s been in use in RskJ

UPDATE 4/27/2021: We listened to the community and will keep JCenter as a read-only repository indefinitely. Our customers and the community can continue to rely on JCenter as a reliable mirror for Java packages.

it looks like that JCenter is gonna provide read-only access to already published dependencies even after Feb 1, 2022, but I believe that it’d be better to migrate away from it in any way due to potential degradation of quality of their service.

## How Has This Been Tested?
Just ran it locally by building the project using `gradlew build` and then running the .jar `/rskj-core/build/libs/rskj-core-3.1.0-SNAPSHOT-all.jar co.rsk.Start`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
