### PR TITLE
eth_syncing fix

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1769,7 +1769,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         return ethModuleTransaction;
     }
 
-    private SyncProcessor getSyncProcessor() {
+    protected SyncProcessor getSyncProcessor() {
         if (syncProcessor == null) {
             syncProcessor = new SyncProcessor(
                     getBlockchain(),

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1219,7 +1219,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 getConfigCapabilities(),
                 getBuildInfo(),
                 getBlocksBloomStore(),
-                getWeb3InformationRetriever());
+                getWeb3InformationRetriever(),
+                getSyncProcessor());
     }
 
     protected synchronized Web3InformationRetriever getWeb3InformationRetriever() {
@@ -1858,6 +1859,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             RskSystemProperties rskSystemProperties = getRskSystemProperties();
             JsonRpcSerializer jsonRpcSerializer = getJsonRpcSerializer();
             Ethereum rsk = getRsk();
+            SyncProcessor syncProcessor = getSyncProcessor();
             EthSubscriptionNotificationEmitter emitter = new EthSubscriptionNotificationEmitter(
                     new BlockHeaderNotificationEmitter(rsk, jsonRpcSerializer),
                     new LogsNotificationEmitter(
@@ -1867,7 +1869,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                             new BlockchainBranchComparator(getBlockStore())
                     ),
                     new PendingTransactionsNotificationEmitter(rsk, jsonRpcSerializer),
-                    new SyncNotificationEmitter(rsk, jsonRpcSerializer, nodeBlockProcessor, blockchain)
+                    new SyncNotificationEmitter(rsk, jsonRpcSerializer, blockchain, syncProcessor)
             );
             RskWebSocketJsonRpcHandler jsonRpcHandler = new RskWebSocketJsonRpcHandler(emitter);
             web3WebSocketServer = new Web3WebSocketServer(

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net;
 
 import co.rsk.core.DifficultyCalculator;

--- a/rskj-core/src/main/java/co/rsk/net/sync/BaseSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/BaseSyncState.java
@@ -59,11 +59,6 @@ public abstract class BaseSyncState implements SyncState {
     @Override
     public void onEnter() { }
 
-    @Override
-    public boolean isSyncing(){
-        return false;
-    }
-
     @VisibleForTesting
     public void messageSent() {
         resetTimeElapsed();

--- a/rskj-core/src/main/java/co/rsk/net/sync/BaseSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/BaseSyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.net.Peer;

--- a/rskj-core/src/main/java/co/rsk/net/sync/CheckingBestHeaderSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/CheckingBestHeaderSyncState.java
@@ -1,6 +1,23 @@
-package co.rsk.net;
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.net.sync;
 
-import co.rsk.net.sync.*;
+import co.rsk.net.Peer;
 import co.rsk.scoring.EventType;
 import co.rsk.validators.BlockHeaderValidationRule;
 import org.ethereum.core.BlockHeader;

--- a/rskj-core/src/main/java/co/rsk/net/sync/ChunkDescriptor.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/ChunkDescriptor.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 public class ChunkDescriptor {

--- a/rskj-core/src/main/java/co/rsk/net/sync/ChunksDownloadHelper.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/ChunksDownloadHelper.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/rskj-core/src/main/java/co/rsk/net/sync/ConnectionPointFinder.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/ConnectionPointFinder.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/rskj-core/src/main/java/co/rsk/net/sync/DecidingSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DecidingSyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.net.Peer;

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.core.BlockDifficulty;

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsHeadersSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsHeadersSyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.crypto.Keccak256;

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
@@ -368,11 +368,6 @@ public class DownloadingBodiesSyncState  extends BaseSyncState {
         return expected != null && expected.nodeID.equals(peerId);
     }
 
-    @Override
-    public boolean isSyncing() {
-        return true;
-    }
-
     @VisibleForTesting
     public void expectBodyResponseFor(long requestId, NodeID nodeID, BlockHeader header) {
         pendingBodyResponses.put(requestId, new PendingBodyResponse(nodeID, header));

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.crypto.Keccak256;

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingHeadersSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingHeadersSyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.core.bc.ConsensusValidationMainchainView;

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingSkeletonSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingSkeletonSyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.net.Peer;

--- a/rskj-core/src/main/java/co/rsk/net/sync/FindingConnectionPointSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/FindingConnectionPointSyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.net.Peer;

--- a/rskj-core/src/main/java/co/rsk/net/sync/PeersInformation.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/PeersInformation.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.core.BlockDifficulty;

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.net.NodeID;

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
@@ -7,6 +7,7 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockIdentifier;
 
+import javax.annotation.Nullable;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,8 @@ public interface SyncEventsHandler {
     void backwardDownloadBodies(Block parent, List<BlockHeader> toRequest, Peer peer);
 
     void stopSyncing();
+
+    void onLongSyncUpdate(boolean isSyncing, @Nullable Long peerBestBlockNumber);
 
     void onErrorSyncing(NodeID peerId, String message, EventType eventType, Object... arguments);
 

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncPeerStatus.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncPeerStatus.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.net.Status;

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncState.java
@@ -26,6 +26,4 @@ public interface SyncState {
     void onEnter();
 
     void tick(Duration duration);
-
-    boolean isSyncing();
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncState.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package co.rsk.net.sync;
 
 import co.rsk.net.Peer;

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncStatesIds.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncStatesIds.java
@@ -1,8 +1,0 @@
-package co.rsk.net.sync;
-
-public enum SyncStatesIds {
-    DECIDING,
-    DOWNLOADING_BODIES,
-    FINDING_CONNECTION_POINT,
-    SYNC_WITH_PEER,
-}

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -25,6 +25,7 @@ import co.rsk.metrics.HashRateCalculator;
 import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
 import co.rsk.net.BlockProcessor;
+import co.rsk.net.SyncProcessor;
 import co.rsk.rpc.modules.debug.DebugModule;
 import co.rsk.rpc.modules.eth.EthModule;
 import co.rsk.rpc.modules.evm.EvmModule;
@@ -92,11 +93,12 @@ public class Web3RskImpl extends Web3Impl {
             ConfigCapabilities configCapabilities,
             BuildInfo buildInfo,
             BlocksBloomStore blocksBloomStore,
-            Web3InformationRetriever retriever) {
+            Web3InformationRetriever retriever,
+            SyncProcessor syncProcessor) {
             super(eth, blockchain, blockStore, receiptStore, properties, minerClient, minerServer,
                     personalModule, ethModule, evmModule, txPoolModule, mnrModule, debugModule, traceModule, rskModule,
                     channelManager, peerScoringManager, peerServer, nodeBlockProcessor,
-                    hashRateCalculator, configCapabilities, buildInfo, blocksBloomStore, retriever);
+                    hashRateCalculator, configCapabilities, buildInfo, blocksBloomStore, retriever, syncProcessor);
 
         this.networkStateExporter = networkStateExporter;
         this.blockStore = blockStore;

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -29,6 +29,7 @@ import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
 import co.rsk.net.BlockProcessor;
 import co.rsk.net.Peer;
+import co.rsk.net.SyncProcessor;
 import co.rsk.rpc.ModuleDescription;
 import co.rsk.rpc.Web3InformationRetriever;
 import co.rsk.rpc.modules.debug.DebugModule;
@@ -40,6 +41,7 @@ import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.trace.TraceModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.*;
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
@@ -78,14 +80,10 @@ import static org.ethereum.rpc.exception.RskJsonRpcRequestException.*;
 public class Web3Impl implements Web3 {
     private static final Logger logger = LoggerFactory.getLogger("web3");
 
-    public Ethereum eth;
-
-    private final String baseClientVersion = "RskJ";
-
-    private long initialBlockNumber;
+    private static final String CLIENT_VERSION_PREFIX = "RskJ";
 
     private final MinerClient minerClient;
-    protected MinerServer minerServer;
+    private final MinerServer minerServer;
     private final ChannelManager channelManager;
     private final PeerScoringManager peerScoringManager;
     private final PeerServer peerServer;
@@ -112,6 +110,9 @@ public class Web3Impl implements Web3 {
     private final DebugModule debugModule;
     private final TraceModule traceModule;
     private final RskModule rskModule;
+    private final SyncProcessor syncProcessor;
+
+    private Ethereum eth;
 
     protected Web3Impl(
             Ethereum eth,
@@ -137,7 +138,8 @@ public class Web3Impl implements Web3 {
             ConfigCapabilities configCapabilities,
             BuildInfo buildInfo,
             BlocksBloomStore blocksBloomStore,
-            Web3InformationRetriever web3InformationRetriever) {
+            Web3InformationRetriever web3InformationRetriever,
+            SyncProcessor syncProcessor) {
         this.eth = eth;
         this.blockchain = blockchain;
         this.blockStore = blockStore;
@@ -163,9 +165,14 @@ public class Web3Impl implements Web3 {
         this.buildInfo = buildInfo;
         this.blocksBloomStore = blocksBloomStore;
         this.web3InformationRetriever = web3InformationRetriever;
-        initialBlockNumber = this.blockchain.getBestBlock().getNumber();
+        this.syncProcessor = syncProcessor;
 
         personalModule.init();
+    }
+
+    @VisibleForTesting
+    void setEth(Ethereum eth) {
+        this.eth = eth;
     }
 
     @Override
@@ -188,7 +195,7 @@ public class Web3Impl implements Web3 {
 
     @Override
     public String web3_clientVersion() {
-        String clientVersion = baseClientVersion + "/" + config.projectVersion() + "/" +
+        String clientVersion = CLIENT_VERSION_PREFIX + "/" + config.projectVersion() + "/" +
                 System.getProperty("os.name") + "/Java1.8/" +
                 config.projectVersionModifier() + "-" + buildInfo.getBuildHash();
 
@@ -279,18 +286,19 @@ public class Web3Impl implements Web3 {
 
     @Override
     public Object eth_syncing() {
-        long currentBlock = this.blockchain.getBestBlock().getNumber();
-        long highestBlock = this.nodeBlockProcessor.getLastKnownBlockNumber();
-
-        if (highestBlock <= currentBlock){
+        if (!syncProcessor.isSyncing()) {
             return false;
         }
 
+        long initialBlockNum = syncProcessor.getInitialBlockNumber();
+        long currentBlockNum = blockchain.getBestBlock().getNumber();
+        long highestBlockNum = syncProcessor.getHighestBlockNumber();
+
         SyncingResult s = new SyncingResult();
         try {
-            s.setStartingBlock(TypeConverter.toQuantityJsonHex(initialBlockNumber));
-            s.setCurrentBlock(TypeConverter.toQuantityJsonHex(currentBlock));
-            s.setHighestBlock(toQuantityJsonHex(highestBlock));
+            s.setStartingBlock(TypeConverter.toQuantityJsonHex(initialBlockNum));
+            s.setCurrentBlock(TypeConverter.toQuantityJsonHex(currentBlockNum));
+            s.setHighestBlock(toQuantityJsonHex(highestBlockNum));
 
             return s;
         } finally {

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -90,7 +90,6 @@ public class Web3Impl implements Web3 {
 
     private final Blockchain blockchain;
     private final ReceiptStore receiptStore;
-    private final BlockProcessor nodeBlockProcessor;
     private final HashRateCalculator hashRateCalculator;
     private final ConfigCapabilities configCapabilities;
     private final BlockStore blockStore;
@@ -157,7 +156,6 @@ public class Web3Impl implements Web3 {
         this.channelManager = channelManager;
         this.peerScoringManager = peerScoringManager;
         this.peerServer = peerServer;
-        this.nodeBlockProcessor = nodeBlockProcessor;
         this.hashRateCalculator = hashRateCalculator;
         this.configCapabilities = configCapabilities;
         this.config = config;

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -412,6 +412,7 @@ public class TransactionModuleTest {
                 configCapabilities,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
@@ -78,12 +78,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Test
@@ -130,12 +127,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -185,12 +179,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -229,12 +220,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -273,12 +261,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -322,12 +307,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -368,12 +350,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -419,9 +398,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node3.joinWithTimeout();
         node4.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -464,12 +443,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -516,12 +492,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -560,12 +533,9 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 
     @Ignore
@@ -609,11 +579,8 @@ public class ThreeAsyncNodeUsingSyncProcessorTest {
         node2.joinWithTimeout();
         node3.joinWithTimeout();
 
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node1.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node3.getSyncProcessor().getSyncState().isSyncing());
-        Assert.assertFalse(node2.getSyncProcessor().getSyncState().isSyncing());
+        Assert.assertFalse(node1.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node2.getSyncProcessor().isSyncing());
+        Assert.assertFalse(node3.getSyncProcessor().isSyncing());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
+++ b/rskj-core/src/test/java/co/rsk/net/simples/SimpleAsyncNode.java
@@ -112,8 +112,6 @@ public class SimpleAsyncNode extends SimpleNode {
         return this.syncProcessor;
     }
 
-
-
     public static SimpleAsyncNode createDefaultNode(Blockchain blockChain){
         return createNode(blockChain, SyncConfiguration.DEFAULT);
     }

--- a/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
@@ -1,6 +1,5 @@
 package co.rsk.net.sync;
 
-
 import co.rsk.net.NodeID;
 import co.rsk.net.Peer;
 import co.rsk.scoring.EventType;
@@ -8,7 +7,7 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockIdentifier;
 
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +63,11 @@ public class SimpleSyncEventsHandler implements SyncEventsHandler {
 
     @Override
     public void stopSyncing() { this.stopSyncingWasCalled_ = true; }
+
+    @Override
+    public void onLongSyncUpdate(boolean isSyncing, @Nullable Long peerBestBlockNumber) {
+
+    }
 
     @Override
     public void onErrorSyncing(NodeID peerId, String message, EventType eventType, Object... arguments) {

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3EthModuleTest.java
@@ -25,6 +25,7 @@ import co.rsk.metrics.HashRateCalculator;
 import co.rsk.mine.MinerClient;
 import co.rsk.mine.MinerServer;
 import co.rsk.net.BlockProcessor;
+import co.rsk.net.SyncProcessor;
 import co.rsk.rpc.modules.debug.DebugModule;
 import co.rsk.rpc.modules.eth.EthModule;
 import co.rsk.rpc.modules.evm.EvmModule;
@@ -77,7 +78,8 @@ public class Web3EthModuleTest {
                 mock(ConfigCapabilities.class),
                 mock(BuildInfo.class),
                 mock(BlocksBloomStore.class),
-                mock(Web3InformationRetriever.class));
+                mock(Web3InformationRetriever.class),
+                mock(SyncProcessor.class));
 
         assertThat(web3.eth_chainId(), is("0x21"));
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3ImplRpcTest.java
@@ -48,7 +48,7 @@ public class Web3ImplRpcTest {
                             null, null, null, null,
                             null, null, null, null,
                             null, null, null, null, null,
-                            null, null, null, null, null, null);
+                            null, null, null, null, null, null, null);
 
         Map<String, String> result = web3.rpc_modules();
 

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -109,6 +109,7 @@ public class Web3RskImplTest {
                 null,
                 null,
                 null,
+                null,
                 null);
         web3.ext_dumpState();
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -1088,7 +1088,8 @@ public class Web3ImplLogsTest {
                 new SimpleConfigCapabilities(),
                 null,
                 new BlocksBloomStore(2, 0, null),
-                mock(Web3InformationRetriever.class));
+                mock(Web3InformationRetriever.class),
+                null);
     }
 
     private void addTwoEmptyBlocks() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -395,6 +395,7 @@ public class Web3ImplScoringTest {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplSnapshotTest.java
@@ -201,6 +201,7 @@ public class Web3ImplSnapshotTest {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -82,7 +82,8 @@ public class Web3ImplUnitTest {
                 mock(ConfigCapabilities.class),
                 mock(BuildInfo.class),
                 mock(BlocksBloomStore.class),
-                retriever);
+                retriever,
+                null);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`eth_syncing` is returning a boolean indicating if it is syncing or not. However, the returned value is now in relation to the chunk is syncing, so it returns false when the chunk is not being synced.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To return `false` after the node is fully synced

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


*fed:eth-syncing-fix*