### PR TITLE
Fix writes after writing to parallel

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/ParallelizeTransactionHandler.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/ParallelizeTransactionHandler.java
@@ -123,13 +123,12 @@ public class ParallelizeTransactionHandler {
 
         if (sublist.isSequential()) {
             sublistOfSender.put(sender, sublist);
-            return;
         } else {
             sublistOfSender.putIfAbsent(sender, sublist);
         }
 
         for (ByteArrayWrapper key: newWrittenKeys) {
-            sublistsHavingWrittenToKey.putIfAbsent(key, sublist);
+            sublistsHavingWrittenToKey.put(key, sublist);
         }
     }
 


### PR DESCRIPTION
Two new cases were fixed:

1. Writing sequential thread wasn't tracked, so reading after writing sequential would return bad candidates
2. Writing to sequential after writing to parallel wasn't updated, hence not giving more precedence on future reads or writes to the sequential

