### PR TITLE
Research/main parallel tx remasc

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -473,7 +473,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             blockExecutor = new BlockExecutor(
                     getRskSystemProperties().getActivationConfig(),
                     getRepositoryLocator(),
-                    getTransactionExecutorFactory()
+                    getTransactionExecutorFactory(),
+                    getRskSystemProperties().isRemascEnabled()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/BlockExecutor.java
@@ -59,6 +59,7 @@ public class BlockExecutor {
     private final RepositoryLocator repositoryLocator;
     private final TransactionExecutorFactory transactionExecutorFactory;
     private final ActivationConfig activationConfig;
+    private boolean remascEnabled;
 
     private final Map<Keccak256, ProgramResult> transactionResults = new ConcurrentHashMap<>();
     private boolean registerProgramResults;
@@ -66,10 +67,12 @@ public class BlockExecutor {
     public BlockExecutor(
             ActivationConfig activationConfig,
             RepositoryLocator repositoryLocator,
-            TransactionExecutorFactory transactionExecutorFactory) {
+            TransactionExecutorFactory transactionExecutorFactory,
+            boolean remascEnabled) {
         this.repositoryLocator = repositoryLocator;
         this.transactionExecutorFactory = transactionExecutorFactory;
         this.activationConfig = activationConfig;
+        this.remascEnabled = remascEnabled;
     }
 
     /**
@@ -388,7 +391,9 @@ public class BlockExecutor {
             loggingTxDone();
         }
 
-        addFeesToRemasc(totalPaidFees, track);
+        if (this.isRemascEnabled()) {
+            addFeesToRemasc(totalPaidFees, track);
+        }
 
         loggingEndTxsExecutions();
 
@@ -546,7 +551,9 @@ public class BlockExecutor {
         totalPaidFees = totalPaidFees.add(txListExecutor.getTotalFees());
         totalGasUsed += txListExecutor.getTotalGas();
 
-        addFeesToRemasc(totalPaidFees, track);
+        if (this.isRemascEnabled()) {
+            addFeesToRemasc(totalPaidFees, track);
+        }
 
         loggingEndTxsExecutions();
         if (!vmTrace) {
@@ -573,6 +580,10 @@ public class BlockExecutor {
             logger.trace("Adding fee to remasc contract account");
             track.addBalance(PrecompiledContracts.REMASC_ADDR, remascFees);
         }
+    }
+
+    private boolean isRemascEnabled() {
+        return this.remascEnabled;
     }
 
     private BlockResult executeForMiningAfterRSKIP144(
@@ -685,7 +696,10 @@ public class BlockExecutor {
             loggingTxDone();
         }
 
-        addFeesToRemasc(totalPaidFees, track);
+        if (this.isRemascEnabled()) {
+            addFeesToRemasc(totalPaidFees, track);
+        }
+
         loggingEndTxsExecutions();
 
         saveTrack(track);

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -1326,8 +1326,8 @@ public class BlockExecutorTest {
                         new ProgramInvokeFactoryImpl(),
                         new PrecompiledContracts(cfg, bridgeSupportFactory),
                         new BlockTxSignatureCache(new ReceivedTxSignatureCache())
-                )
-        );
+                ),
+                cfg.isRemascEnabled());
     }
 
     public static class TestObjects {

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -584,9 +584,8 @@ public class TransactionModuleTest {
         BlockExecutor blockExecutor = new BlockExecutor(
                 config.getActivationConfig(),
                 repositoryLocator,
-//                stateRootHandler,
-                this.transactionExecutorFactory
-        );
+                this.transactionExecutorFactory,
+                config.isRemascEnabled());
 
         MinerServer minerServer = new MinerServerImpl(
                 config,

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -793,8 +793,8 @@ public class SyncProcessorTest {
                         new ProgramInvokeFactoryImpl(),
                         new PrecompiledContracts(config, bridgeSupportFactory),
                         new BlockTxSignatureCache(new ReceivedTxSignatureCache())
-                )
-        );
+                ),
+                config.isRemascEnabled());
         Assert.assertEquals(1, block.getTransactionsList().size());
         blockExecutor.executeAndFillAll(block, genesis.getHeader());
         Assert.assertEquals(21000, block.getFeesPaidToMiner().asBigInteger().intValueExact());

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascProcessMinerFeesTest.java
@@ -1022,7 +1022,7 @@ public class RemascProcessMinerFeesTest {
                         new ProgramInvokeFactoryImpl(),
                         new PrecompiledContracts(config, bridgeSupportFactory),
                         new BlockTxSignatureCache(new ReceivedTxSignatureCache())
-                )
-        );
+                ),
+                config.isRemascEnabled());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -37,7 +37,6 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
-import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.MutableRepository;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
@@ -455,8 +454,8 @@ public class RemascStorageProviderTest {
                         new ProgramInvokeFactoryImpl(),
                         new PrecompiledContracts(config, bridgeSupportFactory),
                         new BlockTxSignatureCache(new ReceivedTxSignatureCache())
-                )
-        );
+                ),
+                config.isRemascEnabled());
 
         for (Block b : blocks) {
             blockExecutor.executeAndFillAll(b, blockchain.getBestBlock().getHeader());

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -146,8 +146,8 @@ class RemascTestRunner {
                         programInvokeFactory,
                         precompiledContracts,
                         blockTxSignatureCache
-                )
-        );
+                ),
+                builder.getConfig().isRemascEnabled());
 
         for(int i = 0; i <= this.initialHeight; i++) {
             int finalI = i;

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -179,8 +179,8 @@ public class World {
                             programInvokeFactory,
                             new PrecompiledContracts(config, bridgeSupportFactory),
                             blockTxSignatureCache
-                    )
-            );
+                    ),
+                    config.isRemascEnabled());
         }
 
         return this.blockExecutor;

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
@@ -116,8 +116,8 @@ public class BlockBuilder {
                             new ProgramInvokeFactoryImpl(),
                             new PrecompiledContracts(config, bridgeSupportFactory),
                             new BlockTxSignatureCache(new ReceivedTxSignatureCache())
-                    )
-            );
+                    ),
+                    config.isRemascEnabled());
             executor.executeAndFill(block, parent.getHeader());
         }
 

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -246,8 +246,8 @@ public class BlockChainBuilder {
         BlockExecutor blockExecutor = new BlockExecutor(
                 config.getActivationConfig(),
                 repositoryLocator,
-                transactionExecutorFactory
-        );
+                transactionExecutorFactory,
+                config.isRemascEnabled());
         BlockChainImpl blockChain = new BlockChainLoader(
                 blockStore,
                 receiptStore,

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -324,8 +324,8 @@ public class WorldDslProcessor {
                             programInvokeFactory,
                             null,
                             world.getBlockTxSignatureCache()
-                    )
-            );
+                    ),
+                    config.isRemascEnabled());
             executor.executeAndFill(block, parent.getHeader());
             world.saveBlock(name, block);
             parent = block;

--- a/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/ImportLightTest.java
@@ -87,8 +87,8 @@ public class ImportLightTest {
                 new BlockExecutor(
                         config.getActivationConfig(),
                         repositoryLocator,
-                        transactionExecutorFactory
-                ),
+                        transactionExecutorFactory,
+                        config.isRemascEnabled()),
                 stateRootHandler
         );
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/TestRunner.java
@@ -167,8 +167,8 @@ public class TestRunner {
                 new BlockExecutor(
                         config.getActivationConfig(),
                         new RepositoryLocator(trieStore, stateRootHandler),
-                        transactionExecutorFactory
-                ),
+                        transactionExecutorFactory,
+                        config.isRemascEnabled()),
                 stateRootHandler
         );
 

--- a/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
+++ b/rskj-core/src/test/java/org/ethereum/jsontestsuite/runners/StateTestRunner.java
@@ -160,8 +160,8 @@ public class StateTestRunner {
                                 new ProgramInvokeFactoryImpl(),
                                 precompiledContracts,
                                 new BlockTxSignatureCache(new ReceivedTxSignatureCache())
-                        )
-                ),
+                        ),
+                        config.isRemascEnabled()),
                 stateRootHandler
         );
 


### PR DESCRIPTION
As it is now, a remascFees variable accumulates the fees for a block and sends them to REMASC after processing all the transactions, REMASC tx included.

So far, this is not an issue since the payment to miners is performed after some blocks called Maturity. For the Regtest network, the Maturity is 10. Nevertheless, if we consider the case Maturity becomes 0, miners won't perceive the fees paid in the same block; but in the next block. 

On this PR I moved the payment just before the REMASC tx execution. There were some edge cases in which there was no REMASC tx in the block. Hence, no fees were added. So, I added a check where if the Block Executor processes the last transaction, even though it is not the REMASC one, it increments the balance of the REMASC account with the fees paid in the block.

Finally, for every place where REMASC receives the fees, I added a check to see if REMASC is enabled.