### PR TITLE
Added support of pending block identifier

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1230,7 +1230,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             web3InformationRetriever = new Web3InformationRetriever(
                     getTransactionPool(),
                     getBlockchain(),
-                    getRepositoryLocator());
+                    getRepositoryLocator(),
+                    getExecutionBlockRetriever());
         }
         return web3InformationRetriever;
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
@@ -63,16 +63,15 @@ public class ExecutionBlockRetriever {
         this.builder = builder;
     }
 
-    @Deprecated
-    public BlockResult getExecutionBlock_workaround(String bnOrId) {
+    public BlockResult retrieveExecutionBlock(String bnOrId) {
         if (LATEST_ID.equals(bnOrId)) {
-            return newBlockResult_workaround(blockchain.getBestBlock());
+            return newBlockResult(blockchain.getBestBlock());
         }
 
         if (PENDING_ID.equals(bnOrId)) {
             Optional<Block> latestBlock = minerServer.getLatestBlock();
             if (latestBlock.isPresent()) {
-                return newBlockResult_workaround(latestBlock.get());
+                return newBlockResult(latestBlock.get());
             }
 
             Block bestBlock = blockchain.getBestBlock();
@@ -107,7 +106,7 @@ public class ExecutionBlockRetriever {
             if (executionBlock == null) {
                 throw invalidParamError(String.format("Invalid block number %d", executionBlockNumber.get()));
             }
-            return newBlockResult_workaround(executionBlock);
+            return newBlockResult(executionBlock);
         }
 
         // If we got here, the specifier given is unsupported
@@ -170,8 +169,7 @@ public class ExecutionBlockRetriever {
                 bnOrId));
     }
 
-    @Deprecated
-    private static BlockResult newBlockResult_workaround(Block block) {
+    private static BlockResult newBlockResult(Block block) {
         return new BlockResult(
                 block,
                 Collections.emptyList(),

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3InformationRetriever.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3InformationRetriever.java
@@ -71,7 +71,7 @@ public class Web3InformationRetriever {
     public Optional<Block> getBlock(String identifier) {
         Block block;
         if (PENDING.equals(identifier)) {
-            block = executionBlockRetriever.getExecutionBlock_workaround(identifier).getBlock();
+            block = executionBlockRetriever.retrieveExecutionBlock(identifier).getBlock();
         } else if (LATEST.equals(identifier)) {
             block = blockchain.getBestBlock();
         } else if (EARLIEST.equals(identifier)) {

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -118,7 +118,7 @@ public class EthModule
     public String call(CallArguments args, String bnOrId) {
         String hReturn = null;
         try {
-            BlockResult blockResult = executionBlockRetriever.getExecutionBlock_workaround(bnOrId);
+            BlockResult blockResult = executionBlockRetriever.retrieveExecutionBlock(bnOrId);
             ProgramResult res;
             if (blockResult.getFinalState() != null) {
                 res = callConstant_workaround(args, blockResult);

--- a/rskj-core/src/test/java/co/rsk/rpc/ExecutionFoundBlockRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/ExecutionFoundBlockRetrieverTest.java
@@ -271,7 +271,7 @@ public class ExecutionFoundBlockRetrieverTest {
         when(blockchain.getBestBlock())
                 .thenReturn(latest);
 
-        assertThat(retriever.getExecutionBlock_workaround("latest").getBlock(), is(latest));
+        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest));
     }
 
     @Test
@@ -282,8 +282,8 @@ public class ExecutionFoundBlockRetrieverTest {
                 .thenReturn(latest1)
                 .thenReturn(latest2);
 
-        assertThat(retriever.getExecutionBlock_workaround("latest").getBlock(), is(latest1));
-        assertThat(retriever.getExecutionBlock_workaround("latest").getBlock(), is(latest2));
+        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest1));
+        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest2));
     }
 
     @Test
@@ -292,7 +292,7 @@ public class ExecutionFoundBlockRetrieverTest {
         when(minerServer.getLatestBlock())
                 .thenReturn(Optional.of(latest));
 
-        assertThat(retriever.getExecutionBlock_workaround("pending").getBlock(), is(latest));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest));
     }
 
     @Test
@@ -303,8 +303,8 @@ public class ExecutionFoundBlockRetrieverTest {
                 .thenReturn(Optional.of(latest1))
                 .thenReturn(Optional.of(latest2));
 
-        assertThat(retriever.getExecutionBlock_workaround("pending").getBlock(), is(latest1));
-        assertThat(retriever.getExecutionBlock_workaround("pending").getBlock(), is(latest2));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest1));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest2));
     }
 
     @Test
