### PR TITLE
Refactor KeyValueDataSource interface

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -97,10 +97,7 @@ import org.ethereum.core.genesis.GenesisLoader;
 import org.ethereum.core.genesis.GenesisLoaderImpl;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.signature.Secp256k1;
-import org.ethereum.datasource.CacheSnapshotHandler;
-import org.ethereum.datasource.DataSourceWithCache;
-import org.ethereum.datasource.DbKind;
-import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.*;
 import org.ethereum.db.IndexedBlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.db.ReceiptStoreImplV2;
@@ -320,7 +317,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 FileUtil.recursiveDelete(rskSystemProperties.databaseDir());
             }
 
-            KeyValueDataSource.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
+            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             if (rskSystemProperties.importEnabled()) {
                 getBootstrapImporter().importData();
@@ -1149,7 +1146,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 .make();
 
         DbKind currentDbKind = getRskSystemProperties().databaseKind();
-        KeyValueDataSource blocksDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "blocks"), currentDbKind);
+        KeyValueDataSource blocksDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "blocks"), currentDbKind);
 
         return new IndexedBlockStore(getBlockFactory(), blocksDB, new MapDBBlocksIndex(indexDB));
     }
@@ -1248,7 +1245,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         int bloomsCacheSize = getRskSystemProperties().getBloomsCacheSize();
         Path bloomsStorePath = Paths.get(getRskSystemProperties().databaseDir(), "blooms");
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(bloomsStorePath, getRskSystemProperties().databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(bloomsStorePath, getRskSystemProperties().databaseKind());
 
         if (bloomsCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = getRskSystemProperties().shouldPersistBloomsCacheSnapshot()
@@ -1329,7 +1326,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int receiptsCacheSize = rskSystemProperties.getReceiptsCacheSize();
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "receipts"), rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "receipts"), rskSystemProperties.databaseKind());
 
         if (receiptsCacheSize != 0) {
             ds = new DataSourceWithCache(ds, receiptsCacheSize);
@@ -1370,7 +1367,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int statesCacheSize = rskSystemProperties.getStatesCacheSize();
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(trieStorePath, rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, rskSystemProperties.databaseKind());
 
         if (statesCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = rskSystemProperties.shouldPersistStatesCacheSnapshot()
@@ -1399,7 +1396,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int stateRootsCacheSize = rskSystemProperties.getStateRootsCacheSize();
-        KeyValueDataSource stateRootsDB = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "stateRoots"), rskSystemProperties.databaseKind());
+        KeyValueDataSource stateRootsDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "stateRoots"), rskSystemProperties.databaseKind());
 
         if (stateRootsCacheSize > 0) {
             stateRootsDB = new DataSourceWithCache(stateRootsDB, stateRootsCacheSize);
@@ -1451,7 +1448,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             return null;
         }
 
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "wallet"), rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "wallet"), rskSystemProperties.databaseKind());
 
         return new Wallet(ds);
     }
