### PR TITLE
Trie changes for storage rent project (WIP)

### DIFF
--- a/rskj-core/src/main/java/co/rsk/db/MutableTrieImpl.java
+++ b/rskj-core/src/main/java/co/rsk/db/MutableTrieImpl.java
@@ -25,6 +25,7 @@ import co.rsk.trie.MutableTrie;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieKeySlice;
 import co.rsk.trie.TrieStore;
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.db.TrieKeyMapper;
 import org.ethereum.vm.DataWord;
@@ -67,7 +68,7 @@ public class MutableTrieImpl implements MutableTrie {
         trie = trie.put(key, value);
     }
 
-    @Override
+    @Override @VisibleForTesting
     public void put(String key, byte[] value) {
         trie = trie.put(key, value);
     }

--- a/rskj-core/src/main/java/co/rsk/db/RepositoryLocator.java
+++ b/rskj-core/src/main/java/co/rsk/db/RepositoryLocator.java
@@ -87,6 +87,7 @@ public class RepositoryLocator {
         Keccak256 stateRoot = stateRootHandler.translate(header);
 
         if (EMPTY_HASH.equals(stateRoot)) {
+            // todo(techdebt), shouldn't instantiate Trie objects from this class
             return Optional.of(new MutableTrieImpl(trieStore, new Trie(trieStore)));
         }
 

--- a/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
+++ b/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
@@ -54,6 +54,7 @@ public class NodeReference {
         this.nodeStopper = Objects.requireNonNull(nodeStopper);
     }
 
+    // todo(techdebt) this doesn't make sense, the node stoper it's always the same, let's initialize it in the full constructor
     public NodeReference(TrieStore store, @Nullable Trie node, @Nullable Keccak256 hash) {
         this(store, node, hash, exitStatus -> System.exit(exitStatus));
     }

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -27,7 +27,11 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.metrics.profilers.Metric;
 import co.rsk.metrics.profilers.Profiler;
 import co.rsk.metrics.profilers.ProfilerFactory;
+import co.rsk.trie.serializer.RSKIP107Serializer;
+import co.rsk.trie.serializer.RSKIP240Serializer;
+import co.rsk.trie.serializer.TrieSerializer;
 import co.rsk.util.NodeStopper;
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.db.TrieKeyMapper;
@@ -36,7 +40,6 @@ import org.ethereum.util.RLP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -74,6 +77,19 @@ public class Trie {
 
     // all zeroed, default hash for empty nodes
     private static final Keccak256 EMPTY_HASH = makeEmptyHash();
+
+    // a long value exceeds 32 bytes
+    public static final int LONG_VALUE = 32 + 1;
+    public static final int TIMESTAMP_SIZE = Long.BYTES;
+    public static final int FLAGS_SIZE = Byte.BYTES;
+    public static final int EMBEDDED_CHILD_LENGTH_SIZE = Uint8.BYTES;
+    public static final int CHILD_HASH_SIZE = 32;
+
+    // to represent a non-initialized rent timestamp
+    public static final long NO_RENT_TIMESTAMP = -1;
+
+    public static final int HOP_TRIE_VERSION = 0b10000000; // todo(fedejinich) this is actually 128 and -128 (casted to byte)
+    public static final int RSKIP107_TRIE_VERSION = 0b01000000;
 
     // this node associated value, if any
     private byte[] value;
@@ -120,6 +136,8 @@ public class Trie {
     // shared Path
     private final TrieKeySlice sharedPath;
 
+    // rent timestamp (checkout rskip240)
+    private final long lastRentPaidTimestamp;
 
     // default constructor, no secure
     public Trie() {
@@ -128,16 +146,16 @@ public class Trie {
 
     // root node
     public Trie(TrieStore store) {
-        this(store, TrieKeySlice.empty(), null);
+        this(store, TrieKeySlice.empty(), null, NO_RENT_TIMESTAMP);
     }
 
     // leaf node
-    private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value) {
-        this(store, sharedPath, value, NodeReference.empty(), NodeReference.empty(), getDataLength(value), null, new VarInt(0));
+    private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, long lastRentPaidTimestamp) {
+        this(store, sharedPath, value, NodeReference.empty(), NodeReference.empty(), getDataLength(value), null, new VarInt(0), lastRentPaidTimestamp);
     }
 
     // full constructor
-    private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash, VarInt childrenSize) {
+    private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash, VarInt childrenSize, long lastRentPaidTimestamp) {
         this.value = value;
         this.left = left;
         this.right = right;
@@ -146,7 +164,7 @@ public class Trie {
         this.valueLength = valueLength;
         this.valueHash = valueHash;
         this.childrenSize = childrenSize;
-        // todo(techdebt) this is always 'exitStatus -> System.exit(exitStatus)'
+        this.lastRentPaidTimestamp = lastRentPaidTimestamp;
         this.nodeStopper = exitStatus -> System.exit(exitStatus);
         checkValueLength();
     }
@@ -162,7 +180,7 @@ public class Trie {
         if (message[0] == ARITY) {
             trie = fromMessageOrchid(message, store);
         } else {
-            trie = fromMessageRskip107(ByteBuffer.wrap(message), store);
+            trie = internalFromMessage(ByteBuffer.wrap(message), store);
         }
 
         profiler.stop(metric);
@@ -247,11 +265,109 @@ public class Trie {
         }
 
         // it doesn't need to clone value since it's retrieved from store or created from message
-        return new Trie(store, sharedPath, value, left, right, lvalue, valueHash, null);
+        // todo(fedejinich) an orchid message should never contain a rent timestamp
+        return new Trie(store, sharedPath, value, left, right, lvalue, valueHash, null, NO_RENT_TIMESTAMP);
     }
 
-    private static Trie fromMessageRskip107(ByteBuffer message, TrieStore store) {
+//    private static Trie fromMessageRskip107(ByteBuffer message, TrieStore store) {
+//        byte flags = message.get();
+//        // if we reached here, we don't need to check the version flag
+//        boolean hasLongVal = (flags & 0b00100000) == 0b00100000;
+//        boolean sharedPrefixPresent = (flags & 0b00010000) == 0b00010000;
+//        boolean leftNodePresent = (flags & 0b00001000) == 0b00001000;
+//        boolean rightNodePresent = (flags & 0b00000100) == 0b00000100;
+//        boolean leftNodeEmbedded = (flags & 0b00000010) == 0b00000010;
+//        boolean rightNodeEmbedded = (flags & 0b00000001) == 0b00000001;
+//
+//        TrieKeySlice sharedPath = SharedPathSerializer.deserialize(message, sharedPrefixPresent);
+//
+//        NodeReference left = NodeReference.empty();
+//        NodeReference right = NodeReference.empty();
+//        if (leftNodePresent) {
+//            if (leftNodeEmbedded) {
+//                byte[] lengthBytes = new byte[Uint8.BYTES];
+//                message.get(lengthBytes);
+//                Uint8 length = Uint8.decode(lengthBytes, 0);
+//
+//                byte[] serializedNode = new byte[length.intValue()];
+//                message.get(serializedNode);
+//                Trie node = fromMessageRskip107(ByteBuffer.wrap(serializedNode), store);
+//                left = new NodeReference(store, node, null);
+//            } else {
+//                byte[] valueHash = new byte[Keccak256Helper.DEFAULT_SIZE_BYTES];
+//                message.get(valueHash);
+//                Keccak256 nodeHash = new Keccak256(valueHash);
+//                left = new NodeReference(store, null, nodeHash);
+//            }
+//        }
+//
+//        if (rightNodePresent) {
+//            if (rightNodeEmbedded) {
+//                byte[] lengthBytes = new byte[Uint8.BYTES];
+//                message.get(lengthBytes);
+//                Uint8 length = Uint8.decode(lengthBytes, 0);
+//
+//                byte[] serializedNode = new byte[length.intValue()];
+//                message.get(serializedNode);
+//                Trie node = fromMessageRskip107(ByteBuffer.wrap(serializedNode), store);
+//                right = new NodeReference(store, node, null);
+//            } else {
+//                byte[] valueHash = new byte[Keccak256Helper.DEFAULT_SIZE_BYTES];
+//                message.get(valueHash);
+//                Keccak256 nodeHash = new Keccak256(valueHash);
+//                right = new NodeReference(store, null, nodeHash);
+//            }
+//        }
+//
+//        VarInt childrenSize = new VarInt(0);
+//        if (leftNodePresent || rightNodePresent) {
+//            childrenSize = readVarInt(message);
+//        }
+//
+//        byte[] value;
+//        Uint24 lvalue;
+//        Keccak256 valueHash;
+//
+//        if (hasLongVal) {
+//            value = null;
+//            byte[] valueHashBytes = new byte[Keccak256Helper.DEFAULT_SIZE_BYTES];
+//            message.get(valueHashBytes);
+//            valueHash = new Keccak256(valueHashBytes);
+//            byte[] lvalueBytes = new byte[Uint24.BYTES];
+//            message.get(lvalueBytes);
+//            lvalue = Uint24.decode(lvalueBytes, 0);
+//        } else {
+//            int remaining = message.remaining();
+//            if (remaining != 0) {
+//                value = new byte[remaining];
+//                message.get(value);
+//                valueHash = new Keccak256(Keccak256Helper.keccak256(value));
+//                lvalue = new Uint24(remaining);
+//            } else {
+//                value = null;
+//                valueHash = null;
+//                lvalue = Uint24.ZERO;
+//            }
+//        }
+//
+//        if (message.hasRemaining()) {
+//            throw new IllegalArgumentException("The message had more data than expected");
+//        }
+//
+//        Trie trie = new Trie(store, sharedPath, value, left, right, lvalue, valueHash, childrenSize);
+//
+//        return trie;
+//    }
+
+    private static Trie internalFromMessage(ByteBuffer message, TrieStore store) {
         byte flags = message.get();
+        TrieSerializer trieSerializer = new RSKIP107Serializer();
+
+        // check if it's an rskip240 trie node
+        if((flags & 0b10000000) == 0b10000000) {
+            trieSerializer = new RSKIP240Serializer();
+        }
+
         // if we reached here, we don't need to check the version flag
         boolean hasLongVal = (flags & 0b00100000) == 0b00100000;
         boolean sharedPrefixPresent = (flags & 0b00010000) == 0b00010000;
@@ -259,6 +375,9 @@ public class Trie {
         boolean rightNodePresent = (flags & 0b00000100) == 0b00000100;
         boolean leftNodeEmbedded = (flags & 0b00000010) == 0b00000010;
         boolean rightNodeEmbedded = (flags & 0b00000001) == 0b00000001;
+
+//        message.getLong()
+        long lastRentPaidTimestamp = trieSerializer.deserializeLastRentPaidTimestamp(message);
 
         TrieKeySlice sharedPath = SharedPathSerializer.deserialize(message, sharedPrefixPresent);
 
@@ -272,7 +391,7 @@ public class Trie {
 
                 byte[] serializedNode = new byte[length.intValue()];
                 message.get(serializedNode);
-                Trie node = fromMessageRskip107(ByteBuffer.wrap(serializedNode), store);
+                Trie node = internalFromMessage(ByteBuffer.wrap(serializedNode), store);
                 left = new NodeReference(store, node, null);
             } else {
                 byte[] valueHash = new byte[Keccak256Helper.DEFAULT_SIZE_BYTES];
@@ -290,7 +409,7 @@ public class Trie {
 
                 byte[] serializedNode = new byte[length.intValue()];
                 message.get(serializedNode);
-                Trie node = fromMessageRskip107(ByteBuffer.wrap(serializedNode), store);
+                Trie node = internalFromMessage(ByteBuffer.wrap(serializedNode), store);
                 right = new NodeReference(store, node, null);
             } else {
                 byte[] valueHash = new byte[Keccak256Helper.DEFAULT_SIZE_BYTES];
@@ -335,7 +454,104 @@ public class Trie {
             throw new IllegalArgumentException("The message had more data than expected");
         }
 
-        Trie trie = new Trie(store, sharedPath, value, left, right, lvalue, valueHash, childrenSize);
+        Trie trie = new Trie(store, sharedPath, value, left, right, lvalue, valueHash, childrenSize, lastRentPaidTimestamp);
+
+        return trie;
+    }
+
+    // todo(fedejinich) it'll be inclued in production in the last storage rent stage.
+    //  this is duplicated code, but the truth is that the old de/serialization method won't be changed because
+    //  it impacts directly in consensus rules (same aplies to further de/serialization methods)
+    @VisibleForTesting
+    private static Trie fromMessageRskip240(ByteBuffer message, TrieStore store) {
+        byte flags = message.get();
+        // if we reached here, we don't need to check the version flag
+        boolean hasLongVal = (flags & 0b00100000) == 0b00100000;
+        boolean sharedPrefixPresent = (flags & 0b00010000) == 0b00010000;
+        boolean leftNodePresent = (flags & 0b00001000) == 0b00001000;
+        boolean rightNodePresent = (flags & 0b00000100) == 0b00000100;
+        boolean leftNodeEmbedded = (flags & 0b00000010) == 0b00000010;
+        boolean rightNodeEmbedded = (flags & 0b00000001) == 0b00000001;
+
+        long lastRentPaidTimestamp = message.getLong();
+
+        TrieKeySlice sharedPath = SharedPathSerializer.deserialize(message, sharedPrefixPresent);
+
+        NodeReference left = NodeReference.empty();
+        NodeReference right = NodeReference.empty();
+        if (leftNodePresent) {
+            if (leftNodeEmbedded) {
+                byte[] lengthBytes = new byte[Uint8.BYTES];
+                message.get(lengthBytes);
+                Uint8 length = Uint8.decode(lengthBytes, 0);
+
+                byte[] serializedNode = new byte[length.intValue()];
+                message.get(serializedNode);
+                Trie node = fromMessageRskip240(ByteBuffer.wrap(serializedNode), store);
+                left = new NodeReference(store, node, null);
+            } else {
+                byte[] valueHash = new byte[Keccak256Helper.DEFAULT_SIZE_BYTES];
+                message.get(valueHash);
+                Keccak256 nodeHash = new Keccak256(valueHash);
+                left = new NodeReference(store, null, nodeHash);
+            }
+        }
+
+        if (rightNodePresent) {
+            if (rightNodeEmbedded) {
+                byte[] lengthBytes = new byte[Uint8.BYTES];
+                message.get(lengthBytes);
+                Uint8 length = Uint8.decode(lengthBytes, 0);
+
+                byte[] serializedNode = new byte[length.intValue()];
+                message.get(serializedNode);
+                Trie node = fromMessageRskip240(ByteBuffer.wrap(serializedNode), store);
+                right = new NodeReference(store, node, null);
+            } else {
+                byte[] valueHash = new byte[Keccak256Helper.DEFAULT_SIZE_BYTES];
+                message.get(valueHash);
+                Keccak256 nodeHash = new Keccak256(valueHash);
+                right = new NodeReference(store, null, nodeHash);
+            }
+        }
+
+        VarInt childrenSize = new VarInt(0);
+        if (leftNodePresent || rightNodePresent) {
+            childrenSize = readVarInt(message);
+        }
+
+        byte[] value;
+        Uint24 lvalue;
+        Keccak256 valueHash;
+
+        if (hasLongVal) {
+            value = null;
+            byte[] valueHashBytes = new byte[Keccak256Helper.DEFAULT_SIZE_BYTES];
+            message.get(valueHashBytes);
+            valueHash = new Keccak256(valueHashBytes);
+            byte[] lvalueBytes = new byte[Uint24.BYTES];
+            message.get(lvalueBytes);
+            lvalue = Uint24.decode(lvalueBytes, 0);
+        } else {
+            int remaining = message.remaining();
+            if (remaining != 0) {
+                value = new byte[remaining];
+                message.get(value);
+                valueHash = new Keccak256(Keccak256Helper.keccak256(value));
+                lvalue = new Uint24(remaining);
+            } else {
+                value = null;
+                valueHash = null;
+                lvalue = Uint24.ZERO;
+            }
+        }
+
+        if (message.hasRemaining()) {
+            throw new IllegalArgumentException("The message had more data than expected");
+        }
+
+        // todo(fedejinich) an rskip107 message should never contain a rent timestamp
+        Trie trie = new Trie(store, sharedPath, value, left, right, lvalue, valueHash, childrenSize, lastRentPaidTimestamp);
 
         return trie;
     }
@@ -449,6 +665,7 @@ public class Trie {
      * @return  a new NewTrie, the top node of a new trie having the key
      * value association
      */
+    @VisibleForTesting
     public Trie put(String key, byte[] value) {
         return put(key.getBytes(StandardCharsets.UTF_8), value);
     }
@@ -671,12 +888,18 @@ public class Trie {
     private void internalToMessage() {
         Uint24 lvalue = this.valueLength;
         boolean hasLongVal = this.hasLongValue();
+        TrieSerializer trieSerializer = new RSKIP107Serializer();
+
+        if(lastRentPaidTimestamp != NO_RENT_TIMESTAMP) {
+            trieSerializer = new RSKIP240Serializer();
+        }
 
         SharedPathSerializer sharedPathSerializer = new SharedPathSerializer(this.sharedPath);
         VarInt childrenSize = getChildrenSize();
 
         ByteBuffer buffer = ByteBuffer.allocate(
                 1 + // flags
+                trieSerializer.lastPaidRentTimestampSize() + // it depends on whether it is timestamped or not
                         sharedPathSerializer.serializedLength() +
                         this.left.serializedLength() +
                         this.right.serializedLength() +
@@ -684,33 +907,42 @@ public class Trie {
                         (hasLongVal ? Keccak256Helper.DEFAULT_SIZE_BYTES + Uint24.BYTES : lvalue.intValue())
         );
 
-        // current serialization version: 01
-        byte flags = 0b01000000;
+        // nodeVersion: 2 bits indicate serialization version (bits 6,7). Currently 01 (bit 6=1).
+        byte flags = trieSerializer.trieVersion();
+
+        // hasLongValue: 1 bit indicate if value length > 32 bytes (bit 5)
         if (hasLongVal) {
             flags = (byte) (flags | 0b00100000);
         }
 
+        // sharedPrefixPresent: 1 bit indicates if there is any prefix (bit 4)
         if (sharedPathSerializer.isPresent()) {
             flags = (byte) (flags | 0b00010000);
         }
 
+        // nodePresent: 2 bits indicate left/right embedded node (bit 2 = left, bit 3 = right)
         if (!this.left.isEmpty()) {
             flags = (byte) (flags | 0b00001000);
         }
 
+        // nodePresent: 2 bits indicate left/right embedded node (bit 2 = left, bit 3 = right)
         if (!this.right.isEmpty()) {
             flags = (byte) (flags | 0b00000100);
         }
 
+        // nodeIsEmbedded: 2 bits indicate left/right node presence (bit 0 = left, bit 1=right)
         if (this.left.isEmbeddable()) {
             flags = (byte) (flags | 0b00000010);
         }
 
+        // nodeIsEmbedded: 2 bits indicate left/right node presence (bit 0 = left, bit 1=right)
         if (this.right.isEmbeddable()) {
             flags = (byte) (flags | 0b00000001);
         }
 
         buffer.put(flags);
+
+        trieSerializer.serializeLastRentPaidTimestamp(buffer, lastRentPaidTimestamp);
 
         sharedPathSerializer.serializeInto(buffer);
 
@@ -755,7 +987,6 @@ public class Trie {
      * @param value     associated value
      *
      * @return the new NewTrie containing the tree with the new key value association
-     *
      */
     private Trie put(TrieKeySlice key, byte[] value, boolean isRecursiveDelete) {
         // First of all, setting the value as an empty byte array is equivalent
@@ -774,6 +1005,7 @@ public class Trie {
             return trie;
         }
 
+        // todo(techdebt) this doesn't make sense: internalPut returns null for empty tries
         if (trie.isEmptyTrie()) {
             return null;
         }
@@ -807,7 +1039,8 @@ public class Trie {
 
         TrieKeySlice newSharedPath = trie.sharedPath.rebuildSharedPath(childImplicitByte, child.sharedPath);
 
-        return new Trie(child.store, newSharedPath, child.value, child.left, child.right, child.valueLength, child.valueHash, child.childrenSize);
+        return new Trie(child.store, newSharedPath, child.value, child.left, child.right, child.valueLength,
+                child.valueHash, child.childrenSize, child.lastRentPaidTimestamp); // todo(fedejinich) is this ok?
     }
 
     private static Uint24 getDataLength(byte[] value) {
@@ -829,6 +1062,8 @@ public class Trie {
             return this.split(commonPath).put(key, value, isRecursiveDelete);
         }
 
+        // todo(fedejinich) already exising key
+        //  probably the part that we need for updatingRent
         if (sharedPath.length() >= key.length()) {
             // To compare values we need to retrieve the previous value
             // if not already done so. We could also compare by hash, to avoid retrieval
@@ -839,13 +1074,15 @@ public class Trie {
             }
 
             if (isRecursiveDelete) {
-                return new Trie(this.store, this.sharedPath, null);
+                // todo(fedejinich) a recursive delete will also clear the rent timestamp
+                return new Trie(this.store, this.sharedPath, null, NO_RENT_TIMESTAMP);
             }
 
             if (isEmptyTrie(getDataLength(value), this.left, this.right)) {
                 return null;
             }
 
+            // todo(fedejinich) updates the already existing key
             return new Trie(
                     this.store,
                     this.sharedPath,
@@ -854,12 +1091,16 @@ public class Trie {
                     this.right,
                     getDataLength(value),
                     null,
-                    this.childrenSize
-            );
+                    this.childrenSize,
+                    this.lastRentPaidTimestamp); // todo(fedejinich) is this ok?
         }
 
         if (isEmptyTrie()) {
-            return new Trie(this.store, key, cloneArray(value));
+            // todo(fedejinich) is this ok? i think we should set the existing timestamp
+            //   or should we initialize with NO_RENT_TIMESTAMP?
+            // new trie leaf
+            return new Trie(this.store, key, cloneArray(value), this.lastRentPaidTimestamp);
+//            return new Trie(this.store, key, cloneArray(value), NO_RENT_TIMESTAMP);
         }
 
         // this bit will be implicit and not present in a shared path
@@ -903,13 +1144,15 @@ public class Trie {
             return null;
         }
 
-        return new Trie(this.store, this.sharedPath, this.value, newLeft, newRight, this.valueLength, this.valueHash, childrenSize);
+        // todo(fedejinich) going up from the already updated/created key, updates the new left or right
+        return new Trie(this.store, this.sharedPath, this.value, newLeft, newRight,
+                this.valueLength, this.valueHash, childrenSize, this.lastRentPaidTimestamp); // todo(fedejinich) is this ok?
     }
 
     private Trie split(TrieKeySlice commonPath) {
         int commonPathLength = commonPath.length();
         TrieKeySlice newChildSharedPath = sharedPath.slice(commonPathLength + 1, sharedPath.length());
-        Trie newChildTrie = new Trie(this.store, newChildSharedPath, this.value, this.left, this.right, this.valueLength, this.valueHash, this.childrenSize);
+        Trie newChildTrie = new Trie(this.store, newChildSharedPath, this.value, this.left, this.right, this.valueLength, this.valueHash, this.childrenSize, this.lastRentPaidTimestamp); // todo(fedejinich) is this ok?
         NodeReference newChildReference = new NodeReference(this.store, newChildTrie, null);
 
         // this bit will be implicit and not present in a shared path
@@ -926,7 +1169,7 @@ public class Trie {
             newRight = newChildReference;
         }
 
-        return new Trie(this.store, commonPath, null, newLeft, newRight, Uint24.ZERO, null, childrenSize);
+        return new Trie(this.store, commonPath, null, newLeft, newRight, Uint24.ZERO, null, childrenSize, this.lastRentPaidTimestamp); // todo(fedejinich) is this ok?
     }
 
     public boolean isTerminal() {
@@ -1140,6 +1383,128 @@ public class Trie {
 
         message.get(bytes);
         return new VarInt(bytes, 0);
+    }
+
+    // todo(fedejinich) need to use internalPut
+    public Trie setLastRentPaidTimestamp(long lastPaidRentTimestamp) {
+        return new Trie(this.store, this.sharedPath, this.value, this.left, this.right,
+                this.valueLength, this.valueHash, this.childrenSize, lastPaidRentTimestamp);
+    }
+
+//     todo(fedejinich) we don't need any 'value', it will be removed and replaced by the already existing 'this.value'
+    public Trie updateLastRentPaidTimestamp(TrieKeySlice key, long lastRentPaidTimestamp) {
+//        todo(fedejinich) i'm not sure about this part yet, why would we split the trie for updates?
+//        TrieKeySlice commonPath = key.commonPath(sharedPath);
+//        if (commonPath.length() < sharedPath.length()) {
+//            // when we are removing a key we know splitting is not necessary. the key wasn't found at this point.
+//            if (value == null) {
+//                return this;
+//            }
+//
+//            return this.split(commonPath).put(key, value, isRecursiveDelete);
+//        }
+
+        // todo(fedejinich) already exising key
+        //  probably the part that we need for updatingRent
+        if (sharedPath.length() >= key.length()) {
+            // To compare values we need to retrieve the previous value
+            // if not already done so. We could also compare by hash, to avoid retrieval
+            // We do a small optimization here: if sizes are not equal, then values
+            // obviously are not.
+            // todo(fedejinich) why would we need this? is it trying to update a value with the same value?
+            //   for storage rent this should never happen
+//            if (this.valueLength.equals(getDataLength(value)) && Arrays.equals(this.getValue(), value)) {
+//                return this;
+//            }
+
+//            todo(fedejinich) no deletes for this operation
+//            if (isRecursiveDelete) {
+//                return new Trie(this.store, this.sharedPath, null, NO_RENT_TIMESTAMP);
+//            }
+
+//            todo(fedejinich) there are no cases to return a null value
+//            if (isEmptyTrie(getDataLength(value), this.left, this.right)) {
+//                return null;
+//            }
+
+            // todo(fedejinich) updates timestamp from the already existing key
+            return new Trie(
+                    this.store,
+                    this.sharedPath,
+                    cloneArray(this.value), // todo(fedejinich) should be 'this.value' because we are updating the timestamp
+                    this.left,
+                    this.right,
+                    getDataLength(this.value),
+                    null,
+                    this.childrenSize,
+                    lastRentPaidTimestamp); // todo(fedejinich) updates the rent timestamp
+        }
+
+//        todo(fedejinich) there won't be new trie leafs
+//        if (isEmptyTrie()) {
+//            return new Trie(this.store, key, cloneArray(value), this.lastRentPaidTimestamp);
+//        }
+
+        // todo(fedejinich) the following part goes down to the next child,
+        //   and tries to update the timestamp (or put a new value for internalPut)
+
+        // this bit will be implicit and not present in a shared path
+        byte pos = key.get(sharedPath.length());
+
+        Trie node = retrieveNode(pos);
+        // todo(fedejinich) this should never happen, it will update timestamp from an already existing trie
+//        if (node == null) {
+//            node = new Trie(this.store);
+//        }
+
+        TrieKeySlice subKey = key.slice(sharedPath.length() + 1, key.length());
+        Trie newNode = node.updateLastRentPaidTimestamp(subKey, lastRentPaidTimestamp);
+
+        // reference equality
+        if (newNode == node) {
+            return this;
+        }
+
+        // todo(fedejinich) if there are new branches, it creates new nodes references,
+        //  and updates child references (from the bottom up to the trie root)
+
+        VarInt childrenSize = this.childrenSize;
+
+        NodeReference newNodeReference = new NodeReference(this.store, newNode, null);
+
+        // todo(techdebt) duplicated code, this should be handled by a method like 'newChildByPos' (same happens at internalPut)
+        NodeReference newLeft;
+        NodeReference newRight;
+        if (pos == 0) {
+            newLeft = newNodeReference;
+            newRight = this.right;
+
+            if (childrenSize != null) {
+                childrenSize = new VarInt(childrenSize.value - this.left.referenceSize() + newLeft.referenceSize());
+            }
+        } else {
+            newLeft = this.left;
+            newRight = newNodeReference;
+
+            if (childrenSize != null) {
+                childrenSize = new VarInt(childrenSize.value - this.right.referenceSize() + newRight.referenceSize());
+            }
+        }
+        // todo(techdebt) end of duplicated code
+
+//        todo(fedejinich) there are no cases to return null value
+//        if (isEmptyTrie(this.valueLength, newLeft, newRight)) {
+//            return null;
+//        }
+
+        // goes up to the trie root with new updated left/right
+        // todo(fedejinich) here we can update also the intermediate nodes by passing newNode.lastRentTimestamp instead of this.lastPaidRentTimestamp
+        return new Trie(this.store, this.sharedPath, this.value, newLeft, newRight,
+                this.valueLength, this.valueHash, childrenSize, this.lastRentPaidTimestamp); // todo(fedejinich) use the already existing timestamp
+    }
+
+    public long getLastRentPaidTimestamp() {
+        return this.lastRentPaidTimestamp;
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -126,18 +126,22 @@ public class Trie {
         this(null);
     }
 
+    // root node
     public Trie(TrieStore store) {
         this(store, TrieKeySlice.empty(), null);
     }
 
+    // leaf node
     private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value) {
         this(store, sharedPath, value, NodeReference.empty(), NodeReference.empty(), getDataLength(value), null, new VarInt(0));
     }
 
+    // todo(techdebt) this constructor it's only called once, call the right constructor and avoid creating a new one for just one use
     public Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash) {
         this(store, sharedPath, value, left, right, valueLength, valueHash, null);
     }
 
+    // todo(techdebt) nonsense constructor, checkout full constructor
     private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash, VarInt childrenSize) {
         this(store, sharedPath, value, left, right, valueLength, valueHash, childrenSize, exitStatus -> System.exit(exitStatus));
     }
@@ -152,6 +156,7 @@ public class Trie {
         this.valueLength = valueLength;
         this.valueHash = valueHash;
         this.childrenSize = childrenSize;
+        // todo(techdebt) this is always 'exitStatus -> System.exit(exitStatus)'
         this.nodeStopper = Objects.requireNonNull(nodeStopper);
         checkValueLength();
     }

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -136,18 +136,8 @@ public class Trie {
         this(store, sharedPath, value, NodeReference.empty(), NodeReference.empty(), getDataLength(value), null, new VarInt(0));
     }
 
-    // todo(techdebt) this constructor it's only called once, call the right constructor and avoid creating a new one for just one use
-    public Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash) {
-        this(store, sharedPath, value, left, right, valueLength, valueHash, null);
-    }
-
-    // todo(techdebt) nonsense constructor, checkout full constructor
-    private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash, VarInt childrenSize) {
-        this(store, sharedPath, value, left, right, valueLength, valueHash, childrenSize, exitStatus -> System.exit(exitStatus));
-    }
-
     // full constructor
-    private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash, VarInt childrenSize, @Nonnull NodeStopper nodeStopper) {
+    private Trie(TrieStore store, TrieKeySlice sharedPath, byte[] value, NodeReference left, NodeReference right, Uint24 valueLength, Keccak256 valueHash, VarInt childrenSize) {
         this.value = value;
         this.left = left;
         this.right = right;
@@ -157,7 +147,7 @@ public class Trie {
         this.valueHash = valueHash;
         this.childrenSize = childrenSize;
         // todo(techdebt) this is always 'exitStatus -> System.exit(exitStatus)'
-        this.nodeStopper = Objects.requireNonNull(nodeStopper);
+        this.nodeStopper = exitStatus -> System.exit(exitStatus);
         checkValueLength();
     }
 
@@ -257,9 +247,7 @@ public class Trie {
         }
 
         // it doesn't need to clone value since it's retrieved from store or created from message
-        Trie trie = new Trie(store, sharedPath, value, left, right, lvalue, valueHash);
-
-        return trie;
+        return new Trie(store, sharedPath, value, left, right, lvalue, valueHash, null);
     }
 
     private static Trie fromMessageRskip107(ByteBuffer message, TrieStore store) {

--- a/rskj-core/src/main/java/co/rsk/trie/serializer/RSKIP107Serializer.java
+++ b/rskj-core/src/main/java/co/rsk/trie/serializer/RSKIP107Serializer.java
@@ -1,0 +1,28 @@
+package co.rsk.trie.serializer;
+
+import java.nio.ByteBuffer;
+
+import static co.rsk.trie.Trie.NO_RENT_TIMESTAMP;
+import static co.rsk.trie.Trie.RSKIP107_TRIE_VERSION;
+
+public class RSKIP107Serializer implements TrieSerializer {
+    @Override
+    public long deserializeLastRentPaidTimestamp(ByteBuffer message) {
+        return NO_RENT_TIMESTAMP;
+    }
+
+    @Override
+    public void serializeLastRentPaidTimestamp(ByteBuffer buffer, long lastRentPaidTimestamp) {
+        // no need to serialize
+    }
+
+    @Override
+    public byte trieVersion() {
+        return RSKIP107_TRIE_VERSION;
+    }
+
+    @Override
+    public int lastPaidRentTimestampSize() {
+        return 0; // since there are no timestamps on rskip107
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/trie/serializer/RSKIP240Serializer.java
+++ b/rskj-core/src/main/java/co/rsk/trie/serializer/RSKIP240Serializer.java
@@ -1,0 +1,28 @@
+package co.rsk.trie.serializer;
+
+import java.nio.ByteBuffer;
+
+import static co.rsk.trie.Trie.HOP_TRIE_VERSION;
+import static co.rsk.trie.Trie.TIMESTAMP_SIZE;
+
+public class RSKIP240Serializer implements TrieSerializer {
+    @Override
+    public long deserializeLastRentPaidTimestamp(ByteBuffer message) {
+        return message.getLong();
+    }
+
+    @Override
+    public void serializeLastRentPaidTimestamp(ByteBuffer buffer, long lastRentPaidTimestamp) {
+        buffer.putLong(lastRentPaidTimestamp);
+    }
+
+    @Override
+    public byte trieVersion() {
+        return (byte) HOP_TRIE_VERSION;
+    }
+
+    @Override
+    public int lastPaidRentTimestampSize() {
+        return TIMESTAMP_SIZE;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/trie/serializer/TrieSerializer.java
+++ b/rskj-core/src/main/java/co/rsk/trie/serializer/TrieSerializer.java
@@ -1,0 +1,13 @@
+package co.rsk.trie.serializer;
+
+import java.nio.ByteBuffer;
+
+public interface TrieSerializer {
+    long deserializeLastRentPaidTimestamp(ByteBuffer message);
+
+    void serializeLastRentPaidTimestamp(ByteBuffer buffer, long lastRentPaidTimestamp);
+
+    byte trieVersion();
+
+    int lastPaidRentTimestampSize();
+}

--- a/rskj-core/src/main/java/org/ethereum/core/genesis/GenesisLoaderImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/core/genesis/GenesisLoaderImpl.java
@@ -205,6 +205,7 @@ public class GenesisLoaderImpl implements GenesisLoader {
     }
 
     private Trie loadGenesisTrie(Genesis genesis) {
+        // todo(techdebt) shouldn't instantiate Trie objects from this class
         Repository repository = new MutableRepository(trieStore, new Trie(trieStore));
         loadGenesisInitalState(repository, genesis);
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieUpdateRentTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieUpdateRentTest.java
@@ -1,0 +1,66 @@
+package co.rsk.trie;
+
+import org.junit.Test;
+
+import static co.rsk.trie.Trie.NO_RENT_TIMESTAMP;
+import static org.bouncycastle.util.encoders.Hex.decode;
+import static org.junit.Assert.assertEquals;
+
+public class TrieUpdateRentTest {
+
+    @Test
+    public void updateRentTimestampBasicTest() {
+        Trie trie = buildTestTrie();
+
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a00")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a80")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a0000")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a0080")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a008000")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a008080")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a8080")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a808000")).getLastRentPaidTimestamp());
+
+        trie = trie.updateLastRentPaidTimestamp(TrieKeySlice.fromKey(decode("0a008080")), 20);
+
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a00")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a80")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a0000")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a0080")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a008000")).getLastRentPaidTimestamp());
+        assertEquals(20, trie.find(decode("0a008080")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a8080")).getLastRentPaidTimestamp());
+        assertEquals(NO_RENT_TIMESTAMP, trie.find(decode("0a808000")).getLastRentPaidTimestamp());
+    }
+
+    /**
+     * @return the following tree
+     *
+     *       6
+     *      / \
+     *     /   \
+     *    /     7
+     *   2       \
+     *  / \       \
+     * 1   \       8
+     *      4     /
+     *     / \   9
+     *    3   5
+     */
+    private static Trie buildTestTrie() {
+        Trie trie = new Trie();
+        trie = trie.put(decode("0a"), new byte[] { 0x06 });
+        trie = trie.put(decode("0a00"), new byte[] { 0x02 });
+        trie = trie.put(decode("0a80"), new byte[] { 0x07 });
+        trie = trie.put(decode("0a0000"), new byte[] { 0x01 });
+        trie = trie.put(decode("0a0080"), new byte[] { 0x04 });
+        trie = trie.put(decode("0a008000"), new byte[] { 0x03 });
+        trie = trie.put(decode("0a008080"), new byte[] { 0x05 });
+        trie = trie.put(decode("0a8080"), new byte[] { 0x08 });
+        trie = trie.put(decode("0a808000"), new byte[] { 0x09 });
+
+        return trie;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/trie/message/TrieHopMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/message/TrieHopMessageTest.java
@@ -1,0 +1,290 @@
+package co.rsk.trie.message;
+
+import co.rsk.core.types.ints.Uint24;
+import co.rsk.core.types.ints.Uint8;
+import co.rsk.trie.*;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.List;
+
+import static co.rsk.trie.Trie.*;
+import static org.bouncycastle.util.encoders.Hex.decode;
+import static org.junit.Assert.*;
+
+// todo(fedejinich) currently the serialization process has one error
+//   it serializes childs with the old internalToMessage -> this will be fixed with a strategy
+public class TrieHopMessageTest {
+
+    private static final long TEST_TIMESTAMP = new Date().getTime();
+
+    @Test
+    public void emptyTrieToMessageHop() {
+        Trie trie = new Trie();
+
+        trie = trie.setLastRentPaidTimestamp(TEST_TIMESTAMP);
+
+        byte[] message = trie.toMessage();
+
+        assertNotNull(message);
+
+        ByteBuffer messageBuffer = ByteBuffer.wrap(message);
+
+        // flags (1 byte) + lastRentPaidTimestamp (8 bytes)
+        assertEquals(FLAGS_SIZE + TIMESTAMP_SIZE, message.length);
+
+        // check flags (version)
+        assertEquals((byte) 0b10000000, messageBuffer.get());
+
+        // check rent timestamp
+        assertEquals(TEST_TIMESTAMP, new Date(messageBuffer.getLong()).getTime());
+
+        assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithLeftEmbeddedChildToMessageHop() {
+        byte[] value1 = {1};
+        byte[] value2 = {7};
+
+        Trie trie = new Trie()
+                .put(decode("0a"), value1)
+                .put(decode("0a00"), value2);
+
+        trie = trie.setLastRentPaidTimestamp(TEST_TIMESTAMP);
+
+        assertArrayEquals(new byte[]{1}, trie.getValue());
+        assertTrue(!trie.getLeft().isEmpty());
+        assertTrue(trie.getLeft().isEmbeddable());
+        assertTrue(trie.getLeft().getNode().get().isTerminal());
+        assertTrue(trie.getRight().isEmpty());
+        assertArrayEquals(new byte[]{7}, trie.getLeft().getNode().get().getValue());
+
+        byte[] message = trie.toMessage();
+
+        assertNotNull(message);
+
+        // flags + lastRentPaidTimestamp + leftEmbeddedChildLength + leftEmbeddedChild + value
+        assertEquals(FLAGS_SIZE + TIMESTAMP_SIZE + EMBEDDED_CHILD_LENGTH_SIZE + 7 + value1.length
+                , message.length);
+
+        ByteBuffer messageBuffer = ByteBuffer.wrap(message);
+
+        // check flags (version + lshared + left + leftEmbedded)
+        assertEquals((byte) 0b10000000 | 0b00010000 | 0b00001000 | 0b00000010, messageBuffer.get());
+
+        // check rent timestamp
+        assertEquals(TEST_TIMESTAMP, new Date(messageBuffer.getLong()).getTime());
+
+        byte[] leftChildLengthBuffer = new byte[Uint8.BYTES];
+        messageBuffer.get(leftChildLengthBuffer);
+        Uint8 embeddedLeftChildLength = Uint8.decode(leftChildLengthBuffer, 0);
+
+        // check left embedChild
+        byte[] embeddedLeftChild = new byte[embeddedLeftChildLength.intValue()];
+        messageBuffer.get(embeddedLeftChild);
+        assertEquals(7, embeddedLeftChild.length);
+        assertArrayEquals(new byte[]{7}, Trie.fromMessage(embeddedLeftChild, null)
+                .getLeft().getNode().get().getValue()); // todo(fedejinich) is this ok ?
+
+        // check value
+        byte[] value = new byte[messageBuffer.remaining()];
+        messageBuffer.get(value);
+        assertArrayEquals(new byte[]{1}, value);
+
+        assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithLeftChildToMessageHop() {
+        Trie rootNode = new Trie()
+                .put(decode("0a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a01"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a0110"), TrieValueTest.makeValue(LONG_VALUE - 1));
+
+        rootNode = rootNode.setLastRentPaidTimestamp(TEST_TIMESTAMP);
+
+        assertTrue(!rootNode.getLeft().isEmpty());
+        assertTrue(rootNode.getRight().isEmpty());
+        assertTrue(!rootNode.getLeft().isEmbeddable());
+
+        Trie intermediateNode = rootNode.getLeft().getNode().get();
+        assertTrue(!intermediateNode.isTerminal());
+
+        assertTrue(!intermediateNode.getLeft().isEmpty());
+        assertTrue(intermediateNode.getRight().isEmpty());
+        assertTrue(intermediateNode.getLeft().isEmbeddable());
+
+        Trie leafNode = intermediateNode.getLeft().getNode().get();
+        assertTrue(leafNode.isTerminal());
+
+        assertEquals(TEST_TIMESTAMP, rootNode.getLastRentPaidTimestamp());
+
+        byte[] message = rootNode.toMessage();
+
+        assertNotNull(message);
+
+        // flags + lastRentPaidTimestamp + leftChildHashLength + value
+        assertEquals(FLAGS_SIZE + TIMESTAMP_SIZE + CHILD_HASH_SIZE
+                , message.length);
+
+        assertEquals(68, message.length); // todo(fedejinich) why?
+
+        ByteBuffer messageBuffer = ByteBuffer.wrap(message);
+
+        // check flags (version + lshared + left) => 0b10000000 | 0b00010000 | 0b00001000
+        assertEquals(0b10011000, messageBuffer.get());
+
+        // check rent timestamp
+        assertEquals(TEST_TIMESTAMP, new Date(messageBuffer.getLong()).getTime());
+
+        // check left node hash
+
+        // todo(fedejinich) here I should check the left intermediate node and also the left leaf node
+
+        assertEquals(rootNode, Trie.fromMessage(message, null));
+    }
+
+    /**
+    @Test
+    public void trieWithEmbeddedLeftRightChildsToMessageHop() {
+        Trie trie = new Trie()
+                .put(decode("1a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("1a10"), TrieValueTest.makeValue(LONG_VALUE - 1));
+        
+        trie = trie.setLastRentPaidTimestamp(TEST_TIMESTAMP);
+
+        assertTrue(trie.getLeft().isEmbeddable());
+        assertTrue(trie.getLeft().getNode().get().isTerminal());
+        assertFalse(trie.getRight().isEmbeddable());
+        assertFalse(trie.getRight().getNode().get().isTerminal());
+        assertEquals(TEST_TIMESTAMP, trie.getLastRentPaidTimestamp());
+        
+        byte[] message = trie.toMessage();
+
+        assertNotNull(message);
+        assertEquals(72, message.length); // todo(fedejinich) why?
+
+        // check flags (version + lshared + left + leftEmbedded + right) => 0b10000000 | 0b00010000 | 0b00001000 | 0b00000010 | 0b00000100
+        assertEquals(0b10011110, message[0]);
+
+        // check rent timestamp
+        assertEquals(TEST_TIMESTAMP, new Date(messageBuffer.getLong()).getTime());
+
+        assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithLeftEmbeddedRightChildsToMessageHop() {
+        Trie trie = new Trie()
+                .put(decode("1a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a10"), TrieValueTest.makeValue(LONG_VALUE - 1));
+
+        trie = trie.setLastRentPaidTimestamp(TEST_TIMESTAMP);
+
+        assertFalse(trie.getLeft().isEmbeddable());
+        assertFalse(trie.getLeft().getNode().get().isTerminal());
+        assertTrue(trie.getRight().isEmbeddable());
+        assertTrue(trie.getRight().getNode().get().isTerminal());
+
+        byte[] message = trie.toMessage();
+
+        assertNotNull(message);
+        assertEquals(72, message.length); // todo(fedejinich) why?
+
+        // check flags (version + lshared + left + right + rightEmbedded) => 0b10000000 | 0b00010000 | 0b00001000 | 0b00000100 | 0b00000001
+        assertEquals(0b10011101, message[0]);
+
+        // check rent timestamp
+        assertEquals(TEST_TIMESTAMP, new Date(messageBuffer.getLong()).getTime());
+
+        assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithBothEmbeddedChildsToMessageHop() {
+        Trie trie = new Trie()
+                .put(decode("0a"), new byte[]{1})
+                .put(decode("10"), new byte[]{9});
+
+        trie = trie.setLastRentPaidTimestamp(TEST_TIMESTAMP);
+
+        byte[] message = trie.toMessage();
+
+        assertNotNull(message);
+        assertEquals(14, message.length); // todo(fedejinich) why?
+
+        // check flags (version + lshared + left + leftEmbedded + right + rightEmbedded) => 0b10000000 | 0b00010000 | 0b00001000 | 0b00000010
+        assertEquals(0b10011111, message[0]);
+
+        // check rent timestamp
+        assertEquals(TEST_TIMESTAMP, new Date(messageBuffer.getLong()).getTime());
+
+        assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithValueToMessageHop() {
+        Trie trie = new Trie().put(new byte[0], new byte[]{1, 2, 3, 4});
+
+        trie = trie.setLastRentPaidTimestamp(TEST_TIMESTAMP);
+
+        byte[] message = trie.toMessage();
+
+        assertNotNull(message);
+
+        // flags (1 byte) + value (4 bytes)
+        assertEquals(5, message.length);
+
+        // check flags
+        assertEquals(0b10000000, message[0]);
+
+        // check rent timestamp
+        assertEquals(TEST_TIMESTAMP, new Date(messageBuffer.getLong()).getTime());
+
+        // check value
+        assertEquals(1, message[1]);
+        assertEquals(2, message[2]);
+        assertEquals(3, message[3]);
+        assertEquals(4, message[4]);
+
+        assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithLongValueToMessageHop() {
+        Trie trie = new Trie().put(new byte[0], TrieValueTest.makeValue(LONG_VALUE));
+
+        trie = trie.setLastRentPaidTimestamp(TEST_TIMESTAMP);
+
+        byte[] message = trie.toMessage();
+
+        assertNotNull(message);
+
+        // flags (1 byte) + valueHash (32 bytes) + valueLength (3 bytes)
+        assertEquals(36, message.length);
+
+        // check flags => 0b10100000 | 0b00100000 todo(fedejinich) checkout this
+        assertEquals(0b10100000, message[0]);
+
+        // check rent timestamp
+        assertEquals(TEST_TIMESTAMP, new Date(messageBuffer.getLong()).getTime());
+
+        // check encoded valueHash
+        byte[] valueHash = trie.getValueHash().getBytes();
+        for (int k = 0; k < valueHash.length; k++) {
+            assertEquals(valueHash[k], message[k + 1]); // the first byte corresponds to flags
+        }
+
+        // check value length
+        assertEquals(new Uint24(LONG_VALUE), Uint24.decode(new byte[]{message[33], message[34], message[35]}, 0));
+
+        assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    */
+}

--- a/rskj-core/src/test/java/co/rsk/trie/message/TrieOrchidMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/message/TrieOrchidMessageTest.java
@@ -16,18 +16,24 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package co.rsk.trie;
+package co.rsk.trie.message;
 
+import co.rsk.core.types.ints.Uint24;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieValueTest;
 import org.ethereum.crypto.Keccak256Helper;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.bouncycastle.util.encoders.Hex.decode;
 
 /**
  * Created by ajlopez on 11/01/2017.
  */
 public class TrieOrchidMessageTest {
+
     @Test
-    public void emptyTrieToMessage() {
+    public void emptyTrieToMessageOrchid() {
         Trie trie = new Trie();
 
         byte[] message = trie.toMessageOrchid(false);
@@ -43,8 +49,8 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithValueToMessage() {
-        Trie trie = new Trie().put(new byte[0], new byte[] { 1, 2, 3, 4 });
+    public void trieWithValueToMessageOrchid() {
+        Trie trie = new Trie().put(new byte[0], new byte[]{1, 2, 3, 4});
 
         byte[] message = trie.toMessageOrchid(false);
 
@@ -63,7 +69,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithLongValueToMessage() {
+    public void trieWithLongValueToMessageOrchid() {
         Trie trie = new Trie().put(new byte[0], TrieValueTest.makeValue(33));
 
         byte[] message = trie.toMessageOrchid(false);
@@ -85,8 +91,8 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithSubtrieAndNoValueToMessage() {
-        Trie trie = new Trie().put(new byte[] { 0x2 }, new byte[] { 1, 2, 3, 4 });
+    public void trieWithSubtrieAndNoValueToMessageOrchid() {
+        Trie trie = new Trie().put(new byte[]{0x2}, new byte[]{1, 2, 3, 4});
 
         byte[] message = trie.toMessageOrchid(false);
 
@@ -109,9 +115,9 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithSubtriesAndNoValueToMessage() {
-        Trie trie = new Trie().put(new byte[] { 0x2 }, new byte[] { 1, 2, 3, 4 })
-                .put(new byte[] { 0x12 }, new byte[] { 1, 2, 3, 4 });
+    public void trieWithSubtriesAndNoValueToMessageOrchid() {
+        Trie trie = new Trie().put(new byte[]{0x2}, new byte[]{1, 2, 3, 4})
+                .put(new byte[]{0x12}, new byte[]{1, 2, 3, 4});
 
         byte[] message = trie.toMessageOrchid(false);
 
@@ -127,7 +133,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void emptyTrieToMessageSecure() {
+    public void emptyTrieToMessageOrchidSecure() {
         Trie trie = new Trie();
 
         byte[] message = trie.toMessageOrchid(true);
@@ -143,11 +149,11 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithValueToMessageSecure() {
+    public void trieWithValueToMessageOrchidSecure() {
         byte[] oldKey = new byte[0];
         byte[] key = Keccak256Helper.keccak256(oldKey);
 
-        Trie trie = new Trie().put(key, new byte[] { 1, 2, 3, 4 });
+        Trie trie = new Trie().put(key, new byte[]{1, 2, 3, 4});
 
         byte[] message = trie.toMessageOrchid(true);
 
@@ -170,7 +176,7 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithLongValueToMessageSecure() {
+    public void trieWithLongValueToMessageOrchidSecure() {
         byte[] oldKey = new byte[0];
         byte[] key = Keccak256Helper.keccak256(oldKey);
 
@@ -198,11 +204,11 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithSubtrieAndNoValueToMessageSecure() {
-        byte[] oldKey = new byte[] { 0x02 };
+    public void trieWithSubtrieAndNoValueToMessageOrchidSecure() {
+        byte[] oldKey = new byte[]{0x02};
         byte[] key = Keccak256Helper.keccak256(oldKey);
 
-        Trie trie = new Trie().put(key, new byte[] { 1, 2, 3, 4 });
+        Trie trie = new Trie().put(key, new byte[]{1, 2, 3, 4});
 
         byte[] message = trie.toMessageOrchid(true);
 
@@ -225,10 +231,10 @@ public class TrieOrchidMessageTest {
     }
 
     @Test
-    public void trieWithSubtriesAndNoValueToMessageSecure() {
+    public void trieWithSubtriesAndNoValueToMessageOrchidSecure() {
         Trie trie = new Trie()
-                .put(Keccak256Helper.keccak256(new byte[] { 0x2 }), new byte[] { 1, 2, 3, 4 })
-                .put(Keccak256Helper.keccak256(new byte[] { 0x12 }), new byte[] { 1, 2, 3, 4 });
+                .put(Keccak256Helper.keccak256(new byte[]{0x2}), new byte[]{1, 2, 3, 4})
+                .put(Keccak256Helper.keccak256(new byte[]{0x12}), new byte[]{1, 2, 3, 4});
 
         byte[] message = trie.toMessageOrchid(true);
 

--- a/rskj-core/src/test/java/co/rsk/trie/message/TrieWasabiMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/message/TrieWasabiMessageTest.java
@@ -1,0 +1,199 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.trie.message;
+
+import co.rsk.core.types.ints.Uint24;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieValueTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static co.rsk.trie.Trie.LONG_VALUE;
+import static org.bouncycastle.util.encoders.Hex.decode;
+
+public class TrieWasabiMessageTest {
+
+    @Test
+    public void emptyTrieToMessageWasabiToMessageWasabi() {
+        Trie trie = new Trie();
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+
+        // flags (1 byte)
+        Assert.assertEquals(1, message.length);
+
+        // check flags
+        Assert.assertEquals(0b01000000, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithLeftEmbeddedChildToMessageWasabi() {
+        Trie trie = new Trie()
+                .put(decode("0a"), new byte[]{1})
+                .put(decode("0a00"), new byte[]{7});
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(10, message.length); // todo(fedejinich) why?
+
+        // check flags (version + lshared + left + leftEmbedded) => 0b01000000 | 0b00010000 | 0b00001000 | 0b00000010
+        Assert.assertEquals(0b01011010, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithLeftChildToMessageWasabi() {
+        Trie trie = new Trie()
+                .put(decode("0a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a01"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a0110"), TrieValueTest.makeValue(LONG_VALUE - 1));
+
+        Assert.assertTrue(trie.getLeft().getNode().isPresent());
+        Assert.assertFalse(trie.getLeft().isEmbeddable());
+        Assert.assertFalse(trie.getRight().getNode().isPresent());
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(68, message.length); // todo(fedejinich) why?
+
+        // check flags (version + lshared + left) => 0b01000000 | 0b00010000 | 0b00001000
+        Assert.assertEquals(0b01011000, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithEmbeddedLeftRightChildsToMessageWasabi() {
+        Trie trie = new Trie()
+                .put(decode("1a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("1a10"), TrieValueTest.makeValue(LONG_VALUE - 1));
+
+        Assert.assertTrue(trie.getLeft().isEmbeddable());
+        Assert.assertTrue(trie.getLeft().getNode().get().isTerminal());
+        Assert.assertFalse(trie.getRight().isEmbeddable());
+        Assert.assertFalse(trie.getRight().getNode().get().isTerminal());
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(72, message.length); // todo(fedejinich) why?
+
+        // check flags (version + lshared + left + leftEmbedded + right) => 0b01000000 | 0b00010000 | 0b00001000 | 0b00000010 | 0b00000100
+        Assert.assertEquals(0b01011110, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithLeftEmbeddedRightChildsToMessageWasabi() {
+        Trie trie = new Trie()
+                .put(decode("1a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a"), TrieValueTest.makeValue(LONG_VALUE - 1))
+                .put(decode("0a10"), TrieValueTest.makeValue(LONG_VALUE - 1));
+
+        Assert.assertFalse(trie.getLeft().isEmbeddable());
+        Assert.assertFalse(trie.getLeft().getNode().get().isTerminal());
+        Assert.assertTrue(trie.getRight().isEmbeddable());
+        Assert.assertTrue(trie.getRight().getNode().get().isTerminal());
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(72, message.length); // todo(fedejinich) why?
+
+        // check flags (version + lshared + left + right + rightEmbedded) => 0b01000000 | 0b00010000 | 0b00001000 | 0b00000100 | 0b00000001
+        Assert.assertEquals(0b01011101, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithBothEmbeddedChildsToMessageWasabi() {
+        Trie trie = new Trie()
+                .put(decode("0a"), new byte[]{1})
+                .put(decode("10"), new byte[]{9});
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+        Assert.assertEquals(14, message.length); // todo(fedejinich) why?
+
+        // check flags (version + lshared + left + leftEmbedded + right + rightEmbedded) => 0b01000000 | 0b00010000 | 0b00001000 | 0b00000010
+        Assert.assertEquals(0b01011111, message[0]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithValueToMessageWasabi() {
+        Trie trie = new Trie().put(new byte[0], new byte[]{1, 2, 3, 4});
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+
+        // flags (1 byte) + value (4 bytes)
+        Assert.assertEquals(5, message.length);
+
+        // check flags
+        Assert.assertEquals(0b01000000, message[0]);
+
+        // check value
+        Assert.assertEquals(1, message[1]);
+        Assert.assertEquals(2, message[2]);
+        Assert.assertEquals(3, message[3]);
+        Assert.assertEquals(4, message[4]);
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
+    }
+
+    @Test
+    public void trieWithLongValueToMessageWasabi() {
+        Trie trie = new Trie().put(new byte[0], TrieValueTest.makeValue(LONG_VALUE));
+
+        byte[] message = trie.toMessage();
+
+        Assert.assertNotNull(message);
+
+        // flags (1 byte) + valueHash (32 bytes) + valueLength (3 bytes)
+        Assert.assertEquals(36, message.length);
+
+        // check flags => 0b01100000 | 0b00100000
+        Assert.assertEquals(0b01100000, message[0]);
+
+        // check encoded valueHash
+        byte[] valueHash = trie.getValueHash().getBytes();
+        for (int k = 0; k < valueHash.length; k++) {
+            Assert.assertEquals(valueHash[k], message[k + 1]); // the first byte corresponds to flags
+        }
+
+        // check value length
+        Assert.assertEquals(new Uint24(LONG_VALUE), Uint24.decode(new byte[]{message[33], message[34], message[35]}, 0));
+
+        Assert.assertEquals(trie, Trie.fromMessage(message, null));
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
@@ -24,7 +24,6 @@ import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * Created by martin.medina on 3/7/17.


### PR DESCRIPTION
According to the [RSKIP240](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP240.md), this PR modifies the unitire to support the storage rent feature.

Changes:
- Different trie nodes: rskip240 nodes (with rent) and rskip107 nodes (without rent). 
- Modified de/serialization process: each trie instance will contain a trieSerializer (a strategy), to serialize different versions.
- New `updateLastRentPaidTimestamp` method: useful to update node timestamps (inspired by [shree's](https://github.com/rsksmart/rskj/tree/storageRent2021) PR).


Refactor:
- Three tests suites for different trie serialization (orchid, rskip107, and rskip240)
- Removed unnecessary trie constructors

NOTES
-  I'm still wondering how to test trie encoding properly 
-  Need a comment cleanup (there are tons of comments, some of them might be useful, some others will be removed)