### PR TITLE
Avoid requesting for advanced (far) blocks.

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -98,10 +98,13 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processNewBlockHashesMessage(final Peer sender, final NewBlockHashesMessage message) {
+        //TODO - change this method (make use of isAdvancedBlock to avoid requesting far blocks)
         message.getBlockIdentifiers().stream()
+                .filter(bi -> !isAdvancedBlock(bi.getNumber()))
                 .map(bi -> new Keccak256(bi.getHash()))
                 .distinct()
                 .filter(b -> !hasBlock(b.getBytes()))
+               // .filter(b -> !hasBlock(b.getBytes()) && !isAdvancedBlock(b.getBlockNumber()))
                 .forEach(
                         b -> {
                             sender.sendMessage(new GetBlockMessage(b.getBytes()));

--- a/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/NodeBlockProcessor.java
@@ -98,13 +98,11 @@ public class NodeBlockProcessor implements BlockProcessor {
      */
     @Override
     public void processNewBlockHashesMessage(final Peer sender, final NewBlockHashesMessage message) {
-        //TODO - change this method (make use of isAdvancedBlock to avoid requesting far blocks)
         message.getBlockIdentifiers().stream()
                 .filter(bi -> !isAdvancedBlock(bi.getNumber()))
                 .map(bi -> new Keccak256(bi.getHash()))
                 .distinct()
                 .filter(b -> !hasBlock(b.getBytes()))
-               // .filter(b -> !hasBlock(b.getBytes()) && !isAdvancedBlock(b.getBlockNumber()))
                 .forEach(
                         b -> {
                             sender.sendMessage(new GetBlockMessage(b.getBytes()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In the processNewBlockHashesMessage method we could probably avoid requesting too advanced blocks (for example, if node is on early stages of a full-sync).

The main idea of this change is to avoid requesting these "far" blocks which will be later discarded. And by doing that, we can optimize the "processNewBlockHashesMessage" method.

This way we could save some unnecessary load in both nodes.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
