### PR TITLE
Using iterator instead of loading all keys to avoid java heap errors

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -184,19 +184,17 @@ public class DbMigrate extends CliToolRskContextAware {
 
         logger.info("Migrating data source: {}", sourceKeyValueDataSource.getName());
 
-        DataSourceKeyIterator iterator = sourceKeyValueDataSource.keyIterator();
+        try (DataSourceKeyIterator iterator = sourceKeyValueDataSource.keyIterator()) {
+            iterator.seekToFirst();
 
-        while (iterator.hasNext()) {
-            byte[] data = iterator.next().getData();
+            while (iterator.hasNext()) {
+                byte[] data = iterator.next().getData();
 
-            targetKeyValueDataSource.put(
-                    data,
-                    sourceKeyValueDataSource.get(data)
-            );
-        }
-
-        try {
-            iterator.close();
+                targetKeyValueDataSource.put(
+                        data,
+                        sourceKeyValueDataSource.get(data)
+                );
+            }
         } catch (Exception e) {
             logger.error("An error happened closing DB Key Iterator", e);
             throw new RuntimeException(e);

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -185,8 +185,6 @@ public class DbMigrate extends CliToolRskContextAware {
         logger.info("Migrating data source: {}", sourceKeyValueDataSource.getName());
 
         try (DataSourceKeyIterator iterator = sourceKeyValueDataSource.keyIterator()) {
-            iterator.seekToFirst();
-
             while (iterator.hasNext()) {
                 byte[] data = iterator.next();
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -188,7 +188,7 @@ public class DbMigrate extends CliToolRskContextAware {
             iterator.seekToFirst();
 
             while (iterator.hasNext()) {
-                byte[] data = iterator.next().getData();
+                byte[] data = iterator.next();
 
                 targetKeyValueDataSource.put(
                         data,

--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -47,7 +47,7 @@ import co.rsk.util.HexUtils;
 
 public class Wallet {
     @GuardedBy("accessLock")
-    private final KeyValueDataSource keyDS;
+    private final KeyValueDataSource<?> keyDS;
 
     @GuardedBy("accessLock")
     private final Map<RskAddress, byte[]> accounts = new HashMap<>();

--- a/rskj-core/src/main/java/co/rsk/core/Wallet.java
+++ b/rskj-core/src/main/java/co/rsk/core/Wallet.java
@@ -47,7 +47,7 @@ import co.rsk.util.HexUtils;
 
 public class Wallet {
     @GuardedBy("accessLock")
-    private final KeyValueDataSource<?> keyDS;
+    private final KeyValueDataSource keyDS;
 
     @GuardedBy("accessLock")
     private final Map<RskAddress, byte[]> accounts = new HashMap<>();

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceKeyIterator.java
@@ -19,10 +19,8 @@
 
 package org.ethereum.datasource;
 
-import org.ethereum.db.ByteArrayWrapper;
-
 import java.util.*;
 
-public interface DataSourceKeyIterator extends Iterator<ByteArrayWrapper>, AutoCloseable {
+public interface DataSourceKeyIterator extends Iterator<byte[]>, AutoCloseable {
     void seekToFirst();
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceKeyIterator.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.datasource;
+
+import org.ethereum.db.ByteArrayWrapper;
+
+import java.util.*;
+
+public interface DataSourceKeyIterator extends Iterator<ByteArrayWrapper>, AutoCloseable {
+    void seekToFirst();
+}

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceKeyIterator.java
@@ -22,5 +22,4 @@ package org.ethereum.datasource;
 import java.util.*;
 
 public interface DataSourceKeyIterator extends Iterator<byte[]>, AutoCloseable {
-    void seekToFirst();
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -33,7 +33,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class DataSourceWithCache implements KeyValueDataSource {
+public class DataSourceWithCache implements KeyValueDataSource<Iterator<ByteArrayWrapper>> {
 
     private static final Logger logger = LoggerFactory.getLogger("datasourcewithcache");
 
@@ -198,6 +198,11 @@ public class DataSourceWithCache implements KeyValueDataSource {
         Stream<ByteArrayWrapper> knownKeys = Stream.concat(Stream.concat(baseKeys, committedKeys), uncommittedKeys);
         return knownKeys.filter(k -> !uncommittedKeysToRemove.contains(k))
                 .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    @Override
+    public Iterator<ByteArrayWrapper> iterator() {
+        return keys().iterator();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -33,7 +33,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class DataSourceWithCache implements KeyValueDataSource<Iterator<ByteArrayWrapper>> {
+public class DataSourceWithCache implements KeyValueDataSource {
 
     private static final Logger logger = LoggerFactory.getLogger("datasourcewithcache");
 
@@ -201,8 +201,8 @@ public class DataSourceWithCache implements KeyValueDataSource<Iterator<ByteArra
     }
 
     @Override
-    public Iterator<ByteArrayWrapper> iterator() {
-        return keys().iterator();
+    public DataSourceKeyIterator keyIterator() {
+        return new DefaultKeyIterator(keys());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DataSourceWithCache.java
@@ -202,7 +202,11 @@ public class DataSourceWithCache implements KeyValueDataSource {
 
     @Override
     public DataSourceKeyIterator keyIterator() {
-        return new DefaultKeyIterator(keys());
+        if(!uncommittedCache.isEmpty()) {
+            throw new IllegalStateException("There are uncommitted keys");
+        }
+
+        return new DefaultKeyIterator(base.keys());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/DefaultKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DefaultKeyIterator.java
@@ -47,8 +47,4 @@ public class DefaultKeyIterator implements DataSourceKeyIterator {
         }
         return this.iterator.next().getData();
     }
-
-    @Override
-    public void seekToFirst() {
-    }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/DefaultKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DefaultKeyIterator.java
@@ -42,6 +42,9 @@ public class DefaultKeyIterator implements DataSourceKeyIterator {
 
     @Override
     public ByteArrayWrapper next() throws NoSuchElementException {
+        if (!this.hasNext()) {
+            throw new NoSuchElementException();
+        }
         return this.iterator.next();
     }
 

--- a/rskj-core/src/main/java/org/ethereum/datasource/DefaultKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DefaultKeyIterator.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.datasource;
+
+import org.ethereum.db.ByteArrayWrapper;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class DefaultKeyIterator implements DataSourceKeyIterator {
+    private Iterator<ByteArrayWrapper> iterator;
+
+    public DefaultKeyIterator(Collection<ByteArrayWrapper> collection) {
+        this.iterator = collection.iterator();
+    }
+
+    @Override
+    public void close() throws Exception {
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.iterator.hasNext();
+    }
+
+    @Override
+    public ByteArrayWrapper next() throws NoSuchElementException {
+        return this.iterator.next();
+    }
+
+    @Override
+    public void seekToFirst() {
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/datasource/DefaultKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/DefaultKeyIterator.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 public class DefaultKeyIterator implements DataSourceKeyIterator {
-    private Iterator<ByteArrayWrapper> iterator;
+    private final Iterator<ByteArrayWrapper> iterator;
 
     public DefaultKeyIterator(Collection<ByteArrayWrapper> collection) {
         this.iterator = collection.iterator();
@@ -41,11 +41,11 @@ public class DefaultKeyIterator implements DataSourceKeyIterator {
     }
 
     @Override
-    public ByteArrayWrapper next() throws NoSuchElementException {
+    public byte[] next() throws NoSuchElementException {
         if (!this.hasNext()) {
             throw new NoSuchElementException();
         }
-        return this.iterator.next();
+        return this.iterator.next().getData();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/HashMapDB.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/HashMapDB.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.ethereum.util.ByteUtil.wrap;
 
-public class HashMapDB implements KeyValueDataSource<Iterator<ByteArrayWrapper> > {
+public class HashMapDB implements KeyValueDataSource {
 
     private final Map<ByteArrayWrapper, byte[]> storage = new ConcurrentHashMap<>();
     private boolean clearOnClose = true;
@@ -73,8 +73,8 @@ public class HashMapDB implements KeyValueDataSource<Iterator<ByteArrayWrapper> 
     }
 
     @Override
-    public synchronized Iterator<ByteArrayWrapper> iterator() {
-        return storage.keySet().iterator();
+    public synchronized DataSourceKeyIterator keyIterator() {
+        return new DefaultKeyIterator(storage.keySet());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/HashMapDB.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/HashMapDB.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.ethereum.util.ByteUtil.wrap;
 
-public class HashMapDB implements KeyValueDataSource {
+public class HashMapDB implements KeyValueDataSource<Iterator<ByteArrayWrapper> > {
 
     private final Map<ByteArrayWrapper, byte[]> storage = new ConcurrentHashMap<>();
     private boolean clearOnClose = true;
@@ -70,6 +70,11 @@ public class HashMapDB implements KeyValueDataSource {
     @Override
     public synchronized Set<ByteArrayWrapper> keys() {
         return new HashSet<>(storage.keySet());
+    }
+
+    @Override
+    public synchronized Iterator<ByteArrayWrapper> iterator() {
+        return storage.keySet().iterator();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
@@ -20,6 +20,7 @@
 package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
+import org.rocksdb.RocksIterator;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
@@ -31,7 +32,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 
-public interface KeyValueDataSource extends DataSource {
+public interface KeyValueDataSource<DbIterator> extends DataSource {
     String DB_KIND_PROPERTIES_FILE = "dbKind.properties";
     String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
     String KEYVALUE_DATASOURCE = "KeyValueDataSource";
@@ -49,6 +50,8 @@ public interface KeyValueDataSource extends DataSource {
     void delete(byte[] key);
 
     Set<ByteArrayWrapper> keys();
+
+    DbIterator iterator();
 
     /**
      * Note that updateBatch() does not imply the operation is atomic:
@@ -91,7 +94,7 @@ public interface KeyValueDataSource extends DataSource {
     static void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
         Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
         for (Path originPath : originPaths) {
-            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
+            KeyValueDataSource<?> singleOriginDataSource = makeDataSource(originPath, kind);
             for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
                 mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
             }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSource.java
@@ -20,7 +20,6 @@
 package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
-import org.rocksdb.RocksIterator;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
@@ -32,7 +31,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 
-public interface KeyValueDataSource<DbIterator> extends DataSource {
+public interface KeyValueDataSource extends DataSource {
     String DB_KIND_PROPERTIES_FILE = "dbKind.properties";
     String KEYVALUE_DATASOURCE_PROP_NAME = "keyvalue.datasource";
     String KEYVALUE_DATASOURCE = "KeyValueDataSource";
@@ -51,7 +50,7 @@ public interface KeyValueDataSource<DbIterator> extends DataSource {
 
     Set<ByteArrayWrapper> keys();
 
-    DbIterator iterator();
+    DataSourceKeyIterator keyIterator();
 
     /**
      * Note that updateBatch() does not imply the operation is atomic:
@@ -94,7 +93,7 @@ public interface KeyValueDataSource<DbIterator> extends DataSource {
     static void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
         Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
         for (Path originPath : originPaths) {
-            KeyValueDataSource<?> singleOriginDataSource = makeDataSource(originPath, kind);
+            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
             for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
                 mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
             }

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -26,7 +26,6 @@ import co.rsk.panic.PanicProcessor;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
 import org.iq80.leveldb.*;
-import org.rocksdb.RocksIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +40,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import static java.lang.System.getProperty;
 import static org.fusesource.leveldbjni.JniDBFactory.factory;
 
-public class LevelDbDataSource implements KeyValueDataSource<DBIterator> {
+public class LevelDbDataSource implements KeyValueDataSource {
 
     private static final Logger logger = LoggerFactory.getLogger("db");
     private static final Profiler profiler = ProfilerFactory.getInstance();
@@ -223,8 +222,8 @@ public class LevelDbDataSource implements KeyValueDataSource<DBIterator> {
     }
 
     @Override
-    public DBIterator iterator() {
-        return db.iterator();
+    public DataSourceKeyIterator keyIterator() {
+        return new LevelDbKeyIterator(this.db);
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -26,6 +26,7 @@ import co.rsk.panic.PanicProcessor;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
 import org.iq80.leveldb.*;
+import org.rocksdb.RocksIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import static java.lang.System.getProperty;
 import static org.fusesource.leveldbjni.JniDBFactory.factory;
 
-public class LevelDbDataSource implements KeyValueDataSource {
+public class LevelDbDataSource implements KeyValueDataSource<DBIterator> {
 
     private static final Logger logger = LoggerFactory.getLogger("db");
     private static final Profiler profiler = ProfilerFactory.getInstance();
@@ -219,6 +220,11 @@ public class LevelDbDataSource implements KeyValueDataSource {
             resetDbLock.readLock().unlock();
             profiler.stop(metric);
         }
+    }
+
+    @Override
+    public DBIterator iterator() {
+        return db.iterator();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.datasource;
+
+import org.ethereum.db.ByteArrayWrapper;
+import org.ethereum.util.ByteUtil;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBIterator;
+
+import java.util.NoSuchElementException;
+
+public class LevelDbKeyIterator implements DataSourceKeyIterator {
+    private DBIterator iterator;
+
+    public LevelDbKeyIterator(DB db) {
+        this.iterator = db.iterator();
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.iterator.close();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.iterator.hasNext();
+    }
+
+    @Override
+    public ByteArrayWrapper next() throws NoSuchElementException {
+        byte[] key = this.iterator.next().getKey();
+        return ByteUtil.wrap(key);
+    }
+
+    @Override
+    public void seekToFirst() {
+        this.iterator.seekToFirst();
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
@@ -18,15 +18,13 @@
  */
 package org.ethereum.datasource;
 
-import org.ethereum.db.ByteArrayWrapper;
-import org.ethereum.util.ByteUtil;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
 
 import java.util.NoSuchElementException;
 
 public class LevelDbKeyIterator implements DataSourceKeyIterator {
-    private DBIterator iterator;
+    private final DBIterator iterator;
 
     public LevelDbKeyIterator(DB db) {
         this(db, false);
@@ -51,12 +49,11 @@ public class LevelDbKeyIterator implements DataSourceKeyIterator {
     }
 
     @Override
-    public ByteArrayWrapper next() throws NoSuchElementException {
+    public byte[] next() throws NoSuchElementException {
         if (!this.hasNext()) {
             throw new NoSuchElementException();
         }
-        byte[] key = this.iterator.next().getKey();
-        return ByteUtil.wrap(key);
+        return this.iterator.next().getKey();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
@@ -43,14 +43,6 @@ public class LevelDbKeyIterator implements DataSourceKeyIterator {
 
     @Override
     public byte[] next() throws NoSuchElementException {
-        if (!this.hasNext()) {
-            throw new NoSuchElementException();
-        }
-
-        byte[] key = this.iterator.peekNext().getKey();
-
-        this.iterator.next();
-
-        return key;
+        return this.iterator.next().getKey();
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
@@ -29,7 +29,15 @@ public class LevelDbKeyIterator implements DataSourceKeyIterator {
     private DBIterator iterator;
 
     public LevelDbKeyIterator(DB db) {
+        this(db, false);
+    }
+
+    public LevelDbKeyIterator(DB db, boolean avoidSeekFirst) {
         this.iterator = db.iterator();
+
+        if (!avoidSeekFirst) {
+            this.iterator.seekToFirst();
+        }
     }
 
     @Override
@@ -44,6 +52,9 @@ public class LevelDbKeyIterator implements DataSourceKeyIterator {
 
     @Override
     public ByteArrayWrapper next() throws NoSuchElementException {
+        if (!this.hasNext()) {
+            throw new NoSuchElementException();
+        }
         byte[] key = this.iterator.next().getKey();
         return ByteUtil.wrap(key);
     }

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbKeyIterator.java
@@ -25,19 +25,10 @@ import java.util.NoSuchElementException;
 
 public class LevelDbKeyIterator implements DataSourceKeyIterator {
     private final DBIterator iterator;
-    private boolean blockIteration;
 
     public LevelDbKeyIterator(DB db) {
-        this(db, false);
-    }
-
-    public LevelDbKeyIterator(DB db, boolean avoidSeekFirst) {
-        this.blockIteration = false;
         this.iterator = db.iterator();
-
-        if (!avoidSeekFirst) {
-            this.iterator.seekToFirst();
-        }
+        this.iterator.seekToFirst();
     }
 
     @Override
@@ -52,23 +43,14 @@ public class LevelDbKeyIterator implements DataSourceKeyIterator {
 
     @Override
     public byte[] next() throws NoSuchElementException {
-        byte[] key = this.iterator.peekNext().getKey();
-
-        if (blockIteration) {
+        if (!this.hasNext()) {
             throw new NoSuchElementException();
         }
 
-        if (this.hasNext()) {
-            this.iterator.next();
-        } else {
-            this.blockIteration = true;
-        }
+        byte[] key = this.iterator.peekNext().getKey();
+
+        this.iterator.next();
 
         return key;
-    }
-
-    @Override
-    public void seekToFirst() {
-        this.iterator.seekToFirst();
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
@@ -39,7 +39,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static java.lang.System.getProperty;
 
-public class RocksDbDataSource implements KeyValueDataSource {
+public class RocksDbDataSource implements KeyValueDataSource<RocksIterator> {
 
     private static final Long GENERAL_SIZE = 10L * 1024L * 1024L;
     private static final int MAX_RETRIES = 2;
@@ -244,6 +244,11 @@ public class RocksDbDataSource implements KeyValueDataSource {
             resetDbLock.readLock().unlock();
             profiler.stop(metric);
         }
+    }
+
+    @Override
+    public RocksIterator iterator() {
+        return db.newIterator();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
@@ -39,7 +39,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static java.lang.System.getProperty;
 
-public class RocksDbDataSource implements KeyValueDataSource<RocksIterator> {
+public class RocksDbDataSource implements KeyValueDataSource {
 
     private static final Long GENERAL_SIZE = 10L * 1024L * 1024L;
     private static final int MAX_RETRIES = 2;
@@ -247,8 +247,8 @@ public class RocksDbDataSource implements KeyValueDataSource<RocksIterator> {
     }
 
     @Override
-    public RocksIterator iterator() {
-        return db.newIterator();
+    public DataSourceKeyIterator keyIterator() {
+        return new RocksDbKeyIterator(this.db);
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
@@ -28,16 +28,9 @@ public class RocksDbKeyIterator implements DataSourceKeyIterator {
     private boolean blockIteration;
 
     public RocksDbKeyIterator(RocksDB db) {
-        this(db, false);
-    }
-
-    public RocksDbKeyIterator(RocksDB db, boolean avoidSeekFirst) {
         this.blockIteration = false;
         this.iterator = db.newIterator();
-
-        if (!avoidSeekFirst) {
-            this.iterator.seekToFirst();
-        }
+        this.iterator.seekToFirst();
     }
 
     @Override
@@ -52,23 +45,14 @@ public class RocksDbKeyIterator implements DataSourceKeyIterator {
 
     @Override
     public byte[] next() throws NoSuchElementException {
-        byte[] key = this.iterator.key();
-
-        if (blockIteration) {
+        if (!this.hasNext()) {
             throw new NoSuchElementException();
         }
 
-        if (this.hasNext()) {
-            this.iterator.next();
-        } else {
-            this.blockIteration = true;
-        }
+        byte[] key = this.iterator.key();
+
+        this.iterator.next();
 
         return key;
-    }
-
-    @Override
-    public void seekToFirst() {
-        this.iterator.seekToFirst();
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
@@ -18,15 +18,13 @@
  */
 package org.ethereum.datasource;
 
-import org.ethereum.db.ByteArrayWrapper;
-import org.ethereum.util.ByteUtil;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksIterator;
 
 import java.util.NoSuchElementException;
 
 public class RocksDbKeyIterator implements DataSourceKeyIterator {
-    private RocksIterator iterator;
+    private final RocksIterator iterator;
 
     public RocksDbKeyIterator(RocksDB db) {
         this(db, false);
@@ -51,14 +49,13 @@ public class RocksDbKeyIterator implements DataSourceKeyIterator {
     }
 
     @Override
-    public ByteArrayWrapper next() throws NoSuchElementException {
+    public byte[] next() throws NoSuchElementException {
         if (!this.hasNext()) {
             throw new NoSuchElementException();
         }
 
         this.iterator.next();
-        byte[] key = this.iterator.key();
-        return ByteUtil.wrap(key);
+        return this.iterator.key();
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.datasource;
+
+import org.ethereum.db.ByteArrayWrapper;
+import org.ethereum.util.ByteUtil;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksIterator;
+
+import java.util.NoSuchElementException;
+
+public class RocksDbKeyIterator implements DataSourceKeyIterator {
+    private RocksIterator iterator;
+
+    public RocksDbKeyIterator(RocksDB db) {
+        this.iterator = db.newIterator();
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.iterator.close();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.iterator.isValid();
+    }
+
+    @Override
+    public ByteArrayWrapper next() throws NoSuchElementException {
+        this.iterator.next();
+        byte[] key = this.iterator.key();
+        return ByteUtil.wrap(key);
+    }
+
+    @Override
+    public void seekToFirst() {
+        this.iterator.seekToFirst();
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
@@ -25,10 +25,8 @@ import java.util.NoSuchElementException;
 
 public class RocksDbKeyIterator implements DataSourceKeyIterator {
     private final RocksIterator iterator;
-    private boolean blockIteration;
 
     public RocksDbKeyIterator(RocksDB db) {
-        this.blockIteration = false;
         this.iterator = db.newIterator();
         this.iterator.seekToFirst();
     }

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbKeyIterator.java
@@ -29,7 +29,15 @@ public class RocksDbKeyIterator implements DataSourceKeyIterator {
     private RocksIterator iterator;
 
     public RocksDbKeyIterator(RocksDB db) {
+        this(db, false);
+    }
+
+    public RocksDbKeyIterator(RocksDB db, boolean avoidSeekFirst) {
         this.iterator = db.newIterator();
+
+        if (!avoidSeekFirst) {
+            this.iterator.seekToFirst();
+        }
     }
 
     @Override
@@ -44,6 +52,10 @@ public class RocksDbKeyIterator implements DataSourceKeyIterator {
 
     @Override
     public ByteArrayWrapper next() throws NoSuchElementException {
+        if (!this.hasNext()) {
+            throw new NoSuchElementException();
+        }
+
         this.iterator.next();
         byte[] key = this.iterator.key();
         return ByteUtil.wrap(key);

--- a/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
@@ -40,6 +40,16 @@ public class DataSourceWithCacheTest {
         dataSourceWithCache.get(randomKey);
         dataSourceWithCache.get(randomKey);
 
+        try (DataSourceKeyIterator iterator = dataSourceWithCache.keyIterator()){
+
+            iterator.seekToFirst();
+
+            assertTrue(iterator.hasNext());
+            assertEquals(iterator.next(), ByteUtil.wrap(randomKey));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         verify(baseDataSource, times(1)).get(any(byte[].class));
 
         dataSourceWithCache.flush();

--- a/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
@@ -3,6 +3,7 @@ package org.ethereum.datasource;
 import org.ethereum.TestUtils;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -41,13 +42,10 @@ public class DataSourceWithCacheTest {
         dataSourceWithCache.get(randomKey);
 
         try (DataSourceKeyIterator iterator = dataSourceWithCache.keyIterator()){
-
-            iterator.seekToFirst();
-
             assertTrue(iterator.hasNext());
             assertArrayEquals(iterator.next(), randomKey);
         } catch (Exception e) {
-            e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
 
         verify(baseDataSource, times(1)).get(any(byte[].class));

--- a/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/DataSourceWithCacheTest.java
@@ -45,7 +45,7 @@ public class DataSourceWithCacheTest {
             iterator.seekToFirst();
 
             assertTrue(iterator.hasNext());
-            assertEquals(iterator.next(), ByteUtil.wrap(randomKey));
+            assertArrayEquals(iterator.next(), randomKey);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
@@ -76,7 +76,11 @@ public class KeyValueDataSourceTest {
 
             assertArrayEquals(expectedValue, randomKey);
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            if (!withFlush && keyValueDataSource instanceof DataSourceWithCache) {
+                assertEquals(e.getMessage(), "There are uncommitted keys");
+            } else {
+                Assert.fail(e.getMessage());
+            }
         }
     }
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
@@ -55,7 +55,6 @@ public class KeyValueDataSourceTest {
     public void put() {
         byte[] randomKey = "testing-key".getBytes();
         byte[] randomValue = "testing-value".getBytes();
-        ByteArrayWrapper randomKeyByteWrapper = ByteUtil.wrap(randomKey);
 
         keyValueDataSource.put(randomKey, randomValue);
         if (withFlush) {
@@ -69,16 +68,16 @@ public class KeyValueDataSourceTest {
 
             assertTrue(iterator.hasNext());
 
-            ByteArrayWrapper expectedValue = null;
+            byte[] expectedValue = null;
 
             while (iterator.hasNext()) {
                 expectedValue = iterator.next();
-                if (expectedValue.equals(randomKeyByteWrapper)) {
+                if (ByteUtil.wrap(expectedValue).equals(ByteUtil.wrap(randomKey))) {
                     break;
                 }
             }
 
-            assertEquals(expectedValue, randomKeyByteWrapper);
+            assertArrayEquals(expectedValue, randomKey);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
@@ -53,14 +53,35 @@ public class KeyValueDataSourceTest {
 
     @Test
     public void put() {
-        byte[] randomKey = TestUtils.randomBytes(20);
-        byte[] randomValue = TestUtils.randomBytes(20);
+        byte[] randomKey = "testing-key".getBytes();
+        byte[] randomValue = "testing-value".getBytes();
+        ByteArrayWrapper randomKeyByteWrapper = ByteUtil.wrap(randomKey);
 
         keyValueDataSource.put(randomKey, randomValue);
         if (withFlush) {
             keyValueDataSource.flush();
         }
         assertThat(keyValueDataSource.get(randomKey), is(randomValue));
+
+        try (DataSourceKeyIterator iterator = keyValueDataSource.keyIterator()) {
+
+            iterator.seekToFirst();
+
+            assertTrue(iterator.hasNext());
+
+            ByteArrayWrapper expectedValue = null;
+
+            while (iterator.hasNext()) {
+                expectedValue = iterator.next();
+                if (expectedValue.equals(randomKeyByteWrapper)) {
+                    break;
+                }
+            }
+
+            assertEquals(expectedValue, randomKeyByteWrapper);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Test(expected = NullPointerException.class)

--- a/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
@@ -63,9 +63,6 @@ public class KeyValueDataSourceTest {
         assertThat(keyValueDataSource.get(randomKey), is(randomValue));
 
         try (DataSourceKeyIterator iterator = keyValueDataSource.keyIterator()) {
-
-            iterator.seekToFirst();
-
             assertTrue(iterator.hasNext());
 
             byte[] expectedValue = null;
@@ -79,7 +76,7 @@ public class KeyValueDataSourceTest {
 
             assertArrayEquals(expectedValue, randomKey);
         } catch (Exception e) {
-            e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
@@ -21,6 +21,7 @@ package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -49,13 +50,10 @@ public class LevelDbDataSourceTest {
         assertEquals(batchSize, dataSource.keys().size());
 
         try (DataSourceKeyIterator iterator = dataSource.keyIterator()){
-
-            iterator.seekToFirst();
-
             assertTrue(iterator.hasNext());
             assertNotNull(iterator.next());
         } catch (Exception e) {
-            e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
 
         dataSource.close();

--- a/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
@@ -21,20 +21,14 @@ package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
-import org.iq80.leveldb.DBIterator;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.ethereum.TestUtils.randomBytes;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
 public class LevelDbDataSourceTest {
@@ -53,11 +47,17 @@ public class LevelDbDataSourceTest {
         dataSource.updateBatch(batch, Collections.emptySet());
 
         assertEquals(batchSize, dataSource.keys().size());
-        DBIterator iterator = dataSource.iterator();
-        iterator.seekToFirst();
-        assertTrue(iterator.hasNext());
 
-        iterator.close();
+        try (DataSourceKeyIterator iterator = dataSource.keyIterator()){
+
+            iterator.seekToFirst();
+
+            assertTrue(iterator.hasNext());
+            assertNotNull(iterator.next());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         dataSource.close();
     }
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
@@ -21,6 +21,7 @@ package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
+import org.iq80.leveldb.DBIterator;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,8 +35,7 @@ import java.util.stream.Collectors;
 import static org.ethereum.TestUtils.randomBytes;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class LevelDbDataSourceTest {
 
@@ -53,7 +53,11 @@ public class LevelDbDataSourceTest {
         dataSource.updateBatch(batch, Collections.emptySet());
 
         assertEquals(batchSize, dataSource.keys().size());
+        DBIterator iterator = dataSource.iterator();
+        iterator.seekToFirst();
+        assertTrue(iterator.hasNext());
 
+        iterator.close();
         dataSource.close();
     }
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
@@ -21,6 +21,7 @@ package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -49,13 +50,10 @@ public class RocksDbDataSourceTest {
         assertEquals(batchSize, dataSource.keys().size());
 
         try (DataSourceKeyIterator iterator = dataSource.keyIterator()){
-
-            iterator.seekToFirst();
-
             assertTrue(iterator.hasNext());
             assertNotNull(iterator.next());
         } catch (Exception e) {
-            e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
 
         dataSource.close();

--- a/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
@@ -21,19 +21,15 @@ package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.RocksIterator;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.ethereum.TestUtils.randomBytes;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
@@ -53,11 +49,17 @@ public class RocksDbDataSourceTest {
         dataSource.updateBatch(batch, Collections.emptySet());
 
         assertEquals(batchSize, dataSource.keys().size());
-        RocksIterator iterator = dataSource.iterator();
-        iterator.seekToFirst();
-        assertTrue(iterator.isValid());
 
-        iterator.close();
+        try (DataSourceKeyIterator iterator = dataSource.keyIterator()){
+
+            iterator.seekToFirst();
+
+            assertTrue(iterator.hasNext());
+            assertNotNull(iterator.next());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         dataSource.close();
     }
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
@@ -24,13 +24,11 @@ import org.ethereum.util.ByteUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.rocksdb.RocksIterator;
 
 import java.io.IOException;
 import java.util.*;
 
 import static org.ethereum.TestUtils.randomBytes;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
 public class RocksDbDataSourceTest {

--- a/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.rocksdb.RocksIterator;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -34,8 +35,7 @@ import java.util.stream.Collectors;
 import static org.ethereum.TestUtils.randomBytes;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class RocksDbDataSourceTest {
 
@@ -53,7 +53,11 @@ public class RocksDbDataSourceTest {
         dataSource.updateBatch(batch, Collections.emptySet());
 
         assertEquals(batchSize, dataSource.keys().size());
-        
+        RocksIterator iterator = dataSource.iterator();
+        iterator.seekToFirst();
+        assertTrue(iterator.isValid());
+
+        iterator.close();
         dataSource.close();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Improving db migration process by using iterator instead of getting all the keys

## Motivation and Context
In large databases it is not a good idea to get all existing keys. Instead we are using an iterator to iterate key by key.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
