### PR TITLE
Updating ethereum_summitTransaction method and personal_sendTransaction

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -40,7 +40,7 @@ public interface Ethereum {
 
     /**
      * @param transaction submit transaction to the net, return option to wait for net
-     *                    return the result of adding the transaction to the pool.
+     * @return the result of adding the transaction to the pool.
      */
     TransactionPoolAddResult submitTransaction(Transaction transaction);
 

--- a/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -23,6 +23,7 @@ import co.rsk.core.Coin;
 import org.ethereum.core.Block;
 import org.ethereum.core.ImportResult;
 import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionPoolAddResult;
 import org.ethereum.listener.EthereumListener;
 
 /**
@@ -39,9 +40,9 @@ public interface Ethereum {
 
     /**
      * @param transaction submit transaction to the net, return option to wait for net
-     *                    return this transaction as approved
+     *                    return the result of adding the transaction to the pool.
      */
-    void submitTransaction(Transaction transaction);
+    TransactionPoolAddResult submitTransaction(Transaction transaction);
 
     /**
      * Calculates a 'reasonable' Gas price based on statistics of the latest transaction's Gas prices

--- a/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -74,8 +74,8 @@ public class EthereumImpl implements Ethereum {
     }
 
     @Override
-    public void submitTransaction(Transaction transaction) {
-        transactionGateway.receiveTransaction(transaction);
+    public TransactionPoolAddResult submitTransaction(Transaction transaction) {
+        return transactionGateway.receiveTransaction(transaction);
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
@@ -17,10 +17,10 @@
  */
 
 package co.rsk.rpc.modules.personal;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.core.Wallet;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionPoolAddResult;
 import org.ethereum.datasource.HashMapDB;
@@ -29,9 +29,9 @@ import org.ethereum.rpc.CallArguments;
 import org.ethereum.util.TransactionFactoryHelper;
 import org.junit.jupiter.api.Test;
 
-import co.rsk.config.TestSystemProperties;
-import co.rsk.core.RskAddress;
-import co.rsk.core.Wallet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class PersonalModuleTest {
 
@@ -51,10 +51,12 @@ class PersonalModuleTest {
 		Transaction tx = TransactionFactoryHelper.createTransaction(args, props.getNetworkConstants().getChainId(), wallet.getAccount(sender, PASS_FRASE));
 		String txExpectedResult = tx.getHash().toJsonString();
 
-		TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
-		when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+        TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+        when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+        when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
 
-		Ethereum ethereum = mock(Ethereum.class);
+        Ethereum ethereum = mock(Ethereum.class);
+        when(ethereum.submitTransaction(tx)).thenReturn(transactionPoolAddResult);
 
 		PersonalModuleWalletEnabled personalModuleWalletEnabled = new PersonalModuleWalletEnabled(props, ethereum, wallet, null);
 

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/personal/PersonalModuleTest.java
@@ -53,7 +53,6 @@ class PersonalModuleTest {
 
         TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
         when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
-        when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
 
         Ethereum ethereum = mock(Ethereum.class);
         when(ethereum.submitTransaction(tx)).thenReturn(transactionPoolAddResult);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Simples/SimpleEthereum.java
@@ -28,7 +28,8 @@ import org.ethereum.listener.GasPriceTracker;
 import org.ethereum.listener.TestCompositeEthereumListener;
 
 import javax.annotation.Nonnull;
-import static org.mockito.Mockito.*;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by Ruben Altman on 09/06/2016.
@@ -68,8 +69,9 @@ public class SimpleEthereum implements Ethereum {
     }
 
     @Override
-    public void submitTransaction(Transaction transaction) {
+    public TransactionPoolAddResult submitTransaction(Transaction transaction) {
         tx = transaction;
+        return TransactionPoolAddResult.okPendingTransaction(transaction);
     }
 
     @Override

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -22,8 +22,6 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.*;
 import co.rsk.core.bc.BlockChainImpl;
-import co.rsk.core.bc.MiningMainchainView;
-import co.rsk.core.bc.MiningMainchainViewImpl;
 import co.rsk.core.bc.TransactionPoolImpl;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
@@ -2077,54 +2075,105 @@ class Web3ImplTest {
     }
 
     @Test
-    void sendPersonalTransaction() {
-        Web3Impl web3 = createWeb3();
+    void sendPersonalTransaction() throws Exception {
 
         // **** Initializes data ******************
-        String addr1 = web3.personal_newAccount("passphrase1");
-        String addr2 = web3.personal_newAccount("passphrase2");
+        Ethereum ethereumMock = Web3Mocks.getMockEthereum();
+        Web3Impl web3 = createWeb3(ethereumMock);
+        TransactionPoolAddResult pendingTransactionResult = TransactionPoolAddResult.okPendingTransaction(Mockito.mock(Transaction.class));
 
-        String toAddress = addr2;
+        String fromAddress = web3.personal_newAccount("passphrase1");
+        String toAddress = web3.personal_newAccount("passphrase2");
         BigInteger value = BigInteger.valueOf(7);
         BigInteger gasPrice = BigInteger.valueOf(8);
         BigInteger gasLimit = BigInteger.valueOf(9);
         String data = "0xff";
         BigInteger nonce = BigInteger.ONE;
 
-        // ***** Executes the transaction *******************
         CallArguments args = new CallArguments();
-        args.setFrom(addr1);
-        args.setTo(addr2);
+        args.setFrom(fromAddress);
+        args.setTo(toAddress);
         args.setData(data);
         args.setGas(HexUtils.toQuantityJsonHex(gasLimit));
         args.setGasPrice(HexUtils.toQuantityJsonHex(gasPrice));
         args.setValue(value.toString());
         args.setNonce(nonce.toString());
-
-        String txHash = null;
-        try {
-            txHash = web3.personal_sendTransaction(args, "passphrase1");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
         // ***** Verifies tx hash
-        Transaction tx = Transaction
+        Transaction expectedTx = Transaction
                 .builder()
                 .destination(toAddress.substring(2))
                 .value(value)
                 .nonce(nonce)
                 .gasPrice(gasPrice)
                 .gasLimit(gasLimit)
-                .data(args.getData())
+                .data(args.getData().substring(2))
                 .chainId(config.getNetworkConstants().getChainId())
                 .build();
-        Account account = wallet.getAccount(new RskAddress(addr1), "passphrase1");
-        tx.sign(account.getEcKey().getPrivKeyBytes());
 
-        String expectedHash = tx.getHash().toJsonString();
+        Account account = wallet.getAccount(new RskAddress(fromAddress), "passphrase1");
+        expectedTx.sign(account.getEcKey().getPrivKeyBytes());
+        String expectedHash = expectedTx.getHash().toJsonString();
 
+        when(ethereumMock.submitTransaction(expectedTx)).thenReturn(pendingTransactionResult);
+
+        String txHash = null;
+
+        // ***** Executes the transaction *******************
+        txHash = web3.personal_sendTransaction(args, "passphrase1");
+
+
+        // ***** Checking expected result *******************
         assertEquals(0, expectedHash.compareTo(txHash), "Method is not creating the expected transaction");
+    }
+
+    @Test
+    void sendPersonalTransactionFailsIfTransactionIsNotQueued(){
+
+        Ethereum ethereumMock = Web3Mocks.getMockEthereum();
+        Web3Impl web3 = createWeb3(ethereumMock);
+        TransactionPoolAddResult pendingTransactionResult = TransactionPoolAddResult.withError("Testing error");
+
+        String fromAddress = web3.personal_newAccount("passphrase1");
+        String toAddress = web3.personal_newAccount("passphrase2");
+        BigInteger value = BigInteger.valueOf(7);
+        BigInteger gasPrice = BigInteger.valueOf(8);
+        BigInteger gasLimit = BigInteger.valueOf(9);
+        String data = "0xff";
+        BigInteger nonce = BigInteger.ONE;
+
+        CallArguments args = new CallArguments();
+        args.setFrom(fromAddress);
+        args.setTo(toAddress);
+        args.setData(data);
+        args.setGas(HexUtils.toQuantityJsonHex(gasLimit));
+        args.setGasPrice(HexUtils.toQuantityJsonHex(gasPrice));
+        args.setValue(value.toString());
+        args.setNonce(nonce.toString());
+
+        Transaction expectedTx = Transaction
+                .builder()
+                .destination(toAddress.substring(2))
+                .value(value)
+                .nonce(nonce)
+                .gasPrice(gasPrice)
+                .gasLimit(gasLimit)
+                .data(args.getData().substring(2))
+                .chainId(config.getNetworkConstants().getChainId())
+                .build();
+
+        Account account = wallet.getAccount(new RskAddress(fromAddress), "passphrase1");
+        expectedTx.sign(account.getEcKey().getPrivKeyBytes());
+
+        when(ethereumMock.submitTransaction(expectedTx)).thenReturn(pendingTransactionResult);
+
+        // ***** Executes the transaction *******************
+        RskJsonRpcRequestException thrownEx = Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
+            web3.personal_sendTransaction(args, "passphrase1");
+        });
+
+        assertEquals(-32010,thrownEx.getCode(), "Unexpected exception code");
+        assertEquals(pendingTransactionResult.getErrorMessage(),thrownEx.getMessage(),"Exception message should be the same as the one from add transaction result.");
+
     }
 
     @Test
@@ -2170,13 +2219,6 @@ class Web3ImplTest {
         Account account1 = wallet.getAccount(new RskAddress(addr));
 
         assertNull(account1);
-    }
-
-    private Web3Impl createWeb3() {
-        return createWeb3(
-                Web3Mocks.getMockEthereum(), Web3Mocks.getMockBlockchain(), Web3Mocks.getMockRepositoryLocator(), Web3Mocks.getMockTransactionPool(),
-                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache
-        );
     }
 
     @Test
@@ -2323,6 +2365,20 @@ class Web3ImplTest {
         Assertions.assertEquals("0x", result);
     }
 
+    private Web3Impl createWeb3() {
+        return createWeb3(
+                Web3Mocks.getMockEthereum(), Web3Mocks.getMockBlockchain(), Web3Mocks.getMockRepositoryLocator(), Web3Mocks.getMockTransactionPool(),
+                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache
+        );
+    }
+
+    private Web3Impl createWeb3(Ethereum ethereum) {
+        return createWeb3(
+                ethereum, Web3Mocks.getMockBlockchain(), Web3Mocks.getMockRepositoryLocator(), Web3Mocks.getMockTransactionPool(),
+                Web3Mocks.getMockBlockStore(), null, null, null, signatureCache
+        );
+    }
+
     private Web3Impl createWeb3(World world) {
         return createWeb3(world, null);
     }
@@ -2399,7 +2455,7 @@ class Web3ImplTest {
         BlockStore blockStore = world.getBlockStore();
         TransactionExecutorFactory transactionExecutorFactory = buildTransactionExecutorFactory(blockStore, world.getBlockTxSignatureCache());
         TransactionPool transactionPool = new TransactionPoolImpl(config, world.getRepositoryLocator(), blockStore,
-                                                                  blockFactory, null, transactionExecutorFactory, world.getReceivedTxSignatureCache(), 10, 100, Mockito.mock(TxQuotaChecker.class), Mockito.mock(GasPriceTracker.class));
+                blockFactory, null, transactionExecutorFactory, world.getReceivedTxSignatureCache(), 10, 100, Mockito.mock(TxQuotaChecker.class), Mockito.mock(GasPriceTracker.class));
         return createWeb3(eth, world, transactionPool, receiptStore);
     }
 
@@ -2432,7 +2488,7 @@ class Web3ImplTest {
         BlockStore blockStore = world.getBlockStore();
         TransactionExecutorFactory transactionExecutorFactory = buildTransactionExecutorFactory(blockStore, world.getBlockTxSignatureCache());
         TransactionPool transactionPool = new TransactionPoolImpl(config, world.getRepositoryLocator(),
-                                                                  blockStore, blockFactory, null, transactionExecutorFactory, world.getReceivedTxSignatureCache(), 10, 100, Mockito.mock(TxQuotaChecker.class), Mockito.mock(GasPriceTracker.class));
+                blockStore, blockFactory, null, transactionExecutorFactory, world.getReceivedTxSignatureCache(), 10, 100, Mockito.mock(TxQuotaChecker.class), Mockito.mock(GasPriceTracker.class));
         RepositoryLocator repositoryLocator = new RepositoryLocator(world.getTrieStore(), world.getStateRootHandler());
         return createWeb3(
                 Web3Mocks.getMockEthereum(), blockChain, repositoryLocator, transactionPool,


### PR DESCRIPTION
Updated `Ethereum#summitTransaction` method to return the result of adding the transaction to the pool so the caller can check if it was successful or not.
Updated the JRPC method `personal_sendTransaction` to behave the same as `eth_sendTransaction` when the transaction can not be added to the pool.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

*fed:update_eth_add_transaction_response*