### PR TITLE
Added option to set signature fields to 0x0 for Remasc on RPC response

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -146,7 +146,7 @@ public class RskSystemProperties extends SystemProperties {
     public boolean updateWorkOnNewTransaction() {
         return getBoolean("miner.server.updateWorkOnNewTransaction", false);
     }
-    
+
     public long minerMinGasPrice() {
         return configFromFiles.getLong("miner.minGasPrice");
     }
@@ -413,5 +413,9 @@ public class RskSystemProperties extends SystemProperties {
 
     public Integer getMessageQueueMaxSize() {
         return configFromFiles.getInt("peer.messageQueue.maxSizePerPeer");
+    }
+
+    public boolean rpcZeroSignatureIfRemasc() {
+        return configFromFiles.getBoolean("rpc.zeroSignatureIfRemasc");
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -637,7 +637,7 @@ public class Web3Impl implements Web3 {
     }
 
     public BlockResultDTO getBlockResult(Block b, boolean fullTx) {
-        return BlockResultDTO.fromBlock(b, fullTx, this.blockStore, config.skipRemasc());
+        return BlockResultDTO.fromBlock(b, fullTx, this.blockStore, config.skipRemasc(), config.rpcZeroSignatureIfRemasc());
     }
 
     public BlockInformationResult[] eth_getBlocksByNumber(String number) {
@@ -705,7 +705,7 @@ public class Web3Impl implements Web3 {
 
                 for (Transaction tx : txs) {
                     if (tx.getHash().equals(txHash)) {
-                        return s = new TransactionResultDTO(null, null, tx);
+                        return s = new TransactionResultDTO(null, null, tx, config.rpcZeroSignatureIfRemasc());
                     }
                 }
             } else {
@@ -722,7 +722,7 @@ public class Web3Impl implements Web3 {
                 return null;
             }
 
-            return s = new TransactionResultDTO(block, txInfo.getIndex(), txInfo.getReceipt().getTransaction());
+            return s = new TransactionResultDTO(block, txInfo.getIndex(), txInfo.getReceipt().getTransaction(), config.rpcZeroSignatureIfRemasc());
         } finally {
             logger.debug("eth_getTransactionByHash({}): {}", transactionHash, s);
         }
@@ -746,7 +746,7 @@ public class Web3Impl implements Web3 {
 
             Transaction tx = b.getTransactionsList().get(idx);
 
-            return s = new TransactionResultDTO(b, idx, tx);
+            return s = new TransactionResultDTO(b, idx, tx, config.rpcZeroSignatureIfRemasc());
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug("eth_getTransactionByBlockHashAndIndex({}, {}): {}", blockHash, index, s);
@@ -769,7 +769,7 @@ public class Web3Impl implements Web3 {
                 return null;
             }
 
-            s = new TransactionResultDTO(block.get(), idx, txs.get(idx));
+            s = new TransactionResultDTO(block.get(), idx, txs.get(idx), config.rpcZeroSignatureIfRemasc());
             return s;
         } finally {
             if (logger.isDebugEnabled()) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -18,18 +18,19 @@
 
 package org.ethereum.rpc.dto;
 
-import org.ethereum.core.Block;
-import org.ethereum.core.Transaction;
-import org.ethereum.crypto.signature.ECDSASignature;
-
 import co.rsk.core.Coin;
 import co.rsk.remasc.RemascTransaction;
 import co.rsk.util.HexUtils;
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.signature.ECDSASignature;
 
 /**
  * Created by Ruben on 8/1/2016.
  */
 public class TransactionResultDTO {
+
+    private static final String HEX_ZERO = "0x0";
 
     private String hash;
     private String nonce;
@@ -46,7 +47,7 @@ public class TransactionResultDTO {
     private String r;
     private String s;
 
-    public TransactionResultDTO(Block b, Integer index, Transaction tx) {
+    public TransactionResultDTO(Block b, Integer index, Transaction tx, boolean zeroSignatureIfRemasc) {
         hash = tx.getHash().toJsonString();
 
         nonce = HexUtils.toQuantityJsonHex(tx.getNonce());
@@ -69,13 +70,18 @@ public class TransactionResultDTO {
 
         input = HexUtils.toUnformattedJsonHex(tx.getData());
 
-        if (!(tx instanceof RemascTransaction)) {
+        boolean isRemasc = tx instanceof RemascTransaction;
+        if (!isRemasc) {
             ECDSASignature signature = tx.getSignature();
 
             v = String.format("0x%02x", tx.getEncodedV());
 
             r = HexUtils.toQuantityJsonHex(signature.getR());
             s = HexUtils.toQuantityJsonHex(signature.getS());
+        } else if (zeroSignatureIfRemasc) {
+            v = HEX_ZERO;
+            r = HEX_ZERO;
+            s = HEX_ZERO;
         }
     }
 

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -260,6 +260,7 @@ rpc = {
         }
     ]
     skipRemasc: <enabled>
+    zeroSignatureIfRemasc = <enabled>
     gasEstimationCap = <gas>
 }
 wire = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -159,8 +159,8 @@ miner {
         # the number of milliseconds that should pass from a previous submission of a mining solution before next one is allowed
         # set this value to zero or any negative number to disable this limit
         workSubmissionRateLimitInMills = 0
-        
-        # Toggles the behaviour of the miner server to prepare a new work for the miners when the node gets a new pending transaction 
+
+        # Toggles the behaviour of the miner server to prepare a new work for the miners when the node gets a new pending transaction
         updateWorkOnNewTransaction = false
     }
 
@@ -413,6 +413,8 @@ rpc {
          }
     ]
     skipRemasc: false
+    # set signature to zero (instead of null) for Remasc transaction on RPC DTOs
+    zeroSignatureIfRemasc = true
     gasEstimationCap = 6800000 # block gasLimit, rpc DoS protection for gas estimation
 }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
@@ -31,10 +31,13 @@ import java.util.Random;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 public class TransactionResultDTOTest {
+
+    private static final String HEX_ZERO = "0x0";
+
     private final TestSystemProperties config = new TestSystemProperties();
     private final byte chainId = config.getNetworkConstants().getChainId();
 
@@ -42,7 +45,7 @@ public class TransactionResultDTOTest {
     public void remascAddressSerialization() {
         RemascTransaction remascTransaction = new RemascTransaction(new Random().nextLong());
 
-        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, remascTransaction);
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, remascTransaction, false);
         assertThat(dto.getFrom(), is("0x0000000000000000000000000000000000000000"));
         assertThat(dto.getR(), is(nullValue()));
         assertThat(dto.getS(), is(nullValue()));
@@ -58,7 +61,7 @@ public class TransactionResultDTOTest {
 
         originalTransaction.sign(new byte[]{});
 
-        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction);
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction, false);
 
         Assert.assertNotNull(dto.getR());
         Assert.assertNotNull(dto.getS());
@@ -78,7 +81,7 @@ public class TransactionResultDTOTest {
 
         originalTransaction.sign(new byte[]{});
 
-        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction);
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction, false);
 
         Assert.assertNotNull(dto.getNonce());
         Assert.assertEquals("0x0", dto.getNonce());
@@ -93,10 +96,28 @@ public class TransactionResultDTOTest {
 
         originalTransaction.sign(new byte[]{});
 
-        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction);
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction, false);
 
         Assert.assertNotNull(dto.getNonce());
         Assert.assertEquals("0x1", dto.getNonce());
+    }
+
+    @Test
+    public void transactionRemascHasSignatureNullWhenFlagIsFalse() {
+        RemascTransaction remascTransaction = new RemascTransaction(new Random().nextLong());
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, remascTransaction, false);
+        assertNull(dto.getV());
+        assertNull(dto.getR());
+        assertNull(dto.getS());
+    }
+
+    @Test
+    public void transactionRemascHasSignatureZeroWhenFlagIsTrue() {
+        RemascTransaction remascTransaction = new RemascTransaction(new Random().nextLong());
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, remascTransaction, true);
+        assertEquals(HEX_ZERO, dto.getV());
+        assertEquals(HEX_ZERO, dto.getR());
+        assertEquals(HEX_ZERO, dto.getS());
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added flag to conditionally return `0x0` for signature fields of Remasc Transaction

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Unit tests
- Running Hardhat _Mainnet Forking_ test pointing to a Boton instance with this fix + content-header fix
- Postman RPC calls to affected methods with both flag `true` and `false`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