@@ -327,7 +327,7 @@ public class ExecutionFoundBlockRetrieverTest {
                 .thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(builtBlock);
 
-        assertThat(retriever.getExecutionBlock_workaround("pending").getBlock(), is(builtBlock));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(builtBlock));
     }
 
     @Test
@@ -357,8 +357,8 @@ public class ExecutionFoundBlockRetrieverTest {
                 .thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(builtBlock);
 
-        assertThat(retriever.getExecutionBlock_workaround("pending"), is(blockResult));
-        assertThat(retriever.getExecutionBlock_workaround("pending"), is(blockResult));
+        assertThat(retriever.retrieveExecutionBlock("pending"), is(blockResult));
+        assertThat(retriever.retrieveExecutionBlock("pending"), is(blockResult));
         // TODO(mc): the cache doesn't work properly in getExecutionBlock_workaround.
         //           this is a known bug in version 1.0.1, and should be fixed in master
         verify(builder, times(2)).build(mainchainHeaders, null);
@@ -398,8 +398,8 @@ public class ExecutionFoundBlockRetrieverTest {
         when(blockResult2.getBlock()).thenReturn(builtBlock2);
         when(builder.build(new ArrayList<>(Collections.singleton(bestHeader2)), null)).thenReturn(blockResult2);
 
-        assertThat(retriever.getExecutionBlock_workaround("pending").getBlock(), is(builtBlock1));
-        assertThat(retriever.getExecutionBlock_workaround("pending").getBlock(), is(builtBlock2));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(builtBlock1));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(builtBlock2));
     }
 
     @Test
@@ -408,8 +408,8 @@ public class ExecutionFoundBlockRetrieverTest {
         when(blockchain.getBlockByNumber(123))
                 .thenReturn(myBlock);
 
-        assertThat(retriever.getExecutionBlock_workaround("0x7B").getBlock(), is(myBlock));
-        assertThat(retriever.getExecutionBlock_workaround("0x7b").getBlock(), is(myBlock));
+        assertThat(retriever.retrieveExecutionBlock("0x7B").getBlock(), is(myBlock));
+        assertThat(retriever.retrieveExecutionBlock("0x7b").getBlock(), is(myBlock));
     }
 
     @Test
@@ -418,7 +418,7 @@ public class ExecutionFoundBlockRetrieverTest {
         when(blockchain.getBlockByNumber(123))
                 .thenReturn(myBlock);
 
-        assertThat(retriever.getExecutionBlock_workaround("123").getBlock(), is(myBlock));
+        assertThat(retriever.retrieveExecutionBlock("123").getBlock(), is(myBlock));
     }
 
     @Test
@@ -428,7 +428,7 @@ public class ExecutionFoundBlockRetrieverTest {
 
         RskJsonRpcRequestException e = TestUtils
                 .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock_workaround("0x7B"));
+                        () -> retriever.retrieveExecutionBlock("0x7B"));
         Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
     }
 
@@ -438,7 +438,7 @@ public class ExecutionFoundBlockRetrieverTest {
                 .thenReturn(null);
         RskJsonRpcRequestException e = TestUtils
                 .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock_workaround("123"));
+                        () -> retriever.retrieveExecutionBlock("123"));
         Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
     }
 
