### PR TITLE
Fixed ext_dumpState (it didn't work in Mainnet) / added partial export

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
+++ b/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Iterator;
 
@@ -60,6 +59,14 @@ public class NetworkStateExporter {
         return exportStatus(outputFile, "",true,true);
     }
 
+    public void exportAllAccounts(ObjectNode mainNode,RepositorySnapshot frozenRepository,boolean exportStorageKeys,boolean exportCode) {
+        for (RskAddress addr : frozenRepository.getAccountsKeys()) {
+            if (!addr.equals(RskAddress.nullAddress())) {
+                mainNode.set(addr.toString(), createAccountNode(mainNode, addr, frozenRepository, exportStorageKeys,exportCode));
+            }
+        }
+    }
+
     public boolean exportStatus(String outputFile,String accountKey, boolean exportStorageKeys,boolean exportCode) {
         RepositorySnapshot frozenRepository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
 
@@ -69,11 +76,7 @@ public class NetworkStateExporter {
             JsonNodeFactory jsonFactory = new JsonNodeFactory(false);
             ObjectNode mainNode = jsonFactory.objectNode();
             if (accountKey.length()==0) {
-                for (RskAddress addr : frozenRepository.getAccountsKeys()) {
-                    if (!addr.equals(RskAddress.nullAddress())) {
-                        mainNode.set(addr.toString(), createAccountNode(mainNode, addr, frozenRepository, exportStorageKeys,exportCode));
-                    }
-                }
+                exportAllAccounts(mainNode,frozenRepository, exportStorageKeys,exportCode);
             } else {
                 RskAddress addr = new RskAddress(accountKey);
                 if (!addr.equals(RskAddress.nullAddress())) {

--- a/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
+++ b/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
@@ -98,7 +98,7 @@ public class NetworkStateExporter {
             byte[] code = accountInformation.getCode(addr);
             String codeStr = "";
             if (code == null) {
-                codeStr = "<empty>";
+                codeStr = "";
             } else {
                 codeStr = ByteUtil.toHexString(code);
             }

--- a/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
+++ b/rskj-core/src/main/java/co/rsk/core/NetworkStateExporter.java
@@ -61,9 +61,13 @@ public class NetworkStateExporter {
 
     public void exportAllAccounts(ObjectNode mainNode,RepositorySnapshot frozenRepository,boolean exportStorageKeys,boolean exportCode) {
         for (RskAddress addr : frozenRepository.getAccountsKeys()) {
-            if (!addr.equals(RskAddress.nullAddress())) {
-                mainNode.set(addr.toString(), createAccountNode(mainNode, addr, frozenRepository, exportStorageKeys,exportCode));
-            }
+            exportAccount(addr, mainNode, frozenRepository, exportStorageKeys, exportCode);
+        }
+    }
+
+    public void exportAccount(RskAddress addr ,ObjectNode mainNode,RepositorySnapshot frozenRepository,boolean exportStorageKeys,boolean exportCode) {
+        if (!addr.equals(RskAddress.nullAddress())) {
+            mainNode.set(addr.toString(), createAccountNode(mainNode, addr, frozenRepository, exportStorageKeys, exportCode));
         }
     }
 
@@ -79,10 +83,7 @@ public class NetworkStateExporter {
                 exportAllAccounts(mainNode,frozenRepository, exportStorageKeys,exportCode);
             } else {
                 RskAddress addr = new RskAddress(accountKey);
-                if (!addr.equals(RskAddress.nullAddress())) {
-                    mainNode.set(addr.toString(), createAccountNode(mainNode, addr, frozenRepository, exportStorageKeys,exportCode));
-                }
-
+                exportAccount(addr,mainNode,frozenRepository, exportStorageKeys,exportCode);
             }
             ObjectMapper mapper = new ObjectMapper();
             ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();

--- a/rskj-core/src/main/java/co/rsk/core/bc/AccountInformationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/AccountInformationProvider.java
@@ -20,6 +20,7 @@ package co.rsk.core.bc;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
 import org.ethereum.vm.DataWord;
 
 import javax.annotation.Nullable;
@@ -95,4 +96,14 @@ public interface AccountInformationProvider {
      * @return value of the nonce
      */
     BigInteger getNonce(RskAddress addr);
+
+    /**
+     * This method can retrieve the hash code without actually retrieving the code
+     * in some cases.
+     * This is the PRE RSKIP169 implementation, which has a bug we need to preserve
+     * before the implementation
+     * @param addr of the account
+     * @return hash of the contract code
+     */
+    Keccak256 getCodeHashStandard(RskAddress addr);
 }

--- a/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/PendingState.java
@@ -20,6 +20,7 @@ package co.rsk.core.bc;
 
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositorySnapshot;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
@@ -83,6 +84,10 @@ public class PendingState implements AccountInformationProvider {
         return postExecutionReturn(executedRepository -> executedRepository.getCode(addr));
     }
 
+    @Override
+    public Keccak256 getCodeHashStandard(RskAddress addr) {
+        return postExecutionReturn(executedRepository -> executedRepository.getCodeHashStandard(addr));
+    }
     @Override
     public boolean isContract(RskAddress addr) {
         return postExecutionReturn(executedRepository -> executedRepository.isContract(addr));

--- a/rskj-core/src/main/java/co/rsk/db/RepositorySnapshot.java
+++ b/rskj-core/src/main/java/co/rsk/db/RepositorySnapshot.java
@@ -58,15 +58,6 @@ public interface RepositorySnapshot extends AccountInformationProvider {
     Keccak256 getCodeHashNonStandard(RskAddress addr);
 
     /**
-     * This method can retrieve the hash code without actually retrieving the code
-     * in some cases.
-     * This is the POST RSKIP169 implementation which fixes the bug
-     * @param addr of the account
-     * @return hash of the contract code
-     */
-    Keccak256 getCodeHashStandard(RskAddress addr);
-
-    /**
      * @param addr - account to check
      * @return - true if account exist,
      *           false otherwise

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -110,12 +110,13 @@ public class Web3RskImpl extends Web3Impl {
                 bestBlcock.getHash(), bestBlcock.getNumber(),account);
         String name = "rskdump";
         if (account.length()!=0) {
-            if (!account.toUpperCase().matches("^[0-9A-F]+$"))
+            if (!account.toUpperCase().matches("^[0-9A-F]+$")) {
                 return;
+            }
             name = name +"-"+account;
         }
-        String filename = System.getProperty("user.dir") + "/" + name+".json";
-        logger.info("Dumping in file: "+filename);
+        String filename = System.getProperty("user.dir") +  File.separatorChar + name+".json";
+        logger.info("Dumping in file: {} ",filename);
         networkStateExporter.exportStatus(filename,account,exportStorageKeys,exportCode);
         logger.info("Dump finished");
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -104,10 +104,20 @@ public class Web3RskImpl extends Web3Impl {
         this.blockStore = blockStore;
     }
 
-    public void ext_dumpState() {
+    public void ext_dumpState(String account,boolean exportStorageKeys,boolean exportCode) {
         Block bestBlcock = blockStore.getBestBlock();
-        logger.info("Dumping state for block hash {}, block number {}", bestBlcock.getHash(), bestBlcock.getNumber());
-        networkStateExporter.exportStatus(System.getProperty("user.dir") + "/" + "rskdump.json");
+        logger.info("Dumping state for block hash {}, block number {}, account {}",
+                bestBlcock.getHash(), bestBlcock.getNumber(),account);
+        String name = "rskdump";
+        if (account.length()!=0) {
+            if (!account.toUpperCase().matches("^[0-9A-F]+$"))
+                return;
+            name = name +"-"+account;
+        }
+        String filename = System.getProperty("user.dir") + "/" + name+".json";
+        logger.info("Dumping in file: "+filename);
+        networkStateExporter.exportStatus(filename,account,exportStorageKeys,exportCode);
+        logger.info("Dump finished");
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -20,6 +20,7 @@ package co.rsk.rpc;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.NetworkStateExporter;
+import co.rsk.core.RskAddress;
 import co.rsk.logfilter.BlocksBloomStore;
 import co.rsk.metrics.HashRateCalculator;
 import co.rsk.mine.MinerClient;
@@ -35,6 +36,7 @@ import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.trace.TraceModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.PeerScoringManager;
+import org.bouncycastle.util.encoders.DecoderException;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Blockchain;
@@ -110,10 +112,18 @@ public class Web3RskImpl extends Web3Impl {
                 bestBlcock.getHash(), bestBlcock.getNumber(),account);
         String name = "rskdump";
         if (account.length()!=0) {
-            if (!account.toUpperCase().matches("^[0-9A-F]+$")) {
+            RskAddress addrToCheck;
+            try {
+                addrToCheck = new RskAddress(account);
+
+                // Now make sure we don't enable path-traversal vulnerabilities in case
+                // the address format is ever changed.
+                if (account.indexOf(File.separatorChar)>=0)
+                    return;
+            } catch (DecoderException e) {
                 return;
             }
-            name = name +"-"+account;
+            name = name +"-"+addrToCheck.toHexString();
         }
         String filename = System.getProperty("user.dir") +  File.separatorChar + name+".json";
         logger.info("Dumping in file: {} ",filename);

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskImpl.java
@@ -118,8 +118,9 @@ public class Web3RskImpl extends Web3Impl {
 
                 // Now make sure we don't enable path-traversal vulnerabilities in case
                 // the address format is ever changed.
-                if (account.indexOf(File.separatorChar)>=0)
+                if (account.indexOf(File.separatorChar)>=0) {
                     return;
+                }
             } catch (DecoderException e) {
                 return;
             }

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -1045,6 +1045,14 @@ public class Trie {
         return new PreOrderIterator(this,false);
     }
 
+     /**
+     * Returns a Pre-order iterator
+     *
+     * @param stopAtAccountDepth     if true, only nodes up to the account level will ve traversed
+     *                               excluding contract storage and contract code nodes.
+     *
+     * @return iterator
+     */
     public Iterator<IterationElement> getPreOrderIterator(boolean stopAtAccountDepth) {
         return new PreOrderIterator(this,stopAtAccountDepth);
     }

--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -299,7 +299,7 @@ public class MutableRepository implements Repository {
         //TODO(diegoll): this is needed when trie is a MutableTrieCache, check if makes sense to commit here
         mutableTrie.commit();
         Trie trie = mutableTrie.getTrie();
-        Iterator<Trie.IterationElement> preOrderIterator = trie.getPreOrderIterator();
+        Iterator<Trie.IterationElement> preOrderIterator = trie.getPreOrderIterator(true);
         while (preOrderIterator.hasNext()) {
             TrieKeySlice nodeKey = preOrderIterator.next().getNodeKey();
             int nodeKeyLength = nodeKey.length();

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -112,7 +112,7 @@ public class Web3RskImplTest {
                 null,
                 null,
                 null);
-        web3.ext_dumpState();
+        web3.ext_dumpState("",true,true);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -18,29 +18,13 @@
 
 package co.rsk.rpc;
 
-import co.rsk.config.TestSystemProperties;
-import co.rsk.core.NetworkStateExporter;
-import co.rsk.core.Wallet;
-import co.rsk.core.WalletFactory;
-import co.rsk.core.bc.MiningMainchainView;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.BridgeSupportFactory;
-import co.rsk.peg.PegTestUtils;
-import co.rsk.rpc.modules.debug.DebugModule;
-import co.rsk.rpc.modules.debug.DebugModuleImpl;
-import co.rsk.rpc.modules.eth.EthModule;
-import co.rsk.rpc.modules.eth.EthModuleWalletEnabled;
-import co.rsk.rpc.modules.personal.PersonalModule;
-import co.rsk.rpc.modules.personal.PersonalModuleWalletEnabled;
-import co.rsk.rpc.modules.txpool.TxPoolModule;
-import co.rsk.rpc.modules.txpool.TxPoolModuleImpl;
 import org.ethereum.core.Block;
-import org.ethereum.core.Blockchain;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.BlockStore;
-import org.ethereum.facade.Ethereum;
-import org.ethereum.rpc.*;
+import org.ethereum.rpc.CallArguments;
+import org.ethereum.rpc.FilterRequest;
+import org.ethereum.rpc.LogFilterElement;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.junit.Test;
@@ -53,67 +37,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class Web3RskImplTest {
-
-    @Test
-    public void web3_ext_dumpState() {
-        Ethereum rsk = mock(Ethereum.class);
-        Blockchain blockchain = mock(Blockchain.class);
-        MiningMainchainView mainchainView = mock(MiningMainchainView.class);
-
-        NetworkStateExporter networkStateExporter = mock(NetworkStateExporter.class);
-        Mockito.when(networkStateExporter.exportStatus(Mockito.anyString())).thenReturn(true);
-
-        Block block = mock(Block.class);
-        Mockito.when(block.getHash()).thenReturn(PegTestUtils.createHash3());
-        Mockito.when(block.getNumber()).thenReturn(1L);
-
-        BlockStore blockStore = mock(BlockStore.class);
-        Mockito.when(blockStore.getBestBlock()).thenReturn(block);
-        Mockito.when(networkStateExporter.exportStatus(Mockito.anyString())).thenReturn(true);
-
-        Mockito.when(blockchain.getBestBlock()).thenReturn(block);
-
-        Wallet wallet = WalletFactory.createWallet();
-        TestSystemProperties config = new TestSystemProperties();
-        PersonalModule pm = new PersonalModuleWalletEnabled(config, rsk, wallet, null);
-        EthModule em = new EthModule(
-                config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), blockchain, null,
-                null, new ExecutionBlockRetriever(mainchainView, blockchain, null, null),
-                null, new EthModuleWalletEnabled(wallet), null,
-                new BridgeSupportFactory(
-                        null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig()),
-                config.getGasEstimationCap()
-        );
-        TxPoolModule tpm = new TxPoolModuleImpl(Web3Mocks.getMockTransactionPool());
-        DebugModule dm = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null);
-        Web3RskImpl web3 = new Web3RskImpl(
-                rsk,
-                blockchain,
-                config,
-                Web3Mocks.getMockMinerClient(),
-                Web3Mocks.getMockMinerServer(),
-                pm,
-                em,
-                null,
-                tpm,
-                null,
-                dm,
-                null, null,
-                Web3Mocks.getMockChannelManager(),
-                null,
-                networkStateExporter,
-                blockStore,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
-        web3.ext_dumpState("",true,true);
-    }
 
     @Test
     public void web3_LogFilterElementNullAddress_toString() {


### PR DESCRIPTION
The function ext_dumpState() didn't work in Mainnet for several reasons:
1) It threw an exception when getCode() returns null
2) It takes too long to finish (more than 30 minutes)
3) It exhaust all available memory

This PR fixes all 3.

## Description

It fixes 1 by returning "" (empty string) when the code is missing.
It fixes 2 and 3 by allowing partial requests.

Three (3) arguments are added:
* String account,
* boolean exportStorageKeys
* boolean exportCode

The argument account, if non-empty, generates a dump limited to a single account. If empty, all accounts are processed.
The argument exportStorageKeys enables or disables the dump of contract storage key/values.
The argument exportCode enables or disables the dump of the contract code.

Also a new field "codeHash" was added to enable first requesting all codeHashes, and then selectively requesting code for those accounts whose code matches a specific hash.

## Motivation and Context
It fixes the method ext_dumpState() which didn't work for Mainnet (and probably for testnet also)

## How Has This Been Tested?

A unit test was added that tests partial dumps.

To iterate over the Trie without getting into the storage cells, a new preorder iterator was added to the Trie class.
Note that it would be recommended that in another PR all iterators are moved away from the Trie class.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

It introduces a breaking change because more arguments were added to dumpState() however since currently this method doesn't work clearly nobody (except me) is using this method, so it is highly improbable that anything breaks with my change.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

In the future we can support debug_accountRange, which is the way geth enables this functionality.
