### PR TITLE
Flush databases by RPC

### DIFF
--- a/rskj-core/src/main/java/co/rsk/Flusher.java
+++ b/rskj-core/src/main/java/co/rsk/Flusher.java
@@ -1,0 +1,5 @@
+package co.rsk;
+
+public interface Flusher {
+    void forceFlush();
+}

--- a/rskj-core/src/main/java/co/rsk/Flusher.java
+++ b/rskj-core/src/main/java/co/rsk/Flusher.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2022 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package co.rsk;
 
 public interface Flusher {

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -875,15 +875,19 @@ public class RskContext implements NodeContext, NodeBootstrapper {
     }
 
     public synchronized BlockChainFlusher getBlockChainFlusher() {
-        if (this.blockChainFlusher==null)
-        this.blockChainFlusher = new BlockChainFlusher(
-                getRskSystemProperties().flushNumberOfBlocks(),
-                getCompositeEthereumListener(),
-                getTrieStore(),
-                getBlockStore(),
-                getReceiptStore(),
-                getBlocksBloomStore(),
-                getStateRootsStore());
+        checkIfNotClosed();
+
+        if (this.blockChainFlusher == null) {
+            this.blockChainFlusher = new BlockChainFlusher(
+                    getRskSystemProperties().flushNumberOfBlocks(),
+                    getCompositeEthereumListener(),
+                    getTrieStore(),
+                    getBlockStore(),
+                    getReceiptStore(),
+                    getBlocksBloomStore(),
+                    getStateRootsStore());
+        }
+
         return blockChainFlusher;
     }
 

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -868,7 +868,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                     getBlockStore(),
                     getReceiptStore(),
                     getWeb3InformationRetriever(),
-                    getFlusher());
+                    getBlockChainFlusher());
         }
 
         return rskModule;
@@ -889,10 +889,6 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         }
 
         return blockChainFlusher;
