### PR TITLE
Fix write the same value - avoid write on add balance 0

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -299,6 +299,10 @@ public class MutableRepository implements Repository {
     public synchronized Coin addBalance(RskAddress addr, Coin value) {
         AccountState account = getAccountStateOrCreateNew(addr);
 
+        if (value == Coin.ZERO) {
+            return account.getBalance();
+        }
+
         Coin result = account.addToBalance(value);
         updateAccountState(addr, account);
 

--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -387,11 +387,6 @@ public class MutableRepository implements Repository {
     }
 
     private void internalPut(byte[] key, byte[] value) {
-        // writes the same value
-        if (Arrays.equals(value, mutableTrie.get(key))) {
-            return;
-        }
-
         tracker.addNewWrittenKey(new ByteArrayWrapper(key));
         mutableTrie.put(key, value);
     }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
@@ -170,13 +170,13 @@ public class RepositoryTrackingTest {
         assertRepositoryHasSize(1, 1);
     }
 
-    public void tracksReadAndWriteOnAddBalanceZeroOfExistent () {
+    public void doesntTrackWriteOnAddBalanceZeroOfExistent () {
         repository.addBalance(COW, Coin.valueOf(1));
 
         tracker.clear();
 
         repository.addBalance(COW, Coin.valueOf(0));
 
-        assertRepositoryHasSize(1, 1);
+        assertRepositoryHasSize(1, 0);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
@@ -16,8 +16,10 @@ import static org.junit.Assert.assertEquals;
 import java.math.BigInteger;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
 public class RepositoryTrackingTest {
     public static final RskAddress COW = new RskAddress("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
 

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
@@ -19,7 +19,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class RepositoryTrackingTest {
     public static final RskAddress COW = new RskAddress("CD2A3D9F938E13CD947EC05ABC7FE734DF8DD826");
 
@@ -93,16 +92,6 @@ public class RepositoryTrackingTest {
     }
 
     @Test
-    public void doesntTrackWriteInAddBalanceZero () {
-        repository.createAccount(COW);
-        tracker.clear();
-
-        repository.addBalance(COW, Coin.ZERO);
-
-        assertRepositoryHasSize(1, 0);
-    }
-
-    @Test
     public void tracksReadOnGetStorageBytes () {
         repository.createAccount(COW);
         tracker.clear();
@@ -144,7 +133,7 @@ public class RepositoryTrackingTest {
     }
 
     @Test
-    public void doesntTrackWriteOnAddStorageSameBytes () {
+    public void tracksWriteOnAddStorageSameBytes () {
         repository.createAccount(COW);
 
         byte[] cowValue = Hex.decode("A4A5A6");
@@ -156,6 +145,38 @@ public class RepositoryTrackingTest {
 
         repository.addStorageBytes(COW, DataWord.valueOf(cowKey), cowValue);
 
-        assertRepositoryHasSize(1, 0);
+        assertRepositoryHasSize(1, 1);
+    }
+
+    public void tracksReadAndWriteOnAddBalanceOfNonExistent () {
+        repository.addBalance(COW, Coin.valueOf(1));
+
+        assertRepositoryHasSize(1, 1);
+    }
+
+    public void tracksReadAndWriteOnAddBalanceZeroOfNonExistent () {
+        repository.addBalance(COW, Coin.valueOf(0));
+
+        assertRepositoryHasSize(1, 1);
+    }
+
+    public void tracksReadAndWriteOnAddBalanceOfExistent () {
+        repository.addBalance(COW, Coin.valueOf(1));
+
+        tracker.clear();
+
+        repository.addBalance(COW, Coin.valueOf(1));
+
+        assertRepositoryHasSize(1, 1);
+    }
+
+    public void tracksReadAndWriteOnAddBalanceZeroOfExistent () {
+        repository.addBalance(COW, Coin.valueOf(1));
+
+        tracker.clear();
+
+        repository.addBalance(COW, Coin.valueOf(0));
+
+        assertRepositoryHasSize(1, 1);
     }
 }


### PR DESCRIPTION
### Remove avoid writing on same value

Ref: https://github.com/rsksmart/rskj/pull/1811/files#r919225159

### Avoid writing on add balance 0

There are 4 cases on add balance:
- Account doesn't exist: avoids changing the current functionality. Account is created, wether it adds balance non-0 or 0
- Account exists
  - Adds balance non-0: reads account state and then writes the new balance, as current functionality
  - Adds balance 0: reads account, avoids writing since value doesn't change
