### PR TITLE
Research/parallel-tx/Fix isRemascTransaction validation and pass correct index

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -641,6 +641,7 @@ public class BlockExecutor {
                     return getBlockResultAndLogExecutionInterrupted(block, metric, tx);
                 }
                 loggingDiscardedBlock(block, tx);
+                txindex++;
                 continue;
             }
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -608,7 +608,7 @@ public class BlockExecutor {
 
             TransactionExecutor txExecutor = transactionExecutorFactory.newInstance(
                     tx,
-                    txindex++,
+                    txindex,
                     block.getCoinbase(),
                     track,
                     block,
@@ -629,7 +629,7 @@ public class BlockExecutor {
             }
 
             Optional<Long> sublistGasAccumulated;
-            if (tx.isRemascTransaction(txindex-1, transactionsList.size())) {
+            if (tx.isRemascTransaction(txindex, transactionsList.size())) {
                 sublistGasAccumulated = parallelizeTransactionHandler.addRemascTransaction(tx, txExecutor.getGasUsed());
             } else {
                 sublistGasAccumulated = parallelizeTransactionHandler.addTransaction(tx, readWrittenKeysTracker.getTemporalReadKeys(), readWrittenKeysTracker.getTemporalWrittenKeys(), txExecutor.getGasUsed());
@@ -670,6 +670,7 @@ public class BlockExecutor {
             loggingExecuteTxAndReceipt(block, i, tx);
 
             i++;
+            txindex++;
 
             receiptsByTx.put(tx, receipt);
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -625,6 +625,7 @@ public class BlockExecutor {
                 }
 
                 loggingDiscardedBlock(block, tx);
+                txindex++;
                 continue;
             }
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -629,7 +629,7 @@ public class BlockExecutor {
             }
 
             Optional<Long> sublistGasAccumulated;
-            if (tx.isRemascTransaction(txindex, transactionsList.size())) {
+            if (tx.isRemascTransaction(txindex-1, transactionsList.size())) {
                 sublistGasAccumulated = parallelizeTransactionHandler.addRemascTransaction(tx, txExecutor.getGasUsed());
             } else {
                 sublistGasAccumulated = parallelizeTransactionHandler.addTransaction(tx, readWrittenKeysTracker.getTemporalReadKeys(), readWrittenKeysTracker.getTemporalWrittenKeys(), txExecutor.getGasUsed());

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -559,7 +559,9 @@ public class Transaction {
     }
 
     private boolean checkRemascTxZeroValues() {
-        if (null != getData() || null != getSignature()) {
+        byte[] data = getData();
+
+        if ((null != data && data.length != 0) || null != getSignature()) {
             return false;
         }
 

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -559,9 +559,9 @@ public class Transaction {
     }
 
     private boolean checkRemascTxZeroValues() {
-        byte[] data = getData();
+        byte[] currentData = getData();
 
-        if ((null != data && data.length != 0) || null != getSignature()) {
+        if ((null != currentData && currentData.length != 0) || null != getSignature()) {
             return false;
         }
 

--- a/rskj-core/src/test/java/co/rsk/core/TransactionIsRemascTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionIsRemascTest.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.core;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.*;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RLP;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TransactionIsRemascTest {
+    int txPosition = 6;
+    int txsSize = 7;
+    RskAddress destination = PrecompiledContracts.REMASC_ADDR;
+    byte[] data = null;
+    Coin value = Coin.ZERO;
+    byte[] gasPrice = Hex.decode("00");
+    byte[] gasLimit = Hex.decode("00");
+
+    private Transaction buildTx(
+        RskAddress destination,
+        byte[] data,
+        Coin value,
+        byte[] gasPrice,
+        byte[] gasLimit
+    ) {
+        return Transaction.builder()
+            .destination(destination)
+            .data(data)
+            .value(value)
+            .gasPrice(gasPrice)
+            .gasLimit(gasLimit)
+            .build();
+    }
+
+    private void assertIsRemascTransaction(
+        RskAddress destination,
+        byte[] data,
+        Coin value,
+        byte[] gasPrice,
+        byte[] gasLimit,
+        int txPosition,
+        int txsSize
+    ) {
+        Transaction tx = buildTx(destination, data, value, gasPrice, gasLimit);
+
+        assertTrue(tx.isRemascTransaction(txPosition, txsSize));
+    }
+
+    private void assertIsNotRemascTransaction(
+        Transaction tx,
+        int txPosition,
+        int txsSize
+    ) {
+        assertFalse(tx.isRemascTransaction(txPosition, txsSize));
+    }
+
+    private void assertIsNotRemascTransaction(
+        RskAddress destination,
+        byte[] data,
+        Coin value,
+        byte[] gasPrice,
+        byte[] gasLimit,
+        int txPosition,
+        int txsSize
+    ) {
+        Transaction tx = buildTx(destination, data, value, gasPrice, gasLimit);
+
+        assertIsNotRemascTransaction(tx, txPosition, txsSize);
+    }
+
+    @Test
+    public void validRemascTransactionNullData() {
+        assertIsRemascTransaction(destination, data, value, gasPrice, gasLimit, txPosition, txsSize);
+    }
+
+    @Test
+    public void validRemascTransactionEmptyData() {
+        byte[] data = {};
+        assertIsRemascTransaction(destination, data, value, gasPrice, gasLimit, txPosition, txsSize);
+    }
+
+    @Test
+    public void notRemascTransactionNotLastTx() {
+        int txPosition = 3;
+        assertIsNotRemascTransaction(destination, data, value, gasPrice, gasLimit, txPosition, txsSize);
+    }
+
+    @Test
+    public void notRemascTransactionNotEmptyData() {
+        byte[] data = { 1, 2, 3, 4 };
+        assertIsNotRemascTransaction(destination, data, value, gasPrice, gasLimit, txPosition, txsSize);
+    }
+
+    @Test
+    public void notRemascTransactionNotNullSig() {
+        byte[] senderPrivateKey = HashUtil.keccak256("cow".getBytes());
+        Transaction tx = buildTx(destination, data, value, gasPrice, gasLimit);
+        tx.sign(senderPrivateKey);
+
+        assertIsNotRemascTransaction(tx, txPosition, txsSize);
+    }
+
+    @Test
+    public void notRemascTransactionReceiverIsNotRemasc() {
+        byte[] privateKey = HashUtil.keccak256("cat".getBytes());
+        ECKey ecKey = ECKey.fromPrivate(privateKey);
+        RskAddress destination =  RLP.parseRskAddress(ByteUtil.cloneBytes(ecKey.getAddress()));
+
+        assertIsNotRemascTransaction(destination, data, value, gasPrice, gasLimit, txPosition, txsSize);
+    }
+
+
+    @Test
+    public void notRemascTransactionValueIsNotZero() {
+        Coin value = Coin.valueOf(10);
+        assertIsNotRemascTransaction(destination, data, value, gasPrice, gasLimit, txPosition, txsSize);
+    }
+
+
+    @Test
+    public void notRemascTransactionGasPriceIsNotZero() {
+        byte[] gasPrice = { 10 };
+        assertIsNotRemascTransaction(destination, data, value, gasPrice, gasLimit, txPosition, txsSize);
+    }
+
+
+    @Test
+    public void notRemascTransactionGasLimitIsNotZero() {
+        byte[] gasLimit = { 10 };
+        assertIsNotRemascTransaction(destination, data, value, gasPrice, gasLimit, txPosition, txsSize);
+    }
+}
+

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -660,6 +660,42 @@ public class BlockExecutorTest {
         Assert.assertArrayEquals(block1.getHash().getBytes(), block2.getHash().getBytes());
     }
 
+    private void testBlockWithTxTxEdgesMatchAndRemascTxIsAtLastPosition (int txAmount, short [] expectedSublistsEdges) {
+        Block parent = blockchain.getBestBlock();
+        Block block = getBlockWithNIndependentTransactions(txAmount, BigInteger.valueOf(21000), true);
+        BlockResult blockResult = executor.executeAndFill(block, parent.getHeader());
+
+        int expectedTxSize = txAmount + 1;
+
+        Assert.assertArrayEquals(expectedSublistsEdges, blockResult.getTxEdges());
+        Assert.assertEquals(expectedTxSize, blockResult.getExecutedTransactions().size());
+        Assert.assertTrue(blockResult.getExecutedTransactions().get(txAmount).isRemascTransaction(txAmount, expectedTxSize));
+    }
+
+    @Test
+    public void blockWithOnlyRemascShouldGoToSequentialSublist () {
+        if (!activeRskip144) return;
+        testBlockWithTxTxEdgesMatchAndRemascTxIsAtLastPosition(0, new short[]{});
+    }
+
+    @Test
+    public void blockWithOneTxRemascShouldGoToSequentialSublist () {
+        if (!activeRskip144) return;
+        testBlockWithTxTxEdgesMatchAndRemascTxIsAtLastPosition(1, new short[]{ 1 });
+    }
+
+    @Test
+    public void blockWithManyTxsRemascShouldGoToSequentialSublist () {
+        if (!activeRskip144) return;
+        testBlockWithTxTxEdgesMatchAndRemascTxIsAtLastPosition(3, new short[]{ 1, 2, 3 });
+    }
+
+    @Test
+    public void blockWithMoreThanThreadsTxsRemascShouldGoToSequentialSublist () {
+        if (!activeRskip144) return;
+        testBlockWithTxTxEdgesMatchAndRemascTxIsAtLastPosition(5, new short[]{ 2, 3, 4, 5 });
+    }
+
     @Test
     public void validateStateRootWithRskip126DisabledAndValidStateRoot() {
         TrieStore trieStore = new TrieStoreImpl(new HashMapDB());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `txindex` started in 1. So `isLastTx` was false
- `data` was empty but not null in `SnapshotManagerTest` (idk why) so `checkRemascTxZeroValues` was also false

## Motivation and Context

The remasc transaction was added to a parallel thread instead of the sequential one because it was wrongly identified as non-remasc tx

## How Has This Been Tested?

All tests pass now 😄 (see #1794)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
