### PR TITLE
Handler's been refactorized

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -630,17 +630,6 @@ public class BlockExecutor {
 
         for (Transaction tx : transactionsList) {
             logger.trace("apply block: [{}] tx: [{}] ", block.getNumber(), i);
-            if (!parallelizeTransactionHandler.sequentialBucketHasGasAvailable(tx)) {
-                if (discardInvalidTxs) {
-                    logger.warn("block: [{}] discarded tx: [{}]", block.getNumber(), tx.getHash());
-                    continue;
-                } else {
-                    logger.warn("block: [{}] execution interrupted because of invalid tx: [{}]",
-                            block.getNumber(), tx.getHash());
-                    profiler.stop(metric);
-                    return BlockResult.INTERRUPTED_EXECUTION_BLOCK_RESULT;
-                }
-            }
 
             TransactionExecutor txExecutor = transactionExecutorFactory.newInstance(
                     tx,

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -566,8 +566,8 @@ public class BlockExecutor {
         logger.trace("Building execution results.");
         BlockResult result = new BlockResult(
                 block,
-                new LinkedList(executedTransactions.values()),
-                new LinkedList(receipts.values()),
+                new LinkedList<>(executedTransactions.values()),
+                new LinkedList<>(receipts.values()),
                 new short[0],
                 totalGasUsed.longValue(),
                 Coin.valueOf(totalPaidFees.longValue()),
@@ -692,6 +692,7 @@ public class BlockExecutor {
             logger.trace("track commit");
 
             long gasUsed = txExecutor.getGasUsed();
+            totalGasUsed = parallelizeTransactionHandler.getGasUsedInSequential();
 
             Coin paidFees = txExecutor.getPaidFees();
             if (paidFees != null) {
@@ -750,7 +751,7 @@ public class BlockExecutor {
                 executedTransactions,
                 receipts,
                 bucketOrder,
-                totalGasUsed,
+                totalGasUsed, // totalBlock = parallel1 + parallel2 + sequential?
                 totalPaidFees,
                 vmTrace ? null : track.getTrie()
         );

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -616,7 +616,7 @@ public class BlockExecutor {
         maintainPrecompiledContractStorageRoots(track, activationConfig.forBlock(block.getNumber()));
 
         int i = 1;
-        long totalGasUsed = 0;
+        long gasUsedInBlock = 0;
         Coin totalPaidFees = Coin.ZERO;
         Map<Transaction, TransactionReceipt> receiptsByTx = new HashMap<>();
         Set<DataWord> deletedAccounts = new HashSet<>();
@@ -637,7 +637,7 @@ public class BlockExecutor {
                     block.getCoinbase(),
                     track,
                     block,
-                    totalGasUsed,
+                    parallelizeTransactionHandler.getGasUsedInSequential(),
                     vmTrace,
                     vmTraceOptions,
                     deletedAccounts,
@@ -692,7 +692,7 @@ public class BlockExecutor {
             logger.trace("track commit");
 
             long gasUsed = txExecutor.getGasUsed();
-            totalGasUsed = parallelizeTransactionHandler.getGasUsedInSequential();
+            gasUsedInBlock += gasUsed;
 
             Coin paidFees = txExecutor.getPaidFees();
             if (paidFees != null) {
@@ -751,7 +751,7 @@ public class BlockExecutor {
                 executedTransactions,
                 receipts,
                 bucketOrder,
-                totalGasUsed, // totalBlock = parallel1 + parallel2 + sequential?
+                gasUsedInBlock,
                 totalPaidFees,
                 vmTrace ? null : track.getTrie()
         );

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -702,7 +702,14 @@ public class BlockExecutor {
 
             TransactionReceipt receipt = new TransactionReceipt();
             receipt.setGasUsed(gasUsed);
-            bucketGasAccumulated.ifPresent(receipt::setCumulativeGas);
+
+            if (bucketGasAccumulated.isPresent()) {
+                receipt.setCumulativeGas(bucketGasAccumulated.get());
+            } else {
+                //This line is used for testing only when acceptInvalidTransactions is set.
+                receipt.setCumulativeGas(parallelizeTransactionHandler.getGasUsedIn(buckets));
+            }
+
             receipt.setTxStatus(txExecutor.getReceipt().isSuccessful());
             receipt.setTransaction(tx);
             receipt.setLogInfoList(txExecutor.getVMLogs());

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -22,7 +22,6 @@ import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.TransactionListExecutor;
-import co.rsk.core.bc.ParallelizeTransactionHandler.TransactionBucket;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.metrics.profilers.Metric;

--- a/rskj-core/src/main/java/co/rsk/core/bc/ParallelizeTransactionHandler.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/ParallelizeTransactionHandler.java
@@ -26,9 +26,9 @@ import org.ethereum.vm.GasCost;
 import java.util.*;
 
 public class ParallelizeTransactionHandler {
-    private final HashMap<ByteArrayWrapper, Short> bucketByWrittenKey;
-    private final HashMap<ByteArrayWrapper, Set<Short>> bucketByReadKey;
-    private final Map<RskAddress, Short> bucketBySender;
+    private final HashMap<ByteArrayWrapper, TransactionBucket> bucketByWrittenKey;
+    private final HashMap<ByteArrayWrapper, Set<TransactionBucket>> bucketByReadKey;
+    private final Map<RskAddress, TransactionBucket> bucketBySender;
     private final ArrayList<TransactionBucket> buckets;
 
     public ParallelizeTransactionHandler(short buckets, long bucketGasLimit) {
@@ -42,20 +42,30 @@ public class ParallelizeTransactionHandler {
         this.buckets.add(new TransactionBucket(buckets, bucketGasLimit, true));
     }
 
-    public Optional<Short> addTransaction(Transaction tx, Set<ByteArrayWrapper> newReadKeys, Set<ByteArrayWrapper> newWrittenKeys, long gasUsedByTx) {
+    public Optional<Long> addTransaction(Transaction tx, Set<ByteArrayWrapper> newReadKeys, Set<ByteArrayWrapper> newWrittenKeys, long gasUsedByTx) {
         TransactionBucket bucketCandidate = getBucketCandidates(tx, newReadKeys, newWrittenKeys);
-        Optional<Short> addedBucket = bucketCandidate.addTransaction(this, tx, newReadKeys, newWrittenKeys, gasUsedByTx);
 
-        if (!addedBucket.isPresent()) {
-            return addedBucket;
+        if (!bucketCandidate.hasGasAvailable(GasCost.toGas(tx.getGasLimit()))) {
+            if (bucketCandidate.isSequential()) {
+                return Optional.empty();
+            }
+            bucketCandidate = getSequentialBucket();
         }
 
-        addNewKeysToMaps(tx.getSender(), addedBucket.get(), newReadKeys, newWrittenKeys);
-        return addedBucket;
+        Optional<TransactionBucket> addedBucket = bucketCandidate.addTransaction(tx, gasUsedByTx);
+
+        if (!addedBucket.isPresent()) {
+            return Optional.empty();
+        }
+
+        TransactionBucket transactionBucket = addedBucket.get();
+        addNewKeysToMaps(tx.getSender(), transactionBucket, newReadKeys, newWrittenKeys);
+        return Optional.of(transactionBucket.getGasUsed());
     }
 
-    public Optional<Short> addRemascTransaction(Transaction tx, Set<ByteArrayWrapper> newReadKeys, Set<ByteArrayWrapper> newWrittenKeys, long gasUsedByTx) {
-        return getSequentialBucket().addTransaction(this, tx, newReadKeys, newWrittenKeys, gasUsedByTx);
+    public Optional<Long> addRemascTransaction(Transaction tx, long gasUsedByTx) {
+        Optional<TransactionBucket> transactionBucket = getSequentialBucket().addTransaction(tx, gasUsedByTx);
+        return transactionBucket.map(TransactionBucket::getGasUsed);
     }
 
     public long getGasUsedIn(Short bucketId) {
@@ -97,67 +107,63 @@ public class ParallelizeTransactionHandler {
         return bucketOrder;
     }
 
-    private void addNewKeysToMaps(RskAddress sender, Short bucketId, Set<ByteArrayWrapper> newReadKeys, Set<ByteArrayWrapper> newWrittenKeys) {
+    private void addNewKeysToMaps(RskAddress sender, TransactionBucket bucket, Set<ByteArrayWrapper> newReadKeys, Set<ByteArrayWrapper> newWrittenKeys) {
         for (ByteArrayWrapper key : newReadKeys) {
-            Set<Short> bucketIds = bucketByReadKey.getOrDefault(key, new HashSet<>());
-            bucketIds.add(bucketId);
-            bucketByReadKey.put(key, bucketIds);
+            Set<TransactionBucket> bucketsAlreadyRead = bucketByReadKey.getOrDefault(key, new HashSet<>());
+            bucketsAlreadyRead.add(bucket);
+            bucketByReadKey.put(key, bucketsAlreadyRead);
         }
 
-        if (isSequentialId(bucketId) || !bucketBySender.containsKey(sender)) {
-            bucketBySender.put(sender, bucketId);
+        if (bucket.isSequential() || !bucketBySender.containsKey(sender)) {
+            bucketBySender.put(sender, bucket);
         }
 
-        if (bucketId.equals(getSequentialBucket().getId())) {
+        if (bucket.equals(getSequentialBucket())) {
             return;
         }
 
         for (ByteArrayWrapper key: newWrittenKeys) {
-            bucketByWrittenKey.putIfAbsent(key, bucketId);
+            bucketByWrittenKey.putIfAbsent(key, bucket);
         }
     }
 
-    private boolean isSequentialId(Short bucketId) {
-        return getSequentialBucket().getId() == bucketId;
-    }
-
-    private Optional<Short> getBucketBySender(Transaction tx) {
+    private Optional<TransactionBucket> getBucketBySender(Transaction tx) {
         return Optional.ofNullable(bucketBySender.get(tx.getSender()));
     }
 
-    private Optional<Short> getAvailableBucketWithLessUsedGas(long txGasLimit) {
+    private Optional<TransactionBucket> getAvailableBucketWithLessUsedGas(long txGasLimit) {
         long gasUsed = Long.MAX_VALUE;
-        Optional<Short> bucketId =  Optional.empty();
+        Optional<TransactionBucket> bucketCandidate =  Optional.empty();
 
         for (TransactionBucket bucket : buckets) {
             if (!bucket.isSequential() && bucket.hasGasAvailable(txGasLimit) && bucket.getGasUsed() < gasUsed) {
-                    bucketId = Optional.of(bucket.getId());
+                    bucketCandidate = Optional.of(bucket);
                     gasUsed = bucket.getGasUsed();
             }
         }
 
-        return bucketId;
+        return bucketCandidate;
     }
 
 
     private TransactionBucket getBucketCandidates(Transaction tx, Set<ByteArrayWrapper> newReadKeys, Set<ByteArrayWrapper> newWrittenKeys) {
-        Optional<Short> bucketCandidate = getBucketBySender(tx);
+        Optional<TransactionBucket> bucketCandidate = getBucketBySender(tx);
 
-        if (bucketCandidate.isPresent() && isSequentialId(bucketCandidate.get())) {
+        if (bucketCandidate.isPresent() && bucketCandidate.get().isSequential()) {
             return getSequentialBucket();
         }
 
         // read - written
         for (ByteArrayWrapper newReadKey : newReadKeys) {
             if (bucketByWrittenKey.containsKey(newReadKey)) {
-                Short bucketId = bucketByWrittenKey.get(newReadKey);
+                TransactionBucket bucket = bucketByWrittenKey.get(newReadKey);
 
                 if (bucketCandidate.isPresent()) {
-                    if(!bucketCandidate.get().equals(bucketId)) {
+                    if(!bucketCandidate.get().equals(bucket)) {
                        return getSequentialBucket();
                     }
                 } else {
-                    bucketCandidate = Optional.of(bucketId);
+                    bucketCandidate = Optional.of(bucket);
                 }
             }
         }
@@ -165,30 +171,30 @@ public class ParallelizeTransactionHandler {
         for (ByteArrayWrapper newWrittenKey : newWrittenKeys) {
             // written - written,
             if (bucketByWrittenKey.containsKey(newWrittenKey)) {
-                Short bucketId = bucketByWrittenKey.get(newWrittenKey);
+                TransactionBucket bucket = bucketByWrittenKey.get(newWrittenKey);
 
                 if (bucketCandidate.isPresent()) {
-                    if(!bucketCandidate.get().equals(bucketId)) {
+                    if(!bucketCandidate.get().equals(bucket)) {
                         return getSequentialBucket();
                     }
                 } else {
-                    bucketCandidate = Optional.of(bucketId);
+                    bucketCandidate = Optional.of(bucket);
                 }
             }
             // read - written
             if (bucketByReadKey.containsKey(newWrittenKey)) {
-                Set<Short> bucketIds = bucketByReadKey.get(newWrittenKey);
+                Set<TransactionBucket> bucketsWritten = bucketByReadKey.get(newWrittenKey);
 
-                if (bucketIds.size() > 1) {
+                if (bucketsWritten.size() > 1) {
                     return getSequentialBucket();
                 }
 
                 if (bucketCandidate.isPresent()) {
-                    if(!bucketIds.contains(bucketCandidate.get())) {
+                    if(!bucketsWritten.contains(bucketCandidate.get())) {
                         return getSequentialBucket();
                     }
                 } else {
-                    bucketCandidate = Optional.of(bucketIds.iterator().next());
+                    bucketCandidate = Optional.of(bucketsWritten.iterator().next());
                 }
             }
         }
@@ -196,28 +202,21 @@ public class ParallelizeTransactionHandler {
         return getTransactionBucket(tx, bucketCandidate);
     }
 
-    private TransactionBucket getTransactionBucket(Transaction tx, Optional<Short> bucketCandidate) {
+    private TransactionBucket getTransactionBucket(Transaction tx, Optional<TransactionBucket> bucketCandidate) {
         if (bucketCandidate.isPresent()) {
-            return this.buckets.get(bucketCandidate.get());
+            return bucketCandidate.get();
         }
 
-        Optional<Short> availableBucketWithLessUsedGas = getAvailableBucketWithLessUsedGas(GasCost.toGas(tx.getGasLimit()));
-        if (!availableBucketWithLessUsedGas.isPresent()) {
-            return getSequentialBucket();
-        }
+        Optional<TransactionBucket> availableBucketWithLessUsedGas = getAvailableBucketWithLessUsedGas(GasCost.toGas(tx.getGasLimit()));
+        return availableBucketWithLessUsedGas.orElseGet(this::getSequentialBucket);
 
-        return this.buckets.get(availableBucketWithLessUsedGas.get());
-    }
-
-    private Optional<Short> addInSequentialBucket(Transaction tx, Set<ByteArrayWrapper> newReadKeys, Set<ByteArrayWrapper> newWrittenKeys, long gasUsedByTx) {
-        return getSequentialBucket().addTransaction(this, tx, newReadKeys, newWrittenKeys, gasUsedByTx);
     }
 
     private TransactionBucket getSequentialBucket() {
         return this.buckets.get(this.buckets.size()-1);
     }
 
-    private static class TransactionBucket {
+    public static class TransactionBucket {
 
         final Short id;
         final long gasLimit;
@@ -233,25 +232,14 @@ public class ParallelizeTransactionHandler {
             this.gasUsedInBucket = 0;
         }
 
-        private short getId() {
+        public short getId() {
             return id;
         }
 
-        private Optional<Short> addTransaction(ParallelizeTransactionHandler handler, Transaction tx, Set<ByteArrayWrapper> newReadKeys, Set<ByteArrayWrapper> newWrittenKeys, long gasUsedByTx) {
-            if (!this.hasGasAvailable(GasCost.toGas(tx.getGasLimit()))) {
-                if (isSequential) {
-                    return Optional.empty();
-                }
-                return handler.addInSequentialBucket(tx, newReadKeys, newWrittenKeys, gasUsedByTx);
-            }
-
-            addInternalTx(tx, gasUsedByTx);
-            return Optional.of(this.getId());
-        }
-
-        private void addInternalTx(Transaction tx, long gasUsedByTx) {
+        private Optional<TransactionBucket> addTransaction(Transaction tx, long gasUsedByTx) {
             transactions.add(tx);
             gasUsedInBucket = gasUsedInBucket + gasUsedByTx;
+            return Optional.of(this);
         }
 
         private boolean hasGasAvailable(long txGasLimit) {

--- a/rskj-core/src/main/java/co/rsk/core/bc/ParallelizeTransactionHandler.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/ParallelizeTransactionHandler.java
@@ -202,6 +202,10 @@ public class ParallelizeTransactionHandler {
         return this.buckets.get(this.buckets.size()-1);
     }
 
+    public long getGasUsedInSequential() {
+        return getSequentialBucket().getGasUsed();
+    }
+
     private static class TransactionBucket {
 
         final Short id;
@@ -224,6 +228,7 @@ public class ParallelizeTransactionHandler {
         }
 
         private boolean hasGasAvailable(long txGasLimit) {
+            //TODO(JULI): Re-check a thousand of times this line.
             long cumulativeGas = GasCost.add(gasUsedInBucket, txGasLimit);
             return cumulativeGas <= gasLimit;
         }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -28,6 +28,7 @@ import co.rsk.db.*;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.BtcBlockStoreWithCache.Factory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
+import co.rsk.remasc.RemascTransaction;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
@@ -49,6 +50,7 @@ import org.ethereum.net.rlpx.Node;
 import org.ethereum.net.server.Channel;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RskTestFactory;
+import org.ethereum.vm.GasCost;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import org.junit.Assert;
@@ -438,6 +440,156 @@ public class BlockExecutorTest {
     }
 
     @Test
+    public void executeSequentiallyATransactionAndGasShouldBeSustractedCorrectly() {
+        if (!activeRskip144) {
+            return;
+        }
+
+        short[] expectedEdges = new short[]{1};
+        Block parent = blockchain.getBestBlock();
+        long expectedGasUsed = 0L;
+        long expectedAcumulatedGas = 21000L;
+
+        Block block = getBlockWithNIndependentTransactions(1, BigInteger.valueOf(expectedAcumulatedGas), false);
+        List<Transaction> txs = block.getTransactionsList();
+        BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
+
+        Assert.assertEquals(txs, blockResult.getExecutedTransactions());
+        Assert.assertEquals(expectedGasUsed, blockResult.getGasUsed());
+        Assert.assertArrayEquals(expectedEdges, blockResult.getTxEdges());
+
+        List<TransactionReceipt> transactionReceipts = blockResult.getTransactionReceipts();
+        for (TransactionReceipt receipt: transactionReceipts) {
+            Assert.assertEquals(expectedAcumulatedGas, GasCost.toGas(receipt.getCumulativeGas()));
+        }
+    }
+
+    @Test
+    public void executeSequentiallyTenIndependentTxsAndThemShouldGoInBothBuckets() {
+        if (!activeRskip144) {
+            return;
+        }
+
+        long expectedGasUsed = 0L;
+        long expectedAcumulatedGas = 21000L;
+        short[] expectedEdges = new short[]{5, 10};
+        Block parent = blockchain.getBestBlock();
+        Block block = getBlockWithNIndependentTransactions(10, BigInteger.valueOf(expectedAcumulatedGas), false);
+        List<Transaction> txs = block.getTransactionsList();
+        BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
+
+        Assert.assertEquals(txs.size(), blockResult.getExecutedTransactions().size());
+        Assert.assertTrue(txs.containsAll(blockResult.getExecutedTransactions()));
+        Assert.assertArrayEquals(expectedEdges, blockResult.getTxEdges());
+        Assert.assertEquals(expectedGasUsed, blockResult.getGasUsed());
+
+        List<TransactionReceipt> transactionReceipts = blockResult.getTransactionReceipts();
+        long accumulatedGasUsed = 0L;
+        short i = 0;
+        short edgeIndex = 0;
+        for (TransactionReceipt receipt: transactionReceipts) {
+            if ((edgeIndex < expectedEdges.length) && (i == expectedEdges[edgeIndex])) {
+                edgeIndex++;
+                accumulatedGasUsed = expectedGasUsed;
+            }
+
+            accumulatedGasUsed += expectedAcumulatedGas;
+            Assert.assertEquals(accumulatedGasUsed, GasCost.toGas(receipt.getCumulativeGas()));
+            i++;
+        }
+
+        Assert.assertEquals(i, transactionReceipts.size());
+    }
+
+    @Test
+    public void executeBigIndependentTxsSequentiallyTheLastOneShouldGoToSequential() {
+        if (!activeRskip144) {
+            return;
+        }
+        Block parent = blockchain.getBestBlock();
+        long blockGasLimit = GasCost.toGas(parent.getGasLimit());
+        long bucketGasLimit = blockGasLimit/2;
+        int gasLimit = 21000;
+        int transactionNumber = (int) (bucketGasLimit/gasLimit);
+        short[] expectedEdges = new short[]{(short) transactionNumber, (short) (transactionNumber*2)};
+        int transactionsInSequential = 1;
+
+        Block block = getBlockWithNIndependentTransactions(transactionNumber*2+transactionsInSequential, BigInteger.valueOf(gasLimit), false);
+        List<Transaction> transactionsList = block.getTransactionsList();
+        BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
+
+        Assert.assertArrayEquals(expectedEdges, blockResult.getTxEdges());
+        Assert.assertEquals(transactionsList.size(), blockResult.getExecutedTransactions().size());
+        Assert.assertTrue(transactionsList.containsAll(blockResult.getExecutedTransactions()));
+
+        List<TransactionReceipt> transactionReceipts = blockResult.getTransactionReceipts();
+        long accumulatedGasUsed = 0L;
+        short i = 0;
+        short edgeIndex = 0;
+        for (TransactionReceipt receipt: transactionReceipts) {
+            accumulatedGasUsed += gasLimit;
+
+            if ((edgeIndex < expectedEdges.length) && (i == expectedEdges[edgeIndex])) {
+                edgeIndex++;
+                accumulatedGasUsed = gasLimit;
+            }
+            Assert.assertEquals(accumulatedGasUsed, GasCost.toGas(receipt.getCumulativeGas()));
+            i++;
+        }
+
+        Assert.assertEquals(i, transactionReceipts.size());
+    }
+
+    @Test
+    public void executeATxInSequentialAndBlockResultShouldTrackTheGasUsedInTheSequentialBucket() {
+        if (!activeRskip144) {
+            return;
+        }
+        Block parent = blockchain.getBestBlock();
+        long blockGasLimit = GasCost.toGas(parent.getGasLimit());
+        long bucketGasLimit = blockGasLimit/2;
+        int gasLimit = 21000;
+        int transactionNumberToFillParallelBucket = (int) (bucketGasLimit/ gasLimit);
+        int transactionsInSequential = 1;
+        Block block = getBlockWithNIndependentTransactions(transactionNumberToFillParallelBucket*2+ transactionsInSequential, BigInteger.valueOf(gasLimit), false);
+        BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
+
+        Assert.assertEquals(gasLimit, blockResult.getGasUsed());
+    }
+
+    @Test
+    public void withTheBucketsFullTheLastTransactionShouldNotFit() {
+        if (!activeRskip144) {
+            return;
+        }
+        Block parent = blockchain.getBestBlock();
+        long blockGasLimit = GasCost.toGas(parent.getGasLimit());
+        long bucketGasLimit = blockGasLimit/2;
+        int gasLimit = 21000;
+        int transactionNumberToFillParallelBucket = (int) (bucketGasLimit/ gasLimit);
+        int totalTxs = (transactionNumberToFillParallelBucket) * 3 + 1;
+        Block block = getBlockWithNIndependentTransactions(totalTxs, BigInteger.valueOf(gasLimit), false);
+        BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
+        Assert.assertEquals(totalTxs, blockResult.getExecutedTransactions().size() + 1);
+    }
+
+    @Test
+    public void withSequentialBucketFullRemascTxShouldFit() {
+        if (!activeRskip144) {
+            return;
+        }
+        Block parent = blockchain.getBestBlock();
+        long blockGasLimit = GasCost.toGas(parent.getGasLimit());
+        long bucketGasLimit = blockGasLimit/2;
+        int gasLimit = 21000;
+        int transactionNumberToFillABucket = (int) (bucketGasLimit/ gasLimit);
+        int expectedNumberOfTx = transactionNumberToFillABucket*3 + 1;
+        Block block = getBlockWithNIndependentTransactions(transactionNumberToFillABucket*3, BigInteger.valueOf(gasLimit), true);
+        BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
+        Assert.assertEquals(expectedNumberOfTx, blockResult.getExecutedTransactions().size());
+    }
+
+    @Test
     public void executeParallelBlocksWithDifferentSubsets() {
         if (!activeRskip144) {
             return;
@@ -786,6 +938,53 @@ public class BlockExecutorTest {
                         bestBlock.getGasLimit(),
                         bestBlock.getCoinbase(),
                         edges
+                );
+    }
+
+    private Block getBlockWithNIndependentTransactions(int number, BigInteger txGasLimit, boolean withRemasc) {
+        int nTxs = number;
+        int nAccounts = nTxs * 2;
+        Repository track = repository.startTracking();
+        List<Account> accounts = new LinkedList<>();
+
+        for (int i = 0; i < nAccounts; i++) {
+            accounts.add(createAccount("accounttest" + i, track, Coin.valueOf(600000)));
+        }
+        track.commit();
+        Block bestBlock = blockchain.getBestBlock();
+        bestBlock.setStateRoot(repository.getRoot());
+
+        List<Transaction> txs = new LinkedList<>();
+
+        for (int i = 0; i < nTxs; i++) {
+            Transaction tx = Transaction.builder()
+                    .nonce(BigInteger.ZERO)
+                    .gasPrice(BigInteger.ONE)
+                    .gasLimit(txGasLimit)
+                    .destination(accounts.get(i + nTxs).getAddress())
+                    .chainId(CONFIG.getNetworkConstants().getChainId())
+                    .value(BigInteger.TEN)
+                    .build();
+            tx.sign(accounts.get(i).getEcKey().getPrivKeyBytes());
+            txs.add(tx);
+        }
+
+        if (withRemasc) {
+            txs.add(new RemascTransaction(1L));
+        }
+
+        List<BlockHeader> uncles = new ArrayList<>();
+
+        return new BlockGenerator(Constants.regtest(), activationConfig)
+                .createChildBlock(
+                        bestBlock,
+                        txs,
+                        uncles,
+                        1,
+                        null,
+                        bestBlock.getGasLimit(),
+                        bestBlock.getCoinbase(),
+                        null
                 );
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -440,27 +440,26 @@ public class BlockExecutorTest {
     }
 
     @Test
-    public void executeSequentiallyATransactionAndGasShouldBeSustractedCorrectly() {
+    public void executeSequentiallyATransactionAndGasShouldBeSubtractedCorrectly() {
         if (!activeRskip144) {
             return;
         }
 
         short[] expectedEdges = new short[]{1};
         Block parent = blockchain.getBestBlock();
-        long expectedGasUsed = 0L;
-        long expectedAcumulatedGas = 21000L;
+        long expectedAccumulatedGas = 21000L;
 
-        Block block = getBlockWithNIndependentTransactions(1, BigInteger.valueOf(expectedAcumulatedGas), false);
+        Block block = getBlockWithNIndependentTransactions(1, BigInteger.valueOf(expectedAccumulatedGas), false);
         List<Transaction> txs = block.getTransactionsList();
         BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
 
         Assert.assertEquals(txs, blockResult.getExecutedTransactions());
-        Assert.assertEquals(expectedGasUsed, blockResult.getGasUsed());
+        Assert.assertEquals(expectedAccumulatedGas, blockResult.getGasUsed());
         Assert.assertArrayEquals(expectedEdges, blockResult.getTxEdges());
 
         List<TransactionReceipt> transactionReceipts = blockResult.getTransactionReceipts();
         for (TransactionReceipt receipt: transactionReceipts) {
-            Assert.assertEquals(expectedAcumulatedGas, GasCost.toGas(receipt.getCumulativeGas()));
+            Assert.assertEquals(expectedAccumulatedGas, GasCost.toGas(receipt.getCumulativeGas()));
         }
     }
 
@@ -471,17 +470,17 @@ public class BlockExecutorTest {
         }
 
         long expectedGasUsed = 0L;
-        long expectedAcumulatedGas = 21000L;
+        long expectedAccumulatedGas = 21000L;
         short[] expectedEdges = new short[]{5, 10};
         Block parent = blockchain.getBestBlock();
-        Block block = getBlockWithNIndependentTransactions(10, BigInteger.valueOf(expectedAcumulatedGas), false);
+        Block block = getBlockWithNIndependentTransactions(10, BigInteger.valueOf(expectedAccumulatedGas), false);
         List<Transaction> txs = block.getTransactionsList();
         BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
 
         Assert.assertEquals(txs.size(), blockResult.getExecutedTransactions().size());
         Assert.assertTrue(txs.containsAll(blockResult.getExecutedTransactions()));
         Assert.assertArrayEquals(expectedEdges, blockResult.getTxEdges());
-        Assert.assertEquals(expectedGasUsed, blockResult.getGasUsed());
+        Assert.assertEquals(expectedAccumulatedGas*10, blockResult.getGasUsed());
 
         List<TransactionReceipt> transactionReceipts = blockResult.getTransactionReceipts();
         long accumulatedGasUsed = 0L;
@@ -493,7 +492,7 @@ public class BlockExecutorTest {
                 accumulatedGasUsed = expectedGasUsed;
             }
 
-            accumulatedGasUsed += expectedAcumulatedGas;
+            accumulatedGasUsed += expectedAccumulatedGas;
             Assert.assertEquals(accumulatedGasUsed, GasCost.toGas(receipt.getCumulativeGas()));
             i++;
         }
@@ -541,7 +540,7 @@ public class BlockExecutorTest {
     }
 
     @Test
-    public void executeATxInSequentialAndBlockResultShouldTrackTheGasUsedInTheSequentialBucket() {
+    public void executeATxInSequentialAndBlockResultShouldTrackTheGasUsedInTheBlock() {
         if (!activeRskip144) {
             return;
         }
@@ -551,10 +550,11 @@ public class BlockExecutorTest {
         int gasLimit = 21000;
         int transactionNumberToFillParallelBucket = (int) (bucketGasLimit/ gasLimit);
         int transactionsInSequential = 1;
-        Block block = getBlockWithNIndependentTransactions(transactionNumberToFillParallelBucket*2+ transactionsInSequential, BigInteger.valueOf(gasLimit), false);
+        int totalTxsNumber = transactionNumberToFillParallelBucket * 2 + transactionsInSequential;
+        Block block = getBlockWithNIndependentTransactions(totalTxsNumber, BigInteger.valueOf(gasLimit), false);
         BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
 
-        Assert.assertEquals(gasLimit, blockResult.getGasUsed());
+        Assert.assertEquals(gasLimit*totalTxsNumber, blockResult.getGasUsed());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/core/bc/ParallelizeTransactionHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/ParallelizeTransactionHandlerTest.java
@@ -116,7 +116,7 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys, new HashSet<>(), gasUsedByTx);
@@ -132,8 +132,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithDifferentReadKeysShouldBeAddedInDifferentBuckets() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys2 = createAMapAndAddAKey(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -152,7 +152,7 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithSameWrittenKeysShouldBeAddedInTheSameBucket() {
         short[] expectedTransactionEdgeList = new short[]{2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -171,8 +171,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithDifferentWrittenKeysShouldBeAddedInDifferentBuckets() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> writtenKeys2 = createAMapAndAddAKey(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -191,8 +191,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithTheSameWrittenReadKeyShouldBeAddedInTheSameBucket() {
         short[] expectedTransactionEdgeList = new short[]{2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -211,8 +211,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithTheSameReadWrittenKeyShouldBeAddedInTheSameBucket() {
         short[] expectedTransactionEdgeList = new short[]{2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -231,8 +231,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithDifferentReadWrittenKeysShouldBeAddedInDifferentBuckets() {
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -251,8 +251,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionWithDifferentWrittenReadKeyShouldBeAddedInDifferentBuckets() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -271,8 +271,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoIndependentTxsAndAThirdOneCollidingWithBothAndShouldBeAddedInTheSequential() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> differentWrittenKeys = createAMapAndAddAKey(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> differentWrittenKeys = createAMapAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -299,7 +299,7 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoDependentTxsWithTheSecondInSequentialAndAThirdOneCollidingWithBothAndShouldBeAddedInTheSequential() {
         short[] expectedTransactionEdgeList = new short[]{1};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -328,7 +328,7 @@ public class ParallelizeTransactionHandlerTest {
     public void addABigTransactionAndAnotherWithTheSameWrittenKeyAndTheLastOneShouldGoToSequential() {
         short[] expectedTransactionEdgeList = new short[]{1};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
@@ -349,8 +349,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addABigTxAndAnotherWithTheSameReadWrittenKeyAndShouldGoToSequential() {
         short[] expectedTransactionEdgeList = new short[]{1};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
@@ -371,8 +371,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addABigTxAndAnotherWithTheSameWrittenReadKeyAndShouldGoToSequential() {
         short[] expectedTransactionEdgeList = new short[]{1};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
@@ -405,11 +405,108 @@ public class ParallelizeTransactionHandlerTest {
     }
 
     @Test
+    public void ifATxHasTheSameSenderThatAnotherAlreadyAddedIntoTheSequentialShouldGoToTheSequential() {
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
+        short[] expectedTransactionEdgeList = new short[]{1,2};
+
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey, aDifferentWrapperKey);
+
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys2, gasUsedByTx);
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx3, readKeys, new HashSet<>(), gasUsedByTx3);
+        Optional<Long> bucketGasUsed4 = handler.addTransaction(tx3, new HashSet<>(), new HashSet<>(), gasUsedByTx3);
+        assertTrue(bucketGasUsed3.isPresent() && bucketGasUsed4.isPresent());
+        assertEquals(gasUsedByTx3*2, handler.getGasUsedIn(sequentialBucketNumber));
+
+        List<Transaction> expectedListOfTxs = Arrays.asList(tx, tx2, tx3, tx3);
+        assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
+        assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
+    }
+
+    @Test
+    public void ifATxReadTwoDifferentWrittenKeysShouldGoToSequential() {
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
+        short[] expectedTransactionEdgeList = new short[]{1,2};
+
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey, aDifferentWrapperKey);
+
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys2, gasUsedByTx);
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx3, readKeys, new HashSet<>(), gasUsedByTx3);
+        assertTrue(bucketGasUsed3.isPresent());
+        assertEquals(gasUsedByTx3, handler.getGasUsedIn(sequentialBucketNumber));
+
+        List<Transaction> expectedListOfTxs = Arrays.asList(tx, tx2, tx3);
+        assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
+        assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
+    }
+
+    @Test
+    public void ifATxWritesAKeyAlreadyReadByTwoTxsPlacedInDifferentBucketsShouldGoToTheSequential() {
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
+        short[] expectedTransactionEdgeList = new short[]{1,2};
+
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys2 = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys2, new HashSet<>(), gasUsedByTx);
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx3, new HashSet<>(), writtenKeys, gasUsedByTx3);
+        assertTrue(bucketGasUsed3.isPresent());
+        assertEquals(gasUsedByTx3, handler.getGasUsedIn(sequentialBucketNumber));
+
+        List<Transaction> expectedListOfTxs = Arrays.asList(tx, tx2, tx3);
+        assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
+        assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
+    }
+
+    @Test
+    public void ifATxReadTwoKeysThatAreInDifferentBucketsShouldGoToTheSequential() {
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
+        short[] expectedTransactionEdgeList = new short[]{1,2};
+
+        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey, aDifferentWrapperKey);
+
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys2, new HashSet<>(), gasUsedByTx);
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx3, new HashSet<>(), writtenKeys, gasUsedByTx3);
+        assertTrue(bucketGasUsed3.isPresent());
+        assertEquals(gasUsedByTx3, handler.getGasUsedIn(sequentialBucketNumber));
+
+        List<Transaction> expectedListOfTxs = Arrays.asList(tx, tx2, tx3);
+        assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
+        assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
+    }
+
+    @Test
     public void ifATxCollidesWithAnotherOneThatAlsoHasTheSameSenderShouldGoIntoTheSameBucket() {
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
@@ -427,7 +524,7 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, gasUsedByTx2);
@@ -538,7 +635,7 @@ public class ParallelizeTransactionHandlerTest {
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByBigTx2 = GasCost.toGas(bigTx2.getGasLimit());
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, new HashSet<>(), writtenKeys, gasUsedByBigTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), gasUsedByBigTx2);
@@ -600,11 +697,8 @@ public class ParallelizeTransactionHandlerTest {
             assertTrue(true);
         }
     }
-
-    private HashSet<ByteArrayWrapper> createAMapAndAddAKey(ByteArrayWrapper aKey) {
-        HashSet<ByteArrayWrapper> aMap = new HashSet<>();
-        aMap.add(aKey);
-        return aMap;
+    private HashSet<ByteArrayWrapper> createAMapAndAddKeys(ByteArrayWrapper... aKey) {
+        return new HashSet<>(Arrays.asList(aKey));
     }
 
     private void assertTwoTransactionsWereAddedProperlyIntoTheBuckets(Transaction tx, Transaction tx2, short[] expectedTransactionEdgeList) {

--- a/rskj-core/src/test/java/co/rsk/core/bc/ParallelizeTransactionHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/ParallelizeTransactionHandlerTest.java
@@ -89,12 +89,12 @@ public class ParallelizeTransactionHandlerTest {
 
     @Test
     public void addTransactionIntoTheHandlerAndShouldBeAddedInTheFirstParallelBucket() {
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), 0);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), 0);
         short[] expectedTransactionEdgeList = new short[]{1};
-        short expectedBucketId = 0;
+        long expectedGasUsed = 0;
 
-        assertTrue(bucketId.isPresent());
-        assertEquals((Short) expectedBucketId, bucketId.get());
+        assertTrue(bucketGasUsed.isPresent());
+        assertEquals(expectedGasUsed, (long) bucketGasUsed.get());
 
         List<Transaction> expectedListOfTxs = new ArrayList<>();
         expectedListOfTxs.add(tx);
@@ -105,10 +105,10 @@ public class ParallelizeTransactionHandlerTest {
     @Test
     public void addTransactionIntoTheHandlerAndShouldBeSubtractedGasUsedInTheBucket() {
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
 
-        assertTrue(bucketId.isPresent());
-        assertEquals(gasUsedByTx, handler.getGasUsedIn(bucketId.get()));
+        assertTrue(bucketGasUsed.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
     }
 
     @Test
@@ -118,10 +118,13 @@ public class ParallelizeTransactionHandlerTest {
 
         HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, readKeys, new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys, new HashSet<>(), gasUsedByTx);
 
-        assertNotEquals(bucketId, bucketId2);
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed2.get());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx2, expectedTransactionEdgeList);
     }
 
@@ -132,10 +135,16 @@ public class ParallelizeTransactionHandlerTest {
         HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
         HashSet<ByteArrayWrapper> readKeys2 = createAMapAndAddAKey(aDifferentWrapperKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, readKeys, new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, readKeys2, new HashSet<>(), GasCost.toGas(tx2.getGasLimit()));
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
 
-        assertNotEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys2, new HashSet<>(), gasUsedByTx2);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx2, expectedTransactionEdgeList);
     }
 
@@ -145,10 +154,16 @@ public class ParallelizeTransactionHandlerTest {
 
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), writtenKeys, GasCost.toGas(tx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, GasCost.toGas(tx2.getGasLimit()));
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
 
-        assertEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, gasUsedByTx2);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx+gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx2, expectedTransactionEdgeList);
     }
 
@@ -157,13 +172,18 @@ public class ParallelizeTransactionHandlerTest {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
-
         HashSet<ByteArrayWrapper> writtenKeys2 = createAMapAndAddAKey(aDifferentWrapperKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), writtenKeys, GasCost.toGas(tx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys2, GasCost.toGas(tx2.getGasLimit()));
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
 
-        assertNotEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys2, gasUsedByTx2);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx2, expectedTransactionEdgeList);
     }
 
@@ -174,10 +194,16 @@ public class ParallelizeTransactionHandlerTest {
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
         HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), writtenKeys, GasCost.toGas(tx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, readKeys, new HashSet<>(), GasCost.toGas(tx2.getGasLimit()));
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
 
-        assertEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys, new HashSet<>(), gasUsedByTx2);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx+gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx2, expectedTransactionEdgeList);
     }
 
@@ -188,10 +214,16 @@ public class ParallelizeTransactionHandlerTest {
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
         HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, readKeys, new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, GasCost.toGas(tx2.getGasLimit()));
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
 
-        assertEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, gasUsedByTx2);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx+gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx2, expectedTransactionEdgeList);
     }
 
@@ -202,10 +234,16 @@ public class ParallelizeTransactionHandlerTest {
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
         HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aDifferentWrapperKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, readKeys, new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, GasCost.toGas(tx2.getGasLimit()));
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
 
-        assertNotEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, gasUsedByTx2);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx2, expectedTransactionEdgeList);
     }
 
@@ -216,37 +254,43 @@ public class ParallelizeTransactionHandlerTest {
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
         HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aDifferentWrapperKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, writtenKeys,  new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, readKeys, new HashSet<>(), GasCost.toGas(tx2.getGasLimit()));
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
 
-        assertNotEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, writtenKeys,  new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys, new HashSet<>(), gasUsedByTx2);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx2, expectedTransactionEdgeList);
     }
 
     @Test
     public void addTwoIndependentTxsAndAThirdOneCollidingWithBothAndShouldBeAddedInTheSequential() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
-        long tx3GasLimit = GasCost.toGas(tx3.getGasLimit());
 
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
         HashSet<ByteArrayWrapper> differentWrittenKeys = createAMapAndAddAKey(aDifferentWrapperKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), writtenKeys, GasCost.toGas(tx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, new HashSet<>(), differentWrittenKeys, GasCost.toGas(tx2.getGasLimit()));
-        Optional<Short> bucketId3 = handler.addTransaction(tx3, differentWrittenKeys, writtenKeys, tx3GasLimit);
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
+        long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
 
-        assertTrue(bucketId.isPresent() && bucketId2.isPresent() && bucketId3.isPresent());
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), differentWrittenKeys, gasUsedByTx2);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
 
-        assertEquals((short) 0, (short) bucketId.get());
-        assertEquals((short) 1, (short) bucketId2.get());
-        assertEquals(sequentialBucketNumber, (short) bucketId3.get());
-        assertEquals(handler.getGasUsedIn(sequentialBucketNumber), tx3GasLimit);
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx3, differentWrittenKeys, writtenKeys, gasUsedByTx3);
 
-        List<Transaction> expectedListOfTxs = new ArrayList<>();
-        expectedListOfTxs.add(tx);
-        expectedListOfTxs.add(tx2);
-        expectedListOfTxs.add(tx3);
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent() && bucketGasUsed3.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(gasUsedByTx3, (long) bucketGasUsed3.get());
+        assertEquals(gasUsedByTx3, handler.getGasUsedIn(sequentialBucketNumber));
 
+        List<Transaction> expectedListOfTxs = Arrays.asList(tx, tx2, tx3);
         assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
         assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
     }
@@ -257,21 +301,25 @@ public class ParallelizeTransactionHandlerTest {
 
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(bigTx, new HashSet<>(), writtenKeys, GasCost.toGas(bigTx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, GasCost.toGas(tx2.getGasLimit()));
-        Optional<Short> bucketId3 = handler.addTransaction(tx3, new HashSet<>(), writtenKeys, GasCost.toGas(tx3.getGasLimit()));
+        long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
+        long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
+        long totalGasInSequential = gasUsedByTx2 + gasUsedByTx3;
 
-        assertTrue(bucketId.isPresent() && bucketId2.isPresent() && bucketId3.isPresent());
 
-        assertEquals((short) 0, (short) bucketId.get());
-        assertEquals(sequentialBucketNumber, (short) bucketId2.get());
-        assertEquals(sequentialBucketNumber, (short) bucketId3.get());
+        Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, new HashSet<>(), writtenKeys, gasUsedByBigTx);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
 
-        List<Transaction> expectedListOfTxs = new ArrayList<>();
-        expectedListOfTxs.add(bigTx);
-        expectedListOfTxs.add(tx2);
-        expectedListOfTxs.add(tx3);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, gasUsedByTx2);
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx3, new HashSet<>(), writtenKeys, gasUsedByTx3);
 
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent() && bucketGasUsed3.isPresent());
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(totalGasInSequential, (long) bucketGasUsed3.get());
+        assertEquals(totalGasInSequential, handler.getGasUsedIn(sequentialBucketNumber));
+
+        List<Transaction> expectedListOfTxs = Arrays.asList(bigTx, tx2, tx3);
         assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
         assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
     }
@@ -282,10 +330,18 @@ public class ParallelizeTransactionHandlerTest {
 
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(bigTx, new HashSet<>(), writtenKeys, GasCost.toGas(bigTx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, GasCost.toGas(tx.getGasLimit()));
+        long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
 
-        assertNotEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, new HashSet<>(), writtenKeys, gasUsedByBigTx);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed2.get());
+        assertEquals(gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(bigTx, tx, expectedTransactionEdgeList);
     }
 
@@ -296,10 +352,18 @@ public class ParallelizeTransactionHandlerTest {
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
         HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(bigTx, readKeys, new HashSet<>(), GasCost.toGas(bigTx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, GasCost.toGas(tx.getGasLimit()));
+        long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
 
-        assertNotEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, readKeys, new HashSet<>(), gasUsedByBigTx);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed2.get());
+        assertEquals(gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(bigTx, tx, expectedTransactionEdgeList);
     }
 
@@ -310,10 +374,18 @@ public class ParallelizeTransactionHandlerTest {
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
         HashSet<ByteArrayWrapper> readKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(bigTx, new HashSet<>(), writtenKeys, GasCost.toGas(bigTx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(tx, readKeys, new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
+        long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
 
-        assertNotEquals(bucketId, bucketId2);
+        Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, new HashSet<>(), writtenKeys, gasUsedByBigTx);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed2.get());
+        assertEquals(gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(bigTx, tx, expectedTransactionEdgeList);
     }
 
@@ -322,10 +394,13 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{2};
 
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
-        Optional<Short> bucketId2 = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
 
-        assertEquals(bucketId, bucketId2);
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(2*gasUsedByTx, (long) bucketGasUsed2.get());
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx, expectedTransactionEdgeList);
     }
 
@@ -336,36 +411,36 @@ public class ParallelizeTransactionHandlerTest {
 
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
-        Optional<Short> bucketId2 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
 
-        assertEquals(bucketId, bucketId2);
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(2*gasUsedByTx, (long) bucketGasUsed2.get());
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(tx, tx, expectedTransactionEdgeList);
     }
 
     @Test
     public void ifATransactionHasAnAlreadyAddedSenderButCollidesWithAnotherTxShouldBeAddedIntoTheSequential() {
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+        long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
         HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddAKey(aWrappedKey);
 
-        Optional<Short> bucketId = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
-        Optional<Short> bucketId2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, GasCost.toGas(tx2.getGasLimit()));
-        Optional<Short> bucketId3 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
+        Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, gasUsedByTx2);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
 
-        assertNotEquals(bucketId, bucketId2);
-        assertNotEquals(bucketId, bucketId3);
-        assertNotEquals(bucketId2, bucketId3);
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
 
-        assertTrue(bucketId3.isPresent());
-        assertEquals(sequentialBucketNumber, (short) bucketId3.get());
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent() && bucketGasUsed3.isPresent());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByTx2, (long) bucketGasUsed2.get());
+        assertEquals(gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
 
-        List<Transaction> expectedListOfTxs = new ArrayList<>();
-        expectedListOfTxs.add(tx);
-        expectedListOfTxs.add(tx2);
-        expectedListOfTxs.add(tx);
-
+        List<Transaction> expectedListOfTxs = Arrays.asList(tx, tx2, tx);
         assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
         assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
     }
@@ -373,6 +448,8 @@ public class ParallelizeTransactionHandlerTest {
     @Test
     public void ifANewTxComesAndAllThePossibleBucketsAreFullTheTxShouldNotBeAdded() {
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
+        long gasUsedByBigTx2 = GasCost.toGas(bigTx2.getGasLimit());
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
         List<Transaction> expectedListOfTxs = new ArrayList<>();
@@ -380,16 +457,20 @@ public class ParallelizeTransactionHandlerTest {
         expectedListOfTxs.add(bigTx2);
         expectedListOfTxs.add(bigTx);
 
-        Optional<Short> bucketId = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), gasUsedByBigTx);
-        Optional<Short> bucketId2 = handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx2.getGasLimit()));
-        Optional<Short> bucketId3 = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), gasUsedByBigTx);
-        Optional<Short> bucketId4 = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
+        Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), gasUsedByBigTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), gasUsedByBigTx2);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
 
-        assertEquals((short) 0, (short) bucketId.get());
-        assertEquals((short) 1, (short) bucketId2.get());
-        assertEquals(sequentialBucketNumber, (short) bucketId3.get());
-        assertFalse(bucketId4.isPresent());
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), gasUsedByBigTx);
+        Optional<Long> bucketGasUsed4 = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
 
+        assertFalse(bucketGasUsed4.isPresent());
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent() && bucketGasUsed3.isPresent());
+
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByBigTx2, (long) bucketGasUsed2.get());
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed3.get());
+        assertEquals(gasUsedByBigTx, handler.getGasUsedIn(sequentialBucketNumber));
         assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
         assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
     }
@@ -403,14 +484,22 @@ public class ParallelizeTransactionHandlerTest {
         expectedListOfTxs.add(bigTx2);
         expectedListOfTxs.add(tx);
 
-        Optional<Short> bucketId = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx2.getGasLimit()));
-        Optional<Short> bucketId3 = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
+        long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
+        long gasUsedByBigTx2 = GasCost.toGas(bigTx2.getGasLimit());
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
 
-        assertEquals((short) 0, (short) bucketId.get());
-        assertEquals((short) 1, (short) bucketId2.get());
-        assertEquals(sequentialBucketNumber, (short) bucketId3.get());
+        Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), gasUsedByBigTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), gasUsedByBigTx2);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
 
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
+
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent() && bucketGasUsed3.isPresent());
+
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByBigTx2, (long) bucketGasUsed2.get());
+        assertEquals(gasUsedByTx, (long) bucketGasUsed3.get());
+        assertEquals(gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
         assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
         assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
     }
@@ -418,22 +507,26 @@ public class ParallelizeTransactionHandlerTest {
     @Test
     public void ifAllTheBucketsAreFullTheNewTxShouldntBeIncluded() {
         short[] expectedTransactionEdgeList = new short[]{1,2};
+        List<Transaction> expectedListOfTxs = Arrays.asList(bigTx, bigTx2, bigTx);
 
-        List<Transaction> expectedListOfTxs = new ArrayList<>();
-        expectedListOfTxs.add(bigTx);
-        expectedListOfTxs.add(bigTx2);
-        expectedListOfTxs.add(bigTx);
+        long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
+        long gasUsedByBigTx2 = GasCost.toGas(bigTx2.getGasLimit());
 
-        Optional<Short> bucketId = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx.getGasLimit()));
-        Optional<Short> bucketId2 = handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx2.getGasLimit()));
-        Optional<Short> bucketId3 = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx.getGasLimit()));
-        Optional<Short> emptyBucket = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
+        Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), gasUsedByBigTx);
+        Optional<Long> bucketGasUsed2 = handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), gasUsedByBigTx2);
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
 
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), gasUsedByBigTx);
+        assertTrue(bucketGasUsed3.isPresent());
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed3.get());
+        assertEquals(gasUsedByBigTx, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> emptyBucket = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), GasCost.toGas(tx.getGasLimit()));
+        assertEquals(gasUsedByBigTx, handler.getGasUsedIn(sequentialBucketNumber));
         assertFalse(emptyBucket.isPresent());
-        assertEquals((short) 0, (short) bucketId.get());
-        assertEquals((short) 1, (short) bucketId2.get());
-        assertEquals(sequentialBucketNumber, (short) bucketId3.get());
-
+        assertTrue(bucketGasUsed.isPresent() && bucketGasUsed2.isPresent());
+        assertEquals(gasUsedByBigTx, (long) bucketGasUsed.get());
+        assertEquals(gasUsedByBigTx2, (long) bucketGasUsed2.get());
         assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
         assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
     }
@@ -441,14 +534,20 @@ public class ParallelizeTransactionHandlerTest {
     @Test
     public void aRemascTxAddedShouldBeInTheSequentialBucket() {
         List<Transaction> expectedListOfTxs = Collections.singletonList(tx);
-        Optional<Short> bucketId = handler.addRemascTransaction(tx, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx.getGasLimit()));
-        assertEquals(sequentialBucketNumber, (short) bucketId.get());
+        long gasUsedByTx = GasCost.toGas(bigTx.getGasLimit());
+
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+        Optional<Long> sequentialBucketGasUsed = handler.addRemascTransaction(tx, gasUsedByTx);
+
+        assertTrue(sequentialBucketGasUsed.isPresent());
+        assertEquals(gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
+        assertEquals(gasUsedByTx, (long) sequentialBucketGasUsed.get());
         assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
     }
 
     @Test
     public void ifItsSequentialTheEdgesListShouldHaveSizeZero() {
-        handler.addRemascTransaction(tx, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx.getGasLimit()));
+        handler.addRemascTransaction(tx, GasCost.toGas(bigTx.getGasLimit()));
         assertEquals(0, handler.getTransactionsPerBucketInOrder().length);
     }
 
