### PR TITLE
Limit amount of inputs in a migration transaction

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -78,6 +78,8 @@ public class BridgeConstants {
 
     protected int minimumPegoutValuePercentageToReceiveAfterFee;
 
+    protected int maxInputsPerPegoutTransaction;
+
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
     }
@@ -162,5 +164,9 @@ public class BridgeConstants {
 
     public int getMinimumPegoutValuePercentageToReceiveAfterFee() {
         return minimumPegoutValuePercentageToReceiveAfterFee;
+    }
+
+    public int getMaxInputsPerPegoutTransaction() {
+        return maxInputsPerPegoutTransaction;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -157,5 +157,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
         maxDepthBlockchainAccepted = 25;
 
         minimumPegoutValuePercentageToReceiveAfterFee = 20;
+
+        maxInputsPerPegoutTransaction = 150;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -148,6 +148,8 @@ public class BridgeMainNetConstants extends BridgeConstants {
         maxDepthBlockchainAccepted = 25;
 
         minimumPegoutValuePercentageToReceiveAfterFee = 80;
+
+        maxInputsPerPegoutTransaction = 150;
     }
 
     public static BridgeMainNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -159,6 +159,8 @@ public class BridgeRegTestConstants extends BridgeConstants {
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
 
         minimumPegoutValuePercentageToReceiveAfterFee = 20;
+
+        maxInputsPerPegoutTransaction = 20;
     }
 
     public static BridgeRegTestConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -151,6 +151,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
         maxDepthBlockchainAccepted = 25;
 
         minimumPegoutValuePercentageToReceiveAfterFee = 80;
+
+        maxInputsPerPegoutTransaction = 150;
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -916,6 +916,58 @@ public class BridgeSupport {
         updateFederationCreationBlockHeights();
     }
 
+    private void processFundsMigration(Transaction rskTx) throws IOException {
+        Wallet retiringFederationWallet = activations.isActive(RSKIP294) ?
+            getRetiringFederationWallet(true, bridgeConstants.getMaxInputsPerPegoutTransaction()) :
+            getRetiringFederationWallet(true);
+
+        List<UTXO> availableUTXOs = getRetiringFederationBtcUTXOs();
+        Federation activeFederation = getActiveFederation();
+
+        if (federationIsInMigrationAge(activeFederation) && hasMinimumFundsToMigrate(retiringFederationWallet)) {
+            logger.info(
+                "Active federation (age={}) is in migration age and retiring federation has funds to migrate: {}.",
+                rskExecutionBlock.getNumber() - activeFederation.getCreationBlockNumber(),
+                retiringFederationWallet.getBalance().toFriendlyString()
+            );
+
+            migrateFunds(
+                rskTx.getHash(),
+                retiringFederationWallet,
+                activeFederation.getAddress(),
+                availableUTXOs
+            );
+        }
+
+        if (retiringFederationWallet != null && federationIsPastMigrationAge(activeFederation)) {
+            if (retiringFederationWallet.getBalance().isGreaterThan(Coin.ZERO)) {
+                logger.info(
+                    "Federation is past migration age and will try to migrate remaining balance: {}.",
+                    retiringFederationWallet.getBalance().toFriendlyString()
+                );
+
+                try {
+                    migrateFunds(
+                        rskTx.getHash(),
+                        retiringFederationWallet,
+                        activeFederation.getAddress(),
+                        availableUTXOs
+                    );
+                } catch (Exception e) {
+                    logger.error(
+                        "Unable to complete retiring federation migration. Balance left: {} in {}",
+                        retiringFederationWallet.getBalance().toFriendlyString(),
+                        getRetiringFederationAddress()
+                    );
+                    panicProcessor.panic("updateCollection", "Unable to complete retiring federation migration.");
+                }
+            }
+
+            logger.info("Retiring federation migration finished. Available UTXOs left: {}.", availableUTXOs.size());
+            provider.setOldFederation(null);
+        }
+    }
+
     private boolean federationIsInMigrationAge(Federation federation) {
         long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
         long ageBegin = bridgeConstants.getFederationActivationAge() + bridgeConstants.getFundsMigrationAgeSinceActivationBegin();
@@ -938,85 +990,33 @@ public class BridgeSupport {
                 && retiringFederationWallet.getBalance().isGreaterThan(minimumFundsToMigrate);
     }
 
-    private void processFundsMigration(Transaction rskTx) throws IOException {
-        Wallet retiringFederationWallet = activations.isActive(RSKIP294) ?
-            getRetiringFederationWallet(true, bridgeConstants.getMaxInputsPerPegoutTransaction()) :
-            getRetiringFederationWallet(true);
+    private void migrateFunds(
+        Keccak256 rskTxHash,
+        Wallet retiringFederationWallet,
+        Address activeFederationAddress,
+        List<UTXO> availableUTXOs) throws IOException {
 
-        List<UTXO> availableUTXOs = getRetiringFederationBtcUTXOs();
         ReleaseTransactionSet releaseTransactionSet = provider.getReleaseTransactionSet();
-        Federation activeFederation = getActiveFederation();
+        Pair<BtcTransaction, List<UTXO>> createResult = createMigrationTransaction(retiringFederationWallet, activeFederationAddress);
+        BtcTransaction btcTx = createResult.getLeft();
+        List<UTXO> selectedUTXOs = createResult.getRight();
 
-        if (federationIsInMigrationAge(activeFederation) && hasMinimumFundsToMigrate(retiringFederationWallet)) {
-            logger.info(
-                "Active federation (age={}) is in migration age and retiring federation has funds to migrate: {}.",
-                rskExecutionBlock.getNumber() - activeFederation.getCreationBlockNumber(),
-                retiringFederationWallet.getBalance().toFriendlyString()
-            );
-
-            Pair<BtcTransaction, List<UTXO>> createResult = createMigrationTransaction(retiringFederationWallet, activeFederation.getAddress());
-            BtcTransaction btcTx = createResult.getLeft();
-            List<UTXO> selectedUTXOs = createResult.getRight();
-
-            // Add the TX to the release set
-            if (activations.isActive(ConsensusRule.RSKIP146)) {
-                Coin amountMigrated = selectedUTXOs.stream()
-                    .map(UTXO::getValue)
-                    .reduce(Coin.ZERO, Coin::add);
-                releaseTransactionSet.add(btcTx, rskExecutionBlock.getNumber(), rskTx.getHash());
-                // Log the Release request
-                eventLogger.logReleaseBtcRequested(rskTx.getHash().getBytes(), btcTx, amountMigrated);
-            } else {
-                releaseTransactionSet.add(btcTx, rskExecutionBlock.getNumber());
-            }
-
-            // Mark UTXOs as spent
-            availableUTXOs.removeIf(utxo -> selectedUTXOs.stream().anyMatch(selectedUtxo ->
-                utxo.getHash().equals(selectedUtxo.getHash()) && utxo.getIndex() == selectedUtxo.getIndex()
-            ));
+        // Add the TX to the release set
+        if (activations.isActive(ConsensusRule.RSKIP146)) {
+            Coin amountMigrated = selectedUTXOs.stream()
+                .map(UTXO::getValue)
+                .reduce(Coin.ZERO, Coin::add);
+            releaseTransactionSet.add(btcTx, rskExecutionBlock.getNumber(), rskTxHash);
+            // Log the Release request
+            eventLogger.logReleaseBtcRequested(rskTxHash.getBytes(), btcTx, amountMigrated);
+        } else {
+            releaseTransactionSet.add(btcTx, rskExecutionBlock.getNumber());
         }
 
-        if (retiringFederationWallet != null && federationIsPastMigrationAge(activeFederation)) {
-            if (retiringFederationWallet.getBalance().isGreaterThan(Coin.ZERO)) {
-                logger.info(
-                    "Federation is past migration age and will try to migrate remaining balance: {}.",
-                    retiringFederationWallet.getBalance().toFriendlyString()
-                );
-
-                try {
-                    Pair<BtcTransaction, List<UTXO>> createResult = createMigrationTransaction(retiringFederationWallet, activeFederation.getAddress());
-                    BtcTransaction btcTx = createResult.getLeft();
-                    List<UTXO> selectedUTXOs = createResult.getRight();
-
-                    // Add the TX to the release set
-                    if (activations.isActive(ConsensusRule.RSKIP146)) {
-                        Coin amountMigrated = selectedUTXOs.stream()
-                            .map(UTXO::getValue)
-                            .reduce(Coin.ZERO, Coin::add);
-                        releaseTransactionSet.add(btcTx, rskExecutionBlock.getNumber(), rskTx.getHash());
-                        // Log the Release request
-                        eventLogger.logReleaseBtcRequested(rskTx.getHash().getBytes(), btcTx, amountMigrated);
-                    } else {
-                        releaseTransactionSet.add(btcTx, rskExecutionBlock.getNumber());
-                    }
-
-                    // Mark UTXOs as spent
-                    availableUTXOs.removeIf(utxo -> selectedUTXOs.stream().anyMatch(selectedUtxo ->
-                        utxo.getHash().equals(selectedUtxo.getHash()) && utxo.getIndex() == selectedUtxo.getIndex()
-                    ));
-                } catch (Exception e) {
-                    logger.error(
-                        "Unable to complete retiring federation migration. Balance left: {} in {}",
-                        retiringFederationWallet.getBalance().toFriendlyString(),
-                        getRetiringFederationAddress()
-                    );
-                    panicProcessor.panic("updateCollection", "Unable to complete retiring federation migration.");
-                }
-            }
-
-            logger.info("Retiring federation migration finished. Available UTXOs left: {}.", availableUTXOs.size());
-            provider.setOldFederation(null);
-        }
+        // Mark UTXOs as spent
+        availableUTXOs.removeIf(utxo -> selectedUTXOs.stream().anyMatch(selectedUtxo ->
+            utxo.getHash().equals(selectedUtxo.getHash()) && utxo.getIndex() == selectedUtxo.getIndex()
+        ));
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -71,7 +71,8 @@ public enum ConsensusRule {
     RSKIP219("rskip219"),
     RSKIP220("rskip220"),
     RSKIP284("rskip284"),
-    RSKIP290("rskip290"); // Testnet difficulty should drop to a higher difficulty
+    RSKIP290("rskip290"), // Testnet difficulty should drop to a higher difficulty
+    RSKIP294("rskip294");
 
     private String configKey;
 

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -68,6 +68,7 @@ blockchain = {
              rskip220 = <hardforkName>
              rskip284 = <hardforkName>
              rskip290 = <hardforkName>
+             rskip294 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -58,6 +58,7 @@ blockchain = {
             rskip220 = iris300
             rskip284 = hop400
             rskip290 = hop400
+            rskip294 = hop400
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -7603,7 +7603,7 @@ public class BridgeSupportTest {
         List<UTXO> utxosToMigrate = new ArrayList<>();
         for (int i = 0; i < utxosToCreate; i++) {
             utxosToMigrate.add(new UTXO(
-                Sha256Hash.of(new byte[]{(byte)i}),
+                PegTestUtils.createHash(i),
                 0,
                 Coin.COIN,
                 0,
@@ -7641,7 +7641,7 @@ public class BridgeSupportTest {
                 utxosToCreate / expectedTransactions;
             Assert.assertEquals(
                 expectedSize,
-                new ArrayList<>(releaseTransactionSet.getEntries()).get(0).getTransaction().getInputs().size()
+                new ArrayList<>(releaseTransactionSet.getEntries()).get(i).getTransaction().getInputs().size()
             );
         }
     }

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -71,7 +71,11 @@ public class PegTestUtils {
 
     public static Sha256Hash createHash(int nHash) {
         byte[] bytes = new byte[32];
-        bytes[0] = (byte) nHash;
+        bytes[0] = (byte) (0xFF & nHash);
+        bytes[1] = (byte) (0xFF & nHash >> 8);
+        bytes[2] = (byte) (0xFF & nHash >> 16);
+        bytes[3] = (byte) (0xFF & nHash >> 24);
+
         return Sha256Hash.wrap(bytes);
     }
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -94,6 +94,7 @@ public class ActivationConfigTest {
             "    rskip220: iris300",
             "    rskip284: hop400",
             "    rskip290: hop400",
+            "    rskip294: hop400",
             "}"
     ));
 


### PR DESCRIPTION
Limit the amount to be inputs to be included in a migration transaction, since HSM can't sign more than 253 inputs at once