### PR TITLE
Set pegout creation entry to null when pegout gets fully signed

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -981,7 +981,6 @@ public class BridgeStorageProvider {
         if (
             this.pegoutCreationEntry == null
                 || this.pegoutCreationEntry.getBtcTxHash() == null
-                || this.pegoutCreationEntry.getRskTxHash() == null
                 || !activations.isActive(RSKIP298)
         ){
             return;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1454,16 +1454,7 @@ public class BridgeSupport {
             provider.getRskTxsWaitingForSignatures().remove(new Keccak256(rskTxHash));
             eventLogger.logReleaseBtc(btcTx, rskTxHash);
 
-            if (activations.isActive(RSKIP298)){
-                // Remove signatures to get the unsigned btcTxHash
-                BridgeUtils.removeSignaturesFromTransaction(btcTx, federation);
-                Sha256Hash unsignedBtcTxHash = btcTx.getHash();
-                Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(unsignedBtcTxHash);
-                // To only set to null existing entries, this check if exists a pegout creation entry for the given unsigned btcTxHash
-                if (pegoutCreationEntry.isPresent()){
-                    provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTx.getHash(), null));
-                }
-            }
+            removePegoutCreationEntry(btcTx, federation);
         } else if (logger.isDebugEnabled()) {
             int missingSignatures = BridgeUtils.countMissingSignatures(btcContext, btcTx);
             int neededSignatures = federation.getNumberOfSignaturesRequired();
@@ -1471,6 +1462,19 @@ public class BridgeSupport {
 
             logger.debug("Tx {} not yet fully signed. Requires {}/{} signatures but has {}",
                     new Keccak256(rskTxHash), neededSignatures, getFederationSize(), signaturesCount);
+        }
+    }
+
+    private void removePegoutCreationEntry(BtcTransaction btcTx, Federation federation) {
+        if (activations.isActive(RSKIP298)){
+            // Remove signatures to get the unsigned btcTxHash
+            BridgeUtils.removeSignaturesFromTransaction(btcTx, federation);
+            Sha256Hash unsignedBtcTxHash = btcTx.getHash();
+            Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(unsignedBtcTxHash);
+            // To only set to null existing entries, this check if exists a pegout creation entry for the given unsigned btcTxHash
+            if (pegoutCreationEntry.isPresent()){
+                provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTx.getHash(), null));
+            }
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -87,10 +87,10 @@ public class BridgeUtils {
             //Get redeem script for current input
             TransactionInput txInput = tx.getInput(inputIndex);
             Script inputRedeemScript = getRedeemScriptFromInput(txInput);
-            logger.trace("[removeSignaturesFromTransaction] input {} scriptSig {}", inputIndex, tx.getInput(inputIndex).getScriptSig());
+            logger.trace("[removeSignaturesFromTransaction] input {} scriptSig {}", inputIndex, txInput.getScriptSig());
             logger.trace("[removeSignaturesFromTransaction] input {} redeem script {}", inputIndex, inputRedeemScript);
 
-            txInput.setScriptSig(createBaseInputScriptThatSpendsFromTheFederation(spendingFed, inputRedeemScript));
+            txInput.setScriptSig(createBaseInputScriptThatSpendsFromTheFederation(spendingFed));
             logger.debug("[removeSignaturesFromTransaction] Updated input {} scriptSig with base input script that " +
                              "spends from the federation {}", inputIndex, spendingFed.getAddress());
         }
@@ -104,13 +104,11 @@ public class BridgeUtils {
         return new Script(program);
     }
 