@@ -481,10 +580,7 @@ public class ParallelizeTransactionHandlerTest {
     }
 
     private void assertTwoTransactionsWereAddedProperlyIntoTheBuckets(Transaction tx, Transaction tx2, short[] expectedTransactionEdgeList) {
-        List<Transaction> expectedListOfTxs = new ArrayList<>();
-        expectedListOfTxs.add(tx);
-        expectedListOfTxs.add(tx2);
-
+        List<Transaction> expectedListOfTxs = Arrays.asList(tx, tx2);
         assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
         assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/ParallelizeTransactionHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/ParallelizeTransactionHandlerTest.java
@@ -116,7 +116,7 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
+        Set<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys, new HashSet<>(), gasUsedByTx);
@@ -132,8 +132,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithDifferentReadKeysShouldBeAddedInDifferentBuckets() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys2 = createASetAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -151,8 +151,7 @@ public class ParallelizeTransactionHandlerTest {
     @Test
     public void addTwoTransactionsWithSameWrittenKeysShouldBeAddedInTheSameBucket() {
         short[] expectedTransactionEdgeList = new short[]{2};
-
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -171,8 +170,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithDifferentWrittenKeysShouldBeAddedInDifferentBuckets() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> writtenKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys2 = createASetAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -191,8 +190,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithTheSameWrittenReadKeyShouldBeAddedInTheSameBucket() {
         short[] expectedTransactionEdgeList = new short[]{2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -211,8 +210,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithTheSameReadWrittenKeyShouldBeAddedInTheSameBucket() {
         short[] expectedTransactionEdgeList = new short[]{2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -231,8 +230,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionsWithDifferentReadWrittenKeysShouldBeAddedInDifferentBuckets() {
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -251,8 +250,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoTransactionWithDifferentWrittenReadKeyShouldBeAddedInDifferentBuckets() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -271,8 +270,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addTwoIndependentTxsAndAThirdOneCollidingWithBothAndShouldBeAddedInTheSequential() {
         short[] expectedTransactionEdgeList = new short[]{1, 2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> differentWrittenKeys = createAMapAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> differentWrittenKeys = createASetAndAddKeys(aDifferentWrapperKey);
 
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -298,8 +297,7 @@ public class ParallelizeTransactionHandlerTest {
     @Test
     public void addTwoDependentTxsWithTheSecondInSequentialAndAThirdOneCollidingWithBothAndShouldBeAddedInTheSequential() {
         short[] expectedTransactionEdgeList = new short[]{1};
-
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
@@ -327,8 +325,7 @@ public class ParallelizeTransactionHandlerTest {
     @Test
     public void addABigTransactionAndAnotherWithTheSameWrittenKeyAndTheLastOneShouldGoToSequential() {
         short[] expectedTransactionEdgeList = new short[]{1};
-
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
@@ -349,8 +346,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addABigTxAndAnotherWithTheSameReadWrittenKeyAndShouldGoToSequential() {
         short[] expectedTransactionEdgeList = new short[]{1};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey);
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
@@ -371,8 +368,8 @@ public class ParallelizeTransactionHandlerTest {
     public void addABigTxAndAnotherWithTheSameWrittenReadKeyAndShouldGoToSequential() {
         short[] expectedTransactionEdgeList = new short[]{1};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey);
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
@@ -387,6 +384,30 @@ public class ParallelizeTransactionHandlerTest {
         assertEquals(gasUsedByTx, (long) bucketGasUsed2.get());
         assertEquals(gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
         assertTwoTransactionsWereAddedProperlyIntoTheBuckets(bigTx, tx, expectedTransactionEdgeList);
+    }
+
+    @Test
+    public void addTwoTransactionsWithTheSameSenderToTheSequentialBucketAndTheSecondShouldBeAddedCorrectly() {
+        short[] expectedTransactionEdgeList = new short[]{1,2};
+        List<Transaction> expectedListOfTxs = Arrays.asList(bigTx, bigTx2, tx, tx);
+        long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
+
+        handler.addTransaction(bigTx, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx.getGasLimit()));
+        handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), GasCost.toGas(bigTx2.getGasLimit()));
+        assertEquals(0, handler.getGasUsedIn(sequentialBucketNumber));
+
+        Optional<Long> bucketGasUsed3 = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
+        assertTrue(bucketGasUsed3.isPresent());
+        assertEquals(gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
+        assertEquals(gasUsedByTx, (long) bucketGasUsed3.get());
+
+        Optional<Long> bucketGasUsed4 = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
+        assertTrue(bucketGasUsed4.isPresent());
+        assertEquals(2*gasUsedByTx, handler.getGasUsedIn(sequentialBucketNumber));
+        assertEquals(2*gasUsedByTx, (long) bucketGasUsed4.get());
+
+        assertEquals(expectedListOfTxs, handler.getTransactionsInOrder());
+        assertArrayEquals(expectedTransactionEdgeList, handler.getTransactionsPerBucketInOrder());
     }
 
     @Test
@@ -410,9 +431,9 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> writtenKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey, aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys2 = createASetAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey, aDifferentWrapperKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys2, gasUsedByTx);
@@ -435,9 +456,9 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> writtenKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey, aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys2 = createASetAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey, aDifferentWrapperKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys2, gasUsedByTx);
@@ -459,9 +480,9 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys2 = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys2 = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys2, new HashSet<>(), gasUsedByTx);
@@ -483,9 +504,9 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx3 = GasCost.toGas(tx3.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1,2};
 
-        HashSet<ByteArrayWrapper> readKeys = createAMapAndAddKeys(aWrappedKey);
-        HashSet<ByteArrayWrapper> readKeys2 = createAMapAndAddKeys(aDifferentWrapperKey);
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey, aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> readKeys = createASetAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> readKeys2 = createASetAndAddKeys(aDifferentWrapperKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey, aDifferentWrapperKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, readKeys, new HashSet<>(), gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, readKeys2, new HashSet<>(), gasUsedByTx);
@@ -505,8 +526,7 @@ public class ParallelizeTransactionHandlerTest {
     public void ifATxCollidesWithAnotherOneThatAlsoHasTheSameSenderShouldGoIntoTheSameBucket() {
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{2};
-
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx, new HashSet<>(), writtenKeys, gasUsedByTx);
@@ -523,8 +543,7 @@ public class ParallelizeTransactionHandlerTest {
         long gasUsedByTx = GasCost.toGas(tx.getGasLimit());
         long gasUsedByTx2 = GasCost.toGas(tx2.getGasLimit());
         short[] expectedTransactionEdgeList = new short[]{1,2};
-
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(tx, new HashSet<>(), new HashSet<>(), gasUsedByTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(tx2, new HashSet<>(), writtenKeys, gasUsedByTx2);
@@ -635,7 +654,7 @@ public class ParallelizeTransactionHandlerTest {
 
         long gasUsedByBigTx = GasCost.toGas(bigTx.getGasLimit());
         long gasUsedByBigTx2 = GasCost.toGas(bigTx2.getGasLimit());
-        HashSet<ByteArrayWrapper> writtenKeys = createAMapAndAddKeys(aWrappedKey);
+        HashSet<ByteArrayWrapper> writtenKeys = createASetAndAddKeys(aWrappedKey);
 
         Optional<Long> bucketGasUsed = handler.addTransaction(bigTx, new HashSet<>(), writtenKeys, gasUsedByBigTx);
         Optional<Long> bucketGasUsed2 = handler.addTransaction(bigTx2, new HashSet<>(), new HashSet<>(), gasUsedByBigTx2);
@@ -697,7 +716,7 @@ public class ParallelizeTransactionHandlerTest {
             assertTrue(true);
         }
     }
-    private HashSet<ByteArrayWrapper> createAMapAndAddKeys(ByteArrayWrapper... aKey) {
+    private HashSet<ByteArrayWrapper> createASetAndAddKeys(ByteArrayWrapper... aKey) {
         return new HashSet<>(Arrays.asList(aKey));
     }
 


### PR DESCRIPTION
We made the next change in the PrallelilizeTransactionHandle class:
- bucketBySender: instead of storing the list of buckets where a tx is located given the sender if the sender is in the sequential, no changes are made. If the sender was already stored in a parallel bucket and the Handler is adding another tx with the same sender to the sequential, the sequential number is settled given the sender.
- getBucketCandidates():  Changed the algorithm to a simpler one that returns the bucketId:
  -  If the tx sender is in the sequential, goes to the sequential.
  -  If there is a collision with more than one key placed in two different buckets, goes to the sequential. Otherwise, if it is the same bucket, goes to that bucket. If there is no collision, it goes to the bucket with gas the less.

- We added a  Double Dispatch, then deleted in the [PR](https://github.com/rsksmart/rskj/pull/1764)
