### PR TITLE
Satate DB Migration tool

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1117,7 +1117,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 .make();
 
         DbKind currentDbKind = getRskSystemProperties().databaseKind();
-        KeyValueDataSource blocksDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "blocks"), currentDbKind);
+        KeyValueDataSource blocksDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "blocks"), currentDbKind);
 
         return new IndexedBlockStore(getBlockFactory(), blocksDB, new MapDBBlocksIndex(indexDB));
     }
@@ -1216,7 +1216,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         int bloomsCacheSize = getRskSystemProperties().getBloomsCacheSize();
         Path bloomsStorePath = Paths.get(getRskSystemProperties().databaseDir(), "blooms");
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(bloomsStorePath, getRskSystemProperties().databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(bloomsStorePath, getRskSystemProperties().databaseKind());
 
         if (bloomsCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = getRskSystemProperties().shouldPersistBloomsCacheSnapshot()
@@ -1296,7 +1296,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int receiptsCacheSize = rskSystemProperties.getReceiptsCacheSize();
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "receipts"), rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "receipts"), rskSystemProperties.databaseKind());
 
         if (receiptsCacheSize != 0) {
             ds = new DataSourceWithCache(ds, receiptsCacheSize);
@@ -1337,7 +1337,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int statesCacheSize = rskSystemProperties.getStatesCacheSize();
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(trieStorePath, rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, rskSystemProperties.databaseKind());
 
         if (statesCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = rskSystemProperties.shouldPersistStatesCacheSnapshot()
@@ -1366,7 +1366,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int stateRootsCacheSize = rskSystemProperties.getStateRootsCacheSize();
-        KeyValueDataSource stateRootsDB = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "stateRoots"), rskSystemProperties.databaseKind());
+        KeyValueDataSource stateRootsDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "stateRoots"), rskSystemProperties.databaseKind());
 
         if (stateRootsCacheSize > 0) {
             stateRootsDB = new DataSourceWithCache(stateRootsDB, stateRootsCacheSize);
@@ -1417,7 +1417,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             return null;
         }
 
-        KeyValueDataSource ds = KeyValueDataSource.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "wallet"), rskSystemProperties.databaseKind());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "wallet"), rskSystemProperties.databaseKind());
 
         return new Wallet(ds);
     }
