### PR TITLE
Trie serialization (toMessage) tests

### DIFF
--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -960,6 +960,7 @@ public class Trie {
     }
 
     public boolean hasLongValue() {
+        // todo(techdebt) 32 needs to be extracted to a public (used for TrieMessageTest) constant
         return this.valueLength.compareTo(new Uint24(32)) > 0;
     }
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieMessageTest.java
@@ -270,6 +270,8 @@ public class TrieMessageTest {
 
         // check flags
         Assert.assertEquals(0b01000000, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
     }
 
     @Test
@@ -285,6 +287,8 @@ public class TrieMessageTest {
 
         // check flags (version + lshared + left + leftEmbedded) => 0b01000000 | 0b00010000 | 0b00001000 | 0b00000010
         Assert.assertEquals(0b01011010, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
     }
 
     @Test
@@ -305,6 +309,8 @@ public class TrieMessageTest {
 
         // check flags (version + lshared + left) => 0b01000000 | 0b00010000 | 0b00001000
         Assert.assertEquals(0b01011000, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
     }
 
     @Test
@@ -326,6 +332,8 @@ public class TrieMessageTest {
 
         // check flags (version + lshared + left + leftEmbedded + right) => 0b01000000 | 0b00010000 | 0b00001000 | 0b00000010 | 0b00000100
         Assert.assertEquals(0b01011110, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
     }
 
     @Test
@@ -347,6 +355,8 @@ public class TrieMessageTest {
 
         // check flags (version + lshared + left + right + rightEmbedded) => 0b01000000 | 0b00010000 | 0b00001000 | 0b00000100 | 0b00000001
         Assert.assertEquals(0b01011101, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
     }
 
     @Test
@@ -362,6 +372,8 @@ public class TrieMessageTest {
 
         // check flags (version + lshared + left + leftEmbedded + right + rightEmbedded) => 0b01000000 | 0b00010000 | 0b00001000 | 0b00000010
         Assert.assertEquals(0b01011111, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
     }
 
     @Test
@@ -383,6 +395,8 @@ public class TrieMessageTest {
         Assert.assertEquals(2, message[2]);
         Assert.assertEquals(3, message[3]);
         Assert.assertEquals(4, message[4]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
     }
 
     @Test
@@ -407,5 +421,7 @@ public class TrieMessageTest {
 
         // check value length
         Assert.assertEquals(new Uint24(LONG_VALUE), Uint24.decode(new byte[]{message[33], message[34], message[35]}, 0));
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/trie/TrieMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieMessageTest.java
@@ -25,9 +25,14 @@ import org.junit.Test;
 /**
  * Created by ajlopez on 11/01/2017.
  */
-public class TrieOrchidMessageTest {
+public class TrieMessageTest {
+
+    /**
+     * Orchid message serialization tests
+     **/
+
     @Test
-    public void emptyTrieToMessage() {
+    public void emptyTrieToMessageOrchid() {
         Trie trie = new Trie();
 
         byte[] message = trie.toMessageOrchid(false);
@@ -43,7 +48,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithValueToMessage() {
+    public void trieWithValueToMessageOrchid() {
         Trie trie = new Trie().put(new byte[0], new byte[] { 1, 2, 3, 4 });
 
         byte[] message = trie.toMessageOrchid(false);
@@ -63,7 +68,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithLongValueToMessage() {
+    public void trieWithLongValueToMessageOrchid() {
         Trie trie = new Trie().put(new byte[0], TrieValueTest.makeValue(33));
 
         byte[] message = trie.toMessageOrchid(false);
@@ -85,7 +90,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithSubtrieAndNoValueToMessage() {
+    public void trieWithSubtrieAndNoValueToMessageOrchid() {
         Trie trie = new Trie().put(new byte[] { 0x2 }, new byte[] { 1, 2, 3, 4 });
 
         byte[] message = trie.toMessageOrchid(false);
@@ -109,7 +114,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithSubtriesAndNoValueToMessage() {
+    public void trieWithSubtriesAndNoValueToMessageOrchid() {
         Trie trie = new Trie().put(new byte[] { 0x2 }, new byte[] { 1, 2, 3, 4 })
                 .put(new byte[] { 0x12 }, new byte[] { 1, 2, 3, 4 });
 
@@ -127,7 +132,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void emptyTrieToMessageSecure() {
+    public void emptyTrieToMessageOrchidSecure() {
         Trie trie = new Trie();
 
         byte[] message = trie.toMessageOrchid(true);
@@ -143,7 +148,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithValueToMessageSecure() {
+    public void trieWithValueToMessageOrchidSecure() {
         byte[] oldKey = new byte[0];
         byte[] key = Keccak256Helper.keccak256(oldKey);
 
@@ -170,7 +175,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithLongValueToMessageSecure() {
+    public void trieWithLongValueToMessageOrchidSecure() {
         byte[] oldKey = new byte[0];
         byte[] key = Keccak256Helper.keccak256(oldKey);
 
@@ -198,7 +203,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithSubtrieAndNoValueToMessageSecure() {
+    public void trieWithSubtrieAndNoValueToMessageOrchidSecure() {
         byte[] oldKey = new byte[] { 0x02 };
         byte[] key = Keccak256Helper.keccak256(oldKey);
 
@@ -225,7 +230,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithSubtriesAndNoValueToMessageSecure() {
+    public void trieWithSubtriesAndNoValueToMessageOrchidSecure() {
         Trie trie = new Trie()
                 .put(Keccak256Helper.keccak256(new byte[] { 0x2 }), new byte[] { 1, 2, 3, 4 })
                 .put(Keccak256Helper.keccak256(new byte[] { 0x12 }), new byte[] { 1, 2, 3, 4 });


### PR DESCRIPTION
This PR adds coverage for unitrie nodes serialization and deserialization. The covered behavior has already been tackled in other tests but still, we're lacking specific unit tests.