### PR TITLE
New erp script updates

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -120,10 +120,8 @@ public abstract class BridgeConstants {
 
     public Coin getMinimumPegoutTxValueInSatoshis() { return minimumPegoutTxValueInSatoshis; }
 
-    public long getFederationActivationAge(ActivationConfig.ForBlock activations) {
-        return activations.isActive(ConsensusRule.RSKIP353) ?
-            specialCaseFederationActivationAge :
-            federationActivationAge;
+    public long getFederationActivationAge() {
+        return federationActivationAge;
     }
 
     public long getFundsMigrationAgeSinceActivationBegin() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -129,7 +129,7 @@ public abstract class BridgeConstants {
     }
 
     public long getFundsMigrationAgeSinceActivationEnd(ActivationConfig.ForBlock activations) {
-        return activations.isActive(ConsensusRule.RSKIP353) ?
+        return activations.isActive(ConsensusRule.RSKIP357) ?
             specialCaseFundsMigrationAgeSinceActivationEnd :
             fundsMigrationAgeSinceActivationEnd;
     }

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -105,7 +105,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
         );
 
         federationActivationAge = 10L;
-        specialCaseFederationActivationAge = 10L;
 
         fundsMigrationAgeSinceActivationBegin = 15L;
         fundsMigrationAgeSinceActivationEnd = 100L;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -94,7 +94,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
         );
 
         federationActivationAge = 18500L;
-        specialCaseFederationActivationAge = 5_760; // 48 hours considering 1 block every 30 seconds
 
         fundsMigrationAgeSinceActivationBegin = 0L;
         fundsMigrationAgeSinceActivationEnd = 10585L;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -91,7 +91,6 @@ public class BridgeRegTestConstants extends BridgeConstants {
         );
 
         federationActivationAge = 10L;
-        specialCaseFederationActivationAge = 10L;
 
         fundsMigrationAgeSinceActivationBegin = 15L;
         fundsMigrationAgeSinceActivationEnd = 150L;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -104,7 +104,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
         );
 
         federationActivationAge = 60L;
