### PR TITLE
Validates transaction execution lists edges

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1015,7 +1015,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                     commonConstants.getNewBlockMaxSecondsInTheFuture(),
                     rskSystemProperties.getActivationConfig()
             );
-            blockValidationRule = new BlockValidatorRule(
+            blockValidationRule = new BlockCompositeRule(
                     new TxsMinGasPriceRule(),
                     new BlockUnclesValidationRule(
                             getBlockStore(),
@@ -1041,7 +1041,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                     blockTimeStampValidationRule,
                     new GasLimitRule(commonConstants.getMinGasLimit()),
                     new ExtraDataRule(commonConstants.getMaximumExtraDataSize()),
-                    getForkDetectionDataRule()
+                    getForkDetectionDataRule(),
+                    new ValidTxExecutionListsEdgesRule()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/validators/ValidTxExecutionListsEdgesRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/ValidTxExecutionListsEdgesRule.java
@@ -1,0 +1,47 @@
+package co.rsk.validators;
+
+import org.ethereum.config.Constants;
+import org.ethereum.core.Block;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+    Validates that:
+        - There are no more defined transaction subsets than the max number of execution threads
+        - All the edges are within the range of the list of transactions
+        - The edges do not define any empty subset
+        - The edges are in ascending order
+ */
+public class ValidTxExecutionListsEdgesRule implements BlockValidationRule {
+
+    private static final Logger logger = LoggerFactory.getLogger("blockvalidator");
+
+    @Override
+    public boolean isValid(Block block) {
+        short[] edges = block.getHeader().getTxExecutionListsEdges();
+        int nTxs = block.getTransactionsList().size();
+
+        if (edges == null) {
+            return true;
+        }
+        if (edges.length > Constants.getMaxTransactionExecutionThreads()) {
+            logger.warn("Invalid block: number of execution lists edges is greater than number of execution threads ({} vs {})",
+                        edges.length, Constants.getMaxTransactionExecutionThreads());
+            return false;
+        }
+        short prev = 0;
+
+        for (short edge : edges) {
+            if (edge <= prev) {
+                logger.warn("Invalid block: execution lists edges are not in ascending order");
+                return false;
+            }
+            if (edge > nTxs) {
+                logger.warn("Invalid block: execution list edge is out of bounds: {}", edge);
+                return false;
+            }
+            prev = edge;
+        }
+        return true;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -219,6 +219,8 @@ public class Constants {
         return 960;
     }
 
+    public static int getMaxTransactionExecutionThreads() { return 4; }
+
     public static Constants mainnet() {
         return new Constants(
                 MAINNET_CHAIN_ID,

--- a/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
@@ -1,0 +1,92 @@
+package co.rsk.validators;
+
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ValidTxExecutionListsEdgesTest {
+
+    private BlockHeader blockHeader;
+    private Block block;
+    private List txList;
+
+    @Before
+    public void setUp() {
+        blockHeader = Mockito.mock(org.ethereum.core.BlockHeader.class);
+        block = Mockito.mock(Block.class);
+        txList = Mockito.mock(LinkedList.class);
+        Mockito.when(block.getHeader()).thenReturn(blockHeader);
+        Mockito.when(block.getTransactionsList()).thenReturn(txList);
+        Mockito.when(txList.size()).thenReturn(10);
+    }
+
+    @Test
+    public void blockWithValidEdges() {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 5, 6});
+
+        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
+        Assert.assertTrue(rule.isValid(block));
+    }
+
+    @Test
+    public void blockWithNullEdges() {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(null);
+
+        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
+        Assert.assertTrue(rule.isValid(block));
+    }
+
+    @Test
+    public void blockWithEmptyEdges() {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[0]);
+
+        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
+        Assert.assertTrue(rule.isValid(block));
+    }
+
+    @Test
+    public void blockWithTooManyEdges() {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 5, 6, 8, 10, 12, 14});
+
+        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
+        Assert.assertFalse(rule.isValid(block));
+    }
+
+    @Test
+    public void blockWithOutOfBoundsEdges() {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{12});
+
+        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
+        Assert.assertFalse(rule.isValid(block));
+    }
+
+    @Test
+    public void blockWithNegativeEdge() {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{-2});
+
+        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
+        Assert.assertFalse(rule.isValid(block));
+    }
+
+    @Test
+    public void blockWithEmptyListDefined() {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 2});
+
+        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
+        Assert.assertFalse(rule.isValid(block));
+    }
+
+    @Test
+    public void blockWithEdgesNotInOrder() {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 4, 3});
+
+        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
+        Assert.assertFalse(rule.isValid(block));
+    }
+}


### PR DESCRIPTION
Adds validation for the transaction execution list edges field in block header.