@@ -1491,7 +1488,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
                 boolean gcWasEnabled = !multiTrieStorePaths.isEmpty();
                 if (gcWasEnabled) {
-                    KeyValueDataSource.mergeDataSources(trieStorePath, multiTrieStorePaths, rskSystemProperties.databaseKind());
+                    KeyValueDataSourceUtils.mergeDataSources(trieStorePath, multiTrieStorePaths, rskSystemProperties.databaseKind());
                     // cleanup MultiTrieStore data sources
                     multiTrieStorePaths.stream()
                             .map(Path::toString)

--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -22,6 +22,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.util.Factory;
 import co.rsk.util.NodeStopper;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +89,7 @@ public abstract class CliToolRskContextAware {
 
             RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
 
-            KeyValueDataSource.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
+            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             onExecute(args, ctx);
 

--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -21,7 +21,6 @@ import co.rsk.RskContext;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.util.Factory;
 import co.rsk.util.NodeStopper;
-import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.KeyValueDataSourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -21,6 +21,7 @@ import co.rsk.cli.PicoCliToolRskContextAware;
 import org.ethereum.datasource.DataSourceKeyIterator;
 import org.ethereum.datasource.DbKind;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 import org.ethereum.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,7 +132,7 @@ public class DbMigrate extends PicoCliToolRskContextAware {
                     .forEach(this::migrate);
         }
 
-        KeyValueDataSource.validateDbKind(targetDbKind, targetDbDir, true);
+        KeyValueDataSourceUtils.validateDbKind(targetDbKind, targetDbDir, true);
 
         String nodeIdFilePath = "/" + NODE_ID_FILE;
 
@@ -155,8 +156,8 @@ public class DbMigrate extends PicoCliToolRskContextAware {
     ) {
         logger.info("Preparing data sources for db: {}", dbName);
 
-        KeyValueDataSource sourceDataSource = KeyValueDataSource.makeDataSource(Paths.get(sourceDbDir, dbName), sourceDbKind);
-        KeyValueDataSource targetDataSource = KeyValueDataSource.makeDataSource(Paths.get(targetDbDir, dbName), targetDbKind);
+        KeyValueDataSource sourceDataSource = KeyValueDataSourceUtils.makeDataSource(Paths.get(sourceDbDir, dbName), sourceDbKind);
+        KeyValueDataSource targetDataSource = KeyValueDataSourceUtils.makeDataSource(Paths.get(targetDbDir, dbName), targetDbKind);
 
         logger.info("Data sources prepared successfully");
         logger.info("Preparing indexes for db: {}", dbName);

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -24,6 +24,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.KeyValueDataSource;
 import picocli.CommandLine;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -53,7 +54,7 @@ public class ImportState extends PicoCliToolRskContextAware {
         RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
 
-        KeyValueDataSource trieDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
 
         try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
             importState(reader, trieDB);

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -71,6 +71,7 @@ public abstract class SystemProperties {
     public static final String PROPERTY_BC_CONFIG_NAME = PROPERTY_BLOCKCHAIN_CONFIG + ".name";
     public static final String PROPERTY_BC_VERIFY = PROPERTY_BLOCKCHAIN_CONFIG + ".verify";
     public static final String PROPERTY_GENESIS_CONSTANTS_FEDERATION_PUBLICKEYS = "genesis_constants.federationPublicKeys";
+    public static final String PROPERTY_KEYVALUE_DATASOURCE = "keyvalue.datasource";
     public static final String PROPERTY_PEER_PORT = "peer.port";
     public static final String PROPERTY_BASE_PATH = "database.dir";
     public static final String PROPERTY_DB_RESET = "database.reset";
@@ -726,7 +727,7 @@ public abstract class SystemProperties {
     }
 
     public DbKind databaseKind() {
-        return DbKind.ofName(configFromFiles.getString(KeyValueDataSource.KEYVALUE_DATASOURCE_PROP_NAME));
+        return DbKind.ofName(configFromFiles.getString(PROPERTY_KEYVALUE_DATASOURCE));
     }
 
     public long getCallGasCap() {

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -31,7 +31,6 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.DbKind;
-import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.net.p2p.P2pHandler;
 import org.ethereum.net.rlpx.MessageCodec;
 import org.ethereum.net.rlpx.Node;
@@ -65,7 +64,8 @@ import java.util.stream.Collectors;
  * @since 22.05.2014
  */
 public abstract class SystemProperties {
-    private static Logger logger = LoggerFactory.getLogger("general");
+
+    private static final Logger logger = LoggerFactory.getLogger("general");
 
     public static final String PROPERTY_BLOCKCHAIN_CONFIG = "blockchain.config";
     public static final String PROPERTY_BC_CONFIG_NAME = PROPERTY_BLOCKCHAIN_CONFIG + ".name";

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
@@ -20,21 +20,12 @@
 package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
-import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
 
 public interface KeyValueDataSource extends DataSource {
-    String DB_KIND_PROPERTIES_FILE = "dbKind.properties";
-    String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
-    String KEYVALUE_DATASOURCE = "KeyValueDataSource";
 
     @Nullable
     byte[] get(byte[] key);
@@ -58,8 +49,8 @@ public interface KeyValueDataSource extends DataSource {
      * others don't.
      * IMPORTANT: keysToRemove override entriesToUpdate
      *
-     * @param entriesToUpdate
-     * @param keysToRemove
+     * @param entriesToUpdate entries to update
+     * @param keysToRemove keys to remove
      */
     void updateBatch(Map<ByteArrayWrapper, byte[]> entriesToUpdate, Set<ByteArrayWrapper> keysToRemove);
 
@@ -68,101 +59,4 @@ public interface KeyValueDataSource extends DataSource {
      */
     void flush();
 
-    @Nonnull
-    static KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
-        String name = datasourcePath.getFileName().toString();
-        String databaseDir = datasourcePath.getParent().toString();
-
-        KeyValueDataSource ds;
-        switch (kind) {
-            case LEVEL_DB:
-                ds = new LevelDbDataSource(name, databaseDir);
-                break;
-            case ROCKS_DB:
-                ds = new RocksDbDataSource(name, databaseDir);
-                break;
-            default:
-                throw new IllegalArgumentException("kind");
-        }
-
-        ds.init();
-
-        return ds;
-    }
-
-    static void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
-        Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
-        for (Path originPath : originPaths) {
-            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
-            for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
-                mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
-            }
-            singleOriginDataSource.close();
-        }
-        KeyValueDataSource destinationDataSource = makeDataSource(destinationPath, kind);
-        destinationDataSource.updateBatch(mergedStores, Collections.emptySet());
-        destinationDataSource.close();
-    }
-
-    static DbKind getDbKindValueFromDbKindFile(String databaseDir) {
-        try {
-            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
-            Properties props = new Properties();
-
-            if (file.exists() && file.canRead()) {
-                try (FileReader reader = new FileReader(file)) {
-                    props.load(reader);
-                }
-
-                return DbKind.ofName(props.getProperty(KEYVALUE_DATASOURCE_PROP_NAME));
-            }
-
-            return DbKind.LEVEL_DB;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    static void generatedDbKindFile(DbKind dbKind, String databaseDir) {
-        try {
-            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
-            Properties props = new Properties();
-            props.setProperty(KEYVALUE_DATASOURCE_PROP_NAME, dbKind.name());
-            file.getParentFile().mkdirs();
-            try (FileWriter writer = new FileWriter(file)) {
-                props.store(writer, "Generated dbKind. In order to follow selected db.");
-
-                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).info("Generated dbKind.properties file.");
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    static void validateDbKind(DbKind currentDbKind, String databaseDir, boolean databaseReset) {
-        File dir = new File(databaseDir);
-
-        if (dir.exists() && !dir.isDirectory()) {
-            LoggerFactory.getLogger(KEYVALUE_DATASOURCE).error("database.dir should be a folder.");
-            throw new IllegalStateException("database.dir should be a folder");
-        }
-
-        boolean databaseDirExists = dir.exists() && dir.isDirectory();
-
-        if (!databaseDirExists || dir.list().length == 0) {
-            KeyValueDataSource.generatedDbKindFile(currentDbKind, databaseDir);
-            return;
-        }
-
-        DbKind prevDbKind = KeyValueDataSource.getDbKindValueFromDbKindFile(databaseDir);
-
-        if (prevDbKind != currentDbKind) {
-            if (databaseReset) {
-                KeyValueDataSource.generatedDbKindFile(currentDbKind, databaseDir);
-            } else {
-                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).warn("Use the flag --reset when running the application if you are using a different datasource. Also you can use the cli tool DbMigrate, in order to migrate data between databases.");
-                throw new IllegalStateException("DbKind mismatch. You have selected " + currentDbKind.name() + " when the previous detected DbKind was " + prevDbKind.name() + ".");
-            }
-        }
-    }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -19,7 +19,7 @@ public class KeyValueDataSourceUtils {
     private KeyValueDataSourceUtils() { /* hidden */ }
 
     @Nonnull
-    static public KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
+    public static KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
         String name = datasourcePath.getFileName().toString();
         String databaseDir = datasourcePath.getParent().toString();
 

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -16,6 +16,8 @@ public class KeyValueDataSourceUtils {
     public static final String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
     public static final String KEYVALUE_DATASOURCE = "KeyValueDataSource";
 
+    private KeyValueDataSourceUtils() { /* hidden */ }
+
     @Nonnull
     static public KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
         String name = datasourcePath.getFileName().toString();

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -1,0 +1,116 @@
+package org.ethereum.datasource;
+
+import org.ethereum.db.ByteArrayWrapper;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+
+public class KeyValueDataSourceUtils {
+    public static final String DB_KIND_PROPERTIES_FILE = "dbKind.properties";
+    public static final String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
+    public static final String KEYVALUE_DATASOURCE = "KeyValueDataSource";
+
+    @Nonnull
+    static public KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
+        String name = datasourcePath.getFileName().toString();
+        String databaseDir = datasourcePath.getParent().toString();
+
+        KeyValueDataSource ds;
+        switch (kind) {
+            case LEVEL_DB:
+                ds = new LevelDbDataSource(name, databaseDir);
+                break;
+            case ROCKS_DB:
+                ds = new RocksDbDataSource(name, databaseDir);
+                break;
+            default:
+                throw new IllegalArgumentException("kind");
+        }
+
+        ds.init();
+
+        return ds;
+    }
+
+    public static void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
+        Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
+        for (Path originPath : originPaths) {
+            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
+            for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
+                mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
+            }
+            singleOriginDataSource.close();
+        }
+        KeyValueDataSource destinationDataSource = makeDataSource(destinationPath, kind);
+        destinationDataSource.updateBatch(mergedStores, Collections.emptySet());
+        destinationDataSource.close();
+    }
+
+    public static DbKind getDbKindValueFromDbKindFile(String databaseDir) {
+        try {
+            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
+            Properties props = new Properties();
+
+            if (file.exists() && file.canRead()) {
+                try (FileReader reader = new FileReader(file)) {
+                    props.load(reader);
+                }
+
+                return DbKind.ofName(props.getProperty(KEYVALUE_DATASOURCE_PROP_NAME));
+            }
+
+            return DbKind.LEVEL_DB;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void generatedDbKindFile(DbKind dbKind, String databaseDir) {
+        try {
+            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
+            Properties props = new Properties();
+            props.setProperty(KEYVALUE_DATASOURCE_PROP_NAME, dbKind.name());
+            file.getParentFile().mkdirs();
+            try (FileWriter writer = new FileWriter(file)) {
+                props.store(writer, "Generated dbKind. In order to follow selected db.");
+
+                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).info("Generated dbKind.properties file.");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void validateDbKind(DbKind currentDbKind, String databaseDir, boolean databaseReset) {
+        File dir = new File(databaseDir);
+
+        if (dir.exists() && !dir.isDirectory()) {
+            LoggerFactory.getLogger(KEYVALUE_DATASOURCE).error("database.dir should be a folder.");
+            throw new IllegalStateException("database.dir should be a folder");
+        }
+
+        boolean databaseDirExists = dir.exists() && dir.isDirectory();
+
+        if (!databaseDirExists || dir.list().length == 0) {
+            KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
+            return;
+        }
+
+        DbKind prevDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(databaseDir);
+
+        if (prevDbKind != currentDbKind) {
+            if (databaseReset) {
+                KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
+            } else {
+                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).warn("Use the flag --reset when running the application if you are using a different datasource. Also you can use the cli tool DbMigrate, in order to migrate data between databases.");
+                throw new IllegalStateException("DbKind mismatch. You have selected " + currentDbKind.name() + " when the previous detected DbKind was " + prevDbKind.name() + ".");
+            }
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -50,6 +50,7 @@ import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.DbKind;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.IndexedBlockStore;
 import org.ethereum.db.ReceiptStore;
@@ -384,7 +385,7 @@ class CliToolsTest {
         importStateCliTool.execute(args, () -> rskContext, stopper);
 
         byte[] key = new Keccak256(Keccak256Helper.keccak256(value)).getBytes();
-        KeyValueDataSource trieDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
         byte[] result = trieDB.get(key);
         trieDB.close();
 
@@ -504,7 +505,7 @@ class CliToolsTest {
     @Test
     void dbMigrate() throws IOException {
         File nodeIdPropsFile = tempDir.resolve("nodeId.properties").toFile();
-        File dbKindPropsFile = tempDir.resolve(KeyValueDataSource.DB_KIND_PROPERTIES_FILE).toFile();
+        File dbKindPropsFile = tempDir.resolve(KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE).toFile();
 
         if (nodeIdPropsFile.createNewFile()) {
             FileWriter myWriter = new FileWriter(nodeIdPropsFile);

--- a/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
@@ -20,26 +20,26 @@ class NotParameterizedKeyValueDataSourceTest {
 
     @Test
     void testShouldValidateKindWithEmptyDbDirAndResetDbFalseSuccessfully() {
-        KeyValueDataSource.validateDbKind(DbKind.ROCKS_DB, tempDir.toString(), false);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, tempDir.toString(), false);
     }
 
     @Test()
     void testShouldThrowErrorWhenValidatingDifferentKinds() throws IOException {
-        FileWriter fileWriter = new FileWriter(new File(tempDir.toString(), KeyValueDataSource.DB_KIND_PROPERTIES_FILE));
+        FileWriter fileWriter = new FileWriter(new File(tempDir.toString(), KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE));
         fileWriter.write("keyvalue.datasource=ROCKS_DB\n");
         fileWriter.close();
         String path = tempDir.toString();
-        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSource.validateDbKind(DbKind.LEVEL_DB, path, false));
+        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, path, false));
     }
 
     @Test()
     void testShouldThrowErrorWhenDbDirIsAFile() throws IOException {
-        File file = new File(tempDir.toString(), KeyValueDataSource.DB_KIND_PROPERTIES_FILE);
+        File file = new File(tempDir.toString(), KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE);
         FileWriter fileWriter = new FileWriter(file);
         fileWriter.write("keyvalue.datasource=ROCKS_DB\n");
         fileWriter.close();
         String path = file.getPath();
-        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSource.validateDbKind(DbKind.LEVEL_DB, path, false));
+        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, path, false));
     }
 
     @Test
@@ -55,64 +55,64 @@ class NotParameterizedKeyValueDataSourceTest {
     @Test
     void getDbKindValueFromDbKindFileTest() throws IOException {
         String dbPath = tempDir.toString();
-        File dbKindFile = tempDir.resolve(KeyValueDataSource.DB_KIND_PROPERTIES_FILE).toFile();
+        File dbKindFile = tempDir.resolve(KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE).toFile();
         String propName = "keyvalue.datasource=";
 
         BufferedWriter writer = new BufferedWriter(new FileWriter(dbKindFile));
         writer.write(propName + DbKind.LEVEL_DB);
         writer.close();
-        DbKind dbKindLevel = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When DbKind file is LEVEL_DB, calculated should too");
 
         dbKindFile.delete();
         writer = new BufferedWriter(new FileWriter(dbKindFile));
         writer.write(propName + DbKind.ROCKS_DB);
         writer.close();
-        DbKind dbKindRocks = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindRocks, "When DbKind file is ROCKS_DB, calculated should too");
 
         dbKindFile.delete();
-        DbKind dbKindFallback = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindFallback = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindFallback, "When missing DbKind, LEVEL_DB should be returned as fallback");
     }
 
     @Test
     void generatedDbKindFileDbKindFileTest() {
         String dbPath = tempDir.toString();
-        File dbKindFile = tempDir.resolve(KeyValueDataSource.DB_KIND_PROPERTIES_FILE).toFile();
+        File dbKindFile = tempDir.resolve(KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE).toFile();
 
-        KeyValueDataSource.generatedDbKindFile(DbKind.LEVEL_DB, dbPath);
-        DbKind dbKindLevel = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        KeyValueDataSourceUtils.generatedDbKindFile(DbKind.LEVEL_DB, dbPath);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When LEVEL_DB is provided on generate, that should be the value when requested");
 
         dbKindFile.delete();
 
-        KeyValueDataSource.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        DbKind dbKindRocks = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
+        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindRocks, "When ROCKS_DB is provided on generate, that should be the value when requested");
     }
 
     @Test
     void validateDbKindNoFolder() throws IOException {
         String dbPathNoDir = Files.createFile(Paths.get(tempDir.toString(), "no_file")).toAbsolutePath().toString();
-        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSource.validateDbKind(DbKind.LEVEL_DB, dbPathNoDir, false));
+        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPathNoDir, false));
     }
 
     @Test
     void validateDbKindMissingFolder() {
         String dbPath = tempDir.toString();
-        KeyValueDataSource.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
-        DbKind dbKindLevel = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When DbKind file is missing validation should create it with the provided value");
     }
 
     @Test
     void validateDbKindExistingFolderDifferentDbWithoutResetThrows() {
         String dbPath = tempDir.toString();
-        KeyValueDataSource.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
+        KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
 
         try {
-            KeyValueDataSource.validateDbKind(DbKind.LEVEL_DB, dbPath, false);
+            KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath, false);
             Assertions.fail("Should've thrown exception due to already existing dbKind file without reset flag");
         } catch (RuntimeException re) {
             Assertions.assertTrue(re.getMessage().startsWith("DbKind mismatch. You have selected"));
@@ -122,27 +122,27 @@ class NotParameterizedKeyValueDataSourceTest {
     @Test
     void validateDbKindExistingFolderDifferentDbWithResetGeneratesNewFileThrows() {
         String dbPath = tempDir.toString();
-        KeyValueDataSource.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        KeyValueDataSource.validateDbKind(DbKind.LEVEL_DB, dbPath, true);
-        DbKind dbKindLevel = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath, true);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When DbKind changes and reset flag is specified on validation, new DbKind file should be generated");
     }
 
     @Test
     void validateDbKindExistingFolderSameDbWithoutResetDoesNothing() {
         String dbPath = tempDir.toString();
-        KeyValueDataSource.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        KeyValueDataSource.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
-        DbKind dbKindLevel = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When same DB without reset specified on validation, nothing changes on DbKind file");
     }
 
     @Test
     void validateDbKindExistingFolderSameDbWithResetDoesNothing() {
         String dbPath = tempDir.toString();
-        KeyValueDataSource.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        KeyValueDataSource.validateDbKind(DbKind.ROCKS_DB, dbPath, true);
-        DbKind dbKindLevel = KeyValueDataSource.getDbKindValueFromDbKindFile(dbPath);
+        KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, true);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When same DB and reset specified on validation, nothing changes on DbKind file");
     }
 
@@ -155,23 +155,23 @@ class NotParameterizedKeyValueDataSourceTest {
         byte[] keyMultiTrie = "keyMultiTrie".getBytes();
         createDS(multiTriePath, dbKind, keyMultiTrie, "valueMultiTrie".getBytes());
 
-        KeyValueDataSource.mergeDataSources(triePath, Collections.singletonList(multiTriePath), dbKind);
+        KeyValueDataSourceUtils.mergeDataSources(triePath, Collections.singletonList(multiTriePath), dbKind);
 
         // being able to init the DS proves it was closed on mergeDataSources
-        KeyValueDataSource trieDS = KeyValueDataSource.makeDataSource(triePath, dbKind);
+        KeyValueDataSource trieDS = KeyValueDataSourceUtils.makeDataSource(triePath, dbKind);
         Assertions.assertNull(trieDS.get("missingKey".getBytes()), "Key not present on any DS should not be present after merge");
         Assertions.assertNotNull(trieDS.get(keyTrie), "Pre-existing key on destination should exist after merge");
         Assertions.assertNotNull(trieDS.get(keyMultiTrie), "Key from origination should exist on destination after merge");
 
         // being able to init the DS proves it was closed on mergeDataSources
-        KeyValueDataSource multiTrieDS = KeyValueDataSource.makeDataSource(multiTriePath, dbKind);
+        KeyValueDataSource multiTrieDS = KeyValueDataSourceUtils.makeDataSource(multiTriePath, dbKind);
         Assertions.assertNull(multiTrieDS.get("missingKey".getBytes()), "Origination should remain intact, key not present before should not exist after merge");
         Assertions.assertNull(multiTrieDS.get(keyTrie), "Origination should remain intact, nothing copied from destination");
         Assertions.assertNotNull(multiTrieDS.get(keyMultiTrie), "Origination should remain intact, pre-existing key should exist after merge");
     }
 
     private static void createDS(Path triePath, DbKind rocksDb, byte[] key, byte[] value) {
-        KeyValueDataSource trieDS = KeyValueDataSource.makeDataSource(triePath, rocksDb);
+        KeyValueDataSource trieDS = KeyValueDataSourceUtils.makeDataSource(triePath, rocksDb);
         trieDS.put(key, value);
         trieDS.flush();
         trieDS.close();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removal of execution code from the KeyValueDataSource interface, and move it to KeyValueDataSourceUtils. 
The refactor revealed a potential source of confusion where the key KEYVALUE_DATASOURCE_PROP_NAME was used for two unrelated things (database type determination and node configuration). 
Now there are two different keys: 
* PROPERTY_KEYVALUE_DATASOURCE  (for configuration)
* KEYVALUE_DATASOURCE_PROP_NAME (for database type determination)

## Description
We take out of the KeyValueDataSource interface the functionality to create a database  (LevelDB or RocksDB).

<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- An interface should not contain execution code
- An abstract interface should not reference concrete implementations of that interface (LevelDB / RocksDB) because that defeats its abstraction purpose
- An identifier (KEYVALUE_DATASOURCE_PROP_NAME) should not be used for two unrelated things
- The KEYVALUE_DATASOURCE_PROP_NAME identifier should be private and not public, to enable changing the database type determination in the future.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
All tests pass. 
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

