### PR TITLE
Allow configuration of different database backend for the trie store

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1117,7 +1117,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 .make();
 
         DbKind currentDbKind = getRskSystemProperties().databaseKind();
-        KeyValueDataSource blocksDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "blocks"), currentDbKind);
+        KeyValueDataSource blocksDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "blocks"), currentDbKind);
 
         return new IndexedBlockStore(getBlockFactory(), blocksDB, new MapDBBlocksIndex(indexDB));
     }
@@ -1216,7 +1216,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         int bloomsCacheSize = getRskSystemProperties().getBloomsCacheSize();
         Path bloomsStorePath = Paths.get(getRskSystemProperties().databaseDir(), "blooms");
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(bloomsStorePath, getRskSystemProperties().databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(bloomsStorePath, getRskSystemProperties().databaseKind());
 
         if (bloomsCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = getRskSystemProperties().shouldPersistBloomsCacheSnapshot()
@@ -1296,7 +1296,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int receiptsCacheSize = rskSystemProperties.getReceiptsCacheSize();
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "receipts"), rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "receipts"), rskSystemProperties.databaseKind());
 
         if (receiptsCacheSize != 0) {
             ds = new DataSourceWithCache(ds, receiptsCacheSize);
@@ -1337,7 +1337,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int statesCacheSize = rskSystemProperties.getStatesCacheSize();
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(trieStorePath, rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, rskSystemProperties.databaseKind());
 
         if (statesCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = rskSystemProperties.shouldPersistStatesCacheSnapshot()
@@ -1366,7 +1366,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int stateRootsCacheSize = rskSystemProperties.getStateRootsCacheSize();
-        KeyValueDataSource stateRootsDB = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "stateRoots"), rskSystemProperties.databaseKind());
+        KeyValueDataSource stateRootsDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "stateRoots"), rskSystemProperties.databaseKind());
 
         if (stateRootsCacheSize > 0) {
             stateRootsDB = new DataSourceWithCache(stateRootsDB, stateRootsCacheSize);
@@ -1417,7 +1417,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             return null;
         }
 
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "wallet"), rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "wallet"), rskSystemProperties.databaseKind());
 
         return new Wallet(ds);
     }
