### PR TITLE
Modified the REMASC payment

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/TransactionExecutorFactory.java
+++ b/rskj-core/src/main/java/co/rsk/core/TransactionExecutorFactory.java
@@ -29,6 +29,7 @@ import org.ethereum.vm.program.invoke.ProgramInvokeFactory;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.LongAccumulator;
 
 public class TransactionExecutorFactory {
 
@@ -64,7 +65,17 @@ public class TransactionExecutorFactory {
             Repository track,
             Block block,
             long totalGasUsed) {
-        return newInstance(tx, txindex, coinbase, track, block, totalGasUsed, false, 0, new HashSet<>());
+        return newInstance(tx, txindex, coinbase, track, block, totalGasUsed, new LongAccumulator(Long::sum, 0));
+    }
+
+    public TransactionExecutor newInstance(
+            Transaction tx,
+            int txindex,
+            RskAddress coinbase,
+            Repository track,
+            Block block,
+            long totalGasUsed, LongAccumulator remascFees) {
+        return newInstance(tx, txindex, coinbase, track, block, totalGasUsed, false, 0, new HashSet<>(), remascFees);
     }
 
     public TransactionExecutor newInstance(
@@ -76,7 +87,8 @@ public class TransactionExecutorFactory {
             long totalGasUsed,
             boolean vmTrace,
             int vmTraceOptions,
-            Set<DataWord> deletedAccounts) {
+            Set<DataWord> deletedAccounts,
+            LongAccumulator remascFees) {
         // Tracing configuration is scattered across different files (VM, DetailedProgramTrace, etc.) and
         // TransactionExecutor#extractTrace doesn't work when called independently.
         // It would be great to decouple from VmConfig#vmTrace, but sadly that's a major refactor we can't do now.
@@ -109,7 +121,8 @@ public class TransactionExecutorFactory {
                 config.isRemascEnabled(),
                 precompiledContracts,
                 deletedAccounts,
-                blockTxSignatureCache
+                blockTxSignatureCache,
+                remascFees
         );
     }
 }

--- a/rskj-core/src/main/java/co/rsk/core/TransactionListExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/TransactionListExecutor.java
@@ -32,6 +32,7 @@ public class TransactionListExecutor implements Callable {
     private final Map<Integer, TransactionReceipt> receipts;
     private final Map<Keccak256, ProgramResult> transactionResults;
     private final ProgramTraceProcessor programTraceProcessor;
+    private final LongAccumulator remascFees;
     private final LongAccumulator accumulatedFees;
     private final LongAccumulator accumulatedGas;
 
@@ -53,6 +54,7 @@ public class TransactionListExecutor implements Callable {
             Map<Keccak256, ProgramResult> transactionResults,
             boolean registerProgramResults,
             @Nullable ProgramTraceProcessor programTraceProcessor,
+            LongAccumulator remascFees,
             LongAccumulator accumulatedFees,
             LongAccumulator accumulatedGas,
             int firstTxIndex) {
@@ -73,6 +75,7 @@ public class TransactionListExecutor implements Callable {
         this.accumulatedFees = accumulatedFees;
         this.accumulatedGas = accumulatedGas;
         this.i = firstTxIndex;
+        this.remascFees = remascFees;
     }
 
     @Override
@@ -90,7 +93,8 @@ public class TransactionListExecutor implements Callable {
                     totalGasUsed,
                     vmTrace,
                     vmTraceOptions,
-                    deletedAccounts
+                    deletedAccounts,
+                    remascFees
             );
             boolean transactionExecuted = txExecutor.executeTransaction();
 

--- a/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
+++ b/rskj-core/src/test/java/co/rsk/vm/MinerHelper.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.LongAccumulator;
 
 /**
  * Created by Sergio on 18/07/2016.
@@ -71,6 +72,8 @@ public class MinerHelper {
         totalGasUsed = 0;
         totalPaidFees = Coin.ZERO;
         txReceipts = new ArrayList<>();
+        LongAccumulator remascFees = new LongAccumulator(Long::sum, 0);
+
 
         Repository track = repositoryLocator.startTrackingAt(parent.getHeader());
 
@@ -103,7 +106,7 @@ public class MinerHelper {
                     null,
                     new PrecompiledContracts(config, bridgeSupportFactory), blockTxSignatureCache);
             TransactionExecutor executor = transactionExecutorFactory
-                    .newInstance(tx, txindex++, block.getCoinbase(), track, block, totalGasUsed);
+                    .newInstance(tx, txindex++, block.getCoinbase(), track, block, totalGasUsed, remascFees);
 
             executor.executeTransaction();
 
@@ -111,6 +114,18 @@ public class MinerHelper {
             Coin paidFees = executor.getPaidFees();
             totalGasUsed += gasUsed;
             totalPaidFees = totalPaidFees.add(paidFees);
+
+            /*
+            * This method is a helper of the test "testSEND_1". It is replicating the
+            * behavior of BlockExecutor but slightly different. In the BlockExecutor, the
+            * fees are sent to the Remasc address once all the transactions are executed.
+            * Since the only test using this helper processes one transaction, so the loop has no sense.
+            * */
+            long fees = remascFees.get();
+            if (fees > 0) {
+                track.addBalance(PrecompiledContracts.REMASC_ADDR, Coin.valueOf(fees));
+                track.commit();
+            }
 
             track.commit();
 

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionExecutorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionExecutorTest.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.LongAccumulator;
 
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertFalse;
@@ -80,7 +81,7 @@ public class TransactionExecutorTest {
                 repository, blockStore, receiptStore, blockFactory,
                 programInvokeFactory, executionBlock, gasUsedInTheBlock, vmConfig,
                 true, precompiledContracts, deletedAccounts,
-                blockTxSignatureCache
+                blockTxSignatureCache, new LongAccumulator(Long::sum, 0)
         );
 
 
@@ -186,7 +187,7 @@ public class TransactionExecutorTest {
                 repository, blockStore, receiptStore, blockFactory,
                 programInvokeFactory, executionBlock, gasUsedInTheBlock, vmConfig,
                 true, precompiledContracts, deletedAccounts,
-                blockTxSignatureCache
+                blockTxSignatureCache, new LongAccumulator(Long::sum, 0)
         );
 
         assertEquals(0, transaction.transactionCost(constants, activationConfig.forBlock(executionBlock.getNumber())));
@@ -219,7 +220,7 @@ public class TransactionExecutorTest {
                 repository, blockStore, receiptStore, blockFactory,
                 programInvokeFactory, executionBlock, gasUsedInTheBlock, vmConfig,
                 true, precompiledContracts, deletedAccounts,
-                blockTxSignatureCache
+                blockTxSignatureCache, new LongAccumulator(Long::sum, 0)
         );
 
         assertEquals(0, transaction.transactionCost(constants, activationConfig.forBlock(executionBlock.getNumber())));
@@ -295,7 +296,7 @@ public class TransactionExecutorTest {
                 repository, blockStore, receiptStore, blockFactory,
                 programInvokeFactory, executionBlock, gasUsedInTheBlock, vmConfig,
                 true, precompiledContracts, deletedAccounts,
-                blockTxSignatureCache
+                blockTxSignatureCache, new LongAccumulator(Long::sum, 0)
         );
 
         return txExecutor.executeTransaction();


### PR DESCRIPTION
Instead of paying to the REMASC contract…every transaction, the fees are accumulated into a variable and once all of the transactions are processed, the fees are added to the Remasc's balance in the MutableRepository. If the rREMASCFee is greater than 0 the payment is made. Some tests had to be changed since they replicate the behavior of the block executor and the REMASC payment is actually made in the block executor so the tests were modified as well