### PR TITLE
Added bootstrap node into cli tools

### DIFF
--- a/rskj-core/src/main/java/co/rsk/NodeRunnerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/NodeRunnerImpl.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class FullNodeRunner implements NodeRunner {
+public class NodeRunnerImpl implements NodeRunner {
 
     private static final Logger logger = LoggerFactory.getLogger("fullnoderunner");
 
@@ -44,7 +44,7 @@ public class FullNodeRunner implements NodeRunner {
 
     private volatile ExecState state = ExecState.CREATED;
 
-    public FullNodeRunner(
+    public NodeRunnerImpl(
             NodeContext nodeContext,
             List<InternalService> internalServices,
             RskSystemProperties rskSystemProperties,

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1177,7 +1177,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
     protected synchronized NodeRunner buildNodeRunner() {
         checkIfNotClosed();
 
-        return new FullNodeRunner(
+        return new NodeRunnerImpl(
                 this,
                 buildInternalServices(),
                 getRskSystemProperties(),
@@ -1451,7 +1451,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         );
     }
 
-    private PeerExplorer getPeerExplorer() {
+    protected PeerExplorer getPeerExplorer() {
         if (peerExplorer == null) {
             RskSystemProperties rskSystemProperties = getRskSystemProperties();
             ECKey key = rskSystemProperties.getMyKey();

--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -33,11 +33,17 @@ public class Start {
     public static void main(String[] args) {
         setUpThread(Thread.currentThread());
 
+        RskContext ctx = null;
         try {
-            RskContext ctx = new RskContext(args);
+            ctx = new RskContext(args);
             runNode(Runtime.getRuntime(), new PreflightChecksUtils(ctx), ctx);
         } catch (Exception e) {
             logger.error("The RSK node main thread failed, closing program", e);
+
+            if (ctx != null) {
+                ctx.close();
+            }
+
             System.exit(1);
         }
     }

--- a/rskj-core/src/main/java/co/rsk/cli/tools/StartBootstrap.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/StartBootstrap.java
@@ -58,20 +58,21 @@ public class StartBootstrap {
                                  @Nonnull PreflightChecksUtils preflightChecks,
                                  @Nonnull Runtime runtime,
                                  @Nonnull NodeStopper nodeStopper) {
-        NodeRunner runner = ctx.getNodeRunner();
         try {
             // make preflight checks
             preflightChecks.runChecks();
 
-            // start node runner
-            runner.run();
-
             // subscribe to shutdown hook
-            runtime.addShutdownHook(new Thread(runner::stop, "stopper"));
+            runtime.addShutdownHook(new Thread(ctx::close, "stopper"));
+
+            // start node runner
+            NodeRunner runner = ctx.getNodeRunner();
+            runner.run();
         } catch (Exception e) {
             logger.error("Main thread of RSK bootstrap node crashed", e);
 
-            runner.stop();
+            ctx.close();
+
             nodeStopper.stop(1);
         }
     }

--- a/rskj-core/src/main/java/co/rsk/cli/tools/StartBootstrap.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/StartBootstrap.java
@@ -92,7 +92,7 @@ public class StartBootstrap {
         }
 
         @Override
-        public List<InternalService> buildInternalServices() {
+        public synchronized List<InternalService> buildInternalServices() {
             RskSystemProperties rskSystemProperties = getRskSystemProperties();
             UDPServer udpServer = new UDPServer(
                     rskSystemProperties.getBindAddress().getHostAddress(),

--- a/rskj-core/src/main/java/co/rsk/cli/tools/StartBootstrap.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/StartBootstrap.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2021 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.cli.tools;
+
+import co.rsk.NodeRunner;
+import co.rsk.RskContext;
+import co.rsk.config.InternalService;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.net.discovery.UDPServer;
+import co.rsk.util.NodeStopper;
+import co.rsk.util.PreflightChecksUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Entry point of RSK bootstrap node.
+ *
+ * The bootstrap node starts one service which only participates in the peer discovery protocol. All other capabilities
+ * (which are usually part of a full node, e.g. blocks propagation, syncing, JSON-RPC interface etc.) are disabled.
+ *
+ * Note: this is an experimental tool
+ */
+public class StartBootstrap {
+
+    private static final Logger logger = LoggerFactory.getLogger("bootstrap");
+
+    public static void main(String[] args) {
+        setUpThread(Thread.currentThread());
+
+        RskContext ctx = new BootstrapRskContext(args);
+        PreflightChecksUtils preflightChecks = new PreflightChecksUtils(ctx);
+        Runtime runtime = Runtime.getRuntime();
+        NodeStopper nodeStopper = System::exit;
+
+        runBootstrapNode(ctx, preflightChecks, runtime, nodeStopper);
+    }
+
+    static void runBootstrapNode(@Nonnull RskContext ctx,
+                                 @Nonnull PreflightChecksUtils preflightChecks,
+                                 @Nonnull Runtime runtime,
+                                 @Nonnull NodeStopper nodeStopper) {
+        NodeRunner runner = ctx.getNodeRunner();
+        try {
+            // make preflight checks
+            preflightChecks.runChecks();
+
+            // start node runner
+            runner.run();
+
+            // subscribe to shutdown hook
+            runtime.addShutdownHook(new Thread(runner::stop, "stopper"));
+        } catch (Exception e) {
+            logger.error("Main thread of RSK bootstrap node crashed", e);
+
+            runner.stop();
+            nodeStopper.stop(1);
+        }
+    }
+
+    static void setUpThread(@Nonnull Thread thread) {
+        thread.setName("main");
+    }
+
+    /**
+     * Bootstrap {@link RskContext} that spins up only one internal service - {@link UDPServer} - which takes part in
+     * the peer discovery process.
+     */
+    static class BootstrapRskContext extends RskContext {
+
+        BootstrapRskContext(String[] args) {
+            super(args);
+        }
+
+        @Override
+        public List<InternalService> buildInternalServices() {
+            RskSystemProperties rskSystemProperties = getRskSystemProperties();
+            UDPServer udpServer = new UDPServer(
+                    rskSystemProperties.getBindAddress().getHostAddress(),
+                    rskSystemProperties.getPeerPort(),
+                    getPeerExplorer()
+            );
+
+            return Collections.singletonList(udpServer);
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/discovery/table/NodeDistanceTable.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/table/NodeDistanceTable.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  * Created by mario on 21/02/17.
  */
 public class NodeDistanceTable {
-    private Map<Integer, Bucket> buckets = new ConcurrentHashMap<>();
+    private final Map<Integer, Bucket> buckets = new ConcurrentHashMap<>();
     private final Node localNode;
     private final DistanceCalculator distanceCalculator;
 

--- a/rskj-core/src/test/java/co/rsk/NodeRunnerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/NodeRunnerImplTest.java
@@ -31,10 +31,10 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-public class FullNodeRunnerTest {
+public class NodeRunnerImplTest {
     private NodeContext nodeContext;
     private List<InternalService> internalServices;
-    private FullNodeRunner runner;
+    private NodeRunnerImpl runner;
 
     @Before
     public void setup() {
@@ -44,7 +44,7 @@ public class FullNodeRunnerTest {
                 mock(InternalService.class)
         );
 
-        runner = new FullNodeRunner(nodeContext, internalServices, mock(RskSystemProperties.class), mock(BuildInfo.class));
+        runner = new NodeRunnerImpl(nodeContext, internalServices, mock(RskSystemProperties.class), mock(BuildInfo.class));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -416,7 +416,7 @@ public class CliToolsTest {
         verify(preflightChecks, times(2)).runChecks();
         verify(runner, times(1)).run();
         verify(runtime, times(1)).addShutdownHook(any());
-        verify(runner, times(1)).stop();
+        verify(ctx, times(1)).close();
         verify(nodeStopper, times(1)).stop(1);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds bootstrap node launcher to the list of cli tools

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows to run an RSK node in the special "bootstrap" mode, which means that the only peer discovery protocol is active, all other capabilities, like syncing, blocks / txs propagation etc., are disabled. This should offload the bootstrap node from other responsibilities and allow it to focus only on helping other peers to boot.

The bootstrap node can be started, for example, via the following command:
```java
java -cp ./rskj-core-3.1.0-SNAPSHOT-all.jar co.rsk.cli.tools.StartBootstrap --testnet
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

