### PR TITLE
Changed difficulty min value for testnet

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/DifficultyCalculator.java
+++ b/rskj-core/src/main/java/co/rsk/core/DifficultyCalculator.java
@@ -41,7 +41,7 @@ public class DifficultyCalculator {
         if (!rskip97Active) {
             // If more than 10 minutes, reset to minimum difficulty to allow private mining
             if (header.getTimestamp() >= parentHeader.getTimestamp() + 600) {
-                return constants.getMinimumDifficulty();
+                return constants.getMinimumDifficulty(header.getNumber());
             }
         }
 
@@ -57,7 +57,7 @@ public class DifficultyCalculator {
         long curBlockTS = curBlockHeader.getTimestamp();
         int duration = constants.getDurationLimit();
         BigInteger difDivisor = constants.getDifficultyBoundDivisor(activationConfig.forBlock(curBlockHeader.getNumber()));
-        BlockDifficulty minDif = constants.getMinimumDifficulty();
+        BlockDifficulty minDif = constants.getMinimumDifficulty(curBlockHeader.getNumber());
         return calcDifficultyWithTimeStamps(curBlockTS, parentBlockTS, pd, uncleCount, duration, difDivisor, minDif);
     }
 

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -50,10 +50,34 @@ public class Constants {
     private final boolean seedCowAccounts;
     private final int durationLimit;
     private final BlockDifficulty minimumDifficulty;
+    private final BlockDifficulty minimumDifficultyForRskip290;
     private final BlockDifficulty fallbackMiningDifficulty;
     private final BigInteger difficultyBoundDivisor;
     private final int newBlockMaxSecondsInTheFuture;
     public final BridgeConstants bridgeConstants;
+    private final ActivationConfig activationConfig;
+
+    public Constants(
+            byte chainId,
+            boolean seedCowAccounts,
+            int durationLimit,
+            BlockDifficulty minimumDifficulty,
+            BlockDifficulty fallbackMiningDifficulty,
+            BigInteger difficultyBoundDivisor,
+            int newBlockMaxSecondsInTheFuture,
+            BridgeConstants bridgeConstants,
+            ActivationConfig activationConfig) {
+        this.chainId = chainId;
+        this.seedCowAccounts = seedCowAccounts;
+        this.durationLimit = durationLimit;
+        this.minimumDifficulty = minimumDifficulty;
+        this.fallbackMiningDifficulty = fallbackMiningDifficulty;
+        this.difficultyBoundDivisor = difficultyBoundDivisor;
+        this.newBlockMaxSecondsInTheFuture = newBlockMaxSecondsInTheFuture;
+        this.bridgeConstants = bridgeConstants;
+        this.activationConfig = activationConfig;
+        this.minimumDifficultyForRskip290 = new BlockDifficulty(new BigInteger("550000000"));
+    }
 
     public Constants(
             byte chainId,
@@ -64,14 +88,15 @@ public class Constants {
             BigInteger difficultyBoundDivisor,
             int newBlockMaxSecondsInTheFuture,
             BridgeConstants bridgeConstants) {
-        this.chainId = chainId;
-        this.seedCowAccounts = seedCowAccounts;
-        this.durationLimit = durationLimit;
-        this.minimumDifficulty = minimumDifficulty;
-        this.fallbackMiningDifficulty = fallbackMiningDifficulty;
-        this.difficultyBoundDivisor = difficultyBoundDivisor;
-        this.newBlockMaxSecondsInTheFuture = newBlockMaxSecondsInTheFuture;
-        this.bridgeConstants = bridgeConstants;
+        this(chainId,
+                seedCowAccounts,
+                durationLimit,
+                minimumDifficulty,
+                fallbackMiningDifficulty,
+                difficultyBoundDivisor,
+                newBlockMaxSecondsInTheFuture,
+                bridgeConstants,
+                null);
     }
 
     public boolean seedCowAccounts() {
@@ -84,7 +109,13 @@ public class Constants {
     }
 
     public BlockDifficulty getMinimumDifficulty() {
-        return minimumDifficulty;
+        return getMinimumDifficulty(null);
+    }
+
+    public BlockDifficulty getMinimumDifficulty(Long blockNumber) {
+        boolean isRskip290Enabled = chainId == TESTNET_CHAIN_ID && blockNumber != null && activationConfig != null
+                && activationConfig.isActive(ConsensusRule.RSKIP290, blockNumber);
+        return isRskip290Enabled ? minimumDifficultyForRskip290 : minimumDifficulty;
     }
 
     public BlockDifficulty getFallbackMiningDifficulty() {
@@ -215,6 +246,10 @@ public class Constants {
     }
 
     public static Constants testnet() {
+        return testnet(null);
+    }
+
+    public static Constants testnet(ActivationConfig activationConfig) {
         return new Constants(
                 TESTNET_CHAIN_ID,
                 false,
@@ -223,7 +258,8 @@ public class Constants {
                 new BlockDifficulty(BigInteger.valueOf((long) 14E15)),
                 BigInteger.valueOf(50),
                 540,
-                BridgeTestNetConstants.getInstance()
+                BridgeTestNetConstants.getInstance(),
+                activationConfig
         );
     }
 

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -66,7 +66,8 @@ public class Constants {
             BigInteger difficultyBoundDivisor,
             int newBlockMaxSecondsInTheFuture,
             BridgeConstants bridgeConstants,
-            ActivationConfig activationConfig) {
+            ActivationConfig activationConfig,
+            BlockDifficulty minimumDifficultyForRskip290) {
         this.chainId = chainId;
         this.seedCowAccounts = seedCowAccounts;
         this.durationLimit = durationLimit;
@@ -76,7 +77,7 @@ public class Constants {
         this.newBlockMaxSecondsInTheFuture = newBlockMaxSecondsInTheFuture;
         this.bridgeConstants = bridgeConstants;
         this.activationConfig = activationConfig;
-        this.minimumDifficultyForRskip290 = new BlockDifficulty(new BigInteger("550000000"));
+        this.minimumDifficultyForRskip290 = minimumDifficultyForRskip290;
     }
 
     public Constants(
@@ -87,7 +88,8 @@ public class Constants {
             BlockDifficulty fallbackMiningDifficulty,
             BigInteger difficultyBoundDivisor,
             int newBlockMaxSecondsInTheFuture,
-            BridgeConstants bridgeConstants) {
+            BridgeConstants bridgeConstants,
+            BlockDifficulty minimumDifficultyForRskip290) {
         this(chainId,
                 seedCowAccounts,
                 durationLimit,
@@ -96,7 +98,9 @@ public class Constants {
                 difficultyBoundDivisor,
                 newBlockMaxSecondsInTheFuture,
                 bridgeConstants,
-                null);
+                null,
+                minimumDifficultyForRskip290
+                );
     }
 
     public boolean seedCowAccounts() {
@@ -106,10 +110,6 @@ public class Constants {
     // Average Time between blocks
     public int getDurationLimit() {
         return durationLimit;
-    }
-
-    public BlockDifficulty getMinimumDifficulty() {
-        return getMinimumDifficulty(null);
     }
 
     public BlockDifficulty getMinimumDifficulty(Long blockNumber) {
@@ -228,7 +228,8 @@ public class Constants {
                 new BlockDifficulty(BigInteger.valueOf((long) 14E15)),
                 BigInteger.valueOf(50),
                 60,
-                BridgeMainNetConstants.getInstance()
+                BridgeMainNetConstants.getInstance(),
+                new BlockDifficulty(new BigInteger("550000000"))
         );
     }
 
@@ -241,7 +242,8 @@ public class Constants {
                 new BlockDifficulty(BigInteger.valueOf((long) 14E15)),
                 BigInteger.valueOf(50),
                 540,
-                new BridgeDevNetConstants(federationPublicKeys)
+                new BridgeDevNetConstants(federationPublicKeys),
+                new BlockDifficulty(new BigInteger("550000000"))
         );
     }
 
@@ -259,7 +261,8 @@ public class Constants {
                 BigInteger.valueOf(50),
                 540,
                 BridgeTestNetConstants.getInstance(),
-                activationConfig
+                activationConfig,
+                new BlockDifficulty(new BigInteger("550000000"))
         );
     }
 
@@ -272,7 +275,8 @@ public class Constants {
                 BlockDifficulty.ZERO,
                 BigInteger.valueOf(2048),
                 0,
-                BridgeRegTestConstants.getInstance()
+                BridgeRegTestConstants.getInstance(),
+                new BlockDifficulty(new BigInteger("550000000"))
         );
     }
 
@@ -285,7 +289,8 @@ public class Constants {
                 BlockDifficulty.ZERO,
                 BigInteger.valueOf(2048),
                 0,
-                new BridgeRegTestConstants(genesisFederationPublicKeys)
+                new BridgeRegTestConstants(genesisFederationPublicKeys),
+                new BlockDifficulty(new BigInteger("550000000"))
         );
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -247,10 +247,6 @@ public class Constants {
         );
     }
 
-    public static Constants testnet() {
-        return testnet(null);
-    }
-
     public static Constants testnet(ActivationConfig activationConfig) {
         return new Constants(
                 TESTNET_CHAIN_ID,

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -167,7 +167,7 @@ public abstract class SystemProperties {
                     constants = Constants.mainnet();
                     break;
                 case "testnet":
-                    constants = Constants.testnet();
+                    constants = Constants.testnet(getActivationConfig());
                     break;
                 case "devnet":
                     constants = Constants.devnetWithFederation(

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -69,7 +69,8 @@ public enum ConsensusRule {
     RSKIP201("rskip201"),
     RSKIP218("rskip218"), // New rewards fee adddress
     RSKIP219("rskip219"),
-    RSKIP220("rskip220");
+    RSKIP220("rskip220"),
+    RSKIP290("rskip290"); // Testnet difficulty should drop to a higher difficulty
 
     private String configKey;
 

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
@@ -27,7 +27,8 @@ public enum NetworkUpgrade {
     WASABI_100("wasabi100"),
     PAPYRUS_200("papyrus200"),
     TWOTOTHREE("twoToThree"),
-    IRIS300("iris300");
+    IRIS300("iris300"),
+    HOP400("hop400");
 
     private String name;
 

--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -8,7 +8,8 @@ blockchain.config {
         wasabi100 = 0,
         twoToThree = 0,
         papyrus200 = 0,
-        iris300 = 0
+        iris300 = 0,
+        hop400 = 0
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -9,6 +9,7 @@ blockchain.config {
         twoToThree = 2018000,
         papyrus200 = 2392700
         iris300 = 3614800
+        hop400 = 0
     }
 }
 

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -9,7 +9,7 @@ blockchain.config {
         twoToThree = 2018000,
         papyrus200 = 2392700
         iris300 = 3614800
-        hop400 = 0
+        hop400 = -1
     }
 }
 

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -9,6 +9,7 @@ blockchain.config {
         twoToThree = 0,
         papyrus200 = 0
         iris300 = 0
+        hop400 = 0
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -9,7 +9,7 @@ blockchain.config {
         twoToThree = 504000,
         papyrus200 = 863000,
         iris300 = 2060500,
-        hop400 = 0
+        hop400 = -1
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -8,7 +8,8 @@ blockchain.config {
         wasabi100 = 0,
         twoToThree = 504000,
         papyrus200 = 863000,
-        iris300 = 2060500
+        iris300 = 2060500,
+        hop400 = 0
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -12,6 +12,7 @@ blockchain = {
             papyrus200 = <height>
             twoToThree = <height>
             iris300 = <height>
+            hop400 = <height>
         }
         consensusRules = {
              areBridgeTxsPaid = <hardforkName>
@@ -65,6 +66,7 @@ blockchain = {
              rskip218 = <hardforkName>
              rskip219 = <hardforkName>
              rskip220 = <hardforkName>
+             rskip290 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -56,6 +56,7 @@ blockchain = {
             rskip218 = iris300
             rskip219 = iris300
             rskip220 = iris300
+            rskip290 = hop400
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/RskContextTest.java
+++ b/rskj-core/src/test/java/co/rsk/RskContextTest.java
@@ -170,7 +170,7 @@ public class RskContextTest {
         doReturn(1L).when(testProperties).getPeerScoringSummaryTime();
         doReturn(mock(ActivationConfig.class)).when(testProperties).getActivationConfig();
         doReturn(mock(ECKey.class)).when(testProperties).getMyKey();
-        doReturn(Constants.testnet()).when(testProperties).getNetworkConstants();
+        doReturn(Constants.testnet(null)).when(testProperties).getNetworkConstants();
 
         rskContext.buildInternalServices();
 

--- a/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
+++ b/rskj-core/src/test/java/co/rsk/jsontestsuite/LocalBasicTest.java
@@ -55,12 +55,36 @@ public class LocalBasicTest {
     }
 
     @Test
+    public void runDifficultyTestBeforeRSKIP290() throws IOException {
+        activationConfig = ActivationConfigsForTest.allBut(ConsensusRule.RSKIP290);
+        Constants networkConstants = Constants.testnet(activationConfig);
+        String jsonName = "difficulty";
+        runJsonTest(jsonName, activationConfig, networkConstants);
+    }
+
+    @Test
+    public void runDifficultyTestAfterRSKIP290() throws IOException {
+        activationConfig = ActivationConfigsForTest.all();
+        Constants networkConstants = Constants.testnet(activationConfig);
+        String jsonName = "difficulty1";
+        runJsonTest(jsonName, activationConfig, networkConstants);
+    }
+
+    @Test
     public void runDifficultyTest() throws IOException {
         String jsonName = "difficulty";
         runJsonTest(jsonName);
     }
 
     private void runJsonTest(String jsonName) throws IOException {
+        runJsonTest(jsonName, activationConfig, this.networkConstants);
+    }
+
+    private void runJsonTest(
+            String jsonName,
+            ActivationConfig activationConfig,
+            Constants networkConstants
+            ) throws IOException {
         BlockFactory blockFactory = new BlockFactory(activationConfig);
 
         String json = getJSON(jsonName);
@@ -75,16 +99,15 @@ public class LocalBasicTest {
             BlockHeader parent = testCase.getParent(blockFactory);
             BlockDifficulty calc = new DifficultyCalculator(activationConfig, networkConstants).calcDifficulty(current, parent);
             int c = calc.compareTo(parent.getDifficulty());
-            if (c>0)
+            if (c > 0)
                 logger.info(" Difficulty increase test\n");
-            else
-            if (c<0)
+            else if (c < 0)
                 logger.info(" Difficulty decrease test\n");
             else
                 logger.info(" Difficulty without change test\n");
 
 
-            assertEquals(testCase.getExpectedDifficulty(),calc);
+            assertEquals(testCase.getExpectedDifficulty(), calc);
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -304,7 +304,7 @@ public class RemascStorageProviderTest {
 
     @Test
     public void doesntPayFedBelowMinimumRewardAfterRFS() throws IOException {
-        Constants constants = spy(Constants.testnet());
+        Constants constants = spy(Constants.testnet(null));
         // we need to pass chain id check, and make believe that testnet config has same chain id as cow account
         when(constants.getChainId()).thenReturn(Constants.REGTEST_CHAIN_ID);
         when(constants.getMinimumPayableGas()).thenReturn(BigInteger.valueOf(0));
@@ -330,7 +330,7 @@ public class RemascStorageProviderTest {
 
     @Test
     public void doesntPayBelowMinimumRewardAfterRFS() throws IOException {
-        Constants constants = spy(Constants.testnet());
+        Constants constants = spy(Constants.testnet(null));
         // we need to pass chain id check, and make believe that testnet config has same chain id as cow account
         when(constants.getChainId()).thenReturn(Constants.REGTEST_CHAIN_ID);
         when(constants.getMinimumPayableGas()).thenReturn(BigInteger.valueOf(10000L));
@@ -353,7 +353,7 @@ public class RemascStorageProviderTest {
 
     @Test
     public void paysFedWhenHigherThanMinimumRewardAfterRFS() throws IOException {
-        Constants constants = spy(Constants.testnet());
+        Constants constants = spy(Constants.testnet(null));
         // we need to pass chain id check, and make believe that testnet config has same chain id as cow account
         when(constants.getChainId()).thenReturn(Constants.REGTEST_CHAIN_ID);
         when(constants.getMinimumPayableGas()).thenReturn(BigInteger.valueOf(0));
@@ -381,7 +381,7 @@ public class RemascStorageProviderTest {
 
     @Test
     public void paysWhenHigherThanMinimumRewardAfterRFS() throws IOException {
-        Constants constants = spy(Constants.testnet());
+        Constants constants = spy(Constants.testnet(null));
         // we need to pass chain id check, and make believe that testnet config has same chain id as cow account
         when(constants.getChainId()).thenReturn(Constants.REGTEST_CHAIN_ID);
         when(constants.getMinimumPayableGas()).thenReturn(BigInteger.valueOf(21000L));
@@ -406,7 +406,7 @@ public class RemascStorageProviderTest {
 
     @Test
     public void paysOnlyBlocksWithEnoughBalanceAccumulatedAfterRFS() throws IOException {
-        Constants constants = spy(Constants.testnet());
+        Constants constants = spy(Constants.testnet(null));
         // we need to pass chain id check, and make believe that testnet config has same chain id as cow account
         when(constants.getChainId()).thenReturn(Constants.REGTEST_CHAIN_ID);
         when(constants.getMinimumPayableGas()).thenReturn(BigInteger.valueOf(21000L));

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -38,6 +38,7 @@ public class ActivationConfigTest {
             "    papyrus200: 0",
             "    twoToThree: 0",
             "    iris300: 0",
+            "    hop400: 0",
             "},",
             "consensusRules: {",
             "    areBridgeTxsPaid: afterBridgeSync,",
@@ -91,6 +92,7 @@ public class ActivationConfigTest {
             "    rskip218: iris300",
             "    rskip219: iris300",
             "    rskip220: iris300",
+            "    rskip290: hop400",
             "}"
     ));
 

--- a/rskj-core/src/test/resources/json/BasicTests/difficulty1.json
+++ b/rskj-core/src/test/resources/json/BasicTests/difficulty1.json
@@ -1,0 +1,9 @@
+{
+ "DifficultyTest1" : {
+		"parentTimestamp" : "0xff6f9889aec4a8ab",
+		"parentDifficulty" : "0xcfb97a9",
+		"currentTimestamp" : "0xff6f9889aec4a8ab",
+		"currentBlockNumber" : "0x01",
+		"currentDifficulty" : "0x20C85580"
+	}
+}


### PR DESCRIPTION
Difficulty drop in Testnet should drop to a higher difficulty (current one is too low)

## Description
<!--- Describe your changes in detail -->
 Testnet it's processing a lot a blocks when the following condition happens:

1. Miner with a lot of hardware resources gets in.
2. Block Validation Difficulty Increases.
3. Miner with a lot of hardware leaves the net.
4. Difficulty drops really fast at a point that Miner with low resources can process blocks every second

## Motivation and Context
This change will ensure Testnet consensus to happen so fast

## How Has This Been Tested?
Added 2 tests for it

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)


* **Other information**:
