### PR TITLE
web3_sha3 decode hex value on jsonrpc call (compatibility)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/util/HexUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/HexUtils.java
@@ -1,0 +1,294 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.util;
+
+
+import co.rsk.core.Coin;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.util.ByteUtil;
+
+import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+/**
+ * Hex utils
+ */
+public class HexUtils {
+	
+    private static final Pattern LEADING_ZEROS_PATTERN = Pattern.compile("0x(0)+");
+
+    private static final String HEX_PREFIX = "0x";
+
+    private static final byte[] HEX_PREFIX_BYTE_ARRAY = HEX_PREFIX.getBytes();
+
+    private static final byte[] ZERO_BYTE_ARRAY = "0".getBytes();
+    
+    private HexUtils() {
+        throw new IllegalAccessError("Utility class");
+    }
+
+    public static BigInteger stringNumberAsBigInt(String input) {
+        if (hasHexPrefix(input)) {
+            return HexUtils.stringHexToBigInteger(input);
+        } else {
+            return HexUtils.stringDecimalToBigInteger(input);
+        }
+    }
+
+    public static BigInteger stringHexToBigInteger(String input) {
+        if(!hasHexPrefix(input)) {
+            throw new NumberFormatException("Invalid hex number, expected 0x prefix");
+        }
+        String hexa = input.substring(2);
+        return new BigInteger(hexa, 16);
+    }
+
+    private static BigInteger stringDecimalToBigInteger(String input) {
+        return new BigInteger(input);
+    }
+
+    public static byte[] stringHexToByteArray(final String param) {
+        
+    	String result = removeHexPrefix(param);
+        
+        if (result.length() % 2 != 0) {
+            result = "0" + result;
+        }
+        return Hex.decode(result);
+    }
+
+    public static byte[] stringToByteArray(String input) {
+        return input.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public static String toJsonHex(byte[] x) {
+        String result = toUnformattedJsonHex(x);
+
+        if (HEX_PREFIX.equals(result)) {
+            return "0x00";
+        }
+
+        return result;
+    }
+
+    public static String toJsonHex(Coin x) {
+        return x != null ? x.asBigInteger().toString() : "" ;
+    }
+
+    public static String toJsonHex(String x) {
+        return HEX_PREFIX + x;
+    }
+
+    /**
+     * @return A Hex representation of n WITHOUT leading zeroes
+     */
+    public static String toQuantityJsonHex(long n) {
+        return HEX_PREFIX + Long.toHexString(n);
+    }
+
+    /**
+     * @return A Hex representation of n WITHOUT leading zeroes
+     */
+    public static String toQuantityJsonHex(BigInteger n) {
+        return HEX_PREFIX + n.toString(16);
+    }
+
+    /**
+     * Converts a byte array to a string according to ethereum json-rpc specifications, null and empty
+     * convert to 0x.
+     *
+     * @param x An unformatted byte array
+     * @return A hex representation of the input with two hex digits per byte
+     */
+    public static String toUnformattedJsonHex(byte[] x) {
+        return HEX_PREFIX + (x == null ? "" : ByteUtil.toHexString(x));
+    }
+
+    /**
+     * Converts a byte array representing a quantity according to ethereum json-rpc specifications.
+     *
+     * <p>
+     * 0x000AEF -> 0x2AEF
+     * <p>
+     * 0x00 -> 0x0
+     * @param x A hex string with or without leading zeroes ("0x00AEF"). If null, it is considered as zero.
+     * @return A hex string without leading zeroes ("0xAEF")
+     */
+    public static String toQuantityJsonHex(byte[] x) {
+        String withoutLeading = LEADING_ZEROS_PATTERN.matcher(toJsonHex(x)).replaceFirst("0x");
+        if (HEX_PREFIX.equals(withoutLeading)) {
+            return "0x0";
+        }
+
+        return withoutLeading;
+    }
+
+    /**
+     * Converts "0x876AF" to "876AF"
+     */
+    public static String removeZeroX(String str) {
+        return str.substring(2);
+    }
+
+    public static long JSonHexToLong(String x) {
+        if (!hasHexPrefix(x)) {
+            throw new NumberFormatException("Incorrect hex syntax");
+        }
+        x = removeHexPrefix(x);
+        return Long.parseLong(x, 16);
+    }
+
+    /**
+     * if the paramenter has the hex prefix 
+     */
+    public static boolean hasHexPrefix(final String data) {
+    	return data != null && data.startsWith(HEX_PREFIX);
+    }
+    
+    /**
+     * if the paramenter has the hex prefix 
+     */
+    public static boolean hasHexPrefix(final byte[] data) {
+    	
+    	for(int i = 0; i < HEX_PREFIX_BYTE_ARRAY.length; i++) {
+    		if(HEX_PREFIX_BYTE_ARRAY[i] != data[i]) {
+    			return false;
+    		}
+    	}
+    	
+    	return true;
+    }
+    
+    /**
+     * if string is hexadecimal with 0x prefix
+     */
+	public static boolean isHexWithPrefix(final String data) {
+		
+		if(data == null) {
+			return false;
+		} 
+		
+	    String value = data.toLowerCase();
+
+	    if (value.startsWith("-")) {
+	        value = value.substring(1);
+	    }
+	    
+	    if (value.length() <= 2 || !hasHexPrefix(value)) {
+	        return false;
+	    }
+
+	    // start testing after 0x prefix
+	    return isHex(value, 2);
+	}
+	
+	/**
+	 * if a string is composed solely of hexa chars
+	 */
+	public static boolean isHex(final String data) {
+		return isHex(data, 0);
+	}
+	
+	/**
+	 * if a string is composed solely of hexa chars
+	 * Starting at the given index
+	 */
+	public static boolean isHex(final String data, int startAt) {
+		
+	    for (int i = startAt; i < data.length(); i++){
+	        char c = data.charAt(i);
+
+	        if (!(c >= '0' && c <= '9' || c >= 'a' && c <= 'f')) {
+	            return false;
+	        }
+	    }
+		
+	    return true;
+	}
+	
+	/**
+	 * Receives a plain byte array -> converts it to hexa and prepend the 0x  
+	 */
+    public static byte[] encodeToHexByteArray(final byte[] input) {
+    	byte[] encoded = Hex.encode(input);
+    	
+    	byte[] result = new byte[HEX_PREFIX_BYTE_ARRAY.length + encoded.length];
+    	
+        System.arraycopy(HEX_PREFIX_BYTE_ARRAY, 0, result, 0, HEX_PREFIX_BYTE_ARRAY.length);
+        System.arraycopy(encoded, 0, result, HEX_PREFIX_BYTE_ARRAY.length, encoded.length);
+        
+        return result;
+    } 
+    
+    /**
+     * remove Hex Prefix from string
+     */
+	public static String removeHexPrefix(final String data) {
+		String result = data;
+        if (hasHexPrefix(result)) {
+            result = data.substring(2);
+        }
+        return result;
+	}
+	
+    /**
+     * remove Hex Prefix from byte array
+     */
+	public static byte[] removeHexPrefix(final byte[] data) {
+		byte[] result = data;
+		if(hasHexPrefix(data)) {
+		
+			result = new byte[data.length - HEX_PREFIX_BYTE_ARRAY.length];
+		
+        	System.arraycopy(data, HEX_PREFIX_BYTE_ARRAY.length, result, 0, result.length);
+		}
+		
+        return result;
+	}
+	
+	public static byte[] leftPad(final byte[] data) {
+		byte[] result = data;
+        if (data.length % 2 != 0) {
+        	result = new byte[data.length + ZERO_BYTE_ARRAY.length];
+            System.arraycopy(ZERO_BYTE_ARRAY, 0, result, 0, ZERO_BYTE_ARRAY.length);
+            System.arraycopy(data, 0, result, ZERO_BYTE_ARRAY.length, data.length);
+        }
+		
+        return result;
+	}
+
+	public static byte[] decode(byte[] dataBytes) {
+		return Hex.decode(HexUtils.leftPad(HexUtils.removeHexPrefix(dataBytes)));
+	}
+
+    public static int JSonHexToInt(final String param) {
+        if (!hasHexPrefix(param)) {
+            throw invalidParamError("Incorrect hex syntax");
+        }
+        
+        String preResult = removeHexPrefix(param);
+        
+        return Integer.parseInt(preResult, 16);
+    }
+	
+}
+
+

--- a/rskj-core/src/main/java/org/ethereum/rpc/TypeConverter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/TypeConverter.java
@@ -28,7 +28,9 @@ import java.util.regex.Pattern;
 
 /**
  * Created by Ruben on 19/11/2015.
+ * @deprecated in favor of {@link co.rsk.util.HexUtils HexUtils}.
  */
+@Deprecated
 public class TypeConverter {
     private static final Pattern LEADING_ZEROS_PATTERN = Pattern.compile("0x(0)+");
 
@@ -71,6 +73,9 @@ public class TypeConverter {
         return input.getBytes(StandardCharsets.UTF_8);
     }
 
+    /**
+     *@deprecated in favor of {@link co.rsk.util.HexUtils HexUtils}.
+     */
     public static String toJsonHex(byte[] x) {
         String result = toUnformattedJsonHex(x);
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3.java
@@ -18,13 +18,18 @@
 
 package org.ethereum.rpc;
 
+import java.util.Map;
+
 import co.rsk.config.InternalService;
-import co.rsk.rpc.*;
+import co.rsk.rpc.Web3DebugModule;
+import co.rsk.rpc.Web3EthModule;
+import co.rsk.rpc.Web3EvmModule;
+import co.rsk.rpc.Web3MnrModule;
+import co.rsk.rpc.Web3RskModule;
+import co.rsk.rpc.Web3TraceModule;
+import co.rsk.rpc.Web3TxPoolModule;
 import co.rsk.scoring.PeerScoringInformation;
 import co.rsk.scoring.PeerScoringReputationSummary;
-
-import java.util.Arrays;
-import java.util.Map;
 
 public interface Web3 extends InternalService, Web3TxPoolModule, Web3EthModule, Web3EvmModule, Web3MnrModule, Web3DebugModule, Web3TraceModule, Web3RskModule {
 

--- a/rskj-core/src/test/java/co/rsk/util/HexUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/HexUtilsTest.java
@@ -1,0 +1,195 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.util;
+
+import co.rsk.core.Coin;
+import co.rsk.util.HexUtils;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * Created by martin.medina on 3/7/17.
+ */
+public class HexUtilsTest {
+
+    @Test
+    public void stringToByteArray() {
+        Assert.assertArrayEquals(new byte[] { 116, 105, 110, 99, 104, 111 }, HexUtils.stringToByteArray("tincho"));
+    }
+
+    @Test
+    public void stringHexToByteArrayStartsWithZeroX() {
+        Assert.assertArrayEquals(new byte[] { 32 }, HexUtils.stringHexToByteArray("0x20"));
+    }
+
+    @Test
+    public void stringHexToByteArrayLengthNotModTwo() {
+        Assert.assertArrayEquals(new byte[] { 2 }, HexUtils.stringHexToByteArray("0x2"));
+    }
+
+    @Test
+    public void stringHexToByteArray() {
+        Assert.assertArrayEquals(new byte[] { 32 }, HexUtils.stringHexToByteArray("20"));
+    }
+
+    @Test
+    public void toJsonHex() {
+        Assert.assertEquals("0x20", HexUtils.toJsonHex(new byte[] { 32 }));
+    }
+
+    @Test
+    public void toJsonHexNullInput() {
+        Assert.assertEquals("0x00", HexUtils.toJsonHex((byte[])null));
+    }
+
+    @Test
+    public void toUnformattedJsonHex() {
+        Assert.assertEquals("0x20", HexUtils.toUnformattedJsonHex(new byte[] { 0x20 }));
+    }
+
+    @Test
+    public void toUnformattedJsonHex_nullArray() {
+        Assert.assertEquals("0x", HexUtils.toUnformattedJsonHex(null));
+    }
+
+    @Test
+    public void toUnformattedJsonHex_empty() {
+        Assert.assertEquals("0x", HexUtils.toUnformattedJsonHex(new byte[0]));
+    }
+
+    @Test
+    public void toUnformattedJsonHex_twoHex() {
+        Assert.assertEquals("0x02", HexUtils.toUnformattedJsonHex(new byte[] {0x2}));
+    }
+
+    @Test
+    public void toQuantityJsonHex() {
+        byte[] toEncode = new byte[]{0x0A};
+        Assert.assertEquals("0xa", HexUtils.toQuantityJsonHex(toEncode));
+    }
+
+    @Test
+    public void toQuantityJsonHex_Zero() {
+        byte[] toEncode = new byte[]{0x00, 0x00};
+        Assert.assertEquals("0x0", HexUtils.toQuantityJsonHex(toEncode));
+    }
+
+    @Test
+    public void toQuantityJsonHex_EmptyByteArray() {
+        byte[] toEncode = new byte[0];
+        Assert.assertEquals("0x0", HexUtils.toQuantityJsonHex(toEncode));
+    }
+
+    @Test
+    public void toJsonHexCoin() {
+        Assert.assertEquals("1234", HexUtils.toJsonHex(new Coin(new BigInteger("1234"))));
+    }
+
+    @Test
+    public void toJsonHexNullCoin() {
+        Assert.assertEquals("", HexUtils.toJsonHex((Coin) null));
+    }
+
+
+    @Test
+    public void stringHexToBigIntegerDefaultCase() {
+        Assert.assertEquals(new BigInteger("1"), HexUtils.stringHexToBigInteger("0x1"));
+    }
+
+    @Test
+    public void stringHexToBigIntegerDefaultCase2() {
+        Assert.assertEquals(new BigInteger("255"), HexUtils.stringHexToBigInteger("0xff"));
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void stringHexToBigIntegerWhenThereIsNoNumber() {
+        HexUtils.stringHexToBigInteger("0x");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void stringHexToBigIntegerWhenItIsNotHexa() {
+        HexUtils.stringHexToBigInteger("0xg");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void stringHexToBigIntegerWhenItHasLessThanTwoCharacters() {
+        HexUtils.stringHexToBigInteger("0");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void stringHexToBigIntegerWhenItIsEmpty() {
+        HexUtils.stringHexToBigInteger("");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void stringHexToBigIntegerWhenItDoesNotStartWith0x() {
+        HexUtils.stringHexToBigInteger("0d99");
+    }
+    
+    @Test
+    public void test_hasHexPrefix_valid_case() {
+    	Assert.assertTrue(HexUtils.hasHexPrefix("0x746573746530"));
+    }
+    
+    @Test
+    public void test_isHexWithPrefix_valid_invalid_case() {
+    	
+    	boolean trueCase = HexUtils.isHexWithPrefix("0x746573746530");
+    	boolean falseCase = HexUtils.isHexWithPrefix("internet");
+    	
+    	Assert.assertTrue(trueCase);
+    	Assert.assertFalse(falseCase);
+    }
+   
+    @Test
+    public void test_encodeToHexByteArray_compare_preencoded() {
+    	
+    	byte[] strBytes = "internet".getBytes();
+    	
+    	String encoded = "0x" + Hex.toHexString(strBytes);
+
+		byte[] strEncoded = HexUtils.encodeToHexByteArray(strBytes);
+		
+		Assert.assertTrue(Arrays.equals(encoded.getBytes(), strEncoded));
+    }
+ 
+    @Test
+    public void test_hasHexPrefix() {
+    	byte[] data = "0x746573746530".getBytes();
+    	boolean hasHexPrefix = HexUtils.hasHexPrefix(data);
+    	Assert.assertTrue(hasHexPrefix);
+    }
+    
+    @Test
+    public void test_removeHexPrefix() {
+    	
+    	byte[] data = "0x746573746530".getBytes();
+    	
+    	byte[] clean = HexUtils.removeHexPrefix(data);
+
+    	Assert.assertEquals("746573746530", new String(clean));
+    }
+    
+    
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -140,15 +140,25 @@ public class Web3ImplTest {
 
     @Test
     public void web3_sha3() throws Exception {
-        String toHash = "RSK";
+        
+    	String toHash = "internet";
+        
+    	String toHashInHex = "0x696e7465726e6574"; // 'internet' in hexa
 
         Web3 web3 = createWeb3();
 
         String result = web3.web3_sha3(toHash);
 
+        String resultFromHex = web3.web3_sha3(toHashInHex);        
+
+        System.out.println(result);
+        
         // Function must apply the Keccak-256 algorithm
         // Result taken from https://emn178.github.io/online-tools/keccak_256.html
-        assertTrue("hash does not match", result.compareTo("0x80553b6b348ae45ab8e8bf75e77064818c0a772f13cf8d3a175d3815aec59b56") == 0);
+        assertTrue("hash does not match", result.compareTo("0x2949b355406e040cb594c48726db3cf34bd8f963605e2c39a6b0b862e46825a5") == 0);
+
+        // result from hexa and plain must be the same
+        assertTrue("hash from plain text hand hexa does not match", result.compareTo(resultFromHex) == 0);
     }
 
     @Test


### PR DESCRIPTION
## Description
Handling input now tests if the content is hex encoded and decodes it to make the hash o the plain version.
If the content is already plain text just hashs it

## Motivation and Context
https://github.com/rsksmart/rskj/issues/1607

## How Has This Been Tested?
uniot tests

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [    ] New feature (non-breaking change which adds functionality)
- [    ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