-    private static Script createBaseInputScriptThatSpendsFromTheFederation(Federation federation, Script customRedeemScript) {
+    private static Script createBaseInputScriptThatSpendsFromTheFederation(Federation federation) {
         Script scriptPubKey = federation.getP2SHScript();
         Script redeemScript = federation.getRedeemScript();
         RedeemData redeemData = RedeemData.of(federation.getBtcPublicKeys(), redeemScript);
-
-        // customRedeemScript might not be actually custom, but just in case, use the provided redeemScript
-        return scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), customRedeemScript);
+        return scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript);
     }
 
     public static Wallet getFederationNoSpendWallet(

--- a/rskj-core/src/main/java/co/rsk/peg/PegoutCreationEntry.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegoutCreationEntry.java
@@ -30,19 +30,25 @@ public class PegoutCreationEntry {
         }
 
         PegoutCreationEntry that = (PegoutCreationEntry) o;
-        return getBtcTxHash().equals(that.getBtcTxHash()) && getRskTxHash().equals(that.getRskTxHash());
+
+        if (!getBtcTxHash().equals(that.getBtcTxHash())) {
+            return false;
+        }
+        return getRskTxHash() != null ? getRskTxHash().equals(that.getRskTxHash()) : that.getRskTxHash() == null;
     }
 
     @Override
     public int hashCode() {
-        return getBtcTxHash().hashCode() + getRskTxHash().hashCode();
+        int result = getBtcTxHash().hashCode();
+        result = 31 * result + (getRskTxHash() != null ? getRskTxHash().hashCode() : 0);
+        return result;
     }
 
     @Override
     public String toString() {
         return "PegoutCreationEntry{" +
                    "btcTxHash=" + btcTxHash +
-                   ", rskTxHash=" + rskTxHash +
+                   ", rskTxHash=" + (rskTxHash == null? "null":rskTxHash) +
                    '}';
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -3551,10 +3551,10 @@ class BridgeStorageProviderTest {
         provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTxHash, rskTxHash));
         provider.save();
 
-        verify(repository, never()).addStorageBytes(
+        verify(repository, atLeastOnce()).addStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
             storageKeyForPegoutCreationIndex,
-            BridgeSerializationUtils.serializeKeccak256(rskTxHash)
+            null
         );
 
         Optional<Keccak256> pegoutCreationEntry = provider.getPegoutCreationRskTxHashByBtcTxHash(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -3551,7 +3551,7 @@ class BridgeStorageProviderTest {
         provider.setPegoutCreationEntry(new PegoutCreationEntry(btcTxHash, rskTxHash));
         provider.save();
 
-        verify(repository, atLeastOnce()).addStorageBytes(
+        verify(repository, times(1)).addStorageBytes(
             PrecompiledContracts.BRIDGE_ADDR,
             storageKeyForPegoutCreationIndex,
             null

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -5644,6 +5644,7 @@ class BridgeSupportTest extends BridgeSupportTestBase {
         Assertions.assertEquals(TxType.MIGRATION, bridgeSupport.getTransactionType(tx));
     }
 
+
     @Test
     void getTransactionType_sentFromOldFed_beforeRskip199_pegin_tx() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -24,6 +24,8 @@ import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.TransactionInput;
+import co.rsk.bitcoinj.core.TransactionOutPoint;
 import co.rsk.bitcoinj.core.TransactionOutput;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.params.RegTestParams;
@@ -87,6 +89,18 @@ public class PegTestUtils {
         bytes[3] = (byte) (0xFF & nHash >> 24);
 
         return Sha256Hash.wrap(bytes);
+    }
+
+    public static TransactionInput createTransactionInputFromFed(Federation federation, NetworkParameters networkParameters) {
+        TransactionInput txIn = new TransactionInput(
+            networkParameters,
+            null,
+            new byte[]{},
+            new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
+        );
+        // Create script to be signed by federation members
+        txIn.setScriptSig(createBaseInputScriptThatSpendsFromTheFederation(federation));
+        return txIn;
     }
 
     public static Script createBaseInputScriptThatSpendsFromTheFederation(Federation federation) {


### PR DESCRIPTION
Add functionality to set to null entries in the pegout creation index when a pegout gets fully signed.

# Key changes

- Add BridgeUtils.removeSignaturesFromTransaction method, which is not really a new method, is just an util method brought from powpeg project to rskj. So, now it can be used in both projects.
- Add tests for BridgeUtils.removeSignaturesFromTransaction.
- Add logic to set to null entry on BridgeSupport.addSignature method when pegout meet fully signed condition.
- Add new tests for BridgeSupport.addSignature method, testing new fucntionality.