### PR TITLE
RSKIP 351

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -226,7 +226,7 @@ public class NodeBlockProcessor implements BlockProcessor {
             return;
         }
 
-        Message responseMessage = new BodyResponseMessage(requestId, block.getTransactionsList(), block.getUncleList());
+        Message responseMessage = new BodyResponseMessage(requestId, block.getTransactionsList(), block.getUncleList(), block.getHeader().getExtension());
         sender.sendMessage(responseMessage);
     }
 

--- a/rskj-core/src/main/java/co/rsk/net/messages/BlockHeadersResponseMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/BlockHeadersResponseMessage.java
@@ -32,7 +32,7 @@ public class BlockHeadersResponseMessage extends MessageWithId {
     @Override
     protected byte[] getEncodedMessageWithoutId() {
         byte[][] rlpHeaders = this.blockHeaders.stream()
-                .map(BlockHeader::getFullEncoded)
+                .map(BlockHeader::getEncodedForHeaderMessage)
                 .toArray(byte[][]::new);
 
         return RLP.encodeList(RLP.encodeList(rlpHeaders));

--- a/rskj-core/src/main/java/co/rsk/net/messages/BodyResponseMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/BodyResponseMessage.java
@@ -1,6 +1,8 @@
 package co.rsk.net.messages;
 
+import com.google.common.collect.Lists;
 import org.ethereum.core.BlockHeader;
+import org.ethereum.core.BlockHeaderExtension;
 import org.ethereum.core.Transaction;
 import org.ethereum.util.RLP;
 
@@ -13,11 +15,13 @@ public class BodyResponseMessage extends MessageWithId {
     private long id;
     private List<Transaction> transactions;
     private List<BlockHeader> uncles;
+    private BlockHeaderExtension blockHeaderExtension;
 
-    public BodyResponseMessage(long id, List<Transaction> transactions, List<BlockHeader> uncles) {
+    public BodyResponseMessage(long id, List<Transaction> transactions, List<BlockHeader> uncles, BlockHeaderExtension blockHeaderExtension) {
         this.id = id;
         this.transactions = transactions;
         this.uncles = uncles;
+        this.blockHeaderExtension = blockHeaderExtension;
     }
 
     @Override
@@ -26,6 +30,7 @@ public class BodyResponseMessage extends MessageWithId {
     public List<Transaction> getTransactions() { return this.transactions; }
 
     public List<BlockHeader> getUncles() { return this.uncles; }
+    public BlockHeaderExtension getBlockHeaderExtension() { return this.blockHeaderExtension; }
 
     @Override
     protected byte[] getEncodedMessageWithoutId() {
@@ -40,7 +45,13 @@ public class BodyResponseMessage extends MessageWithId {
             rlpUncles[k] = this.uncles.get(k).getFullEncoded();
         }
 
-        return RLP.encodeList(RLP.encodeList(rlpTransactions), RLP.encodeList(rlpUncles));
+        List<byte[]> elements = Lists.newArrayList(RLP.encodeList(rlpTransactions), RLP.encodeList(rlpUncles));
+
+        if (this.blockHeaderExtension != null) {
+            elements.add(this.blockHeaderExtension.getEncoded());
+        }
+
+        return RLP.encodeList(elements.toArray(new byte[][]{}));
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/net/messages/MessageType.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/MessageType.java
@@ -232,7 +232,11 @@ public enum MessageType {
                 uncles.add(blockFactory.decodeHeader(element.getRLPData()));
             }
 
-            return new BodyResponseMessage(id, transactions, uncles);
+            BlockHeaderExtension blockHeaderExtension = message.size() == 3
+                    ? BlockHeaderExtension.fromEncoded((RLPList) RLP.decode2(message.get(2).getRLPData()).get(0))
+                    : null;
+
+            return new BodyResponseMessage(id, transactions, uncles, blockHeaderExtension);
         }
     },
     SKELETON_REQUEST_MESSAGE(16) {

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncState.java
@@ -94,6 +94,7 @@ public class DownloadingBackwardsBodiesSyncState extends BaseSelectedPeerSyncSta
             return;
         }
 
+        requestedHeader.setExtension(body.getBlockHeaderExtension());
         Block block = blockFactory.newBlock(requestedHeader, body.getTransactions(), body.getUncles());
         block.seal();
 

--- a/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/DownloadingBodiesSyncState.java
@@ -116,6 +116,7 @@ public class DownloadingBodiesSyncState extends BaseSyncState {
 
         // we already checked that this message was expected
         BlockHeader header = pendingBodyResponses.remove(requestId).header;
+        header.setExtension(message.getBlockHeaderExtension());
         Block block;
         try {
             block = blockFactory.newBlock(header, message.getTransactions(), message.getUncles());

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ActivationConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ActivationConfig.java
@@ -44,9 +44,9 @@ public class ActivationConfig {
         this.activationHeights = activationHeights;
     }
 
-    public int getHeaderVersion(long blockNumber) {
-        if (this.isActive(ConsensusRule.RSKIP351, blockNumber)) return 1;
-        return 0;
+    public byte getHeaderVersion(long blockNumber) {
+        if (this.isActive(ConsensusRule.RSKIP351, blockNumber)) return 0x1;
+        return 0x0;
     }
 
     public boolean isActive(ConsensusRule consensusRule, long blockNumber) {

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ActivationConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ActivationConfig.java
@@ -44,6 +44,11 @@ public class ActivationConfig {
         this.activationHeights = activationHeights;
     }
 
+    public int getHeaderVersion(long blockNumber) {
+        if (this.isActive(ConsensusRule.RSKIP351, blockNumber)) return 1;
+        return 0;
+    }
+
     public boolean isActive(ConsensusRule consensusRule, long blockNumber) {
         long activationHeight = activationHeights.get(consensusRule);
         return 0 <= activationHeight && activationHeight <= blockNumber;

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -76,7 +76,8 @@ public enum ConsensusRule {
     RSKIP290("rskip290"), // Testnet difficulty should drop to a higher difficulty
     RSKIP293("rskip293"), // Flyover improvements
     RSKIP294("rskip294"),
-    RSKIP297("rskip297"); // Increase max timestamp difference between btc and rsk blocks for Testnet
+    RSKIP297("rskip297"), // Increase max timestamp difference between btc and rsk blocks for Testnet
+    RSKIP351("rskip351"); // block header extension v1
 
     private String configKey;
 

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -195,8 +195,17 @@ public class BlockFactory {
                     stateRoot);
         }
 
-        return new BlockHeader(
-                activationConfig.getHeaderVersion(blockNumber),
+        if (activationConfig.getHeaderVersion(blockNumber) == 1) return new BlockHeaderV1(
+                parentHash, unclesHash, coinbase, stateRoot,
+                txTrieRoot, receiptTrieRoot, logsBloom, difficulty,
+                blockNumber, glBytes, gasUsed, timestamp, extraData,
+                paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
+                bitcoinMergedMiningCoinbaseTransaction, new byte[0],
+                minimumGasPrice, uncleCount, sealed, useRskip92Encoding, includeForkDetectionData,
+                ummRoot
+        );
+
+        return new BlockHeaderV0(
                 parentHash, unclesHash, coinbase, stateRoot,
                 txTrieRoot, receiptTrieRoot, logsBloom, difficulty,
                 blockNumber, glBytes, gasUsed, timestamp, extraData,

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -196,6 +196,7 @@ public class BlockFactory {
         }
 
         return new BlockHeader(
+                activationConfig.getHeaderVersion(blockNumber),
                 parentHash, unclesHash, coinbase, stateRoot,
                 txTrieRoot, receiptTrieRoot, logsBloom, difficulty,
                 blockNumber, glBytes, gasUsed, timestamp, extraData,

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -50,7 +50,7 @@ public class BlockHeader {
     private static final int UMM_LEAVES_LENGTH = 20;
 
     /* RSKIP 351 version */
-    private final int version;
+    private final byte version;
 
     /* The SHA3 256-bit hash of the parent block, in its entirety */
     private final byte[] parentHash;
@@ -126,7 +126,7 @@ public class BlockHeader {
     /* Indicates if Block hash for merged mining should have the format described in RSKIP-110 */
     private final boolean includeForkDetectionData;
 
-    public BlockHeader(int version,
+    public BlockHeader(byte version,
                        byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
                        byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] logsBloom, BlockDifficulty difficulty,
                        long number, byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
@@ -162,7 +162,7 @@ public class BlockHeader {
         this.ummRoot = ummRoot != null ? Arrays.copyOf(ummRoot, ummRoot.length) : null;
     }
 
-    public int getVersion() { return version; }
+    public byte getVersion() { return version; }
 
     @VisibleForTesting
     public boolean isSealed() {

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -49,6 +49,9 @@ public class BlockHeader {
     private static final int FORK_DETECTION_DATA_LENGTH = 12;
     private static final int UMM_LEAVES_LENGTH = 20;
 
+    /* RSKIP 351 version */
+    private final int version;
+
     /* The SHA3 256-bit hash of the parent block, in its entirety */
     private final byte[] parentHash;
     /* The SHA3 256-bit hash of the uncles list portion of this block */
@@ -123,13 +126,15 @@ public class BlockHeader {
     /* Indicates if Block hash for merged mining should have the format described in RSKIP-110 */
     private final boolean includeForkDetectionData;
 
-    public BlockHeader(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
+    public BlockHeader(int version,
+                       byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
                        byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] logsBloom, BlockDifficulty difficulty,
                        long number, byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
                        Coin paidFees, byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
                        byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] mergedMiningForkDetectionData,
                        Coin minimumGasPrice, int uncleCount, boolean sealed,
                        boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot) {
+        this.version = version;
         this.parentHash = parentHash;
         this.unclesHash = unclesHash;
         this.coinbase = coinbase;
@@ -156,6 +161,8 @@ public class BlockHeader {
         this.includeForkDetectionData = includeForkDetectionData;
         this.ummRoot = ummRoot != null ? Arrays.copyOf(ummRoot, ummRoot.length) : null;
     }
+
+    public int getVersion() { return version; }
 
     @VisibleForTesting
     public boolean isSealed() {

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
@@ -309,8 +309,21 @@ public class BlockHeaderBuilder {
             }
         }
 
-        return new BlockHeader(
-                activationConfig.getHeaderVersion(number),
+        if (activationConfig.getHeaderVersion(number) == 0x1) return new BlockHeaderV1(
+                parentHash, unclesHash, coinbase,
+                stateRoot, txTrieRoot, receiptTrieRoot,
+                logsBloom, difficulty, number,
+                gasLimit, gasUsed, timestamp, extraData, paidFees,
+                bitcoinMergedMiningHeader,
+                bitcoinMergedMiningMerkleProof,
+                bitcoinMergedMiningCoinbaseTransaction,
+                mergedMiningForkDetectionData,
+                minimumGasPrice, uncleCount,
+                false, useRskip92Encoding,
+                includeForkDetectionData, ummRoot
+        );
+
+        return new BlockHeaderV0(
                 parentHash, unclesHash, coinbase,
                 stateRoot, txTrieRoot, receiptTrieRoot,
                 logsBloom, difficulty, number,

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
@@ -310,6 +310,7 @@ public class BlockHeaderBuilder {
         }
 
         return new BlockHeader(
+                activationConfig.getHeaderVersion(number),
                 parentHash, unclesHash, coinbase,
                 stateRoot, txTrieRoot, receiptTrieRoot,
                 logsBloom, difficulty, number,

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtension.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtension.java
@@ -1,0 +1,14 @@
+package org.ethereum.core;
+
+import org.ethereum.util.RLPList;
+
+public abstract class BlockHeaderExtension {
+    public abstract byte getHeaderVersion();
+    public abstract byte[] getEncoded();
+
+    public static BlockHeaderExtension fromEncoded(RLPList encoded) {
+        byte version = encoded.get(0).getRLPData()[0];
+        if (version == 0x1) return BlockHeaderExtensionV1.fromEncoded(encoded.getRLPData());
+        return null;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV1.java
@@ -1,0 +1,37 @@
+package org.ethereum.core;
+
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
+
+public class BlockHeaderExtensionV1 extends BlockHeaderExtension {
+    @Override
+    public byte getHeaderVersion() { return 0x1; }
+
+    private byte[] logsBloom;
+    public byte[] getLogsBloom() { return this.logsBloom; }
+    public void setLogsBloom(byte[] logsBloom) { this.logsBloom = logsBloom; }
+
+    public BlockHeaderExtensionV1(byte[] logsBloom) {
+        this.logsBloom = logsBloom;
+    }
+
+    public byte[] getHash() {
+        return HashUtil.keccak256(this.getEncoded());
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return  RLP.encodeList(
+                RLP.encodeByte(this.getHeaderVersion()),
+                RLP.encodeElement(this.getLogsBloom())
+        );
+    }
+
+    public static BlockHeaderExtensionV1 fromEncoded(byte[] encoded) {
+        RLPList rlpExtension = RLP.decodeList(encoded);
+        return new BlockHeaderExtensionV1(
+                rlpExtension.get(1).getRLPData()
+        );
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV0.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV0.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2017 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.core;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import org.ethereum.util.RLP;
+
+public class BlockHeaderV0 extends BlockHeader {
+    // block header for blocks before rskip351
+    @Override
+    public byte getVersion() { return 0x0; }
+    @Override
+    public BlockHeaderExtension getExtension() { return null; }
+    @Override
+    public void setExtension(BlockHeaderExtension extension) {}
+
+    private byte[] logsBloom;
+
+    public BlockHeaderV0(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
+        byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] logsBloom, BlockDifficulty difficulty,
+        long number, byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
+        Coin paidFees, byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
+        byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] mergedMiningForkDetectionData,
+        Coin minimumGasPrice, int uncleCount, boolean sealed,
+        boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot) {
+        super(parentHash,unclesHash, coinbase, stateRoot,
+                txTrieRoot, receiptTrieRoot, difficulty,
+                number, gasLimit, gasUsed, timestamp, extraData,
+                paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
+                bitcoinMergedMiningCoinbaseTransaction, mergedMiningForkDetectionData,
+                minimumGasPrice, uncleCount, sealed,
+                useRskip92Encoding, includeForkDetectionData, ummRoot);
+        this.logsBloom = logsBloom;
+    }
+
+    @Override
+    public byte[] getLogsBloom() { return logsBloom; }
+
+    public void setLogsBloom(byte[] logsBloom) {
+        if (this.sealed) {
+            throw new SealedBlockHeaderException("trying to alter logs bloom");
+        }
+        this.hash = null;
+
+        this.logsBloom = logsBloom;
+    }
+
+    @Override
+    public byte[] getLogsBloomFieldEncoded() {
+        return RLP.encodeElement(this.logsBloom);
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
@@ -1,0 +1,57 @@
+package org.ethereum.core;
+
+import co.rsk.core.BlockDifficulty;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import org.ethereum.util.RLP;
+
+public class BlockHeaderV1 extends BlockHeader {
+    @Override
+    public byte getVersion() { return 0x1; }
+
+    private BlockHeaderExtensionV1 extension;
+    public BlockHeaderExtensionV1 getExtension() { return this.extension; }
+    public void setExtension(BlockHeaderExtension extension) { this.extension = (BlockHeaderExtensionV1) extension; }
+
+    public BlockHeaderV1(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
+                         byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] logsBloom, BlockDifficulty difficulty,
+                         long number, byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
+                         Coin paidFees, byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
+                         byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] mergedMiningForkDetectionData,
+                         Coin minimumGasPrice, int uncleCount, boolean sealed,
+                         boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot) {
+        super(parentHash,unclesHash, coinbase, stateRoot,
+                txTrieRoot, receiptTrieRoot, difficulty,
+                number, gasLimit, gasUsed, timestamp, extraData,
+                paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
+                bitcoinMergedMiningCoinbaseTransaction, mergedMiningForkDetectionData,
+                minimumGasPrice, uncleCount, sealed,
+                useRskip92Encoding, includeForkDetectionData, ummRoot);
+
+        this.extension = new BlockHeaderExtensionV1(logsBloom);
+    }
+
+    @Override
+    public byte[] getLogsBloom() {
+        return this.extension.getLogsBloom();
+    }
+
+    public void setLogsBloom(byte[] logsBloom) {
+        /* A sealed block header is immutable, cannot be changed */
+        if (this.sealed) {
+            throw new SealedBlockHeaderException("trying to alter logs bloom");
+        }
+        this.hash = null;
+
+        this.extension.setLogsBloom(logsBloom);
+    }
+
+    @Override
+    public byte[] getLogsBloomFieldEncoded() {
+        byte[] ecnoded = new byte[Bloom.BLOOM_BYTES];
+        ecnoded[0] = 0x1;
+        byte[] logsBloomHash = this.extension.getHash();
+        System.arraycopy(logsBloomHash, 0, ecnoded, 1, logsBloomHash.length);
+        return RLP.encodeElement(ecnoded);
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/core/GenesisHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/GenesisHeader.java
@@ -29,6 +29,7 @@ public class GenesisHeader extends BlockHeader {
                          byte[] coinbase,
                          byte[] stateRootHash) {
         super(
+                0,
                 parentHash,
                 unclesHash,
                 new RskAddress(coinbase),
@@ -72,6 +73,7 @@ public class GenesisHeader extends BlockHeader {
                          boolean useRskip92Encoding,
                          byte[] coinbase) {
         super(
+                0,
                 parentHash,
                 unclesHash,
                 new RskAddress(coinbase),

--- a/rskj-core/src/main/java/org/ethereum/core/GenesisHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/GenesisHeader.java
@@ -8,7 +8,7 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 
-public class GenesisHeader extends BlockHeader {
+public class GenesisHeader extends BlockHeaderV0 {
 
     private final byte[] difficulty;
 
@@ -29,7 +29,6 @@ public class GenesisHeader extends BlockHeader {
                          byte[] coinbase,
                          byte[] stateRootHash) {
         super(
-                (byte) 0x0,
                 parentHash,
                 unclesHash,
                 new RskAddress(coinbase),
@@ -73,7 +72,6 @@ public class GenesisHeader extends BlockHeader {
                          boolean useRskip92Encoding,
                          byte[] coinbase) {
         super(
-                (byte) 0x0,
                 parentHash,
                 unclesHash,
                 new RskAddress(coinbase),

--- a/rskj-core/src/main/java/org/ethereum/core/GenesisHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/GenesisHeader.java
@@ -29,7 +29,7 @@ public class GenesisHeader extends BlockHeader {
                          byte[] coinbase,
                          byte[] stateRootHash) {
         super(
-                0,
+                (byte) 0x0,
                 parentHash,
                 unclesHash,
                 new RskAddress(coinbase),
@@ -73,7 +73,7 @@ public class GenesisHeader extends BlockHeader {
                          boolean useRskip92Encoding,
                          byte[] coinbase) {
         super(
-                0,
+                (byte) 0x0,
                 parentHash,
                 unclesHash,
                 new RskAddress(coinbase),

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -74,6 +74,7 @@ blockchain = {
              rskip293 = <hardforkName>
              rskip294 = <hardforkName>
              rskip297 = <hardforkName>
+             rskip351 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -63,6 +63,7 @@ blockchain = {
             rskip293 = hop400
             rskip294 = hop400
             rskip297 = hop400
+            rskip351 = fingerroot500
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.ethereum.TestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.Blockchain;
@@ -266,7 +267,7 @@ class CliToolsTest {
         doReturn(world.getBlockStore()).when(rskContext).getBlockStore();
         doReturn(world.getTrieStore()).when(rskContext).getTrieStore();
         doReturn(receiptStore).when(rskContext).getReceiptStore();
-        doReturn(new BlockFactory(ActivationConfigsForTest.all())).when(rskContext).getBlockFactory();
+        doReturn(new BlockFactory(ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351))).when(rskContext).getBlockFactory();
         doReturn(world.getTrieStore()).when(rskContext).getTrieStore();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
         doReturn(tempDir.toString()).when(rskSystemProperties).databaseDir();
@@ -320,7 +321,7 @@ class CliToolsTest {
         RskContext rskContext = mock(RskContext.class);
         RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
         doReturn(world.getBlockStore()).when(rskContext).getBlockStore();
-        doReturn(new BlockFactory(ActivationConfigsForTest.all())).when(rskContext).getBlockFactory();
+        doReturn(new BlockFactory(ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351))).when(rskContext).getBlockFactory();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
         doReturn(tempDir.toString()).when(rskSystemProperties).databaseDir();
         doReturn(DbKind.LEVEL_DB).when(rskSystemProperties).databaseKind();

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -131,7 +131,7 @@ class BlockFactoryTest {
 
         BlockHeader header = createBlockHeaderWithMergedMiningFields(number, forkDetectionData, null);
 
-        byte[] encodedBlock = header.getEncoded(false, false);
+        byte[] encodedBlock = header.getEncoded(false, false, false);
         byte[] hashForMergedMining = Arrays.copyOfRange(HashUtil.keccak256(encodedBlock), 0, 20);
         byte[] coinbase = org.bouncycastle.util.Arrays.concatenate(hashForMergedMining, forkDetectionData);
         coinbase = org.bouncycastle.util.Arrays.concatenate(RskMiningConstants.RSK_TAG, coinbase);
@@ -158,7 +158,7 @@ class BlockFactoryTest {
 
         BlockHeader header = createBlockHeader(number, new byte[0], null);
 
-        byte[] encodedHeader = header.getEncoded(false, false);
+        byte[] encodedHeader = header.getEncoded(false, false, false);
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         MatcherAssert.assertThat(headerRLP.size(), is(16));
 
@@ -179,7 +179,7 @@ class BlockFactoryTest {
         byte[] forkDetectionData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         BlockHeader header = createBlockHeader(number, forkDetectionData, null);
 
-        byte[] encodedHeader = header.getEncoded(false, false);
+        byte[] encodedHeader = header.getEncoded(false, false, false);
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         MatcherAssert.assertThat(headerRLP.size(), is(16));
 

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -289,6 +289,11 @@ class BlockFactoryTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> factory.decodeHeader(encodedHeader));
     }
 
+    @Test
+    public void genesisHasVersion0() {
+        assertEquals((byte) 0x0, factory.decodeBlock(genesisRaw()).getHeader().getVersion());
+    }
+
     private void enableRulesAt(long number, ConsensusRule... consensusRules) {
         for (ConsensusRule consensusRule : consensusRules) {
             when(activationConfig.isActive(eq(consensusRule), geq(number))).thenReturn(true);

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionTest.java
@@ -1,0 +1,73 @@
+package co.rsk.core;
+
+import org.ethereum.core.BlockHeaderExtensionV1;
+import org.ethereum.core.Bloom;
+import org.ethereum.util.RLP;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class BlockHeaderExtensionTest {
+    @Test
+    public void createFromBlockHeader() {
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 0x01;
+        logsBloom[1] = 0x02;
+        logsBloom[2] = 0x03;
+        logsBloom[3] = 0x04;
+
+        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(logsBloom);
+
+        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
+    }
+
+    @Test
+    public void setLogsBloom() {
+        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(new byte[32]);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 0x01;
+        logsBloom[1] = 0x02;
+        logsBloom[2] = 0x03;
+        logsBloom[3] = 0x04;
+
+        extension.setLogsBloom(logsBloom);
+
+        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
+    }
+
+    @Test
+    public void hashIncludesLogsBloom() {
+        byte[] logsBloom1 = new byte[Bloom.BLOOM_BYTES];
+        logsBloom1[0] = 0x01;
+        logsBloom1[1] = 0x02;
+        logsBloom1[2] = 0x03;
+        logsBloom1[3] = 0x04;
+        BlockHeaderExtensionV1 extension1 = new BlockHeaderExtensionV1(logsBloom1);
+
+        byte[] logsBloom2 = new byte[Bloom.BLOOM_BYTES];
+        logsBloom2[0] = 0x01;
+        logsBloom2[1] = 0x02;
+        logsBloom2[2] = 0x03;
+        logsBloom2[3] = 0x05;
+        BlockHeaderExtensionV1 extension2 = new BlockHeaderExtensionV1(logsBloom2);
+
+        Assertions.assertFalse(Arrays.equals(extension1.getHash(), extension2.getHash()));
+    }
+
+    @Test
+    public void encodeDecode() {
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 0x01;
+        logsBloom[1] = 0x02;
+        logsBloom[2] = 0x03;
+        logsBloom[3] = 0x04;
+
+        BlockHeaderExtensionV1 extension = BlockHeaderExtensionV1.fromEncoded(
+                new BlockHeaderExtensionV1(logsBloom).getEncoded()
+        );
+
+        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionTest.java
@@ -1,8 +1,10 @@
 package co.rsk.core;
 
+import org.ethereum.core.BlockHeaderExtension;
 import org.ethereum.core.BlockHeaderExtensionV1;
 import org.ethereum.core.Bloom;
 import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -10,64 +12,19 @@ import java.util.Arrays;
 
 public class BlockHeaderExtensionTest {
     @Test
-    public void createFromBlockHeader() {
+    public void decodeV1() {
         byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
         logsBloom[0] = 0x01;
         logsBloom[1] = 0x02;
         logsBloom[2] = 0x03;
         logsBloom[3] = 0x04;
-
         BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(logsBloom);
 
-        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
-    }
-
-    @Test
-    public void setLogsBloom() {
-        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(new byte[32]);
-
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
-
-        extension.setLogsBloom(logsBloom);
-
-        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
-    }
-
-    @Test
-    public void hashIncludesLogsBloom() {
-        byte[] logsBloom1 = new byte[Bloom.BLOOM_BYTES];
-        logsBloom1[0] = 0x01;
-        logsBloom1[1] = 0x02;
-        logsBloom1[2] = 0x03;
-        logsBloom1[3] = 0x04;
-        BlockHeaderExtensionV1 extension1 = new BlockHeaderExtensionV1(logsBloom1);
-
-        byte[] logsBloom2 = new byte[Bloom.BLOOM_BYTES];
-        logsBloom2[0] = 0x01;
-        logsBloom2[1] = 0x02;
-        logsBloom2[2] = 0x03;
-        logsBloom2[3] = 0x05;
-        BlockHeaderExtensionV1 extension2 = new BlockHeaderExtensionV1(logsBloom2);
-
-        Assertions.assertFalse(Arrays.equals(extension1.getHash(), extension2.getHash()));
-    }
-
-    @Test
-    public void encodeDecode() {
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
-
-        BlockHeaderExtensionV1 extension = BlockHeaderExtensionV1.fromEncoded(
-                new BlockHeaderExtensionV1(logsBloom).getEncoded()
+        BlockHeaderExtension decoded = BlockHeaderExtension.fromEncoded(
+                RLP.decodeList(extension.getEncoded())
         );
 
-        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
+        Assertions.assertEquals(extension.getHeaderVersion(), decoded.getHeaderVersion());
+        Assertions.assertArrayEquals(extension.getHash(), extension.getHash());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionV1Test.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionV1Test.java
@@ -1,0 +1,80 @@
+package co.rsk.core;
+
+import org.ethereum.TestUtils;
+import org.ethereum.core.BlockHeaderExtension;
+import org.ethereum.core.BlockHeaderExtensionV1;
+import org.ethereum.core.Bloom;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class BlockHeaderExtensionV1Test {
+    @Test
+    public void hasVersion1 () {
+        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(TestUtils.randomBytes(256));
+        Assertions.assertEquals(1, extension.getHeaderVersion());
+    }
+
+    @Test
+    public void createWithLogsBloom() {
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 0x01;
+        logsBloom[1] = 0x02;
+        logsBloom[2] = 0x03;
+        logsBloom[3] = 0x04;
+
+        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(logsBloom);
+
+        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
+    }
+
+    @Test
+    public void setLogsBloom() {
+        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(new byte[32]);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 0x01;
+        logsBloom[1] = 0x02;
+        logsBloom[2] = 0x03;
+        logsBloom[3] = 0x04;
+
+        extension.setLogsBloom(logsBloom);
+
+        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
+    }
+
+    @Test
+    public void hashIncludesLogsBloom() {
+        byte[] logsBloom1 = new byte[Bloom.BLOOM_BYTES];
+        logsBloom1[0] = 0x01;
+        logsBloom1[1] = 0x02;
+        logsBloom1[2] = 0x03;
+        logsBloom1[3] = 0x04;
+        BlockHeaderExtensionV1 extension1 = new BlockHeaderExtensionV1(logsBloom1);
+
+        byte[] logsBloom2 = new byte[Bloom.BLOOM_BYTES];
+        logsBloom2[0] = 0x01;
+        logsBloom2[1] = 0x02;
+        logsBloom2[2] = 0x03;
+        logsBloom2[3] = 0x05;
+        BlockHeaderExtensionV1 extension2 = new BlockHeaderExtensionV1(logsBloom2);
+
+        Assertions.assertFalse(Arrays.equals(extension1.getHash(), extension2.getHash()));
+    }
+
+    @Test
+    public void encodeDecode() {
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 0x01;
+        logsBloom[1] = 0x02;
+        logsBloom[2] = 0x03;
+        logsBloom[3] = 0x04;
+
+        BlockHeaderExtensionV1 extension = BlockHeaderExtensionV1.fromEncoded(
+                new BlockHeaderExtensionV1(logsBloom).getEncoded()
+        );
+
+        Assertions.assertArrayEquals(logsBloom, extension.getLogsBloom());
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
@@ -325,6 +325,19 @@ class BlockHeaderTest {
         });
     }
 
+    private void testHeaderVersion(int version) {
+        BlockHeader header = createBlockHeaderWithVersion(version);
+        assertEquals(version, header.getVersion());
+    }
+
+    @Test
+    public void getVersion0() { this.testHeaderVersion(0); }
+
+    @Test
+    public void getVersion1() {
+        this.testHeaderVersion(1);
+    }
+
     private BlockHeader createBlockHeaderWithMergedMiningFields(
             byte[] forkDetectionData,
             boolean includeForkDetectionData, byte[] ummRoot) {
@@ -352,11 +365,25 @@ class BlockHeaderTest {
     private BlockHeader createBlockHeader(byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
                                           byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] forkDetectionData,
                                           boolean includeForkDetectionData, byte[] ummRoot, boolean sealed) {
-        return createBlockHeader(bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
+        return createBlockHeader(0, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
                 forkDetectionData, includeForkDetectionData, ummRoot, true, sealed);
     }
 
     private BlockHeader createBlockHeader(byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
+                                          byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] forkDetectionData,
+                                          boolean includeForkDetectionData, byte[] ummRoot, boolean useRskip92Encoding,
+                                          boolean sealed) {
+        return createBlockHeader(0, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
+                forkDetectionData, includeForkDetectionData, ummRoot, useRskip92Encoding, sealed);
+    }
+
+    private BlockHeader createBlockHeaderWithVersion(int version) {
+        return createBlockHeader(version, new byte[80], new byte[32], new byte[128],
+                new byte[0], false, null, false, false);
+    }
+
+    private BlockHeader createBlockHeader(int version,
+                                          byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
                                           byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] forkDetectionData,
                                           boolean includeForkDetectionData, byte[] ummRoot, boolean useRskip92Encoding,
                                           boolean sealed) {
@@ -366,6 +393,7 @@ class BlockHeaderTest {
         long timestamp = 7731067; // Friday, 10 May 2019 6:04:05
 
         return new BlockHeader(
+                version,
                 PegTestUtils.createHash3().getBytes(),
                 HashUtil.keccak256(RLP.encodeList()),
                 new RskAddress(TestUtils.randomAddress().getBytes()),

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
@@ -325,17 +325,17 @@ class BlockHeaderTest {
         });
     }
 
-    private void testHeaderVersion(int version) {
+    private void testHeaderVersion(byte version) {
         BlockHeader header = createBlockHeaderWithVersion(version);
         assertEquals(version, header.getVersion());
     }
 
     @Test
-    public void getVersion0() { this.testHeaderVersion(0); }
+    public void getVersion0() { this.testHeaderVersion((byte) 0x0); }
 
     @Test
     public void getVersion1() {
-        this.testHeaderVersion(1);
+        this.testHeaderVersion((byte) 0x1);
     }
 
     private BlockHeader createBlockHeaderWithMergedMiningFields(
@@ -365,7 +365,7 @@ class BlockHeaderTest {
     private BlockHeader createBlockHeader(byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
                                           byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] forkDetectionData,
                                           boolean includeForkDetectionData, byte[] ummRoot, boolean sealed) {
-        return createBlockHeader(0, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
+        return createBlockHeader((byte) 0x0, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
                 forkDetectionData, includeForkDetectionData, ummRoot, true, sealed);
     }
 
@@ -373,16 +373,16 @@ class BlockHeaderTest {
                                           byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] forkDetectionData,
                                           boolean includeForkDetectionData, byte[] ummRoot, boolean useRskip92Encoding,
                                           boolean sealed) {
-        return createBlockHeader(0, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
+        return createBlockHeader((byte) 0x0, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
                 forkDetectionData, includeForkDetectionData, ummRoot, useRskip92Encoding, sealed);
     }
 
-    private BlockHeader createBlockHeaderWithVersion(int version) {
+    private BlockHeader createBlockHeaderWithVersion(byte version) {
         return createBlockHeader(version, new byte[80], new byte[32], new byte[128],
                 new byte[0], false, null, false, false);
     }
 
-    private BlockHeader createBlockHeader(int version,
+    private BlockHeader createBlockHeader(byte version,
                                           byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
                                           byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] forkDetectionData,
                                           boolean includeForkDetectionData, byte[] ummRoot, boolean useRskip92Encoding,

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderV0Test.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderV0Test.java
@@ -1,0 +1,69 @@
+package co.rsk.core;
+
+import co.rsk.peg.PegTestUtils;
+import org.ethereum.TestUtils;
+import org.ethereum.core.BlockHeaderExtensionV1;
+import org.ethereum.core.BlockHeaderV0;
+import org.ethereum.core.BlockHeaderV1;
+import org.ethereum.core.Bloom;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.RLP;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+public class BlockHeaderV0Test {
+    private BlockHeaderV0 createBlockHeader(byte[] logsBloom) {
+        return new BlockHeaderV0(
+                PegTestUtils.createHash3().getBytes(),
+                HashUtil.keccak256(RLP.encodeList()),
+                new RskAddress(TestUtils.randomAddress().getBytes()),
+                HashUtil.EMPTY_TRIE_HASH,
+                "tx_trie_root".getBytes(),
+                HashUtil.EMPTY_TRIE_HASH,
+                logsBloom,
+                new BlockDifficulty(BigInteger.ONE),
+                1,
+                BigInteger.valueOf(6800000).toByteArray(),
+                3000000,
+                7731067,
+                new byte[0],
+                Coin.ZERO,
+                new byte[80],
+                new byte[32],
+                new byte[128],
+                new byte[0],
+                Coin.valueOf(10L),
+                0,
+                false,
+                false,
+                false,
+                null
+        );
+    }
+
+    @Test
+    void hasNullExtension() {
+        BlockHeaderV0 header = createBlockHeader(TestUtils.randomBytes(256));
+        Assertions.assertEquals(null, header.getExtension());
+    }
+
+    @Test
+    void setsExtensionIsVoid() {
+        BlockHeaderV0 header = createBlockHeader(TestUtils.randomBytes(256));
+        byte[] bloom = Arrays.copyOf(header.getLogsBloom(), header.getLogsBloom().length);
+        header.setExtension(new BlockHeaderExtensionV1(TestUtils.randomBytes(256)));
+        Assertions.assertEquals(null, header.getExtension());
+        Assertions.assertArrayEquals(bloom, header.getLogsBloom());
+    }
+
+    @Test
+    void logsBloomFieldEncoded() {
+        byte[] bloom = TestUtils.randomBytes(256);
+        BlockHeaderV0 header = createBlockHeader(bloom);
+        byte[] field = RLP.decode2(header.getLogsBloomFieldEncoded()).get(0).getRLPData();
+        Assertions.assertArrayEquals(bloom, field);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderV1Test.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderV1Test.java
@@ -1,0 +1,105 @@
+package co.rsk.core;
+
+import co.rsk.peg.PegTestUtils;
+import org.ethereum.TestUtils;
+import org.ethereum.core.BlockHeaderExtensionV1;
+import org.ethereum.core.BlockHeaderV1;
+import org.ethereum.core.Bloom;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.RLP;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+public class BlockHeaderV1Test {
+    private BlockHeaderV1 createBlockHeader(byte[] logsBloom) {
+        return new BlockHeaderV1(
+                PegTestUtils.createHash3().getBytes(),
+                HashUtil.keccak256(RLP.encodeList()),
+                new RskAddress(TestUtils.randomAddress().getBytes()),
+                HashUtil.EMPTY_TRIE_HASH,
+                "tx_trie_root".getBytes(),
+                HashUtil.EMPTY_TRIE_HASH,
+                logsBloom,
+                new BlockDifficulty(BigInteger.ONE),
+                1,
+                BigInteger.valueOf(6800000).toByteArray(),
+                3000000,
+                7731067,
+                new byte[0],
+                Coin.ZERO,
+                new byte[80],
+                new byte[32],
+                new byte[128],
+                new byte[0],
+                Coin.valueOf(10L),
+                0,
+                false,
+                false,
+                false,
+                null
+        );
+    }
+
+    @Test
+    void createsAnExtensionWithGivenData() {
+        byte[] bloom = TestUtils.randomBytes(256);
+        BlockHeaderV1 header = createBlockHeader(bloom);
+        Assertions.assertArrayEquals(bloom, header.getExtension().getLogsBloom());
+    }
+
+    @Test
+    void setsExtension() {
+        byte[] bloom = TestUtils.randomBytes(256);
+        BlockHeaderV1 header = createBlockHeader(bloom);
+        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(bloom);
+        header.setExtension(extension);
+        Assertions.assertArrayEquals(extension.getEncoded(), header.getExtension().getEncoded());
+    }
+
+    @Test
+    void setsLogsBloomToExtension() {
+        byte[] bloom = TestUtils.randomBytes(256);
+        BlockHeaderV1 header = createBlockHeader(new byte[]{});
+        header.setLogsBloom(bloom);
+        Assertions.assertArrayEquals(bloom, header.getExtension().getLogsBloom());
+    }
+
+    @Test
+    void logsBloomFieldEncoded() {
+        byte[] bloom = TestUtils.randomBytes(256);
+        BlockHeaderV1 header = createBlockHeader(bloom);
+        byte[] field = RLP.decode2(header.getLogsBloomFieldEncoded()).get(0).getRLPData();
+        Assertions.assertEquals((byte) 0x1, field[0]);
+        for (int i = 33; i < 256; i++) Assertions.assertEquals((byte) 0x0, field[i]);
+        Assertions.assertEquals(field.length, Bloom.BLOOM_BYTES);
+    }
+
+    BlockHeaderV1 encodedHeaderWithRandomLogsBloom() {
+        return createBlockHeader(TestUtils.randomBytes(256));
+    }
+
+    byte[] getLogsBloomFieldHashPart(byte[] encodedHeader) {
+        return Arrays.copyOfRange(encodedHeader, 1, 33);
+    }
+
+    @Test
+    void logsBloomFieldEncodedIncludesExtensionHash() {
+        BlockHeaderV1 header = encodedHeaderWithRandomLogsBloom();
+        BlockHeaderExtensionV1 extension = Mockito.mock(BlockHeaderExtensionV1.class);
+        byte[] hash = TestUtils.randomBytes(32);
+        Mockito.when(extension.getHash()).thenReturn(hash);
+        header.setExtension(extension);
+        byte[] encoded = header.getLogsBloomFieldEncoded();
+
+        BlockHeaderExtensionV1 otherExtension = Mockito.mock(BlockHeaderExtensionV1.class);
+        byte[] otherHash = TestUtils.randomBytes(32);
+        Mockito.when(otherExtension.getHash()).thenReturn(otherHash);
+        header.setExtension(otherExtension);
+
+        Assertions.assertFalse(Arrays.equals(encoded, header.getLogsBloomFieldEncoded()));
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/mine/BlockToMineBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/BlockToMineBuilderTest.java
@@ -179,14 +179,14 @@ class BlockToMineBuilderTest {
 
     @Test
     public void buildBlockBeforeRskip351() {
-        when(activationConfig.getHeaderVersion(501L)).thenReturn(0);
+        when(activationConfig.getHeaderVersion(501L)).thenReturn((byte) 0x0);
         Block actualBlock = this.prepareForActivationTest();
         assertEquals(0, actualBlock.getHeader().getVersion());
     }
 
     @Test
     public void buildBlockAfterRskip351() {
-        when(activationConfig.getHeaderVersion(501L)).thenReturn(1);
+        when(activationConfig.getHeaderVersion(501L)).thenReturn((byte) 0x1);
         Block actualBlock = this.prepareForActivationTest();
         assertEquals(1, actualBlock.getHeader().getVersion());
     }
@@ -211,7 +211,7 @@ class BlockToMineBuilderTest {
 
     private BlockHeader createBlockHeader() {
         return new BlockHeader(
-                0,
+                (byte) 0x0,
                 EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, TestUtils.randomAddress(),
                 EMPTY_TRIE_HASH, null, EMPTY_TRIE_HASH,
                 new Bloom().getData(), BlockDifficulty.ZERO, 1L,

--- a/rskj-core/src/test/java/co/rsk/mine/BlockToMineBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/BlockToMineBuilderTest.java
@@ -210,8 +210,7 @@ class BlockToMineBuilderTest {
     }
 
     private BlockHeader createBlockHeader() {
-        return new BlockHeader(
-                (byte) 0x0,
+        return new BlockHeaderV0(
                 EMPTY_BYTE_ARRAY, EMPTY_BYTE_ARRAY, TestUtils.randomAddress(),
                 EMPTY_TRIE_HASH, null, EMPTY_TRIE_HASH,
                 new Bloom().getData(), BlockDifficulty.ZERO, 1L,

--- a/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SyncProcessorTest.java
@@ -577,7 +577,7 @@ class SyncProcessorTest {
                 mock(Genesis.class),
                 mock(EthereumListener.class));
 
-        BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), null, null);
+        BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), null, null, null);
         processor.registerExpectedMessage(response);
 
         processor.processBodyResponse(sender, response);
@@ -614,8 +614,9 @@ class SyncProcessorTest {
                 mock(EthereumListener.class));
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
+        BlockHeaderExtension extension = blockchain.getBestBlock().getHeader().getExtension();
         long lastRequestId = new Random().nextLong();
-        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles);
+        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles, extension);
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();
@@ -666,6 +667,7 @@ class SyncProcessorTest {
                 mock(Genesis.class),
                 listener);
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
+        BlockHeaderExtension extension = blockchain.getBestBlock().getHeader().getExtension();
         Account senderAccount = createAccount("sender");
         Account receiverAccount = createAccount("receiver");
         Transaction tx = createTransaction(senderAccount, receiverAccount, BigInteger.valueOf(1000000), BigInteger.ZERO);
@@ -673,7 +675,7 @@ class SyncProcessorTest {
         txs.add(tx);
 
         long lastRequestId = new Random().nextLong();
-        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, txs, uncles);
+        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, txs, uncles, extension);
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();
@@ -729,8 +731,9 @@ class SyncProcessorTest {
                 mock(EthereumListener.class));
         List<Transaction> transactions = blockchain.getBestBlock().getTransactionsList();
         List<BlockHeader> uncles = blockchain.getBestBlock().getUncleList();
+        BlockHeaderExtension extension = blockchain.getBestBlock().getHeader().getExtension();
         long lastRequestId = new Random().nextLong();
-        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles);
+        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles, extension);
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();
@@ -820,8 +823,9 @@ class SyncProcessorTest {
                 mock(EthereumListener.class));
         List<Transaction> transactions = block.getTransactionsList();
         List<BlockHeader> uncles = block.getUncleList();
+        BlockHeaderExtension extension = block.getHeader().getExtension();
         long lastRequestId = new Random().nextLong();
-        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles);
+        BodyResponseMessage response = new BodyResponseMessage(lastRequestId, transactions, uncles, extension);
         processor.registerExpectedMessage(response);
 
         Deque<BlockHeader> headerStack = new ArrayDeque<>();

--- a/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
@@ -289,7 +289,7 @@ class ThreeAsyncNodeUsingSyncProcessorTest {
         node3.waitUntilNTasksWithTimeout(setupRequests);
         node3.waitUntilNTasksWithTimeout(5);
         // synchronize 200 (extra tasks are from old sync protocol messages)
-        BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), null, null);
+        BodyResponseMessage response = new BodyResponseMessage(new Random().nextLong(), null, null, null);
         node3.getSyncProcessor().registerExpectedMessage(response);
         node3.getSyncProcessor().processBodyResponse(node1.getMessageChannel(node3), response);
         node3.waitExactlyNTasksWithTimeout(200 + setupRequests - 15);

--- a/rskj-core/src/test/java/co/rsk/net/messages/BodyResponseMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/BodyResponseMessageTest.java
@@ -36,7 +36,7 @@ class BodyResponseMessageTest {
             parent = block;
         }
 
-        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles);
+        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles, null);
 
         Assertions.assertEquals(100, message.getId());
 
@@ -69,7 +69,7 @@ class BodyResponseMessageTest {
         List<Transaction> transactions = new LinkedList<>();
         List<BlockHeader> uncles = new LinkedList<>();
 
-        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles);
+        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles, null);
 
         MessageVisitor visitor = mock(MessageVisitor.class);
 

--- a/rskj-core/src/test/java/co/rsk/net/messages/BodyResponseMessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/BodyResponseMessageTest.java
@@ -3,10 +3,7 @@ package co.rsk.net.messages;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
-import org.ethereum.core.Account;
-import org.ethereum.core.Block;
-import org.ethereum.core.BlockHeader;
-import org.ethereum.core.Transaction;
+import org.ethereum.core.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -18,8 +15,7 @@ import java.util.List;
 import static org.mockito.Mockito.*;
 
 class BodyResponseMessageTest {
-    @Test
-    void createMessage() {
+    BodyResponseMessage testCreateMessage(BlockHeaderExtension extension) {
         List<Transaction> transactions = new ArrayList<>();
 
         for (int k = 1; k <= 10; k++)
@@ -36,7 +32,7 @@ class BodyResponseMessageTest {
             parent = block;
         }
 
-        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles, null);
+        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles, extension);
 
         Assertions.assertEquals(100, message.getId());
 
@@ -52,6 +48,21 @@ class BodyResponseMessageTest {
 
         for (int k = 0; k < uncles.size(); k++)
             Assertions.assertArrayEquals(uncles.get(k).getFullEncoded(), message.getUncles().get(k).getFullEncoded());
+
+        return  message;
+    }
+    @Test
+    void createMessage() {
+        BodyResponseMessage message = testCreateMessage(null);
+        Assertions.assertNull(message.getBlockHeaderExtension());
+    }
+
+    @Test
+    void createMessageWithExtension() {
+        Bloom bloom = new Bloom();
+        BlockHeaderExtension extension = new BlockHeaderExtensionV1(bloom.getData());
+        BodyResponseMessage message = testCreateMessage(extension);
+        Assertions.assertArrayEquals(extension.getEncoded(), message.getBlockHeaderExtension().getEncoded());
     }
 
     private static Transaction createTransaction(int number) {

--- a/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/messages/MessageTest.java
@@ -26,6 +26,7 @@ import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
 import org.junit.jupiter.api.Assertions;
@@ -194,6 +195,8 @@ class MessageTest {
 
     @Test
     void encodeDecodeBlockHeadersResponseMessage() {
+        BlockGenerator blockGenerator = new BlockGenerator(Constants.regtest(), ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351));
+        BlockFactory blockFactory = new BlockFactory(ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351));
         List<BlockHeader> headers = new ArrayList<>();
 
         for (int k = 1; k <= 4; k++)
@@ -475,7 +478,7 @@ class MessageTest {
             parent = block;
         }
 
-        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles);
+        BodyResponseMessage message = new BodyResponseMessage(100, transactions, uncles, null);
 
         byte[] encoded = message.getEncoded();
 

--- a/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBackwardsBodiesSyncStateTest.java
@@ -182,7 +182,7 @@ class DownloadingBackwardsBodiesSyncStateTest {
             toRequest.addFirst(headerToRequest);
             when(syncEventsHandler.sendBodyRequest(any(), eq(headerToRequest))).thenReturn(i);
 
-            BodyResponseMessage response = new BodyResponseMessage(i, new LinkedList<>(), new LinkedList<>());
+            BodyResponseMessage response = new BodyResponseMessage(i, new LinkedList<>(), new LinkedList<>(), null);
             responses.addFirst(response);
 
             Block block = mock(Block.class);
@@ -248,7 +248,7 @@ class DownloadingBackwardsBodiesSyncStateTest {
             toRequest.addFirst(headerToRequest);
             when(syncEventsHandler.sendBodyRequest(any(), eq(headerToRequest))).thenReturn(i);
 
-            BodyResponseMessage response = new BodyResponseMessage(i, new LinkedList<>(), new LinkedList<>());
+            BodyResponseMessage response = new BodyResponseMessage(i, new LinkedList<>(), new LinkedList<>(), null);
             responses.addFirst(response);
 
             Block block = mock(Block.class);

--- a/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBodiesSyncStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/DownloadingBodiesSyncStateTest.java
@@ -85,7 +85,7 @@ class DownloadingBodiesSyncStateTest {
         pendingBodyResponses.put(messageId, pendingBodyResponse);
         TestUtils.setInternalState(state, "pendingBodyResponses", pendingBodyResponses);
 
-        BodyResponseMessage message = new BodyResponseMessage(33L, Collections.emptyList(), Collections.emptyList());
+        BodyResponseMessage message = new BodyResponseMessage(33L, Collections.emptyList(), Collections.emptyList(), null);
         state.newBody(message, peer);
         verify(peersInformation, times(1))
                 .reportEventToPeerScoring(peer, EventType.UNEXPECTED_MESSAGE,
@@ -111,7 +111,7 @@ class DownloadingBodiesSyncStateTest {
         pendingBodyResponses.put(messageId, pendingBodyResponse);
         TestUtils.setInternalState(state, "pendingBodyResponses", pendingBodyResponses);
 
-        BodyResponseMessage message = new BodyResponseMessage(messageId, Collections.emptyList(), Collections.emptyList());
+        BodyResponseMessage message = new BodyResponseMessage(messageId, Collections.emptyList(), Collections.emptyList(), null);
         state.newBody(message, peer);
         verify(peersInformation, times(1))
                 .reportEventToPeerScoring(peer, EventType.UNEXPECTED_MESSAGE,

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -288,6 +288,7 @@ class RemascTestRunner {
                 Block parentBlock, RskAddress coinbase, Block genesis, List<Transaction> txs,
                 BlockDifficulty finalDifficulty, Coin paidFees, List<BlockHeader> uncles, Keccak256 blockHash) {
             super(
+                    0,
                     parentBlock.getHash().getBytes(), RemascTestRunner.EMPTY_LIST_HASH, coinbase,
                     genesis.getStateRoot(), BlockHashesHelper.getTxTrieRoot(txs, true),
                     HashUtil.EMPTY_TRIE_HASH, new Bloom().getData(), finalDifficulty, parentBlock.getNumber() + 1,

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -281,14 +281,13 @@ class RemascTestRunner {
         );
     }
 
-    private static class HardcodedHashBlockHeader extends BlockHeader {
+    private static class HardcodedHashBlockHeader extends BlockHeaderV0 {
         private final Keccak256 blockHash;
 
         public HardcodedHashBlockHeader(
                 Block parentBlock, RskAddress coinbase, Block genesis, List<Transaction> txs,
                 BlockDifficulty finalDifficulty, Coin paidFees, List<BlockHeader> uncles, Keccak256 blockHash) {
             super(
-                    (byte) 0x0,
                     parentBlock.getHash().getBytes(), RemascTestRunner.EMPTY_LIST_HASH, coinbase,
                     genesis.getStateRoot(), BlockHashesHelper.getTxTrieRoot(txs, true),
                     HashUtil.EMPTY_TRIE_HASH, new Bloom().getData(), finalDifficulty, parentBlock.getNumber() + 1,

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTestRunner.java
@@ -288,7 +288,7 @@ class RemascTestRunner {
                 Block parentBlock, RskAddress coinbase, Block genesis, List<Transaction> txs,
                 BlockDifficulty finalDifficulty, Coin paidFees, List<BlockHeader> uncles, Keccak256 blockHash) {
             super(
-                    0,
+                    (byte) 0x0,
                     parentBlock.getHash().getBytes(), RemascTestRunner.EMPTY_LIST_HASH, coinbase,
                     genesis.getStateRoot(), BlockHashesHelper.getTxTrieRoot(txs, true),
                     HashUtil.EMPTY_TRIE_HASH, new Bloom().getData(), finalDifficulty, parentBlock.getNumber() + 1,

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/EthSubscriptionNotificationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/EthSubscriptionNotificationTest.java
@@ -20,6 +20,9 @@ package co.rsk.rpc.modules.eth.subscribe;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.rpc.JacksonBasedRpcSerializer;
 import co.rsk.rpc.JsonRpcSerializer;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.junit.jupiter.api.Test;
 
@@ -29,9 +32,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class EthSubscriptionNotificationTest {
-    private static final Block TEST_BLOCK = new BlockGenerator().createBlock(12, 0);
+    private static final Block TEST_BLOCK = new BlockGenerator(Constants.regtest(), ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351)).createBlock(12, 0);
     private static final String TEST_BLOCK_RESULT_JSON = "{\"difficulty\":\"0x20000\",\"extraData\":\"0x\",\"gasLimit\":\"0x2fefd8\",\"gasUsed\":\"0x0\",\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"miner\":\"0xe94aef644e428941ee0a3741f28d80255fddba7f\",\"number\":\"0xc\",\"parentHash\":\"0xbe5de0c9c661653c979ec457f610444dcd0048007e683b2d04ce05729af56280\",\"receiptsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"sha3Uncles\":\"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\",\"stateRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"timestamp\":\"0x1\",\"transactionsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"hash\":\"0x35b063d13f7d7b3c13ae508e2c2b3aa7e7ba110d4dda17f3d822ac24b1f952b7\"}";
-    private static final Block TEST_BLOCK_2 = new BlockGenerator().createBlock(12, 0, 1000000L);
+    private static final Block TEST_BLOCK_2 = new BlockGenerator(Constants.regtest(), ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351)).createBlock(12, 0, 1000000L);
     private static final String TEST_BLOCK_RESULT_JSON_2 = "{\"difficulty\":\"0x20000\",\"extraData\":\"0x\",\"gasLimit\":\"0xf4240\",\"gasUsed\":\"0x0\",\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"miner\":\"0xe94aef644e428941ee0a3741f28d80255fddba7f\",\"number\":\"0xc\",\"parentHash\":\"0x82d804adc43b6382427216a764963f77c612694065f19b3b97c804338c6ceeec\",\"receiptsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"sha3Uncles\":\"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\",\"stateRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"timestamp\":\"0x1\",\"transactionsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"hash\":\"0xa31b89729ad3f84b988a9418e629adf1de918dfcff8286ed65e06837574e80d8\"}";
 
     private static final String TEST_SYNC_RESULT_JSON = "{\"syncing\":true,\"status\":{\"startingBlock\":0,\"currentBlock\":1,\"highestBlock\":1000}}";

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -195,8 +195,6 @@ public class World {
         return this.blockExecutor;
     }
 
-    public RskSystemProperties getConfig() { return this.config; }
-
     public StateRootHandler getStateRootHandler() {
         return this.stateRootHandler;
     }

--- a/rskj-core/src/test/java/co/rsk/test/World.java
+++ b/rskj-core/src/test/java/co/rsk/test/World.java
@@ -80,12 +80,17 @@ public class World {
         this(new BlockChainBuilder());
     }
 
+
     public World(RskSystemProperties config) {
         this(new BlockChainBuilder().setConfig(config));
     }
 
     public World(ReceiptStore receiptStore) {
         this(new BlockChainBuilder().setReceiptStore(receiptStore));
+    }
+
+    public World(ReceiptStore receiptStore, RskSystemProperties config) {
+        this(new BlockChainBuilder().setReceiptStore(receiptStore).setConfig(config));
     }
 
     @VisibleForTesting
@@ -185,6 +190,8 @@ public class World {
 
         return this.blockExecutor;
     }
+
+    public RskSystemProperties getConfig() { return this.config; }
 
     public StateRootHandler getStateRootHandler() {
         return this.stateRootHandler;

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
@@ -19,6 +19,7 @@
 package co.rsk.test.builders;
 
 import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.TransactionExecutorFactory;
 import co.rsk.core.bc.BlockExecutor;
@@ -64,7 +65,7 @@ public class BlockBuilder {
     }
 
     public BlockBuilder(Blockchain blockChain, BridgeSupportFactory bridgeSupportFactory, BlockStore blockStore) {
-        this(blockChain, bridgeSupportFactory, blockStore, new BlockGenerator(Constants.regtest(), ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351)));
+        this(blockChain, bridgeSupportFactory, blockStore, new BlockGenerator());
     }
 
     public BlockBuilder parent(Block parent) {
@@ -107,10 +108,14 @@ public class BlockBuilder {
     }
 
     public Block build() {
+        final TestSystemProperties config = new TestSystemProperties();
+        return this.build(config);
+    }
+
+    public Block build(final RskSystemProperties config) {
         Block block = blockGenerator.createChildBlock(parent, txs, uncles, difficulty, this.minGasPrice, gasLimit);
 
         if (blockChain != null) {
-            final TestSystemProperties config = new TestSystemProperties();
             StateRootHandler stateRootHandler = new StateRootHandler(config.getActivationConfig(), new StateRootsStoreImpl(new HashMapDB()));
             BlockExecutor executor = new BlockExecutor(
                     config.getActivationConfig(),

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockBuilder.java
@@ -28,6 +28,9 @@ import co.rsk.db.StateRootsStoreImpl;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.trie.TrieStore;
 import org.bouncycastle.util.BigIntegers;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.BlockStore;
@@ -53,11 +56,15 @@ public class BlockBuilder {
     private final BridgeSupportFactory bridgeSupportFactory;
     private BlockStore blockStore;
 
-    public BlockBuilder(Blockchain blockChain, BridgeSupportFactory bridgeSupportFactory, BlockStore blockStore) {
+    public BlockBuilder(Blockchain blockChain, BridgeSupportFactory bridgeSupportFactory, BlockStore blockStore, BlockGenerator blockGenerator) {
         this.blockChain = blockChain;
-        this.blockGenerator = new BlockGenerator();
+        this.blockGenerator = blockGenerator;
         this.bridgeSupportFactory = bridgeSupportFactory;
         this.blockStore = blockStore;
+    }
+
+    public BlockBuilder(Blockchain blockChain, BridgeSupportFactory bridgeSupportFactory, BlockStore blockStore) {
+        this(blockChain, bridgeSupportFactory, blockStore, new BlockGenerator(Constants.regtest(), ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351)));
     }
 
     public BlockBuilder parent(Block parent) {

--- a/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BlockChainBuilder.java
@@ -281,12 +281,20 @@ public class BlockChainBuilder {
         return ofSize(size, false);
     }
 
+    public Blockchain ofSize(int size, BlockGenerator blockGenerator) {
+        return ofSize(size, false, Collections.emptyMap(), blockGenerator);
+    }
+
     public Blockchain ofSize(int size, boolean mining) {
         return ofSize(size, mining, Collections.emptyMap());
     }
 
+
     public Blockchain ofSize(int size, boolean mining, Map<RskAddress, AccountState> accounts) {
-        BlockGenerator blockGenerator = new BlockGenerator();
+        return ofSize(size, mining, accounts, new BlockGenerator());
+    }
+
+    public Blockchain ofSize(int size, boolean mining, Map<RskAddress, AccountState> accounts, BlockGenerator blockGenerator) {
         Genesis genesis = blockGenerator.getGenesisBlock(accounts);
         BlockChainImpl blockChain = setGenesis(genesis).build();
 

--- a/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
+++ b/rskj-core/src/test/java/co/rsk/test/dsl/WorldDslProcessor.java
@@ -18,6 +18,7 @@
 
 package co.rsk.test.dsl;
 
+import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
@@ -55,7 +56,8 @@ public class WorldDslProcessor {
     public WorldDslProcessor(World world) {
         this.world = world;
         BlockBuilder blockBuilder = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
-                                                     world.getBlockStore()).trieStore(world.getTrieStore());
+                                                     world.getBlockStore(), new BlockGenerator(world.getConfig().getNetworkConstants(), world.getConfig().getActivationConfig())
+        ).trieStore(world.getTrieStore());
         blockBuilder.parent(world.getBlockChain().getBestBlock());
         this.blockBuilder = blockBuilder;
     }

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -178,6 +178,6 @@ class ActivationConfigTest {
     @Test
     public void headerVersion1() {
         ActivationConfig config = ActivationConfigsForTest.all();
-        Assertions.assertEquals((byte) 0x1,, config.getHeaderVersion(10));
+        Assertions.assertEquals((byte) 0x1, config.getHeaderVersion(10));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -172,12 +172,12 @@ class ActivationConfigTest {
     @Test
     public void headerVersion0() {
         ActivationConfig config = ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351);
-        Assertions.assertEquals(0, config.getHeaderVersion(10));
+        Assertions.assertEquals((byte) 0x0, config.getHeaderVersion(10));
     }
 
     @Test
     public void headerVersion1() {
         ActivationConfig config = ActivationConfigsForTest.all();
-        Assertions.assertEquals(1, config.getHeaderVersion(10));
+        Assertions.assertEquals((byte) 0x1,, config.getHeaderVersion(10));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class ActivationConfigTest {
     private static final Config BASE_CONFIG = ConfigFactory.parseString(String.join("\n",
@@ -102,6 +101,7 @@ class ActivationConfigTest {
             "    rskip293: hop400",
             "    rskip294: hop400",
             "    rskip297: hop400",
+            "    rskip351: fingerroot500",
             "}"
     ));
 
@@ -167,5 +167,17 @@ class ActivationConfigTest {
     void failsReadingWithUnknownUpgradeConfiguration() {
         Config config = BASE_CONFIG.withValue("consensusRules.rskip420", ConfigValueFactory.fromAnyRef("orchid"));
         Assertions.assertThrows(IllegalArgumentException.class, () -> ActivationConfig.read(config));
+    }
+
+    @Test
+    public void headerVersion0() {
+        ActivationConfig config = ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351);
+        Assertions.assertEquals(0, config.getHeaderVersion(10));
+    }
+
+    @Test
+    public void headerVersion1() {
+        ActivationConfig config = ActivationConfigsForTest.all();
+        Assertions.assertEquals(1, config.getHeaderVersion(10));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/core/BlockHeaderBuilderTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockHeaderBuilderTest.java
@@ -419,22 +419,22 @@ class BlockHeaderBuilderTest {
     public void createsHeaderWithVersion0BeforeRskip351() {
         // RSKIP351 = -1
         BlockHeader header = new BlockHeaderBuilder(ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351)).build();
-        assertEquals(0, header.getVersion());
+        assertEquals((byte) 0x0, header.getVersion());
     }
 
     @Test
     public void createHeaderWithVersion0BeforeRskip351() {
         // RSKIP351 > header number
         ActivationConfig activationConfig = Mockito.mock(ActivationConfig.class);
-        when(activationConfig.getHeaderVersion(geq(2))).thenReturn(0);
+        when(activationConfig.getHeaderVersion(geq(2))).thenReturn((byte) 0x0);
         BlockHeader header = new BlockHeaderBuilder(activationConfig).setNumber(1).build();
-        assertEquals(0, header.getVersion());
+        assertEquals((byte) 0x0, header.getVersion());
     }
 
     @Test
     public void createHeaderWithVersion1AfterRskip351() {
         // RSKIP351 = 0
         BlockHeader header = new BlockHeaderBuilder(ActivationConfigsForTest.all()).build();
-        assertEquals(1, header.getVersion());
+        assertEquals((byte) 0x1, header.getVersion());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/core/BlockHeaderBuilderTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockHeaderBuilderTest.java
@@ -416,14 +416,14 @@ class BlockHeaderBuilderTest {
     }
 
     @Test
-    public void createsHeaderWithVersion0BeforeRskip351() {
+    public void createsHeaderWithVersion0WithNoRskip351() {
         // RSKIP351 = -1
         BlockHeader header = new BlockHeaderBuilder(ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351)).build();
         assertEquals((byte) 0x0, header.getVersion());
     }
 
     @Test
-    public void createHeaderWithVersion0BeforeRskip351() {
+    public void createsHeaderWithVersion0BeforeRskip351() {
         // RSKIP351 > header number
         ActivationConfig activationConfig = Mockito.mock(ActivationConfig.class);
         when(activationConfig.getHeaderVersion(geq(2))).thenReturn((byte) 0x0);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -27,6 +27,10 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import co.rsk.blockchain.utils.BlockGenerator;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Account;
 import org.ethereum.core.Block;
 import org.ethereum.core.Blockchain;
@@ -1176,7 +1180,7 @@ class Web3ImplLogsTest {
 
         List<Transaction> txs = new ArrayList<>();
         txs.add(tx);
-        Block block1 = new BlockBuilder(blockChain, null, blockStore)
+        Block block1 = new BlockBuilder(blockChain, null, blockStore, new BlockGenerator(Constants.regtest(), ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351)))
                 .trieStore(trieStore).parent(genesis).transactions(txs).build();
         assertEquals(ImportResult.IMPORTED_BEST, blockChain.tryToConnect(block1));
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -18,6 +18,7 @@
 
 package org.ethereum.rpc;
 
+import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.RskSystemProperties;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.*;
@@ -58,6 +59,9 @@ import co.rsk.util.HexUtils;
 import co.rsk.util.TestContract;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -1038,8 +1042,12 @@ class Web3ImplTest {
         Block block1 = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
                 world.getBlockStore()).trieStore(world.getTrieStore()).difficulty(10).parent(genesis).build();
         assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
-        Block block1b = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
-                world.getBlockStore()).trieStore(world.getTrieStore()).difficulty(2).parent(genesis).build();
+        Block block1b = new BlockBuilder(
+                world.getBlockChain(),
+                world.getBridgeSupportFactory(),
+                world.getBlockStore(),
+                new BlockGenerator(Constants.regtest(), ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351)))
+                .trieStore(world.getTrieStore()).difficulty(2).parent(genesis).build();
         block1b.setBitcoinMergedMiningHeader(new byte[]{0x01});
         Block block2b = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
                 world.getBlockStore()).trieStore(world.getTrieStore()).difficulty(11).parent(block1b).build();
@@ -1180,8 +1188,11 @@ class Web3ImplTest {
                 world.getBlockStore()).trieStore(world.getTrieStore()).difficulty(10).parent(genesis).build();
         block1.setBitcoinMergedMiningHeader(new byte[]{0x01});
         assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
-        Block block1b = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
-                world.getBlockStore()).trieStore(world.getTrieStore()).difficulty(block1.getDifficulty().asBigInteger().longValue() - 1).parent(genesis).build();
+        Block block1b = new BlockBuilder(
+                world.getBlockChain(),
+                world.getBridgeSupportFactory(),
+                world.getBlockStore(),
+                new BlockGenerator(Constants.regtest(), ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351))).trieStore(world.getTrieStore()).difficulty(block1.getDifficulty().asBigInteger().longValue() - 1).parent(genesis).build();
         block1b.setBitcoinMergedMiningHeader(new byte[]{0x01});
         Block block2b = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
                 world.getBlockStore()).trieStore(world.getTrieStore()).difficulty(2).parent(block1b).build();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implementation for RSKIP 351. Summary:
- some info of the block header is passed as header extension on body message
- the encoded block header has the hash of the extension in the rlp list on logs bloom element position padded to the same size to keep header-only clients compatible

## Motivation and Context
- new info is added to the block header, this rskip prevents block header message to become larger

## How Has This Been Tested?
Tests added activating/deactivating RSKIP351 or Fingerroot500 associated hard fork

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)


* **Other information**:
