### PR TITLE
Fixing addBalance with zero

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
+++ b/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java
@@ -296,7 +296,7 @@ public class MutableRepository implements Repository {
     public synchronized Coin addBalance(RskAddress addr, Coin value) {
         AccountState account = getAccountStateOrCreateNew(addr);
 
-        if (value == Coin.ZERO) {
+        if (value.equals(Coin.ZERO)) {
             return account.getBalance();
         }
 

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
@@ -148,8 +148,34 @@ public class RepositoryTrackingTest {
     }
 
     @Test
-    void addZeroBalanceShouldNotWriteAKey() {
-        repository.createAccount(COW);
+    public void tracksReadAndWriteOnAddBalanceOfNonExistent () {
+        repository.addBalance(COW, Coin.valueOf(1));
+
+        assertRepositoryHasSize(1, 1);
+    }
+
+    @Test
+    public void tracksReadAndWriteOnAddBalanceZeroOfNonExistent () {
+        repository.addBalance(COW, Coin.valueOf(0));
+
+        assertRepositoryHasSize(1, 1);
+    }
+
+    @Test
+    public void tracksReadAndWriteOnAddBalanceOfExistent () {
+        repository.addBalance(COW, Coin.valueOf(1));
+
+        tracker.clear();
+
+        repository.addBalance(COW, Coin.valueOf(1));
+
+        assertRepositoryHasSize(1, 1);
+    }
+
+    @Test
+    public void doesntTrackWriteOnAddBalanceZeroOfExistent () {
+        repository.addBalance(COW, Coin.valueOf(1));
+
         tracker.clear();
 
         repository.addBalance(COW, Coin.valueOf(0));

--- a/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/RepositoryTrackingTest.java
@@ -147,31 +147,9 @@ public class RepositoryTrackingTest {
         assertRepositoryHasSize(1, 1);
     }
 
-    public void tracksReadAndWriteOnAddBalanceOfNonExistent () {
-        repository.addBalance(COW, Coin.valueOf(1));
-
-        assertRepositoryHasSize(1, 1);
-    }
-
-    public void tracksReadAndWriteOnAddBalanceZeroOfNonExistent () {
-        repository.addBalance(COW, Coin.valueOf(0));
-
-        assertRepositoryHasSize(1, 1);
-    }
-
-    public void tracksReadAndWriteOnAddBalanceOfExistent () {
-        repository.addBalance(COW, Coin.valueOf(1));
-
-        tracker.clear();
-
-        repository.addBalance(COW, Coin.valueOf(1));
-
-        assertRepositoryHasSize(1, 1);
-    }
-
-    public void doesntTrackWriteOnAddBalanceZeroOfExistent () {
-        repository.addBalance(COW, Coin.valueOf(1));
-
+    @Test
+    void addZeroBalanceShouldNotWriteAKey() {
+        repository.createAccount(COW);
         tracker.clear();
 
         repository.addBalance(COW, Coin.valueOf(0));


### PR DESCRIPTION
The checking: `value == Coin.Zero` returns false even when the value is Coin.Zero. It was fixed with value.equals(Coin.Zero)
and tested. Also, It was removed some ignored tests.