### PR TITLE
Update netty

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -58,7 +58,7 @@ tasks.withType(AbstractArchiveTask) {
 
 ext {
     libVersions = [
-            nettyVer               : '4.0.56.Final',
+            nettyVer               : '4.1.78.Final',
             spongyCastleVer        : '1.58.0.0',
             bouncyCastleVer        : '1.59',
             ethereumLeveldbJniVer  : '1.18.3',

--- a/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/RskWebSocketServerProtocolHandler.java
@@ -15,7 +15,10 @@ public class RskWebSocketServerProtocolHandler extends WebSocketServerProtocolHa
 
     public RskWebSocketServerProtocolHandler(String websocketPath, int maxFrameSize) {
         // there are no subprotocols nor extensions
-        super(websocketPath, null, false, maxFrameSize, true);
+        // Note: A port:host can only have one webSocketPath, and that's a Netty limitation.
+        // For more information about
+        // Netty limitations: https://stackoverflow.com/questions/8778806/how-to-handle-different-url-websocket-connections-in-netty/71757361#71757361
+        super(websocketPath, null, false, maxFrameSize, false, true);
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update netty version

## Motivation and Context
On scope of Java upgrade task, we tried to upgrade Netty library to the stable and recommended 4.1.78.Final

All tests ran fine but after a merge with master, one of the added tests started failing. The cause is that com.squareup.okhttp.ws.WebSocketListener#onOpen is not called in co.rsk.rpc.netty.Web3WebSocketServerTest#smokeTest(byte[], java.lang.String) with the new version but it is on the old one.

Apparently it only happens for tests using the default path /websocket (#smokeTest and #smokeTestWithBigJson) and, when launched in batch, only for the first one using this path fails, the second one seems to be working fine. When launched isolated, both fail. This suggests that we are sharing some state between them.

Therefore the upgrade was reverted. Further investigation is needed to ensure it is only an issue with the test or anything else could be affected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
PowPeg PR: https://github.com/rsksmart/powpeg-node/pull/107

*fed:update-netty-version*