### PR TITLE
Not dispose Options instance in RocksDbDataSource until db is closed

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
@@ -51,7 +51,7 @@ public class RocksDbDataSource implements KeyValueDataSource {
     private final String databaseDir;
     private final String name;
 
-    private static Options options = null;
+    private final Options options = createOptions();
     private RocksDB db;
     private boolean alive;
 
@@ -81,7 +81,6 @@ public class RocksDbDataSource implements KeyValueDataSource {
     public void init() {
         resetDbLock.writeLock().lock();
         Metric metric = profiler.start(Profiler.PROFILING_TYPE.DB_INIT);
-        instantiateOptionsInternal();
 
         try {
             logger.debug("~> RocksDbDataSource.init(): {}", name);
@@ -370,20 +369,13 @@ public class RocksDbDataSource implements KeyValueDataSource {
         // All is flushed immediately: there is no uncommittedCache to flush
     }
 
-    private synchronized static void instantiateOptionsInternal() {
-        if (options == null) {
-            try {
-                options = new Options();
-                options.setCreateIfMissing(true);
-                options.setCompressionType(CompressionType.NO_COMPRESSION);
-                options.setArenaBlockSize(GENERAL_SIZE);
-                options.setWriteBufferSize(GENERAL_SIZE);
-                options.setParanoidChecks(true);
-            } catch (Exception ioe) {
-                logger.error(ioe.getMessage(), ioe);
-                panicProcessor.panic("rocksdb", ioe.getMessage());
-                throw new RuntimeException("Can't instance Options class");
-            }
-        }
+    private static Options createOptions() {
+        Options tempOptions = new Options();
+        tempOptions.setCreateIfMissing(true);
+        tempOptions.setCompressionType(CompressionType.NO_COMPRESSION);
+        tempOptions.setArenaBlockSize(GENERAL_SIZE);
+        tempOptions.setWriteBufferSize(GENERAL_SIZE);
+        tempOptions.setParanoidChecks(true);
+        return tempOptions;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
@@ -97,7 +97,7 @@ public class RocksDbDataSource implements KeyValueDataSource {
             Files.createDirectories(dbPath.getParent());
 
             logger.debug("Initializing new or existing database: '{}'", name);
-            openDb(options, dbPath);
+            openDb(dbPath);
 
             logger.debug("<~ RocksDbDataSource.init(): {}", name);
         } catch (RocksDBException ioe) {
@@ -114,7 +114,7 @@ public class RocksDbDataSource implements KeyValueDataSource {
         }
     }
 
-    private void openDb(Options options, Path dbPath) throws RocksDBException {
+    private void openDb(Path dbPath) throws RocksDBException {
         db = RocksDB.open(options, dbPath.toString());
 
         alive = true;
@@ -370,12 +370,12 @@ public class RocksDbDataSource implements KeyValueDataSource {
     }
 
     private static Options createOptions() {
-        Options tempOptions = new Options();
-        tempOptions.setCreateIfMissing(true);
-        tempOptions.setCompressionType(CompressionType.NO_COMPRESSION);
-        tempOptions.setArenaBlockSize(GENERAL_SIZE);
-        tempOptions.setWriteBufferSize(GENERAL_SIZE);
-        tempOptions.setParanoidChecks(true);
-        return tempOptions;
+        Options options = new Options();
+        options.setCreateIfMissing(true);
+        options.setCompressionType(CompressionType.NO_COMPRESSION);
+        options.setArenaBlockSize(GENERAL_SIZE);
+        options.setWriteBufferSize(GENERAL_SIZE);
+        options.setParanoidChecks(true);
+        return options;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
@@ -50,13 +50,15 @@ public class RocksDbDataSource implements KeyValueDataSource {
 
     private final String databaseDir;
     private final String name;
+
+    private static Options options = null;
     private RocksDB db;
     private boolean alive;
 
     // The native LevelDB insert/update/delete are normally thread-safe
     // However close operation is not thread-safe and may lead to a native crash when
     // accessing a closed DB.
-    // The rocksdbJNI lib has a protection over accessing closed DB but it is not synchronized
+    // The rocksdbJNI lib has a protection over accessing closed DB, but it is not synchronized
     // This ReadWriteLock still permits concurrent execution of insert/delete/update operations
     // however blocks them on init/close/delete operations
     private final ReadWriteLock resetDbLock = new ReentrantReadWriteLock();
@@ -77,7 +79,17 @@ public class RocksDbDataSource implements KeyValueDataSource {
     public void init() {
         resetDbLock.writeLock().lock();
         Metric metric = profiler.start(Profiler.PROFILING_TYPE.DB_INIT);
-        try (Options options = new Options()) {
+
+        if (options == null) {
+            options = new Options();
+            options.setCreateIfMissing(true);
+            options.setCompressionType(CompressionType.NO_COMPRESSION);
+            options.setArenaBlockSize(GENERAL_SIZE);
+            options.setWriteBufferSize(GENERAL_SIZE);
+            options.setParanoidChecks(true);
+        }
+
+        try {
             logger.debug("~> RocksDbDataSource.init(): {}", name);
 
             if (isAlive()) {
@@ -85,13 +97,6 @@ public class RocksDbDataSource implements KeyValueDataSource {
             }
 
             Objects.requireNonNull(name, "no name set to the db");
-
-            options.setCreateIfMissing(true);
-            options.setCompressionType(CompressionType.NO_COMPRESSION);
-            options.setArenaBlockSize(GENERAL_SIZE);
-            options.setWriteBufferSize(GENERAL_SIZE);
-
-            options.setParanoidChecks(true);
 
             logger.debug("Opening database");
             Path dbPath = getPathForName(name, databaseDir);


### PR DESCRIPTION
## Description

Not dispose Options instance in RocksDbDataSource until db is closed

## Motivation and Context

As of now, we are disposing and creating a new instance of the Options class every time we init RocksDB. According to the RocksDB’s javadoc we should not do that until db instance is closed.

## How Has This Been Tested?

Haven’t created unit tests for this specific change because I would like the team to review the changes made and see if there’s any other optimal solution. But all the existing unit tests are going through perfectly, and everything appears to be working fine by running the node locally.

## Types of changes

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x]  My code follows the code style of this project.
- [ ]  My change requires a change to the documentation.
- [ ]  I have updated the documentation accordingly.
- [ ]  Tests for the changes have been added (for bug fixes / features)
- [ ]  Requires Activation Code (Hard Fork)
- **Other information**: