### PR TITLE
Documented RemascTransaction check usage across the platform

### DIFF
--- a/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
@@ -28,7 +28,19 @@ import org.ethereum.vm.PrecompiledContracts;
 import static org.ethereum.rpc.TypeConverter.toUnformattedJsonHex;
 
 /**
+ * <p>
  * Tx that invokes Remasc's processMinersFees method.
+ * </p>
+ * <p>
+ * If you would like an easier to know if a transaction is a Remasc transaction rather than using
+ * #{@link Transaction#isRemascTransaction(int, int)}, you could use:
+ * <blockquote>obj instanceOf RemascTransaction</blockquote>
+ * </p>
+ * <p>
+ * <b>NOTE:</b> Consider that this only will work if you create an instance of this class, otherwise using
+ * #{@link Transaction#isRemascTransaction(int, int)} is more safe.
+ * </p>
+ *
  * @author Oscar Guindzberg
  */
 public class RemascTransaction extends Transaction {

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascTransaction.java
@@ -29,16 +29,24 @@ import static org.ethereum.rpc.TypeConverter.toUnformattedJsonHex;
 
 /**
  * <p>
- * Tx that invokes Remasc's processMinersFees method.
+ *  Tx that invokes Remasc's processMinersFees method.
  * </p>
  * <p>
- * If you would like an easier to know if a transaction is a Remasc transaction rather than using
+ *  Use #{@link Transaction#isRemascTransaction(int, int)} if you have not yet parsed the transaction
+ *  and it is still in binary format.
+ * </p>
+ * <p>
+ *  Use <b></b><i></>instanceOf<i/><b/> to know if a parsed transaction is a remasc transaction.
+ * </p>
+ * <p>
+ * If you would like an easier way to know if a transaction is a Remasc transaction rather than using
  * #{@link Transaction#isRemascTransaction(int, int)}, you could use:
  * <blockquote>obj instanceOf RemascTransaction</blockquote>
  * </p>
  * <p>
- * <b>NOTE:</b> Consider that this only will work if you create an instance of this class, otherwise using
- * #{@link Transaction#isRemascTransaction(int, int)} is more safe.
+ * <b>NOTE:</b> Consider that <b></b><i></>instanceOf<i/><b/> only will work if you create an
+ * instance of this class, otherwise using #{@link Transaction#isRemascTransaction(int, int)} is more
+ * recommended and safe.
  * </p>
  *
  * @author Oscar Guindzberg

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -532,6 +532,20 @@ public class Transaction {
         this.isLocalCall = isLocalCall;
     }
 
+    /**
+     * <p>
+     * Returns true if the current transaction is a Remasc transaction by checking if the transaction position is the
+     * last one, if receive address is equals to #PrecompiledContracts.REMASC_ADDR and finally if there is a signature
+     * and data having value, gas limit and gas price equals to 0, otherwise returns false.
+     * </p>
+     * <p>
+     * Use this method when you don't know if the transaction is a remasc transaction from the parameters given above.
+     * </p>
+     *
+     * @param txPosition transaction position
+     * @param txsSize    transaction size
+     * @return true if the current transaction is a Remasc transaction, otherwise returns false.
+     */
     public boolean isRemascTransaction(int txPosition, int txsSize) {
         return isLastTx(txPosition, txsSize) && checkRemascAddress() && checkRemascTxZeroValues();
     }


### PR DESCRIPTION
Documented RemascTransaction check usage across the platform

## Description
Basically we are documenting the usage of:

```
obj instanceof RemascTransaction
```
and 
```
transaction.isRemascTransaction(x, y)
```

Since they are used on multiple scenarios but with the goal, we need to make sure things are clear.

## Motivation and Context
This issue https://github.com/rsksmart/rskj/issues/1582, wants to refactor the check to determine whether a transaction is remasc or not but the refactor is not worth since it's being used inconsistently, but not in a bad way, in multiple places.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