@@ -1464,7 +1464,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
                 boolean gcWasEnabled = !multiTrieStorePaths.isEmpty();
                 if (gcWasEnabled) {
-                    KeyValueDataSource.mergeDataSources(trieStorePath, multiTrieStorePaths, rskSystemProperties.databaseKind());
+                    KeyValueDataSourceUtils.mergeDataSources(trieStorePath, multiTrieStorePaths, rskSystemProperties.databaseKind());
                     // cleanup MultiTrieStore data sources
                     multiTrieStorePaths.stream()
                             .map(Path::toString)

--- a/rskj-core/src/main/java/co/rsk/Start.java
+++ b/rskj-core/src/main/java/co/rsk/Start.java
@@ -20,6 +20,7 @@ package co.rsk;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.util.PreflightChecksUtils;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ public class Start {
             ctx = new RskContext(args);
 
             RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
-            KeyValueDataSource.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
+            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             runNode(Runtime.getRuntime(), new PreflightChecksUtils(ctx), ctx);
         } catch (Exception e) {

--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -22,6 +22,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.util.Factory;
 import co.rsk.util.NodeStopper;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +69,7 @@ public abstract class CliToolRskContextAware {
 
             RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
 
-            KeyValueDataSource.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
+            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             onExecute(args, ctx);
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -24,6 +24,7 @@ import co.rsk.crypto.Keccak256;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
@@ -49,7 +50,7 @@ public class ImportState extends CliToolRskContextAware {
         RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
 
-        KeyValueDataSource trieDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
 
         String filename = args[0];
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/MigrateState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/MigrateState.java
@@ -1,0 +1,149 @@
+package co.rsk.cli.tools;
+
+import co.rsk.RskContext;
+import co.rsk.cli.CliToolRskContextAware;
+import co.rsk.trie.NodeReference;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieStore;
+import org.ethereum.core.Block;
+import org.ethereum.datasource.DbKind;
+import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
+import org.ethereum.db.BlockStore;
+
+import javax.annotation.Nonnull;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Paths;
+import java.text.NumberFormat;
+import java.util.Optional;
+
+/**
+ * The entry point for export state CLI tool
+ * This is an experimental/unsupported tool
+ *
+ * This tool can be interrupted and re-started and it will continue the migration from
+ * the point where it left.
+ *
+ * Required cli args:
+ * - args[0] - block number
+ * - args[1] - file path
+ * - args[2] - Destination database format
+ *
+ * For maximum performance, disable the state cache by adding the argument:
+ *  -Xcache.states.max-elements=0
+ */
+public class MigrateState extends CliToolRskContextAware  {
+
+    public static void main(String[] args) {
+        create(MethodHandles.lookup().lookupClass()).execute(args);
+    }
+
+    @Override
+    protected void onExecute(@Nonnull String[] args, @Nonnull RskContext ctx) throws Exception {
+        String filePath = args[1];
+        BlockStore blockStore = ctx.getBlockStore();
+        TrieStore trieStore = ctx.getTrieStore();
+
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(filePath),
+                DbKind.ofName(args[2]));
+
+        migrateStateToDatabase(args, blockStore, trieStore, ds);
+        ds.close();
+
+    }
+
+    private void showMem() {
+        Runtime runtime = Runtime.getRuntime();
+
+        NumberFormat format = NumberFormat.getInstance();
+
+        long memory = runtime.totalMemory() - runtime.freeMemory();
+        System.gc();
+        long memory2 = runtime.totalMemory() - runtime.freeMemory();
+        System.out.println("  used memory: " + format.format(memory/ 1000) + "k -> "+
+                        format.format(memory2/ 1000) + "k");
+
+    }
+
+    int nodesExported =0;
+    long skipped =0;
+
+    private boolean migrateStateToDatabase(String[] args, BlockStore blockStore, TrieStore trieStore,
+                                        KeyValueDataSource ds) {
+        long blockNumber = Long.parseLong(args[0]);
+        Block block = blockStore.getChainBlockByNumber(blockNumber);
+
+        Optional<Trie> otrie = trieStore.retrieve(block.getStateRoot());
+
+        if (!otrie.isPresent()) {
+            System.out.println("Root not found");
+            return false;
+        }
+
+        Trie trie = otrie.get();
+
+        processTrie(trie, ds);
+        showStat();
+        return true;
+    }
+
+
+    private void showStat() {
+        System.out.println("nodes scanned: " +(nodesExported/1000)+"k skipped: "+skipped+"k");
+    }
+
+    private void processTrie(Trie trie, KeyValueDataSource ds) {
+
+        nodesExported++;
+        if (nodesExported % 5000 == 0) {
+            showStat();
+            showMem();
+            ds.flush();
+        }
+
+        byte[] hash = trie.getHash().getBytes();
+        if (ds.get(hash) != null) {
+            skipped++;
+            return; // already exists
+        }
+
+
+        NodeReference leftReference = trie.getLeft();
+
+        if (!leftReference.isEmpty()) {
+            Optional<Trie> left = leftReference.getNodeDetached();
+
+            if (left.isPresent()) {
+                Trie leftTrie = left.get();
+
+                if (!leftReference.isEmbeddable()) {
+                    processTrie(leftTrie, ds);
+                }
+            }
+        }
+
+        NodeReference rightReference = trie.getRight();
+
+        if (!rightReference.isEmpty()) {
+            Optional<Trie> right = rightReference.getNodeDetached();
+
+            if (right.isPresent()) {
+                Trie rightTrie = right.get();
+
+                if (!rightReference.isEmbeddable()) {
+                    processTrie(rightTrie, ds);
+                }
+            }
+        }
+
+        // copy those that are not on the cache
+        byte[] m = trie.toMessage();
+        ds.put(hash, m);
+        if (trie.hasLongValue()) {
+            ds.put(trie.getValueHash().getBytes(), trie.getValue());
+
+        }
+
+    }
+
+}

--- a/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
+++ b/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
@@ -90,6 +90,26 @@ public class NodeReference {
         return node;
     }
 
+    public Optional<Trie> getNodeDetached() {
+        if (lazyNode != null) {
+            return Optional.of(lazyNode);
+        }
+
+        if (lazyHash == null) {
+            return Optional.empty();
+        }
+
+        Optional<Trie> node = store.retrieve(lazyHash.getBytes());
+
+        // Broken database, can't continue
+        if (!node.isPresent()) {
+            logger.error("Broken database, execution can't continue");
+            nodeStopper.stop(1);
+            return Optional.empty();
+        }
+
+        return node;
+    }
     /**
      * The hash or empty if this is an empty reference.
      * If the hash is not present but its node is known, it will be calculated.

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -71,6 +71,7 @@ public abstract class SystemProperties {
     public static final String PROPERTY_BC_CONFIG_NAME = PROPERTY_BLOCKCHAIN_CONFIG + ".name";
     public static final String PROPERTY_BC_VERIFY = PROPERTY_BLOCKCHAIN_CONFIG + ".verify";
     public static final String PROPERTY_GENESIS_CONSTANTS_FEDERATION_PUBLICKEYS = "genesis_constants.federationPublicKeys";
+    public static final String PROPERTY_KEYVALUE_DATASOURCE = "keyvalue.datasource";
     public static final String PROPERTY_PEER_PORT = "peer.port";
     public static final String PROPERTY_BASE_PATH = "database.dir";
     public static final String PROPERTY_DB_RESET = "database.reset";
@@ -708,6 +709,6 @@ public abstract class SystemProperties {
     }
 
     public DbKind databaseKind() {
-        return DbKind.ofName(configFromFiles.getString(KeyValueDataSource.KEYVALUE_DATASOURCE_PROP_NAME));
+        return DbKind.ofName(configFromFiles.getString(PROPERTY_KEYVALUE_DATASOURCE));
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
@@ -32,8 +32,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 public interface KeyValueDataSource extends DataSource {
-    String DB_KIND_PROPERTIES_FILE = "dbKind.properties";
-    String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
+
 
     @Nullable
     byte[] get(byte[] key);
@@ -65,95 +64,5 @@ public interface KeyValueDataSource extends DataSource {
      */
     void flush();
 
-    @Nonnull
-    static KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
-        String name = datasourcePath.getFileName().toString();
-        String databaseDir = datasourcePath.getParent().toString();
 
-        KeyValueDataSource ds;
-        switch (kind) {
-            case LEVEL_DB:
-                ds = new LevelDbDataSource(name, databaseDir);
-                break;
-            case ROCKS_DB:
-                ds = new RocksDbDataSource(name, databaseDir);
-                break;
-            default:
-                throw new IllegalArgumentException("kind");
-        }
-
-        ds.init();
-
-        return ds;
-    }
-
-    static void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
-        Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
-        for (Path originPath : originPaths) {
-            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
-            for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
-                mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
-            }
-            singleOriginDataSource.close();
-        }
-        KeyValueDataSource destinationDataSource = makeDataSource(destinationPath, kind);
-        destinationDataSource.updateBatch(mergedStores, Collections.emptySet());
-        destinationDataSource.close();
-    }
-
-    static DbKind getDbKindValueFromDbKindFile(String databaseDir) {
-        try {
-            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
-            Properties props = new Properties();
-
-            if (file.exists() && file.canRead()) {
-                try (FileReader reader = new FileReader(file)) {
-                    props.load(reader);
-                }
-
-                return DbKind.ofName(props.getProperty(KEYVALUE_DATASOURCE_PROP_NAME));
-            }
-
-            return DbKind.LEVEL_DB;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    static void generatedDbKindFile(DbKind dbKind, String databaseDir) {
-        try {
-            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
-            Properties props = new Properties();
-            props.setProperty(KEYVALUE_DATASOURCE_PROP_NAME, dbKind.name());
-            file.getParentFile().mkdirs();
-            try (FileWriter writer = new FileWriter(file)) {
-                props.store(writer, "Generated dbKind. In order to follow selected db.");
-
-                LoggerFactory.getLogger("KeyValueDataSource").info("Generated dbKind.properties file.");
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    static void validateDbKind(DbKind currentDbKind, String databaseDir, boolean databaseReset) {
-        File dir = new File(databaseDir);
-        boolean databaseDirExists = dir.exists() && dir.isDirectory();
-
-        if (!databaseDirExists) {
-            KeyValueDataSource.generatedDbKindFile(currentDbKind, databaseDir);
-            return;
-        }
-
-        DbKind prevDbKind = KeyValueDataSource.getDbKindValueFromDbKindFile(databaseDir);
-
-        if (prevDbKind != currentDbKind) {
-            if (databaseReset) {
-                KeyValueDataSource.generatedDbKindFile(currentDbKind, databaseDir);
-            } else {
-                LoggerFactory.getLogger("KeyValueDataSource").warn("Use the flag --reset when running the application if you are using a different datasource.");
-                throw new IllegalStateException("DbKind mismatch. You have selected " + currentDbKind.name() + " when the previous detected DbKind was " + prevDbKind.name() + ".");
-            }
-        }
-    }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -1,0 +1,109 @@
+package org.ethereum.datasource;
+
+import org.ethereum.db.ByteArrayWrapper;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+
+public class KeyValueDataSourceUtils {
+    static private String DB_KIND_PROPERTIES_FILE = "dbKind.properties";
+    static private String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
+
+    @Nonnull
+    static public KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
+        String name = datasourcePath.getFileName().toString();
+        String databaseDir = datasourcePath.getParent().toString();
+
+        KeyValueDataSource ds;
+        switch (kind) {
+            case LEVEL_DB:
+                ds = new LevelDbDataSource(name, databaseDir);
+                break;
+            case ROCKS_DB:
+                ds = new RocksDbDataSource(name, databaseDir);
+                break;
+            default:
+                throw new IllegalArgumentException("kind");
+        }
+
+        ds.init();
+
+        return ds;
+    }
+
+    static public void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
+        Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
+        for (Path originPath : originPaths) {
+            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
+            for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
+                mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
+            }
+            singleOriginDataSource.close();
+        }
+        KeyValueDataSource destinationDataSource = makeDataSource(destinationPath, kind);
+        destinationDataSource.updateBatch(mergedStores, Collections.emptySet());
+        destinationDataSource.close();
+    }
+
+    static public DbKind getDbKindValueFromDbKindFile(String databaseDir) {
+        try {
+            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
+            Properties props = new Properties();
+
+            if (file.exists() && file.canRead()) {
+                try (FileReader reader = new FileReader(file)) {
+                    props.load(reader);
+                }
+
+                return DbKind.ofName(props.getProperty(KEYVALUE_DATASOURCE_PROP_NAME));
+            }
+
+            return DbKind.LEVEL_DB;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static public void generatedDbKindFile(DbKind dbKind, String databaseDir) {
+        try {
+            File file = new File(databaseDir, DB_KIND_PROPERTIES_FILE);
+            Properties props = new Properties();
+            props.setProperty(KEYVALUE_DATASOURCE_PROP_NAME, dbKind.name());
+            file.getParentFile().mkdirs();
+            try (FileWriter writer = new FileWriter(file)) {
+                props.store(writer, "Generated dbKind. In order to follow selected db.");
+
+                LoggerFactory.getLogger("KeyValueDataSource").info("Generated dbKind.properties file.");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static public void validateDbKind(DbKind currentDbKind, String databaseDir, boolean databaseReset) {
+        File dir = new File(databaseDir);
+        boolean databaseDirExists = dir.exists() && dir.isDirectory();
+
+        if (!databaseDirExists) {
+            KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
+            return;
+        }
+
+        DbKind prevDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(databaseDir);
+
+        if (prevDbKind != currentDbKind) {
+            if (databaseReset) {
+                KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
+            } else {
+                LoggerFactory.getLogger("KeyValueDataSource").warn("Use the flag --reset when running the application if you are using a different datasource.");
+                throw new IllegalStateException("DbKind mismatch. You have selected " + currentDbKind.name() + " when the previous detected DbKind was " + prevDbKind.name() + ".");
+            }
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -358,7 +358,7 @@ public class CliToolsTest {
         importStateCliTool.execute(args, () -> rskContext, stopper);
 
         byte[] key = new Keccak256(Keccak256Helper.keccak256(value)).getBytes();
-        KeyValueDataSource trieDB = KeyValueDataSource.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
         byte[] result = trieDB.get(key);
         trieDB.close();
 

--- a/rskj-core/src/test/java/co/rsk/trie/NodeReferenceTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/NodeReferenceTest.java
@@ -29,6 +29,32 @@ import static org.mockito.Mockito.*;
 public class NodeReferenceTest {
 
     @Test
+    public void testGetNode_lazyNodeIsNullLazyHashIsNotNullAndTrieStoreCanRetrieveNodeButKeepDetached_returnsNode() {
+        // Given
+        Keccak256 lazyHashMock = mock(Keccak256.class);
+        byte[] bytesMock = new byte[0];
+        doReturn(bytesMock).when(lazyHashMock).getBytes();
+
+        Trie trieMock = mock(Trie.class);
+
+        TrieStoreImpl trieStoreMock = mock(TrieStoreImpl.class);
+        doReturn(Optional.of(trieMock)).when(trieStoreMock).retrieve(bytesMock);
+
+        NodeReference nodeReference = new NodeReference(trieStoreMock, null, lazyHashMock);
+
+        // When
+        Optional<Trie> result = nodeReference.getNodeDetached();
+
+        // Then
+        assertTrue(result.isPresent());
+        assertFalse(nodeReference.wasLoaded());
+        assertEquals(trieMock, result.get());
+
+        verify(lazyHashMock, times(1)).getBytes();
+        verify(trieStoreMock, times(1)).retrieve(bytesMock);
+    }
+
+    @Test
     public void testGetNode_lazyNodeIsNotNull_returnsOptionalOfLazyNode() {
         // Given
         Trie lazyNodeMock = mock(Trie.class);
@@ -75,6 +101,7 @@ public class NodeReferenceTest {
         // Then
         assertTrue(result.isPresent());
         assertEquals(trieMock, result.get());
+        assertTrue(nodeReference.wasLoaded());
 
         verify(lazyHashMock, times(1)).getBytes();
         verify(trieStoreMock, times(1)).retrieve(bytesMock);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This command-line tool enables the migration of a state database to another format.
## Description
<!--- Describe your changes in detail -->
The migration tool does not copy all key/values, but only a snapshot at certain block height. It works by recursively scanning the state trie. It is not intended to be an automatic migration system, but just a manual tool.
We also added a new method getNodeDetached() to NodeReference.java to avoid getting out of memory errors while processing the trie recursively.
The method getNode() stores a copy of the loaded node into the NodeReference object so it prevents traversed nodes to be garbage collected leading to the whole trie to be loaded into Java heap.
This tool can be interrupted and re-started and it will continue the migration from the point where it left.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Migration of the state DB is useful for several use cases:
* Migration from LevelDB to FlatDB in the future
* Create a snapshot of the state DB for debugging or analysis of corrupted DBs 

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

There is no official documentation for any of the command-line tools. We follow the this strict standard of no documentation. (unofficial documentation was fond [here](https://angeljavalopez.medium.com/command-line-tools-for-rsk-node-565d53c240c1))
Tests for getNodeDetached() have been added.

**Other information**:
