### PR TITLE
Mitigated db inconsistency issue after improper node shutdown

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1132,10 +1132,10 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         }
 
         // then close data stores
-        if (blockStore != null) {
-            logger.trace("closing blockStore.");
-            blockStore.close();
-            logger.trace("blockStore closed.");
+        if (trieStore != null) {
+            logger.trace("disposing trieStore.");
+            trieStore.dispose();
+            logger.trace("trieStore disposed.");
         }
 
         if (stateRootsStore != null) {
@@ -1144,16 +1144,16 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             logger.trace("stateRootsStore closed.");
         }
 
-        if (trieStore != null) {
-            logger.trace("disposing trieStore.");
-            trieStore.dispose();
-            logger.trace("trieStore disposed.");
-        }
-
         if (receiptStore != null) {
             logger.trace("closing receiptStore.");
             receiptStore.close();
             logger.trace("receiptStore closed.");
+        }
+
+        if (blockStore != null) {
+            logger.trace("closing blockStore.");
+            blockStore.close();
+            logger.trace("blockStore closed.");
         }
 
         if (blocksBloomStore != null) {
@@ -1513,7 +1513,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                     getBlockValidator(),
                     getBlockExecutor(),
                     getGenesis(),
-                    getStateRootHandler()
+                    getStateRootHandler(),
+                    getRepositoryLocator()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -86,4 +86,12 @@ public abstract class CliToolRskContextAware {
      * Actual execution should be implemented in this method in derived classes.
      */
     protected abstract void onExecute(@Nonnull String[] args, @Nonnull RskContext ctx) throws Exception;
+
+    /**
+     * Handy interface for printing strings.
+     */
+    @FunctionalInterface
+    public interface Printer {
+        void println(String x);
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/cli/tools/RewindBlocks.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/RewindBlocks.java
@@ -19,17 +19,28 @@ package co.rsk.cli.tools;
 
 import co.rsk.RskContext;
 import co.rsk.cli.CliToolRskContextAware;
+import co.rsk.crypto.Keccak256;
+import co.rsk.db.RepositoryLocator;
+import com.google.common.annotations.VisibleForTesting;
+import org.ethereum.core.Block;
 import org.ethereum.db.BlockStore;
 
 import javax.annotation.Nonnull;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * The entry point for rewind blocks state CLI tool
  * This is an experimental/unsupported tool
  *
  * Required cli args:
- * - args[0] - block number
+ * - args[0] - block number or "fmi"/"rbc" options ("find min inconsistent block" / "rewind to best consistent block" respectively)
+ *
+ * Notes:
+ * - inconsistent block is the one with missing state in the states db (this can happen in case of improper node shutdown);
+ * - "fmi" option can be used for finding minimum inconsistent block number and printing it to stdout. It'll print -1, if no such block is found;
+ * - "rbc" option does two things: it looks for minimum inconsistent block and, if there's such, rewinds blocks from top one till the found one inclusively.
  */
 public class RewindBlocks extends CliToolRskContextAware {
 
@@ -37,12 +48,77 @@ public class RewindBlocks extends CliToolRskContextAware {
         create(MethodHandles.lookup().lookupClass()).execute(args);
     }
 
+    private final Printer printer;
+
+    @SuppressWarnings("unused")
+    public RewindBlocks() { // used via reflection
+        this(RewindBlocks::printInfo);
+    }
+
+    @VisibleForTesting
+    RewindBlocks(@Nonnull Printer printer) {
+        this.printer = Objects.requireNonNull(printer);
+    }
+
     @Override
     protected void onExecute(@Nonnull String[] args, @Nonnull RskContext ctx) {
-        long blockNumber = Long.parseLong(args[0]);
         BlockStore blockStore = ctx.getBlockStore();
+        String blockNumOrOp = args[0];
 
-        rewindBlocks(blockNumber, blockStore);
+        if ("fmi".equals(blockNumOrOp)) {
+            RepositoryLocator repositoryLocator = ctx.getRepositoryLocator();
+
+            printMinInconsistentBlock(blockStore, repositoryLocator);
+        } else if ("rbc".equals(blockNumOrOp)) {
+            RepositoryLocator repositoryLocator = ctx.getRepositoryLocator();
+
+            rewindInconsistentBlocks(blockStore, repositoryLocator);
+        } else {
+            long blockNumber = Long.parseLong(blockNumOrOp);
+
+            rewindBlocks(blockNumber, blockStore);
+        }
+    }
+
+    private void printMinInconsistentBlock(@Nonnull BlockStore blockStore, @Nonnull RepositoryLocator repositoryLocator) {
+        printInfo("Highest block number stored in db: {}", Optional.ofNullable(blockStore.getBestBlock()).map(Block::getNumber).orElse(-1L));
+
+        long minInconsistentBlockNum = findMinInconsistentBlock(blockStore, repositoryLocator);
+        if (minInconsistentBlockNum == -1) {
+            printer.println("No inconsistent block has been found");
+        } else {
+            printer.println("Min inconsistent block number: " + minInconsistentBlockNum);
+        }
+    }
+
+    private void rewindInconsistentBlocks(@Nonnull BlockStore blockStore, @Nonnull RepositoryLocator repositoryLocator) {
+        long minInconsistentBlockNum = findMinInconsistentBlock(blockStore, repositoryLocator);
+        if (minInconsistentBlockNum == -1) {
+            printer.println("No inconsistent block has been found. Nothing to do");
+        } else {
+            printer.println("Min inconsistent block number: " + minInconsistentBlockNum);
+            rewindBlocks(minInconsistentBlockNum - 1, blockStore);
+        }
+    }
+
+    private long findMinInconsistentBlock(@Nonnull BlockStore blockStore, @Nonnull RepositoryLocator repositoryLocator) {
+        long minInconsistentBlockNum = -1L;
+        Block block = blockStore.getBestBlock();
+
+        if (block != null) { // block index is not empty
+            while (!repositoryLocator.findSnapshotAt(block.getHeader()).isPresent()) {
+                minInconsistentBlockNum = block.getNumber();
+
+                Keccak256 parentHash = Objects.requireNonNull(block.getParentHash());
+
+                block = blockStore.getBlockByHash(parentHash.getBytes());
+                if (block == null) { // parent of genesis / non-indexed block
+                    break;
+                }
+            }
+        }
+
+        return minInconsistentBlockNum;
     }
 
     private void rewindBlocks(long blockNumber, BlockStore blockStore) {
@@ -56,10 +132,12 @@ public class RewindBlocks extends CliToolRskContextAware {
 
             blockStore.rewind(blockNumber);
 
+            printer.println("Done");
+
             maxNumber = blockStore.getMaxNumber();
-            printInfo("Done. New highest block number stored in db: {}", maxNumber);
+            printer.println("New highest block number stored in db: " + maxNumber);
         } else {
-            printInfo("No need to rewind");
+            printer.println("No need to rewind");
         }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ShowStateInfo.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ShowStateInfo.java
@@ -22,6 +22,7 @@ import co.rsk.cli.CliToolRskContextAware;
 import co.rsk.trie.NodeReference;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStore;
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.core.Block;
 import org.ethereum.db.BlockStore;
 import org.ethereum.util.ByteUtil;
@@ -51,7 +52,8 @@ public class ShowStateInfo extends CliToolRskContextAware {
         this(ShowStateInfo::printInfo);
     }
 
-    public ShowStateInfo(@Nonnull Printer printer) {
+    @VisibleForTesting
+    ShowStateInfo(@Nonnull Printer printer) {
         this.printer = Objects.requireNonNull(printer);
     }
 
@@ -139,11 +141,6 @@ public class ShowStateInfo extends CliToolRskContextAware {
             stateInfo.nvalues++;
             stateInfo.nbytes += trie.getValue().length;
         }
-    }
-
-    @FunctionalInterface
-    public interface Printer {
-        void println(String x);
     }
 
     private static class StateInfo {

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainFlusher.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainFlusher.java
@@ -113,19 +113,19 @@ public class BlockChainFlusher implements InternalService {
         }
 
         saveTime = System.nanoTime();
-        blockStore.flush();
-        totalTime = System.nanoTime() - saveTime;
-
-        if (logger.isTraceEnabled()) {
-            logger.trace("blockstore flush: [{}]seconds", FormatUtils.formatNanosecondsToSeconds(totalTime));
-        }
-
-        saveTime = System.nanoTime();
         receiptStore.flush();
         totalTime = System.nanoTime() - saveTime;
 
         if (logger.isTraceEnabled()) {
             logger.trace("receiptstore flush: [{}]seconds", FormatUtils.formatNanosecondsToSeconds(totalTime));
+        }
+
+        saveTime = System.nanoTime();
+        blockStore.flush();
+        totalTime = System.nanoTime() - saveTime;
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("blockstore flush: [{}]seconds", FormatUtils.formatNanosecondsToSeconds(totalTime));
         }
 
         saveTime = System.nanoTime();

--- a/rskj-core/src/main/java/co/rsk/util/ExecState.java
+++ b/rskj-core/src/main/java/co/rsk/util/ExecState.java
@@ -18,5 +18,13 @@
 package co.rsk.util;
 
 public enum ExecState {
-    CREATED, RUNNING, FINISHED
+    CREATED, RUNNING, FINISHED;
+
+    public boolean isCreated() {
+        return this == CREATED;
+    }
+
+    public boolean isRunning() {
+        return this == RUNNING;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
+++ b/rskj-core/src/main/java/org/ethereum/db/IndexedBlockStore.java
@@ -186,6 +186,8 @@ public class IndexedBlockStore implements BlockStore {
     }
 
     public synchronized void close() {
+        flush();
+
         index.close();
         blocks.close();
     }

--- a/rskj-core/src/test/java/co/rsk/RskContextTest.java
+++ b/rskj-core/src/test/java/co/rsk/RskContextTest.java
@@ -27,6 +27,7 @@ import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Genesis;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.RskTestContext;
@@ -199,6 +200,7 @@ public class RskContextTest {
         doReturn(true).when(testProperties).fastBlockPropagation();
 
         ActivationConfig config = mock(ActivationConfig.class);
+        doReturn(true).when(config).isActive(eq(ConsensusRule.RSKIP126), anyLong());
         doReturn(config).when(testProperties).getActivationConfig();
 
         Constants constants = mock(Constants.class);

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -238,7 +238,8 @@ public class BlockChainBuilder {
                 blockValidator,
                 blockExecutor,
                 genesis,
-                stateRootHandler
+                stateRootHandler,
+                repositoryLocator
         ).loadBlockchain();
 
         if (this.testing) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This tries to mitigate an issue of data inconsistency after improper node shut down.

This also adds a new capability to the `RewindBlocks` cli tool, which allows to find minimum inconsistent block number as well as to "rewind" inconsistent blocks(`fmi` and `rbc` cli flags respectively).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recommended ways to stop the node is to use `Ctrl+C` or via the `kill -TERM <PID>` command.

Sometimes (rather rarely), if the node is not properly shut down, for instance, when it's killed via `kill -KILL <PID>`, stopping an IDE debugger or after machine powering off, the database goes into the inconsistent state - very often when a best block's state root hash points to a missing record in the states db.

This PR adds a few tricks to mitigate the issue, for instance, blocks are flushed after the trie states.

This change also adds a capability to find a minimum inconsistent block number, e.g. via the following command:
```bash
java -cp ./rskj-core/build/libs/rskj-core-3.2.0-SNAPSHOT-all.jar co.rsk.cli.tools.RewindBlocks fmi --testnet
```

which would print a number of first inconsistent block (or `-1` if not found). Or rewind inconsistent blocks, if any, like this:
```bash
java -cp ./rskj-core/build/libs/rskj-core-3.2.0-SNAPSHOT-all.jar co.rsk.cli.tools.RewindBlocks rbc --testnet
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