-        specialCaseFederationActivationAge = 60L;
 
         fundsMigrationAgeSinceActivationBegin = 60L;
         fundsMigrationAgeSinceActivationEnd = 900L;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -972,7 +972,7 @@ public class BridgeSupport {
     }
 
     private boolean federationIsInMigrationAge(Federation federation) {
-        long federationActivationAge = bridgeConstants.getFederationActivationAge(activations);
+        long federationActivationAge = bridgeConstants.getFederationActivationAge();
         long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
         long ageBegin = federationActivationAge + bridgeConstants.getFundsMigrationAgeSinceActivationBegin();
         long ageEnd = federationActivationAge + bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
@@ -982,7 +982,7 @@ public class BridgeSupport {
 
     private boolean federationIsPastMigrationAge(Federation federation) {
         long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
-        long ageEnd = bridgeConstants.getFederationActivationAge(activations) +
+        long ageEnd = bridgeConstants.getFederationActivationAge() +
             bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
 
         return federationAge >= ageEnd;
@@ -1266,7 +1266,7 @@ public class BridgeSupport {
             long nextFederationCreationBlockHeight = nextFederationCreationBlockHeightOpt.get();
             long curBlockHeight = rskExecutionBlock.getNumber();
 
-            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge(activations)) {
+            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge()) {
                 provider.setActiveFederationCreationBlockHeight(nextFederationCreationBlockHeight);
                 provider.clearNextFederationCreationBlockHeight();
             }
@@ -2606,7 +2606,7 @@ public class BridgeSupport {
         if (nextFederationCreationBlockHeightOpt.isPresent()) {
             long nextFederationCreationBlockHeight = nextFederationCreationBlockHeightOpt.get();
             long curBlockHeight = rskExecutionBlock.getNumber();
-            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge(activations)) {
+            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge()) {
                 return nextFederationCreationBlockHeight;
             }
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -412,7 +412,8 @@ public class BridgeUtils {
                     // There's no reason for someone to send an actual pegin of this type before the new fed is active.
                     // TODO: Remove this if block after RSKIP353 activation
                     if (!activations.isActive(ConsensusRule.RSKIP353) &&
-                        redeemScriptParser.getMultiSigType() == MultiSigType.P2SH_ERP_FED) {
+                        (redeemScriptParser.getMultiSigType() == MultiSigType.P2SH_ERP_FED ||
+                        redeemScriptParser.getMultiSigType() == MultiSigType.FAST_BRIDGE_P2SH_ERP_FED)) {
                         String message = "Tried to register a transaction with a P2SH ERP federation redeem script before RSKIP353 activation";
                         logger.warn("[isValidPegInTx] {}", message);
                         throw new ScriptException(message);
@@ -442,7 +443,7 @@ public class BridgeUtils {
         Coin minimumPegInTxValue = getMinimumPegInTxValue(activations, bridgeConstants);
 
         boolean isUTXOsOrTxAmountBelowMinimum =
-            activations.isActive(RSKIP293)? isAnyUTXOAmountBelowMinimum(
+            activations.isActive(RSKIP293) ? isAnyUTXOAmountBelowMinimum(
                 activations,
                 bridgeConstants,
                 tx,

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -388,7 +388,7 @@ public class BridgeUtils {
         BridgeConstants bridgeConstants,
         ActivationConfig.ForBlock activations) {
 
-        // First, check tx is not a typical release tx (tx spending from the any of the federation addresses and
+        // First, check tx is not a typical release tx (tx spending from any of the federation addresses and
         // optionally sending some change to any of the federation addresses)
         for (int i = 0; i < tx.getInputs().size(); i++) {
             final int index = i;
@@ -405,6 +405,18 @@ public class BridgeUtils {
             if (activations.isActive(ConsensusRule.RSKIP201)) {
                 RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(tx.getInput(index).getScriptSig().getChunks());
                 try {
+                    // Consider transactions that have an input with a redeem script of type P2SH ERP FED
+                    // to be "future transactions" that should not be pegins. These are gonna be considered pegouts.
+                    // This is only for backwards compatibility reasons. As soon as RSKIP353 activates,
+                    // pegins to the new federation should be valid again.
+                    // There's no reason for someone to send an actual pegin of this type before the new fed is active.
+                    // TODO: Remove this if block after RSKIP353 activation
+                    if (!activations.isActive(ConsensusRule.RSKIP353) &&
+                        redeemScriptParser.getMultiSigType() == MultiSigType.P2SH_ERP_FED) {
+                        String message = "Tried to register a transaction with a P2SH ERP federation redeem script before RSKIP353 activation";
+                        logger.warn("[isValidPegInTx] {}", message);
+                        throw new ScriptException(message);
+                    }
                     Script inputStandardRedeemScript = redeemScriptParser.extractStandardRedeemScript();
                     if (activeFederations.stream().anyMatch(federation -> federation.getStandardRedeemScript().equals(inputStandardRedeemScript))) {
                         return false;

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -234,6 +234,6 @@ public class FederationSupport {
 
     private boolean shouldFederationBeActive(Federation federation) {
         long federationAge = executionBlock.getNumber() - federation.getCreationBlockNumber();
-        return federationAge >= bridgeConstants.getFederationActivationAge(activations);
+        return federationAge >= bridgeConstants.getFederationActivationAge();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -160,7 +160,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
         byte[] newFedFlatPubKeys = flatKeysAsRlpCollection(newFederation.getBtcPublicKeys());
         byte[] newFedData = RLP.encodeList(RLP.encodeElement(newFederation.getAddress().getHash160()), RLP.encodeList(newFedFlatPubKeys));
 
-        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge(activations);
+        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge();
 
         byte[] data = RLP.encodeList(oldFedData, newFedData, RLP.encodeString(Long.toString(newFedActivationBlockNumber)));
 
@@ -173,7 +173,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
         String oldFederationBtcAddress = oldFederation.getAddress().toBase58();
         byte[] newFederationFlatPubKeys = flatKeysAsByteArray(newFederation.getBtcPublicKeys());
         String newFederationBtcAddress = newFederation.getAddress().toBase58();
-        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge(activations);
+        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge();
 
         CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION.getEvent();
         byte[][] encodedTopicsInBytes = event.encodeEventTopics();

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -76,7 +76,8 @@ public enum ConsensusRule {
     RSKIP293("rskip293"), // Flyover improvements
     RSKIP294("rskip294"),
     RSKIP297("rskip297"), // Increase max timestamp difference between btc and rsk blocks for Testnet
-    RSKIP353("rskip353");
+    RSKIP353("rskip353"),
+    RSKIP357("rskip357"),;
 
     private String configKey;
 

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -77,7 +77,7 @@ public enum ConsensusRule {
     RSKIP294("rskip294"),
     RSKIP297("rskip297"), // Increase max timestamp difference between btc and rsk blocks for Testnet
     RSKIP353("rskip353"),
-    RSKIP357("rskip357"),;
+    RSKIP357("rskip357");
 
     private String configKey;
 

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
@@ -29,7 +29,7 @@ public enum NetworkUpgrade {
     TWOTOTHREE("twoToThree"),
     IRIS300("iris300"),
     HOP400("hop400"),
-    HOP500("hop500");
+    HOP401("hop401");
 
     private String name;
 

--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -10,7 +10,7 @@ blockchain.config {
         papyrus200 = 0,
         iris300 = 0,
         hop400 = 0,
-        hop500 = 0
+        hop401 = 0
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -10,7 +10,7 @@ blockchain.config {
         papyrus200 = 2392700,
         iris300 = 3614800,
         hop400 = 4598500,
-        hop500 = -1
+        hop401 = -1
     }
 }
 

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -10,7 +10,7 @@ blockchain.config {
         papyrus200 = 0,
         iris300 = 0,
         hop400 = 0,
-        hop500 = 0
+        hop401 = 0
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -10,7 +10,7 @@ blockchain.config {
         papyrus200 = 863000,
         iris300 = 2060500,
         hop400 = 3103000,
-        hop500 = -1
+        hop401 = -1
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -74,6 +74,7 @@ blockchain = {
              rskip294 = <hardforkName>
              rskip297 = <hardforkName>
              rskip353 = <hardforkName>
+             rskip357 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -13,7 +13,7 @@ blockchain = {
             twoToThree = <height>
             iris300 = <height>
             hop400 = <height>
-            hop500 = <height>
+            hop401 = <height>
         }
         consensusRules = {
              areBridgeTxsPaid = <hardforkName>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -63,6 +63,7 @@ blockchain = {
             rskip294 = hop400
             rskip297 = hop400
             rskip353 = hop401
+            rskip357 = hop401
         }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -62,7 +62,7 @@ blockchain = {
             rskip293 = hop400
             rskip294 = hop400
             rskip297 = hop400
-            rskip353 = hop500
+            rskip353 = hop401
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -90,7 +90,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -231,7 +231,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -374,7 +374,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -541,7 +541,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -1575,7 +1575,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -1758,7 +1758,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -1951,7 +1951,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -2144,7 +2144,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -2310,7 +2310,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -2491,7 +2491,7 @@ public class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -108,10 +108,10 @@ public class BridgeSupportProcessFundsMigrationTest {
 
         long federationCreationBlockNumber = 5L;
         long federationInMigrationAgeHeight = federationCreationBlockNumber +
-            bridgeConstants.getFederationActivationAge(activations) +
+            bridgeConstants.getFederationActivationAge() +
             bridgeConstants.getFundsMigrationAgeSinceActivationBegin() + 1;
         long federationPastMigrationAgeHeight = federationCreationBlockNumber +
-            bridgeConstants.getFederationActivationAge(activations) +
+            bridgeConstants.getFederationActivationAge() +
             bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations) + 1;
 
         Federation newFederation = new Federation(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -43,7 +43,7 @@ public class BridgeSupportProcessFundsMigrationTest {
     }
 
     @Test
-    public void processFundsMigration_in_migration_age_after_rskip_353_activation_testnet() throws IOException {
+    public void processFundsMigration_in_migration_age_after_rskip_357_activation_testnet() throws IOException {
         test_processFundsMigration(BridgeTestNetConstants.getInstance(), true, true, true);
     }
 
@@ -58,7 +58,7 @@ public class BridgeSupportProcessFundsMigrationTest {
     }
 
     @Test
-    public void processFundsMigration_past_migration_age_after_rskip_353_activation_testnet() throws IOException {
+    public void processFundsMigration_past_migration_age_after_rskip_357_activation_testnet() throws IOException {
         test_processFundsMigration(BridgeTestNetConstants.getInstance(), true, true, false);
     }
 
@@ -73,7 +73,7 @@ public class BridgeSupportProcessFundsMigrationTest {
     }
 
     @Test
-    public void processFundsMigration_in_migration_age_after_rskip_353_activation_mainnet() throws IOException {
+    public void processFundsMigration_in_migration_age_after_rskip_357_activation_mainnet() throws IOException {
         test_processFundsMigration(BridgeMainNetConstants.getInstance(), true, true, true);
     }
 
@@ -88,19 +88,19 @@ public class BridgeSupportProcessFundsMigrationTest {
     }
 
     @Test
-    public void processFundsMigration_past_migration_age_after_rskip_353_activation_mainnet() throws IOException {
+    public void processFundsMigration_past_migration_age_after_rskip_357_activation_mainnet() throws IOException {
         test_processFundsMigration(BridgeMainNetConstants.getInstance(), true, true, false);
     }
 
     private void test_processFundsMigration(
         BridgeConstants bridgeConstants,
         boolean isRskip146Active,
-        boolean isRskip353Active,
+        boolean isRskip357Active,
         boolean inMigrationAge) throws IOException {
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(isRskip146Active);
-        when(activations.isActive(ConsensusRule.RSKIP353)).thenReturn(isRskip353Active);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(isRskip357Active);
 
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -6372,7 +6372,7 @@ public class BridgeSupportTest extends BridgeSupportTestBase {
         Block block = mock(Block.class);
         // Set block right after the migration should start
         long blockNumber = newFed.getCreationBlockNumber() +
-            bridgeConstantsRegtest.getFederationActivationAge(activations) +
+            bridgeConstantsRegtest.getFederationActivationAge() +
             bridgeConstantsRegtest.getFundsMigrationAgeSinceActivationBegin() +
             1;
         when(block.getNumber()).thenReturn(blockNumber);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestPowerMock.java
@@ -3769,8 +3769,8 @@ public class BridgeSupportTestPowerMock {
         when(constantsMock.getBtcParams()).thenReturn(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         when(constantsMock.getFederationChangeAuthorizer()).thenReturn(bridgeConstants.getFederationChangeAuthorizer());
 
-        long federationActivationAge = bridgeConstants.getFederationActivationAge(mock(ActivationConfig.ForBlock.class));
-        when(constantsMock.getFederationActivationAge(any())).thenReturn(federationActivationAge);
+        long federationActivationAge = bridgeConstants.getFederationActivationAge();
+        when(constantsMock.getFederationActivationAge()).thenReturn(federationActivationAge);
 
         class FederationHolder {
             private PendingFederation pendingFederation;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1137,6 +1137,67 @@ public class BridgeUtilsTest {
     }
 
     @Test
+    public void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
+        Address activeFederationAddress = bridgeConstantsRegtest.getGenesisFederation().getAddress();
+        testIsValidPegInTx_fromP2shErpScriptSender(false, activeFederationAddress, true);
+    }
+
+    // It shouldn't identify transactions sent to random addresses as peg-in, but it is the current behaviour
+    @Test
+    public void testIsValidPegInTx_p2shErpScript_sends_funds_to_random_address_before_RSKIP353() {
+        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+        testIsValidPegInTx_fromP2shErpScriptSender(false, randomAddress, true);
+    }
+
+    @Test
+    public void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
+        Address activeFederationAddress = bridgeConstantsRegtest.getGenesisFederation().getAddress();
+        testIsValidPegInTx_fromP2shErpScriptSender(true, activeFederationAddress, false);
+    }
+
+    @Test
+    public void testIsValidPegInTx_p2shErpScript_sends_funds_to_random_address_after_RSKIP353() {
+        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+        testIsValidPegInTx_fromP2shErpScriptSender(true, randomAddress, false);
+    }
+
+    private void testIsValidPegInTx_fromP2shErpScriptSender(boolean isRskip353Active, Address destinationAddress, boolean expectedResult) {
+        when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP353)).thenReturn(isRskip353Active);
+
+        Context btcContext = new Context(networkParameters);
+        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+
+        List<BtcECKey> emergencyKeys = PegTestUtils.createRandomBtcECKeys(3);
+        long activationDelay = 256L;
+
+        Federation p2shErpFederation = new P2shErpFederation(
+            activeFederation.getMembers(),
+            activeFederation.getCreationTime(),
+            activeFederation.getCreationBlockNumber(),
+            networkParameters,
+            emergencyKeys,
+            activationDelay,
+            activations
+        );
+
+        // Create a tx from the p2sh erp fed
+        BtcTransaction tx = new BtcTransaction(networkParameters);
+        tx.addOutput(Coin.COIN, destinationAddress);
+        tx.addInput(Sha256Hash.ZERO_HASH, 0, p2shErpFederation.getRedeemScript());
+
+        Assert.assertEquals(expectedResult, BridgeUtils.isValidPegInTx(
+            tx,
+            activeFederation,
+            btcContext,
+            bridgeConstantsRegtest,
+            activations)
+        );
+    }
+
+
+    @Test
     public void testTxIsProcessableInLegacyVersion() {
         // Before hard fork
         when(activations.isActive(ConsensusRule.RSKIP143)).thenReturn(false);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1161,7 +1161,11 @@ public class BridgeUtilsTest {
         testIsValidPegInTx_fromP2shErpScriptSender(true, randomAddress, false);
     }
 
-    private void testIsValidPegInTx_fromP2shErpScriptSender(boolean isRskip353Active, Address destinationAddress, boolean expectedResult) {
+    private void testIsValidPegInTx_fromP2shErpScriptSender(
+        boolean isRskip353Active,
+        Address destinationAddress,
+        boolean expectedResult) {
+
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP353)).thenReturn(isRskip353Active);
@@ -1195,7 +1199,6 @@ public class BridgeUtilsTest {
             activations)
         );
     }
-
 
     @Test
     public void testTxIsProcessableInLegacyVersion() {
@@ -3594,7 +3597,7 @@ public class BridgeUtilsTest {
         );
     }
 
-    @Test()
+    @Test
     public void testGetUTXOsSentToAddresses_multiple_utxo_sent_to_multiple_addresses_before_RSKIP293() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
@@ -3634,7 +3637,7 @@ public class BridgeUtilsTest {
         Assert.assertEquals(amount, expectedAmount);
     }
 
-    @Test()
+    @Test
     public void testGetUTXOsSentToAddresses_no_utxo_sent_to_given_address_before_RSKIP293() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
@@ -3663,7 +3666,7 @@ public class BridgeUtilsTest {
         Assert.assertTrue(foundUTXOs.isEmpty());
     }
 
-    @Test()
+    @Test
     public void testGetUTXOsSentToAddresses_multiple_utxos_sent_to_random_address_and_one_utxo_sent_to_bech32_address_after_RSKIP293() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
@@ -3697,7 +3700,7 @@ public class BridgeUtilsTest {
         Assert.assertEquals(amount, expectedAmount);
     }
 
-    @Test()
+    @Test
     public void testGetUTXOsSentToAddresses_multiple_utxo_sent_to_multiple_addresses_after_RSKIP293() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
@@ -3744,7 +3747,7 @@ public class BridgeUtilsTest {
         Assert.assertEquals(amount, expectedAmount);
     }
 
-    @Test()
+    @Test
     public void testGetUTXOsSentToAddresses_no_utxo_sent_to_given_address_after_RSKIP293() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -90,7 +90,7 @@ public class FederationSupportTest {
         when(provider.getNewFederation()).thenReturn(newFederation);
         when(provider.getOldFederation()).thenReturn(oldFederation);
         when(executionBlock.getNumber()).thenReturn(80L);
-        when(bridgeConstants.getFederationActivationAge(any())).thenReturn(10L);
+        when(bridgeConstants.getFederationActivationAge()).thenReturn(10L);
 
         assertThat(federationSupport.getActiveFederation(), is(oldFederation));
     }
@@ -103,7 +103,7 @@ public class FederationSupportTest {
         when(provider.getNewFederation()).thenReturn(newFederation);
         when(provider.getOldFederation()).thenReturn(oldFederation);
         when(executionBlock.getNumber()).thenReturn(80L);
-        when(bridgeConstants.getFederationActivationAge(any())).thenReturn(10L);
+        when(bridgeConstants.getFederationActivationAge()).thenReturn(10L);
 
         assertThat(federationSupport.getActiveFederation(), is(newFederation));
     }

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -398,7 +398,7 @@ public class BridgeEventLoggerImplTest {
 
         // Assert new federation activation block number
         Assert.assertEquals(
-            15L + CONSTANTS.getFederationActivationAge(activations),
+            15L + CONSTANTS.getFederationActivationAge(),
             Long.valueOf(new String(dataList.get(2).getRLPData(), StandardCharsets.UTF_8)).longValue()
         );
     }
@@ -455,7 +455,7 @@ public class BridgeEventLoggerImplTest {
         String oldFederationBtcAddress = oldFederation.getAddress().toBase58();
         byte[] newFederationFlatPubKeys = flatKeysAsByteArray(newFederation.getBtcPublicKeys());
         String newFederationBtcAddress = newFederation.getAddress().toBase58();
-        long newFedActivationBlockNumber = executionBlock.getNumber() + CONSTANTS.getFederationActivationAge(activations);
+        long newFedActivationBlockNumber = executionBlock.getNumber() + CONSTANTS.getFederationActivationAge();
         Object[] data = new Object[]{
             oldFederationFlatPubKeys,
             oldFederationBtcAddress,

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -100,6 +100,7 @@ public class ActivationConfigTest {
             "    rskip294: hop400",
             "    rskip297: hop400",
             "    rskip353: hop401",
+            "    rskip357: hop401",
             "}"
     ));
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -39,7 +39,7 @@ public class ActivationConfigTest {
             "    twoToThree: 0",
             "    iris300: 0",
             "    hop400: 0",
-            "    hop500: 0",
+            "    hop401: 0",
             "},",
             "consensusRules: {",
             "    areBridgeTxsPaid: afterBridgeSync,",

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -99,7 +99,7 @@ public class ActivationConfigTest {
             "    rskip293: hop400",
             "    rskip294: hop400",
             "    rskip297: hop400",
-            "    rskip353: hop500",
+            "    rskip353: hop401",
             "}"
     ));
 


### PR DESCRIPTION
- Rename Hop500 network upgrade to Hop401
- Remove special case federation activation age
- Use RSKIP357 for new federation migration age
- Consider transactions with a p2sh erp redeem script before RSKIP353 when checking the transaction type