@@ -446,7 +446,7 @@ public class ExecutionFoundBlockRetrieverTest {
     public void getByNumberInvalidHex_workaround() {
         RskJsonRpcRequestException e = TestUtils
                 .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock_workaround("0xzz"));
+                        () -> retriever.retrieveExecutionBlock("0xzz"));
         Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
 
         verify(blockchain, never()).getBlockByNumber(any(long.class));
@@ -456,7 +456,7 @@ public class ExecutionFoundBlockRetrieverTest {
     public void getByNumberInvalidDec_workaround() {
         RskJsonRpcRequestException e = TestUtils
                 .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock_workaround("zz"));
+                        () -> retriever.retrieveExecutionBlock("zz"));
         Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
         verify(blockchain, never()).getBlockByNumber(any(long.class));
     }
@@ -465,7 +465,7 @@ public class ExecutionFoundBlockRetrieverTest {
     public void getOtherThanPendingLatestOrNumberThrows_workaround() {
         RskJsonRpcRequestException e = TestUtils
                 .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock_workaround("other"));
+                        () -> retriever.retrieveExecutionBlock("other"));
         Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/ExecutionFoundBlockRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/ExecutionFoundBlockRetrieverTest.java
@@ -65,7 +65,7 @@ public class ExecutionFoundBlockRetrieverTest {
         when(blockchain.getBestBlock())
                 .thenReturn(latest);
 
-        assertThat(retriever.getExecutionBlock("latest"), is(latest));
+        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest));
     }
 
     @Test
@@ -76,8 +76,8 @@ public class ExecutionFoundBlockRetrieverTest {
                 .thenReturn(latest1)
                 .thenReturn(latest2);
 
-        assertThat(retriever.getExecutionBlock("latest"), is(latest1));
-        assertThat(retriever.getExecutionBlock("latest"), is(latest2));
+        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest1));
+        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest2));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class ExecutionFoundBlockRetrieverTest {
         when(minerServer.getLatestBlock())
                 .thenReturn(Optional.of(latest));
 
-        assertThat(retriever.getExecutionBlock("pending"), is(latest));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest));
     }
 
     @Test
@@ -97,8 +97,8 @@ public class ExecutionFoundBlockRetrieverTest {
                 .thenReturn(Optional.of(latest1))
                 .thenReturn(Optional.of(latest2));
 
-        assertThat(retriever.getExecutionBlock("pending"), is(latest1));
-        assertThat(retriever.getExecutionBlock("pending"), is(latest2));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest1));
+        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest2));
     }
 
     @Test
