### PR TITLE
Add tool to migrate betweeen databases

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -1,0 +1,211 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.cli.tools;
+
+import co.rsk.RskContext;
+import co.rsk.cli.CliToolRskContextAware;
+import org.ethereum.datasource.DbKind;
+import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+/**
+ * The entry point for db migration CLI tool
+ * This is an experimental/unsupported tool
+ *
+ * Required cli args:
+ * - args[0] - database target where we are going to insert the information from the current selected database.
+ *
+ * We do support the migrations between the following databases:
+ * - LevelDb (leveldb as argument)
+ * - RocksDb (rocksdb as argument)
+ */
+public class DbMigrate extends CliToolRskContextAware {
+    private static final Logger logger = LoggerFactory.getLogger(DbMigrate.class);
+    private static final String NODE_ID_FILE = "nodeId.properties";
+
+    private static class DbInformation {
+        private final KeyValueDataSource keyValueDataSource;
+        private final String indexPath;
+
+        public DbInformation(KeyValueDataSource keyValueDataSource, String indexPath) {
+            this.keyValueDataSource = keyValueDataSource;
+            this.indexPath = indexPath;
+        }
+
+        public KeyValueDataSource getKeyValueDataSource() {
+            return keyValueDataSource;
+        }
+
+        public String getIndexPath() {
+            return indexPath;
+        }
+    }
+
+    private static class DbMigrationInformation {
+        private final DbInformation targetDbInformation;
+        private final DbInformation sourceDbInformation;
+
+        public DbMigrationInformation(DbInformation targetDbInformation, DbInformation sourceDbInformation) {
+            this.targetDbInformation = targetDbInformation;
+            this.sourceDbInformation = sourceDbInformation;
+        }
+
+        public DbInformation getTargetDbInformation() {
+            return targetDbInformation;
+        }
+
+        public DbInformation getSourceDbInformation() {
+            return sourceDbInformation;
+        }
+    }
+
+
+    public static void main(String[] args) {
+        create(MethodHandles.lookup().lookupClass()).execute(args);
+    }
+
+    @SuppressWarnings("unused")
+    public DbMigrate() {
+    }
+
+    @Override
+    protected void onExecute(@Nonnull String[] args, @Nonnull RskContext ctx) throws IOException {
+        logger.info("Starting db migration...");
+
+        DbKind sourceDbKind = ctx.getRskSystemProperties().databaseKind();
+        DbKind targetDbKind = DbKind.ofName(args[0]);
+
+        if (sourceDbKind == targetDbKind) {
+            throw new IllegalArgumentException(String.format(
+                    "Cannot migrate to the same database, current db is %s and target db is %s",
+                    sourceDbKind,
+                    targetDbKind
+            ));
+        }
+
+        String sourceDbDir = ctx.getRskSystemProperties().databaseDir();
+        String targetDbDir = sourceDbDir + "_tmp";
+
+        logger.info("Preparing to migrate from {} to {}", sourceDbKind.name(), targetDbKind.name());
+
+        FileUtil.recursiveDelete(targetDbDir);
+
+        try (Stream<Path> databasePaths = Files.list(Paths.get(sourceDbDir))) {
+            databasePaths.filter(path -> path.toFile().isDirectory())
+                    .map(path -> path.getFileName().toString())
+                    .map(dbName -> buildDbMigrationInformation(sourceDbDir, targetDbDir, sourceDbKind, targetDbKind, dbName))
+                    .forEach(this::migrate);
+        }
+
+        KeyValueDataSource.validateDbKind(targetDbKind, targetDbDir, true);
+
+        String nodeIdFilePath = "/" + NODE_ID_FILE;
+
+        if (new File(sourceDbDir, NODE_ID_FILE).exists()) {
+            Files.move(Paths.get(sourceDbDir + nodeIdFilePath), Paths.get(targetDbDir + nodeIdFilePath));
+        }
+
+        FileUtil.recursiveDelete(sourceDbDir);
+
+        Files.move(Paths.get(targetDbDir), Paths.get(sourceDbDir));
+    }
+
+    private DbMigrationInformation buildDbMigrationInformation(
+            String sourceDbDir,
+            String targetDbDir,
+            DbKind sourceDbKind,
+            DbKind targetDbKind,
+            String dbName
+    ) {
+        logger.info("Preparing data sources for db: {}", dbName);
+
+        KeyValueDataSource sourceDataSource = KeyValueDataSource.makeDataSource(Paths.get(sourceDbDir, dbName), sourceDbKind);
+        KeyValueDataSource targetDataSource = KeyValueDataSource.makeDataSource(Paths.get(targetDbDir, dbName), targetDbKind);
+
+        logger.info("Data sources prepared successfully");
+        logger.info("Preparing indexes for db: {}", dbName);
+
+        String sourceIndexPath = getIndexDbPath(sourceDbDir, dbName);
+        String targetIndexPath = getIndexDbPath(targetDbDir, dbName);
+
+        logger.info("Indexes prepared successfully");
+        logger.info("Preparing target and source db information...");
+
+        DbInformation sourceDbInformation = new DbInformation(
+                sourceDataSource,
+                sourceIndexPath
+        );
+        DbInformation targetDbInformation = new DbInformation(
+                targetDataSource,
+                targetIndexPath
+        );
+
+        return new DbMigrationInformation(targetDbInformation, sourceDbInformation);
+    }
+
+    private String getIndexDbPath(String databaseDir, String dbName) {
+        return databaseDir + "/" + dbName + "/index";
+    }
+
+    private void migrate(DbMigrationInformation dbMigrationInformation) {
+        KeyValueDataSource sourceKeyValueDataSource = dbMigrationInformation.getSourceDbInformation().getKeyValueDataSource();
+        KeyValueDataSource targetKeyValueDataSource = dbMigrationInformation.getTargetDbInformation().getKeyValueDataSource();
+
+        logger.info("Migrating data source: {}", sourceKeyValueDataSource.getName());
+
+        sourceKeyValueDataSource.keys().forEach(sourceKey ->
+                targetKeyValueDataSource.put(
+                        sourceKey.getData(),
+                        sourceKeyValueDataSource.get(sourceKey.getData())
+                )
+        );
+
+        sourceKeyValueDataSource.close();
+        targetKeyValueDataSource.close();
+
+        logger.info("{} data source migrated successfully", sourceKeyValueDataSource.getName());
+        logger.info("Migrating index for data source: {}", sourceKeyValueDataSource.getName());
+
+        String sourceIndexPath = dbMigrationInformation.getSourceDbInformation().getIndexPath();
+        String targetIndexPath = dbMigrationInformation.getTargetDbInformation().getIndexPath();
+        File sourceIndexFile = new File(sourceIndexPath);
+
+        if (sourceIndexFile.exists() && sourceIndexFile.isFile()) {
+            try {
+                Files.move(Paths.get(sourceIndexPath), Paths.get(targetIndexPath));
+
+                logger.info("Indexes for {} were migrated successfully", sourceKeyValueDataSource.getName());
+            } catch (IOException e) {
+                logger.error("An error happened while migrating indexes", e);
+            }
+        } else {
+            logger.info("No indexes found for {}", sourceKeyValueDataSource.getName());
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -98,6 +98,10 @@ public class DbMigrate extends CliToolRskContextAware {
     protected void onExecute(@Nonnull String[] args, @Nonnull RskContext ctx) throws IOException {
         logger.info("Starting db migration...");
 
+        if (args.length == 0) {
+            throw new IllegalArgumentException("Db to migrate not specified. Please specify in the first argument.");
+        }
+
         DbKind sourceDbKind = ctx.getRskSystemProperties().databaseKind();
         DbKind targetDbKind = DbKind.ofName(args[0]);
 
@@ -203,6 +207,7 @@ public class DbMigrate extends CliToolRskContextAware {
                 logger.info("Indexes for {} were migrated successfully", sourceKeyValueDataSource.getName());
             } catch (IOException e) {
                 logger.error("An error happened while migrating indexes", e);
+                throw new RuntimeException(e);
             }
         } else {
             logger.info("No indexes found for {}", sourceKeyValueDataSource.getName());

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
@@ -151,7 +151,7 @@ public interface KeyValueDataSource extends DataSource {
             if (databaseReset) {
                 KeyValueDataSource.generatedDbKindFile(currentDbKind, databaseDir);
             } else {
-                LoggerFactory.getLogger("KeyValueDataSource").warn("Use the flag --reset when running the application if you are using a different datasource.");
+                LoggerFactory.getLogger("KeyValueDataSource").warn("Use the flag --reset when running the application if you are using a different datasource. Also you can use the cli tool DbMigrate, in order to migrate data between databases.");
                 throw new IllegalStateException("DbKind mismatch. You have selected " + currentDbKind.name() + " when the previous detected DbKind was " + prevDbKind.name() + ".");
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Created a tool that allows the user to migrate between databases: `rocksdb and leveldb`

Tool class is: `co.rsk.cli.tools.DbMigrate`

Required cli args:
* args[0] - database target where we are going to insert the information from the current selected database.

Be aware that you cannot migrate to the same database, an error will be thrown.

It is highly recommended to turn off the node in order to perform the migration since latest data could be lost.

Example:
```
java -cp rsk-core-<VERSION>.jar co.rsk.cli.tools.DbMigrate rocksdb
```

## Motivation and Context
When we want to use rocks db we need to reset the database and do a full sync. We wanted a way of just migrating what we have downloaded

## How Has This Been Tested?
* Unit tests
* Migrating data between databases using boton.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
