### PR TITLE
Research/main parallel tx refactor validblock

### DIFF
--- a/rskj-core/src/main/java/co/rsk/validators/ValidTxExecutionListsEdgesRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/ValidTxExecutionListsEdgesRule.java
@@ -19,28 +19,30 @@ public class ValidTxExecutionListsEdgesRule implements BlockValidationRule {
     @Override
     public boolean isValid(Block block) {
         short[] edges = block.getHeader().getTxExecutionListsEdges();
-        int nTxs = block.getTransactionsList().size();
 
-        if (edges == null) {
+        if (edges == null || edges.length == 0) {
             return true;
         }
+
         if (edges.length > Constants.getMaxTransactionExecutionThreads()) {
             logger.warn("Invalid block: number of execution lists edges is greater than number of execution threads ({} vs {})",
                         edges.length, Constants.getMaxTransactionExecutionThreads());
             return false;
         }
-        short prev = 0;
 
+        short prev = 0;
         for (short edge : edges) {
             if (edge <= prev) {
                 logger.warn("Invalid block: execution lists edges are not in ascending order");
                 return false;
             }
-            if (edge > nTxs) {
-                logger.warn("Invalid block: execution list edge is out of bounds: {}", edge);
-                return false;
-            }
             prev = edge;
+        }
+
+        int txListSize = block.getTransactionsList().size();
+        if (edges[edges.length-1] > txListSize) {
+            logger.warn("Invalid block: execution list edge is out of bounds");
+            return false;
         }
         return true;
     }

--- a/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
@@ -78,7 +78,7 @@ public class ValidTxExecutionListsEdgesTest {
     }
 
     @Test
-    public void blockWithEmptyListDefined() {
+    public void blockWithRepeatedEdge() {
         mockGetTxExecutionListsEdges(new short[]{2, 2});
 
         Assert.assertFalse(rule.isValid(block));

--- a/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
@@ -15,6 +15,7 @@ public class ValidTxExecutionListsEdgesTest {
     private BlockHeader blockHeader;
     private Block block;
     private List txList;
+    private ValidTxExecutionListsEdgesRule rule;
 
     @Before
     public void setUp() {
@@ -24,13 +25,14 @@ public class ValidTxExecutionListsEdgesTest {
         Mockito.when(block.getHeader()).thenReturn(blockHeader);
         Mockito.when(block.getTransactionsList()).thenReturn(txList);
         Mockito.when(txList.size()).thenReturn(10);
+
+        rule = new ValidTxExecutionListsEdgesRule();
     }
 
     @Test
     public void blockWithValidEdges() {
         Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 5, 6});
 
-        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
         Assert.assertTrue(rule.isValid(block));
     }
 
@@ -38,7 +40,6 @@ public class ValidTxExecutionListsEdgesTest {
     public void blockWithNullEdges() {
         Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(null);
 
-        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
         Assert.assertTrue(rule.isValid(block));
     }
 
@@ -46,7 +47,6 @@ public class ValidTxExecutionListsEdgesTest {
     public void blockWithEmptyEdges() {
         Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[0]);
 
-        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
         Assert.assertTrue(rule.isValid(block));
     }
 
@@ -54,7 +54,6 @@ public class ValidTxExecutionListsEdgesTest {
     public void blockWithTooManyEdges() {
         Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 5, 6, 8, 10, 12, 14});
 
-        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
         Assert.assertFalse(rule.isValid(block));
     }
 
@@ -62,7 +61,6 @@ public class ValidTxExecutionListsEdgesTest {
     public void blockWithOutOfBoundsEdges() {
         Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{12});
 
-        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
         Assert.assertFalse(rule.isValid(block));
     }
 
@@ -70,7 +68,6 @@ public class ValidTxExecutionListsEdgesTest {
     public void blockWithNegativeEdge() {
         Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{-2});
 
-        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
         Assert.assertFalse(rule.isValid(block));
     }
 
@@ -78,7 +75,6 @@ public class ValidTxExecutionListsEdgesTest {
     public void blockWithEmptyListDefined() {
         Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 2});
 
-        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
         Assert.assertFalse(rule.isValid(block));
     }
 

--- a/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
@@ -78,6 +78,13 @@ public class ValidTxExecutionListsEdgesTest {
     }
 
     @Test
+    public void blockWithEdgeZero() {
+        mockGetTxExecutionListsEdges(new short[]{0, 2});
+
+        Assert.assertFalse(rule.isValid(block));
+    }
+
+    @Test
     public void blockWithRepeatedEdge() {
         mockGetTxExecutionListsEdges(new short[]{2, 2});
 

--- a/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
@@ -29,60 +29,63 @@ public class ValidTxExecutionListsEdgesTest {
         rule = new ValidTxExecutionListsEdgesRule();
     }
 
+    private void mockGetTxExecutionListsEdges (short[] edges) {
+        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(edges);
+    }
+
     @Test
     public void blockWithValidEdges() {
-        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 5, 6});
+        mockGetTxExecutionListsEdges(new short[]{2, 5, 6});
 
         Assert.assertTrue(rule.isValid(block));
     }
 
     @Test
     public void blockWithNullEdges() {
-        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(null);
+        mockGetTxExecutionListsEdges(null);
 
         Assert.assertTrue(rule.isValid(block));
     }
 
     @Test
     public void blockWithEmptyEdges() {
-        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[0]);
+        mockGetTxExecutionListsEdges(new short[0]);
 
         Assert.assertTrue(rule.isValid(block));
     }
 
     @Test
     public void blockWithTooManyEdges() {
-        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 5, 6, 8, 10, 12, 14});
+        mockGetTxExecutionListsEdges(new short[]{2, 5, 6, 8, 10, 12, 14});
 
         Assert.assertFalse(rule.isValid(block));
     }
 
     @Test
     public void blockWithOutOfBoundsEdges() {
-        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{12});
+        mockGetTxExecutionListsEdges(new short[]{12});
 
         Assert.assertFalse(rule.isValid(block));
     }
 
     @Test
     public void blockWithNegativeEdge() {
-        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{-2});
+        mockGetTxExecutionListsEdges(new short[]{-2});
 
         Assert.assertFalse(rule.isValid(block));
     }
 
     @Test
     public void blockWithEmptyListDefined() {
-        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 2});
+        mockGetTxExecutionListsEdges(new short[]{2, 2});
 
         Assert.assertFalse(rule.isValid(block));
     }
 
     @Test
     public void blockWithEdgesNotInOrder() {
-        Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(new short[]{2, 4, 3});
+        mockGetTxExecutionListsEdges(new short[]{2, 4, 3});
 
-        ValidTxExecutionListsEdgesRule rule = new ValidTxExecutionListsEdgesRule();
         Assert.assertFalse(rule.isValid(block));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
+++ b/rskj-core/src/test/java/co/rsk/validators/ValidTxExecutionListsEdgesTest.java
@@ -33,6 +33,7 @@ public class ValidTxExecutionListsEdgesTest {
         Mockito.when(blockHeader.getTxExecutionListsEdges()).thenReturn(edges);
     }
 
+    // valid cases
     @Test
     public void blockWithValidEdges() {
         mockGetTxExecutionListsEdges(new short[]{2, 5, 6});
@@ -54,9 +55,10 @@ public class ValidTxExecutionListsEdgesTest {
         Assert.assertTrue(rule.isValid(block));
     }
 
+    // invalid cases
     @Test
     public void blockWithTooManyEdges() {
-        mockGetTxExecutionListsEdges(new short[]{2, 5, 6, 8, 10, 12, 14});
+        mockGetTxExecutionListsEdges(new short[]{1, 2, 3, 4, 5});
 
         Assert.assertFalse(rule.isValid(block));
     }


### PR DESCRIPTION
Refactored tests and a little bit of the implementation. Also corrected one test that hit two cases at the same time, now hits one of the two.

Things we need to further look at:
- Why would we check if the block has `edges`. If it is validating edges it means it is already marked as post-RSKIP144, so we should asume edges exist
- Discussion already opened, why could a block have less than max edges?