@@ -1464,7 +1464,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
                 boolean gcWasEnabled = !multiTrieStorePaths.isEmpty();
                 if (gcWasEnabled) {
-                    KeyValueDataSource.mergeDataSources(trieStorePath, multiTrieStorePaths, rskSystemProperties.databaseKind());
+                    KeyValueDataSourceUtils.mergeDataSources(trieStorePath, multiTrieStorePaths, rskSystemProperties.databaseKind());
                     // cleanup MultiTrieStore data sources
                     multiTrieStorePaths.stream()
                             .map(Path::toString)

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1337,7 +1337,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int statesCacheSize = rskSystemProperties.getStatesCacheSize();
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, rskSystemProperties.trieStoreDatabaseKind());
 
         if (statesCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = rskSystemProperties.shouldPersistStatesCacheSnapshot()

--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -20,6 +20,7 @@ package co.rsk;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.util.PreflightChecksUtils;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ public class Start {
             ctx = new RskContext(args);
 
             RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
-            KeyValueDataSource.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
+            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             runNode(Runtime.getRuntime(), new PreflightChecksUtils(ctx), ctx);
         } catch (Exception e) {

--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -22,6 +22,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.util.Factory;
 import co.rsk.util.NodeStopper;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +69,7 @@ public abstract class CliToolRskContextAware {
 
             RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
 
-            KeyValueDataSource.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
+            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             onExecute(args, ctx);
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -24,6 +24,7 @@ import co.rsk.crypto.Keccak256;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
@@ -49,7 +50,7 @@ public class ImportState extends CliToolRskContextAware {
         RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
 
-        KeyValueDataSource trieDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
 
         String filename = args[0];
 

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -71,6 +71,7 @@ public abstract class SystemProperties {
     public static final String PROPERTY_BC_CONFIG_NAME = PROPERTY_BLOCKCHAIN_CONFIG + ".name";
     public static final String PROPERTY_BC_VERIFY = PROPERTY_BLOCKCHAIN_CONFIG + ".verify";
     public static final String PROPERTY_GENESIS_CONSTANTS_FEDERATION_PUBLICKEYS = "genesis_constants.federationPublicKeys";
+    public static final String PROPERTY_KEYVALUE_DATASOURCE = "keyvalue.datasource";
     public static final String PROPERTY_PEER_PORT = "peer.port";
     public static final String PROPERTY_BASE_PATH = "database.dir";
     public static final String PROPERTY_DB_RESET = "database.reset";
@@ -708,6 +709,6 @@ public abstract class SystemProperties {
     }
 
     public DbKind databaseKind() {
-        return DbKind.ofName(configFromFiles.getString(KeyValueDataSource.KEYVALUE_DATASOURCE_PROP_NAME));
+        return DbKind.ofName(configFromFiles.getString(PROPERTY_KEYVALUE_DATASOURCE));
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -31,7 +31,6 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.DbKind;
-import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.net.p2p.P2pHandler;
 import org.ethereum.net.rlpx.MessageCodec;
 import org.ethereum.net.rlpx.Node;
@@ -72,6 +71,7 @@ public abstract class SystemProperties {
     public static final String PROPERTY_BC_VERIFY = PROPERTY_BLOCKCHAIN_CONFIG + ".verify";
     public static final String PROPERTY_GENESIS_CONSTANTS_FEDERATION_PUBLICKEYS = "genesis_constants.federationPublicKeys";
     public static final String PROPERTY_KEYVALUE_DATASOURCE = "keyvalue.datasource";
+    public static final String PROPERTY_TRIESTORE_DATASOURCE = "triestore.datasource";
     public static final String PROPERTY_PEER_PORT = "peer.port";
     public static final String PROPERTY_BASE_PATH = "database.dir";
     public static final String PROPERTY_DB_RESET = "database.reset";
@@ -710,5 +710,9 @@ public abstract class SystemProperties {
 
     public DbKind databaseKind() {
         return DbKind.ofName(configFromFiles.getString(PROPERTY_KEYVALUE_DATASOURCE));
+    }
+
+  public DbKind trieStoreDatabaseKind() {
+        return DbKind.ofName(configFromFiles.getString(PROPERTY_TRIESTORE_DATASOURCE));
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
@@ -32,8 +32,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 public interface KeyValueDataSource extends DataSource {
-    String DB_KIND_PROPERTIES_FILE = "dbKind.properties";
-    String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
+
 
     @Nullable
     byte[] get(byte[] key);
@@ -65,95 +64,5 @@ public interface KeyValueDataSource extends DataSource {
      */
     void flush();
 
-    @Nonnull
-    static KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
-        String name = datasourcePath.getFileName().toString();
-        String databaseDir = datasourcePath.getParent().toString();
 
-        KeyValueDataSource ds;
-        switch (kind) {
-            case LEVEL_DB:
-                ds = new LevelDbDataSource(name, databaseDir);
-                break;
-            case ROCKS_DB:
-                ds = new RocksDbDataSource(name, databaseDir);
-                break;
-            default:
-                throw new IllegalArgumentException("kind");
-        }
-
-        ds.init();
-
-        return ds;
-    }
-
-    static void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
-        Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
-        for (Path originPath : originPaths) {
-            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
-            for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
-                mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
-            }
-            singleOriginDataSource.close();
-        }
-        KeyValueDataSource destinationDataSource = makeDataSource(destinationPath, kind);
-        destinationDataSource.updateBatch(mergedStores, Collections.emptySet());
-        destinationDataSource.close();
-    }
-
-    static DbKind getDbKindValueFromDbKindFile(String databaseDir) {
-        try {
-            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
-            Properties props = new Properties();
-
-            if (file.exists() && file.canRead()) {
-                try (FileReader reader = new FileReader(file)) {
-                    props.load(reader);
-                }
-
-                return DbKind.ofName(props.getProperty(KEYVALUE_DATASOURCE_PROP_NAME));
-            }
-
-            return DbKind.LEVEL_DB;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    static void generatedDbKindFile(DbKind dbKind, String databaseDir) {
-        try {
-            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
-            Properties props = new Properties();
-            props.setProperty(KEYVALUE_DATASOURCE_PROP_NAME, dbKind.name());
-            file.getParentFile().mkdirs();
-            try (FileWriter writer = new FileWriter(file)) {
-                props.store(writer, "Generated dbKind. In order to follow selected db.");
-
-                LoggerFactory.getLogger("KeyValueDataSource").info("Generated dbKind.properties file.");
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    static void validateDbKind(DbKind currentDbKind, String databaseDir, boolean databaseReset) {
-        File dir = new File(databaseDir);
-        boolean databaseDirExists = dir.exists() && dir.isDirectory();
-
-        if (!databaseDirExists) {
-            KeyValueDataSource.generatedDbKindFile(currentDbKind, databaseDir);
-            return;
-        }
-
-        DbKind prevDbKind = KeyValueDataSource.getDbKindValueFromDbKindFile(databaseDir);
-
-        if (prevDbKind != currentDbKind) {
-            if (databaseReset) {
-                KeyValueDataSource.generatedDbKindFile(currentDbKind, databaseDir);
-            } else {
-                LoggerFactory.getLogger("KeyValueDataSource").warn("Use the flag --reset when running the application if you are using a different datasource.");
-                throw new IllegalStateException("DbKind mismatch. You have selected " + currentDbKind.name() + " when the previous detected DbKind was " + prevDbKind.name() + ".");
-            }
-        }
-    }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -1,0 +1,109 @@
+package org.ethereum.datasource;
+
+import org.ethereum.db.ByteArrayWrapper;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+
+public class KeyValueDataSourceUtils {
+    static private String DB_KIND_PROPERTIES_FILE = "dbKind.properties";
+    static private String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
+
+    @Nonnull
+    static public KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
+        String name = datasourcePath.getFileName().toString();
+        String databaseDir = datasourcePath.getParent().toString();
+
+        KeyValueDataSource ds;
+        switch (kind) {
+            case LEVEL_DB:
+                ds = new LevelDbDataSource(name, databaseDir);
+                break;
+            case ROCKS_DB:
+                ds = new RocksDbDataSource(name, databaseDir);
+                break;
+            default:
+                throw new IllegalArgumentException("kind");
+        }
+
+        ds.init();
+
+        return ds;
+    }
+
+    static public void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
+        Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
+        for (Path originPath : originPaths) {
+            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
+            for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
+                mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
+            }
+            singleOriginDataSource.close();
+        }
+        KeyValueDataSource destinationDataSource = makeDataSource(destinationPath, kind);
+        destinationDataSource.updateBatch(mergedStores, Collections.emptySet());
+        destinationDataSource.close();
+    }
+
+    static public DbKind getDbKindValueFromDbKindFile(String databaseDir) {
+        try {
+            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
+            Properties props = new Properties();
+
+            if (file.exists() && file.canRead()) {
+                try (FileReader reader = new FileReader(file)) {
+                    props.load(reader);
+                }
+
+                return DbKind.ofName(props.getProperty(KEYVALUE_DATASOURCE_PROP_NAME));
+            }
+
+            return DbKind.LEVEL_DB;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static public void generatedDbKindFile(DbKind dbKind, String databaseDir) {
+        try {
+            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
+            Properties props = new Properties();
+            props.setProperty(KEYVALUE_DATASOURCE_PROP_NAME, dbKind.name());
+            file.getParentFile().mkdirs();
+            try (FileWriter writer = new FileWriter(file)) {
+                props.store(writer, "Generated dbKind. In order to follow selected db.");
+
+                LoggerFactory.getLogger("KeyValueDataSource").info("Generated dbKind.properties file.");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static public void validateDbKind(DbKind currentDbKind, String databaseDir, boolean databaseReset) {
+        File dir = new File(databaseDir);
+        boolean databaseDirExists = dir.exists() && dir.isDirectory();
+
+        if (!databaseDirExists) {
+            KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
+            return;
+        }
+
+        DbKind prevDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(databaseDir);
+
+        if (prevDbKind != currentDbKind) {
+            if (databaseReset) {
+                KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
+            } else {
+                LoggerFactory.getLogger("KeyValueDataSource").warn("Use the flag --reset when running the application if you are using a different datasource.");
+                throw new IllegalStateException("DbKind mismatch. You have selected " + currentDbKind.name() + " when the previous detected DbKind was " + prevDbKind.name() + ".");
+            }
+        }
+    }
+}

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -208,6 +208,7 @@ vm = {
     }
 }
 keyvalue.datasource = <datasource>
+triestore.datasource = <datasource>
 sync = {
     enabled = <enabled>
     heartBeat.enabled = <enabled>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -261,6 +261,9 @@ vm {
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = leveldb
 
+# Trie store data source values: [leveldb/rocksdb]
+triestore.datasource = leveldb
+
 sync {
     # block chain synchronization can be: [true/false]
     enabled = true

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -358,7 +358,7 @@ public class CliToolsTest {
         importStateCliTool.execute(args, () -> rskContext, stopper);
 
         byte[] key = new Keccak256(Keccak256Helper.keccak256(value)).getBytes();
-        KeyValueDataSource trieDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
         byte[] result = trieDB.get(key);
         trieDB.close();
 

--- a/rskj-core/src/test/resources/rskj.conf
+++ b/rskj-core/src/test/resources/rskj.conf
@@ -242,6 +242,7 @@ root.hash.start = null
 
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = leveldb
+triestore.datasource = leveldb
 
 # Redis cloud enabled flag.
 # Allows using RedisConnection for creating cloud based data structures.

--- a/rskj-core/src/test/resources/test-rskj.conf
+++ b/rskj-core/src/test/resources/test-rskj.conf
@@ -144,6 +144,7 @@ GitHubTests.VMTest.loadLocal = false
 
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = leveldb
+triestore.datasource = leveldb
 
 # structured trace
 # is the trace being


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We create a new configuration option `triestore.datasource` to enable changing the type of database to be used for the trie store.
## Description
<!--- Describe your changes in detail -->
not required.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The trie store is a special database that is accessed with a special pattern:
* No deletions
* Key is always hash of value
* More reads that writes

This characteristics make using a certain database type (optimized for this access pattern) better. For example, we may use in the future flatdb for the trie store (and only for this database).
 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Changing the configuration file and making sure the trie is created with a different database type.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

