### PR TITLE
getLogs perf improvements

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/tools/IndexBlooms.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/IndexBlooms.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2021 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.cli.tools;
+
+import co.rsk.RskContext;
+import co.rsk.logfilter.BlocksBloom;
+import co.rsk.logfilter.BlocksBloomStore;
+import org.ethereum.core.Block;
+import org.ethereum.core.Bloom;
+import org.ethereum.db.BlockStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The entry point for indexing block blooms
+ * This is an experimental/unsupported tool
+ */
+public class IndexBlooms {
+
+    private static final Logger logger = LoggerFactory.getLogger(IndexBlooms.class);
+
+    private static final String EARLIEST = "earliest";
+    private static final String LATEST = "latest";
+
+    public static void main(String[] args) {
+        try (RskContext ctx = new RskContext(args)) {
+            BlockStore blockStore = ctx.getBlockStore();
+            BlocksBloomStore blocksBloomStore = ctx.getBlocksBloomStore();
+
+            long minNumber = blockStore.getMinNumber();
+            long maxNumber = blockStore.getMaxNumber();
+
+            long fromBlockNumber = EARLIEST.equals(args[0]) ? minNumber : Long.parseLong(args[0]);
+            long toBlockNumber = LATEST.equals(args[1]) ? maxNumber : Long.parseLong(args[1]);
+
+            if (fromBlockNumber < 0 || fromBlockNumber > toBlockNumber) {
+                throw new IllegalArgumentException("Invalid 'from' and/or 'to' block number");
+            }
+
+            if (fromBlockNumber < minNumber) {
+                throw new IllegalArgumentException("'from' block number is lesser than the min block number stored");
+            }
+
+            if (toBlockNumber > maxNumber) {
+                throw new IllegalArgumentException("'to' block number is greater than the best block number");
+            }
+
+            execute(fromBlockNumber, toBlockNumber, blockStore, blocksBloomStore);
+        }
+    }
+
+    public static void execute(long fromBlockNumber,
+                               long toBlockNumber,
+                               BlockStore blockStore,
+                               BlocksBloomStore blocksBloomStore) {
+        BlocksBloom auxiliaryBlocksBloom = null;
+        long curProgress = 0L;
+
+        for (long blockNum = fromBlockNumber; blockNum <= toBlockNumber; blockNum++) {
+            if (blocksBloomStore.firstNumberInRange(blockNum) == blockNum) {
+                auxiliaryBlocksBloom = new BlocksBloom();
+            }
+
+            if (auxiliaryBlocksBloom == null) {
+                continue;
+            }
+
+            Block block = blockStore.getChainBlockByNumber(blockNum);
+
+            auxiliaryBlocksBloom.addBlockBloom(blockNum, new Bloom(block.getLogBloom()));
+
+            if (blocksBloomStore.lastNumberInRange(blockNum) == blockNum) {
+                blocksBloomStore.addBlocksBloom(auxiliaryBlocksBloom);
+            }
+
+            long progress = 100 * (blockNum - fromBlockNumber + 1) / (toBlockNumber - fromBlockNumber + 1);
+            if (progress > curProgress) {
+                curProgress = progress;
+                logger.info("Processed {}% of blocks", progress);
+            }
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/config/NodeCliFlags.java
+++ b/rskj-core/src/main/java/co/rsk/config/NodeCliFlags.java
@@ -32,7 +32,6 @@ public enum NodeCliFlags implements CliArg {
     VERIFY_CONFIG("verify-config", SystemProperties.PROPERTY_BC_VERIFY, true),
     PRINT_SYSTEM_INFO("print-system-info", SystemProperties.PROPERTY_PRINT_SYSTEM_INFO, true),
     SKIP_JAVA_CHECK("skip-java-check", SystemProperties.PROPERTY_SKIP_JAVA_VERSION_CHECK, false),
-    PERSIST_STATES_CACHE_SNAPSHOT("persist-states-cache-snapshot", SystemProperties.PROPERTY_PERSIST_STATES_CACHE_SNAPSHOT, true),
     NETWORK_TESTNET("testnet", SystemProperties.PROPERTY_BC_CONFIG_NAME, "testnet"),
     NETWORK_REGTEST("regtest", SystemProperties.PROPERTY_BC_CONFIG_NAME, "regtest"),
     NETWORK_DEVNET("devnet", SystemProperties.PROPERTY_BC_CONFIG_NAME, "devnet"),

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -354,6 +354,10 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getInt("cache.states.max-elements");
     }
 
+    public int getBloomsCacheSize() {
+        return configFromFiles.getInt("cache.blooms.max-elements");
+    }
+
     public int getStateRootsCacheSize() {
         return configFromFiles.getInt("cache.stateRoots.max-elements");
     }

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -95,6 +95,7 @@ public abstract class SystemProperties {
     public static final String PROPERTY_SKIP_JAVA_VERSION_CHECK = "system.checkJavaVersion";
 
     public static final String PROPERTY_PERSIST_STATES_CACHE_SNAPSHOT = "cache.states.persist-snapshot";
+    public static final String PROPERTY_PERSIST_BLOOMS_CACHE_SNAPSHOT = "cache.blooms.persist-snapshot";
 
     /* Testing */
     private static final Boolean DEFAULT_VMTEST_LOAD_LOCAL = false;
@@ -578,6 +579,10 @@ public abstract class SystemProperties {
 
     public boolean shouldPersistStatesCacheSnapshot() {
         return getBoolean(PROPERTY_PERSIST_STATES_CACHE_SNAPSHOT, false);
+    }
+
+    public boolean shouldPersistBloomsCacheSnapshot() {
+        return getBoolean(PROPERTY_PERSIST_BLOOMS_CACHE_SNAPSHOT, false);
     }
 
     protected int getInt(String path, int val) {

--- a/rskj-core/src/main/java/org/ethereum/util/MapSnapshot.java
+++ b/rskj-core/src/main/java/org/ethereum/util/MapSnapshot.java
@@ -129,11 +129,13 @@ public abstract class MapSnapshot<T extends Closeable> implements Closeable {
             }
             for (int i = 0; i < entryCount; i++) {
                 int keySize = dataInput.readInt();
-                if (keySize < 1) {
+                if (keySize < 0) {
                     throw new IOException("Invalid data: key size");
                 }
                 byte[] key = new byte[keySize];
-                dataInput.readFully(key);
+                if (keySize > 0) {
+                    dataInput.readFully(key);
+                }
 
                 int valueSize = dataInput.readInt();
                 if (valueSize < -1) {

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -281,6 +281,10 @@ cache = {
   receipts {
     max-elements = <max-elements>
   },
+  blooms {
+    max-elements = <max-elements>
+    persist-snapshot = <bool>
+  },
   btcBlockStore {
     depth = <depth-elements>
     size = <cache-max-elements>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -446,6 +446,14 @@ cache {
     # ie 200 transactions in 20 blocks
     max-elements: 4000
   },
+  blooms {
+    # each entry represents a range of blocks
+    # initial estimated capacity: 100000 entries
+    max-elements: 100000
+
+    # (experimental, OFF by default) enables persistence of cache snapshots, which speeds up loading of entries from a disk into memory
+    persist-snapshot: false
+  },
   btcBlockStore {
     depth: 5000,
     size: 10000
@@ -469,4 +477,3 @@ blooms {
     service = false
     confirmations = 400
 }
-

--- a/rskj-core/src/test/java/co/rsk/RskContextTest.java
+++ b/rskj-core/src/test/java/co/rsk/RskContextTest.java
@@ -42,6 +42,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -82,6 +83,18 @@ public class RskContextTest {
         assertThat(devnetContext.getCliArgs(), notNullValue());
         assertThat(devnetContext.getCliArgs().getFlags(), contains(NodeCliFlags.NETWORK_DEVNET));
         devnetContext.close();
+    }
+
+    @Test
+    public void shouldResolveCacheSnapshotPath() {
+        Path baseStorePath = Paths.get("./db");
+
+        Path resolvedPath = rskContext.resolveCacheSnapshotPath(baseStorePath);
+
+        assertNotNull(resolvedPath);
+
+        String pathSuffix = resolvedPath.toString().replace(baseStorePath.toString(), "");
+        assertEquals("/rskcache", pathSuffix);
     }
 
     @Test
@@ -228,6 +241,7 @@ public class RskContextTest {
 
         Set<String> methodsToSkip = new HashSet<String>() {{
             add("getCliArgs");
+            add("resolveCacheSnapshotPath");
             add("isClosed");
             add("close");
         }};

--- a/rskj-core/src/test/java/co/rsk/logfilter/BlocksBloomStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/logfilter/BlocksBloomStoreTest.java
@@ -6,33 +6,38 @@ import org.ethereum.datasource.KeyValueDataSource;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by ajlopez on 05/02/2019.
  */
 public class BlocksBloomStoreTest {
     @Test
     public void getFirstNumberInRange() {
-        BlocksBloomStore blocksBloomStore = new BlocksBloomStore(64, 0, null);
+        KeyValueDataSource dataSource = mock(KeyValueDataSource.class);
+        BlocksBloomStore blocksBloomStore = new BlocksBloomStore(64, 0, dataSource);
 
         Assert.assertEquals(0, blocksBloomStore.firstNumberInRange(0));
         Assert.assertEquals(0, blocksBloomStore.firstNumberInRange(1));
         Assert.assertEquals(blocksBloomStore.getNoBlocks(), blocksBloomStore.firstNumberInRange(blocksBloomStore.getNoBlocks()));
-        Assert.assertEquals(blocksBloomStore.getNoBlocks(), blocksBloomStore.firstNumberInRange(blocksBloomStore.getNoBlocks() * 2 - 1));
+        Assert.assertEquals(blocksBloomStore.getNoBlocks(), blocksBloomStore.firstNumberInRange(blocksBloomStore.getNoBlocks() * 2L - 1));
     }
 
     @Test
     public void getLastNumberInRange() {
-        BlocksBloomStore blocksBloomStore = new BlocksBloomStore(64, 0, null);
+        KeyValueDataSource dataSource = mock(KeyValueDataSource.class);
+        BlocksBloomStore blocksBloomStore = new BlocksBloomStore(64, 0, dataSource);
 
         Assert.assertEquals(blocksBloomStore.getNoBlocks() - 1, blocksBloomStore.lastNumberInRange(0));
         Assert.assertEquals(blocksBloomStore.getNoBlocks() - 1, blocksBloomStore.lastNumberInRange(1));
-        Assert.assertEquals(blocksBloomStore.getNoBlocks() * 2 - 1, blocksBloomStore.lastNumberInRange(blocksBloomStore.getNoBlocks()));
-        Assert.assertEquals(blocksBloomStore.getNoBlocks() * 2 - 1, blocksBloomStore.lastNumberInRange(blocksBloomStore.getNoBlocks() * 2 - 1));
+        Assert.assertEquals(blocksBloomStore.getNoBlocks() * 2L - 1, blocksBloomStore.lastNumberInRange(blocksBloomStore.getNoBlocks()));
+        Assert.assertEquals(blocksBloomStore.getNoBlocks() * 2L - 1, blocksBloomStore.lastNumberInRange(blocksBloomStore.getNoBlocks() * 2L - 1));
     }
 
     @Test
     public void noBlocksBloom() {
-        BlocksBloomStore blocksBloomStore = new BlocksBloomStore(64, 0, null);
+        KeyValueDataSource dataSource = mock(KeyValueDataSource.class);
+        BlocksBloomStore blocksBloomStore = new BlocksBloomStore(64, 0, dataSource);
 
         Assert.assertNull(blocksBloomStore.getBlocksBloomByNumber(0));
         Assert.assertNull(blocksBloomStore.getBlocksBloomByNumber(1));
@@ -86,14 +91,18 @@ public class BlocksBloomStoreTest {
         Bloom bloom1 = new Bloom(bytes1);
         Bloom bloom2 = new Bloom(bytes2);
 
-        BlocksBloomStore blocksBloomStore = new BlocksBloomStore(64, 0, null);
+        BlocksBloomStore blocksBloomStore = new BlocksBloomStore(64, 0, new HashMapDB());
 
         blocksBloom.addBlockBloom(blocksBloomStore.getNoBlocks(), bloom1);
         blocksBloom.addBlockBloom(blocksBloomStore.getNoBlocks() + 1, bloom2);
 
         blocksBloomStore.addBlocksBloom(blocksBloom);
 
-        Assert.assertSame(blocksBloom, blocksBloomStore.getBlocksBloomByNumber(blocksBloomStore.getNoBlocks()));
+        BlocksBloom actualBlocksBloom = blocksBloomStore.getBlocksBloomByNumber(blocksBloomStore.getNoBlocks());
+
+        Assert.assertEquals(blocksBloom.fromBlock(), actualBlocksBloom.fromBlock());
+        Assert.assertEquals(blocksBloom.toBlock(), actualBlocksBloom.toBlock());
+        Assert.assertEquals(blocksBloom.getBloom(), actualBlocksBloom.getBloom());
     }
 
     @Test
@@ -115,7 +124,11 @@ public class BlocksBloomStoreTest {
 
         blocksBloomStore.addBlocksBloom(blocksBloom);
 
-        Assert.assertSame(blocksBloom, blocksBloomStore.getBlocksBloomByNumber(blocksBloomStore.getNoBlocks()));
+        BlocksBloom actualBlocksBloom = blocksBloomStore.getBlocksBloomByNumber(blocksBloomStore.getNoBlocks());
+
+        Assert.assertEquals(blocksBloom.fromBlock(), actualBlocksBloom.fromBlock());
+        Assert.assertEquals(blocksBloom.toBlock(), actualBlocksBloom.toBlock());
+        Assert.assertEquals(blocksBloom.getBloom(), actualBlocksBloom.getBloom());
 
         Assert.assertNotNull(dataSource.get(BlocksBloomStore.longToKey(blocksBloomStore.getNoBlocks())));
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -43,6 +43,7 @@ import co.rsk.test.builders.BlockBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.trie.TrieStore;
 import org.ethereum.core.*;
+import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.facade.Ethereum;
@@ -1088,7 +1089,7 @@ public class Web3ImplLogsTest {
                 null,
                 new SimpleConfigCapabilities(),
                 null,
-                new BlocksBloomStore(2, 0, null),
+                new BlocksBloomStore(2, 0, new HashMapDB()),
                 mock(Web3InformationRetriever.class),
                 null);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This introduces some performance improvements to the `eth_getLogs` JSON-RPC method.

To index block blooms which are not indexed yet, this PR adds a new cli tool - `IndexBlooms`. See motivation section for more details.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `eth_getLogs` JSON-RPC call consumes lots of resources, especially when it's triggered on a long block range to retrieve historical data. One way to improve this is to use blocks' bloom filters. Bloom filters are already part of each RSK block, but iterating over each block in a requested range is still time consuming operation, as it requires retrieving blocks from a db.

To improve this some time ago there were introduced "combined" bloom filters for block batches (by default, each such batch has 64 blocks), so during the iteration process we can skip some block batches if their "combined" bloom doesn't fit our filter requirements. This can be thought as some form of indexing of block bloom filters. The node automatically index block batches that are being queried, so next time if blocks from same batches are queried again, their processing time should be lower.

Also the node already has a capability to auto-index blocks' blooms for new blocks that are being added to a chain from the network. But this feature is OFF by default. It can be enabled via this jvm flag - `-Dblooms.service=true` or via setting `blooms.service` to `true` in the node's config.

Besides existing capabilities for block blooms indexing, a new CLI tool is added - `IndexBlooms` - which allows to index in advance some specified block range. It can be triggered like this

```bash
java -cp ./rskj-core/build/libs/rskj-core-3.2.0-SNAPSHOT-all.jar co.rsk.cli.tools.IndexBlooms earliest latest
```
for entire chain or like this
```bash
java -cp ./rskj-core/build/libs/rskj-core-3.2.0-SNAPSHOT-all.jar co.rsk.cli.tools.IndexBlooms 1000 5000
```
for a specific range, in this case: `[1000..5000]`.

One more way to seed up blooms index initialisation is to persist its cache snapshots (same as it was done [here](https://github.com/rsksmart/rskj/pull/1595) for states). This can be achieved by setting `persist-snapshot` to `true` in the config like this:
```
...
  blooms {
    # each entry represents a range of blocks
    # initial estimated capacity: 100000 entries
    max-elements: 100000

    # (experimental, OFF by default) enables persistence of cache snapshots, which speeds up loading of entries from a disk into memory
    persist-snapshot: true
  },
...
```
or by providing the following cli arg: `-Dcache.blooms.persist-snapshot=true`, so, for example, the previous command for blooms indexing could look like the following:
```bash
java -Dcache.blooms.persist-snapshot=true -cp ./rskj-core/build/libs/rskj-core-3.2.0-SNAPSHOT-all.jar co.rsk.cli.tools.IndexBlooms earliest latest --testnet
```
Pay attention that for this to take affect the node should also be started with the `-Dcache.blooms.persist-snapshot=true` flag (which is OFF by default) or with the appropriate config setting. It is also desirable to start the node with auto-indexing enabled. So the command could look like this:
```base
java -Dcache.blooms.persist-snapshot=true -Dblooms.service=true -jar ./rskj-core/build/libs/rskj-core-3.2.0-SNAPSHOT-all.jar --testnet
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
