### PR TITLE
Validating request content before processing the request itself

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3ServerHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3ServerHandler.java
@@ -64,6 +64,7 @@ public class JsonRpcWeb3ServerHandler extends SimpleChannelInboundHandler<ByteBu
 
             responseCode = jsonRpcServer.handleRequest(is, os);
         } catch (IllegalArgumentException e) {
+            LOGGER.error(ErrorResolver.JsonError.PARSE_ERROR.message, e);
             int errorCode = ErrorResolver.JsonError.PARSE_ERROR.code;
             responseContent = buildErrorContent(errorCode, e.getMessage());
             responseCode = ErrorResolver.JsonError.OK.code;

--- a/rskj-core/src/main/java/co/rsk/util/CustomJsonRpcBasicServer.java
+++ b/rskj-core/src/main/java/co/rsk/util/CustomJsonRpcBasicServer.java
@@ -1,0 +1,28 @@
+package co.rsk.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.googlecode.jsonrpc4j.ErrorResolver;
+import com.googlecode.jsonrpc4j.JsonRpcBasicServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class CustomJsonRpcBasicServer extends JsonRpcBasicServer {
+
+    public CustomJsonRpcBasicServer(final Object handler, final Class<?> remoteInterface) {
+        super(handler, remoteInterface);
+    }
+
+    @Override
+    protected ErrorResolver.JsonError handleJsonNodeRequest(final JsonNode node, final OutputStream output) throws IOException {
+        validateRequestContent(node);
+
+        return super.handleJsonNodeRequest(node, output);
+    }
+
+    private void validateRequestContent(JsonNode jsonNode) {
+        if (jsonNode.get("id") == null) {
+            throw new IllegalArgumentException("missing request id");
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/util/CustomJsonRpcBasicServer.java
+++ b/rskj-core/src/main/java/co/rsk/util/CustomJsonRpcBasicServer.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk.util;
 
 import com.fasterxml.jackson.databind.JsonNode;


### PR DESCRIPTION
Validating id property in json request.

## Description
JSON RPC responses of empty HTTP200 status responses, when sending request without id

## Motivation and Context
This issue id the motiviation: https://github.com/rsksmart/rskj/issues/408.

Basically is not following `geth` standards.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
