### PR TITLE
Allow max 1 connection per host on PeerExplorer keeping last one

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1496,7 +1496,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                     rskSystemProperties.peerDiscoveryRefreshPeriod(),
                     rskSystemProperties.peerDiscoveryCleanPeriod(),
                     rskSystemProperties.networkId(),
-                    getPeerScoringManager()
+                    getPeerScoringManager(),
+                    rskSystemProperties.allowMultipleConnectionsPerHost()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -234,6 +234,10 @@ public class RskSystemProperties extends SystemProperties {
         return (period < PD_DEFAULT_REFRESH_PERIOD)? PD_DEFAULT_REFRESH_PERIOD : period;
     }
 
+    public boolean allowMultipleConnectionsPerHost() {
+        return getBoolean("peer.discovery.allowMultipleConnectionsPerHost", true);
+    }
+
     public List<ModuleDescription> getRpcModules() {
         if (this.moduleDescriptions != null) {
             return this.moduleDescriptions;

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -24,12 +24,14 @@ peer {
         # the peer window will show
         # only what retrieved by active
         # peer [true/false]
-        enabled = false
+        enabled = true
 
         # List of the peers to start
         # the search of the online peers
         # values: [ip:port]
         ip.list = [ ]
+
+        allowMultipleConnectionsPerHost = true
     }
 
     # Port for server to listen for incoming connections

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -111,6 +111,7 @@ peer = {
         ip.list = [<ip>]
         msg.timeout = <long>
         refresh.period = <long>
+        allowMultipleConnectionsPerHost = <bool>
     }
     port = <port>
     networkId = <networkId>

--- a/rskj-core/src/test/java/co/rsk/net/discovery/NodeChallengeManagerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/NodeChallengeManagerTest.java
@@ -65,7 +65,7 @@ public class NodeChallengeManagerTest {
         Node node3 = new Node(key3.getNodeId(), HOST_3, PORT_3);
 
         NodeDistanceTable distanceTable = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node1);
-        PeerExplorer peerExplorer = new PeerExplorer(new ArrayList<>(), node1, distanceTable, new ECKey(), TIMEOUT, UPDATE, CLEAN, NETWORK_ID, mock(PeerScoringManager.class));
+        PeerExplorer peerExplorer = new PeerExplorer(new ArrayList<>(), node1, distanceTable, new ECKey(), TIMEOUT, UPDATE, CLEAN, NETWORK_ID, mock(PeerScoringManager.class), true);
         peerExplorer.setUDPChannel(mock(UDPChannel.class));
 
         NodeChallengeManager manager = new NodeChallengeManager();

--- a/rskj-core/src/test/java/co/rsk/net/discovery/UDPServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/discovery/UDPServerTest.java
@@ -99,9 +99,9 @@ public class UDPServerTest {
         NodeDistanceTable distanceTable2 = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node2);
         NodeDistanceTable distanceTable3 = new NodeDistanceTable(KademliaOptions.BINS, KademliaOptions.BUCKET_SIZE, node3);
 
-        PeerExplorer peerExplorer1 = new PeerExplorer(node1BootNode, node1, distanceTable1, key1, TIMEOUT, UPDATE, CLEAN, NETWORK_ID, mock(PeerScoringManager.class));
-        PeerExplorer peerExplorer2 = new PeerExplorer(node2BootNode, node2, distanceTable2, key2, TIMEOUT, UPDATE, CLEAN, NETWORK_ID, mock(PeerScoringManager.class));
-        PeerExplorer peerExplorer3 = new PeerExplorer(node3BootNode, node3, distanceTable3, key3, TIMEOUT, UPDATE, CLEAN, NETWORK_ID, mock(PeerScoringManager.class));
+        PeerExplorer peerExplorer1 = new PeerExplorer(node1BootNode, node1, distanceTable1, key1, TIMEOUT, UPDATE, CLEAN, NETWORK_ID, mock(PeerScoringManager.class), true);
+        PeerExplorer peerExplorer2 = new PeerExplorer(node2BootNode, node2, distanceTable2, key2, TIMEOUT, UPDATE, CLEAN, NETWORK_ID, mock(PeerScoringManager.class), true);
+        PeerExplorer peerExplorer3 = new PeerExplorer(node3BootNode, node3, distanceTable3, key3, TIMEOUT, UPDATE, CLEAN, NETWORK_ID, mock(PeerScoringManager.class), true);
 
         assertEquals(0, peerExplorer1.getNodes().size());
         assertEquals(0, peerExplorer2.getNodes().size());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a configuration flag in order to allow or reject multiple connections of the same host (IP+port) to PeerExplorer (and, as a consequence, to DistanceTable).

When multiple Pings from the same host with different _nodeId_ are received, we have two scenarios depending on the mentioned flag value:
1. If set to _true_: the current behaviour remains, therefore multiple connections are allowed for same host (as many as different _nodeIds_ are received
2. If set to _false_: just the last connection remains as active, the other ones are disconnected / removed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related issue https://rsklabs.atlassian.net/browse/CORE-648

The issue is based on the fact that attacker can establish many connections using single IP:PORT and that _sendPing_ sends only one PING request to a single _IP:PORT_ at a time. Therefore, attacker can fill _distanceTable_ using different _NodeId_ and maintain connections with only one _PONG_ at a time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested both with unit tests and locally with a RSKj node connected to _regtest_: I've run a Python script that sends 500 pings changing the _NodeID_. With the flag set to _true_ multiple connections are accepted; with it set to _false_, just the last one remains. I've added a second device to the test to check the behaviour with a different host and its connection was added successfully, again keeping just last one if multiple were sent.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
