### PR TITLE
Automated reproducible on prerelease (Former PR 1586)

### DIFF
--- a/.github/workflows/reproducible.yml
+++ b/.github/workflows/reproducible.yml
@@ -1,0 +1,94 @@
+name: Reproducible build
+on: 
+  release:
+    types: [prereleased]
+
+jobs:
+  build_jar:
+    runs-on: ubuntu-20.04
+    container: 
+      image: openjdk:8-jdk-slim-buster
+    outputs:
+      fatjar_name: ${{ steps.vars.outputs.fatjar_name }}
+      sha256sum: ${{ steps.vars.outputs.sha256sum }}
+
+    steps:
+      - name: Install packages
+        run: |
+          apt-get update -y && apt-get install -y git curl gnupg
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Verify files integrity
+        run: |
+          gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
+          gpg --verify --output SHA256SUMS SHA256SUMS.asc && sha256sum --check SHA256SUMS
+      - name: Build rskj
+        run: |
+          ./configure.sh && ./gradlew --no-daemon clean build -x test
+            
+      - name: Set variable and SHA256SUMS file
+        id: vars
+        working-directory: rskj-core/build/libs
+        run: |       
+          echo "::set-output name=fatjar_name::$(echo *-all.jar)"
+          sha256sum $(echo *-all.jar) > ./SHA256SUMS
+          echo "::set-output name=sha256sum::$(cut -d " " -f 1 <SHA256SUMS)"
+      
+      - name: Upload rskj-artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: rskj-artifacts
+          path: |
+            rskj-core/build/libs/${{ steps.vars.outputs.fatjar_name }}
+            rskj-core/build/libs/SHA256SUMS
+  upload_asset_to_prerelease:
+    needs: build_jar
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download rskj-artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: rskj-artifacts
+          path: ${HOME} 
+
+      - name: Insert jar asset into prerelase
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${HOME}/${{ needs.build_jar.outputs.fatjar_name }}
+          asset_name: ${{ needs.build_jar.outputs.fatjar_name }}
+          asset_content_type: application/octet-stream
+
+      - name: Insert SHA256SUMS asset into prerelase
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${HOME}/SHA256SUMS
+          asset_name: SHA256SUMS
+          asset_content_type: text/plain
+
+      - name: Edit prerelase Description
+        env:
+          TMP_FOLDER: /tmp
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          hub release show ${{ github.event.release.tag_name }} > ${{ env.TMP_FOLDER }}/body
+          cat <<'EOF' >> ${{ env.TMP_FOLDER }}/body  
+          
+          Reproducible builds allow you to match our provided binary with the source
+          code you find on the repository. As more people reproduce the code, the more
+          sure you can be that the code has not been tampered with.
+          
+          - **Want to perform a reproducible build?** Follow this [guide](https://developers.rsk.co/rsk/node/reproducible/). 
+          - **SHA256SUM** `${{ needs.build_jar.outputs.sha256sum }}`
+          EOF
+          hub release edit -F ${{ env.TMP_FOLDER }}/body ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Automated reproducible

## Description
This change triggers an automated reproducible generation using a Github Action providing hash checksum and jar files on prerelease

## Motivation and Context
Avoid human intervention on hash and reproducible generation related tasks

## How Has This Been Tested?
On forked repository made a github action workflow and reproduced using a Dockerfile as seen on `reproducible-builds` repo

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)