@@ -121,217 +121,11 @@ public class ExecutionFoundBlockRetrieverTest {
                 .thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(builtBlock);
 
-        assertThat(retriever.getExecutionBlock("pending"), is(builtBlock));
-    }
-
-    @Test
-    public void getPendingReturnsCachedBlockIfMinerServerHasNoWork() {
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.empty())
-                .thenReturn(Optional.empty());
-
-        BlockHeader bestHeader = mock(BlockHeader.class);
-        Block bestBlock = mock(Block.class);
-        when(bestBlock.getHeader()).thenReturn(bestHeader);
-        when(blockchain.getBestBlock())
-                .thenReturn(bestBlock)
-                .thenReturn(bestBlock);
-
-        List<BlockHeader> mainchainHeaders = new ArrayList<>();
-        mainchainHeaders.add(bestBlock.getHeader());
-        mainchainHeaders.add(bestBlock.getHeader());
-        when(miningMainchainView.get())
-                .thenReturn(mainchainHeaders);
-
-        BlockResult blockResult = mock(BlockResult.class);
-        Block builtBlock = mock(Block.class);
-        when(bestBlock.isParentOf(builtBlock))
-                .thenReturn(true);
-        when(builder.build(mainchainHeaders, null))
-                .thenReturn(blockResult);
-        when(blockResult.getBlock()).thenReturn(builtBlock);
-
-        assertThat(retriever.getExecutionBlock("pending"), is(builtBlock));
-        assertThat(retriever.getExecutionBlock("pending"), is(builtBlock));
-        verify(builder, times(1)).build(mainchainHeaders, null);
-    }
-
-    @Test
-    public void getPendingDoesntUseCacheIfBestBlockHasChanged() {
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.empty())
-                .thenReturn(Optional.empty());
-
-        BlockHeader bestHeader1 = mock(BlockHeader.class);
-        Block bestBlock1 = mock(Block.class);
-        when(bestBlock1.getHeader()).thenReturn(bestHeader1);
-
-        BlockHeader bestHeader2 = mock(BlockHeader.class);
-        Block bestBlock2 = mock(Block.class);
-        when(bestBlock2.getHeader()).thenReturn(bestHeader2);
-
-        when(blockchain.getBestBlock())
-                .thenReturn(bestBlock1)
-                .thenReturn(bestBlock2);
-
-        when(miningMainchainView.get())
-                .thenReturn(new ArrayList<>(Collections.singleton(bestHeader1)))
-                .thenReturn(new ArrayList<>(Collections.singleton(bestHeader2)));
-
-        Block builtBlock1 = mock(Block.class);
-        when(bestBlock1.isParentOf(builtBlock1)).thenReturn(true);
-        BlockResult blockResult1 = mock(BlockResult.class);
-        when(blockResult1.getBlock()).thenReturn(builtBlock1);
-        when(builder.build(new ArrayList<>(Collections.singleton(bestHeader1)), null)).thenReturn(blockResult1);
-
-        Block builtBlock2 = mock(Block.class);
-        when(bestBlock2.isParentOf(builtBlock2)).thenReturn(true);
-        BlockResult blockResult2 = mock(BlockResult.class);
-        when(blockResult2.getBlock()).thenReturn(builtBlock2);
-        when(builder.build(new ArrayList<>(Collections.singleton(bestHeader2)), null)).thenReturn(blockResult2);
-
-        assertThat(retriever.getExecutionBlock("pending"), is(builtBlock1));
-        assertThat(retriever.getExecutionBlock("pending"), is(builtBlock2));
-    }
-
-    @Test
-    public void getByNumberBlockExistsHex() {
-        Block myBlock = mock(Block.class);
-        when(blockchain.getBlockByNumber(123))
-                .thenReturn(myBlock);
-
-        assertThat(retriever.getExecutionBlock("0x7B"), is(myBlock));
-        assertThat(retriever.getExecutionBlock("0x7b"), is(myBlock));
-    }
-
-    @Test
-    public void getByNumberBlockExistsDec() {
-        Block myBlock = mock(Block.class);
-        when(blockchain.getBlockByNumber(123))
-                .thenReturn(myBlock);
-
-        assertThat(retriever.getExecutionBlock("123"), is(myBlock));
-    }
-
-    @Test
-    public void getByNumberInvalidBlockNumberHex() {
-        when(blockchain.getBlockByNumber(123))
-                .thenReturn(null);
-
-        RskJsonRpcRequestException e = TestUtils
-                .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock("0x7B"));
-        Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
-
-    }
-
-    @Test
-    public void getByNumberInvalidBlockNumberDec() {
-        when(blockchain.getBlockByNumber(123))
-                .thenReturn(null);
-
-        RskJsonRpcRequestException e = TestUtils
-                .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock("123"));
-        Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
-    }
-
-    @Test
-    public void getByNumberInvalidHex() {
-        RskJsonRpcRequestException e = TestUtils
-                .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock("0xzz"));
-        Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
-
-        verify(blockchain, never()).getBlockByNumber(any(long.class));
-    }
-
-    @Test
-    public void getByNumberInvalidDec() {
-        RskJsonRpcRequestException e = TestUtils
-                .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock("zz"));
-        Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
-
-        verify(blockchain, never()).getBlockByNumber(any(long.class));
-    }
-
-    @Test
-    public void getOtherThanPendingLatestOrNumberThrows() {
-        RskJsonRpcRequestException e = TestUtils
-                .assertThrows(RskJsonRpcRequestException.class,
-                        () -> retriever.getExecutionBlock("other"));
-
-        Assert.assertEquals(INVALID_PARAM_ERROR_CODE, (int) e.getCode());
-    }
-
-    @Test
-    public void getLatest_workaround() {
-        Block latest = mock(Block.class);
-        when(blockchain.getBestBlock())
-                .thenReturn(latest);
-
-        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest));
-    }
-
-    @Test
-    public void getLatestIsUpToDate_workaround() {
-        Block latest1 = mock(Block.class);
-        Block latest2 = mock(Block.class);
-        when(blockchain.getBestBlock())
-                .thenReturn(latest1)
-                .thenReturn(latest2);
-
-        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest1));
-        assertThat(retriever.retrieveExecutionBlock("latest").getBlock(), is(latest2));
-    }
-
-    @Test
-    public void getPendingUsesMinerServerLatestBlock_workaround() {
-        Block latest = mock(Block.class);
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.of(latest));
-
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest));
-    }
-
-    @Test
-    public void getPendingUsesMinerServerAndIsUpToDate_workaround() {
-        Block latest1 = mock(Block.class);
-        Block latest2 = mock(Block.class);
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.of(latest1))
-                .thenReturn(Optional.of(latest2));
-
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest1));
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest2));
-    }
-
-    @Test
-    public void getPendingBuildsPendingBlockIfMinerServerHasNoWork_workaround() {
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.empty());
-
-        BlockHeader bestHeader = mock(BlockHeader.class);
-        Block bestBlock = mock(Block.class);
-        when(bestBlock.getHeader()).thenReturn(bestHeader);
-        when(blockchain.getBestBlock())
-                .thenReturn(bestBlock);
-
-        when(miningMainchainView.get())
-                .thenReturn(new ArrayList<>(Collections.singleton(bestHeader)));
-
-        Block builtBlock = mock(Block.class);
-        BlockResult blockResult = mock(BlockResult.class);
-        when(builder.build(new ArrayList<>(Collections.singleton(bestHeader)), null))
-                .thenReturn(blockResult);
-        when(blockResult.getBlock()).thenReturn(builtBlock);
-
         assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(builtBlock));
     }
 
     @Test
-    public void getPendingReturnsCachedBlockIfMinerServerHasNoWork_workaround() {
+    public void getPendingReturnsCachedBlockIfMinerServerHasNoWork() {
         when(minerServer.getLatestBlock())
                 .thenReturn(Optional.empty())
                 .thenReturn(Optional.empty());
@@ -365,7 +159,7 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getPendingDoesntUseCacheIfBestBlockHasChanged_workaround() {
+    public void getPendingDoesntUseCacheIfBestBlockHasChanged() {
         when(minerServer.getLatestBlock())
                 .thenReturn(Optional.empty())
                 .thenReturn(Optional.empty());
@@ -403,7 +197,7 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getByNumberBlockExistsHex_workaround() {
+    public void getByNumberBlockExistsHex() {
         Block myBlock = mock(Block.class);
         when(blockchain.getBlockByNumber(123))
                 .thenReturn(myBlock);
@@ -413,7 +207,7 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getByNumberBlockExistsDec_workaround() {
+    public void getByNumberBlockExistsDec() {
         Block myBlock = mock(Block.class);
         when(blockchain.getBlockByNumber(123))
                 .thenReturn(myBlock);
@@ -422,7 +216,7 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getByNumberInvalidBlockNumberHex_workaround() {
+    public void getByNumberInvalidBlockNumberHex() {
         when(blockchain.getBlockByNumber(123))
                 .thenReturn(null);
 
@@ -433,7 +227,7 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getByNumberInvalidBlockNumberDec_workaround() {
+    public void getByNumberInvalidBlockNumberDec() {
         when(blockchain.getBlockByNumber(123))
                 .thenReturn(null);
         RskJsonRpcRequestException e = TestUtils
@@ -443,7 +237,7 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getByNumberInvalidHex_workaround() {
+    public void getByNumberInvalidHex() {
         RskJsonRpcRequestException e = TestUtils
                 .assertThrows(RskJsonRpcRequestException.class,
                         () -> retriever.retrieveExecutionBlock("0xzz"));
@@ -453,7 +247,7 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getByNumberInvalidDec_workaround() {
+    public void getByNumberInvalidDec() {
         RskJsonRpcRequestException e = TestUtils
                 .assertThrows(RskJsonRpcRequestException.class,
                         () -> retriever.retrieveExecutionBlock("zz"));
@@ -462,7 +256,7 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getOtherThanPendingLatestOrNumberThrows_workaround() {
+    public void getOtherThanPendingLatestOrNumberThrows() {
         RskJsonRpcRequestException e = TestUtils
                 .assertThrows(RskJsonRpcRequestException.class,
                         () -> retriever.retrieveExecutionBlock("other"));

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3InformationRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3InformationRetrieverTest.java
@@ -1,6 +1,7 @@
 package co.rsk.rpc;
 
 import co.rsk.core.bc.AccountInformationProvider;
+import co.rsk.core.bc.BlockResult;
 import co.rsk.core.bc.PendingState;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
@@ -22,28 +23,33 @@ import static org.mockito.Mockito.when;
 
 public class Web3InformationRetrieverTest {
 
-    private static final int UNIMPLEMENTED_ERROR_CODE = -32201;
     private static final int INVALID_PARAM_ERROR_CODE = -32602;
 
     private Web3InformationRetriever target;
     private Blockchain blockchain;
     private TransactionPool txPool;
     private RepositoryLocator locator;
+    private ExecutionBlockRetriever executionBlockRetriever;
 
     @Before
     public void setUp() {
         txPool = mock(TransactionPool.class);
         blockchain = mock(Blockchain.class);
         locator = mock(RepositoryLocator.class);
-        target = new Web3InformationRetriever(txPool, blockchain, locator);
+        executionBlockRetriever = mock(ExecutionBlockRetriever.class);
+        target = new Web3InformationRetriever(txPool, blockchain, locator, executionBlockRetriever);
     }
 
     @Test
     public void getBlock_pending() {
-        RskJsonRpcRequestException e = TestUtils
-                .assertThrows(RskJsonRpcRequestException.class, () -> target.getBlock("pending"));
+        Block pendingBlock = mock(Block.class);
+        BlockResult pendingBlockResult = mock(BlockResult.class);
+        when(pendingBlockResult.getBlock()).thenReturn(pendingBlock);
+        when(executionBlockRetriever.getExecutionBlock_workaround("pending")).thenReturn(pendingBlockResult);
+        Optional<Block> result = target.getBlock("pending");
 
-        assertEquals(UNIMPLEMENTED_ERROR_CODE, (int) e.getCode());
+        assertTrue(result.isPresent());
+        assertEquals(pendingBlock, result.get());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3InformationRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3InformationRetrieverTest.java
@@ -45,7 +45,7 @@ public class Web3InformationRetrieverTest {
         Block pendingBlock = mock(Block.class);
         BlockResult pendingBlockResult = mock(BlockResult.class);
         when(pendingBlockResult.getBlock()).thenReturn(pendingBlock);
-        when(executionBlockRetriever.getExecutionBlock_workaround("pending")).thenReturn(pendingBlockResult);
+        when(executionBlockRetriever.retrieveExecutionBlock("pending")).thenReturn(pendingBlockResult);
         Optional<Block> result = target.getBlock("pending");
 
         assertTrue(result.isPresent());

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -63,7 +63,7 @@ public class EthModuleTest {
         BlockResult blockResult = mock(BlockResult.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
-        when(retriever.getExecutionBlock_workaround("latest"))
+        when(retriever.retrieveExecutionBlock("latest"))
                 .thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(block);
 
@@ -101,7 +101,7 @@ public class EthModuleTest {
         BlockResult blockResult = mock(BlockResult.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
-        when(retriever.getExecutionBlock_workaround("latest"))
+        when(retriever.retrieveExecutionBlock("latest"))
                 .thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(block);
 
@@ -139,7 +139,7 @@ public class EthModuleTest {
         BlockResult blockResult = mock(BlockResult.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
-        when(retriever.getExecutionBlock_workaround("latest"))
+        when(retriever.retrieveExecutionBlock("latest"))
                 .thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(block);
 
@@ -230,7 +230,7 @@ public class EthModuleTest {
             assertEquals("Could not find account for address: " + addressFrom.toJsonString(), ex.getMessage());
         }
     }
-    
+
     @Test
     public void getCode() {
         byte[] expectedCode = new byte[] {1, 2, 3};

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -2344,7 +2344,8 @@ public class Web3ImplTest {
                 new Web3InformationRetriever(
                         transactionPool,
                         blockchain,
-                        mock(RepositoryLocator.class)),
+                        mock(RepositoryLocator.class),
+                        mock(ExecutionBlockRetriever.class)),
                 null);
     }
 
@@ -2404,6 +2405,7 @@ public class Web3ImplTest {
             ConfigCapabilities configCapabilities,
             ReceiptStore receiptStore) {
         MiningMainchainView miningMainchainViewMock = mock(MiningMainchainView.class);
+        ExecutionBlockRetriever executionBlockRetriever = mock(ExecutionBlockRetriever.class);
         wallet = WalletFactory.createWallet();
         PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, transactionPool);
 
@@ -2412,7 +2414,7 @@ public class Web3ImplTest {
             buildTransactionExecutorFactory(blockStore, null)
         );
 
-        Web3InformationRetriever retriever = new Web3InformationRetriever(transactionPool, blockchain, repositoryLocator);
+        Web3InformationRetriever retriever = new Web3InformationRetriever(transactionPool, blockchain, repositoryLocator, executionBlockRetriever);
         TransactionGateway transactionGateway = new TransactionGateway(new SimpleChannelManager(), transactionPool);
         EthModule ethModule = new EthModule(
                 config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), blockchain, transactionPool, executor,
@@ -2465,13 +2467,14 @@ public class Web3ImplTest {
             ConfigCapabilities configCapabilities,
             ReceiptStore receiptStore) {
         MiningMainchainView miningMainchainViewMock = mock(MiningMainchainView.class);
+        ExecutionBlockRetriever executionBlockRetriever = mock(ExecutionBlockRetriever.class);
         wallet = WalletFactory.createWallet();
         PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, transactionPool);
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
         ProgramResult res = new ProgramResult();
         res.setHReturn(new byte[0]);
         when(executor.executeTransaction(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(res);
-        Web3InformationRetriever retriever = new Web3InformationRetriever(transactionPool, blockchain, repositoryLocator);
+        Web3InformationRetriever retriever = new Web3InformationRetriever(transactionPool, blockchain, repositoryLocator, executionBlockRetriever);
         EthModule ethModule = new EthModule(
                 config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), blockchain, transactionPool, executor,
                 new ExecutionBlockRetriever(miningMainchainViewMock, blockchain, null, null), repositoryLocator,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds support of the "pending" block identifier (see [The default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter) section).

This capability has been introduced in the following JSON-RPC methods:

- `eth_getBlockByNumber`
- `eth_getTransactionByBlockNumberAndIndex`
- `eth_getUncleCountByBlockNumber`
- `eth_getUncleByBlockNumberAndIndex`

Fixes #1578.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Besides already implemented "earliest" and "latest" block identifiers, add support of "pending", as described in the [spec](https://eth.wiki/json-rpc/API#the-default-block-parameter).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
