### PR TITLE
Disable sco debug trace modules

### DIFF
--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -350,7 +350,7 @@ rpc {
         {
             name: "sco",
             version: "1.0",
-            enabled: "true",
+            enabled: "false",
         },
         {
             name: "txpool",
@@ -365,12 +365,12 @@ rpc {
         {
             name: "debug",
             version: "1.0",
-            enabled: "true"
+            enabled: "false"
         },
         {
             name: "trace",
             version: "1.0",
-            enabled: "true"
+            enabled: "false"
         },
          {
              name: "rsk",

--- a/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
@@ -18,10 +18,13 @@
 
 package co.rsk.config;
 
+import co.rsk.cli.CliArgs;
+import co.rsk.rpc.ModuleDescription;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 
 import java.util.List;
 
@@ -35,6 +38,8 @@ import static org.mockito.Mockito.mock;
 public class RskSystemPropertiesTest {
 
     private final TestSystemProperties config = new TestSystemProperties();
+    @Mock
+    private CliArgs<NodeCliOptions, NodeCliFlags> cliArgs;
 
     @Test
     public void defaultValues() {
@@ -94,5 +99,35 @@ public class RskSystemPropertiesTest {
         assertEquals(12, bloomNumberOfConfirmations);
         assertTrue(expectedConfig.hasPath(configKeyCaptorForHasPath.getValue()));
         assertTrue(expectedConfig.hasPath(configKeyCaptorForGetInt.getValue()));
+    }
+
+    @Test
+    public void testRpcModules() {
+        RskSystemProperties rskSystemProperties = new RskSystemProperties(
+                new ConfigLoader(
+                        new CliArgs.Parser<>(
+                                NodeCliOptions.class,
+                                NodeCliFlags.class
+                        ).parse(new String[]{})
+                )
+        );
+        assertFalse(
+                rskSystemProperties.getRpcModules().stream()
+                .filter(md -> md.getName().equals("trace"))
+                .map(ModuleDescription::isEnabled)
+                .findFirst().orElse(true)
+        );
+        assertFalse(
+                rskSystemProperties.getRpcModules().stream()
+                        .filter(md -> md.getName().equals("debug"))
+                        .map(ModuleDescription::isEnabled)
+                        .findFirst().orElse(true)
+        );
+        assertFalse(
+                rskSystemProperties.getRpcModules().stream()
+                        .filter(md -> md.getName().equals("sco"))
+                        .map(ModuleDescription::isEnabled)
+                        .findFirst().orElse(true)
+        );
     }
 }


### PR DESCRIPTION
Disable by default sco, debug and trace rpc modules in HOP

## Description
Disable sco, debug and trace modules

## Motivation and Context
The Security team has already been insisting for quite a long time to disable by default a few RPC modules, for instance, personal, debug etc.

## How Has This Been Tested?
Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


*ci: rskj-400-rc-ver*