### PR TITLE
RSKIP 351 updates

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/messages/BlockHeadersResponseMessage.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/BlockHeadersResponseMessage.java
@@ -32,7 +32,7 @@ public class BlockHeadersResponseMessage extends MessageWithId {
     @Override
     protected byte[] getEncodedMessageWithoutId() {
         byte[][] rlpHeaders = this.blockHeaders.stream()
-                .map(BlockHeader::getEncodedForHeaderMessage)
+                .map(BlockHeader::getEncodedCompressed)
                 .toArray(byte[][]::new);
 
         return RLP.encodeList(RLP.encodeList(rlpHeaders));

--- a/rskj-core/src/main/java/co/rsk/net/messages/MessageType.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/MessageType.java
@@ -143,7 +143,7 @@ public enum MessageType {
 
             for (int k = 0; k < rlpHeaders.size(); k++) {
                 RLPElement element = rlpHeaders.get(k);
-                BlockHeader header = blockFactory.decodeHeader(element.getRLPData());
+                BlockHeader header = blockFactory.decodeHeader(element.getRLPData(), true);
                 headers.add(header);
             }
 
@@ -229,7 +229,7 @@ public enum MessageType {
 
             for (int j = 0; j < rlpUncles.size(); j++) {
                 RLPElement element = rlpUncles.get(j);
-                uncles.add(blockFactory.decodeHeader(element.getRLPData()));
+                uncles.add(blockFactory.decodeHeader(element.getRLPData(), false));
             }
 
             BlockHeaderExtension blockHeaderExtension = message.size() == 3

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -204,27 +204,15 @@ public class BlockFactory {
         }
 
         if (version == 1) {
-            if (compressed) {
-                return new BlockHeaderV1(
-                        parentHash, unclesHash, coinbase, stateRoot,
-                        txTrieRoot, receiptTrieRoot, extensionData, difficulty,
-                        blockNumber, glBytes, gasUsed, timestamp, extraData,
-                        paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
-                        bitcoinMergedMiningCoinbaseTransaction, new byte[0],
-                        minimumGasPrice, uncleCount, sealed, useRskip92Encoding, includeForkDetectionData,
-                        ummRoot
-                );
-            } else {
-                return new BlockHeaderV1(
-                        parentHash, unclesHash, coinbase, stateRoot,
-                        txTrieRoot, receiptTrieRoot, extensionData, difficulty,
-                        blockNumber, glBytes, gasUsed, timestamp, extraData,
-                        paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
-                        bitcoinMergedMiningCoinbaseTransaction, new byte[0],
-                        minimumGasPrice, uncleCount, sealed, useRskip92Encoding, includeForkDetectionData,
-                        ummRoot, txExecutionSublistsEdges
-                );
-            }
+            return new BlockHeaderV1(
+                    parentHash, unclesHash, coinbase, stateRoot,
+                    txTrieRoot, receiptTrieRoot, extensionData, difficulty,
+                    blockNumber, glBytes, gasUsed, timestamp, extraData,
+                    paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
+                    bitcoinMergedMiningCoinbaseTransaction, new byte[0],
+                    minimumGasPrice, uncleCount, sealed, useRskip92Encoding, includeForkDetectionData,
+                    ummRoot, txExecutionSublistsEdges, compressed
+            );
         }
 
         return new BlockHeaderV0(

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -117,7 +117,7 @@ public class BlockFactory {
             receiptTrieRoot = EMPTY_TRIE_HASH;
         }
 
-        byte[] logsBloomField = rlpHeader.get(6).getRLPData(); // logs bloom when decoding extended, list(version, hash(extension)) when compressed
+        byte[] extensionData = rlpHeader.get(6).getRLPData(); // rskip351: logs bloom when decoding extended, list(version, hash(extension)) when compressed
         byte[] difficultyBytes = rlpHeader.get(7).getRLPData();
         BlockDifficulty difficulty = RLP.parseBlockDifficulty(difficultyBytes);
 
@@ -158,7 +158,7 @@ public class BlockFactory {
 
         if (activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber)) {
             version = compressed
-                    ? RLP.decodeList(logsBloomField).get(0).getRLPData()[0]
+                    ? RLP.decodeList(extensionData).get(0).getRLPData()[0]
                     : rlpHeader.get(r++).getRLPData()[0];
         }
 
@@ -187,7 +187,7 @@ public class BlockFactory {
             return new GenesisHeader(
                     parentHash,
                     unclesHash,
-                    logsBloomField,
+                    extensionData,
                     difficultyBytes,
                     blockNumber,
                     glBytes,
@@ -207,7 +207,7 @@ public class BlockFactory {
             if (compressed) {
                 return new BlockHeaderV1(
                         parentHash, unclesHash, coinbase, stateRoot,
-                        txTrieRoot, receiptTrieRoot, logsBloomField, difficulty,
+                        txTrieRoot, receiptTrieRoot, extensionData, difficulty,
                         blockNumber, glBytes, gasUsed, timestamp, extraData,
                         paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
                         bitcoinMergedMiningCoinbaseTransaction, new byte[0],
@@ -217,7 +217,7 @@ public class BlockFactory {
             } else {
                 return new BlockHeaderV1(
                         parentHash, unclesHash, coinbase, stateRoot,
-                        txTrieRoot, receiptTrieRoot, logsBloomField, difficulty,
+                        txTrieRoot, receiptTrieRoot, extensionData, difficulty,
                         blockNumber, glBytes, gasUsed, timestamp, extraData,
                         paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
                         bitcoinMergedMiningCoinbaseTransaction, new byte[0],
@@ -229,7 +229,7 @@ public class BlockFactory {
 
         return new BlockHeaderV0(
                 parentHash, unclesHash, coinbase, stateRoot,
-                txTrieRoot, receiptTrieRoot, logsBloomField, difficulty,
+                txTrieRoot, receiptTrieRoot, extensionData, difficulty,
                 blockNumber, glBytes, gasUsed, timestamp, extraData,
                 paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
                 bitcoinMergedMiningCoinbaseTransaction, new byte[0],

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -241,17 +241,18 @@ public class BlockFactory {
     private boolean canBeDecoded(RLPList rlpHeader, long blockNumber, boolean compressed) {
         int preUmmHeaderSizeAdjustment = activationConfig.isActive(ConsensusRule.RSKIPUMM, blockNumber) ? 0 : 1;
         int preParallelSizeAdjustment = activationConfig.isActive(ConsensusRule.RSKIP144, blockNumber) ? 0 : 1;
-        int preRSKIP351SizeAdjustment = activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber) ? 0 : 1;
+        int preRSKIP351SizeAdjustment = getRSKIP351SizeAdjustment(blockNumber, compressed, preParallelSizeAdjustment);
 
-        int compressionSizeAdjustment = 0;
-        if (activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber) && compressed) {
-            compressionSizeAdjustment = activationConfig.isActive(ConsensusRule.RSKIP144, blockNumber) ? 2 : 1;
-        }
-
-        int expectedSize = RLP_HEADER_SIZE - preUmmHeaderSizeAdjustment - preParallelSizeAdjustment - preRSKIP351SizeAdjustment - compressionSizeAdjustment;
-        int expectedSizeMM = RLP_HEADER_SIZE_WITH_MERGED_MINING - preUmmHeaderSizeAdjustment - preParallelSizeAdjustment - preRSKIP351SizeAdjustment - compressionSizeAdjustment;
+        int expectedSize = RLP_HEADER_SIZE - preUmmHeaderSizeAdjustment - preParallelSizeAdjustment - preRSKIP351SizeAdjustment;
+        int expectedSizeMM = RLP_HEADER_SIZE_WITH_MERGED_MINING - preUmmHeaderSizeAdjustment - preParallelSizeAdjustment - preRSKIP351SizeAdjustment;
 
         return rlpHeader.size() == expectedSize || rlpHeader.size() == expectedSizeMM;
+    }
+
+    private int getRSKIP351SizeAdjustment(long blockNumber, boolean compressed, int preParallelSizeAdjustment) {
+        if (!activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber)) return 1; // remove version
+        if (compressed) return 2 - preParallelSizeAdjustment; // remove version and edges if existent
+        return 0;
     }
 
     private static BigInteger parseBigInteger(byte[] bytes) {

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -164,10 +164,9 @@ public class BlockFactory {
 
         short[] txExecutionSublistsEdges = null;
 
-        if (!activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber) || !compressed) {
-            if (rlpHeader.size() > r && activationConfig.isActive(ConsensusRule.RSKIP144, blockNumber)) {
-                txExecutionSublistsEdges = ByteUtil.rlpToShorts(rlpHeader.get(r++).getRLPRawData());
-            }
+        if ((!activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber) || !compressed) &&
+                (rlpHeader.size() > r && activationConfig.isActive(ConsensusRule.RSKIP144, blockNumber))) {
+            txExecutionSublistsEdges = ByteUtil.rlpToShorts(rlpHeader.get(r++).getRLPRawData());
         }
 
         byte[] bitcoinMergedMiningHeader = null;
@@ -183,6 +182,20 @@ public class BlockFactory {
         boolean includeForkDetectionData = activationConfig.isActive(ConsensusRule.RSKIP110, blockNumber) &&
                 blockNumber >= MiningConfig.REQUIRED_NUMBER_OF_BLOCKS_FOR_FORK_DETECTION_CALCULATION;
 
+        return createBlockHeader(compressed, sealed, parentHash, unclesHash,
+                coinBaseBytes, coinbase, stateRoot, txTrieRoot, receiptTrieRoot, extensionData,
+                difficultyBytes, difficulty, glBytes, blockNumber, gasUsed, timestamp, extraData,
+                paidFees, minimumGasPriceBytes, minimumGasPrice, uncleCount, ummRoot, version, txExecutionSublistsEdges,
+                bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
+                useRskip92Encoding, includeForkDetectionData);
+    }
+
+    private BlockHeader createBlockHeader(boolean compressed, boolean sealed, byte[] parentHash, byte[] unclesHash,
+                                          byte[] coinBaseBytes, RskAddress coinbase, byte[] stateRoot, byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] extensionData,
+                                          byte[] difficultyBytes, BlockDifficulty difficulty, byte[] glBytes, long blockNumber, long gasUsed, long timestamp, byte[] extraData,
+                                          Coin paidFees, byte[] minimumGasPriceBytes, Coin minimumGasPrice, int uncleCount, byte[] ummRoot, byte version, short[] txExecutionSublistsEdges,
+                                          byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof, byte[] bitcoinMergedMiningCoinbaseTransaction,
+                                          boolean useRskip92Encoding, boolean includeForkDetectionData) {
         if (blockNumber == Genesis.NUMBER) {
             return new GenesisHeader(
                     parentHash,
@@ -238,8 +251,14 @@ public class BlockFactory {
     }
 
     private int getRSKIP351SizeAdjustment(long blockNumber, boolean compressed, int preParallelSizeAdjustment) {
-        if (!activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber)) return 1; // remove version
-        if (compressed) return 2 - preParallelSizeAdjustment; // remove version and edges if existent
+        if (!activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber)) {
+            return 1; // remove version
+        }
+
+        if (compressed) {
+            return 2 - preParallelSizeAdjustment; // remove version and edges if existent
+        }
+
         return 0;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -370,10 +370,6 @@ public abstract class BlockHeader {
             fieldToEncodeList.add(RLP.encodeElement(this.ummRoot));
         }
 
-        if (this.getVersion() > 0) {
-            fieldToEncodeList.add(RLP.encodeByte(this.getVersion()));
-        }
-
         this.addExtraFieldsToEncodedHeader(compressed, fieldToEncodeList);
 
         if (withMergedMiningFields && hasMiningFields()) {

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeader.java
@@ -51,8 +51,7 @@ public abstract class BlockHeader {
     public abstract void setExtension(BlockHeaderExtension extension);
 
     // contains the logs bloom or the hash of the extension depending on version
-    protected byte[] extensionData;
-    public byte[] getExtensionData() { return this.extensionData; };
+    public byte[] getExtensionData() { return this.extensionData; }
 
     // fields from block header extension
     public abstract byte[] getLogsBloom();
@@ -120,6 +119,8 @@ public abstract class BlockHeader {
     private byte[] miningForkDetectionData;
 
     private final byte[] ummRoot;
+
+    protected byte[] extensionData;
 
     /**
      * The mgp for a tx to be included in the block.

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
@@ -333,7 +333,7 @@ public class BlockHeaderBuilder {
             }
         }
 
-        if (createParallelCompliantHeader && txExecutionSublistsEdges == null) {
+        if (activationConfig.isActive(ConsensusRule.RSKIP144, number) && createParallelCompliantHeader && txExecutionSublistsEdges == null) {
             txExecutionSublistsEdges = new short[0];
         }
 

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderBuilder.java
@@ -348,7 +348,7 @@ public class BlockHeaderBuilder {
                 mergedMiningForkDetectionData,
                 minimumGasPrice, uncleCount,
                 false, useRskip92Encoding,
-                includeForkDetectionData, ummRoot, txExecutionSublistsEdges
+                includeForkDetectionData, ummRoot, txExecutionSublistsEdges, false
         );
 
         return new BlockHeaderV0(

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtension.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtension.java
@@ -3,8 +3,8 @@ package org.ethereum.core;
 import org.ethereum.util.RLPList;
 
 public interface BlockHeaderExtension {
-    byte getHeaderVersion();
     byte[] getEncoded();
+    byte[] getHash();
 
     static BlockHeaderExtension fromEncoded(RLPList encoded) {
         byte version = encoded.get(0).getRLPData()[0];

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV1.java
@@ -10,9 +10,6 @@ import java.util.Arrays;
 import java.util.List;
 
 public class BlockHeaderExtensionV1 implements BlockHeaderExtension {
-    @Override
-    public byte getHeaderVersion() { return 0x1; }
-
     private byte[] logsBloom;
     private short[] txExecutionSublistsEdges;
 
@@ -20,35 +17,43 @@ public class BlockHeaderExtensionV1 implements BlockHeaderExtension {
     public void setLogsBloom(byte[] logsBloom) { this.logsBloom = logsBloom; }
 
     public short[] getTxExecutionSublistsEdges() { return this.txExecutionSublistsEdges != null ? Arrays.copyOf(this.txExecutionSublistsEdges, this.txExecutionSublistsEdges.length) : null; }
-
-    public void setTxExecutionSublistsEdges(short[] edges) {
-        this.txExecutionSublistsEdges =  edges != null? Arrays.copyOf(edges, edges.length) : null;
-    }
+    public void setTxExecutionSublistsEdges(short[] edges) { this.txExecutionSublistsEdges =  edges != null? Arrays.copyOf(edges, edges.length) : null; }
 
     public BlockHeaderExtensionV1(byte[] logsBloom, short[] edges) {
         this.logsBloom = logsBloom;
         this.txExecutionSublistsEdges = edges != null ? Arrays.copyOf(edges, edges.length) : null;
     }
 
+    @Override
     public byte[] getHash() {
-        return HashUtil.keccak256(this.getEncoded());
+        return HashUtil.keccak256(this.getEncodedForHash());
     }
 
-    @Override
-    public byte[] getEncoded() {
-        List<byte[]> fieldToEncodeList = Lists.newArrayList(RLP.encodeByte(this.getHeaderVersion()), RLP.encodeElement(this.getLogsBloom()));
+    private void addEdgesEncoded(List<byte[]> fieldToEncodeList) {
         short[] txExecutionSublistsEdges = this.getTxExecutionSublistsEdges();
         if (txExecutionSublistsEdges != null) {
             fieldToEncodeList.add(ByteUtil.shortsToRLP(this.getTxExecutionSublistsEdges()));
         }
+    }
+
+    private byte[] getEncodedForHash() {
+        List<byte[]> fieldToEncodeList = Lists.newArrayList(RLP.encodeElement(HashUtil.keccak256(this.getLogsBloom())));
+        this.addEdgesEncoded(fieldToEncodeList);
+        return RLP.encodeList(fieldToEncodeList.toArray(new byte[][]{}));
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        List<byte[]> fieldToEncodeList = Lists.newArrayList(RLP.encodeElement(this.getLogsBloom()));
+        this.addEdgesEncoded(fieldToEncodeList);
         return RLP.encodeList(fieldToEncodeList.toArray(new byte[][]{}));
     }
 
     public static BlockHeaderExtensionV1 fromEncoded(byte[] encoded) {
         RLPList rlpExtension = RLP.decodeList(encoded);
         return new BlockHeaderExtensionV1(
-                rlpExtension.get(1).getRLPData(),
-                rlpExtension.size() == 3 ? ByteUtil.rlpToShorts(rlpExtension.get(2).getRLPData()): null
+                rlpExtension.get(0).getRLPData(),
+                rlpExtension.size() == 2 ? ByteUtil.rlpToShorts(rlpExtension.get(1).getRLPData()): null
         );
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV0.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV0.java
@@ -79,8 +79,11 @@ public class BlockHeaderV0 extends BlockHeader {
 
     @Override
     public void addExtraFieldsToEncodedHeader(boolean usingCompressedEncoding, List<byte[]> fieldsToEncode) {
-        // block headers v0 encoded should remain the same
-        // edges are added using compressed encoding too
+        // adding edges to
+        // 1. keep RSKIP 351 and RSKIP 144 independent
+        //    either can be activated at any height independently
+        // 2. keep compressed encoding the same as uncompressed
+        //    since this difference should not exist on v0
         this.addTxExecutionSublistsEdgesIfAny(fieldsToEncode);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV0.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV0.java
@@ -37,7 +37,6 @@ public class BlockHeaderV0 extends BlockHeader {
         // block header v0 has no extension
     }
 
-    private byte[] logsBloom;
     private short[] txExecutionSublistsEdges;
 
     public BlockHeaderV0(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
@@ -48,41 +47,40 @@ public class BlockHeaderV0 extends BlockHeader {
         Coin minimumGasPrice, int uncleCount, boolean sealed,
         boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot, short[] txExecutionSublistsEdges) {
         super(parentHash,unclesHash, coinbase, stateRoot,
-                txTrieRoot, receiptTrieRoot, difficulty,
+                txTrieRoot, receiptTrieRoot, logsBloom, difficulty,
                 number, gasLimit, gasUsed, timestamp, extraData,
                 paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
                 bitcoinMergedMiningCoinbaseTransaction, mergedMiningForkDetectionData,
                 minimumGasPrice, uncleCount, sealed,
                 useRskip92Encoding, includeForkDetectionData, ummRoot);
-        this.logsBloom = logsBloom;
         this.txExecutionSublistsEdges = txExecutionSublistsEdges != null ? Arrays.copyOf(txExecutionSublistsEdges, txExecutionSublistsEdges.length) : null;
     }
 
+    // logs bloom is stored in the extension data
     @Override
-    public byte[] getLogsBloom() { return logsBloom; }
-
+    public byte[] getLogsBloom() { return extensionData; }
+    @Override
     public void setLogsBloom(byte[] logsBloom) {
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter logs bloom");
         }
         this.hash = null;
 
-        this.logsBloom = logsBloom;
+        this.extensionData = logsBloom;
     }
 
+    @Override
     public short[] getTxExecutionSublistsEdges() { return this.txExecutionSublistsEdges != null ? Arrays.copyOf(this.txExecutionSublistsEdges, this.txExecutionSublistsEdges.length) : null; }
 
+    @Override
     public void setTxExecutionSublistsEdges(short[] edges) {
         this.txExecutionSublistsEdges =  edges != null? Arrays.copyOf(edges, edges.length) : null;
     }
 
     @Override
-    public byte[] getLogsBloomFieldEncoded() {
-        return RLP.encodeElement(this.logsBloom);
-    }
-
-    @Override
-    public void addExtraFieldsToEncoded(boolean useExtensionEncoding, List<byte[]> fieldsToEncode) {
+    public void addExtraFieldsToEncodedHeader(boolean usingCompressedEncoding, List<byte[]> fieldsToEncode) {
+        // block headers v0 encoded should remain the same
+        // edges are added using compressed encoding too
         this.addTxExecutionSublistsEdgesIfAny(fieldsToEncode);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
@@ -19,46 +19,25 @@ public class BlockHeaderV1 extends BlockHeader {
     @Override
     public void setExtension(BlockHeaderExtension extension) { this.extension = (BlockHeaderExtensionV1) extension; }
 
-    // this constructor is used when all the header info is existent
-    public BlockHeaderV1(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
-                         byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] logsBloom, BlockDifficulty difficulty,
-                         long number, byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
-                         Coin paidFees, byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
-                         byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] mergedMiningForkDetectionData,
-                         Coin minimumGasPrice, int uncleCount, boolean sealed,
-                         boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot, short[] txExecutionSublistsEdges) {
-        super(parentHash,unclesHash, coinbase, stateRoot,
-                txTrieRoot, receiptTrieRoot, null, difficulty,
-                number, gasLimit, gasUsed, timestamp, extraData,
-                paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
-                bitcoinMergedMiningCoinbaseTransaction, mergedMiningForkDetectionData,
-                minimumGasPrice, uncleCount, sealed,
-                useRskip92Encoding, includeForkDetectionData, ummRoot);
-
-        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(logsBloom, txExecutionSublistsEdges);
-
-        this.extensionData = BlockHeaderV1.createExtensionData(extension.getHash()); // update after calculating
-        this.extension = extension;
-    }
-
-    // this constructor is used when header is created with compressed encoding and receives extension
-    // on body message
     public BlockHeaderV1(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
                          byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] extensionData, BlockDifficulty difficulty,
                          long number, byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
                          Coin paidFees, byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
                          byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] mergedMiningForkDetectionData,
                          Coin minimumGasPrice, int uncleCount, boolean sealed,
-                         boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot) {
+                         boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot, short[] txExecutionSublistsEdges, boolean compressed) {
         super(parentHash,unclesHash, coinbase, stateRoot,
-                txTrieRoot, receiptTrieRoot, extensionData, difficulty,
+                txTrieRoot, receiptTrieRoot, compressed ? extensionData : null, difficulty,
                 number, gasLimit, gasUsed, timestamp, extraData,
                 paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
                 bitcoinMergedMiningCoinbaseTransaction, mergedMiningForkDetectionData,
                 minimumGasPrice, uncleCount, sealed,
                 useRskip92Encoding, includeForkDetectionData, ummRoot);
+        this.extension = compressed
+                ? new BlockHeaderExtensionV1(null, null)
+                : new BlockHeaderExtensionV1(extensionData, txExecutionSublistsEdges);
+        if(!compressed) this.updateExtensionData(); // update after calculating
 
-        this.extension = new BlockHeaderExtensionV1(null, null);
     }
 
     @VisibleForTesting

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
@@ -3,7 +3,6 @@ package org.ethereum.core;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
-import org.ethereum.util.RLP;
 
 import java.util.Arrays;
 import java.util.List;
@@ -13,9 +12,12 @@ public class BlockHeaderV1 extends BlockHeader {
     public byte getVersion() { return 0x1; }
 
     private BlockHeaderExtensionV1 extension;
+    @Override
     public BlockHeaderExtensionV1 getExtension() { return this.extension; }
+    @Override
     public void setExtension(BlockHeaderExtension extension) { this.extension = (BlockHeaderExtensionV1) extension; }
 
+    // this constructor is used when all the header info is existent
     public BlockHeaderV1(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
                          byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] logsBloom, BlockDifficulty difficulty,
                          long number, byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
@@ -24,29 +26,55 @@ public class BlockHeaderV1 extends BlockHeader {
                          Coin minimumGasPrice, int uncleCount, boolean sealed,
                          boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot, short[] txExecutionSublistsEdges) {
         super(parentHash,unclesHash, coinbase, stateRoot,
-                txTrieRoot, receiptTrieRoot, difficulty,
+                txTrieRoot, receiptTrieRoot, null, difficulty,
                 number, gasLimit, gasUsed, timestamp, extraData,
                 paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
                 bitcoinMergedMiningCoinbaseTransaction, mergedMiningForkDetectionData,
                 minimumGasPrice, uncleCount, sealed,
                 useRskip92Encoding, includeForkDetectionData, ummRoot);
 
-        this.extension = new BlockHeaderExtensionV1(logsBloom, txExecutionSublistsEdges);
+        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(logsBloom, txExecutionSublistsEdges);
+
+        this.extensionData = extension.getHash(); // update after calculating
+        this.extension = extension;
+    }
+
+    // this constructor is used when header is created with compressed encoding and receives extension
+    // on body message
+    public BlockHeaderV1(byte[] parentHash, byte[] unclesHash, RskAddress coinbase, byte[] stateRoot,
+                         byte[] txTrieRoot, byte[] receiptTrieRoot, byte[] extensionData, BlockDifficulty difficulty,
+                         long number, byte[] gasLimit, long gasUsed, long timestamp, byte[] extraData,
+                         Coin paidFees, byte[] bitcoinMergedMiningHeader, byte[] bitcoinMergedMiningMerkleProof,
+                         byte[] bitcoinMergedMiningCoinbaseTransaction, byte[] mergedMiningForkDetectionData,
+                         Coin minimumGasPrice, int uncleCount, boolean sealed,
+                         boolean useRskip92Encoding, boolean includeForkDetectionData, byte[] ummRoot) {
+        super(parentHash,unclesHash, coinbase, stateRoot,
+                txTrieRoot, receiptTrieRoot, extensionData, difficulty,
+                number, gasLimit, gasUsed, timestamp, extraData,
+                paidFees, bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof,
+                bitcoinMergedMiningCoinbaseTransaction, mergedMiningForkDetectionData,
+                minimumGasPrice, uncleCount, sealed,
+                useRskip92Encoding, includeForkDetectionData, ummRoot);
+
+        this.extension = new BlockHeaderExtensionV1(null, null);
+    }
+
+    private void updateExtensionData() {
+        this.extensionData = this.extension.getHash();
     }
 
     @Override
-    public byte[] getLogsBloom() {
-        return this.extension.getLogsBloom();
-    }
+    public byte[] getLogsBloom() { return this.extension.getLogsBloom(); }
 
+    @Override
     public void setLogsBloom(byte[] logsBloom) {
-        /* A sealed block header is immutable, cannot be changed */
         if (this.sealed) {
             throw new SealedBlockHeaderException("trying to alter logs bloom");
         }
         this.hash = null;
 
         this.extension.setLogsBloom(logsBloom);
+        this.updateExtensionData();
     }
 
     @Override
@@ -54,30 +82,19 @@ public class BlockHeaderV1 extends BlockHeader {
 
     @Override
     public void setTxExecutionSublistsEdges(short[] edges) {
-        /* A sealed block header is immutable, cannot be changed */
         if (this.sealed) {
-            throw new SealedBlockHeaderException("trying to alter logs bloom");
+            throw new SealedBlockHeaderException("trying to alter edges");
         }
         this.hash = null;
 
         this.extension.setTxExecutionSublistsEdges(edges != null ? Arrays.copyOf(edges, edges.length) : null);
+        this.updateExtensionData();
     }
 
     @Override
-    public byte[] getLogsBloomFieldEncoded() {
-        byte[] ecnoded = new byte[Bloom.BLOOM_BYTES];
-        ecnoded[0] = 0x1;
-        byte[] hash = this.extension.getHash();
-        System.arraycopy(hash, 0, ecnoded, 1, hash.length);
-        return RLP.encodeElement(ecnoded);
-    }
-
-    @Override
-    public void addExtraFieldsToEncoded(boolean useExtensionEncoding, List<byte[]> fieldsToEncode) {
-        if (!useExtensionEncoding) {
+    public void addExtraFieldsToEncodedHeader(boolean usingCompressedEncoding, List<byte[]> fieldsToEncode) {
+        if (!usingCompressedEncoding) {
             this.addTxExecutionSublistsEdgesIfAny(fieldsToEncode);
         }
     }
-
-
 }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
@@ -36,7 +36,9 @@ public class BlockHeaderV1 extends BlockHeader {
         this.extension = compressed
                 ? new BlockHeaderExtensionV1(null, null)
                 : new BlockHeaderExtensionV1(extensionData, txExecutionSublistsEdges);
-        if(!compressed) this.updateExtensionData(); // update after calculating
+        if(!compressed) {
+            this.updateExtensionData(); // update after calculating
+        }
 
     }
 

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
@@ -3,6 +3,9 @@ package org.ethereum.core;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
+import com.google.common.annotations.VisibleForTesting;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +38,7 @@ public class BlockHeaderV1 extends BlockHeader {
 
         BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(logsBloom, txExecutionSublistsEdges);
 
-        this.extensionData = extension.getHash(); // update after calculating
+        this.extensionData = BlockHeaderV1.createExtensionData(extension.getHash()); // update after calculating
         this.extension = extension;
     }
 
@@ -59,8 +62,16 @@ public class BlockHeaderV1 extends BlockHeader {
         this.extension = new BlockHeaderExtensionV1(null, null);
     }
 
+    @VisibleForTesting
+    public static byte[] createExtensionData(byte[] extensionHash) {
+        return RLP.encodeList(
+                RLP.encodeByte((byte) 0x1),
+                RLP.encodeElement(extensionHash)
+        );
+    }
+
     private void updateExtensionData() {
-        this.extensionData = this.extension.getHash();
+        this.extensionData = BlockHeaderV1.createExtensionData(this.extension.getHash());
     }
 
     @Override
@@ -94,6 +105,7 @@ public class BlockHeaderV1 extends BlockHeader {
     @Override
     public void addExtraFieldsToEncodedHeader(boolean usingCompressedEncoding, List<byte[]> fieldsToEncode) {
         if (!usingCompressedEncoding) {
+            fieldsToEncode.add(RLP.encodeByte(this.getVersion()));
             this.addTxExecutionSublistsEdgesIfAny(fieldsToEncode);
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderV1.java
@@ -5,7 +5,6 @@ import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.util.RLP;
-import org.ethereum.util.RLPList;
 
 import java.util.Arrays;
 import java.util.List;

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -295,12 +295,12 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void genesisHasVersion0() {
+    void genesisHasVersion0() {
         Assertions.assertEquals((byte) 0x0, factory.decodeBlock(genesisRaw()).getHeader().getVersion());
     }
 
     @Test
-    public void headerIsVersion0Before351Activation () {
+    void headerIsVersion0Before351Activation () {
         long number = 20L;
         enableRskip351At(number);
         BlockHeader header = factory.getBlockHeaderBuilder().setNumber(number - 1).build();
@@ -308,7 +308,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void headerIsVersion1After351Activation () {
+    void headerIsVersion1After351Activation () {
         long number = 20L;
         enableRskip351At(number);
         BlockHeader header = factory.getBlockHeaderBuilder().setNumber(number).build();
@@ -334,7 +334,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeCompressedBefore351() {
+    void decodeCompressedBefore351() {
         long number = 20L;
         enableRulesAt(number, RSKIP144);
         enableRskip351At(number);
@@ -357,7 +357,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeCompressedBefore351WithEdges() {
+    void decodeCompressedBefore351WithEdges() {
         long number = 20L;
         long blockNumber = number - 1;
         enableRulesAt(blockNumber, RSKIP144);
@@ -384,7 +384,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeCompressedWithNoEdgesAndMergedMiningFields() {
+    void decodeCompressedWithNoEdgesAndMergedMiningFields() {
         long blockNumber = 20L;
         enableRulesAt(blockNumber, RSKIP144, RSKIP92, RSKIPUMM);
         enableRskip351At(blockNumber);
@@ -416,7 +416,7 @@ class BlockFactoryTest {
      */
 
     @Test
-    public void decodeCompressedOfExtendedBefore351() {
+    void decodeCompressedOfExtendedBefore351() {
         long number = 20L;
         enableRulesAt(number, RSKIP144);
         enableRskip351At(number);
@@ -439,7 +439,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeCompressedOfExtendedBefore351WithEdges() {
+    void decodeCompressedOfExtendedBefore351WithEdges() {
         long number = 20L;
         long blockNumber = number - 1;
         enableRulesAt(blockNumber, RSKIP144);
@@ -466,7 +466,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeCompressedAfter351WithEdges() {
+    void decodeCompressedAfter351WithEdges() {
         long blockNumber = 20L;
         enableRulesAt(blockNumber, RSKIP144);
         enableRskip351At(blockNumber);
@@ -492,7 +492,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeFullBefore351And144() {
+    void decodeFullBefore351And144() {
         long number = 20L;
         long blockNumber = number - 1;
         enableRulesAt(number, RSKIP144);
@@ -516,7 +516,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeFullBefore351WithEdges() {
+    void decodeFullBefore351WithEdges() {
         long number = 20L;
         long blockNumber = number - 1;
         enableRulesAt(blockNumber, RSKIP144);
@@ -543,7 +543,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeFullAfter351WithEdges() {
+    void decodeFullAfter351WithEdges() {
         long blockNumber = 20L;
         enableRulesAt(blockNumber, RSKIP144);
         enableRskip351At(blockNumber);
@@ -569,7 +569,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeBlockRskip144OnRskipUMMOnAndMergedMiningFields() {
+    void decodeBlockRskip144OnRskipUMMOnAndMergedMiningFields() {
         long number = 500L;
         enableRulesAt(number, RSKIPUMM, RSKIP144);
         short[] edges = TestUtils.randomShortArray(4);
@@ -587,7 +587,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeBlockRskip144OnRskipUMMOnAndNoMergedMiningFields() {
+    void decodeBlockRskip144OnRskipUMMOnAndNoMergedMiningFields() {
         long number = 500L;
         enableRulesAt(number, RSKIPUMM, RSKIP144);
         short[] edges = TestUtils.randomShortArray(4);
@@ -605,7 +605,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeBlockRskip144OnRskipUMMOffAndMergedMiningFields() {
+    void decodeBlockRskip144OnRskipUMMOffAndMergedMiningFields() {
         long number = 500L;
         enableRulesAt(number, RSKIP144);
         short[] edges = TestUtils.randomShortArray(4);
@@ -623,7 +623,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void decodeBlockRskip144OnRskipUMMOffAndNoMergedMiningFields() {
+    void decodeBlockRskip144OnRskipUMMOffAndNoMergedMiningFields() {
         long number = 500L;
         enableRulesAt(number, RSKIP144);
         short[] edges = TestUtils.randomShortArray(4);
@@ -728,7 +728,6 @@ class BlockFactoryTest {
                 .setTxExecutionSublistsEdges(edges)
                 .build();
     }
-
 
     private static byte[] genesisRawHash() {
         return Hex.decode("cabb7fbe88cd6d922042a32ffc08ce8b1fbb37d650b9d4e7dbfe2a7469adfa42");

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -383,6 +383,28 @@ class BlockFactoryTest {
         Assertions.assertArrayEquals(logsBloom, decodedHeader.getExtensionData());
     }
 
+    @Test
+    public void decodeCompressedWithNoEdgesAndMergedMiningFields() {
+        long blockNumber = 20L;
+        enableRulesAt(blockNumber, RSKIP144, RSKIP92, RSKIPUMM);
+        enableRskip351At(blockNumber);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        BlockHeader header = createBlockHeaderWithMergedMiningFields(blockNumber, new byte[0], new byte[0], null, logsBloom);
+
+        byte[] encoded = header.getEncodedCompressed();
+
+        BlockHeader decodedHeader = testRSKIP351CompressedHeaderEncoding(encoded, (byte) 1,  null, null);
+
+        Assertions.assertArrayEquals(header.getExtensionData(), decodedHeader.getExtensionData());
+        assertThat(header.getHash(), is(decodedHeader.getHash()));
+        assertThat(header.getUmmRoot(), is(decodedHeader.getUmmRoot()));
+    }
     /**
      * note on decodeCompressedOfExtendedBefore351 &
      * decodeCompressedOfExtendedBefore351WithEdges:
@@ -635,6 +657,15 @@ class BlockFactoryTest {
             byte[] forkDetectionData,
             byte[] ummRoot,
             short[] edges) {
+        return createBlockHeaderWithMergedMiningFields(number, forkDetectionData, ummRoot, edges, null);
+    }
+
+    private BlockHeader createBlockHeaderWithMergedMiningFields(
+            long number,
+            byte[] forkDetectionData,
+            byte[] ummRoot,
+            short[] edges,
+            byte[] logsBloom) {
         byte[] difficulty = BigInteger.ONE.toByteArray();
         byte[] gasLimit = BigInteger.valueOf(6800000).toByteArray();
         long timestamp = 7731067; // Friday, 10 May 2019 6:04:05
@@ -662,6 +693,7 @@ class BlockFactoryTest {
                 .setCreateUmmCompliantHeader(ummRoot != null)
                 .setUmmRoot(ummRoot)
                 .setTxExecutionSublistsEdges(edges)
+                .setLogsBloom(logsBloom)
                 .build();
     }
 

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -26,6 +26,7 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
+import org.ethereum.core.BlockHeaderV1;
 import org.ethereum.core.Bloom;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
@@ -465,7 +466,7 @@ class BlockFactoryTest {
         byte[] encoded = header.getEncodedCompressed();
 
         BlockHeader decodedHeader = testRSKIP351CompressedHeaderEncoding(encoded, (byte) 1,  null, null);
-        Assertions.assertArrayEquals(header.getExtension().getHash(), decodedHeader.getExtensionData());
+        Assertions.assertArrayEquals(BlockHeaderV1.createExtensionData(header.getExtension().getHash()), decodedHeader.getExtensionData());
     }
 
     @Test
@@ -542,7 +543,7 @@ class BlockFactoryTest {
         byte[] encoded = header.getFullEncoded();
 
         BlockHeader decodedHeader = testRSKIP351FullHeaderEncoding(encoded, (byte) 1,  logsBloom, edges);
-        Assertions.assertArrayEquals(header.getExtension().getHash(), decodedHeader.getExtensionData());
+        Assertions.assertArrayEquals(BlockHeaderV1.createExtensionData(header.getExtension().getHash()), decodedHeader.getExtensionData());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -26,6 +26,7 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Bloom;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -86,7 +87,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getMiningForkDetectionData(), is(decodedHeader.getMiningForkDetectionData()));
     }
@@ -102,7 +103,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getMiningForkDetectionData(), is(decodedHeader.getMiningForkDetectionData()));
     }
@@ -118,7 +119,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getMiningForkDetectionData(), is(decodedHeader.getMiningForkDetectionData()));
     }
@@ -131,7 +132,8 @@ class BlockFactoryTest {
 
         BlockHeader header = createBlockHeaderWithMergedMiningFields(number, forkDetectionData, null, null);
 
-        byte[] encodedBlock = header.getEncoded(false, false, false);
+        boolean compressed = false;
+        byte[] encodedBlock = header.getEncoded(false, false, compressed);
         byte[] hashForMergedMining = Arrays.copyOfRange(HashUtil.keccak256(encodedBlock), 0, 20);
         byte[] coinbase = org.bouncycastle.util.Arrays.concatenate(hashForMergedMining, forkDetectionData);
         coinbase = org.bouncycastle.util.Arrays.concatenate(RskMiningConstants.RSK_TAG, coinbase);
@@ -142,7 +144,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, compressed);
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getMiningForkDetectionData(), is(decodedHeader.getMiningForkDetectionData()));
     }
@@ -158,11 +160,12 @@ class BlockFactoryTest {
 
         BlockHeader header = createBlockHeader(number, new byte[0], null, null);
 
-        byte[] encodedHeader = header.getEncoded(false, false, false);
+        boolean compressed = false;
+        byte[] encodedHeader = header.getEncoded(false, false, compressed);
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(16));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, compressed);
         assertThat(header.getHash(), is(decodedHeader.getHash()));
     }
 
@@ -179,11 +182,12 @@ class BlockFactoryTest {
         byte[] forkDetectionData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         BlockHeader header = createBlockHeader(number, forkDetectionData, null, null);
 
-        byte[] encodedHeader = header.getEncoded(false, false, false);
+        boolean compressed = false;
+        byte[] encodedHeader = header.getEncoded(false, false, compressed);
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(16));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, compressed);
         assertThat(header.getHash(), is(decodedHeader.getHash()));
     }
 
@@ -199,7 +203,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(17));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
 
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getUmmRoot(), is(decodedHeader.getUmmRoot()));
@@ -216,7 +220,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(17));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
 
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getUmmRoot(), is(decodedHeader.getUmmRoot()));
@@ -235,7 +239,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(16));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> factory.decodeHeader(encodedHeader));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> factory.decodeHeader(encodedHeader, false));
     }
 
     @Test
@@ -250,7 +254,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(20));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
 
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getUmmRoot(), is(decodedHeader.getUmmRoot()));
@@ -267,7 +271,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(20));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
 
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getUmmRoot(), is(decodedHeader.getUmmRoot()));
@@ -286,7 +290,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(19));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> factory.decodeHeader(encodedHeader));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> factory.decodeHeader(encodedHeader, false));
     }
 
     @Test
@@ -295,7 +299,7 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void headerIsVersion0BeforeActivation () {
+    public void headerIsVersion0Before351Activation () {
         long number = 20L;
         enableRskip351At(number);
         BlockHeader header = factory.getBlockHeaderBuilder().setNumber(number - 1).build();
@@ -303,11 +307,242 @@ class BlockFactoryTest {
     }
 
     @Test
-    public void headerIsVersion1AfterActivation () {
+    public void headerIsVersion1After351Activation () {
         long number = 20L;
         enableRskip351At(number);
         BlockHeader header = factory.getBlockHeaderBuilder().setNumber(number).build();
         Assertions.assertEquals(1, header.getVersion());
+    }
+
+    private BlockHeader testRSKIP351FullHeaderEncoding(byte[] encoded, byte expectedVersion, byte[] expectedLogsBloom, short[] expectedEdges) {
+        return testRSKIP351CompressedHeaderEncoding(encoded, expectedVersion, expectedLogsBloom, expectedEdges, false);
+    }
+
+    private BlockHeader testRSKIP351CompressedHeaderEncoding(byte[] encoded, byte expectedVersion, byte[] expectedLogsBloom, short[] expectedEdges) {
+        return testRSKIP351CompressedHeaderEncoding(encoded, expectedVersion, expectedLogsBloom, expectedEdges, true);
+    }
+
+    private BlockHeader testRSKIP351CompressedHeaderEncoding(byte[] encoded, byte expectedVersion, byte[] expectedLogsBloom, short[] expectedEdges, boolean compressed) {
+        BlockHeader decodedHeader = factory.decodeHeader(encoded, compressed);
+
+        Assertions.assertEquals(expectedVersion, decodedHeader.getVersion());
+        Assertions.assertArrayEquals(expectedLogsBloom, decodedHeader.getLogsBloom());
+        Assertions.assertArrayEquals(expectedEdges, decodedHeader.getTxExecutionSublistsEdges());
+
+        return decodedHeader;
+    }
+
+    @Test
+    public void decodeCompressedBefore351() {
+        long number = 20L;
+        enableRulesAt(number, RSKIP144);
+        enableRskip351At(number);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        BlockHeader header = factory.getBlockHeaderBuilder()
+                .setLogsBloom(logsBloom)
+                .setNumber(number - 1)
+                .build();
+
+        byte[] encoded = header.getEncodedCompressed();
+
+        BlockHeader decodedHeader = testRSKIP351CompressedHeaderEncoding(encoded, (byte) 0,  logsBloom, null);
+        Assertions.assertArrayEquals(logsBloom, decodedHeader.getExtensionData());
+    }
+
+    @Test
+    public void decodeCompressedBefore351WithEdges() {
+        long number = 20L;
+        long blockNumber = number - 1;
+        enableRulesAt(blockNumber, RSKIP144);
+        enableRskip351At(number);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        short[] edges = { 1, 2, 3, 4 };
+
+        BlockHeader header = factory.getBlockHeaderBuilder()
+                .setLogsBloom(logsBloom)
+                .setTxExecutionSublistsEdges(edges)
+                .setNumber(blockNumber)
+                .build();
+
+        byte[] encoded = header.getEncodedCompressed();
+
+        BlockHeader decodedHeader = testRSKIP351CompressedHeaderEncoding(encoded, (byte) 0,  logsBloom, edges);
+        Assertions.assertArrayEquals(logsBloom, decodedHeader.getExtensionData());
+    }
+
+    /**
+     * note on decodeCompressedOfExtendedBefore351 &
+     * decodeCompressedOfExtendedBefore351WithEdges:
+     * while nodes activate hf, the new nodes will decode
+     * blocks headers v0 with compressed=true when old nodes send
+     * block headers encoded in the old fashion. in consequence,
+     * decode(compressed=true) needs to handle encoded(compress=false)
+     * for blocks v0
+     */
+
+    @Test
+    public void decodeCompressedOfExtendedBefore351() {
+        long number = 20L;
+        enableRulesAt(number, RSKIP144);
+        enableRskip351At(number);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        BlockHeader header = factory.getBlockHeaderBuilder()
+                .setLogsBloom(logsBloom)
+                .setNumber(number - 1)
+                .build();
+
+        byte[] encoded = header.getFullEncoded(); // used before hf
+
+        BlockHeader decodedHeader = testRSKIP351CompressedHeaderEncoding(encoded, (byte) 0,  logsBloom, null);
+        Assertions.assertArrayEquals(logsBloom, decodedHeader.getExtensionData());
+    }
+
+    @Test
+    public void decodeCompressedOfExtendedBefore351WithEdges() {
+        long number = 20L;
+        long blockNumber = number - 1;
+        enableRulesAt(blockNumber, RSKIP144);
+        enableRskip351At(number);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        short[] edges = { 1, 2, 3, 4 };
+
+        BlockHeader header = factory.getBlockHeaderBuilder()
+                .setLogsBloom(logsBloom)
+                .setTxExecutionSublistsEdges(edges)
+                .setNumber(blockNumber)
+                .build();
+
+        byte[] encoded = header.getFullEncoded(); // used before hf
+
+        BlockHeader decodedHeader = testRSKIP351CompressedHeaderEncoding(encoded, (byte) 0,  logsBloom, edges);
+        Assertions.assertArrayEquals(logsBloom, decodedHeader.getExtensionData());
+    }
+
+    @Test
+    public void decodeCompressedAfter351WithEdges() {
+        long blockNumber = 20L;
+        enableRulesAt(blockNumber, RSKIP144);
+        enableRskip351At(blockNumber);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        short[] edges = { 1, 2, 3, 4 };
+
+        BlockHeader header = factory.getBlockHeaderBuilder()
+                .setLogsBloom(logsBloom)
+                .setTxExecutionSublistsEdges(edges)
+                .setNumber(blockNumber)
+                .build();
+
+        byte[] encoded = header.getEncodedCompressed();
+
+        BlockHeader decodedHeader = testRSKIP351CompressedHeaderEncoding(encoded, (byte) 1,  null, null);
+        Assertions.assertArrayEquals(header.getExtension().getHash(), decodedHeader.getExtensionData());
+    }
+
+    @Test
+    public void decodeFullBefore351And144() {
+        long number = 20L;
+        long blockNumber = number - 1;
+        enableRulesAt(number, RSKIP144);
+        enableRskip351At(number);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        BlockHeader header = factory.getBlockHeaderBuilder()
+                .setLogsBloom(logsBloom)
+                .setNumber(blockNumber)
+                .build();
+
+        byte[] encoded = header.getFullEncoded();
+
+        BlockHeader decodedHeader = testRSKIP351FullHeaderEncoding(encoded, (byte) 0,  logsBloom, null);
+        Assertions.assertArrayEquals(header.getLogsBloom(), decodedHeader.getExtensionData());
+    }
+
+    @Test
+    public void decodeFullBefore351WithEdges() {
+        long number = 20L;
+        long blockNumber = number - 1;
+        enableRulesAt(blockNumber, RSKIP144);
+        enableRskip351At(number);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        short[] edges = { 1, 2, 3, 4 };
+
+        BlockHeader header = factory.getBlockHeaderBuilder()
+                .setLogsBloom(logsBloom)
+                .setTxExecutionSublistsEdges(edges)
+                .setNumber(blockNumber)
+                .build();
+
+        byte[] encoded = header.getFullEncoded();
+
+        BlockHeader decodedHeader = testRSKIP351FullHeaderEncoding(encoded, (byte) 0,  logsBloom, edges);
+        Assertions.assertArrayEquals(header.getLogsBloom(), decodedHeader.getExtensionData());
+    }
+
+    @Test
+    public void decodeFullAfter351WithEdges() {
+        long blockNumber = 20L;
+        enableRulesAt(blockNumber, RSKIP144);
+        enableRskip351At(blockNumber);
+
+        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+        logsBloom[0] = 1;
+        logsBloom[1] = 1;
+        logsBloom[2] = 1;
+        logsBloom[3] = 1;
+
+        short[] edges = { 1, 2, 3, 4 };
+
+        BlockHeader header = factory.getBlockHeaderBuilder()
+                .setLogsBloom(logsBloom)
+                .setTxExecutionSublistsEdges(edges)
+                .setNumber(blockNumber)
+                .build();
+
+        byte[] encoded = header.getFullEncoded();
+
+        BlockHeader decodedHeader = testRSKIP351FullHeaderEncoding(encoded, (byte) 1,  logsBloom, edges);
+        Assertions.assertArrayEquals(header.getExtension().getHash(), decodedHeader.getExtensionData());
     }
 
     @Test
@@ -322,7 +557,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(21));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
 
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getTxExecutionSublistsEdges(), is(edges));
@@ -340,7 +575,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(18));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
 
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getTxExecutionSublistsEdges(), is(edges));
@@ -358,7 +593,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(20));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
 
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getTxExecutionSublistsEdges(), is(edges));
@@ -376,7 +611,7 @@ class BlockFactoryTest {
         RLPList headerRLP = RLP.decodeList(encodedHeader);
         assertThat(headerRLP.size(), is(17));
 
-        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader);
+        BlockHeader decodedHeader = factory.decodeHeader(encodedHeader, false);
 
         assertThat(header.getHash(), is(decodedHeader.getHash()));
         assertThat(header.getTxExecutionSublistsEdges(), is(edges));

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionTest.java
@@ -10,8 +10,6 @@ import org.ethereum.util.RLPList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 public class BlockHeaderExtensionTest {
     @Test
     public void decodeV1() {
@@ -29,8 +27,7 @@ public class BlockHeaderExtensionTest {
                 RLP.decodeList(extension.getEncoded())
         );
 
-        Assertions.assertEquals(extension.getHeaderVersion(), decoded.getHeaderVersion());
-        Assertions.assertArrayEquals(extension.getHash(), extension.getHash());
+        Assertions.assertArrayEquals(extension.getHash(), decoded.getHash());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionV1Test.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderExtensionV1Test.java
@@ -1,7 +1,5 @@
 package co.rsk.core;
 
-import org.ethereum.TestUtils;
-import org.ethereum.core.BlockHeaderExtension;
 import org.ethereum.core.BlockHeaderExtensionV1;
 import org.ethereum.core.Bloom;
 import org.junit.jupiter.api.Assertions;
@@ -11,11 +9,6 @@ import java.util.Arrays;
 
 public class BlockHeaderExtensionV1Test {
     private static short[] EDGES = new short[] { 1, 2, 3, 4 };
-    @Test
-    public void hasVersion1 () {
-        BlockHeaderExtensionV1 extension = new BlockHeaderExtensionV1(TestUtils.randomBytes(256), EDGES);
-        Assertions.assertEquals(1, extension.getHeaderVersion());
-    }
 
     @Test
     public void createWithLogsBloomAndEdges() {

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
@@ -29,6 +29,7 @@ import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -403,16 +404,19 @@ class BlockHeaderTest {
         this.testHeaderVersion((byte) 0x1);
     }
 
-    @Test
-    public void encodeForLogsBloomField() {
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+    private static byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
+    private static short[] edges = new short[]{ 1, 2, 3, 4 };
+
+    @BeforeAll
+    static void setupLogsBloom() {
         logsBloom[0] = 0x01;
         logsBloom[1] = 0x02;
         logsBloom[2] = 0x03;
         logsBloom[3] = 0x04;
+    }
 
-        short[] edges = new short[]{ 1, 2, 3, 4 };
-
+    @Test
+    public void encodeForLogsBloomField() {
         BlockHeaderV1 header = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
         header.setLogsBloom(logsBloom);
         header.setTxExecutionSublistsEdges(edges);
@@ -430,14 +434,6 @@ class BlockHeaderTest {
         // this test is added to assert the blockchain is still serializable
         // it is still possible to serialize wether logs bloom field is the
         // actual logs bloom or the extension data by reading its length != 256
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
-
-        short[] edges = new short[]{ 1, 2, 3, 4 };
-
         BlockHeaderV1 header = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
         header.setLogsBloom(logsBloom);
         header.setTxExecutionSublistsEdges(edges);
@@ -471,12 +467,6 @@ class BlockHeaderTest {
 
     @Test
     public void encodedV0IsTheSameForV0andV1 () {
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
-
         BlockHeaderV0 headerV0 = (BlockHeaderV0) createBlockHeaderWithVersion((byte) 0x0);
         headerV0.setLogsBloom(logsBloom);
 
@@ -487,12 +477,6 @@ class BlockHeaderTest {
 
     @Test
     public void fullEncodedV0IsTheSameForV0andV1 () {
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
-
         BlockHeaderV0 headerV0 = (BlockHeaderV0) createBlockHeaderWithVersion((byte) 0x0);
         headerV0.setLogsBloom(logsBloom);
 
@@ -503,12 +487,6 @@ class BlockHeaderTest {
 
     @Test
     public void fullEncodedV0IsTheSameAsEncodedForHeaderMessage () {
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
-
         BlockHeaderV0 headerV0 = (BlockHeaderV0) createBlockHeaderWithVersion((byte) 0x0);
         headerV0.setLogsBloom(logsBloom);
 
@@ -518,12 +496,6 @@ class BlockHeaderTest {
     @Test
     public void fullEncodedV1IsTheSameAsCompressedButLogsBloomEdgesAndVersion () {
         // this test is added to assert that there were no changes in the rest of the elements
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
-
         BlockHeaderV1 headerV1 = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
         headerV1.setLogsBloom(logsBloom);
 
@@ -550,12 +522,6 @@ class BlockHeaderTest {
         // this test is added to assert that the rlp header size does not change
         // in the hard fork, assuming both RSKIP 351 and RSKIP 144 are activated
         // together
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
-
         BlockHeaderV0 headerV0 = (BlockHeaderV0) createBlockHeaderWithVersion((byte) 0x0);
         headerV0.setLogsBloom(logsBloom);
         headerV0.setTxExecutionSublistsEdges(null);
@@ -574,11 +540,6 @@ class BlockHeaderTest {
     public void hashOfV1IncludesLogsBloom() {
         BlockHeaderV1 headerV1 = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
 
-        byte[] logsBloom = new byte[Bloom.BLOOM_BYTES];
-        logsBloom[0] = 0x01;
-        logsBloom[1] = 0x02;
-        logsBloom[2] = 0x03;
-        logsBloom[3] = 0x04;
         headerV1.setLogsBloom(logsBloom);
         byte[] hash = headerV1.getHash().getBytes();
 
@@ -596,7 +557,6 @@ class BlockHeaderTest {
     public void hashOfV1IncludesEdges() {
         BlockHeaderV1 headerV1 = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
 
-        short[] edges = new short[]{ 1, 2, 3, 4};
         headerV1.setTxExecutionSublistsEdges(edges);
         byte[] hash = headerV1.getHash().getBytes();
 

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
@@ -397,10 +397,10 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void getVersion0() { this.testHeaderVersion((byte) 0x0); }
+    void getVersion0() { this.testHeaderVersion((byte) 0x0); }
 
     @Test
-    public void getVersion1() {
+    void getVersion1() {
         this.testHeaderVersion((byte) 0x1);
     }
 
@@ -416,7 +416,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void encodeForLogsBloomField() {
+    void encodeForLogsBloomField() {
         BlockHeaderV1 header = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
         header.setLogsBloom(logsBloom);
         header.setTxExecutionSublistsEdges(edges);
@@ -430,7 +430,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void encodeForLogsBloomFieldIsNotLogsBloomSize() {
+    void encodeForLogsBloomFieldIsNotLogsBloomSize() {
         // this test is added to assert the blockchain is still serializable
         // it is still possible to serialize wether logs bloom field is the
         // actual logs bloom or the extension data by reading its length != 256
@@ -466,7 +466,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void encodedV0IsTheSameForV0andV1 () {
+    void encodedV0IsTheSameForV0andV1 () {
         BlockHeaderV0 headerV0 = (BlockHeaderV0) createBlockHeaderWithVersion((byte) 0x0);
         headerV0.setLogsBloom(logsBloom);
 
@@ -476,7 +476,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void fullEncodedV0IsTheSameForV0andV1 () {
+    void fullEncodedV0IsTheSameForV0andV1 () {
         BlockHeaderV0 headerV0 = (BlockHeaderV0) createBlockHeaderWithVersion((byte) 0x0);
         headerV0.setLogsBloom(logsBloom);
 
@@ -486,7 +486,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void fullEncodedV0IsTheSameAsEncodedForHeaderMessage () {
+    void fullEncodedV0IsTheSameAsEncodedForHeaderMessage () {
         BlockHeaderV0 headerV0 = (BlockHeaderV0) createBlockHeaderWithVersion((byte) 0x0);
         headerV0.setLogsBloom(logsBloom);
 
@@ -494,7 +494,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void fullEncodedV1IsTheSameAsCompressedButLogsBloomEdgesAndVersion () {
+    void fullEncodedV1IsTheSameAsCompressedButLogsBloomEdgesAndVersion () {
         // this test is added to assert that there were no changes in the rest of the elements
         BlockHeaderV1 headerV1 = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
         headerV1.setLogsBloom(logsBloom);
@@ -518,7 +518,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void compressedEncodingV1HasSameRLPSizeAsFullEncodedV0WithoutEdges () {
+    void compressedEncodingV1HasSameRLPSizeAsFullEncodedV0WithoutEdges () {
         // this test is added to assert that the rlp header size does not change
         // in the hard fork, assuming both RSKIP 351 and RSKIP 144 are activated
         // together
@@ -537,7 +537,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void hashOfV1IncludesLogsBloom() {
+    void hashOfV1IncludesLogsBloom() {
         BlockHeaderV1 headerV1 = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
 
         headerV1.setLogsBloom(logsBloom);
@@ -554,7 +554,7 @@ class BlockHeaderTest {
     }
 
     @Test
-    public void hashOfV1IncludesEdges() {
+    void hashOfV1IncludesEdges() {
         BlockHeaderV1 headerV1 = (BlockHeaderV1) createBlockHeaderWithVersion((byte) 0x1);
 
         headerV1.setTxExecutionSublistsEdges(edges);

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderTest.java
@@ -451,7 +451,7 @@ class BlockHeaderTest {
                 headerV0.getPaidFees(), headerV0.getBitcoinMergedMiningHeader(), headerV0.getBitcoinMergedMiningMerkleProof(),
                 headerV0.getBitcoinMergedMiningCoinbaseTransaction(), headerV0.getMiningForkDetectionData(),
                 headerV0.getMinimumGasPrice(), headerV0.getUncleCount(), headerV0.isSealed(),
-                false, false, headerV0.getUmmRoot(), headerV0.getTxExecutionSublistsEdges()
+                false, false, headerV0.getUmmRoot(), headerV0.getTxExecutionSublistsEdges(), false
         );
     }
 
@@ -647,7 +647,8 @@ class BlockHeaderTest {
                 useRskip92Encoding,
                 includeForkDetectionData,
                 ummRoot,
-                edges);
+                edges,
+                false);
 
         return new BlockHeaderV0(
                 PegTestUtils.createHash3().getBytes(),

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderV0Test.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderV0Test.java
@@ -4,8 +4,6 @@ import co.rsk.peg.PegTestUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.core.BlockHeaderExtensionV1;
 import org.ethereum.core.BlockHeaderV0;
-import org.ethereum.core.BlockHeaderV1;
-import org.ethereum.core.Bloom;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
 import org.junit.jupiter.api.Assertions;
@@ -67,7 +65,7 @@ public class BlockHeaderV0Test {
         byte[] bloom = TestUtils.randomBytes(256);
         short[] edges = new short[]{ 1, 2, 3, 4 };
         BlockHeaderV0 header = createBlockHeader(bloom, edges);
-        byte[] field = RLP.decode2(header.getLogsBloomFieldEncoded()).get(0).getRLPData();
+        byte[] field = header.getExtensionData();
         Assertions.assertArrayEquals(bloom, field);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderV1Test.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderV1Test.java
@@ -4,7 +4,6 @@ import co.rsk.peg.PegTestUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.core.BlockHeaderExtensionV1;
 import org.ethereum.core.BlockHeaderV1;
-import org.ethereum.core.Bloom;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
 import org.junit.jupiter.api.Assertions;
@@ -74,18 +73,13 @@ public class BlockHeaderV1Test {
     void logsBloomFieldEncoded() {
         byte[] bloom = TestUtils.randomBytes(256);
         BlockHeaderV1 header = createBlockHeader(bloom);
-        byte[] field = RLP.decode2(header.getLogsBloomFieldEncoded()).get(0).getRLPData();
-        Assertions.assertEquals((byte) 0x1, field[0]);
-        for (int i = 33; i < 256; i++) Assertions.assertEquals((byte) 0x0, field[i]);
-        Assertions.assertEquals(Bloom.BLOOM_BYTES, field.length);
+        byte[] extensionData = header.getExtensionData();
+        Assertions.assertEquals(32, extensionData.length);
+        Assertions.assertArrayEquals(header.getExtension().getHash(), extensionData);
     }
 
     BlockHeaderV1 encodedHeaderWithRandomLogsBloom() {
         return createBlockHeader(TestUtils.randomBytes(256));
-    }
-
-    byte[] getLogsBloomFieldHashPart(byte[] encodedHeader) {
-        return Arrays.copyOfRange(encodedHeader, 1, 33);
     }
 
     @Test
@@ -95,13 +89,13 @@ public class BlockHeaderV1Test {
         byte[] hash = TestUtils.randomBytes(32);
         Mockito.when(extension.getHash()).thenReturn(hash);
         header.setExtension(extension);
-        byte[] encoded = header.getLogsBloomFieldEncoded();
 
+        BlockHeaderV1 otherHeader = encodedHeaderWithRandomLogsBloom();
         BlockHeaderExtensionV1 otherExtension = Mockito.mock(BlockHeaderExtensionV1.class);
         byte[] otherHash = TestUtils.randomBytes(32);
         Mockito.when(otherExtension.getHash()).thenReturn(otherHash);
-        header.setExtension(otherExtension);
+        otherHeader.setExtension(otherExtension);
 
-        Assertions.assertFalse(Arrays.equals(encoded, header.getLogsBloomFieldEncoded()));
+        Assertions.assertFalse(Arrays.equals(header.getExtensionData(), otherHeader.getExtensionData()));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderV1Test.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderV1Test.java
@@ -6,6 +6,7 @@ import org.ethereum.core.BlockHeaderExtensionV1;
 import org.ethereum.core.BlockHeaderV1;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -73,9 +74,13 @@ public class BlockHeaderV1Test {
     void logsBloomFieldEncoded() {
         byte[] bloom = TestUtils.randomBytes(256);
         BlockHeaderV1 header = createBlockHeader(bloom);
-        byte[] extensionData = header.getExtensionData();
-        Assertions.assertEquals(32, extensionData.length);
-        Assertions.assertArrayEquals(header.getExtension().getHash(), extensionData);
+        RLPList extensionDataRLP = RLP.decodeList(header.getExtensionData());
+
+        byte version = extensionDataRLP.get(0).getRLPData()[0];
+        byte[] extensionHash = extensionDataRLP.get(1).getRLPData();
+
+        Assertions.assertEquals((byte) 0x1, version);
+        Assertions.assertArrayEquals(header.getExtension().getHash(), extensionHash);
     }
 
     BlockHeaderV1 encodedHeaderWithRandomLogsBloom() {

--- a/rskj-core/src/test/java/co/rsk/core/BlockHeaderV1Test.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockHeaderV1Test.java
@@ -41,7 +41,8 @@ public class BlockHeaderV1Test {
                 false,
                 false,
                 null,
-                new short[0]
+                new short[0],
+                false
         );
     }
 

--- a/rskj-core/src/test/java/org/ethereum/core/BlockHeaderBuilderTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockHeaderBuilderTest.java
@@ -261,7 +261,10 @@ class BlockHeaderBuilderTest {
 
     @ParameterizedTest(name = "createHeader: when createConsensusCompliantHeader {0} and useRskip92Encoding {1} then expectedSize {2}")
     @ArgumentsSource(CreateHeaderArgumentsProvider.class)
-    void createsHeaderWith(boolean createConsensusCompliantHeader, boolean useRskip92Encoding, int expectedSize) {
+    void createsHeaderWith(boolean createConsensusCompliantHeader, boolean useRskip92Encoding, boolean useRSKIP351, int expectedSize) {
+        BlockHeaderBuilder blockHeaderBuilder = useRSKIP351
+                ? this.blockHeaderBuilder
+                : new BlockHeaderBuilder(ActivationConfigsForTest.allBut(ConsensusRule.RSKIP351));
         byte[] btcCoinbase = TestUtils.randomBytes(128);
         byte[] btcHeader = TestUtils.randomBytes(80);
         byte[] merkleProof = TestUtils.randomBytes(32);
@@ -502,9 +505,12 @@ class BlockHeaderBuilderTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
-                    Arguments.of(false, false, 21),
-                    Arguments.of(false, true, 19),
-                    Arguments.of(true, false, 19)
+                    Arguments.of(false, false, false, 21),
+                    Arguments.of(false, true, false, 19),
+                    Arguments.of(true, false, false, 19),
+                    Arguments.of(false, false, true, 22),
+                    Arguments.of(false, true, true, 20),
+                    Arguments.of(true, false, true, 20)
             );
         }
     }


### PR DESCRIPTION

- Make extension data (ex logs bloom field) shortest as possible (32 bytes for version 1)
- Add version to RLP encoding (1 extra byte now). Now decode header will read version from RLP
- Express compressed on encode/decode (see `decodeHeader(RLPList rlpHeader, boolean compressed, boolean sealed)`)
- Rename methods and variables (use _extension data_ and _encoded compressed_ terms)
- Make header v0 read from extensionData (now logs bloom is stored in what is called the _extension data_ that both headers v0 and v1 have)
