### PR TITLE
Renamed Storage class to TracedRepository

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -88,7 +88,7 @@ public class Program {
 
     private final Stack stack;
     private final Memory memory;
-    private final Storage storage;
+    private final TracedRepository tracedRepository;
     private byte[] returnDataBuffer;
 
     private final ProgramResult result = new ProgramResult();
@@ -148,7 +148,7 @@ public class Program {
         this.memory = setupProgramListener(new Memory());
         this.stack = setupProgramListener(new Stack());
         this.stack.ensureCapacity(1024); // faster?
-        this.storage = setupProgramListener(new Storage(programInvoke));
+        this.tracedRepository = setupProgramListener(new TracedRepository(programInvoke));
         this.deletedAccountsInBlock = new HashSet<>(deletedAccounts);
 
         precompile();
@@ -424,7 +424,7 @@ public class Program {
     }
 
     public Repository getStorage() {
-        return this.storage;
+        return this.tracedRepository;
     }
 
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
@@ -1221,7 +1221,7 @@ public class Program {
 
     public void saveOpTrace() {
         if (this.pc < ops.length) {
-            trace.addOp(ops[pc], pc, getCallDeep(), getRemainingGas(), this.memory, this.stack, this.storage);
+            trace.addOp(ops[pc], pc, getCallDeep(), getRemainingGas(), this.memory, this.stack, this.tracedRepository);
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/program/TracedRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/TracedRepository.java
@@ -35,17 +35,17 @@ import java.util.Iterator;
 import java.util.Set;
 
 /*
- * A Storage is a proxy class for Repository. It encapsulates a repository providing tracing services.
+ * A TracedRepository is a proxy class for Repository. It encapsulates a repository providing tracing services.
  * It is only used by Program.
  * It does not provide any other functionality different from tracing.
  */
-public class Storage implements Repository, ProgramListenerAware {
+public class TracedRepository implements Repository, ProgramListenerAware {
 
     private final Repository repository;
     private final RskAddress addr;
     private ProgramListener traceListener;
 
-    public Storage(ProgramInvoke programInvoke) {
+    public TracedRepository(ProgramInvoke programInvoke) {
         this.addr = new RskAddress(programInvoke.getOwnerAddress());
         this.repository = programInvoke.getRepository();
     }

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/DetailedProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/DetailedProgramTrace.java
@@ -29,7 +29,7 @@ import org.ethereum.vm.DataWord;
 import org.ethereum.vm.OpCode;
 import org.ethereum.vm.program.Memory;
 import org.ethereum.vm.program.Stack;
-import org.ethereum.vm.program.Storage;
+import org.ethereum.vm.program.TracedRepository;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,7 +205,7 @@ public class DetailedProgramTrace implements ProgramTrace {
     }
 
     @Override
-    public Op addOp(byte code, int pc, int deep, long gas, Memory memory, Stack stack, Storage storage) {
+    public Op addOp(byte code, int pc, int deep, long gas, Memory memory, Stack stack, TracedRepository tracedRepository) {
         Op op = new Op();
         OpCode opcode = OpCode.code(code);
         op.setOp(opcode);
@@ -218,7 +218,7 @@ public class DetailedProgramTrace implements ProgramTrace {
 
         if (this.storageKey != null) {
             RskAddress currentAddress = new RskAddress(this.contractAddress);
-            DataWord value = storage.getStorageValue(currentAddress, this.storageKey);
+            DataWord value = tracedRepository.getStorageValue(currentAddress, this.storageKey);
 
             if (value != null) {
                 this.currentStorage = new HashMap<>(this.currentStorage);

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/EmptyProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/EmptyProgramTrace.java
@@ -22,7 +22,7 @@ package org.ethereum.vm.trace;
 import co.rsk.rpc.modules.trace.ProgramSubtrace;
 import org.ethereum.vm.program.Memory;
 import org.ethereum.vm.program.Stack;
-import org.ethereum.vm.program.Storage;
+import org.ethereum.vm.program.TracedRepository;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
 
 import java.util.List;
@@ -39,7 +39,7 @@ public class EmptyProgramTrace implements ProgramTrace {
     }
 
     @Override
-    public Op addOp(byte code, int pc, int deep, long gas, Memory memory, Stack stack, Storage storage) {
+    public Op addOp(byte code, int pc, int deep, long gas, Memory memory, Stack stack, TracedRepository tracedRepository) {
         return null;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/ProgramTrace.java
@@ -3,7 +3,7 @@ package org.ethereum.vm.trace;
 import co.rsk.rpc.modules.trace.ProgramSubtrace;
 import org.ethereum.vm.program.Memory;
 import org.ethereum.vm.program.Stack;
-import org.ethereum.vm.program.Storage;
+import org.ethereum.vm.program.TracedRepository;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
 
 import java.util.List;
@@ -13,7 +13,7 @@ public interface ProgramTrace {
 
     void saveGasCost(long gasCost);
 
-    Op addOp(byte code, int pc, int deep, long gas, Memory memory, Stack stack, Storage storage);
+    Op addOp(byte code, int pc, int deep, long gas, Memory memory, Stack stack, TracedRepository tracedRepository);
 
     void addSubTrace(ProgramSubtrace programSubTrace);
 

--- a/rskj-core/src/main/java/org/ethereum/vm/trace/SummarizedProgramTrace.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/trace/SummarizedProgramTrace.java
@@ -22,7 +22,7 @@ package org.ethereum.vm.trace;
 import co.rsk.rpc.modules.trace.ProgramSubtrace;
 import org.ethereum.vm.program.Memory;
 import org.ethereum.vm.program.Stack;
-import org.ethereum.vm.program.Storage;
+import org.ethereum.vm.program.TracedRepository;
 import org.ethereum.vm.program.invoke.InvokeData;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
 import org.ethereum.vm.program.invoke.TransferInvoke;
@@ -75,7 +75,7 @@ public class SummarizedProgramTrace implements ProgramTrace {
     }
 
     @Override
-    public Op addOp(byte code, int pc, int deep, long gas, Memory memory, Stack stack, Storage storage) {
+    public Op addOp(byte code, int pc, int deep, long gas, Memory memory, Stack stack, TracedRepository tracedRepository) {
         return null;
     }
 


### PR DESCRIPTION
The old `Storage` class begins with this comment

```java
/*
 * A TracedRepository is a proxy class for Repository. It encapsulates a repository providing tracing services.
 * It is only used by Program.
 * It does not provide any other functionality different from tracing.
 */
```

So I've renamed it to `TracedRepository`, which makes more sense.
