### PR TITLE
Research/parallel-tx/optimize writes

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -391,6 +391,7 @@ public class MutableRepository implements Repository {
     }
 
     private void internalPut(byte[] key, byte[] value) {
+        if (Arrays.equals(value, mutableTrie.get(key))) return; // writes the same value
         tracker.addNewWrittenKey(new ByteArrayWrapper(key));
         mutableTrie.put(key, value);
     }

--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -299,6 +299,10 @@ public class MutableRepository implements Repository {
     public synchronized Coin addBalance(RskAddress addr, Coin value) {
         AccountState account = getAccountStateOrCreateNew(addr);
 
+        if (value.equals(new Coin(BigInteger.ZERO))) {
+            return account.getBalance();
+        }
+
         Coin result = account.addToBalance(value);
         updateAccountState(addr, account);
 

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
@@ -1,0 +1,100 @@
+package co.rsk.db;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.core.bc.IReadWrittenKeysTracker;
+import co.rsk.core.bc.ReadWrittenKeysTracker;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieStore;
+import co.rsk.trie.TrieStoreImpl;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.db.MutableRepository;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class RepositoryTrackingTest {
+    public static final RskAddress COW = new RskAddress("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
+
+    private MutableRepository repository;
+    private MutableTrieImpl mutableTrie;
+    private TrieStore trieStore;
+    private IReadWrittenKeysTracker tracker;
+
+    @Before
+    public void setUp() {
+        trieStore = new TrieStoreImpl(new HashMapDB());
+        mutableTrie = new MutableTrieImpl(trieStore, new Trie(trieStore));
+        tracker = new ReadWrittenKeysTracker();
+        repository = new MutableRepository(mutableTrie, tracker);
+    }
+
+    void assertRepositoryHaveSize(int readRepoSize, int writtenRepoSize) {
+        assertEquals(readRepoSize, tracker.getTemporalReadKeys().size());
+        assertEquals(writtenRepoSize, tracker.getTemporalWrittenKeys().size());
+    }
+
+    @Test
+    public void tracksWriteInCreatedAccount () {
+        repository.createAccount(COW);
+
+        assertRepositoryHaveSize(0, 1);
+    }
+
+    @Test
+    public void tracksWriteInSetupContract () {
+        repository.createAccount(COW);
+        tracker.clear();
+
+        repository.setupContract(COW);
+
+        assertRepositoryHaveSize(0, 1);
+    }
+
+    @Test
+    public void tracksReadInIsExists () {
+        repository.isExist(COW);
+
+        assertRepositoryHaveSize(1, 0);
+    }
+
+    @Test
+    public void tracksReadInGetAccountState () {
+        repository.getAccountState(COW);
+
+        assertRepositoryHaveSize(1, 0);
+    }
+
+    @Test
+    public void tracksWriteInDelete () {
+        repository.createAccount(COW);
+        tracker.clear();
+
+        repository.delete(COW);
+
+        assertRepositoryHaveSize(0, 1);
+    }
+
+    @Test
+    public void tracksWriteInAddBalance () {
+        repository.createAccount(COW);
+        tracker.clear();
+
+        repository.addBalance(COW, new Coin(BigInteger.ONE));
+
+        assertRepositoryHaveSize(1, 1);
+    }
+
+    @Test
+    public void doesntTracksWriteInAddBalanceZero () {
+        repository.createAccount(COW);
+        tracker.clear();
+
+        repository.addBalance(COW, new Coin(BigInteger.ZERO));
+
+        assertRepositoryHaveSize(1, 0);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
@@ -34,7 +34,7 @@ public class RepositoryTrackingTest {
         repository = new MutableRepository(mutableTrie, tracker);
     }
 
-    void assertRepositoryHaveSize(int readRepoSize, int writtenRepoSize) {
+    void assertRepositoryHasSize(int readRepoSize, int writtenRepoSize) {
         assertEquals(readRepoSize, tracker.getTemporalReadKeys().size());
         assertEquals(writtenRepoSize, tracker.getTemporalWrittenKeys().size());
     }
@@ -43,7 +43,7 @@ public class RepositoryTrackingTest {
     public void tracksWriteInCreatedAccount () {
         repository.createAccount(COW);
 
-        assertRepositoryHaveSize(0, 1);
+        assertRepositoryHasSize(0, 1);
     }
 
     @Test
@@ -53,21 +53,21 @@ public class RepositoryTrackingTest {
 
         repository.setupContract(COW);
 
-        assertRepositoryHaveSize(0, 1);
+        assertRepositoryHasSize(0, 1);
     }
 
     @Test
     public void tracksReadInIsExists () {
         repository.isExist(COW);
 
-        assertRepositoryHaveSize(1, 0);
+        assertRepositoryHasSize(1, 0);
     }
 
     @Test
     public void tracksReadInGetAccountState () {
         repository.getAccountState(COW);
 
-        assertRepositoryHaveSize(1, 0);
+        assertRepositoryHasSize(1, 0);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class RepositoryTrackingTest {
 
         repository.delete(COW);
 
-        assertRepositoryHaveSize(0, 1);
+        assertRepositoryHasSize(0, 1);
     }
 
     @Test
@@ -87,17 +87,17 @@ public class RepositoryTrackingTest {
 
         repository.addBalance(COW, new Coin(BigInteger.ONE));
 
-        assertRepositoryHaveSize(1, 1);
+        assertRepositoryHasSize(1, 1);
     }
 
     @Test
-    public void doesntTracksWriteInAddBalanceZero () {
+    public void doesntTrackWriteInAddBalanceZero () {
         repository.createAccount(COW);
         tracker.clear();
 
         repository.addBalance(COW, new Coin(BigInteger.ZERO));
 
-        assertRepositoryHaveSize(1, 0);
+        assertRepositoryHasSize(1, 0);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class RepositoryTrackingTest {
 
         repository.getStorageBytes(COW, DataWord.valueOf(cowKey));
 
-        assertRepositoryHaveSize(1, 0);
+        assertRepositoryHasSize(1, 0);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class RepositoryTrackingTest {
 
         repository.addStorageBytes(COW, DataWord.valueOf(cowKey), cowValue);
 
-        assertRepositoryHaveSize(1, 1);
+        assertRepositoryHasSize(1, 1);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class RepositoryTrackingTest {
         repository.addStorageBytes(COW, DataWord.valueOf(cowKey), cowValue);
         repository.addStorageBytes(COW, DataWord.valueOf(cowKey2), cowValue2);
 
-        assertRepositoryHaveSize(1, 2);
+        assertRepositoryHasSize(1, 2);
     }
 
     @Test
@@ -154,6 +154,6 @@ public class RepositoryTrackingTest {
 
         repository.addStorageBytes(COW, DataWord.valueOf(cowKey), cowValue);
 
-        assertRepositoryHaveSize(1, 0);
+        assertRepositoryHasSize(1, 0);
     }
 }


### PR DESCRIPTION
> This cases should not be considered as writing a key, since they doesn't affect the output of the parallel execution:
> - Adding 0 balance
> - Write a key with the value that was already set

Ref: https://github.com/rsksmart/RSKIPs/pull/296/files#diff-886654e1645d9fd29f3e21aa0b8e9b71fb109544883d9adb4187853983657ddbR76-R78