-    }
-
-    public Flusher getFlusher() {
-        return getBlockChainFlusher();
     }
 
     public synchronized NetworkStateExporter getNetworkStateExporter() {

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainFlusher.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainFlusher.java
@@ -87,8 +87,9 @@ public class BlockChainFlusher implements InternalService, Flusher {
 
     public synchronized void forceFlush() {
         flushAll();
-        nFlush =1; // postpone
+        nFlush = 1; // postpone
     }
+
     private synchronized void flush() {
         if (nFlush == 0) {
             flushAll();

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockChainFlusher.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockChainFlusher.java
@@ -17,6 +17,7 @@
  */
 package co.rsk.core.bc;
 
+import co.rsk.Flusher;
 import co.rsk.config.InternalService;
 import co.rsk.db.StateRootsStore;
 import co.rsk.logfilter.BlocksBloomStore;
@@ -39,7 +40,7 @@ import java.util.List;
 /**
  * Flushes the repository and block store after every flushNumberOfBlocks invocations
  */
-public class BlockChainFlusher implements InternalService {
+public class BlockChainFlusher implements InternalService, Flusher {
     private static final Logger logger = LoggerFactory.getLogger(BlockChainFlusher.class);
 
     private static final Profiler profiler = ProfilerFactory.getInstance();
@@ -84,6 +85,10 @@ public class BlockChainFlusher implements InternalService {
         flushAll();
     }
 
+    public synchronized void forceFlush() {
+        flushAll();
+        nFlush =1; // postpone
+    }
     private synchronized void flush() {
         if (nFlush == 0) {
             flushAll();

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
@@ -26,10 +26,6 @@ public interface Web3RskModule {
         return getRskModule().getRawTransactionReceiptByHash(transactionHash);
     }
 
-    default void rsk_flush() {
-        getRskModule().flush();
-    }
-
     default String[] rsk_getTransactionReceiptNodesByHash(String blockHash, String transactionHash) {
         return getRskModule().getTransactionReceiptNodesByHash(blockHash, transactionHash);
     }
@@ -44,6 +40,10 @@ public interface Web3RskModule {
 
     default void rsk_shutdown() {
         getRskModule().shutdown();
+    }
+
+    default void rsk_flush() {
+        getRskModule().flush();
     }
 
     RskModule getRskModule();

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
@@ -26,6 +26,11 @@ public interface Web3RskModule {
         return getRskModule().getRawTransactionReceiptByHash(transactionHash);
     }
 
+    default String rsk_flush()  {
+        getRskModule().flush();
+        return "";
+    }
+
     default String[] rsk_getTransactionReceiptNodesByHash(String blockHash, String transactionHash) {
         return getRskModule().getTransactionReceiptNodesByHash(blockHash, transactionHash);
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
@@ -22,13 +22,12 @@ import co.rsk.rpc.modules.rsk.RskModule;
 
 public interface Web3RskModule {
 
-    default String rsk_getRawTransactionReceiptByHash(String transactionHash)  {
+    default String rsk_getRawTransactionReceiptByHash(String transactionHash) {
         return getRskModule().getRawTransactionReceiptByHash(transactionHash);
     }
 
-    default String rsk_flush()  {
+    default void rsk_flush() {
         getRskModule().flush();
-        return "";
     }
 
     default String[] rsk_getTransactionReceiptNodesByHash(String blockHash, String transactionHash) {

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModule.java
@@ -29,4 +29,7 @@ public interface RskModule {
     String getRawBlockHeaderByNumber(String bnOrId);
 
     void shutdown();
+
+    void flush();
+
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModuleImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModuleImpl.java
@@ -59,10 +59,6 @@ public class RskModuleImpl implements RskModule {
 
     @Override
     public void flush() {
-        if (flusher == null) {
-            return;
-        }
-
         flusher.forceFlush();
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModuleImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModuleImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 import co.rsk.util.NodeStopper;
+import co.rsk.Flusher;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Transaction;
@@ -30,6 +31,7 @@ public class RskModuleImpl implements RskModule {
     private final BlockStore blockStore;
     private final ReceiptStore receiptStore;
     private final Web3InformationRetriever web3InformationRetriever;
+    private final Flusher flusher;
 
     private final NodeStopper nodeStopper;
 
@@ -37,19 +39,30 @@ public class RskModuleImpl implements RskModule {
                          BlockStore blockStore,
                          ReceiptStore receiptStore,
                          Web3InformationRetriever web3InformationRetriever,
+                         Flusher flusher,
                          NodeStopper nodeStopper) {
         this.blockchain = blockchain;
         this.blockStore = blockStore;
         this.receiptStore = receiptStore;
         this.web3InformationRetriever = web3InformationRetriever;
+        this.flusher = flusher;
         this.nodeStopper = nodeStopper;
     }
 
     public RskModuleImpl(Blockchain blockchain,
                          BlockStore blockStore,
                          ReceiptStore receiptStore,
-                         Web3InformationRetriever web3InformationRetriever) {
-        this(blockchain, blockStore, receiptStore, web3InformationRetriever, System::exit);
+                         Web3InformationRetriever web3InformationRetriever,
+                         Flusher flusher) {
+        this(blockchain, blockStore, receiptStore, web3InformationRetriever, flusher, System::exit);
+    }
+
+    @Override
+    public void flush() {
+        if (flusher==null)
+            return;
+        flusher.forceFlush();
+
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModuleImpl.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/rsk/RskModuleImpl.java
@@ -59,10 +59,11 @@ public class RskModuleImpl implements RskModule {
 
     @Override
     public void flush() {
-        if (flusher==null)
+        if (flusher == null) {
             return;
-        flusher.forceFlush();
+        }
 
+        flusher.forceFlush();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -253,6 +253,7 @@ public class DataSourceWithCache implements KeyValueDataSource {
             if (logger.isTraceEnabled()) {
                 logger.trace("datasource flush: [{}]seconds", FormatUtils.formatNanosecondsToSeconds(totalTime));
             }
+            base.flush();
         } finally {
             this.lock.writeLock().unlock();
         }

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -418,7 +418,7 @@ rpc {
             version: "1.0",
             enabled: "true",
             methods: {
-                disabled: [ "rsk_shutdown" ]
+                disabled: [ "rsk_shutdown", "rsk_flush" ]
             }
         }
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockChainFlusherTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockChainFlusherTest.java
@@ -90,4 +90,15 @@ class BlockChainFlusherTest {
         verify(blocksBloomStore).flush();
         verify(stateRootsStore).flush();
     }
+
+    @Test
+    public void forceFlush_WhenForced_ShouldFlush() {
+        flusher.forceFlush();
+
+        verify(trieStore).flush();
+        verify(blockStore).flush();
+        verify(receiptStore).flush();
+        verify(blocksBloomStore).flush();
+        verify(stateRootsStore).flush();
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -18,6 +18,7 @@
 
 package org.ethereum.rpc;
 
+import co.rsk.Flusher;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.*;
@@ -1164,6 +1165,20 @@ class Web3ImplTest {
 
         String hexString = web3.rsk_getRawBlockHeaderByNumber(bnOrId);
         Assertions.assertNull(hexString);
+    }
+
+    @Test
+    void flush() {
+        Flusher flusher = mock(Flusher.class);
+
+        Web3Impl web3 = createWeb3(
+                Web3Mocks.getMockEthereum(), Web3Mocks.getMockBlockchain(), Web3Mocks.getMockRepositoryLocator(), Web3Mocks.getMockTransactionPool(),
+                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache, flusher, Web3Mocks.getMockNodeStopper()
+        );
+
+        web3.rsk_flush();
+
+        verify(flusher, times(1)).forceFlush();
     }
 
     @Test
@@ -2381,21 +2396,21 @@ class Web3ImplTest {
     private Web3Impl createWeb3() {
         return createWeb3(
                 Web3Mocks.getMockEthereum(), Web3Mocks.getMockBlockchain(), Web3Mocks.getMockRepositoryLocator(), Web3Mocks.getMockTransactionPool(),
-                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache, Web3Mocks.getMockNodeStopper()
+                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache, Web3Mocks.getMockFlusher(), Web3Mocks.getMockNodeStopper()
         );
     }
 
     private Web3Impl createWeb3WithStopper(NodeStopper stopper) {
         return createWeb3(
                 Web3Mocks.getMockEthereum(), Web3Mocks.getMockBlockchain(), Web3Mocks.getMockRepositoryLocator(), Web3Mocks.getMockTransactionPool(),
-                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache, stopper
+                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache, Web3Mocks.getMockFlusher(), stopper
         );
     }
 
     private Web3Impl createWeb3(Ethereum ethereum) {
         return createWeb3(
                 ethereum, Web3Mocks.getMockBlockchain(), Web3Mocks.getMockRepositoryLocator(), Web3Mocks.getMockTransactionPool(),
-                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache, Web3Mocks.getMockNodeStopper()
+                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache, Web3Mocks.getMockFlusher(), Web3Mocks.getMockNodeStopper()
         );
     }
 
@@ -2492,7 +2507,7 @@ class Web3ImplTest {
         RepositoryLocator repositoryLocator = world.getRepositoryLocator();
         return createWeb3(
                 eth, world.getBlockChain(), repositoryLocator, transactionPool, world.getBlockStore(),
-                null, new SimpleConfigCapabilities(), receiptStore, signatureCache, Web3Mocks.getMockNodeStopper()
+                null, new SimpleConfigCapabilities(), receiptStore, signatureCache, Web3Mocks.getMockFlusher(), Web3Mocks.getMockNodeStopper()
         );
     }
 
@@ -2516,6 +2531,7 @@ class Web3ImplTest {
                 blockStore, blockProcessor,
                 new SimpleConfigCapabilities(), receiptStore,
                 signatureCache,
+                Web3Mocks.getMockFlusher(),
                 Web3Mocks.getMockNodeStopper()
         );
     }
@@ -2530,6 +2546,7 @@ class Web3ImplTest {
             ConfigCapabilities configCapabilities,
             ReceiptStore receiptStore,
             SignatureCache signatureCache,
+            Flusher flusher,
             NodeStopper nodeStopper) {
         ExecutionBlockRetriever executionBlockRetriever = mock(ExecutionBlockRetriever.class);
         wallet = WalletFactory.createWallet();
@@ -2553,7 +2570,7 @@ class Web3ImplTest {
         );
         TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool, signatureCache);
         DebugModule debugModule = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null, null);
-        RskModule rskModule = new RskModuleImpl(blockchain, blockStore, receiptStore, retriever,null, nodeStopper);
+        RskModule rskModule = new RskModuleImpl(blockchain, blockStore, receiptStore, retriever, flusher, nodeStopper);
         MinerClient minerClient = new SimpleMinerClient();
         ChannelManager channelManager = new SimpleChannelManager();
         return new Web3RskImpl(
@@ -2616,7 +2633,7 @@ class Web3ImplTest {
                 config.getCallGasCap());
         TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool, signatureCache);
         DebugModule debugModule = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null, null);
-        RskModule rskModule = new RskModuleImpl(blockchain, blockStore, receiptStore, retriever,null);
+        RskModule rskModule = new RskModuleImpl(blockchain, blockStore, receiptStore, retriever, mock(Flusher.class));
         MinerClient minerClient = new SimpleMinerClient();
         ChannelManager channelManager = new SimpleChannelManager();
         return new Web3RskImpl(

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -2553,7 +2553,7 @@ class Web3ImplTest {
         );
         TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool, signatureCache);
         DebugModule debugModule = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null, null);
-        RskModule rskModule = new RskModuleImpl(blockchain, blockStore, receiptStore, retriever, nodeStopper);
+        RskModule rskModule = new RskModuleImpl(blockchain, blockStore, receiptStore, retriever,null, nodeStopper);
         MinerClient minerClient = new SimpleMinerClient();
         ChannelManager channelManager = new SimpleChannelManager();
         return new Web3RskImpl(
@@ -2616,7 +2616,7 @@ class Web3ImplTest {
                 config.getCallGasCap());
         TxPoolModule txPoolModule = new TxPoolModuleImpl(transactionPool, signatureCache);
         DebugModule debugModule = new DebugModuleImpl(null, null, Web3Mocks.getMockMessageHandler(), null, null);
-        RskModule rskModule = new RskModuleImpl(blockchain, blockStore, receiptStore, retriever);
+        RskModule rskModule = new RskModuleImpl(blockchain, blockStore, receiptStore, retriever,null);
         MinerClient minerClient = new SimpleMinerClient();
         ChannelManager channelManager = new SimpleChannelManager();
         return new Web3RskImpl(

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3Mocks.java
@@ -18,6 +18,7 @@
 
 package org.ethereum.rpc;
 
+import co.rsk.Flusher;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.bc.BlockExecutor;
 import co.rsk.db.RepositoryLocator;
@@ -88,5 +89,9 @@ public class Web3Mocks {
 
     public static NodeStopper getMockNodeStopper() {
         return mock(NodeStopper.class);
+    }
+
+    public static Flusher getMockFlusher() {
+        return mock(Flusher.class);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR enables a new RPC method ("rsk_flush") that flushes all state databases to disk.
## Description
<!--- Describe your changes in detail -->
We add a new RPC command which calls the BlockChainFlusher class.
We also fix the flush method of DataSourceWithCache that previously didn't flushed the database (which wasn't a problem before because the databases used so far perform automatic flushing)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are several reasons it is useful to make sure the state of the node databases have been written to disk without interrupting the node:
* If one suspects that power will soon fail
* For fair comparisons between databases (RocksDB vs LevelDB) is it important to assure both have committed all changes to disk
* To safely backup the databases without interrupting the node
* To access the databases in realtime from another application without interrupting the node.
* To accurately compute the current size of the databases without interrupting the node.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
By executing the rsk_flush RPC command by hand and following all the flush code flow in the debugger, and also by checking the state of the database.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


**Other information**:
There is no documentation for RPC commands in the code, so no documentation was added to the code.

If merged, I will contact the developer's site maintainer to update the corresponding page. 