### PR TITLE
Adding new Response Headers

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/Web3ResultHttpResponseHandler.java
@@ -18,6 +18,7 @@
 package co.rsk.rpc.netty;
 
 import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -25,8 +26,9 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaders.Names.*;
 import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_JSON;
+import static io.netty.handler.codec.http.HttpHeaders.Values.CLOSE;
 
 public class Web3ResultHttpResponseHandler extends SimpleChannelInboundHandler<Web3Result> {
 
@@ -38,13 +40,17 @@ public class Web3ResultHttpResponseHandler extends SimpleChannelInboundHandler<W
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, Web3Result msg) {
+        ByteBuf content = msg.getContent();
+
         DefaultFullHttpResponse response = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1,
                 HttpResponseStatus.valueOf(httpStatusCodeProvider.getHttpStatusCode(msg.getCode())),
-                msg.getContent()
+                content
         );
 
         response.headers().add(CONTENT_TYPE, APPLICATION_JSON);
+        response.headers().add(CONTENT_LENGTH, content.readableBytes());
+        response.headers().add(CONNECTION, CLOSE);
 
         ctx.write(response).addListener(ChannelFutureListener.CLOSE);
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/netty/Web3HttpServerTest.java
@@ -21,6 +21,7 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 
 public class Web3HttpServerTest {
@@ -100,9 +101,13 @@ public class Web3HttpServerTest {
         server.start();
         try {
             Response response = sendJsonRpcMessage(randomPort, contentType, host);
-            JsonNode jsonRpcResponse = OBJECT_MAPPER.readTree(response.body().string());
+            String responseBody = response.body().string();
+            JsonNode jsonRpcResponse = OBJECT_MAPPER.readTree(responseBody);
 
             assertThat(response.code(), is(HttpResponseStatus.OK.code()));
+            assertThat(response.header("Content-Length"), is(notNullValue()));
+            assertThat(Integer.parseInt(response.header("Content-Length")), is(responseBody.getBytes().length));
+            assertThat(response.header("Connection"), is("close"));
             assertThat(jsonRpcResponse.at("/result").asText(), is(mockResult));
         } finally {
             server.stop();
@@ -125,7 +130,7 @@ public class Web3HttpServerTest {
         URL url = new URL("http", "localhost", port, "/");
         Request request = new Request.Builder().url(url)
                 .addHeader("Host", host)
-//                .addHeader("Accept-Encoding", "identity")
+                .addHeader("Accept-Encoding", "identity")
                 .post(requestBody).build();
         return getUnsafeOkHttpClient().newCall(request).execute();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding `Content-Length` and `Connection` headers to `JSON-RPC` responses.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`Content-Length` and `Connection` headers should be included in all JSON-RPC responses to increase compatibility with some clients.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Unit Tests
- Integration Tests
- Local Tests
- QA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


*fed:HOP-4.1.0-rc*
*fit:HOP-4.1.0-rc*
*ci:rskj-410-rc-ver*