### PR TITLE
Validate messageid format to UUID

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/FindNodePeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/FindNodePeerMessage.java
@@ -41,12 +41,16 @@ public class FindNodePeerMessage extends PeerDiscoveryMessage {
     private byte[] nodeId;
     private String messageId;
 
-    public FindNodePeerMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
+    private FindNodePeerMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
         super(wire, mdc, signature, type, data);
         this.parse(data);
     }
 
     private FindNodePeerMessage() {
+    }
+    
+    public static FindNodePeerMessage buildFromReceived(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
+        return new FindNodePeerMessage(wire, mdc, signature, type, data);
     }
 
     public static FindNodePeerMessage create(byte[] nodeId, String check, ECKey privKey, Integer networkId) {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/FindNodePeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/FindNodePeerMessage.java
@@ -26,7 +26,6 @@ import org.ethereum.util.RLP;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.OptionalInt;
 
@@ -73,22 +72,21 @@ public class FindNodePeerMessage extends PeerDiscoveryMessage {
     }
 
     @Override
-    public final void parse(byte[] data) {
+    protected final void parse(byte[] data) {
         RLPList dataList = (RLPList) RLP.decode2OneItem(data, 0);
         if (dataList.size() < 2) {
             throw new PeerDiscoveryException(MORE_DATA);
         }
         RLPItem chk = (RLPItem) dataList.get(1);
 
-        this.messageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
+        this.messageId = extractMessageId(chk);
 
         RLPItem nodeRlp = (RLPItem) dataList.get(0);
 
         this.nodeId = nodeRlp.getRLPData();
 
-        this.setNetworkIdWithRLP(dataList.size()>2?dataList.get(2):null);
+        this.setNetworkIdWithRLP(dataList.size() > 2 ? dataList.get(2) : null);
     }
-
 
     public String getMessageId() {
         return this.messageId;

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/NeighborsPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/NeighborsPeerMessage.java
@@ -26,7 +26,6 @@ import org.ethereum.util.RLP;
 import org.ethereum.util.RLPItem;
 import org.ethereum.util.RLPList;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +52,7 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
     }
 
     @Override
-    public final void parse(byte[] data) {
+    protected final void parse(byte[] data) {
         RLPList list = (RLPList) RLP.decode2OneItem(data, 0);
 
         if (list.size() < 2) {
@@ -69,8 +68,7 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
         }
 
         RLPItem chk = (RLPItem) list.get(1);
-
-        this.messageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
+        this.messageId = extractMessageId(chk);
 
         this.setNetworkIdWithRLP(list.size()>2?list.get(2):null);
     }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/NeighborsPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/NeighborsPeerMessage.java
@@ -42,7 +42,7 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
     private List<Node> nodes;
     private String messageId;
 
-    public NeighborsPeerMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
+    private NeighborsPeerMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
         super(wire, mdc, signature, type, data);
         this.nodes = new ArrayList<>();
         this.parse(data);
@@ -51,26 +51,8 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
     private NeighborsPeerMessage() {
     }
 
-    @Override
-    protected final void parse(byte[] data) {
-        RLPList list = (RLPList) RLP.decode2OneItem(data, 0);
-
-        if (list.size() < 2) {
-            throw new PeerDiscoveryException(MORE_DATA);
-        }
-
-        RLPList nodesRLP = (RLPList) list.get(0);
-
-        for (int i = 0; i < nodesRLP.size(); ++i) {
-            RLPList nodeRLP = (RLPList) nodesRLP.get(i);
-            Node node = new Node(nodeRLP.getRLPData());
-            nodes.add(node);
-        }
-
-        RLPItem chk = (RLPItem) list.get(1);
-        this.messageId = extractMessageId(chk);
-
-        this.setNetworkIdWithRLP(list.size()>2?list.get(2):null);
+    public static NeighborsPeerMessage buildFromReceived(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
+        return new NeighborsPeerMessage(wire, mdc, signature, type, data);
     }
 
     public static NeighborsPeerMessage create(List<Node> nodes, String check, ECKey privKey, Integer networkId) {
@@ -101,6 +83,28 @@ public class NeighborsPeerMessage extends PeerDiscoveryMessage {
         neighborsMessage.messageId = check;
 
         return neighborsMessage;
+    }
+
+    @Override
+    protected final void parse(byte[] data) {
+        RLPList list = (RLPList) RLP.decode2OneItem(data, 0);
+
+        if (list.size() < 2) {
+            throw new PeerDiscoveryException(MORE_DATA);
+        }
+
+        RLPList nodesRLP = (RLPList) list.get(0);
+
+        for (int i = 0; i < nodesRLP.size(); ++i) {
+            RLPList nodeRLP = (RLPList) nodesRLP.get(i);
+            Node node = new Node(nodeRLP.getRLPData());
+            nodes.add(node);
+        }
+
+        RLPItem chk = (RLPItem) list.get(1);
+        this.messageId = extractMessageId(chk);
+
+        this.setNetworkIdWithRLP(list.size() > 2 ? list.get(2) : null);
     }
 
     public List<Node> getNodes() {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
@@ -19,6 +19,7 @@
 package co.rsk.net.discovery.message;
 
 import co.rsk.net.NodeID;
+import co.rsk.net.discovery.PeerDiscoveryException;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.crypto.ECKey;
@@ -27,18 +28,23 @@ import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.crypto.signature.Secp256k1;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLPElement;
+import org.ethereum.util.RLPItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.Charset;
 import java.security.SignatureException;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.UUID;
 
 import static org.ethereum.crypto.HashUtil.keccak256;
 import static org.ethereum.util.ByteUtil.merge;
 
 public abstract class PeerDiscoveryMessage {
     private static final Logger logger = LoggerFactory.getLogger(PeerDiscoveryMessage.class);
+
+    private static final String INVALID_MESSAGE_ID = "%s needs valid messageId";
 
     private byte[] wire;
 
@@ -48,9 +54,10 @@ public abstract class PeerDiscoveryMessage {
     private byte[] data;
     private OptionalInt networkId;
 
-    public PeerDiscoveryMessage() {}
+    protected PeerDiscoveryMessage() {
+    }
 
-    public PeerDiscoveryMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data){
+    protected PeerDiscoveryMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
         this.mdc = mdc;
         this.signature = signature;
         this.type = type;
@@ -68,7 +75,7 @@ public abstract class PeerDiscoveryMessage {
         /* [2] Crate signature*/
         ECDSASignature ecdsaSignature = ECDSASignature.fromSignature(privKey.sign(forSig));
 
-        ecdsaSignature.setV((byte)(ecdsaSignature.getV() - 27));
+        ecdsaSignature.setV((byte) (ecdsaSignature.getV() - 27));
 
         byte[] sigBytes =
                 merge(BigIntegers.asUnsignedByteArray(32, ecdsaSignature.getR()),
@@ -161,7 +168,7 @@ public abstract class PeerDiscoveryMessage {
         return data;
     }
 
-    public abstract void parse(byte[] data);
+    protected abstract void parse(byte[] data);
 
     public DiscoveryMessageType getMessageType() {
         return null;
@@ -174,5 +181,15 @@ public abstract class PeerDiscoveryMessage {
                 .append("signature", ByteUtil.toHexString(signature))
                 .append("type", ByteUtil.toHexString(type))
                 .append("data", ByteUtil.toHexString(data)).toString();
+    }
+
+    protected String extractMessageId(RLPItem chk) {
+        String rawMessageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
+        try {
+            return UUID.fromString(rawMessageId).toString();
+        } catch (IllegalArgumentException exception) {
+            String concreteMessageType = this.getClass().getSimpleName();
+            throw new PeerDiscoveryException(String.format(INVALID_MESSAGE_ID, concreteMessageType));
+        }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
@@ -46,6 +46,8 @@ public abstract class PeerDiscoveryMessage {
 
     private static final String INVALID_MESSAGE_ID = "%s needs valid messageId";
 
+    private static final int UUID_VERSION_4 = 4;
+
     private byte[] wire;
 
     private byte[] mdc;
@@ -186,9 +188,13 @@ public abstract class PeerDiscoveryMessage {
     protected String extractMessageId(RLPItem chk) {
         String rawMessageId = new String(chk.getRLPData(), StandardCharsets.UTF_8);
         try {
-            return UUID.fromString(rawMessageId).toString();
+            UUID uuid = UUID.fromString(rawMessageId);
+            if (uuid.version() != UUID_VERSION_4) {
+                throw new IllegalArgumentException("Received an UUID with version != 4");
+            }
+            return uuid.toString();
         } catch (IllegalArgumentException iae) {
-            logger.error("Received message '{}' is not an UUID", rawMessageId, iae);
+            logger.error("Received message '{}' is not a v4 UUID", rawMessageId, iae);
             String concreteMessageType = this.getClass().getSimpleName();
             throw new PeerDiscoveryException(String.format(INVALID_MESSAGE_ID, concreteMessageType));
         }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessage.java
@@ -32,7 +32,7 @@ import org.ethereum.util.RLPItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.SignatureException;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -184,10 +184,11 @@ public abstract class PeerDiscoveryMessage {
     }
 
     protected String extractMessageId(RLPItem chk) {
-        String rawMessageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
+        String rawMessageId = new String(chk.getRLPData(), StandardCharsets.UTF_8);
         try {
             return UUID.fromString(rawMessageId).toString();
-        } catch (IllegalArgumentException exception) {
+        } catch (IllegalArgumentException iae) {
+            logger.error("Received message '{}' is not an UUID", rawMessageId, iae);
             String concreteMessageType = this.getClass().getSimpleName();
             throw new PeerDiscoveryException(String.format(INVALID_MESSAGE_ID, concreteMessageType));
         }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessageFactory.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PeerDiscoveryMessageFactory.java
@@ -22,23 +22,24 @@ package co.rsk.net.discovery.message;
  * Created by mario on 13/02/17.
  */
 public class PeerDiscoveryMessageFactory {
-    private PeerDiscoveryMessageFactory() {}
+    private PeerDiscoveryMessageFactory() {
+    }
 
     public static PeerDiscoveryMessage createMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
         DiscoveryMessageType msgType = DiscoveryMessageType.valueOfType(type[0]);
 
         if (msgType == DiscoveryMessageType.PING) {
-            return new PingPeerMessage(wire, mdc, signature, type, data);
+            return PingPeerMessage.buildFromReceived(wire, mdc, signature, type, data);
         }
 
         if (msgType == DiscoveryMessageType.PONG) {
-            return new PongPeerMessage(wire, mdc, signature, type, data);
+            return PongPeerMessage.buildFromReceived(wire, mdc, signature, type, data);
         }
 
         if (msgType == DiscoveryMessageType.FIND_NODE) {
-            return new FindNodePeerMessage(wire, mdc, signature, type, data);
+            return FindNodePeerMessage.buildFromReceived(wire, mdc, signature, type, data);
         }
 
-        return new NeighborsPeerMessage(wire, mdc, signature, type, data);
+        return NeighborsPeerMessage.buildFromReceived(wire, mdc, signature, type, data);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PingPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PingPeerMessage.java
@@ -82,7 +82,7 @@ public class PingPeerMessage extends PeerDiscoveryMessage {
     }
 
     @Override
-    public final void parse(byte[] data) {
+    protected final void parse(byte[] data) {
         RLPList dataList = (RLPList) RLP.decode2OneItem(data, 0);
 
         if (dataList.size() < 3) {
@@ -100,7 +100,7 @@ public class PingPeerMessage extends PeerDiscoveryMessage {
 
         this.host = new String(ipB, Charset.forName("UTF-8"));
         this.port = ByteUtil.byteArrayToInt(fromList.get(1).getRLPData());
-        this.messageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
+        this.messageId = extractMessageId(chk);
 
         //Message from nodes that do not have this
         this.setNetworkIdWithRLP(dataList.size()>3?dataList.get(3):null);

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PingPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PingPeerMessage.java
@@ -30,9 +30,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.OptionalInt;
 
-import static org.ethereum.util.ByteUtil.intToBytes;
-import static org.ethereum.util.ByteUtil.longToBytes;
-import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
+import static org.ethereum.util.ByteUtil.*;
 
 /**
  * Created by mario on 16/02/17.
@@ -44,12 +42,17 @@ public class PingPeerMessage extends PeerDiscoveryMessage {
     private int port;
     private String messageId;
 
-    public PingPeerMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
+    private PingPeerMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
         super(wire, mdc, signature, type, data);
         this.parse(data);
     }
 
-    private PingPeerMessage() {}
+    private PingPeerMessage() {
+    }
+
+    public static PingPeerMessage buildFromReceived(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
+        return new PingPeerMessage(wire, mdc, signature, type, data);
+    }
 
     public static PingPeerMessage create(String host, int port, String check, ECKey privKey, Integer networkId) {
         /* RLP Encode data */
@@ -68,7 +71,7 @@ public class PingPeerMessage extends PeerDiscoveryMessage {
         byte[] data;
         byte[] tmpNetworkId = intToBytes(networkId);
         byte[] rlpNetworkID = RLP.encodeElement(stripLeadingZeroes(tmpNetworkId));
-            data = RLP.encodeList(rlpFromList, rlpToList, rlpCheck, rlpNetworkID);
+        data = RLP.encodeList(rlpFromList, rlpToList, rlpCheck, rlpNetworkID);
 
         PingPeerMessage message = new PingPeerMessage();
         message.encode(type, data, privKey);
@@ -103,7 +106,7 @@ public class PingPeerMessage extends PeerDiscoveryMessage {
         this.messageId = extractMessageId(chk);
 
         //Message from nodes that do not have this
-        this.setNetworkIdWithRLP(dataList.size()>3?dataList.get(3):null);
+        this.setNetworkIdWithRLP(dataList.size() > 3 ? dataList.get(3) : null);
     }
 
     public String getMessageId() {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PongPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PongPeerMessage.java
@@ -94,7 +94,7 @@ public class PongPeerMessage extends PeerDiscoveryMessage {
     }
 
     @Override
-    public final void parse(byte[] data) {
+    protected final void parse(byte[] data) {
         RLPList dataList = (RLPList) RLP.decode2OneItem(data, 0);
         if (dataList.size() < 3) {
             throw new PeerDiscoveryException(MORE_DATA);
@@ -110,8 +110,7 @@ public class PongPeerMessage extends PeerDiscoveryMessage {
         this.port = ByteUtil.byteArrayToInt(fromList.get(1).getRLPData());
 
         RLPItem chk = (RLPItem) dataList.get(2);
-
-        this.messageId = new String(chk.getRLPData(), Charset.forName("UTF-8"));
+        this.messageId = extractMessageId(chk);
 
         //Message from nodes that do not have this
         this.setNetworkIdWithRLP(dataList.size()>3?dataList.get(3):null);

--- a/rskj-core/src/main/java/co/rsk/net/discovery/message/PongPeerMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/message/PongPeerMessage.java
@@ -30,9 +30,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.OptionalInt;
 
-import static org.ethereum.util.ByteUtil.intToBytes;
-import static org.ethereum.util.ByteUtil.longToBytes;
-import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
+import static org.ethereum.util.ByteUtil.*;
 
 /**
  * Created by mario on 16/02/17.
@@ -44,12 +42,16 @@ public class PongPeerMessage extends PeerDiscoveryMessage {
     private int port;
     private String messageId;
 
-    public PongPeerMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
+    private PongPeerMessage(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
         super(wire, mdc, signature, type, data);
         this.parse(data);
     }
 
     private PongPeerMessage() {
+    }
+
+    public static PongPeerMessage buildFromReceived(byte[] wire, byte[] mdc, byte[] signature, byte[] type, byte[] data) {
+        return new PongPeerMessage(wire, mdc, signature, type, data);
     }
 
     public static PongPeerMessage create(String host, int port, String check, ECKey privKey, Integer networkId) {
@@ -113,7 +115,7 @@ public class PongPeerMessage extends PeerDiscoveryMessage {
         this.messageId = extractMessageId(chk);
 
         //Message from nodes that do not have this
-        this.setNetworkIdWithRLP(dataList.size()>3?dataList.get(3):null);
+        this.setNetworkIdWithRLP(dataList.size() > 3 ? dataList.get(3) : null);
     }
 
     public String getMessageId() {

--- a/rskj-core/src/test/java/co/rsk/net/discovery/PeerMessagesTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/PeerMessagesTest.java
@@ -7,7 +7,7 @@ import co.rsk.net.discovery.message.PongPeerMessage;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Arrays;
 
 public class PeerMessagesTest {
 
@@ -32,7 +32,7 @@ public class PeerMessagesTest {
 
     @Test
     public void testParsePongPeerMessageWithoutNetworkId(){
-        PongPeerMessage pongPeerMessage = new PongPeerMessage(wirePingPongPeerMessage, mdcPingPongPeerMessage, signaturePingPongPeerMessage, typePong, dataWithoutNetworkIdPingPongPeerMessage);
+        PongPeerMessage pongPeerMessage = PongPeerMessage.buildFromReceived(wirePingPongPeerMessage, mdcPingPongPeerMessage, signaturePingPongPeerMessage, typePong, dataWithoutNetworkIdPingPongPeerMessage);
         Assert.assertFalse(pongPeerMessage.getNetworkId().isPresent());
         Assert.assertEquals("7481c139-bcfc-4542-a770-5ca49a4eaa7a",pongPeerMessage.getMessageId());
         Assert.assertEquals(GOOD_HOST,pongPeerMessage.getHost());
@@ -42,7 +42,7 @@ public class PeerMessagesTest {
 
     @Test
     public void testParsePongPeerMessageWithNetworkId() {
-        PongPeerMessage pongPeerMessage = new PongPeerMessage(wirePingPongPeerMessage, mdcPingPongPeerMessage, signaturePingPongPeerMessage, typePong, dataWithNetworkIdPingPongPeerMessage);
+        PongPeerMessage pongPeerMessage = PongPeerMessage.buildFromReceived(wirePingPongPeerMessage, mdcPingPongPeerMessage, signaturePingPongPeerMessage, typePong, dataWithNetworkIdPingPongPeerMessage);
         Assert.assertTrue(pongPeerMessage.getNetworkId().isPresent());
         Assert.assertEquals(-989608247,pongPeerMessage.getNetworkId().getAsInt());
         Assert.assertEquals("0a967855-cfba-4b1b-9890-f6c931a4a7a0",pongPeerMessage.getMessageId());
@@ -53,7 +53,7 @@ public class PeerMessagesTest {
 
     @Test
     public void testParsePingPeerMessageWithoutNetworkId(){
-        PingPeerMessage pingPeerMessage = new PingPeerMessage(wirePingPongPeerMessage, mdcPingPongPeerMessage, signaturePingPongPeerMessage,typePing, dataWithoutNetworkIdPingPongPeerMessage);
+        PingPeerMessage pingPeerMessage = PingPeerMessage.buildFromReceived(wirePingPongPeerMessage, mdcPingPongPeerMessage, signaturePingPongPeerMessage,typePing, dataWithoutNetworkIdPingPongPeerMessage);
         Assert.assertFalse(pingPeerMessage.getNetworkId().isPresent());
         Assert.assertEquals("7481c139-bcfc-4542-a770-5ca49a4eaa7a",pingPeerMessage.getMessageId());
         Assert.assertEquals(GOOD_HOST,pingPeerMessage.getHost());
@@ -63,7 +63,7 @@ public class PeerMessagesTest {
 
     @Test
     public void testParsePingPeerMessageWithNetworkId() {
-        PingPeerMessage pingPeerMessage = new PingPeerMessage(wirePingPongPeerMessage, mdcPingPongPeerMessage, signaturePingPongPeerMessage,typePing, dataWithNetworkIdPingPongPeerMessage);
+        PingPeerMessage pingPeerMessage = PingPeerMessage.buildFromReceived(wirePingPongPeerMessage, mdcPingPongPeerMessage, signaturePingPongPeerMessage,typePing, dataWithNetworkIdPingPongPeerMessage);
         Assert.assertTrue(pingPeerMessage.getNetworkId().isPresent());
         Assert.assertEquals(-989608247,pingPeerMessage.getNetworkId().getAsInt());
         Assert.assertEquals("0a967855-cfba-4b1b-9890-f6c931a4a7a0",pingPeerMessage.getMessageId());
@@ -74,7 +74,7 @@ public class PeerMessagesTest {
 
     @Test
     public void testParseFindNodePeerMessageWithoutNetworkId() {
-        FindNodePeerMessage findNodePeerMessageExpected = new FindNodePeerMessage(wireFindNodePeerMessage,mdcFindNodePeerMessage,signatureFindNodePeerMessage,typeFindNodePeerMessage,dataWithoutNetworkId);
+        FindNodePeerMessage findNodePeerMessageExpected = FindNodePeerMessage.buildFromReceived(wireFindNodePeerMessage,mdcFindNodePeerMessage,signatureFindNodePeerMessage,typeFindNodePeerMessage,dataWithoutNetworkId);
         Assert.assertFalse(findNodePeerMessageExpected.getNetworkId().isPresent());
         Assert.assertEquals("be04abbb-602f-4c12-8c08-e74e31e660aa", findNodePeerMessageExpected.getMessageId());
         Assert.assertTrue(Arrays.equals(findNodePeerMessageExpected.getMdc(), mdcFindNodePeerMessage));
@@ -85,7 +85,7 @@ public class PeerMessagesTest {
 
     @Test
     public void testParseFindNodePeerMessage() {
-        FindNodePeerMessage findNodePeerMessageExpected = new FindNodePeerMessage(wireFindNodePeerMessage,mdcFindNodePeerMessage,signatureFindNodePeerMessage,typeFindNodePeerMessage,dataWithNetworkId);
+        FindNodePeerMessage findNodePeerMessageExpected = FindNodePeerMessage.buildFromReceived(wireFindNodePeerMessage,mdcFindNodePeerMessage,signatureFindNodePeerMessage,typeFindNodePeerMessage,dataWithNetworkId);
         Assert.assertTrue(findNodePeerMessageExpected.getNetworkId().isPresent());
         Assert.assertEquals(-1869051373,findNodePeerMessageExpected.getNetworkId().getAsInt());
         Assert.assertEquals("65b469c6-ba69-4238-bf5a-a485c024e3ce", findNodePeerMessageExpected.getMessageId());

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/FindNodePeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/FindNodePeerMessageTest.java
@@ -54,6 +54,6 @@ public class FindNodePeerMessageTest {
 
         byte[] data = RLP.encodeList(rlpNodeId, rlpCheck, rlpNetworkId);
 
-        return new FindNodePeerMessage(wireFindNodePeerMessage, mdcFindNodePeerMessage, signatureFindNodePeerMessage, type, data);
+        return FindNodePeerMessage.buildFromReceived(wireFindNodePeerMessage, mdcFindNodePeerMessage, signatureFindNodePeerMessage, type, data);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/FindNodePeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/FindNodePeerMessageTest.java
@@ -33,6 +33,17 @@ public class FindNodePeerMessageTest {
     }
 
     @Test
+    public void parseUUIDV1MessageId() {
+        try {
+            String uuidV1 = "06ce06f8-7230-11ec-90d6-0242ac120003";
+            createFindNodePeerMessageWithCheck(uuidV1);
+            Assert.fail("Invalid messageId exception should've been thrown");
+        } catch (PeerDiscoveryException pde) {
+            Assert.assertEquals(FindNodePeerMessage.class.getSimpleName() + " needs valid messageId", pde.getMessage());
+        }
+    }
+
+    @Test
     public void parseValidMessageId() {
         try {
             FindNodePeerMessage message = createFindNodePeerMessageWithCheck(UUID.randomUUID().toString());

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/FindNodePeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/FindNodePeerMessageTest.java
@@ -1,0 +1,59 @@
+package co.rsk.net.discovery.message;
+
+import co.rsk.net.discovery.PeerDiscoveryException;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.util.RLP;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.ethereum.util.ByteUtil.intToBytes;
+import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
+
+public class FindNodePeerMessageTest {
+
+    private static final String KEY_1 = "bd1d20e480dfb1c9c07ba0bc8cf9052f89923d38b5128c5dbfc18d4eea38261f";
+    private static final int NETWORK_ID = 1;
+
+    private static final byte[] signatureFindNodePeerMessage = new byte[]{-88, -13, -116, 63, 18, 39, -90, -30, 120, 126, 94, -25, -90, 90, 93, 63, -124, 120, -3, -116, -62, -38, 41, -84, 39, -69, -114, 114, 73, 52, 117, 6, 49, 66, 68, 14, -31, 17, -115, 19, 82, 9, 80, -57, -111, 119, -15, 108, -19, -89, 105, -59, -7, -52, -4, -73, -66, 111, -11, 68, 39, -46, 42, -120, 1};
+    private static final byte[] wireFindNodePeerMessage = new byte[]{-23, 116, 115, 41, 75, 96, -74, 89, -26, -64, -33, -84, -81, -65, -34, -32, -89, -112, 125, 25, 48, 94, -75, 114, 109, 28, -58, -55, -83, -64, -46, 69, -74, -122, 61, 12, -101, 26, -14, -28, 72, -93, 26, -125, -12, -38, 55, 80, 31, 33, -105, 110, 54, -25, 80, 45, 18, -44, -127, -22, -50, -88, -78, 77, 116, -66, -56, -54, 126, -5, -118, -91, -88, -76, 52, 56, -103, 121, 59, 1, 72, 109, 94, -14, 118, 47, 62, -76, 41, -63, 82, 103, 125, -100, 13, -88, 0, 3, -16, -118, -2, -74, -97, -8, 69, 1, 67, 49, 16, 99, 49, 56, 51, 56, 100, 52, 100, 45, 49, 122, -92, 99, 52, 55, 45, 52, 49, 98, 50, 45, 57, 99, 54, 55, 45, 52, 57, 51, 97, 57, 56, 55, 101, 98, 48, 48, 99};
+    private static final byte[] mdcFindNodePeerMessage = new byte[]{127, 110, 79, 83, 31, 7, 86, 104, 42, 124, 86, -57, 76, -92, 93, 6, 82, -37, 97, -127, -54, 72, 86, -29, -81, -97, -10, 94, -23, -102, -16, -82};
+
+    @Test
+    public void parseInvalidMessageId() {
+        try {
+            createFindNodePeerMessageWithCheck("http://fake-uuid.com/run");
+            Assert.fail("Invalid messageId exception should've been thrown");
+        } catch (PeerDiscoveryException pde) {
+            Assert.assertEquals(FindNodePeerMessage.class.getSimpleName() + " needs valid messageId", pde.getMessage());
+        }
+    }
+
+    @Test
+    public void parseValidMessageId() {
+        try {
+            FindNodePeerMessage message = createFindNodePeerMessageWithCheck(UUID.randomUUID().toString());
+            Assert.assertNotNull(message);
+        } catch (PeerDiscoveryException pde) {
+            Assert.fail(FindNodePeerMessage.class.getSimpleName() + "should've worked with valid messageId");
+        }
+    }
+
+    private FindNodePeerMessage createFindNodePeerMessageWithCheck(String check) {
+        byte[] type = new byte[]{(byte) DiscoveryMessageType.FIND_NODE.getTypeValue()};
+
+        ECKey key1 = ECKey.fromPrivate(Hex.decode(KEY_1)).decompress();
+        byte[] rlpNodeId = RLP.encodeElement(key1.getNodeId());
+
+        byte[] rlpCheck = RLP.encodeElement(check.getBytes(StandardCharsets.UTF_8));
+
+        byte[] rlpNetworkId = RLP.encodeElement(stripLeadingZeroes(intToBytes(NETWORK_ID)));
+
+        byte[] data = RLP.encodeList(rlpNodeId, rlpCheck, rlpNetworkId);
+
+        return new FindNodePeerMessage(wireFindNodePeerMessage, mdcFindNodePeerMessage, signatureFindNodePeerMessage, type, data);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/NeighborsPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/NeighborsPeerMessageTest.java
@@ -30,6 +30,17 @@ public class NeighborsPeerMessageTest {
     }
 
     @Test
+    public void parseUUIDV1MessageId() {
+        try {
+            String uuidV1 = "06ce06f8-7230-11ec-90d6-0242ac120003";
+            createNeighborsPeerMessageWithCheck(uuidV1);
+            Assert.fail("Invalid messageId exception should've been thrown");
+        } catch (PeerDiscoveryException pde) {
+            Assert.assertEquals(NeighborsPeerMessage.class.getSimpleName() + " needs valid messageId", pde.getMessage());
+        }
+    }
+
+    @Test
     public void parseValidMessageId() {
         try {
             NeighborsPeerMessage message = createNeighborsPeerMessageWithCheck(UUID.randomUUID().toString());

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/NeighborsPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/NeighborsPeerMessageTest.java
@@ -49,6 +49,6 @@ public class NeighborsPeerMessageTest {
         byte[] rlpListNodes = RLP.encodeList();
         byte[] data = RLP.encodeList(rlpListNodes, rlpCheck, rlpNetworkId);
 
-        return new NeighborsPeerMessage(wireNeighborsPeerMessage, mdcNeighborsPeerMessage, signatureNeighborsPeerMessage, type, data);
+        return NeighborsPeerMessage.buildFromReceived(wireNeighborsPeerMessage, mdcNeighborsPeerMessage, signatureNeighborsPeerMessage, type, data);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/NeighborsPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/NeighborsPeerMessageTest.java
@@ -1,0 +1,54 @@
+package co.rsk.net.discovery.message;
+
+import co.rsk.net.discovery.PeerDiscoveryException;
+import org.ethereum.util.RLP;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.ethereum.util.ByteUtil.intToBytes;
+import static org.ethereum.util.ByteUtil.stripLeadingZeroes;
+
+public class NeighborsPeerMessageTest {
+
+    private static final int NETWORK_ID = 1;
+
+    private static final byte[] wireNeighborsPeerMessage = new byte[]{113, -5, -63, 15, -4, 21, -42, 93, -10, 19, -95, -37, -29, 63, -92, -125, 28, -27, -60, 99, -85, -33, 43, 86, -12, -74, 66, 100, -31, -41, 32, 107, -69, 20, -38, -122, -33, -110, -118, -126, -12, -85, 20, 91, 44, 44, -5, 79, -101, -53, 124, -57, -29, 118, -81, -48, -89, -99, -29, -93, 8, -17, 113, -87, 100, -123, -124, -77, -99, 76, -51, 54, 4, -78, -41, 116, 84, -116, 35, -35, -30, -12, 16, -87, 23, -32, -73, 124, 71, -26, -105, -28, -14, 91, 122, -114, 1, 1, -8, 76, -48, -119, 108, 111, 99, 97, 108, 104, 111, 115, 116, -126, 31, -112, -126, 31, -112, -48, -119, 108, 111, 99, 97, 108, 104, 111, 115, 116, -126, 31, -112, -126, 31, -112, -92, 48, 97, 57, 54, 55, 56, 53, 53, 45, 99, 102, 98, 97, 45, 52, 98, 49, 98, 45, 57, 56, 57, 48, 45, 102, 54, 99, 57, 51, 49, 97, 52, 97, 55, 97, 48, -124, -59, 3, -58, -55};
+    private static final byte[] mdcNeighborsPeerMessage = new byte[]{113, -5, -63, 15, -4, 21, -42, 93, -10, 19, -95, -37, -29, 63, -92, -125, 28, -27, -60, 99, -85, -33, 43, 86, -12, -74, 66, 100, -31, -41, 32, 107};
+    private static final byte[] signatureNeighborsPeerMessage = new byte[]{-69, 20, -38, -122, -33, -110, -118, -126, -12, -85, 20, 91, 44, 44, -5, 79, -101, -53, 124, -57, -29, 118, -81, -48, -89, -99, -29, -93, 8, -17, 113, -87, 100, -123, -124, -77, -99, 76, -51, 54, 4, -78, -41, 116, 84, -116, 35, -35, -30, -12, 16, -87, 23, -32, -73, 124, 71, -26, -105, -28, -14, 91, 122, -114, 1};
+
+    @Test
+    public void parseInvalidMessageId() {
+        try {
+            createNeighborsPeerMessageWithCheck("http://fake-uuid.com/run");
+            Assert.fail("Invalid messageId exception should've been thrown");
+        } catch (PeerDiscoveryException pde) {
+            Assert.assertEquals(NeighborsPeerMessage.class.getSimpleName() + " needs valid messageId", pde.getMessage());
+        }
+    }
+
+    @Test
+    public void parseValidMessageId() {
+        try {
+            NeighborsPeerMessage message = createNeighborsPeerMessageWithCheck(UUID.randomUUID().toString());
+            Assert.assertNotNull(message);
+        } catch (PeerDiscoveryException pde) {
+            Assert.fail(NeighborsPeerMessage.class.getSimpleName() + " should've worked with valid messageId");
+        }
+    }
+
+    private NeighborsPeerMessage createNeighborsPeerMessageWithCheck(String check) {
+        byte[] type = new byte[]{(byte) DiscoveryMessageType.NEIGHBORS.getTypeValue()};
+
+        byte[] rlpCheck = RLP.encodeElement(check.getBytes(StandardCharsets.UTF_8));
+
+        byte[] rlpNetworkId = RLP.encodeElement(stripLeadingZeroes(intToBytes(NETWORK_ID)));
+
+        byte[] rlpListNodes = RLP.encodeList();
+        byte[] data = RLP.encodeList(rlpListNodes, rlpCheck, rlpNetworkId);
+
+        return new NeighborsPeerMessage(wireNeighborsPeerMessage, mdcNeighborsPeerMessage, signatureNeighborsPeerMessage, type, data);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/PingPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/PingPeerMessageTest.java
@@ -31,6 +31,17 @@ public class PingPeerMessageTest {
     }
 
     @Test
+    public void parseUUIDV1MessageId() {
+        try {
+            String uuidV1 = "06ce06f8-7230-11ec-90d6-0242ac120003";
+            createPingPeerMessageWithCheck(uuidV1);
+            Assert.fail("Invalid messageId exception should've been thrown");
+        } catch (PeerDiscoveryException pde) {
+            Assert.assertEquals(PingPeerMessage.class.getSimpleName() + " needs valid messageId", pde.getMessage());
+        }
+    }
+
+    @Test
     public void parseValidMessageId() {
         try {
             PingPeerMessage message = createPingPeerMessageWithCheck(UUID.randomUUID().toString());

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/PingPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/PingPeerMessageTest.java
@@ -57,6 +57,6 @@ public class PingPeerMessageTest {
 
         byte[] data = RLP.encodeList(rlpFromList, rlpToList, rlpCheck, rlpNetworkId);
 
-        return new PingPeerMessage(wirePingPeerMessage, mdcPingPeerMessage, signaturePingPeerMessage, type, data);
+        return PingPeerMessage.buildFromReceived(wirePingPeerMessage, mdcPingPeerMessage, signaturePingPeerMessage, type, data);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/PingPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/PingPeerMessageTest.java
@@ -1,0 +1,62 @@
+package co.rsk.net.discovery.message;
+
+import co.rsk.net.discovery.PeerDiscoveryException;
+import org.ethereum.util.RLP;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.ethereum.util.ByteUtil.*;
+
+public class PingPeerMessageTest {
+
+    private static final int NETWORK_ID = 1;
+    private static final String HOST = "localhost";
+    private static final int PORT = 44035;
+
+    private static final byte[] wirePingPeerMessage = new byte[]{113, -5, -63, 15, -4, 21, -42, 93, -10, 19, -95, -37, -29, 63, -92, -125, 28, -27, -60, 99, -85, -33, 43, 86, -12, -74, 66, 100, -31, -41, 32, 107, -69, 20, -38, -122, -33, -110, -118, -126, -12, -85, 20, 91, 44, 44, -5, 79, -101, -53, 124, -57, -29, 118, -81, -48, -89, -99, -29, -93, 8, -17, 113, -87, 100, -123, -124, -77, -99, 76, -51, 54, 4, -78, -41, 116, 84, -116, 35, -35, -30, -12, 16, -87, 23, -32, -73, 124, 71, -26, -105, -28, -14, 91, 122, -114, 1, 1, -8, 76, -48, -119, 108, 111, 99, 97, 108, 104, 111, 115, 116, -126, 31, -112, -126, 31, -112, -48, -119, 108, 111, 99, 97, 108, 104, 111, 115, 116, -126, 31, -112, -126, 31, -112, -92, 48, 97, 57, 54, 55, 56, 53, 53, 45, 99, 102, 98, 97, 45, 52, 98, 49, 98, 45, 57, 56, 57, 48, 45, 102, 54, 99, 57, 51, 49, 97, 52, 97, 55, 97, 48, -124, -59, 3, -58, -55};
+    private static final byte[] mdcPingPeerMessage = new byte[]{113, -5, -63, 15, -4, 21, -42, 93, -10, 19, -95, -37, -29, 63, -92, -125, 28, -27, -60, 99, -85, -33, 43, 86, -12, -74, 66, 100, -31, -41, 32, 107};
+    private static final byte[] signaturePingPeerMessage = new byte[]{-69, 20, -38, -122, -33, -110, -118, -126, -12, -85, 20, 91, 44, 44, -5, 79, -101, -53, 124, -57, -29, 118, -81, -48, -89, -99, -29, -93, 8, -17, 113, -87, 100, -123, -124, -77, -99, 76, -51, 54, 4, -78, -41, 116, 84, -116, 35, -35, -30, -12, 16, -87, 23, -32, -73, 124, 71, -26, -105, -28, -14, 91, 122, -114, 1};
+
+    @Test
+    public void parseInvalidMessageId() {
+        try {
+            createPingPeerMessageWithCheck("http://fake-uuid.com/run");
+            Assert.fail("Invalid messageId exception should've been thrown");
+        } catch (PeerDiscoveryException pde) {
+            Assert.assertEquals(PingPeerMessage.class.getSimpleName() + " needs valid messageId", pde.getMessage());
+        }
+    }
+
+    @Test
+    public void parseValidMessageId() {
+        try {
+            PingPeerMessage message = createPingPeerMessageWithCheck(UUID.randomUUID().toString());
+            Assert.assertNotNull(message);
+        } catch (PeerDiscoveryException pde) {
+            Assert.fail(PingPeerMessage.class.getSimpleName() + " should've worked with valid messageId");
+        }
+    }
+
+    private PingPeerMessage createPingPeerMessageWithCheck(String check) {
+        byte[] type = new byte[]{(byte) DiscoveryMessageType.PING.getTypeValue()};
+
+        byte[] rlpIp = RLP.encodeElement(HOST.getBytes(StandardCharsets.UTF_8));
+        byte[] rlpPort = RLP.encodeElement(stripLeadingZeroes(longToBytes(PORT)));
+        byte[] rlpFromList = RLP.encodeList(rlpIp, rlpPort, rlpPort);
+
+        byte[] rlpIpTo = RLP.encodeElement(HOST.getBytes(StandardCharsets.UTF_8));
+        byte[] rlpPortTo = RLP.encodeElement(stripLeadingZeroes(longToBytes(PORT)));
+        byte[] rlpToList = RLP.encodeList(rlpIpTo, rlpPortTo, rlpPortTo);
+
+        byte[] rlpCheck = RLP.encodeElement(check.getBytes(StandardCharsets.UTF_8));
+
+        byte[] rlpNetworkId = RLP.encodeElement(stripLeadingZeroes(intToBytes(NETWORK_ID)));
+
+        byte[] data = RLP.encodeList(rlpFromList, rlpToList, rlpCheck, rlpNetworkId);
+
+        return new PingPeerMessage(wirePingPeerMessage, mdcPingPeerMessage, signaturePingPeerMessage, type, data);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/PongPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/PongPeerMessageTest.java
@@ -1,0 +1,62 @@
+package co.rsk.net.discovery.message;
+
+import co.rsk.net.discovery.PeerDiscoveryException;
+import org.ethereum.util.RLP;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.ethereum.util.ByteUtil.*;
+
+public class PongPeerMessageTest {
+
+    private static final int NETWORK_ID = 1;
+    private static final String HOST = "localhost";
+    private static final int PORT = 44035;
+
+    private static final byte[] wirePongPeerMessage = new byte[]{113, -5, -63, 15, -4, 21, -42, 93, -10, 19, -95, -37, -29, 63, -92, -125, 28, -27, -60, 99, -85, -33, 43, 86, -12, -74, 66, 100, -31, -41, 32, 107, -69, 20, -38, -122, -33, -110, -118, -126, -12, -85, 20, 91, 44, 44, -5, 79, -101, -53, 124, -57, -29, 118, -81, -48, -89, -99, -29, -93, 8, -17, 113, -87, 100, -123, -124, -77, -99, 76, -51, 54, 4, -78, -41, 116, 84, -116, 35, -35, -30, -12, 16, -87, 23, -32, -73, 124, 71, -26, -105, -28, -14, 91, 122, -114, 1, 1, -8, 76, -48, -119, 108, 111, 99, 97, 108, 104, 111, 115, 116, -126, 31, -112, -126, 31, -112, -48, -119, 108, 111, 99, 97, 108, 104, 111, 115, 116, -126, 31, -112, -126, 31, -112, -92, 48, 97, 57, 54, 55, 56, 53, 53, 45, 99, 102, 98, 97, 45, 52, 98, 49, 98, 45, 57, 56, 57, 48, 45, 102, 54, 99, 57, 51, 49, 97, 52, 97, 55, 97, 48, -124, -59, 3, -58, -55};
+    private static final byte[] mdcPongPeerMessage = new byte[]{113, -5, -63, 15, -4, 21, -42, 93, -10, 19, -95, -37, -29, 63, -92, -125, 28, -27, -60, 99, -85, -33, 43, 86, -12, -74, 66, 100, -31, -41, 32, 107};
+    private static final byte[] signaturePongPeerMessage = new byte[]{-69, 20, -38, -122, -33, -110, -118, -126, -12, -85, 20, 91, 44, 44, -5, 79, -101, -53, 124, -57, -29, 118, -81, -48, -89, -99, -29, -93, 8, -17, 113, -87, 100, -123, -124, -77, -99, 76, -51, 54, 4, -78, -41, 116, 84, -116, 35, -35, -30, -12, 16, -87, 23, -32, -73, 124, 71, -26, -105, -28, -14, 91, 122, -114, 1};
+
+    @Test
+    public void parseInvalidMessageId() {
+        try {
+            createPongPeerMessageWithCheck("http://fake-uuid.com/run");
+            Assert.fail("Invalid messageId exception should've been thrown");
+        } catch (PeerDiscoveryException pde) {
+            Assert.assertEquals(PongPeerMessage.class.getSimpleName() + " needs valid messageId", pde.getMessage());
+        }
+    }
+
+    @Test
+    public void parseValidMessageId() {
+        try {
+            PongPeerMessage message = createPongPeerMessageWithCheck(UUID.randomUUID().toString());
+            Assert.assertNotNull(message);
+        } catch (PeerDiscoveryException pde) {
+            Assert.fail(PongPeerMessage.class.getSimpleName() + " should've worked with valid messageId");
+        }
+    }
+
+    private PongPeerMessage createPongPeerMessageWithCheck(String check) {
+        byte[] type = new byte[]{(byte) DiscoveryMessageType.PONG.getTypeValue()};
+
+        byte[] rlpIp = RLP.encodeElement(HOST.getBytes(StandardCharsets.UTF_8));
+        byte[] rlpPort = RLP.encodeElement(stripLeadingZeroes(longToBytes(PORT)));
+        byte[] rlpFromList = RLP.encodeList(rlpIp, rlpPort, rlpPort);
+
+        byte[] rlpIpTo = RLP.encodeElement(HOST.getBytes(StandardCharsets.UTF_8));
+        byte[] rlpPortTo = RLP.encodeElement(stripLeadingZeroes(longToBytes(PORT)));
+        byte[] rlpToList = RLP.encodeList(rlpIpTo, rlpPortTo, rlpPortTo);
+
+        byte[] rlpCheck = RLP.encodeElement(check.getBytes(StandardCharsets.UTF_8));
+
+        byte[] rlpNetworkId = RLP.encodeElement(stripLeadingZeroes(intToBytes(NETWORK_ID)));
+
+        byte[] data = RLP.encodeList(rlpFromList, rlpToList, rlpCheck, rlpNetworkId);
+
+        return new PongPeerMessage(wirePongPeerMessage, mdcPongPeerMessage, signaturePongPeerMessage, type, data);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/PongPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/PongPeerMessageTest.java
@@ -57,6 +57,6 @@ public class PongPeerMessageTest {
 
         byte[] data = RLP.encodeList(rlpFromList, rlpToList, rlpCheck, rlpNetworkId);
 
-        return new PongPeerMessage(wirePongPeerMessage, mdcPongPeerMessage, signaturePongPeerMessage, type, data);
+        return PongPeerMessage.buildFromReceived(wirePongPeerMessage, mdcPongPeerMessage, signaturePongPeerMessage, type, data);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/discovery/message/PongPeerMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/message/PongPeerMessageTest.java
@@ -31,6 +31,17 @@ public class PongPeerMessageTest {
     }
 
     @Test
+    public void parseUUIDV1MessageId() {
+        try {
+            String uuidV1 = "06ce06f8-7230-11ec-90d6-0242ac120003";
+            createPongPeerMessageWithCheck(uuidV1);
+            Assert.fail("Invalid messageId exception should've been thrown");
+        } catch (PeerDiscoveryException pde) {
+            Assert.assertEquals(PongPeerMessage.class.getSimpleName() + " needs valid messageId", pde.getMessage());
+        }
+    }
+
+    @Test
     public void parseValidMessageId() {
         try {
             PongPeerMessage message = createPongPeerMessageWithCheck(UUID.randomUUID().toString());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Validate _messageId_ format when responding to received _Node Discovery Messages_ to ensure it is a valid UUID before sending a response message that contains it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There’s no check of _messageId_ format during _PeerDiscoveryMessages_ parse therefore an attacker can send any payload to make server response with the same payload. With UDP packet spoofing an attacker can put any src IP address to make server send response to the specified address. Therefore UDP packet containing attacker’s payload can be relayed inside the network where RSKj is deployed to attack other internal services (SSRF)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
