### PR TITLE
KeyValueDataSource#keys() result should allow contains() call

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -25,6 +25,7 @@ import org.ethereum.core.Account;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.rpc.TypeConverter;
 import org.bouncycastle.crypto.params.KeyParameter;
 
@@ -59,8 +60,8 @@ public class Wallet {
                 addresses.add(addr.getBytes());
             }
 
-            for (byte[] address: keyDS.keys()) {
-                keys.add(new RskAddress(address));
+            for (ByteArrayWrapper addressWrapped: keyDS.keys()) {
+                keys.add(new RskAddress(addressWrapped.getData()));
             }
 
             keys.addAll(accounts.keySet());

--- a/rskj-core/src/main/java/org/ethereum/datasource/HashMapDB.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/HashMapDB.java
@@ -24,7 +24,6 @@ import org.iq80.leveldb.DBException;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import static org.ethereum.util.ByteUtil.wrap;
 
@@ -69,10 +68,8 @@ public class HashMapDB implements KeyValueDataSource {
     }
 
     @Override
-    public synchronized Set<byte[]> keys() {
-        return storage.keySet().stream()
-                .map(ByteArrayWrapper::getData)
-                .collect(Collectors.toSet());
+    public synchronized Set<ByteArrayWrapper> keys() {
+        return new HashSet<>(storage.keySet());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
@@ -37,7 +37,7 @@ public interface KeyValueDataSource extends DataSource {
 
     void delete(byte[] key);
 
-    Set<byte[]> keys();
+    Set<ByteArrayWrapper> keys();
 
     /**
      * Note that updateBatch() does not imply the operation is atomic:

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
@@ -24,7 +24,6 @@ import org.ethereum.rpc.TypeConverter;
 import org.ethereum.util.ByteUtil;
 import org.junit.Assert;
 import org.junit.Test;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * Created by martin.medina on 3/7/17.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow running contains() on KeyValueDataSource#keys() result 

## Description
<!--- Describe your changes in detail -->
Use ByteArrayWrapper as return type of KeyValueDataSource#keys() instead of byte[] to ensure expected behavior: contains() working, etc.

## Motivation and Context
https://github.com/rsksmart/rskj/issues/1541

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

* **Other information**:
