### PR TITLE
Sets default locale when converting numbers to strings in FormatUtils

### DIFF
--- a/rskj-core/src/main/java/co/rsk/util/FormatUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/FormatUtils.java
@@ -19,12 +19,14 @@
 
 package co.rsk.util;
 
+import java.util.Locale;
+
 public class FormatUtils {
     private FormatUtils() {
 
     }
 
     public static String formatNanosecondsToSeconds(long nanoseconds) {
-        return String.format("%.6f", nanoseconds / 1_000_000_000.0);
+        return String.format(Locale.ROOT, "%.6f", nanoseconds / 1_000_000_000.0);
     }
 }


### PR DESCRIPTION
Forces `String.format` to use `Locale.ROOT` to keep a consistent output across environments.

Closes #1709 

## How Has This Been Tested?

Some tests were failing in a system with Spanish locale (that uses comma as decimal separator instead of a point)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


