### PR TITLE
Added fixed size to the signature response of eth_sign

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
@@ -81,8 +81,8 @@ public class EthModuleWalletEnabled implements EthModuleWallet {
         ECDSASignature signature = ECDSASignature.fromSignature(ecKey.sign(messageHash));
 
         return TypeConverter.toJsonHex(ByteUtil.merge(
-                ByteUtil.bigIntegerToBytes(signature.getR()),
-                ByteUtil.bigIntegerToBytes(signature.getS()),
+                ByteUtil.bigIntegerToBytes(signature.getR(), 32),
+                ByteUtil.bigIntegerToBytes(signature.getS(), 32),
                 new byte[] {signature.getV()}
         ));
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
@@ -20,6 +20,7 @@ package co.rsk.rpc.modules.eth;
 
 import co.rsk.core.RskAddress;
 import co.rsk.core.Wallet;
+import org.bouncycastle.util.BigIntegers;
 import org.ethereum.core.Account;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -81,9 +82,9 @@ public class EthModuleWalletEnabled implements EthModuleWallet {
         ECDSASignature signature = ECDSASignature.fromSignature(ecKey.sign(messageHash));
 
         return TypeConverter.toJsonHex(ByteUtil.merge(
-                ByteUtil.bigIntegerToBytes(signature.getR(), 32),
-                ByteUtil.bigIntegerToBytes(signature.getS(), 32),
-                new byte[] {signature.getV()}
+                BigIntegers.asUnsignedByteArray(32, signature.getR()),
+                BigIntegers.asUnsignedByteArray(32, signature.getS()),
+                new byte[]{signature.getV()}
         ));
     }
 }


### PR DESCRIPTION
Improve transaction tests


<!--- Provide a general summary of your changes in the Title above -->

## Description
For more information: https://github.com/rsksmart/rskj/issues/965

Basically there are leading zeros that are being truncated in Java and we need to keep the size to keep consistency for the decoding process.

## Motivation and Context
For more information: https://github.com/rsksmart/rskj/issues/965

## How Has This Been Tested?
Seems kind of hard to test this since we need leading zeros for either R or S properties after signing the data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
