### PR TITLE
Affecting consensus by changing back federation migration age to its previous value

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -128,9 +128,11 @@ public abstract class BridgeConstants {
     }
 
     public long getFundsMigrationAgeSinceActivationEnd(ActivationConfig.ForBlock activations) {
-        return activations.isActive(ConsensusRule.RSKIP357) ?
-            specialCaseFundsMigrationAgeSinceActivationEnd :
-            fundsMigrationAgeSinceActivationEnd;
+        if (activations.isActive(ConsensusRule.RSKIP357) && !activations.isActive(ConsensusRule.RSKIP374)){
+            return specialCaseFundsMigrationAgeSinceActivationEnd;
+        }
+
+        return fundsMigrationAgeSinceActivationEnd;
     }
 
     public AddressBasedAuthorizer getFederationChangeAuthorizer() { return federationChangeAuthorizer; }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -79,7 +79,9 @@ public enum ConsensusRule {
     RSKIP297("rskip297"), // Increase max timestamp difference between btc and rsk blocks for Testnet
     RSKIP326("rskip326"), // release_request_received event update to use base58 for btcDestinationAddress
     RSKIP353("rskip353"),
-    RSKIP357("rskip357");
+    RSKIP357("rskip357"),
+    RSKIP374("rskip374"),
+    ;
 
     private String configKey;
 

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -78,6 +78,7 @@ blockchain = {
              rskip326 = <hardforkName>
              rskip353 = <hardforkName>
              rskip357 = <hardforkName>
+             rskip374 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -66,6 +66,7 @@ blockchain = {
             rskip326 = fingerroot500
             rskip353 = hop401
             rskip357 = hop401
+            rskip374 = fingerroot500
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/config/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/BridgeConstantsTest.java
@@ -1,0 +1,69 @@
+package co.rsk.config;
+
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BridgeConstantsTest {
+
+    private static Stream<Arguments> generator() {
+        return Stream.of(
+            Arguments.of(BridgeMainNetConstants.getInstance(), false),
+            Arguments.of(BridgeTestNetConstants.getInstance(), true),
+            Arguments.of(BridgeRegTestConstants.getInstance(), true)
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("generator")
+    void test_getFundsMigrationAgeSinceActivationEnd(BridgeConstants bridgeConstants, boolean hasSameValueForBothMigrationAges) {
+        // Arrange
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+
+        // Act
+        long fundsMigrationAgeSinceActivationEnd = bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
+
+        // assert
+        assertEquals(fundsMigrationAgeSinceActivationEnd, bridgeConstants.fundsMigrationAgeSinceActivationEnd);
+        assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("generator")
+    void test_getFundsMigrationAgeSinceActivationEnd_post_RSKIP357(BridgeConstants bridgeConstants, boolean hasSameValueForBothMigrationAges) {
+        // Arrange
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+
+        // Act
+        long fundsMigrationAgeSinceActivationEnd = bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
+
+        // assert
+        assertEquals(fundsMigrationAgeSinceActivationEnd, bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
+        assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.fundsMigrationAgeSinceActivationEnd);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("generator")
+    void test_getFundsMigrationAgeSinceActivationEnd_post_RSKIP374(BridgeConstants bridgeConstants, boolean hasSameValueForBothMigrationAges) {
+        // Arrange
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
+
+        // Act
+        long fundsMigrationAgeSinceActivationEnd = bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
+
+        // assert
+        assertEquals(fundsMigrationAgeSinceActivationEnd, bridgeConstants.fundsMigrationAgeSinceActivationEnd);
+        assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -31,74 +31,153 @@ class BridgeSupportProcessFundsMigrationTest {
 
     @Test
     void processFundsMigration_in_migration_age_before_rskip_146_activation_testnet() throws IOException {
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), false, false, true);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, true);
     }
 
     @Test
     void processFundsMigration_in_migration_age_after_rskip_146_activation_testnet() throws IOException {
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), true, false, true);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, true);
     }
 
     @Test
     void processFundsMigration_in_migration_age_after_rskip_357_activation_testnet() throws IOException {
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), true, true, true);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, true);
+    }
+
+    @Test
+    void processFundsMigration_in_migration_age_after_rskip_374_activation_testnet() throws IOException {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
+        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, true);
     }
 
     @Test
     void processFundsMigration_past_migration_age_before_rskip_146_activation_testnet() throws IOException {
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), false, false, false);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, false);
     }
 
     @Test
     void processFundsMigration_past_migration_age_after_rskip_146_activation_testnet() throws IOException {
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), true, false, false);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, false);
     }
 
     @Test
     void processFundsMigration_past_migration_age_after_rskip_357_activation_testnet() throws IOException {
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), true, true, false);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, false);
+    }
+
+    @Test
+    void processFundsMigration_past_migration_age_after_rskip_374_activation_testnet() throws IOException {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
+        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, false);
     }
 
     @Test
     void processFundsMigration_in_migration_age_before_rskip_146_activation_mainnet() throws IOException {
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), false, false, true);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, true);
     }
 
     @Test
     void processFundsMigration_in_migration_age_after_rskip_146_activation_mainnet() throws IOException {
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), true, false, true);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, true);
     }
 
     @Test
     void processFundsMigration_in_migration_age_after_rskip_357_activation_mainnet() throws IOException {
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), true, true, true);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, true);
+    }
+
+    @Test
+    void processFundsMigration_in_migration_age_after_rskip_374_activation_mainnet() throws IOException {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
+        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, true);
     }
 
     @Test
     void processFundsMigration_past_migration_age_before_rskip_146_activation_mainnet() throws IOException {
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), false, false, false);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, false);
     }
 
     @Test
     void processFundsMigration_past_migration_age_after_rskip_146_activation_mainnet() throws IOException {
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), true, false, false);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, false);
     }
 
     @Test
     void processFundsMigration_past_migration_age_after_rskip_357_activation_mainnet() throws IOException {
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), true, true, false);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
+        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, false);
+    }
+
+    @Test
+    void processFundsMigration_past_migration_age_after_rskip_374_activation_mainnet() throws IOException {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
+        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, false);
     }
 
     private void test_processFundsMigration(
         BridgeConstants bridgeConstants,
-        boolean isRskip146Active,
-        boolean isRskip357Active,
-        boolean inMigrationAge) throws IOException {
-
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(isRskip146Active);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(isRskip357Active);
-
+        ActivationConfig.ForBlock activations,
+        boolean inMigrationAge
+    ) throws IOException {
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
         Federation oldFederation = bridgeConstants.getGenesisFederation();
@@ -149,10 +228,10 @@ class BridgeSupportProcessFundsMigrationTest {
         Transaction updateCollectionsTx = buildUpdateCollectionsTransaction();
         bridgeSupport.updateCollections(updateCollectionsTx);
 
-        Assertions.assertEquals(isRskip146Active ? 0 : 1, provider.getReleaseTransactionSet().getEntriesWithoutHash().size());
-        Assertions.assertEquals(isRskip146Active ? 1 : 0, provider.getReleaseTransactionSet().getEntriesWithHash().size());
+        Assertions.assertEquals(activations.isActive(ConsensusRule.RSKIP146)? 0 : 1, provider.getReleaseTransactionSet().getEntriesWithoutHash().size());
+        Assertions.assertEquals(activations.isActive(ConsensusRule.RSKIP146) ? 1 : 0, provider.getReleaseTransactionSet().getEntriesWithHash().size());
 
-        if (isRskip146Active) {
+        if (activations.isActive(ConsensusRule.RSKIP146)) {
             // Should have been logged with the migrated UTXO
             ReleaseTransactionSet.Entry entry = (ReleaseTransactionSet.Entry) provider.getReleaseTransactionSet()
                 .getEntriesWithHash()

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -105,6 +105,7 @@ class ActivationConfigTest {
             "    rskip326: fingerroot500",
             "    rskip353: hop401",
             "    rskip357: hop401",
+            "    rskip374: fingerroot500",
             "}"
     ));
 


### PR DESCRIPTION
This change consists of changing method co.rsk.config.BridgeConstants#getFundsMigrationAgeSinceActivationEnd to return again the fundsMigrationAgeSinceActivationEnd(10585L) value when the RSKIP374 gets active.