### PR TITLE
Get rid of BridgeSupportTest hierarchy 

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -5,6 +5,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.Context;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.PartialMerkleTree;
 import co.rsk.bitcoinj.core.ScriptException;
 import co.rsk.bitcoinj.core.Sha256Hash;
@@ -16,6 +17,7 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.config.BridgeConstants;
+import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -66,8 +68,15 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static co.rsk.peg.utils.BridgeStorageProviderUtil.*;
 
-class BridgeSupportFlyoverTest extends BridgeSupportTestBase {
+class BridgeSupportFlyoverTest {
+    private final BridgeConstants bridgeConstantsRegtest = BridgeRegTestConstants.getInstance();
+    private final BridgeConstants bridgeConstantsMainnet = BridgeMainNetConstants.getInstance();
+    protected final NetworkParameters btcRegTestParams = bridgeConstantsRegtest.getBtcParams();
+    private BridgeSupportBuilder bridgeSupportBuilder;
+    private ActivationConfig.ForBlock activations;
+
     @BeforeEach
     void setUpOnEachTest() {
         activations = mock(ActivationConfig.ForBlock.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -68,7 +68,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static co.rsk.peg.utils.BridgeStorageProviderUtil.*;
+import static co.rsk.peg.BridgeSupportTestUtil.*;
 
 class BridgeSupportFlyoverTest {
     private final BridgeConstants bridgeConstantsRegtest = BridgeRegTestConstants.getInstance();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -73,7 +73,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
-import static co.rsk.peg.utils.BridgeStorageProviderUtil.*;
+import static co.rsk.peg.BridgeSupportTestUtil.*;
 import static co.rsk.peg.PegTestUtils.createUTXO;
 
 class BridgeSupportTest {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -73,8 +73,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
+import static co.rsk.peg.utils.BridgeStorageProviderUtil.*;
+import static co.rsk.peg.PegTestUtils.createUTXO;
 
-class BridgeSupportTest extends BridgeSupportTestBase {
+class BridgeSupportTest {
+    private final BridgeConstants bridgeConstantsRegtest = BridgeRegTestConstants.getInstance();
+    protected final NetworkParameters btcRegTestParams = bridgeConstantsRegtest.getBtcParams();
+    private BridgeSupportBuilder bridgeSupportBuilder;
+
     private static final String TO_ADDRESS = "0000000000000000000000000000000000000006";
     private static final BigInteger DUST_AMOUNT = new BigInteger("1");
     private static final BigInteger NONCE = new BigInteger("0");

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -1,4 +1,4 @@
-package co.rsk.peg.utils;
+package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.BtcBlock;
 import co.rsk.bitcoinj.core.Sha256Hash;
@@ -6,7 +6,6 @@ import co.rsk.bitcoinj.core.StoredBlock;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.db.MutableTrieCache;
 import co.rsk.db.MutableTrieImpl;
-import co.rsk.peg.BtcBlockStoreWithCache;
 import co.rsk.trie.Trie;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Repository;
@@ -18,7 +17,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class BridgeStorageProviderUtil {
+public final class BridgeSupportTestUtil {
     public static Repository createRepository() {
         return new MutableRepository(new MutableTrieCache(new MutableTrieImpl(null, new Trie())));
     }

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -52,7 +52,7 @@ import org.ethereum.crypto.Keccak256Helper;
 /**
  * Created by oscar on 05/08/2016.
  */
-public class PegTestUtils {
+public final class PegTestUtils {
 
     private static int nhash = 0;
 
@@ -322,5 +322,15 @@ public class PegTestUtils {
             valuesToSend,
             address
         );
+    }
+
+    public static UTXO createUTXO(Coin value, Address address) {
+        return new UTXO(
+            PegTestUtils.createHash(),
+            1,
+            value,
+            0,
+            false,
+            ScriptBuilder.createOutputScript(address));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeStorageProviderUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeStorageProviderUtil.java
@@ -1,23 +1,14 @@
-package co.rsk.peg;
+package co.rsk.peg.utils;
 
-import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcBlock;
-import co.rsk.bitcoinj.core.Coin;
-import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.StoredBlock;
-import co.rsk.bitcoinj.core.UTXO;
-import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.store.BlockStoreException;
-import co.rsk.config.BridgeConstants;
-import co.rsk.config.BridgeMainNetConstants;
-import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.db.MutableTrieCache;
 import co.rsk.db.MutableTrieImpl;
-import co.rsk.test.builders.BridgeSupportBuilder;
+import co.rsk.peg.BtcBlockStoreWithCache;
 import co.rsk.trie.Trie;
 import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Repository;
 import org.ethereum.db.MutableRepository;
 
@@ -27,28 +18,12 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BridgeSupportTestBase {
-    protected final BridgeConstants bridgeConstantsRegtest = BridgeRegTestConstants.getInstance();
-    protected final BridgeConstants bridgeConstantsMainnet = BridgeMainNetConstants.getInstance();
-    protected final NetworkParameters btcRegTestParams = bridgeConstantsRegtest.getBtcParams();
-    protected BridgeSupportBuilder bridgeSupportBuilder;
-    protected ActivationConfig.ForBlock activations;
-
-    protected UTXO createUTXO(Coin value, Address address) {
-        return new UTXO(
-            PegTestUtils.createHash(),
-            1,
-            value,
-            0,
-            false,
-            ScriptBuilder.createOutputScript(address));
-    }
-
-    protected static Repository createRepository() {
+public final class BridgeStorageProviderUtil {
+    public static Repository createRepository() {
         return new MutableRepository(new MutableTrieCache(new MutableTrieImpl(null, new Trie())));
     }
 
-    protected static void mockChainOfStoredBlocks(BtcBlockStoreWithCache btcBlockStore, BtcBlock targetHeader, int headHeight, int targetHeight) throws BlockStoreException {
+    public static void mockChainOfStoredBlocks(BtcBlockStoreWithCache btcBlockStore, BtcBlock targetHeader, int headHeight, int targetHeight) throws BlockStoreException {
         // Simulate that the block is in there by mocking the getter by height,
         // and then simulate that the txs have enough confirmations by setting a high head.
         when(btcBlockStore.getStoredBlockAtMainChainHeight(targetHeight)).thenReturn(new StoredBlock(targetHeader, BigInteger.ONE, targetHeight));


### PR DESCRIPTION
Get rid of the BridgeSupportTest hierarchy, move those methods to util classes, and make test classes independent.