### PR TITLE
Affecting consensus changes on RSK adding the following bridge method: getPegoutCreationRskTxHashByBtcTxHash

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1235,20 +1235,11 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
     public byte[] getPegoutCreationRskTxHashByBtcTxHash(Object[] args) {
         logger.trace("getPegoutCreationRskTxHashByBtcTxHash");
-        try {
-            byte[] hashBytes = (byte[])args[0];
-            Sha256Hash hash = Sha256Hash.wrap(hashBytes);
 
-            Optional<Keccak256> rskTxHash = this.bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(hash);
-            if (rskTxHash.isPresent()){
-                return rskTxHash.get().getBytes();
-            } else {
-                return ByteUtil.EMPTY_BYTE_ARRAY;
-            }
-        } catch (Exception e) {
-            logger.warn("Exception in getPegoutCreationRskTxHashByBtcTxHash", e);
-            return ByteUtil.EMPTY_BYTE_ARRAY;
-        }
+        byte[] btcTxHashInBytes = (byte[])args[0];
+        Sha256Hash btcTxHash = Sha256Hash.wrap(btcTxHashInBytes);
+
+        return this.bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
     }
 
     public static BridgeMethods.BridgeMethodExecutor activeAndRetiringFederationOnly(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -204,6 +204,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
     public static final CallTransaction.Function GET_ACTIVE_POWPEG_REDEEM_SCRIPT = BridgeMethods.GET_ACTIVE_POWPEG_REDEEM_SCRIPT.getFunction();
 
+    public static final CallTransaction.Function GET_PEGOUT_CREATION_RSK_TX_HASH_BY_BTC_TX_HASH = BridgeMethods.GET_PEGOUT_CREATION_RSK_TX_HASH_BY_BTC_TX_HASH.getFunction();
+
     public static final int LOCK_WHITELIST_UNLIMITED_MODE_CODE = 0;
     public static final int LOCK_WHITELIST_ENTRY_NOT_FOUND_CODE = -1;
     public static final int LOCK_WHITELIST_INVALID_ADDRESS_FORMAT_ERROR_CODE = -2;
@@ -1229,6 +1231,24 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         logger.trace("getEstimatedFeesForNextPegOutEvent");
 
         return bridgeSupport.getEstimatedFeesForNextPegOutEvent().value;
+    }
+
+    public byte[] getPegoutCreationRskTxHashByBtcTxHash(Object[] args) {
+        logger.trace("getPegoutCreationRskTxHashByBtcTxHash");
+        try {
+            byte[] hashBytes = (byte[])args[0];
+            Sha256Hash hash = Sha256Hash.wrap(hashBytes);
+
+            Optional<Keccak256> rskTxHash = this.bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(hash);
+            if (rskTxHash.isPresent()){
+                return rskTxHash.get().getBytes();
+            } else {
+                return ByteUtil.EMPTY_BYTE_ARRAY;
+            }
+        } catch (Exception e) {
+            logger.warn("Exception in getPegoutCreationRskTxHashByBtcTxHash", e);
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
     }
 
     public static BridgeMethods.BridgeMethodExecutor activeAndRetiringFederationOnly(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -701,7 +701,19 @@ public enum BridgeMethods {
             (BridgeMethodExecutorTyped) Bridge::getEstimatedFeesForNextPegOutEvent,
             activations -> activations.isActive(RSKIP271),
             fixedPermission(false)
-    );
+    ),
+    GET_PEGOUT_CREATION_RSK_TX_HASH_BY_BTC_TX_HASH(
+        CallTransaction.Function.fromSignature(
+            "getPegoutCreationRskTxHashByBtcTxHash",
+            new String[]{"bytes32"},
+            new String[]{"bytes32"}
+        ),
+        fixedCost(10_000L), // TODO: PENDING TO DEFINE
+        (BridgeMethodExecutorTyped) Bridge::getPegoutCreationRskTxHashByBtcTxHash,
+        activations -> activations.isActive(RSKIP298),
+        fixedPermission(false)
+    ),
+    ;
 
     private final CallTransaction.Function function;
     private final CostProvider costProvider;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -802,17 +802,17 @@ public class BridgeSerializationUtils {
 
     public static byte[] serializeSha256Hash(Sha256Hash hash) {
         if (hash == null){
-            return null;
+            return new byte[]{};
         }
         return RLP.encodeElement(hash.getBytes());
     }
 
-    public static Sha256Hash deserializeSha256Hash(byte[] data) {
+    public static Optional<Sha256Hash> deserializeSha256Hash(byte[] data) {
         RLPElement element = RLP.decodeFirstElement(data, 0);
         if (element == null) {
-            return null;
+            return Optional.empty();
         }
-        return Sha256Hash.wrap(element.getRLPData());
+        return Optional.of(Sha256Hash.wrap(element.getRLPData()));
     }
 
     public static Optional<Keccak256> deserializeKeccak256(byte[] data) {
@@ -820,19 +820,18 @@ public class BridgeSerializationUtils {
             return Optional.empty();
         }
 
-        RLPList rlpList = (RLPList) RLP.decode2(data).get(0);
-        if (rlpList.size() != 1) {
-            throw new RuntimeException(String.format("Invalid serialized keccak256. Expected 1 element, but got %d", rlpList.size()));
+        RLPElement element = RLP.decodeFirstElement(data, 0);
+        if (element == null) {
+            return Optional.empty();
         }
-
-        return Optional.of(new Keccak256(rlpList.get(0).getRLPRawData()));
+        return Optional.of(new Keccak256(element.getRLPRawData()));
     }
 
     public static byte[] serializeKeccak256(Keccak256 data) {
         if (data == null){
-            return null;
+            return new byte[]{};
         }
-        return RLP.encodeList(RLP.encodeElement(data.getBytes()));
+        return RLP.encode(data.getBytes());
     }
 
     public static byte[] serializeScript(Script script) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -801,9 +801,6 @@ public class BridgeSerializationUtils {
     }
 
     public static byte[] serializeSha256Hash(Sha256Hash hash) {
-        if (hash == null){
-            return new byte[]{};
-        }
         return RLP.encodeElement(hash.getBytes());
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -804,12 +804,12 @@ public class BridgeSerializationUtils {
         return RLP.encodeElement(hash.getBytes());
     }
 
-    public static Optional<Sha256Hash> deserializeSha256Hash(byte[] data) {
+    public static Sha256Hash deserializeSha256Hash(byte[] data) {
         RLPElement element = RLP.decodeFirstElement(data, 0);
         if (element == null) {
-            return Optional.empty();
+            return null;
         }
-        return Optional.of(Sha256Hash.wrap(element.getRLPData()));
+        return Sha256Hash.wrap(element.getRLPData());
     }
 
     public static Optional<Keccak256> deserializeKeccak256(byte[] data) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -801,6 +801,9 @@ public class BridgeSerializationUtils {
     }
 
     public static byte[] serializeSha256Hash(Sha256Hash hash) {
+        if (hash == null){
+            return null;
+        }
         return RLP.encodeElement(hash.getBytes());
     }
 
@@ -810,6 +813,26 @@ public class BridgeSerializationUtils {
             return null;
         }
         return Sha256Hash.wrap(element.getRLPData());
+    }
+
+    public static Optional<Keccak256> deserializeKeccak256(byte[] data) {
+        if (data == null) {
+            return Optional.empty();
+        }
+
+        RLPList rlpList = (RLPList) RLP.decode2(data).get(0);
+        if (rlpList.size() != 1) {
+            throw new RuntimeException(String.format("Invalid serialized keccak256. Expected 1 element, but got %d", rlpList.size()));
+        }
+
+        return Optional.of(new Keccak256(rlpList.get(0).getRLPRawData()));
+    }
+
+    public static byte[] serializeKeccak256(Keccak256 data) {
+        if (data == null){
+            return null;
+        }
+        return RLP.encodeList(RLP.encodeElement(data.getBytes()));
     }
 
     public static byte[] serializeScript(Script script) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -684,7 +684,12 @@ public class BridgeStorageProvider {
         }
 
         DataWord storageKey = getStorageKeyForBtcBlockIndex(height);
-        return safeGetFromRepository(storageKey, BridgeSerializationUtils::deserializeSha256Hash);
+        Sha256Hash blockHash = safeGetFromRepository(storageKey, BridgeSerializationUtils::deserializeSha256Hash);
+        if (blockHash != null) {
+            return Optional.of(blockHash);
+        }
+
+        return Optional.empty();
     }
 
     public void setBtcBestBlockHashByHeight(int height, Sha256Hash blockHash) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -960,11 +960,7 @@ public class BridgeStorageProvider {
     }
 
     public Optional<Keccak256> getPegoutCreationRskTxHashByBtcTxHash(Sha256Hash btcTxHash){
-        if(!activations.isActive(RSKIP298)){
-            return Optional.empty();
-        }
-
-        if (btcTxHash == null){
+        if(!activations.isActive(RSKIP298) || btcTxHash == null){
             return Optional.empty();
         }
 
@@ -979,6 +975,8 @@ public class BridgeStorageProvider {
     private void savePegoutCreationEntry(){
         if (
             this.pegoutCreationEntry == null
+                || this.pegoutCreationEntry.getBtcTxHash() == null
+                || this.pegoutCreationEntry.getRskTxHash() == null
                 || !activations.isActive(RSKIP298)
         ){
             return;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -141,6 +141,9 @@ public class BridgeStorageProvider {
 
     private Long nextPegoutHeight;
 
+    private Sha256Hash pegoutCreationEntryBtcTxHash;
+    private Keccak256 pegoutCreationEntryRskTxHash;
+
     public BridgeStorageProvider(
         Repository repository,
         RskAddress contractAddress,
@@ -954,6 +957,45 @@ public class BridgeStorageProvider {
         return getReleaseRequestQueue().getEntries().size();
     }
 
+    public void setPegoutCreationEntry(Sha256Hash btcTxHash, Keccak256 rskTxHash){
+        if (!activations.isActive(RSKIP298)){
+            return;
+        }
+        this.pegoutCreationEntryBtcTxHash = btcTxHash;
+        this.pegoutCreationEntryRskTxHash = rskTxHash;
+    }
+
+    public Optional<Keccak256> getPegoutCreationEntry(Sha256Hash btcTxHash){
+        if(!activations.isActive(RSKIP298)){
+            return Optional.empty();
+        }
+
+        return safeGetFromRepository(
+            getStorageKeyForPegoutCreationIndex(
+                btcTxHash
+            ),
+            BridgeSerializationUtils::deserializeKeccak256
+        );
+    }
+
+    public void savePegoutCreationEntry(){
+        if (
+            this.pegoutCreationEntryBtcTxHash == null
+                || this.pegoutCreationEntryRskTxHash == null
+                || !activations.isActive(RSKIP298)
+        ){
+            return;
+        }
+
+        safeSaveToRepository(
+            getStorageKeyForPegoutCreationIndex(
+                this.pegoutCreationEntryBtcTxHash
+            ),
+            this.pegoutCreationEntryRskTxHash,
+            BridgeSerializationUtils::serializeKeccak256
+        );
+    }
+
     public void save() throws IOException {
         saveBtcTxHashesAlreadyProcessed();
 
@@ -1015,6 +1057,10 @@ public class BridgeStorageProvider {
 
     private DataWord getStorageKeyForFlyoverFederationInformation(byte[] flyoverFederationRedeemScriptHash) {
         return DataWord.fromLongString("fastBridgeFederationInformation-" + Hex.toHexString(flyoverFederationRedeemScriptHash));
+    }
+
+    private DataWord getStorageKeyForPegoutCreationIndex(Sha256Hash btcTxHash) {
+        return DataWord.fromLongString("pegoutCreationIndex-" + btcTxHash);
     }
 
     private DataWord getStorageKeyForNewFederationBtcUtxos() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -964,6 +964,10 @@ public class BridgeStorageProvider {
             return Optional.empty();
         }
 
+        if (btcTxHash == null){
+            return Optional.empty();
+        }
+
         return safeGetFromRepository(
             getStorageKeyForPegoutCreationIndex(
                 btcTxHash

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2864,11 +2864,14 @@ public class BridgeSupport {
         return co.rsk.core.Coin.fromBitcoin(totalAmount).asBigInteger();
     }
 
-    public Optional<Keccak256> getPegoutCreationRskTxHashByBtcTxHash(Sha256Hash btcTxHash) {
+    public byte[] getPegoutCreationRskTxHashByBtcTxHash(Sha256Hash btcTxHash) {
         if (activations.isActive(ConsensusRule.RSKIP298)) {
-            return provider.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+            Optional<Keccak256> rskTxHash = provider.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+            if (rskTxHash.isPresent()){
+                return rskTxHash.get().getBytes();
+            }
         }
-        return Optional.empty();
+        return ByteUtil.EMPTY_BYTE_ARRAY;
     }
 
     protected FlyoverFederationInformation createFlyoverFederationInformation(Keccak256 flyoverDerivationHash) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2864,6 +2864,13 @@ public class BridgeSupport {
         return co.rsk.core.Coin.fromBitcoin(totalAmount).asBigInteger();
     }
 
+    public Optional<Keccak256> getPegoutCreationRskTxHashByBtcTxHash(Sha256Hash btcTxHash) {
+        if (activations.isActive(ConsensusRule.RSKIP298)) {
+            return provider.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+        }
+        return Optional.empty();
+    }
+
     protected FlyoverFederationInformation createFlyoverFederationInformation(Keccak256 flyoverDerivationHash) {
         return createFlyoverFederationInformation(flyoverDerivationHash, getActiveFederation());
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1154,69 +1154,74 @@ public class BridgeSupport {
         long currentBlockNumber = rskExecutionBlock.getNumber();
         long nextPegoutCreationBlockNumber = getNextPegoutCreationBlockNumber();
 
-        if (currentBlockNumber >= nextPegoutCreationBlockNumber) {
-            List<ReleaseRequestQueue.Entry> pegoutEntries = releaseRequestQueue.getEntries();
-            Coin totalPegoutValue = pegoutEntries
-                .stream()
-                .map(ReleaseRequestQueue.Entry::getAmount)
-                .reduce(Coin.ZERO, Coin::add);
+        // Skip processing pegouts in batch if the current block has not reached the next pegout creation block number
+        if (nextPegoutCreationBlockNumber > currentBlockNumber){
+            return;
+        }
 
-            if (wallet.getBalance().isLessThan(totalPegoutValue)) {
-                logger.warn("[processPegoutsInBatch] wallet balance {} is less than the totalPegoutValue {}", wallet.getBalance(), totalPegoutValue);
+        List<ReleaseRequestQueue.Entry> pegoutEntries = releaseRequestQueue.getEntries();
+        Coin totalPegoutValue = pegoutEntries
+            .stream()
+            .map(ReleaseRequestQueue.Entry::getAmount)
+            .reduce(Coin.ZERO, Coin::add);
+
+        if (wallet.getBalance().isLessThan(totalPegoutValue)) {
+            logger.warn("[processPegoutsInBatch] wallet balance {} is less than the totalPegoutValue {}", wallet.getBalance(), totalPegoutValue);
+            return;
+        }
+
+        if (!pegoutEntries.isEmpty()) {
+            logger.info("[processPegoutsInBatch] going to create a batched pegout transaction for {} requests, total amount {}", pegoutEntries.size(), totalPegoutValue);
+            ReleaseTransactionBuilder.BuildResult result = txBuilder.buildBatchedPegouts(pegoutEntries);
+
+            while (pegoutEntries.size() > 1 && result.getResponseCode() == ReleaseTransactionBuilder.Response.EXCEED_MAX_TRANSACTION_SIZE) {
+                logger.info("[processPegoutsInBatch] Max size exceeded, going to divide {} requests in half", pegoutEntries.size());
+                int firstHalfSize = pegoutEntries.size() / 2;
+                pegoutEntries = pegoutEntries.subList(0, firstHalfSize);
+                result = txBuilder.buildBatchedPegouts(pegoutEntries);
+            }
+
+            if (result.getResponseCode() != ReleaseTransactionBuilder.Response.SUCCESS) {
+                logger.warn(
+                    "Couldn't build a pegout BTC tx for {} pending requests (total amount: {}), Reason: {}",
+                    releaseRequestQueue.getEntries().size(),
+                    totalPegoutValue,
+                    result.getResponseCode());
                 return;
             }
 
-            if (!pegoutEntries.isEmpty()) {
-                logger.info("[processPegoutsInBatch] going to create a batched pegout transaction for {} requests, total amount {}", pegoutEntries.size(), totalPegoutValue);
-                ReleaseTransactionBuilder.BuildResult result = txBuilder.buildBatchedPegouts(pegoutEntries);
+            logger.info("[processPegoutsInBatch] pegouts processed with btcTx hash {} and response code {}", result.getBtcTx().getHash(), result.getResponseCode());
 
-                while (pegoutEntries.size() > 1 && result.getResponseCode() == ReleaseTransactionBuilder.Response.EXCEED_MAX_TRANSACTION_SIZE) {
-                    logger.info("[processPegoutsInBatch] Max size exceeded, going to divide {} requests in half", pegoutEntries.size());
-                    int firstHalfSize = pegoutEntries.size() / 2;
-                    pegoutEntries = pegoutEntries.subList(0, firstHalfSize);
-                    result = txBuilder.buildBatchedPegouts(pegoutEntries);
-                }
+            BtcTransaction generatedTransaction = result.getBtcTx();
+            addPegoutTxToReleaseTransactionSet(generatedTransaction, releaseTransactionSet, rskTx.getHash(), totalPegoutValue);
 
-                if (result.getResponseCode() != ReleaseTransactionBuilder.Response.SUCCESS) {
-                    logger.warn(
-                        "Couldn't build a pegout BTC tx for {} pending requests (total amount: {}), Reason: {}",
-                        releaseRequestQueue.getEntries().size(),
-                        totalPegoutValue,
-                        result.getResponseCode());
-                    return;
-                }
+            // Remove batched requests from the queue after successfully batching pegouts
+            releaseRequestQueue.removeEntries(pegoutEntries);
 
-                logger.info("[processPegoutsInBatch] pegouts processed with btcTx hash {} and response code {}", result.getBtcTx().getHash(), result.getResponseCode());
+            // Mark UTXOs as spent
+            List<UTXO> selectedUTXOs = result.getSelectedUTXOs();
+            logger.debug("[processPegoutsInBatch] used {} UTXOs for this pegout", selectedUTXOs.size());
+            availableUTXOs.removeAll(selectedUTXOs);
 
-                BtcTransaction generatedTransaction = result.getBtcTx();
-                addPegoutTxToReleaseTransactionSet(generatedTransaction, releaseTransactionSet, rskTx.getHash(), totalPegoutValue);
-
-                // Remove batched requests from the queue after successfully batching pegouts
-                releaseRequestQueue.removeEntries(pegoutEntries);
-
-                // Mark UTXOs as spent
-                List<UTXO> selectedUTXOs = result.getSelectedUTXOs();
-                logger.debug("[processPegoutsInBatch] used {} UTXOs for this pegout", selectedUTXOs.size());
-                availableUTXOs.removeAll(selectedUTXOs);
-
-                if (activations.isActive(ConsensusRule.RSKIP298)){
-                    provider.setPegoutCreationEntry(
+            if (activations.isActive(ConsensusRule.RSKIP298)) {
+                provider.setPegoutCreationEntry(
+                    new PegoutCreationEntry(
                         generatedTransaction.getHash(),
                         rskTx.getHash()
-                    );
-                }
-                eventLogger.logBatchPegoutCreated(generatedTransaction.getHash(),
-                    pegoutEntries.stream().map(ReleaseRequestQueue.Entry::getRskTxHash).collect(Collectors.toList()));
-
-                adjustBalancesIfChangeOutputWasDust(generatedTransaction, totalPegoutValue, wallet);
+                    )
+                );
             }
+            eventLogger.logBatchPegoutCreated(generatedTransaction.getHash(),
+                pegoutEntries.stream().map(ReleaseRequestQueue.Entry::getRskTxHash).collect(Collectors.toList()));
 
-            // update next Pegout height even if there were no request in queue
-            if (releaseRequestQueue.getEntries().isEmpty()) {
-                long nextPegoutHeight = currentBlockNumber + bridgeConstants.getNumberOfBlocksBetweenPegouts();
-                provider.setNextPegoutHeight(nextPegoutHeight);
-                logger.info("[processPegoutsInBatch] Next Pegout Height updated from {} to {}", currentBlockNumber, nextPegoutHeight);
-            }
+            adjustBalancesIfChangeOutputWasDust(generatedTransaction, totalPegoutValue, wallet);
+        }
+
+        // update next Pegout height even if there were no request in queue
+        if (releaseRequestQueue.getEntries().isEmpty()) {
+            long nextPegoutHeight = currentBlockNumber + bridgeConstants.getNumberOfBlocksBetweenPegouts();
+            provider.setNextPegoutHeight(nextPegoutHeight);
+            logger.info("[processPegoutsInBatch] Next Pegout Height updated from {} to {}", currentBlockNumber, nextPegoutHeight);
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1199,6 +1199,12 @@ public class BridgeSupport {
                 logger.debug("[processPegoutsInBatch] used {} UTXOs for this pegout", selectedUTXOs.size());
                 availableUTXOs.removeAll(selectedUTXOs);
 
+                if (activations.isActive(ConsensusRule.RSKIP298)){
+                    provider.setPegoutCreationEntry(
+                        generatedTransaction.getHash(),
+                        rskTx.getHash()
+                    );
+                }
                 eventLogger.logBatchPegoutCreated(generatedTransaction.getHash(),
                     pegoutEntries.stream().map(ReleaseRequestQueue.Entry::getRskTxHash).collect(Collectors.toList()));
 

--- a/rskj-core/src/main/java/co/rsk/peg/PegoutCreationEntry.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegoutCreationEntry.java
@@ -1,0 +1,48 @@
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.crypto.Keccak256;
+
+public class PegoutCreationEntry {
+    private Sha256Hash btcTxHash;
+    private Keccak256 rskTxHash;
+
+    public PegoutCreationEntry(Sha256Hash btcTxHash, Keccak256 rskTxHash) {
+        this.btcTxHash = btcTxHash;
+        this.rskTxHash = rskTxHash;
+    }
+
+    public Sha256Hash getBtcTxHash() {
+        return btcTxHash;
+    }
+
+    public Keccak256 getRskTxHash() {
+        return rskTxHash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PegoutCreationEntry)) {
+            return false;
+        }
+
+        PegoutCreationEntry that = (PegoutCreationEntry) o;
+        return getBtcTxHash().equals(that.getBtcTxHash()) && getRskTxHash().equals(that.getRskTxHash());
+    }
+
+    @Override
+    public int hashCode() {
+        return getBtcTxHash().hashCode() + getRskTxHash().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "PegoutCreationEntry{" +
+                   "btcTxHash=" + btcTxHash +
+                   ", rskTxHash=" + rskTxHash +
+                   '}';
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -77,6 +77,7 @@ public enum ConsensusRule {
     RSKIP293("rskip293"), // Flyover improvements
     RSKIP294("rskip294"),
     RSKIP297("rskip297"), // Increase max timestamp difference between btc and rsk blocks for Testnet
+    RSKIP298("rskip298"), // peg-out creation index
     RSKIP326("rskip326"), // release_request_received event update to use base58 for btcDestinationAddress
     RSKIP353("rskip353"),
     RSKIP357("rskip357");

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -75,6 +75,7 @@ blockchain = {
              rskip293 = <hardforkName>
              rskip294 = <hardforkName>
              rskip297 = <hardforkName>
+             rskip298 = <hardforkName>
              rskip326 = <hardforkName>
              rskip353 = <hardforkName>
              rskip357 = <hardforkName>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -63,6 +63,7 @@ blockchain = {
             rskip293 = hop400
             rskip294 = hop400
             rskip297 = hop400
+            rskip298 = fingerroot500
             rskip326 = fingerroot500
             rskip353 = hop401
             rskip357 = hop401

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1127,30 +1127,39 @@ class BridgeSerializationUtilsTest {
         });
     }
 
-    private void test_deserializeSha256Hash(byte[] serializedHashBytes, Sha256Hash expectedHash, boolean shouldDeserialize) {
-        Optional<Sha256Hash> result = BridgeSerializationUtils.deserializeSha256Hash(serializedHashBytes);
-        Assertions.assertEquals(shouldDeserialize, result.isPresent());
-        if (shouldDeserialize){
-            Assertions.assertEquals(expectedHash, result.get());
-        }
-
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-    value = {
-        "a00150000000000000000000000000000000000000000000000000000000000000, 0150000000000000000000000000000000000000000000000000000000000000, true",
-        "a00000000000000000000000000000000000000000000000000000000000000000, 0000000000000000000000000000000000000000000000000000000000000000, true",
-        "null, null, false"
-    }, nullValues = "null")
-    void deserializeSha256Hash(String hash, String expectedSha256Hash, boolean shouldDeserialize) {
-        byte[] serializedHashBytes = hash == null? null: Hex.decode(hash);
-        Sha256Hash expectedHash = expectedSha256Hash == null? null:Sha256Hash.wrap(expectedSha256Hash);
-        test_deserializeSha256Hash(serializedHashBytes, expectedHash, shouldDeserialize);
+    private void test_deserializeSha256Hash(byte[] serializedHashBytes, Sha256Hash expectedHash) {
+        Sha256Hash result = BridgeSerializationUtils.deserializeSha256Hash(serializedHashBytes);
+        Assertions.assertEquals(expectedHash, result);
     }
 
     @Test
-    void serializeScript() {
+    public void deserializeSha256Hash() {
+        byte[] serializedHashBytes = Hex.decode("a00200000000000000000000000000000000000000000000000000000000000000");
+        Sha256Hash expectedHash = Sha256Hash.wrap("0200000000000000000000000000000000000000000000000000000000000000");
+        test_deserializeSha256Hash(serializedHashBytes, expectedHash);
+    }
+
+    @Test
+    public void deserializeSha256Hash_zeroHash() {
+        byte[] serializedHashBytes = Hex.decode("a00000000000000000000000000000000000000000000000000000000000000000");
+        Sha256Hash expectedHash = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000000");
+        test_deserializeSha256Hash(serializedHashBytes, expectedHash);
+    }
+
+    @Test
+    public void deserializeSha256Hash_nullValue() {
+        test_deserializeSha256Hash(null, null);
+    }
+
+    @Test
+    public void deserializeSha256Hash_ok() {
+        byte[] serializedHashBytes = Hex.decode("a00150000000000000000000000000000000000000000000000000000000000000");
+        Sha256Hash expectedHash = Sha256Hash.wrap("0150000000000000000000000000000000000000000000000000000000000000");
+        test_deserializeSha256Hash(serializedHashBytes, expectedHash);
+    }
+
+    @Test
+    public void serializeScript() {
         Script expectedScript = ScriptBuilder.createP2SHOutputScript(2, Lists.newArrayList(new BtcECKey(), new BtcECKey(), new BtcECKey()));
 
         byte[] actualData = BridgeSerializationUtils.serializeScript(expectedScript);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1132,34 +1132,22 @@ class BridgeSerializationUtilsTest {
         Assertions.assertEquals(expectedHash, result);
     }
 
-    @Test
-    public void deserializeSha256Hash() {
-        byte[] serializedHashBytes = Hex.decode("a00200000000000000000000000000000000000000000000000000000000000000");
-        Sha256Hash expectedHash = Sha256Hash.wrap("0200000000000000000000000000000000000000000000000000000000000000");
+    @ParameterizedTest
+    @CsvSource(
+        value = {
+            "a00150000000000000000000000000000000000000000000000000000000000000, 0150000000000000000000000000000000000000000000000000000000000000",
+            "a00000000000000000000000000000000000000000000000000000000000000000, 0000000000000000000000000000000000000000000000000000000000000000",
+            "null, null"
+        }
+        , nullValues = "null")
+    void deserializeSha256Hash(String sha256Hash, String expectedSha256Hash) {
+        byte[] serializedHashBytes = sha256Hash == null? null: Hex.decode(sha256Hash);
+        Sha256Hash expectedHash = expectedSha256Hash == null? null: Sha256Hash.wrap(expectedSha256Hash);
         test_deserializeSha256Hash(serializedHashBytes, expectedHash);
     }
 
     @Test
-    public void deserializeSha256Hash_zeroHash() {
-        byte[] serializedHashBytes = Hex.decode("a00000000000000000000000000000000000000000000000000000000000000000");
-        Sha256Hash expectedHash = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000000");
-        test_deserializeSha256Hash(serializedHashBytes, expectedHash);
-    }
-
-    @Test
-    public void deserializeSha256Hash_nullValue() {
-        test_deserializeSha256Hash(null, null);
-    }
-
-    @Test
-    public void deserializeSha256Hash_ok() {
-        byte[] serializedHashBytes = Hex.decode("a00150000000000000000000000000000000000000000000000000000000000000");
-        Sha256Hash expectedHash = Sha256Hash.wrap("0150000000000000000000000000000000000000000000000000000000000000");
-        test_deserializeSha256Hash(serializedHashBytes, expectedHash);
-    }
-
-    @Test
-    public void serializeScript() {
+    void serializeScript() {
         Script expectedScript = ScriptBuilder.createP2SHOutputScript(2, Lists.newArrayList(new BtcECKey(), new BtcECKey(), new BtcECKey()));
 
         byte[] actualData = BridgeSerializationUtils.serializeScript(expectedScript);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -32,6 +32,7 @@ import co.rsk.peg.flyover.FlyoverFederationInformation;
 import co.rsk.peg.whitelist.LockWhitelist;
 import co.rsk.peg.whitelist.LockWhitelistEntry;
 import co.rsk.peg.whitelist.OneOffWhiteListEntry;
+import co.rsk.util.HexUtils;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.UnsignedBytes;
 import org.apache.commons.lang3.tuple.Pair;
@@ -1191,6 +1192,27 @@ class BridgeSerializationUtilsTest {
     @Test
     void deserializeCoinbaseInformation_dataIsNull_returnsNull() {
         Assertions.assertNull(BridgeSerializationUtils.deserializeCoinbaseInformation(null));
+    }
+
+    @Test
+    public void serializeSha256Hash_dataIsNull_returnsNull() {
+        Assert.assertNull(BridgeSerializationUtils.deserializeCoinbaseInformation(null));
+    }
+
+    @Test
+    public void serializeSha256Hash_ok() {
+        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash result = BridgeSerializationUtils.deserializeSha256Hash(BridgeSerializationUtils.serializeSha256Hash(hash));
+        Assert.assertEquals(
+            result,
+            hash
+        );
+    }
+
+    @Test
+    public void deserializeSha256Hash_null() {
+        Sha256Hash result = BridgeSerializationUtils.deserializeSha256Hash(null);
+        Assert.assertNull(result);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1120,9 +1120,11 @@ class BridgeSerializationUtilsTest {
         );
     }
 
-    @Test
+    @Test()
     void serializeSha256Hash_nullValue() {
-        test_serializeSha256Hash(null, new byte[]{});
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            test_serializeSha256Hash(null, null);
+        });
     }
 
     private void test_deserializeSha256Hash(byte[] serializedHashBytes, Sha256Hash expectedHash, boolean shouldDeserialize) {
@@ -1134,30 +1136,17 @@ class BridgeSerializationUtilsTest {
 
     }
 
-    @Test
-    void deserializeSha256Hash() {
-        byte[] serializedHashBytes = Hex.decode("a00200000000000000000000000000000000000000000000000000000000000000");
-        Sha256Hash expectedHash = Sha256Hash.wrap("0200000000000000000000000000000000000000000000000000000000000000");
-        test_deserializeSha256Hash(serializedHashBytes, expectedHash, true);
-    }
-
-    @Test
-    void deserializeSha256Hash_zeroHash() {
-        byte[] serializedHashBytes = Hex.decode("a00000000000000000000000000000000000000000000000000000000000000000");
-        Sha256Hash expectedHash = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000000");
-        test_deserializeSha256Hash(serializedHashBytes, expectedHash, true);
-    }
-
-    @Test
-    void deserializeSha256Hash_nullValue() {
-        test_deserializeSha256Hash(null, null, false);
-    }
-
-    @Test
-    void deserializeSha256Hash_ok() {
-        byte[] serializedHashBytes = Hex.decode("a00150000000000000000000000000000000000000000000000000000000000000");
-        Sha256Hash expectedHash = Sha256Hash.wrap("0150000000000000000000000000000000000000000000000000000000000000");
-        test_deserializeSha256Hash(serializedHashBytes, expectedHash, true);
+    @ParameterizedTest
+    @CsvSource(
+    value = {
+        "a00150000000000000000000000000000000000000000000000000000000000000, 0150000000000000000000000000000000000000000000000000000000000000, true",
+        "a00000000000000000000000000000000000000000000000000000000000000000, 0000000000000000000000000000000000000000000000000000000000000000, true",
+        "null, null, false"
+    }, nullValues = "null")
+    void deserializeSha256Hash(String hash, String expectedSha256Hash, boolean shouldDeserialize) {
+        byte[] serializedHashBytes = hash == null? null: Hex.decode(hash);
+        Sha256Hash expectedHash = expectedSha256Hash == null? null:Sha256Hash.wrap(expectedSha256Hash);
+        test_deserializeSha256Hash(serializedHashBytes, expectedHash, shouldDeserialize);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -46,6 +46,8 @@ import org.ethereum.util.RLPList;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -1057,23 +1059,18 @@ class BridgeSerializationUtilsTest {
         }
     }
 
-    @Test
-    void deserializeKeccak256() {
-        byte[] serializedKeccak256Hash = Hex.decode("a00200000000000000000000000000000000000000000000000000000000000000");
-        Keccak256 expectedHash = new Keccak256("0200000000000000000000000000000000000000000000000000000000000000");
-        test_deserializeKeccak256(serializedKeccak256Hash, expectedHash, true);
-    }
-
-    @Test
-    void deserializeKeccak256_nullValue() {
-        test_deserializeKeccak256(null, null, false);
-    }
-
-    @Test
-    void deserializeKeccak256_zeroHash() {
-        byte[] serializedKeccak256Hash = Hex.decode("a00000000000000000000000000000000000000000000000000000000000000000");
-        Keccak256 expectedHash = new Keccak256("0000000000000000000000000000000000000000000000000000000000000000");
-        test_deserializeKeccak256(serializedKeccak256Hash, expectedHash, true);
+    @ParameterizedTest
+    @CsvSource(
+        value = {
+            "a00200000000000000000000000000000000000000000000000000000000000000, 0200000000000000000000000000000000000000000000000000000000000000, true",
+            "a00000000000000000000000000000000000000000000000000000000000000000, 0000000000000000000000000000000000000000000000000000000000000000, true",
+            "null, null, false"
+        }
+    , nullValues = "null")
+    void deserializeKeccak256(String keccak256Hash, String expectedKeccak256, boolean shouldDeserialize) {
+        byte[] serializedKeccak256Hash = keccak256Hash == null? null: Hex.decode(keccak256Hash);
+        Keccak256 expectedHash = expectedKeccak256 == null? null: new Keccak256(expectedKeccak256);
+        test_deserializeKeccak256(serializedKeccak256Hash, expectedHash, shouldDeserialize);
     }
 
     private void test_serializeKeccak256(Keccak256 keccakHash, byte[] expectedSerializedKeccak256Hash) {
@@ -1082,7 +1079,7 @@ class BridgeSerializationUtilsTest {
     }
 
     @Test
-    public void serializeKeccak256() {
+    void serializeKeccak256() {
         Keccak256 keccakHash = new Keccak256("0200000000000000000000000000000000000000000000000000000000000000");
         byte[] expectedSerializedKeccak256Hash = Hex.decode("a00200000000000000000000000000000000000000000000000000000000000000");
         test_serializeKeccak256(keccakHash, expectedSerializedKeccak256Hash);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -3422,12 +3422,6 @@ class BridgeStorageProviderTest {
         Sha256Hash hash = PegTestUtils.createHash(13);
 
         DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
-        when(
-            repository.getStorageBytes(
-                PrecompiledContracts.BRIDGE_ADDR,
-                storageKeyForPegoutCreationIndex
-            )
-        ).thenReturn(BridgeSerializationUtils.serializeKeccak256(Keccak256.ZERO_HASH));
 
         assertEquals(Optional.empty(), provider.getPegoutCreationRskTxHashByBtcTxHash(
             hash

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -3436,23 +3436,23 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = PegTestUtils.createHash(3);
-        Keccak256 keccak256 = PegTestUtils.createHash3(9);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(3);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(9);
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + btcTxHash);
         when(
             repository.getStorageBytes(
                 PrecompiledContracts.BRIDGE_ADDR,
                 storageKeyForPegoutCreationIndex
             )
-        ).thenReturn(BridgeSerializationUtils.serializeKeccak256(keccak256));
+        ).thenReturn(BridgeSerializationUtils.serializeKeccak256(rskTxHash));
 
         Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
-            hash
+            btcTxHash
         );
         assertTrue(pegoutCreationEntry.isPresent());
 
-        assertEquals(keccak256, pegoutCreationEntry.get());
+        assertEquals(rskTxHash, pegoutCreationEntry.get());
 
         verify(repository, times(1)).getStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
@@ -3491,18 +3491,18 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        Sha256Hash sha256Hash = PegTestUtils.createHash(15);
-        Keccak256 keccak256 = PegTestUtils.createHash3(8);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(15);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(8);
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + sha256Hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + btcTxHash);
 
-        provider.setPegoutCreationEntry(new PegoutCreationEntry(sha256Hash, keccak256));
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTxHash, rskTxHash));
         provider.save();
 
         verify(repository, never()).addStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
             storageKeyForPegoutCreationIndex,
-            BridgeSerializationUtils.serializeKeccak256(keccak256)
+            BridgeSerializationUtils.serializeKeccak256(rskTxHash)
         );
     }
 
@@ -3517,18 +3517,18 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash sha256Hash = PegTestUtils.createHash(14);
-        Keccak256 keccak256 = PegTestUtils.createHash3(7);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(14);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(7);
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + sha256Hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + btcTxHash);
 
-        provider.setPegoutCreationEntry(new PegoutCreationEntry(sha256Hash, keccak256));
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTxHash, rskTxHash));
         provider.save();
 
         verify(repository, times(1)).addStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
             storageKeyForPegoutCreationIndex,
-            BridgeSerializationUtils.serializeKeccak256(keccak256)
+            BridgeSerializationUtils.serializeKeccak256(rskTxHash)
         );
     }
 
@@ -3543,22 +3543,22 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = PegTestUtils.createHash(8);
-        Keccak256 keccak256 = null;
+        Sha256Hash btcTxHash = PegTestUtils.createHash(8);
+        Keccak256 rskTxHash = null;
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + btcTxHash);
 
-        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTxHash, rskTxHash));
         provider.save();
 
         verify(repository, never()).addStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
             storageKeyForPegoutCreationIndex,
-            BridgeSerializationUtils.serializeKeccak256(keccak256)
+            BridgeSerializationUtils.serializeKeccak256(rskTxHash)
         );
 
         Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
-            hash
+            btcTxHash
         );
         assertFalse(pegoutCreationEntry.isPresent());
     }
@@ -3572,22 +3572,22 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        Sha256Hash hash = PegTestUtils.createHash(6);
-        Keccak256 keccak256 = PegTestUtils.createHash3(12);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(6);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(12);
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + btcTxHash);
 
-        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTxHash, rskTxHash));
         provider.save();
 
         verify(repository, never()).addStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
             storageKeyForPegoutCreationIndex,
-            BridgeSerializationUtils.serializeKeccak256(keccak256)
+            BridgeSerializationUtils.serializeKeccak256(rskTxHash)
         );
 
         Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
-            hash
+            btcTxHash
         );
         assertFalse(pegoutCreationEntry.isPresent());
     }
@@ -3603,26 +3603,26 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = PegTestUtils.createHash(17);
-        Keccak256 keccak256 = PegTestUtils.createHash3(4);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(17);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(4);
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + btcTxHash);
 
-        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTxHash, rskTxHash));
         provider.save();
 
         verify(repository, times(1)).addStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
             storageKeyForPegoutCreationIndex,
-            BridgeSerializationUtils.serializeKeccak256(keccak256)
+            BridgeSerializationUtils.serializeKeccak256(rskTxHash)
         );
 
         Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
-            hash
+            btcTxHash
         );
         assertTrue(pegoutCreationEntry.isPresent());
 
-        assertEquals(keccak256, pegoutCreationEntry.get());
+        assertEquals(rskTxHash, pegoutCreationEntry.get());
     }
 
     @Test
@@ -3636,26 +3636,26 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = PegTestUtils.createHash(5);
-        Keccak256 keccak256 = PegTestUtils.createHash3(4);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(5);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(4);
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + btcTxHash);
 
-        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTxHash, rskTxHash));
         provider.save();
 
         verify(repository, times(1)).addStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
             storageKeyForPegoutCreationIndex,
-            BridgeSerializationUtils.serializeKeccak256(keccak256)
+            BridgeSerializationUtils.serializeKeccak256(rskTxHash)
         );
 
         Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
-            hash
+            btcTxHash
         );
         assertTrue(pegoutCreationEntry.isPresent());
 
-        assertEquals(keccak256, pegoutCreationEntry.get());
+        assertEquals(rskTxHash, pegoutCreationEntry.get());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -3412,6 +3412,200 @@ class BridgeStorageProviderTest {
     }
 
     @Test
+    public void getPegoutCreationEntry_before_RSKIP298() {
+        Repository repository = mock(Repository.class);
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        when(
+            repository.getStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                storageKeyForPegoutCreationIndex
+            )
+        ).thenReturn(BridgeSerializationUtils.serializeKeccak256(Keccak256.ZERO_HASH));
+
+        assertEquals(Optional.empty(), provider.getPegoutCreationEntry(
+            hash
+        ));
+
+        verify(repository, never()).getStorageBytes(PrecompiledContracts.BRIDGE_ADDR, storageKeyForPegoutCreationIndex);
+    }
+
+    @Test
+    public void getPegoutCreationEntry_after_RSKIP298() {
+        Repository repository = mock(Repository.class);
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        when(
+            repository.getStorageBytes(
+                PrecompiledContracts.BRIDGE_ADDR,
+                storageKeyForPegoutCreationIndex
+            )
+        ).thenReturn(BridgeSerializationUtils.serializeKeccak256(keccak256));
+
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationEntry(
+            hash
+        );
+        assertTrue(pegoutCreationEntry.isPresent());
+
+        assertEquals(keccak256, pegoutCreationEntry.get());
+
+        verify(repository, times(1)).getStorageBytes(
+            PrecompiledContracts.BRIDGE_ADDR,
+            storageKeyForPegoutCreationIndex
+        );
+    }
+
+    @Test
+    public void setPegoutCreationEntry_before_RSKIP298() {
+        Repository repository = mock(Repository.class);
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+
+        provider.setPegoutCreationEntry(hash, keccak256);
+        provider.savePegoutCreationEntry();
+
+        verify(repository, never()).addStorageBytes(
+            eq(PrecompiledContracts.BRIDGE_ADDR),
+            eq(storageKeyForPegoutCreationIndex),
+            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+        );
+    }
+
+    @Test
+    public void setPegoutCreationEntry_ok_after_RSKIP298() {
+        Repository repository = spy(createRepository());
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+
+        provider.setPegoutCreationEntry(hash, keccak256);
+        provider.savePegoutCreationEntry();
+
+        verify(repository, times(1)).addStorageBytes(
+            eq(PrecompiledContracts.BRIDGE_ADDR),
+            eq(storageKeyForPegoutCreationIndex),
+            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+        );
+    }
+
+    @Test
+    public void setPegoutCreationEntry_rskTxHash_is_null_after_RSKIP298() {
+        Repository repository = spy(createRepository());
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Keccak256 keccak256 = null;
+
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+
+        provider.setPegoutCreationEntry(hash, keccak256);
+        provider.savePegoutCreationEntry();
+
+        verify(repository, never()).addStorageBytes(
+            eq(PrecompiledContracts.BRIDGE_ADDR),
+            eq(storageKeyForPegoutCreationIndex),
+            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+        );
+
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationEntry(
+            hash
+        );
+        assertFalse(pegoutCreationEntry.isPresent());
+    }
+
+    @Test
+    public void savePegoutCreationEntry_before_RSKIP298() {
+        Repository repository = spy(createRepository());
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
+        );
+
+        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+
+        provider.setPegoutCreationEntry(hash, keccak256);
+        provider.savePegoutCreationEntry();
+
+        verify(repository, never()).addStorageBytes(
+            eq(PrecompiledContracts.BRIDGE_ADDR),
+            eq(storageKeyForPegoutCreationIndex),
+            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+        );
+
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationEntry(
+            hash
+        );
+        assertFalse(pegoutCreationEntry.isPresent());
+    }
+
+    @Test
+    public void savePegoutCreationEntry_after_RSKIP298() {
+        Repository repository = spy(createRepository());
+
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+        );
+
+        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+
+        provider.setPegoutCreationEntry(hash, keccak256);
+        provider.savePegoutCreationEntry();
+
+        verify(repository, times(1)).addStorageBytes(
+            eq(PrecompiledContracts.BRIDGE_ADDR),
+            eq(storageKeyForPegoutCreationIndex),
+            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+        );
+
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationEntry(
+            hash
+        );
+        assertTrue(pegoutCreationEntry.isPresent());
+
+        assertEquals(keccak256, pegoutCreationEntry.get());
+    }
+
+    @Test
     void getNewFederationBtcUTXOs_before_RSKIP284_before_RSKIP293_testnet() throws IOException {
         testGetNewFederationBtcUTXOs(false, false, NetworkParameters.ID_TESTNET);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -3407,7 +3407,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298() {
+    void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298() {
         Repository repository = mock(Repository.class);
         BridgeStorageProvider provider = new BridgeStorageProvider(
             repository, PrecompiledContracts.BRIDGE_ADDR,
@@ -3426,7 +3426,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_after_RSKIP298() {
+    void getPegoutCreationRskTxHashByBtcTxHash_after_RSKIP298() {
         Repository repository = mock(Repository.class);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -3461,7 +3461,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_for_a_null_btcTxHash_after_RSKIP298() {
+    void getPegoutCreationRskTxHashByBtcTxHash_for_a_null_btcTxHash_after_RSKIP298() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
@@ -3483,7 +3483,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void setPegoutCreationEntry_before_RSKIP298() throws IOException {
+    void setPegoutCreationEntry_before_RSKIP298() throws IOException {
         Repository repository = mock(Repository.class);
 
         BridgeStorageProvider provider = new BridgeStorageProvider(
@@ -3507,7 +3507,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void setPegoutCreationEntry_ok_after_RSKIP298() throws IOException {
+    void setPegoutCreationEntry_ok_after_RSKIP298() throws IOException {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
@@ -3533,7 +3533,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void setPegoutCreationEntry_rskTxHash_is_null_after_RSKIP298() throws IOException {
+    void setPegoutCreationEntry_rskTxHash_is_null_after_RSKIP298() throws IOException {
         Repository repository = spy(createRepository());
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -3564,7 +3564,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void savePegoutCreationEntry_before_RSKIP298() throws IOException {
+    void savePegoutCreationEntry_before_RSKIP298() throws IOException {
         Repository repository = spy(createRepository());
 
         BridgeStorageProvider provider = new BridgeStorageProvider(
@@ -3593,7 +3593,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void savePegoutCreationEntry_zero_hash_after_RSKIP298() throws IOException {
+    void savePegoutCreationEntry_zero_hash_after_RSKIP298() throws IOException {
         Repository repository = spy(createRepository());
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -3626,7 +3626,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void savePegoutCreationEntry_ok_after_RSKIP298() throws IOException {
+    void savePegoutCreationEntry_ok_after_RSKIP298() throws IOException {
         Repository repository = spy(createRepository());
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -302,8 +302,8 @@ class BridgeStorageProviderTest {
 
         List<UTXO> utxos = provider.getNewFederationBtcUTXOs();
 
-        assertEquals(utxos.get(0).getHash(), hash1);
-        assertEquals(utxos.get(1).getHash(), hash2);
+        assertEquals(hash1, utxos.get(0).getHash());
+        assertEquals(hash2, utxos.get(1).getHash());
     }
 
     @Test
@@ -3412,14 +3412,14 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void getPegoutCreationEntry_before_RSKIP298() {
+    public void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298() {
         Repository repository = mock(Repository.class);
         BridgeStorageProvider provider = new BridgeStorageProvider(
             repository, PrecompiledContracts.BRIDGE_ADDR,
             config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash hash = PegTestUtils.createHash(13);
 
         DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
         when(
@@ -3429,7 +3429,7 @@ class BridgeStorageProviderTest {
             )
         ).thenReturn(BridgeSerializationUtils.serializeKeccak256(Keccak256.ZERO_HASH));
 
-        assertEquals(Optional.empty(), provider.getPegoutCreationEntry(
+        assertEquals(Optional.empty(), provider.getPegoutCreationRskTxHashByBtcTxHash(
             hash
         ));
 
@@ -3437,15 +3437,18 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void getPegoutCreationEntry_after_RSKIP298() {
+    public void getPegoutCreationRskTxHashByBtcTxHash_after_RSKIP298() {
         Repository repository = mock(Repository.class);
+
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
         BridgeStorageProvider provider = new BridgeStorageProvider(
             repository, PrecompiledContracts.BRIDGE_ADDR,
-            config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+            config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
-        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+        Sha256Hash hash = PegTestUtils.createHash(3);
+        Keccak256 keccak256 = PegTestUtils.createHash3(9);
 
         DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
         when(
@@ -3455,7 +3458,7 @@ class BridgeStorageProviderTest {
             )
         ).thenReturn(BridgeSerializationUtils.serializeKeccak256(keccak256));
 
-        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationEntry(
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
             hash
         );
         assertTrue(pegoutCreationEntry.isPresent());
@@ -3469,7 +3472,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    public void setPegoutCreationEntry_before_RSKIP298() {
+    public void setPegoutCreationEntry_before_RSKIP298() throws IOException {
         Repository repository = mock(Repository.class);
 
         BridgeStorageProvider provider = new BridgeStorageProvider(
@@ -3477,76 +3480,80 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
-        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+        Sha256Hash hash = PegTestUtils.createHash(15);
+        Keccak256 keccak256 = PegTestUtils.createHash3(8);
 
         DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
 
-        provider.setPegoutCreationEntry(hash, keccak256);
-        provider.savePegoutCreationEntry();
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.save();
 
         verify(repository, never()).addStorageBytes(
-            eq(PrecompiledContracts.BRIDGE_ADDR),
-            eq(storageKeyForPegoutCreationIndex),
-            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+            PrecompiledContracts.BRIDGE_ADDR,
+            storageKeyForPegoutCreationIndex,
+            BridgeSerializationUtils.serializeKeccak256(keccak256)
         );
     }
 
     @Test
-    public void setPegoutCreationEntry_ok_after_RSKIP298() {
+    public void setPegoutCreationEntry_ok_after_RSKIP298() throws IOException {
         Repository repository = spy(createRepository());
 
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
         BridgeStorageProvider provider = new BridgeStorageProvider(
             repository, PrecompiledContracts.BRIDGE_ADDR,
-            config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+            config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
-        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+        Sha256Hash hash = PegTestUtils.createHash(14);
+        Keccak256 keccak256 = PegTestUtils.createHash3(7);
 
         DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
 
-        provider.setPegoutCreationEntry(hash, keccak256);
-        provider.savePegoutCreationEntry();
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.save();
 
         verify(repository, times(1)).addStorageBytes(
-            eq(PrecompiledContracts.BRIDGE_ADDR),
-            eq(storageKeyForPegoutCreationIndex),
-            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+            PrecompiledContracts.BRIDGE_ADDR,
+            storageKeyForPegoutCreationIndex,
+            BridgeSerializationUtils.serializeKeccak256(keccak256)
         );
     }
 
     @Test
-    public void setPegoutCreationEntry_rskTxHash_is_null_after_RSKIP298() {
+    public void setPegoutCreationEntry_rskTxHash_is_null_after_RSKIP298() throws IOException {
         Repository repository = spy(createRepository());
 
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
         BridgeStorageProvider provider = new BridgeStorageProvider(
             repository, PrecompiledContracts.BRIDGE_ADDR,
-            config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+            config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
+        Sha256Hash hash = PegTestUtils.createHash(8);
         Keccak256 keccak256 = null;
 
         DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
 
-        provider.setPegoutCreationEntry(hash, keccak256);
-        provider.savePegoutCreationEntry();
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.save();
 
         verify(repository, never()).addStorageBytes(
-            eq(PrecompiledContracts.BRIDGE_ADDR),
-            eq(storageKeyForPegoutCreationIndex),
-            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+            PrecompiledContracts.BRIDGE_ADDR,
+            storageKeyForPegoutCreationIndex,
+            BridgeSerializationUtils.serializeKeccak256(keccak256)
         );
 
-        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationEntry(
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
             hash
         );
         assertFalse(pegoutCreationEntry.isPresent());
     }
 
     @Test
-    public void savePegoutCreationEntry_before_RSKIP298() {
+    public void savePegoutCreationEntry_before_RSKIP298() throws IOException {
         Repository repository = spy(createRepository());
 
         BridgeStorageProvider provider = new BridgeStorageProvider(
@@ -3554,50 +3561,85 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
-        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+        Sha256Hash hash = PegTestUtils.createHash(6);
+        Keccak256 keccak256 = PegTestUtils.createHash3(12);
 
         DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
 
-        provider.setPegoutCreationEntry(hash, keccak256);
-        provider.savePegoutCreationEntry();
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.save();
 
         verify(repository, never()).addStorageBytes(
-            eq(PrecompiledContracts.BRIDGE_ADDR),
-            eq(storageKeyForPegoutCreationIndex),
-            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+            PrecompiledContracts.BRIDGE_ADDR,
+            storageKeyForPegoutCreationIndex,
+            BridgeSerializationUtils.serializeKeccak256(keccak256)
         );
 
-        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationEntry(
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
             hash
         );
         assertFalse(pegoutCreationEntry.isPresent());
     }
 
     @Test
-    public void savePegoutCreationEntry_after_RSKIP298() {
+    public void savePegoutCreationEntry_zero_hash_after_RSKIP298() throws IOException {
         Repository repository = spy(createRepository());
 
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
         BridgeStorageProvider provider = new BridgeStorageProvider(
             repository, PrecompiledContracts.BRIDGE_ADDR,
-            config.getNetworkConstants().getBridgeConstants(), activationsAllForks
+            config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = Sha256Hash.ZERO_HASH;
-        Keccak256 keccak256 = Keccak256.ZERO_HASH;
+        Sha256Hash hash = PegTestUtils.createHash(17);
+        Keccak256 keccak256 = PegTestUtils.createHash3(4);
 
         DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
 
-        provider.setPegoutCreationEntry(hash, keccak256);
-        provider.savePegoutCreationEntry();
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.save();
 
         verify(repository, times(1)).addStorageBytes(
-            eq(PrecompiledContracts.BRIDGE_ADDR),
-            eq(storageKeyForPegoutCreationIndex),
-            eq(BridgeSerializationUtils.serializeKeccak256(keccak256))
+            PrecompiledContracts.BRIDGE_ADDR,
+            storageKeyForPegoutCreationIndex,
+            BridgeSerializationUtils.serializeKeccak256(keccak256)
         );
 
-        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationEntry(
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
+            hash
+        );
+        assertTrue(pegoutCreationEntry.isPresent());
+
+        assertEquals(keccak256, pegoutCreationEntry.get());
+    }
+
+    @Test
+    public void savePegoutCreationEntry_ok_after_RSKIP298() throws IOException {
+        Repository repository = spy(createRepository());
+
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activations
+        );
+
+        Sha256Hash hash = PegTestUtils.createHash(5);
+        Keccak256 keccak256 = PegTestUtils.createHash3(4);
+
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.save();
+
+        verify(repository, times(1)).addStorageBytes(
+            PrecompiledContracts.BRIDGE_ADDR,
+            storageKeyForPegoutCreationIndex,
+            BridgeSerializationUtils.serializeKeccak256(keccak256)
+        );
+
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
             hash
         );
         assertTrue(pegoutCreationEntry.isPresent());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -3037,11 +3037,6 @@ class BridgeStorageProviderTest {
             flyoverFederationRedeemScriptHash
         );
 
-        lenient().when(repository.getStorageBytes(
-            PrecompiledContracts.BRIDGE_ADDR,
-            DataWord.fromLongString("fastBridgeFederationInformation-" + Hex.toHexString(flyoverFederationRedeemScriptHash)))
-        ).thenReturn(BridgeSerializationUtils.serializeFlyoverFederationInformation(flyoverFederationInformation));
-
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(false);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -3461,6 +3461,28 @@ class BridgeStorageProviderTest {
     }
 
     @Test
+    public void getPegoutCreationRskTxHashByBtcTxHash_for_a_null_btcTxHash_after_RSKIP298() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
+
+        Repository repository = mock(Repository.class);
+        BridgeStorageProvider provider = new BridgeStorageProvider(
+            repository, PrecompiledContracts.BRIDGE_ADDR,
+            config.getNetworkConstants().getBridgeConstants(), activations
+        );
+
+        Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(
+            null
+        );
+        assertFalse(pegoutCreationEntry.isPresent());
+
+        verify(repository, never()).getStorageBytes(
+            any(),
+            any()
+        );
+    }
+
+    @Test
     public void setPegoutCreationEntry_before_RSKIP298() throws IOException {
         Repository repository = mock(Repository.class);
 
@@ -3469,12 +3491,12 @@ class BridgeStorageProviderTest {
             config.getNetworkConstants().getBridgeConstants(), activationsBeforeFork
         );
 
-        Sha256Hash hash = PegTestUtils.createHash(15);
+        Sha256Hash sha256Hash = PegTestUtils.createHash(15);
         Keccak256 keccak256 = PegTestUtils.createHash3(8);
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + sha256Hash);
 
-        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(sha256Hash, keccak256));
         provider.save();
 
         verify(repository, never()).addStorageBytes(
@@ -3486,21 +3508,21 @@ class BridgeStorageProviderTest {
 
     @Test
     public void setPegoutCreationEntry_ok_after_RSKIP298() throws IOException {
-        Repository repository = spy(createRepository());
-
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
+
+        Repository repository = spy(createRepository());
         BridgeStorageProvider provider = new BridgeStorageProvider(
             repository, PrecompiledContracts.BRIDGE_ADDR,
             config.getNetworkConstants().getBridgeConstants(), activations
         );
 
-        Sha256Hash hash = PegTestUtils.createHash(14);
+        Sha256Hash sha256Hash = PegTestUtils.createHash(14);
         Keccak256 keccak256 = PegTestUtils.createHash3(7);
 
-        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + hash);
+        DataWord storageKeyForPegoutCreationIndex = DataWord.fromLongString("pegoutCreationIndex-" + sha256Hash);
 
-        provider.setPegoutCreationEntry(new PegoutCreationEntry(hash, keccak256));
+        provider.setPegoutCreationEntry(new PegoutCreationEntry(sha256Hash, keccak256));
         provider.save();
 
         verify(repository, times(1)).addStorageBytes(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutCreationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutCreationTest.java
@@ -6,26 +6,27 @@ import co.rsk.test.builders.BridgeSupportBuilder;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
-    @Before
-    public void setUpOnEachTest() {
+class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
+
+    @BeforeEach
+    void setUp() {
         activations = mock(ActivationConfig.ForBlock.class);
         bridgeSupportBuilder = new BridgeSupportBuilder();
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298_activation() {
+    void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(false);
 
         Sha256Hash btcTxHash = PegTestUtils.createHash(15);
@@ -40,7 +41,7 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_ok_after_RSKIP298_activation() {
+    void getPegoutCreationRskTxHashByBtcTxHash_ok_after_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
         Sha256Hash btcTxHash = PegTestUtils.createHash(3);
@@ -60,7 +61,7 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_not_found_after_RSKIP298_activation() {
+    void getPegoutCreationRskTxHashByBtcTxHash_not_found_after_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
         Sha256Hash btcTxHash = PegTestUtils.createHash(9);
@@ -79,7 +80,7 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_by_zero_hash_after_RSKIP298_activation() {
+    void getPegoutCreationRskTxHashByBtcTxHash_by_zero_hash_after_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
         Sha256Hash btcTxHash = Sha256Hash.ZERO_HASH;
@@ -99,7 +100,7 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_btcTxHash_is_null_after_RSKIP298_activation() {
+    void getPegoutCreationRskTxHashByBtcTxHash_btcTxHash_is_null_after_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutCreationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutCreationTest.java
@@ -1,0 +1,172 @@
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.config.BridgeConstants;
+import co.rsk.crypto.Keccak256;
+import co.rsk.test.builders.BridgeSupportBuilder;
+import org.apache.commons.lang3.RandomUtils;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
+    @Before
+    public void setUpOnEachTest() {
+        activations = mock(ActivationConfig.ForBlock.class);
+        bridgeSupportBuilder = new BridgeSupportBuilder();
+    }
+
+    @Test
+    public void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298_activation() {
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(false);
+
+        Sha256Hash btcTxHash = PegTestUtils.createHash(RandomUtils.nextInt());
+        Keccak256 rskTxHash = PegTestUtils.createHash3(RandomUtils.nextInt());
+
+        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.getPegoutCreationRskTxHashByBtcTxHash(any())).thenReturn(Optional.of(rskTxHash));
+        Repository repository = createRepository();
+        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
+        Block executionBlock = Mockito.mock(Block.class);
+
+        BridgeSupport bridgeSupport = bridgeSupportBuilder
+            .withProvider(provider)
+            .withBridgeConstants(bridgeConstants)
+            .withActivations(activations)
+            .withBtcBlockStoreFactory(mockFactory)
+            .withExecutionBlock(executionBlock)
+            .withRepository(repository)
+            .build();
+
+        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+
+        assertFalse(pegoutRskTxHash.isPresent());
+    }
+
+    @Test
+    public void getPegoutCreationRskTxHashByBtcTxHash_ok_after_RSKIP298_activation() {
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
+
+        Sha256Hash btcTxHash = PegTestUtils.createHash(RandomUtils.nextInt());
+        Keccak256 rskTxHash = PegTestUtils.createHash3(RandomUtils.nextInt());
+
+        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash)).thenReturn(Optional.of(rskTxHash));
+        Repository repository = createRepository();
+        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
+        Block executionBlock = Mockito.mock(Block.class);
+
+        BridgeSupport bridgeSupport = bridgeSupportBuilder
+            .withProvider(provider)
+            .withBridgeConstants(bridgeConstants)
+            .withActivations(activations)
+            .withBtcBlockStoreFactory(mockFactory)
+            .withExecutionBlock(executionBlock)
+            .withRepository(repository)
+            .build();
+
+        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+
+        assertTrue(pegoutRskTxHash.isPresent());
+        assertEquals(rskTxHash, pegoutRskTxHash.get());
+    }
+
+    @Test
+    public void getPegoutCreationRskTxHashByBtcTxHash_not_found_after_RSKIP298_activation() {
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
+
+        Sha256Hash btcTxHash = PegTestUtils.createHash(RandomUtils.nextInt());
+
+        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.getPegoutCreationRskTxHashByBtcTxHash(any())).thenReturn(Optional.empty());
+        Repository repository = createRepository();
+        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
+        Block executionBlock = Mockito.mock(Block.class);
+
+        BridgeSupport bridgeSupport = bridgeSupportBuilder
+            .withProvider(provider)
+            .withBridgeConstants(bridgeConstants)
+            .withActivations(activations)
+            .withBtcBlockStoreFactory(mockFactory)
+            .withExecutionBlock(executionBlock)
+            .withRepository(repository)
+            .build();
+
+        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+
+        assertFalse(pegoutRskTxHash.isPresent());
+    }
+
+    @Test
+    public void getPegoutCreationRskTxHashByBtcTxHash_by_zero_hash_after_RSKIP298_activation() {
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
+
+        Sha256Hash btcTxHash = Sha256Hash.ZERO_HASH;
+        Keccak256 rskTxHash = PegTestUtils.createHash3(RandomUtils.nextInt());
+
+        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash)).thenReturn(Optional.of(rskTxHash));
+        Repository repository = createRepository();
+        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
+        Block executionBlock = Mockito.mock(Block.class);
+
+        BridgeSupport bridgeSupport = bridgeSupportBuilder
+            .withProvider(provider)
+            .withBridgeConstants(bridgeConstants)
+            .withActivations(activations)
+            .withBtcBlockStoreFactory(mockFactory)
+            .withExecutionBlock(executionBlock)
+            .withRepository(repository)
+            .build();
+
+        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+
+        assertTrue(pegoutRskTxHash.isPresent());
+        assertEquals(rskTxHash, pegoutRskTxHash.get());
+    }
+
+    @Test
+    public void getPegoutCreationRskTxHashByBtcTxHash_btc_tx_hash_is_null_after_RSKIP298_activation() {
+        when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
+
+        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+
+        when(provider.getPegoutCreationRskTxHashByBtcTxHash(isNull())).thenReturn(Optional.empty());
+
+        Repository repository = createRepository();
+        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
+        Block executionBlock = Mockito.mock(Block.class);
+
+        BridgeSupport bridgeSupport = bridgeSupportBuilder
+            .withProvider(provider)
+            .withBridgeConstants(bridgeConstants)
+            .withActivations(activations)
+            .withBtcBlockStoreFactory(mockFactory)
+            .withExecutionBlock(executionBlock)
+            .withRepository(repository)
+            .build();
+
+        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(null);
+
+        assertFalse(pegoutRskTxHash.isPresent());
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutCreationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutCreationTest.java
@@ -31,7 +31,6 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
         Sha256Hash btcTxHash = PegTestUtils.createHash(15);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
-            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
             .build();
 
@@ -52,7 +51,6 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
             .withProvider(provider)
-            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
             .build();
 
@@ -72,7 +70,6 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
             .withProvider(provider)
-            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
             .build();
 
@@ -93,7 +90,6 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
             .withProvider(provider)
-            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
             .build();
 
@@ -103,7 +99,7 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_by_is_null_after_RSKIP298_activation() {
+    public void getPegoutCreationRskTxHashByBtcTxHash_btcTxHash_is_null_after_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -112,7 +108,6 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
             .withProvider(provider)
-            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
             .build();
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutCreationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutCreationTest.java
@@ -1,24 +1,18 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.config.BridgeConstants;
 import co.rsk.crypto.Keccak256;
 import co.rsk.test.builders.BridgeSupportBuilder;
-import org.apache.commons.lang3.RandomUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.core.Block;
-import org.ethereum.core.Repository;
+import org.ethereum.util.ByteUtil;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.Optional;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -34,84 +28,57 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
     public void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(false);
 
-        Sha256Hash btcTxHash = PegTestUtils.createHash(RandomUtils.nextInt());
-        Keccak256 rskTxHash = PegTestUtils.createHash3(RandomUtils.nextInt());
-
-        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
-        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        when(provider.getPegoutCreationRskTxHashByBtcTxHash(any())).thenReturn(Optional.of(rskTxHash));
-        Repository repository = createRepository();
-        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
-        Block executionBlock = Mockito.mock(Block.class);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(15);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
-            .withProvider(provider)
-            .withBridgeConstants(bridgeConstants)
+            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
-            .withBtcBlockStoreFactory(mockFactory)
-            .withExecutionBlock(executionBlock)
-            .withRepository(repository)
             .build();
 
-        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+        byte[] pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
 
-        assertFalse(pegoutRskTxHash.isPresent());
+        assertEquals(ByteUtil.EMPTY_BYTE_ARRAY, pegoutRskTxHash);
     }
 
     @Test
     public void getPegoutCreationRskTxHashByBtcTxHash_ok_after_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
-        Sha256Hash btcTxHash = PegTestUtils.createHash(RandomUtils.nextInt());
-        Keccak256 rskTxHash = PegTestUtils.createHash3(RandomUtils.nextInt());
+        Sha256Hash btcTxHash = PegTestUtils.createHash(3);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(6);
 
-        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash)).thenReturn(Optional.of(rskTxHash));
-        Repository repository = createRepository();
-        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
-        Block executionBlock = Mockito.mock(Block.class);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
             .withProvider(provider)
-            .withBridgeConstants(bridgeConstants)
+            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
-            .withBtcBlockStoreFactory(mockFactory)
-            .withExecutionBlock(executionBlock)
-            .withRepository(repository)
             .build();
 
-        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+        byte[] pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
 
-        assertTrue(pegoutRskTxHash.isPresent());
-        assertEquals(rskTxHash, pegoutRskTxHash.get());
+        assertArrayEquals(rskTxHash.getBytes(), pegoutRskTxHash);
     }
 
     @Test
     public void getPegoutCreationRskTxHashByBtcTxHash_not_found_after_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
-        Sha256Hash btcTxHash = PegTestUtils.createHash(RandomUtils.nextInt());
+        Sha256Hash btcTxHash = PegTestUtils.createHash(9);
 
-        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        when(provider.getPegoutCreationRskTxHashByBtcTxHash(any())).thenReturn(Optional.empty());
-        Repository repository = createRepository();
-        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
-        Block executionBlock = Mockito.mock(Block.class);
+        when(provider.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash)).thenReturn(Optional.empty());
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
             .withProvider(provider)
-            .withBridgeConstants(bridgeConstants)
+            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
-            .withBtcBlockStoreFactory(mockFactory)
-            .withExecutionBlock(executionBlock)
-            .withRepository(repository)
             .build();
 
-        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+        byte[] pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
 
-        assertFalse(pegoutRskTxHash.isPresent());
+        assertEquals(ByteUtil.EMPTY_BYTE_ARRAY, pegoutRskTxHash);
     }
 
     @Test
@@ -119,54 +86,38 @@ public class BridgeSupportPegoutCreationTest extends BridgeSupportTestBase {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
         Sha256Hash btcTxHash = Sha256Hash.ZERO_HASH;
-        Keccak256 rskTxHash = PegTestUtils.createHash3(RandomUtils.nextInt());
+        Keccak256 rskTxHash = PegTestUtils.createHash3(5);
 
-        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash)).thenReturn(Optional.of(rskTxHash));
-        Repository repository = createRepository();
-        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
-        Block executionBlock = Mockito.mock(Block.class);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
             .withProvider(provider)
-            .withBridgeConstants(bridgeConstants)
+            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
-            .withBtcBlockStoreFactory(mockFactory)
-            .withExecutionBlock(executionBlock)
-            .withRepository(repository)
             .build();
 
-        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
+        byte[] pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash);
 
-        assertTrue(pegoutRskTxHash.isPresent());
-        assertEquals(rskTxHash, pegoutRskTxHash.get());
+        assertArrayEquals(rskTxHash.getBytes(), pegoutRskTxHash);
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_btc_tx_hash_is_null_after_RSKIP298_activation() {
+    public void getPegoutCreationRskTxHashByBtcTxHash_by_is_null_after_RSKIP298_activation() {
         when(activations.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
 
-        BridgeConstants bridgeConstants = this.bridgeConstantsRegtest;
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
 
         when(provider.getPegoutCreationRskTxHashByBtcTxHash(isNull())).thenReturn(Optional.empty());
 
-        Repository repository = createRepository();
-        BtcBlockStoreWithCache.Factory mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
-        Block executionBlock = Mockito.mock(Block.class);
-
         BridgeSupport bridgeSupport = bridgeSupportBuilder
             .withProvider(provider)
-            .withBridgeConstants(bridgeConstants)
+            .withBridgeConstants(bridgeConstantsRegtest)
             .withActivations(activations)
-            .withBtcBlockStoreFactory(mockFactory)
-            .withExecutionBlock(executionBlock)
-            .withRepository(repository)
             .build();
 
-        Optional<Keccak256> pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(null);
+        byte[] pegoutRskTxHash = bridgeSupport.getPegoutCreationRskTxHashByBtcTxHash(null);
 
-        assertFalse(pegoutRskTxHash.isPresent());
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, pegoutRskTxHash);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -40,6 +40,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -176,8 +177,8 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         verify(repository, never()).transfer(any(), any(), any());
-        Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
 
         verify(eventLogger, never()).logReleaseBtcRequested(any(byte[].class), any(BtcTransaction.class), any(Coin.class));
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -200,8 +201,8 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         verify(repository, never()).transfer(any(), any(), any());
-        Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         verify(eventLogger, times(1)).logReleaseBtcRequested(
             any(byte[].class),
             any(BtcTransaction.class),
@@ -227,10 +228,10 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
 
-        Assertions.assertEquals(3, logInfo.size());
+        assertEquals(3, logInfo.size());
         verify(eventLogger, times(1)).logReleaseBtcRequested(
             any(byte[].class),
             any(BtcTransaction.class),
@@ -302,11 +303,11 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         verify(eventLogger, never()).logReleaseBtcRequestRejected(any(), any(), any());
 
-        Assertions.assertEquals(1, logInfo.size());
+        assertEquals(1, logInfo.size());
 
         verify(eventLogger, times(1)).logUpdateCollections(any());
     }
@@ -334,10 +335,10 @@ class BridgeSupportReleaseBtcTest {
             argThat((a) -> a.equals(co.rsk.core.Coin.fromBitcoin(Coin.ZERO)))
         );
 
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
 
-        Assertions.assertEquals(2, logInfo.size());
+        assertEquals(2, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
         verify(eventLogger, times(1)).logReleaseBtcRequestRejected(any(), any(), any());
         verify(eventLogger, times(1)).logUpdateCollections(any());
@@ -366,8 +367,8 @@ class BridgeSupportReleaseBtcTest {
             any(), any(), any()
         );
 
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
         Assertions.assertEquals(2, logInfo.size());
 
@@ -451,9 +452,9 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        Assertions.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
 
-        Assertions.assertEquals(1, logInfo.size());
+        assertEquals(1, logInfo.size());
         verify(eventLogger, times(1)).logReleaseBtcRequestReceived(any(), any(), any());
 
         LogInfo logInfo1 = logInfo.get(0);
@@ -482,9 +483,9 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         rskTx.sign(SENDER.getPrivKeyBytes());
 
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
 
-        Assertions.assertEquals(1, logInfo.size());
+        assertEquals(1, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
         verify(eventLogger, times(1)).logReleaseBtcRequestRejected(any(), any(), any());
     }
@@ -506,9 +507,9 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         rskTx.sign(SENDER.getPrivKeyBytes());
 
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
 
-        Assertions.assertEquals(1, logInfo.size());
+        assertEquals(1, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
         verify(eventLogger, times(1)).logReleaseBtcRequestRejected(any(), any(), any());
     }
@@ -532,9 +533,9 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        Assertions.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
 
-        Assertions.assertEquals(1, logInfo.size());
+        assertEquals(1, logInfo.size());
         verify(eventLogger, times(1)).logReleaseBtcRequestReceived(any(), any(), any());
 
         LogInfo logInfo1 = logInfo.get(0);
@@ -619,7 +620,7 @@ class BridgeSupportReleaseBtcTest {
     }
 
     @Test
-    public void test_pegout_creation_before_RSKIP298_activation_does_not_set_index() throws IOException {
+    void test_pegout_creation_before_RSKIP298_activation_does_not_set_index() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP298)).thenReturn(false);
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(activationMock.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
@@ -666,7 +667,7 @@ class BridgeSupportReleaseBtcTest {
     }
 
     @Test
-    public void test_pegout_creation_after_RSKIP298_activation_sets_index() throws IOException {
+    void test_pegout_creation_after_RSKIP298_activation_sets_index() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(activationMock.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
@@ -740,8 +741,8 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         // assert pegouts were not batched
-        Assertions.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
         verify(provider, never()).getNextPegoutHeight();
         verify(provider, never()).setNextPegoutHeight(any(Long.class));
@@ -787,8 +788,8 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
         BtcTransaction generatedTransaction = provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction();
 
@@ -831,8 +832,8 @@ class BridgeSupportReleaseBtcTest {
         verify(provider, times(1)).getNextPegoutHeight();
         verify(provider, never()).setNextPegoutHeight(any(Long.class));
 
-        Assertions.assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
     }
 
     @Test
@@ -896,8 +897,8 @@ class BridgeSupportReleaseBtcTest {
 
         // Insufficient_Money i.e 4 BTC UTXO Available For 5 BTC Transaction.
         // Pegout requests can't be processed and remains in the queue
-        Assertions.assertEquals(5, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(5, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
     }
 
     @Test
@@ -923,15 +924,15 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         // First Half of the PegoutRequests 600 / 2 = 300 Is Batched For The First Time
-        Assertions.assertEquals(300, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(300, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
         rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
         // The Rest PegoutRequests 600 / 2 = 300 Is Batched The 2nd Time updateCollections Is Called
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(2, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(2, provider.getReleaseTransactionSet().getEntries().size());
     }
 
     @Test
@@ -958,8 +959,8 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        Assertions.assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
     }
 
     @Test
@@ -986,8 +987,8 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        Assertions.assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
     }
 
     @Test
@@ -1023,8 +1024,8 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        Assertions.assertEquals(originalReleaseRequestQueue, provider.getReleaseRequestQueue());
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(originalReleaseRequestQueue, provider.getReleaseRequestQueue());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
     }
 
     @Test
@@ -1072,9 +1073,9 @@ class BridgeSupportReleaseBtcTest {
 
         Assertions.assertNotEquals(originalReleaseRequestQueue, provider.getReleaseRequestQueue());
 
-        Assertions.assertEquals(expectedReleaseRequestQueue, provider.getReleaseRequestQueue());
+        assertEquals(expectedReleaseRequestQueue, provider.getReleaseRequestQueue());
 
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
     }
 
     @Test
@@ -1104,8 +1105,8 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         // 2 remains in queue, 1 is processed to the transaction set
-        Assertions.assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
     }
 
     @Test
@@ -1137,8 +1138,8 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        Assertions.assertEquals(3, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(3, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
 
         verify(eventLogger, never()).logBatchPegoutCreated(any(), any());
         verify(provider, never()).setNextPegoutHeight(any(Long.class));
@@ -1174,8 +1175,8 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        Assertions.assertEquals(3, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(3, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
 
         verify(eventLogger, never()).logBatchPegoutCreated(any(), any());
         verify(provider, never()).setNextPegoutHeight(any(Long.class));
@@ -1193,8 +1194,8 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx2 = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx2);
 
-        Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
-        Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
         verify(eventLogger, times(1)).logBatchPegoutCreated(any(), any());
         verify(provider, times(1)).setNextPegoutHeight(any(Long.class));
@@ -1217,7 +1218,7 @@ class BridgeSupportReleaseBtcTest {
         Coin minValueWithGapAboveFee = minValueAccordingToFee.add(minValueAccordingToFee.times(bridgeConstants.getMinimumPegoutValuePercentageToReceiveAfterFee()).div(100));
         // if shouldPegout true then value should be greater or equals than both required fee plus gap and min pegout value
         // if shouldPegout false then value should be smaller than any of those minimums
-        Assertions.assertEquals(!shouldPegout, value.isLessThan(minValueWithGapAboveFee) ||
+        assertEquals(!shouldPegout, value.isLessThan(minValueWithGapAboveFee) ||
             value.isLessThan(bridgeConstants.getMinimumPegoutTxValueInSatoshis()));
 
         bridgeSupport.releaseBtc(buildReleaseRskTx(value));
@@ -1227,15 +1228,15 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, shouldPegout ? never() : times(1)).transfer(any(), any(), any());
 
-        Assertions.assertEquals(shouldPegout ? 1 : 0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(shouldPegout ? 1 : 0, provider.getReleaseRequestQueue().getEntries().size());
 
-        Assertions.assertEquals(1, logInfo.size());
+        assertEquals(1, logInfo.size());
         verify(eventLogger, shouldPegout ? times(1) : never()).logReleaseBtcRequestReceived(any(), any(), any());
         ArgumentCaptor<RejectedPegoutReason> argumentCaptor = ArgumentCaptor.forClass(RejectedPegoutReason.class);
         verify(eventLogger, shouldPegout ? never() : times(1)).logReleaseBtcRequestRejected(any(), any(), argumentCaptor.capture());
         if (!shouldPegout) {
             // Verify rejected pegout reason using value in comparison with fee and pegout minimum
-            Assertions.assertEquals(
+            assertEquals(
                 value.isLessThan(minValueWithGapAboveFee) ?
                     RejectedPegoutReason.FEE_ABOVE_VALUE :
                     RejectedPegoutReason.LOW_AMOUNT,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -619,37 +619,54 @@ class BridgeSupportReleaseBtcTest {
     }
 
     @Test
-    public void test_processPegoutsIndividually_before_RSKIP298_activation() throws IOException {
+    public void test_pegout_creation_before_RSKIP298_activation_does_not_set_index() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP298)).thenReturn(false);
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(activationMock.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
 
         Federation federation = bridgeConstants.getGenesisFederation();
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(3), federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
+
+        ReleaseRequestQueue releaseRequestQueue = new ReleaseRequestQueue(
+            Arrays.asList(
+                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.MILLICOIN),
+                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.MILLICOIN),
+                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.MILLICOIN)));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
-        when(provider.getReleaseRequestQueue())
-            .thenReturn(new ReleaseRequestQueue(Arrays.asList(
-                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.COIN),
-                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.COIN))));
+        when(provider.getReleaseRequestQueue()).thenReturn(releaseRequestQueue);
         when(provider.getReleaseTransactionSet()).thenReturn(new ReleaseTransactionSet(Collections.emptySet()));
 
+        Coin totalValue = releaseRequestQueue.getEntries()
+            .stream()
+            .map(ReleaseRequestQueue.Entry::getAmount)
+            .reduce(Coin.ZERO, Coin::add);
+
+        List<Keccak256> rskHashesList = releaseRequestQueue.getEntries()
+            .stream()
+            .map(ReleaseRequestQueue.Entry::getRskTxHash)
+            .collect(Collectors.toList());
+
         BridgeSupport bridgeSupport = bridgeSupportBuilder
+            .withActivations(activationMock)
             .withBridgeConstants(bridgeConstants)
             .withProvider(provider)
-            .withActivations(activationMock)
+            .withEventLogger(eventLogger)
             .build();
 
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        verify(provider, never()).setPegoutCreationEntry(any(), any());
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+
+        verify(provider, never()).setPegoutCreationEntry(any());
     }
 
     @Test
-    public void test_processPegoutsInBatch_after_RSKIP298() throws IOException {
+    public void test_pegout_creation_after_RSKIP298_activation_sets_index() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(activationMock.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
@@ -694,7 +711,7 @@ class BridgeSupportReleaseBtcTest {
 
         BtcTransaction generatedTransaction = provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction();
 
-        verify(provider, times(1)).setPegoutCreationEntry(generatedTransaction.getHash(), rskTx.getHash());
+        verify(provider, times(1)).setPegoutCreationEntry(new PegoutCreationEntry(generatedTransaction.getHash(), rskTx.getHash()));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -619,6 +619,85 @@ class BridgeSupportReleaseBtcTest {
     }
 
     @Test
+    public void test_processPegoutsIndividually_before_RSKIP298_activation() throws IOException {
+        when(activationMock.isActive(ConsensusRule.RSKIP298)).thenReturn(false);
+        when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
+        when(activationMock.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+
+        Federation federation = bridgeConstants.getGenesisFederation();
+        List<UTXO> utxos = new ArrayList<>();
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(3), federation.getAddress()));
+
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
+        when(provider.getReleaseRequestQueue())
+            .thenReturn(new ReleaseRequestQueue(Arrays.asList(
+                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.COIN),
+                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.COIN))));
+        when(provider.getReleaseTransactionSet()).thenReturn(new ReleaseTransactionSet(Collections.emptySet()));
+
+        BridgeSupport bridgeSupport = bridgeSupportBuilder
+            .withBridgeConstants(bridgeConstants)
+            .withProvider(provider)
+            .withActivations(activationMock)
+            .build();
+
+        Transaction rskTx = buildUpdateTx();
+        bridgeSupport.updateCollections(rskTx);
+
+        verify(provider, never()).setPegoutCreationEntry(any(), any());
+    }
+
+    @Test
+    public void test_processPegoutsInBatch_after_RSKIP298() throws IOException {
+        when(activationMock.isActive(ConsensusRule.RSKIP298)).thenReturn(true);
+        when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
+        when(activationMock.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+
+        Federation federation = bridgeConstants.getGenesisFederation();
+        List<UTXO> utxos = new ArrayList<>();
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
+
+        ReleaseRequestQueue releaseRequestQueue = new ReleaseRequestQueue(
+            Arrays.asList(
+                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.MILLICOIN),
+                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.MILLICOIN),
+                new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.MILLICOIN)));
+
+        BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
+        when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
+        when(provider.getReleaseRequestQueue()).thenReturn(releaseRequestQueue);
+        when(provider.getReleaseTransactionSet()).thenReturn(new ReleaseTransactionSet(Collections.emptySet()));
+
+        Coin totalValue = releaseRequestQueue.getEntries()
+            .stream()
+            .map(ReleaseRequestQueue.Entry::getAmount)
+            .reduce(Coin.ZERO, Coin::add);
+
+        List<Keccak256> rskHashesList = releaseRequestQueue.getEntries()
+            .stream()
+            .map(ReleaseRequestQueue.Entry::getRskTxHash)
+            .collect(Collectors.toList());
+
+        BridgeSupport bridgeSupport = bridgeSupportBuilder
+            .withActivations(activationMock)
+            .withBridgeConstants(bridgeConstants)
+            .withProvider(provider)
+            .withEventLogger(eventLogger)
+            .build();
+
+        Transaction rskTx = buildUpdateTx();
+        bridgeSupport.updateCollections(rskTx);
+
+        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
+
+        BtcTransaction generatedTransaction = provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction();
+
+        verify(provider, times(1)).setPegoutCreationEntry(generatedTransaction.getHash(), rskTx.getHash());
+    }
+
+    @Test
     void test_processPegoutsIndividually_before_RSKIP271_activation() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -1060,5 +1060,4 @@ class BridgeTest {
         return new BlockGenerator().getGenesisBlock();
     }
 
-
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -83,7 +83,7 @@ class BridgeTest {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298_activation() throws VMException {
+    void getPegoutCreationRskTxHashByBtcTxHash_before_RSKIP298_activation() throws VMException {
         doReturn(false).when(activationConfig).isActive(eq(RSKIP298), anyLong());
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -99,7 +99,7 @@ class BridgeTest {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_after_RSKIP298_activation() throws VMException {
+    void getPegoutCreationRskTxHashByBtcTxHash_after_RSKIP298_activation() throws VMException {
         doReturn(true).when(activationConfig).isActive(eq(RSKIP298), anyLong());
 
         Sha256Hash btcTxHash = PegTestUtils.createHash(13);
@@ -121,7 +121,7 @@ class BridgeTest {
     }
 
     @Test
-    public void getPegoutCreationRskTxHashByBtcTxHash_not_found_after_RSKIP298_activation() throws VMException {
+    void getPegoutCreationRskTxHashByBtcTxHash_not_found_after_RSKIP298_activation() throws VMException {
         doReturn(true).when(activationConfig).isActive(eq(RSKIP298), anyLong());
 
         Sha256Hash btcTxHash = PegTestUtils.createHash(17);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -106,8 +106,8 @@ class BridgeTest {
         Keccak256 rskTxHash = PegTestUtils.createHash3(7);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        when(bridgeSupportMock.getPegoutCreationRskTxHashByBtcTxHash(any())).thenReturn(
-            Optional.of(rskTxHash)
+        when(bridgeSupportMock.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash)).thenReturn(
+            rskTxHash.getBytes()
         );
 
         Bridge bridge = getBridgeInstance(bridgeSupportMock, activationConfig);
@@ -127,8 +127,8 @@ class BridgeTest {
         Sha256Hash btcTxHash = PegTestUtils.createHash(17);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        when(bridgeSupportMock.getPegoutCreationRskTxHashByBtcTxHash(any())).thenReturn(
-            Optional.empty()
+        when(bridgeSupportMock.getPegoutCreationRskTxHashByBtcTxHash(btcTxHash)).thenReturn(
+            ByteUtil.EMPTY_BYTE_ARRAY
         );
 
         Bridge bridge = getBridgeInstance(bridgeSupportMock, activationConfig);

--- a/rskj-core/src/test/java/co/rsk/peg/PegoutCreationEntryTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegoutCreationEntryTest.java
@@ -14,28 +14,33 @@ public class PegoutCreationEntryTest {
 
     @Test
     public void testGetPegoutCreationEntryBtcTxHash() {
-        Sha256Hash sha256Hash = PegTestUtils.createHash(3);
-        Keccak256 keccak256 = PegTestUtils.createHash3(5);
-        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
-        assertEquals(sha256Hash, pegoutCreationEntry.getBtcTxHash());
+        Sha256Hash btcTxHash = PegTestUtils.createHash(3);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(5);
+
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(btcTxHash, rskTxHash);
+
+        assertEquals(btcTxHash, pegoutCreationEntry.getBtcTxHash());
         assertNotNull(pegoutCreationEntry.getBtcTxHash());
     }
 
     @Test
     public void testGetPegoutCreationEntryRskTxHash() {
-        Sha256Hash sha256Hash = PegTestUtils.createHash(5);
-        Keccak256 keccak256 = PegTestUtils.createHash3(3);
-        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(5);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(3);
+
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(btcTxHash, rskTxHash);
+
         assertNotNull(pegoutCreationEntry.getRskTxHash());
-        assertEquals(keccak256, pegoutCreationEntry.getRskTxHash());
+        assertEquals(rskTxHash, pegoutCreationEntry.getRskTxHash());
     }
 
     @Test
     public void testTestEquals() {
-        Sha256Hash sha256Hash = PegTestUtils.createHash(8);
-        Keccak256 keccak256 = PegTestUtils.createHash3(13);
-        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
-        PegoutCreationEntry pegoutCreationEntryWithSameValues = new PegoutCreationEntry(sha256Hash, keccak256);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(8);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(13);
+
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(btcTxHash, rskTxHash);
+        PegoutCreationEntry pegoutCreationEntryWithSameValues = new PegoutCreationEntry(btcTxHash, rskTxHash);
 
         assertEquals(pegoutCreationEntry, pegoutCreationEntryWithSameValues);
 
@@ -49,12 +54,12 @@ public class PegoutCreationEntryTest {
 
     @Test
     public void testTestHashCode() {
-        Sha256Hash sha256Hash = PegTestUtils.createHash(13); // hashcode = 0
-        Keccak256 keccak256 = new Keccak256(
+        Sha256Hash btcTxHash = PegTestUtils.createHash(13); // hashcode = 0
+        Keccak256 rskTxHash = new Keccak256(
             Keccak256Helper.keccak256(ByteUtil.toHexString("rsk".getBytes()))
         ); // hashcode = -1150029211
 
-        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(btcTxHash, rskTxHash);
 
         int hashCodeExpected = -1150029211;
         assertEquals(hashCodeExpected, pegoutCreationEntry.hashCode());
@@ -62,9 +67,10 @@ public class PegoutCreationEntryTest {
 
     @Test
     public void testTestToString() {
-        Sha256Hash sha256Hash = PegTestUtils.createHash(3);
-        Keccak256 keccak256 = PegTestUtils.createHash3(10);
-        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
+        Sha256Hash btcTxHash = PegTestUtils.createHash(3);
+        Keccak256 rskTxHash = PegTestUtils.createHash3(10);
+
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(btcTxHash, rskTxHash);
 
         String expectedResult = "PegoutCreationEntry{btcTxHash=0300000000000000000000000000000000000000000000000000000000000000, rskTxHash=0a00000000000000000000000000000000000000000000000000000000000000}";
         assertEquals(expectedResult, pegoutCreationEntry.toString());

--- a/rskj-core/src/test/java/co/rsk/peg/PegoutCreationEntryTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegoutCreationEntryTest.java
@@ -1,0 +1,72 @@
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.crypto.Keccak256;
+import org.ethereum.crypto.Keccak256Helper;
+import org.ethereum.util.ByteUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+
+public class PegoutCreationEntryTest {
+
+    @Test
+    public void testGetPegoutCreationEntryBtcTxHash() {
+        Sha256Hash sha256Hash = PegTestUtils.createHash(3);
+        Keccak256 keccak256 = PegTestUtils.createHash3(5);
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
+        assertEquals(sha256Hash, pegoutCreationEntry.getBtcTxHash());
+        assertNotNull(pegoutCreationEntry.getBtcTxHash());
+    }
+
+    @Test
+    public void testGetPegoutCreationEntryRskTxHash() {
+        Sha256Hash sha256Hash = PegTestUtils.createHash(5);
+        Keccak256 keccak256 = PegTestUtils.createHash3(3);
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
+        assertNotNull(pegoutCreationEntry.getRskTxHash());
+        assertEquals(keccak256, pegoutCreationEntry.getRskTxHash());
+    }
+
+    @Test
+    public void testTestEquals() {
+        Sha256Hash sha256Hash = PegTestUtils.createHash(8);
+        Keccak256 keccak256 = PegTestUtils.createHash3(13);
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
+        PegoutCreationEntry pegoutCreationEntryWithSameValues = new PegoutCreationEntry(sha256Hash, keccak256);
+
+        assertEquals(pegoutCreationEntry, pegoutCreationEntryWithSameValues);
+
+        PegoutCreationEntry pegoutCreationEntryWithDifferentValues = new PegoutCreationEntry(
+            PegTestUtils.createHash(2),
+            PegTestUtils.createHash3(2)
+        );
+
+        assertNotSame(pegoutCreationEntry, pegoutCreationEntryWithDifferentValues);
+    }
+
+    @Test
+    public void testTestHashCode() {
+        Sha256Hash sha256Hash = PegTestUtils.createHash(13); // hashcode = 0
+        Keccak256 keccak256 = new Keccak256(
+            Keccak256Helper.keccak256(ByteUtil.toHexString("rsk".getBytes()))
+        ); // hashcode = -1150029211
+
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
+
+        int hashCodeExpected = -1150029211;
+        assertEquals(hashCodeExpected, pegoutCreationEntry.hashCode());
+    }
+
+    @Test
+    public void testTestToString() {
+        Sha256Hash sha256Hash = PegTestUtils.createHash(3);
+        Keccak256 keccak256 = PegTestUtils.createHash3(10);
+        PegoutCreationEntry pegoutCreationEntry = new PegoutCreationEntry(sha256Hash, keccak256);
+
+        String expectedResult = "PegoutCreationEntry{btcTxHash=0300000000000000000000000000000000000000000000000000000000000000, rskTxHash=0a00000000000000000000000000000000000000000000000000000000000000}";
+        assertEquals(expectedResult, pegoutCreationEntry.toString());
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/PegoutCreationEntryTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegoutCreationEntryTest.java
@@ -4,16 +4,17 @@ import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.util.ByteUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
-public class PegoutCreationEntryTest {
+
+class PegoutCreationEntryTest {
 
     @Test
-    public void testGetPegoutCreationEntryBtcTxHash() {
+    void testGetPegoutCreationEntryBtcTxHash() {
         Sha256Hash btcTxHash = PegTestUtils.createHash(3);
         Keccak256 rskTxHash = PegTestUtils.createHash3(5);
 
@@ -24,7 +25,7 @@ public class PegoutCreationEntryTest {
     }
 
     @Test
-    public void testGetPegoutCreationEntryRskTxHash() {
+    void testGetPegoutCreationEntryRskTxHash() {
         Sha256Hash btcTxHash = PegTestUtils.createHash(5);
         Keccak256 rskTxHash = PegTestUtils.createHash3(3);
 
@@ -35,7 +36,7 @@ public class PegoutCreationEntryTest {
     }
 
     @Test
-    public void testTestEquals() {
+    void testTestEquals() {
         Sha256Hash btcTxHash = PegTestUtils.createHash(8);
         Keccak256 rskTxHash = PegTestUtils.createHash3(13);
 
@@ -53,7 +54,7 @@ public class PegoutCreationEntryTest {
     }
 
     @Test
-    public void testTestHashCode() {
+    void testTestHashCode() {
         Sha256Hash btcTxHash = PegTestUtils.createHash(13); // hashcode = 0
         Keccak256 rskTxHash = new Keccak256(
             Keccak256Helper.keccak256(ByteUtil.toHexString("rsk".getBytes()))
@@ -66,7 +67,7 @@ public class PegoutCreationEntryTest {
     }
 
     @Test
-    public void testTestToString() {
+    void testTestToString() {
         Sha256Hash btcTxHash = PegTestUtils.createHash(3);
         Keccak256 rskTxHash = PegTestUtils.createHash3(10);
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -102,6 +102,7 @@ class ActivationConfigTest {
             "    rskip293: hop400",
             "    rskip294: hop400",
             "    rskip297: hop400",
+            "    rskip298: fingerroot500",
             "    rskip326: fingerroot500",
             "    rskip353: hop401",
             "    rskip357: hop401",


### PR DESCRIPTION
A short summary of the changes:

- Add methods and logic into BridgeStorageProvider class to manage the new peg-out creation index.
Methods created: getNextPegoutHeight, setNextPegoutHeight, saveNextPegoutHeight

Index structure
```
index key: (DataWord) Combination of the static string pegoutTxIndex- and the given Bitcoin transaction hash (Sha256hash -> 32 bytes). The resulting string should be hashed using Keccak256 to have a valid 32 bytes long DataWord.
index value: RSK transaction hash (Keccak256 -> 32 bytes)
```

- Add new bridge method `getPegoutCreationRskTxHashByBtcTxHash`, to fetch a rskTxHash(the rsk transaction where the peg-out was created)  given a btcTxHash(which belongs to a peg-out).
