### PR TITLE
Fixed issue with eth_call triggered for pending block

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1015,6 +1015,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 getBlocksBloomStore(),
                 getStateRootsStore()));
 
+        internalServices.add(getExecutionBlockRetriever());
+
         return Collections.unmodifiableList(internalServices);
     }
 
@@ -2081,10 +2083,9 @@ public class RskContext implements NodeContext, NodeBootstrapper {
     private ExecutionBlockRetriever getExecutionBlockRetriever() {
         if (executionBlockRetriever == null) {
             executionBlockRetriever = new ExecutionBlockRetriever(
-                    getMiningMainchainView(),
                     getBlockchain(),
-                    getMinerServer(),
-                    getBlockToMineBuilder()
+                    getBlockToMineBuilder(),
+                    getCompositeEthereumListener()
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -66,7 +66,7 @@ public class ReversibleTransactionExecutor {
             byte[] value,
             byte[] data,
             RskAddress fromAddress) {
-        return executeTransaction_workaround(
+        return executeTransaction(
                 repositoryLocator.snapshotAt(executionBlock.getHeader()),
                 executionBlock,
                 coinbase,
@@ -79,10 +79,7 @@ public class ReversibleTransactionExecutor {
         );
     }
 
-
-
-    @Deprecated
-    public ProgramResult executeTransaction_workaround(
+    public ProgramResult executeTransaction(
             RepositorySnapshot snapshot,
             Block executionBlock,
             RskAddress coinbase,

--- a/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/ExecutionBlockRetriever.java
@@ -18,17 +18,20 @@
 
 package co.rsk.rpc;
 
+import co.rsk.config.InternalService;
 import co.rsk.core.Coin;
 import co.rsk.core.bc.BlockResult;
-import co.rsk.core.bc.MiningMainchainView;
 import co.rsk.mine.BlockToMineBuilder;
-import co.rsk.mine.MinerServer;
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.core.Block;
-import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Blockchain;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.listener.EthereumListener;
+import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.util.Utils;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -39,28 +42,22 @@ import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParam
  * Encapsulates the logic to retrieve or create an execution block
  * for Web3 calls.
  */
-public class ExecutionBlockRetriever {
+public class ExecutionBlockRetriever implements InternalService {
     private static final String LATEST_ID = "latest";
     private static final String PENDING_ID = "pending";
 
-    private final MiningMainchainView miningMainchainView;
+    private final Object pendingBlockLock = new Object();
     private final Blockchain blockchain;
-    private final MinerServer minerServer;
     private final BlockToMineBuilder builder;
+    private final CompositeEthereumListener emitter;
+    private final EthereumListener listener = new CachedResultCleaner();
 
-    @Nullable
-    private Block cachedBlock;
-    @Nullable
-    private BlockResult cachedResult;
+    private volatile BlockResult cachedResult;
 
-    public ExecutionBlockRetriever(MiningMainchainView miningMainchainView,
-                                   Blockchain blockchain,
-                                   MinerServer minerServer,
-                                   BlockToMineBuilder builder) {
-        this.miningMainchainView = miningMainchainView;
+    public ExecutionBlockRetriever(Blockchain blockchain, BlockToMineBuilder builder, CompositeEthereumListener emitter) {
         this.blockchain = blockchain;
-        this.minerServer = minerServer;
         this.builder = builder;
+        this.emitter = emitter;
     }
 
     public BlockResult retrieveExecutionBlock(String bnOrId) {
@@ -69,27 +66,26 @@ public class ExecutionBlockRetriever {
         }
 
         if (PENDING_ID.equals(bnOrId)) {
-            Optional<Block> latestBlock = minerServer.getLatestBlock();
-            if (latestBlock.isPresent()) {
-                return newBlockResult(latestBlock.get());
+            Block bestBlock = blockchain.getBestBlock();
+            BlockResult result = cachedResult;
+            // optimistic check without the lock
+            if (result != null && result.getBlock().getParentHash().equals(bestBlock.getHash())) {
+                return result;
             }
 
-            Block bestBlock = blockchain.getBestBlock();
-            if (cachedBlock == null || !bestBlock.isParentOf(cachedBlock)) {
-
-                // If the miner server is not running there is no one to update the mining mainchain view,
-                // thus breaking eth_call with 'pending' parameter
-                //
-                // This is just a provisional fix not intended to remain in the long run
-                if (!minerServer.isRunning()) {
-                    miningMainchainView.addBest(bestBlock.getHeader());
+            synchronized (pendingBlockLock) {
+                // build a new pending block, but before that just in case check if one hasn't been built while being locked
+                bestBlock = blockchain.getBestBlock();
+                result = cachedResult;
+                if (result != null && result.getBlock().getParentHash().equals(bestBlock.getHash())) {
+                    return result;
                 }
 
-                List<BlockHeader> mainchainHeaders = miningMainchainView.get();
-                cachedResult = builder.build(mainchainHeaders, null);
-            }
+                result = builder.buildPending(bestBlock.getHeader());
+                cachedResult = result;
 
-            return cachedResult;
+                return result;
+            }
         }
 
         // Is the block specifier either a hexadecimal or decimal number?
@@ -116,6 +112,11 @@ public class ExecutionBlockRetriever {
                 bnOrId));
     }
 
+    @VisibleForTesting
+    BlockResult getCachedResult() {
+        return cachedResult;
+    }
+
     private static BlockResult newBlockResult(Block block) {
         return new BlockResult(
                 block,
@@ -125,5 +126,31 @@ public class ExecutionBlockRetriever {
                 Coin.ZERO,
                 null
         );
+    }
+
+    @Override
+    public void start() {
+        emitter.addListener(listener);
+    }
+
+    @Override
+    public void stop() {
+        emitter.removeListener(listener);
+    }
+
+    private class CachedResultCleaner extends EthereumListenerAdapter {
+        @Override
+        public void onPendingTransactionsReceived(List<Transaction> transactions) {
+            cleanCachedResult();
+        }
+
+        @Override
+        public void onBestBlock(Block block, List<TransactionReceipt> receipts) {
+            cleanCachedResult();
+        }
+
+        private void cleanCachedResult() {
+            cachedResult = null;
+        }
     }
 }

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -636,7 +636,7 @@ public class TransactionModuleTest {
                 config.getNetworkConstants().getBridgeConstants().getBtcParams());
         EthModule ethModule = new EthModule(
                 config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), blockchain, transactionPool,
-                reversibleTransactionExecutor1, new ExecutionBlockRetriever(mainchainView, blockchain, null, null),
+                reversibleTransactionExecutor1, new ExecutionBlockRetriever(blockchain, null, null),
                 repositoryLocator, new EthModuleWalletEnabled(wallet), transactionModule,
                 new BridgeSupportFactory(
                         btcBlockStoreFactory, config.getNetworkConstants().getBridgeConstants(),

--- a/rskj-core/src/test/java/co/rsk/rpc/ExecutionFoundBlockRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/ExecutionFoundBlockRetrieverTest.java
@@ -44,7 +44,7 @@ public class ExecutionFoundBlockRetrieverTest {
 
     private static final Keccak256 HASH1 = new Keccak256("133e83bb305ef21ea7fc86fcced355db2300887274961a136ca5e8c8763687d9");
     private static final Keccak256 HASH2 = new Keccak256("ee5c851e70650111887bb6c04e18ef4353391abe37846234c17895a9ca2b33d5");
-    private final static int INVALID_PARAM_ERROR_CODE = -32602;
+    private static final int INVALID_PARAM_ERROR_CODE = -32602;
 
     private Blockchain blockchain;
     private BlockToMineBuilder builder;
@@ -92,7 +92,7 @@ public class ExecutionFoundBlockRetrieverTest {
         when(builder.buildPending(bestHeader)).thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(builtBlock);
 
-        assertNull(retriever.getCachedResult());
+        assertNull(retriever.getCachedPendingBlockResult());
         assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
         verify(builder, times(1)).buildPending(any());
     }
@@ -111,9 +111,10 @@ public class ExecutionFoundBlockRetrieverTest {
         when(builder.buildPending(bestHeader)).thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(builtBlock);
 
-        assertNull(retriever.getCachedResult());
+        assertNull(retriever.getCachedPendingBlockResult());
         retriever.retrieveExecutionBlock("pending");
-        assertEquals(blockResult, retriever.getCachedResult());
+        assertEquals(blockResult.getBlock(), retriever.getCachedPendingBlockResult().getBlock());
+        assertEquals(blockResult.getFinalState(), retriever.getCachedPendingBlockResult().getFinalState());
         assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
         verify(builder, times(1)).buildPending(any());
     }
@@ -134,9 +135,10 @@ public class ExecutionFoundBlockRetrieverTest {
         ArgumentCaptor<EthereumListener> captor = ArgumentCaptor.forClass(EthereumListener.class);
         EthereumListener listener;
 
-        assertNull(retriever.getCachedResult());
+        assertNull(retriever.getCachedPendingBlockResult());
         retriever.retrieveExecutionBlock("pending");
-        assertEquals(blockResult, retriever.getCachedResult());
+        assertEquals(blockResult.getBlock(), retriever.getCachedPendingBlockResult().getBlock());
+        assertEquals(blockResult.getFinalState(), retriever.getCachedPendingBlockResult().getFinalState());
         assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
         verify(builder, times(1)).buildPending(any());
 
@@ -144,7 +146,7 @@ public class ExecutionFoundBlockRetrieverTest {
         verify(emitter, times(1)).addListener(captor.capture());
         listener = captor.getValue();
         listener.onPendingTransactionsReceived(Collections.emptyList());
-        assertNull(retriever.getCachedResult());
+        assertNull(retriever.getCachedPendingBlockResult());
 
         assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
         verify(builder, times(2)).buildPending(any());
@@ -181,9 +183,10 @@ public class ExecutionFoundBlockRetrieverTest {
         ArgumentCaptor<EthereumListener> captor = ArgumentCaptor.forClass(EthereumListener.class);
         EthereumListener listener;
 
-        assertNull(retriever.getCachedResult());
+        assertNull(retriever.getCachedPendingBlockResult());
         retriever.retrieveExecutionBlock("pending");
-        assertEquals(blockResult, retriever.getCachedResult());
+        assertEquals(blockResult.getBlock(), retriever.getCachedPendingBlockResult().getBlock());
+        assertEquals(blockResult.getFinalState(), retriever.getCachedPendingBlockResult().getFinalState());
         assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
         verify(builder, times(1)).buildPending(any());
 
@@ -192,7 +195,7 @@ public class ExecutionFoundBlockRetrieverTest {
         listener = captor.getValue();
         when(blockchain.getBestBlock()).thenReturn(newBestBlock);
         listener.onBestBlock(newBestBlock, Collections.emptyList());
-        assertNull(retriever.getCachedResult());
+        assertNull(retriever.getCachedPendingBlockResult());
 
         assertEquals(anotherBuiltBlock, retriever.retrieveExecutionBlock("pending").getBlock());
         verify(builder, times(2)).buildPending(any());

--- a/rskj-core/src/test/java/co/rsk/rpc/ExecutionFoundBlockRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/ExecutionFoundBlockRetrieverTest.java
@@ -20,43 +20,43 @@ package co.rsk.rpc;
 
 import co.rsk.core.bc.BlockChainImpl;
 import co.rsk.core.bc.BlockResult;
-import co.rsk.core.bc.MiningMainchainView;
+import co.rsk.crypto.Keccak256;
 import co.rsk.mine.BlockToMineBuilder;
-import co.rsk.mine.MinerServer;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.Blockchain;
+import org.ethereum.listener.CompositeEthereumListener;
+import org.ethereum.listener.EthereumListener;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class ExecutionFoundBlockRetrieverTest {
 
-    private MiningMainchainView miningMainchainView;
-    private Blockchain blockchain;
-    private MinerServer minerServer;
-    private BlockToMineBuilder builder;
-    private ExecutionBlockRetriever retriever;
+    private static final Keccak256 HASH1 = new Keccak256("133e83bb305ef21ea7fc86fcced355db2300887274961a136ca5e8c8763687d9");
+    private static final Keccak256 HASH2 = new Keccak256("ee5c851e70650111887bb6c04e18ef4353391abe37846234c17895a9ca2b33d5");
     private final static int INVALID_PARAM_ERROR_CODE = -32602;
+
+    private Blockchain blockchain;
+    private BlockToMineBuilder builder;
+    private CompositeEthereumListener emitter;
+    private ExecutionBlockRetriever retriever;
 
     @Before
     public void setUp() {
         blockchain = mock(BlockChainImpl.class);
-        miningMainchainView = mock(MiningMainchainView.class);
-        minerServer = mock(MinerServer.class);
         builder = mock(BlockToMineBuilder.class);
-        retriever = new ExecutionBlockRetriever(miningMainchainView, blockchain, minerServer, builder);
+        emitter = mock(CompositeEthereumListener.class);
+        retriever = new ExecutionBlockRetriever(blockchain, builder, emitter);
     }
 
     @Test
@@ -81,119 +81,124 @@ public class ExecutionFoundBlockRetrieverTest {
     }
 
     @Test
-    public void getPendingUsesMinerServerLatestBlock() {
-        Block latest = mock(Block.class);
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.of(latest));
-
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest));
-    }
-
-    @Test
-    public void getPendingUsesMinerServerAndIsUpToDate() {
-        Block latest1 = mock(Block.class);
-        Block latest2 = mock(Block.class);
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.of(latest1))
-                .thenReturn(Optional.of(latest2));
-
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest1));
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(latest2));
-    }
-
-    @Test
-    public void getPendingBuildsPendingBlockIfMinerServerHasNoWork() {
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.empty());
-
+    public void getPendingBuildsPendingBlockIfNoCachedResult() {
         BlockHeader bestHeader = mock(BlockHeader.class);
         Block bestBlock = mock(Block.class);
         when(bestBlock.getHeader()).thenReturn(bestHeader);
-        when(blockchain.getBestBlock())
-                .thenReturn(bestBlock);
-
-        when(miningMainchainView.get())
-                .thenReturn(new ArrayList<>(Collections.singleton(bestHeader)));
+        when(blockchain.getBestBlock()).thenReturn(bestBlock);
 
         Block builtBlock = mock(Block.class);
         BlockResult blockResult = mock(BlockResult.class);
-        when(builder.build(new ArrayList<>(Collections.singleton(bestHeader)), null))
-                .thenReturn(blockResult);
+        when(builder.buildPending(bestHeader)).thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(builtBlock);
 
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(builtBlock));
+        assertNull(retriever.getCachedResult());
+        assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
+        verify(builder, times(1)).buildPending(any());
     }
 
     @Test
-    public void getPendingReturnsCachedBlockIfMinerServerHasNoWork() {
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.empty())
-                .thenReturn(Optional.empty());
-
+    public void getPendingReturnsCachedBlockNextTime() {
         BlockHeader bestHeader = mock(BlockHeader.class);
         Block bestBlock = mock(Block.class);
         when(bestBlock.getHeader()).thenReturn(bestHeader);
-        when(blockchain.getBestBlock())
-                .thenReturn(bestBlock)
-                .thenReturn(bestBlock);
+        when(bestBlock.getHash()).thenReturn(HASH1);
+        when(blockchain.getBestBlock()).thenReturn(bestBlock);
 
-        List<BlockHeader> mainchainHeaders = new ArrayList<>();
-        mainchainHeaders.add(bestBlock.getHeader());
-        mainchainHeaders.add(bestBlock.getHeader());
-        when(miningMainchainView.get())
-                .thenReturn(mainchainHeaders);
-
-        BlockResult blockResult = mock(BlockResult.class);
         Block builtBlock = mock(Block.class);
-        when(bestBlock.isParentOf(builtBlock))
-                .thenReturn(true);
-        when(builder.build(mainchainHeaders, null))
-                .thenReturn(blockResult);
+        when(builtBlock.getParentHash()).thenReturn(HASH1);
+        BlockResult blockResult = mock(BlockResult.class);
+        when(builder.buildPending(bestHeader)).thenReturn(blockResult);
         when(blockResult.getBlock()).thenReturn(builtBlock);
 
-        assertThat(retriever.retrieveExecutionBlock("pending"), is(blockResult));
-        assertThat(retriever.retrieveExecutionBlock("pending"), is(blockResult));
-        // TODO(mc): the cache doesn't work properly in getExecutionBlock_workaround.
-        //           this is a known bug in version 1.0.1, and should be fixed in master
-        verify(builder, times(2)).build(mainchainHeaders, null);
+        assertNull(retriever.getCachedResult());
+        retriever.retrieveExecutionBlock("pending");
+        assertEquals(blockResult, retriever.getCachedResult());
+        assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
+        verify(builder, times(1)).buildPending(any());
     }
 
     @Test
-    public void getPendingDoesntUseCacheIfBestBlockHasChanged() {
-        when(minerServer.getLatestBlock())
-                .thenReturn(Optional.empty())
-                .thenReturn(Optional.empty());
+    public void getPendingBuildsNewPendingBlockIfPendingTxsArrive() {
+        BlockHeader bestHeader = mock(BlockHeader.class);
+        Block bestBlock = mock(Block.class);
+        when(bestBlock.getHeader()).thenReturn(bestHeader);
+        when(bestBlock.getHash()).thenReturn(HASH1);
+        when(blockchain.getBestBlock()).thenReturn(bestBlock);
 
-        BlockHeader bestHeader1 = mock(BlockHeader.class);
-        Block bestBlock1 = mock(Block.class);
-        when(bestBlock1.getHeader()).thenReturn(bestHeader1);
+        Block builtBlock = mock(Block.class);
+        when(builtBlock.getParentHash()).thenReturn(HASH1);
+        BlockResult blockResult = mock(BlockResult.class);
+        when(builder.buildPending(bestHeader)).thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(builtBlock);
+        ArgumentCaptor<EthereumListener> captor = ArgumentCaptor.forClass(EthereumListener.class);
+        EthereumListener listener;
 
-        BlockHeader bestHeader2 = mock(BlockHeader.class);
-        Block bestBlock2 = mock(Block.class);
-        when(bestBlock2.getHeader()).thenReturn(bestHeader2);
+        assertNull(retriever.getCachedResult());
+        retriever.retrieveExecutionBlock("pending");
+        assertEquals(blockResult, retriever.getCachedResult());
+        assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
+        verify(builder, times(1)).buildPending(any());
 
-        when(blockchain.getBestBlock())
-                .thenReturn(bestBlock1)
-                .thenReturn(bestBlock2);
+        retriever.start();
+        verify(emitter, times(1)).addListener(captor.capture());
+        listener = captor.getValue();
+        listener.onPendingTransactionsReceived(Collections.emptyList());
+        assertNull(retriever.getCachedResult());
 
-        when(miningMainchainView.get())
-                .thenReturn(new ArrayList<>(Collections.singleton(bestHeader1)))
-                .thenReturn(new ArrayList<>(Collections.singleton(bestHeader2)));
+        assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
+        verify(builder, times(2)).buildPending(any());
 
-        Block builtBlock1 = mock(Block.class);
-        when(bestBlock1.isParentOf(builtBlock1)).thenReturn(true);
-        BlockResult blockResult1 = mock(BlockResult.class);
-        when(blockResult1.getBlock()).thenReturn(builtBlock1);
-        when(builder.build(new ArrayList<>(Collections.singleton(bestHeader1)), null)).thenReturn(blockResult1);
+        retriever.stop();
+        verify(emitter, times(1)).removeListener(listener);
+    }
 
-        Block builtBlock2 = mock(Block.class);
-        when(bestBlock2.isParentOf(builtBlock2)).thenReturn(true);
-        BlockResult blockResult2 = mock(BlockResult.class);
-        when(blockResult2.getBlock()).thenReturn(builtBlock2);
-        when(builder.build(new ArrayList<>(Collections.singleton(bestHeader2)), null)).thenReturn(blockResult2);
+    @Test
+    public void getPendingBuildsNewPendingBlockIfNewBestBlockArrives() {
+        BlockHeader bestHeader = mock(BlockHeader.class);
+        Block bestBlock = mock(Block.class);
+        when(bestBlock.getHeader()).thenReturn(bestHeader);
+        when(bestBlock.getHash()).thenReturn(HASH1);
+        when(blockchain.getBestBlock()).thenReturn(bestBlock);
 
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(builtBlock1));
-        assertThat(retriever.retrieveExecutionBlock("pending").getBlock(), is(builtBlock2));
+        BlockHeader newBestHeader = mock(BlockHeader.class);
+        Block newBestBlock = mock(Block.class);
+        when(newBestBlock.getHeader()).thenReturn(newBestHeader);
+        when(newBestBlock.getHash()).thenReturn(HASH2);
+
+        Block builtBlock = mock(Block.class);
+        when(builtBlock.getParentHash()).thenReturn(HASH1);
+        BlockResult blockResult = mock(BlockResult.class);
+        when(builder.buildPending(bestHeader)).thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(builtBlock);
+
+        Block anotherBuiltBlock = mock(Block.class);
+        when(anotherBuiltBlock.getParentHash()).thenReturn(HASH2);
+        BlockResult anotherBlockResult = mock(BlockResult.class);
+        when(builder.buildPending(newBestHeader)).thenReturn(anotherBlockResult);
+        when(anotherBlockResult.getBlock()).thenReturn(anotherBuiltBlock);
+
+        ArgumentCaptor<EthereumListener> captor = ArgumentCaptor.forClass(EthereumListener.class);
+        EthereumListener listener;
+
+        assertNull(retriever.getCachedResult());
+        retriever.retrieveExecutionBlock("pending");
+        assertEquals(blockResult, retriever.getCachedResult());
+        assertEquals(builtBlock, retriever.retrieveExecutionBlock("pending").getBlock());
+        verify(builder, times(1)).buildPending(any());
+
+        retriever.start();
+        verify(emitter, times(1)).addListener(captor.capture());
+        listener = captor.getValue();
+        when(blockchain.getBestBlock()).thenReturn(newBestBlock);
+        listener.onBestBlock(newBestBlock, Collections.emptyList());
+        assertNull(retriever.getCachedResult());
+
+        assertEquals(anotherBuiltBlock, retriever.retrieveExecutionBlock("pending").getBlock());
+        verify(builder, times(2)).buildPending(any());
+
+        retriever.stop();
+        verify(emitter, times(1)).removeListener(listener);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3InformationRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3InformationRetrieverTest.java
@@ -43,7 +43,7 @@ public class Web3InformationRetrieverTest {
     @Test
     public void getBlock_pending() {
         Block pendingBlock = mock(Block.class);
-        BlockResult pendingBlockResult = mock(BlockResult.class);
+        ExecutionBlockRetriever.Result pendingBlockResult = mock(ExecutionBlockRetriever.Result.class);
         when(pendingBlockResult.getBlock()).thenReturn(pendingBlock);
         when(executionBlockRetriever.retrieveExecutionBlock("pending")).thenReturn(pendingBlockResult);
         Optional<Block> result = target.getBlock("pending");

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -18,27 +18,21 @@
 
 package co.rsk.rpc.modules.eth;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyByte;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import co.rsk.config.BridgeConstants;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.ReversibleTransactionExecutor;
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
+import co.rsk.core.bc.PendingState;
+import co.rsk.db.RepositoryLocator;
+import co.rsk.net.TransactionGateway;
+import co.rsk.peg.BridgeSupportFactory;
+import co.rsk.rpc.ExecutionBlockRetriever;
+import co.rsk.util.HexUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.config.Constants;
-import org.ethereum.core.Block;
-import org.ethereum.core.Blockchain;
-import org.ethereum.core.Transaction;
-import org.ethereum.core.TransactionPool;
-import org.ethereum.core.TransactionPoolAddResult;
+import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.rpc.CallArguments;
@@ -49,28 +43,19 @@ import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
-import co.rsk.config.BridgeConstants;
-import co.rsk.config.TestSystemProperties;
-import co.rsk.core.ReversibleTransactionExecutor;
-import co.rsk.core.RskAddress;
-import co.rsk.core.Wallet;
-import co.rsk.core.bc.BlockResult;
-import co.rsk.core.bc.PendingState;
-import co.rsk.db.RepositoryLocator;
-import co.rsk.net.TransactionGateway;
-import co.rsk.peg.BridgeSupportFactory;
-import co.rsk.rpc.ExecutionBlockRetriever;
-import co.rsk.util.HexUtils;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 public class EthModuleTest {
 
-    private TestSystemProperties config = new TestSystemProperties();
-    private String anyAddress = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private final TestSystemProperties config = new TestSystemProperties();
 
     @Test
     public void callSmokeTest() {
         CallArguments args = new CallArguments();
-        BlockResult blockResult = mock(BlockResult.class);
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
         when(retriever.retrieveExecutionBlock("latest"))
@@ -109,7 +94,7 @@ public class EthModuleTest {
     @Test
     public void callWithoutReturn() {
         CallArguments args = new CallArguments();
-        BlockResult blockResult = mock(BlockResult.class);
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
         when(retriever.retrieveExecutionBlock("latest"))
@@ -148,7 +133,7 @@ public class EthModuleTest {
     @Test
     public void test_revertedTransaction() {
         CallArguments args = new CallArguments();
-        BlockResult blockResult = mock(BlockResult.class);
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
         when(retriever.retrieveExecutionBlock("latest"))

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
@@ -18,25 +18,41 @@
 
 package co.rsk.rpc.modules.trace;
 
+import co.rsk.config.GasLimitConfig;
+import co.rsk.config.MiningConfig;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.core.Coin;
+import co.rsk.core.DifficultyCalculator;
+import co.rsk.mine.*;
+import co.rsk.rpc.ExecutionBlockRetriever;
 import co.rsk.test.World;
+import co.rsk.test.builders.AccountBuilder;
+import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.test.dsl.DslParser;
 import co.rsk.test.dsl.DslProcessorException;
 import co.rsk.test.dsl.WorldDslProcessor;
+import co.rsk.validators.DummyBlockValidationRule;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.ethereum.core.Account;
 import org.ethereum.core.Block;
+import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Transaction;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.db.ReceiptStoreImpl;
+import org.ethereum.listener.CompositeEthereumListener;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
+import java.math.BigInteger;
+import java.time.Clock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
 
 public class TraceModuleImplTest {
     @Test
@@ -61,6 +77,26 @@ public class TraceModuleImplTest {
         JsonNode result = traceModule.traceBlock("0x0001020300010203000102030001020300010203000102030001020300010203");
 
         Assert.assertNull(result);
+    }
+
+    @Test
+    public void retrievePendingBlock() throws Exception {
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = executeMultiContract(receiptStore);
+        ExecutionBlockRetriever executionBlockRetriever = createExecutionBlockRetriever(world);
+
+        TraceModuleImpl traceModule = new TraceModuleImpl(world.getBlockChain(), world.getBlockStore(), receiptStore, world.getBlockExecutor(), executionBlockRetriever);
+
+        world.getTransactionPool().addTransaction(createSampleTransaction());
+
+        JsonNode result = traceModule.traceBlock("pending");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray());
+
+        ArrayNode arrResult = (ArrayNode) result;
+
+        Assert.assertEquals(1, arrResult.size());
     }
 
     @Test
@@ -152,6 +188,7 @@ public class TraceModuleImplTest {
         World world = executeMultiContract(receiptStore);
 
         retrieveTraceFilterEmpty(world, receiptStore);
+        retrieveTraceFilterPending(world, receiptStore);
         retrieveTraceFilter1Record(world, receiptStore);
         retrieveTraceFilter3Records(world, receiptStore);
         retrieveTraceFilterNext3RecordsAndOnly1Remains(world, receiptStore);
@@ -362,6 +399,80 @@ public class TraceModuleImplTest {
         ArrayNode aresult = (ArrayNode)result;
 
         Assert.assertEquals(0, aresult.size());
+    }
+
+    private static void retrieveTraceFilterPending(World world, ReceiptStore receiptStore) throws Exception {
+        ExecutionBlockRetriever executionBlockRetriever = createExecutionBlockRetriever(world);
+
+        TraceModuleImpl traceModule = new TraceModuleImpl(world.getBlockChain(), world.getBlockStore(), receiptStore, world.getBlockExecutor(), executionBlockRetriever);
+
+        world.getTransactionPool().addTransaction(createSampleTransaction());
+
+        TraceFilterRequest traceFilterRequest = new TraceFilterRequest();
+
+        traceFilterRequest.setFromBlock("pending");
+        traceFilterRequest.setToBlock("pending");
+
+        JsonNode result = traceModule.traceFilter(traceFilterRequest);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray());
+
+        ArrayNode arrResult = (ArrayNode) result;
+
+        Assert.assertEquals(1, arrResult.size());
+    }
+
+    private static ExecutionBlockRetriever createExecutionBlockRetriever(World world) {
+        RskSystemProperties rskSystemProperties = world.getConfig();
+        MiningConfig miningConfig = new MiningConfig(
+                rskSystemProperties.coinbaseAddress(),
+                rskSystemProperties.minerMinFeesNotifyInDollars(),
+                rskSystemProperties.minerGasUnitInDollars(),
+                rskSystemProperties.minerMinGasPrice(),
+                rskSystemProperties.getNetworkConstants().getUncleListLimit(),
+                rskSystemProperties.getNetworkConstants().getUncleGenerationLimit(),
+                new GasLimitConfig(
+                        rskSystemProperties.getNetworkConstants().getMinGasLimit(),
+                        rskSystemProperties.getTargetGasLimit(),
+                        rskSystemProperties.getForceTargetGasLimit()
+                ),
+                rskSystemProperties.isMinerServerFixedClock(),
+                rskSystemProperties.workSubmissionRateLimitInMills()
+        );
+        BlockToMineBuilder builder = new BlockToMineBuilder(
+                rskSystemProperties.getActivationConfig(),
+                miningConfig,
+                world.getRepositoryLocator(),
+                world.getBlockStore(),
+                world.getTransactionPool(),
+                new DifficultyCalculator(
+                        rskSystemProperties.getActivationConfig(),
+                        rskSystemProperties.getNetworkConstants()
+                ),
+                new GasLimitCalculator(rskSystemProperties.getNetworkConstants()),
+                new ForkDetectionDataCalculator(),
+                new DummyBlockValidationRule(),
+                new MinerClock(miningConfig.isFixedClock(), Clock.systemUTC()),
+                new BlockFactory(rskSystemProperties.getActivationConfig()),
+                world.getBlockExecutor(),
+                new MinimumGasPriceCalculator(Coin.valueOf(miningConfig.getMinGasPriceTarget())),
+                new MinerUtils()
+        );
+
+        return new ExecutionBlockRetriever(world.getBlockChain(), builder, mock(CompositeEthereumListener.class));
+    }
+
+    private static Transaction createSampleTransaction() {
+        Account sender = new AccountBuilder().name("cow").build();
+        Account receiver = new AccountBuilder().name("receiver").build();
+
+        return new TransactionBuilder()
+                .sender(sender)
+                .receiver(receiver)
+                .gasPrice(BigInteger.valueOf(200))
+                .value(BigInteger.TEN)
+                .build();
     }
 
     private static void retrieveTraceFilter1Record(World world, ReceiptStore receiptStore) throws Exception {

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -156,6 +156,10 @@ public class World {
         return world;
     }
 
+    public RskSystemProperties getConfig() {
+        return config;
+    }
+
     public NodeBlockProcessor getBlockProcessor() { return this.blockProcessor; }
 
     public BlockExecutor getBlockExecutor() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -1067,7 +1067,7 @@ public class Web3ImplLogsTest {
         PersonalModule personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, transactionPool);
         EthModule ethModule = new EthModule(
                 config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), blockChain, transactionPool,
-                null, new ExecutionBlockRetriever(mainchainView, blockChain, null, null),
+                null, new ExecutionBlockRetriever(blockChain, null, null),
                 null, new EthModuleWalletEnabled(wallet), null,
                 new BridgeSupportFactory(
                         null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig()),

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplScoringTest.java
@@ -398,14 +398,13 @@ public class Web3ImplScoringTest {
 
         World world = new World();
         rsk.blockchain = world.getBlockChain();
-        MiningMainchainView miningMainchainView = new MiningMainchainViewImpl(world.getBlockStore(), 2);
 
         Wallet wallet = WalletFactory.createWallet();
         TestSystemProperties config = new TestSystemProperties();
         PersonalModule pm = new PersonalModuleWalletEnabled(config, rsk, wallet, null);
         EthModule em = new EthModule(
                 config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), world.getBlockChain(), null,
-                null, new ExecutionBlockRetriever(miningMainchainView, world.getBlockChain(), null, null),
+                null, new ExecutionBlockRetriever(world.getBlockChain(), null, null),
                 null, new EthModuleWalletEnabled(wallet), null,
                 new BridgeSupportFactory(
                         null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig()),

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -2337,13 +2337,11 @@ public class Web3ImplTest {
     private Web3Impl createWeb3(SimpleEthereum eth, PeerServer peerServer) {
         wallet = WalletFactory.createWallet();
         Blockchain blockchain = Web3Mocks.getMockBlockchain();
-        BlockStore blockStore = Web3Mocks.getMockBlockStore();
-        MiningMainchainView mainchainView = new MiningMainchainViewImpl(blockStore, 449);
         TransactionPool transactionPool = Web3Mocks.getMockTransactionPool();
         PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, null);
         EthModule ethModule = new EthModule(
                 config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), blockchain, transactionPool,
-                null, new ExecutionBlockRetriever(mainchainView, blockchain, null, null),
+                null, new ExecutionBlockRetriever(blockchain, null, null),
                 null, new EthModuleWalletEnabled(wallet), null,
                 new BridgeSupportFactory(
                         null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig()),
@@ -2440,7 +2438,6 @@ public class Web3ImplTest {
             BlockProcessor nodeBlockProcessor,
             ConfigCapabilities configCapabilities,
             ReceiptStore receiptStore) {
-        MiningMainchainView miningMainchainViewMock = mock(MiningMainchainView.class);
         ExecutionBlockRetriever executionBlockRetriever = mock(ExecutionBlockRetriever.class);
         wallet = WalletFactory.createWallet();
         PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, transactionPool);
@@ -2454,7 +2451,7 @@ public class Web3ImplTest {
         TransactionGateway transactionGateway = new TransactionGateway(new SimpleChannelManager(), transactionPool);
         EthModule ethModule = new EthModule(
                 config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), blockchain, transactionPool, executor,
-                new ExecutionBlockRetriever(miningMainchainViewMock, blockchain, null, null), repositoryLocator, new EthModuleWalletEnabled(wallet),
+                new ExecutionBlockRetriever(blockchain, null, null), repositoryLocator, new EthModuleWalletEnabled(wallet),
                 new EthModuleTransactionBase(config.getNetworkConstants(), wallet, transactionPool, transactionGateway),
                 new BridgeSupportFactory(
                         null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig()),
@@ -2504,7 +2501,6 @@ public class Web3ImplTest {
             BlockProcessor nodeBlockProcessor,
             ConfigCapabilities configCapabilities,
             ReceiptStore receiptStore) {
-        MiningMainchainView miningMainchainViewMock = mock(MiningMainchainView.class);
         ExecutionBlockRetriever executionBlockRetriever = mock(ExecutionBlockRetriever.class);
         wallet = WalletFactory.createWallet();
         PersonalModuleWalletEnabled personalModule = new PersonalModuleWalletEnabled(config, eth, wallet, transactionPool);
@@ -2515,7 +2511,7 @@ public class Web3ImplTest {
         Web3InformationRetriever retriever = new Web3InformationRetriever(transactionPool, blockchain, repositoryLocator, executionBlockRetriever);
         EthModule ethModule = new EthModule(
                 config.getNetworkConstants().getBridgeConstants(), config.getNetworkConstants().getChainId(), blockchain, transactionPool, executor,
-                new ExecutionBlockRetriever(miningMainchainViewMock, blockchain, null, null), repositoryLocator,
+                new ExecutionBlockRetriever(blockchain, null, null), repositoryLocator,
                 new EthModuleWalletEnabled(wallet),
                 new EthModuleTransactionBase(config.getNetworkConstants(), wallet, transactionPool, null),
                 new BridgeSupportFactory(

--- a/rskj-core/src/test/java/org/ethereum/util/EthModuleTestUtils.java
+++ b/rskj-core/src/test/java/org/ethereum/util/EthModuleTestUtils.java
@@ -33,7 +33,6 @@ import co.rsk.test.World;
 import org.ethereum.config.Constants;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.TransactionPool;
-import org.ethereum.rpc.CallArguments;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
@@ -50,7 +49,7 @@ public class EthModuleTestUtils {
                 world.getBlockChain(),
                 null,
                 new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),
-                new ExecutionBlockRetriever(null, world.getBlockChain(), null, null),
+                new ExecutionBlockRetriever(world.getBlockChain(), null, null),
                 null,
                 null,
                 null,
@@ -68,7 +67,7 @@ public class EthModuleTestUtils {
                 world.getBlockChain(),
                 null,
                 new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),
-                new ExecutionBlockRetriever(null, world.getBlockChain(), null, null),
+                new ExecutionBlockRetriever(world.getBlockChain(), null, null),
                 null,
                 null,
                 null,

--- a/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
@@ -206,7 +206,7 @@ public class NestedContractsTest {
                 world.getBlockChain(),
                 world.getTransactionPool(),
                 new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),
-                new ExecutionBlockRetriever(null, world.getBlockChain(), null, null),
+                new ExecutionBlockRetriever(world.getBlockChain(), null, null),
                 world.getRepositoryLocator(),
                 null,
                 null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the issue when requesting a "pending" block data via JSON-RPC api (only reproducible when mining is enabled). The issue was introduced in this [PR](https://github.com/rsksmart/rskj/pull/1885).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In #1885 implicit saving of a trie during block template creation was removed. But it turns out that some json-rpc methods were dependant on this, meaning that they expected the sate of a pending block to be sitting in the store.

This pull request adds one more method - `buildPending()` - which is specifically dedicated to the purpose of building a pending block with its final state (a trie) and cache them in memory for reuse if needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


*ci:rskj-420-rc-ver*