### PR TITLE
Accept websocket connection without '/websocket'

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
@@ -15,7 +15,7 @@ public class RskWebSocketServerProtocolHandler extends WebSocketServerProtocolHa
 
     public RskWebSocketServerProtocolHandler(String websocketPath, int maxFrameSize) {
         // there are no subprotocols nor extensions
-        super(websocketPath, null, false, maxFrameSize);
+        super(websocketPath, null, false, maxFrameSize, true);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3WebSocketServer.java
@@ -83,7 +83,7 @@ public class Web3WebSocketServer implements InternalService {
                     p.addLast(new HttpServerCodec());
                     p.addLast(new HttpObjectAggregator(maxAggregatedFrameSize));
                     p.addLast(new WriteTimeoutHandler(serverWriteTimeoutSeconds, TimeUnit.SECONDS));
-                    p.addLast(new RskWebSocketServerProtocolHandler("/websocket", maxFrameSize));
+                    p.addLast(new RskWebSocketServerProtocolHandler("/", maxFrameSize));
                     p.addLast(new WebSocketFrameAggregator(maxAggregatedFrameSize));
                     p.addLast(webSocketJsonRpcHandler);
                     p.addLast(web3ServerHandler);

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3WebSocketServerTest.java
@@ -84,12 +84,21 @@ public class Web3WebSocketServerTest {
         smokeTest(getJsonRpcBigMessage());
     }
 
+    @Test
+    public void smokeTestWithBigJsonUsingAnotherServerPath() throws Exception {
+        smokeTest(getJsonRpcBigMessage(), "/");
+    }
+
     @After
     public void tearDown() {
         wsExecutor.shutdown();
     }
 
-    private void smokeTest(byte [] msg) throws Exception {
+    private void smokeTest(byte[] msg) throws Exception {
+        smokeTest(msg, "/websocket");
+    }
+
+    private void smokeTest(byte[] msg, String serverPath) throws Exception {
         Web3 web3Mock = mock(Web3.class);
         String mockResult = "output";
         when(web3Mock.web3_sha3(anyString())).thenReturn(mockResult);
@@ -121,7 +130,7 @@ public class Web3WebSocketServerTest {
         websocketServer.start();
 
         OkHttpClient wsClient = new OkHttpClient();
-        Request wsRequest = new Request.Builder().url("ws://localhost:"+randomPort+"/websocket").build();
+        Request wsRequest = new Request.Builder().url("ws://localhost:" + randomPort + serverPath).build();
         WebSocketCall wsCall = WebSocketCall.create(wsClient, wsRequest);
 
         CountDownLatch wsAsyncResultLatch = new CountDownLatch(1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change allows `WebSocketServerProtocolHandler` to accept any url path. Basically ignores everything after `host:server`.

## Motivation and Context
Alejandro Cavallero reported that there are users reporting that is tricky and a problem to require ‘/websocket’ in the endpoint. Is it possible to accept both ws://your-ip:4445 and ws://your-ip:4445/websocket

## How Has This Been Tested?
We added a unit test and also we did some manual testing using Postman websockets feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
