### PR TITLE
Return "0x0" type in transaction receipt and result

### DIFF
--- a/doc/rpc/components/schemas/Receipt.json
+++ b/doc/rpc/components/schemas/Receipt.json
@@ -14,7 +14,8 @@
       "logsBloom",
       "to",
       "transactionHash",
-      "transactionIndex"
+      "transactionIndex",
+      "type"
     ],
     "properties": {
       "blockHash": {
@@ -72,6 +73,11 @@
         "title": "ReceiptStatus",
         "description": "Whether or not the transaction threw an error.",
         "type": "boolean"
+      },
+      "type": {
+        "title": "ReceiptType",
+        "description": "is a positive unsigned 8-bit number that represents the type of the transaction.",
+        "type": "string"
       },
       "root": {
         "title": "Receipt Root",

--- a/doc/rpc/components/schemas/Transaction.json
+++ b/doc/rpc/components/schemas/Transaction.json
@@ -67,6 +67,11 @@
         "title": "transactionSigS",
         "type": "string",
         "description": "ECDSA signature s"
+      },
+      "type": {
+        "title": "ReceiptType",
+        "description": "is a positive unsigned 8-bit number that represents the type of the transaction.",
+        "type": "string"
       }
     }
   }

--- a/doc/rpc/components/schemas/TransactionExampleResult.json
+++ b/doc/rpc/components/schemas/TransactionExampleResult.json
@@ -13,6 +13,7 @@
     "value": "0xf3dbb76162000",
     "v": "0x25",
     "r": "0x1b5e176d927f8e9ab405058b2d2457392da3e20f328b16ddabcebc33eaac5fea",
-    "s": "0x4ba69724e8f69de52f0125ad8b3c5c2cef33019bac3249e2c0a2192766d1721c"
+    "s": "0x4ba69724e8f69de52f0125ad8b3c5c2cef33019bac3249e2c0a2192766d1721c",
+    "type": "0x0"
   }
 }

--- a/doc/rpc/methods/eth_getTransactionReceipt.json
+++ b/doc/rpc/methods/eth_getTransactionReceipt.json
@@ -57,7 +57,8 @@
               }
             ],
             "logsBloom": "0x00...0",
-            "status": "0x1"
+            "status": "0x1",
+            "type": "0x0"
           }
         ]
       }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -72,7 +72,7 @@ public class TransactionReceiptDTO {
         transactionHash = receipt.getTransaction().getHash().toJsonString();
         transactionIndex = HexUtils.toQuantityJsonHex(txInfo.getIndex());
         logsBloom = HexUtils.toUnformattedJsonHex(txInfo.getReceipt().getBloomFilter().getData());
-        type = "0x00";
+        type = "0x0";
     }
 
     public String getTransactionHash() {

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -43,6 +43,7 @@ public class TransactionReceiptDTO {
     private String to;                   // address of the receiver. null when it's a contract creation transaction.
     private String status;               // either 1 (success) or 0 (failure)
     private String logsBloom;            // Bloom filter for light clients to quickly retrieve related logs.
+    private String type;
 
     public TransactionReceiptDTO(Block block, TransactionInfo txInfo, SignatureCache signatureCache) {
         TransactionReceipt receipt = txInfo.getReceipt();
@@ -71,6 +72,7 @@ public class TransactionReceiptDTO {
         transactionHash = receipt.getTransaction().getHash().toJsonString();
         transactionIndex = HexUtils.toQuantityJsonHex(txInfo.getIndex());
         logsBloom = HexUtils.toUnformattedJsonHex(txInfo.getReceipt().getBloomFilter().getData());
+        type = "0x00";
     }
 
     public String getTransactionHash() {
@@ -119,5 +121,9 @@ public class TransactionReceiptDTO {
 
     public String getLogsBloom() {
         return logsBloom;
+    }
+
+    public String getType() {
+        return type;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -31,6 +31,8 @@ import co.rsk.util.HexUtils;
  * Created by Ruben on 5/1/2016.
  */
 public class TransactionReceiptDTO {
+    private static final String TRANSACTION_TYPE = "0x0";
+
     private String transactionHash;      // hash of the transaction.
     private String transactionIndex;     // integer of the transactions index position in the block.
     private String blockHash;            // hash of the block where this transaction was in.
@@ -43,7 +45,7 @@ public class TransactionReceiptDTO {
     private String to;                   // address of the receiver. null when it's a contract creation transaction.
     private String status;               // either 1 (success) or 0 (failure)
     private String logsBloom;            // Bloom filter for light clients to quickly retrieve related logs.
-    private String type;
+    private String type = TRANSACTION_TYPE;     // is a positive unsigned 8-bit number that represents the type of the transaction.
 
     public TransactionReceiptDTO(Block block, TransactionInfo txInfo, SignatureCache signatureCache) {
         TransactionReceipt receipt = txInfo.getReceipt();
@@ -72,7 +74,6 @@ public class TransactionReceiptDTO {
         transactionHash = receipt.getTransaction().getHash().toJsonString();
         transactionIndex = HexUtils.toQuantityJsonHex(txInfo.getIndex());
         logsBloom = HexUtils.toUnformattedJsonHex(txInfo.getReceipt().getBloomFilter().getData());
-        type = "0x0";
     }
 
     public String getTransactionHash() {

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -47,6 +47,7 @@ public class TransactionResultDTO {
     private String v;
     private String r;
     private String s;
+    private String type;
 
     public TransactionResultDTO(Block b, Integer index, Transaction tx, boolean zeroSignatureIfRemasc, SignatureCache signatureCache) {
         hash = tx.getHash().toJsonString();
@@ -62,6 +63,8 @@ public class TransactionResultDTO {
         gas = HexUtils.toQuantityJsonHex(tx.getGasLimit());
 
         gasPrice = HexUtils.toQuantityJsonHex(tx.getGasPrice().getBytes());
+
+        type = "0x0";
 
         if (Coin.ZERO.equals(tx.getValue())) {
             value = "0x0";
@@ -142,4 +145,7 @@ public class TransactionResultDTO {
         return s;
     }
 
+    public String getType() {
+        return type;
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -32,6 +32,7 @@ import co.rsk.util.HexUtils;
 public class TransactionResultDTO {
 
     private static final String HEX_ZERO = "0x0";
+    private static final String TRANSACTION_TYPE = "0x0";
 
     private String hash;
     private String nonce;
@@ -47,7 +48,7 @@ public class TransactionResultDTO {
     private String v;
     private String r;
     private String s;
-    private String type;
+    private String type = TRANSACTION_TYPE;
 
     public TransactionResultDTO(Block b, Integer index, Transaction tx, boolean zeroSignatureIfRemasc, SignatureCache signatureCache) {
         hash = tx.getHash().toJsonString();
@@ -63,8 +64,6 @@ public class TransactionResultDTO {
         gas = HexUtils.toQuantityJsonHex(tx.getGasLimit());
 
         gasPrice = HexUtils.toQuantityJsonHex(tx.getGasPrice().getBytes());
-
-        type = "0x0";
 
         if (Coin.ZERO.equals(tx.getValue())) {
             value = "0x0";

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -2945,4 +2945,26 @@ class Web3ImplTest {
 
         return block;
     }
+
+    @Test
+    void transactionReceiptAndResultHasTypeField() {
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = new World(receiptStore);
+        Web3Impl web3 = createWeb3(world, receiptStore);
+
+        Account acc1 = new AccountBuilder(world).name("acc1").balance(Coin.valueOf(2000000)).build();
+        Account acc2 = new AccountBuilder().name("acc2").build();
+        Transaction tx = new TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
+        List<Transaction> txs = new ArrayList<>();
+        txs.add(tx);
+        Block block1 = createCanonicalBlock(world, txs);
+
+        String hashString = tx.getHash().toHexString();
+
+        TransactionReceiptDTO txReceipt = web3.eth_getTransactionReceipt(hashString);
+        TransactionResultDTO txResult = web3.eth_getTransactionByHash(hashString);
+
+        assertEquals("0x0", txReceipt.getType());
+        assertEquals("0x0", txResult.getType());
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionReceiptDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionReceiptDTOTest.java
@@ -153,4 +153,33 @@ class TransactionReceiptDTOTest {
         assertNotNull(actualStatus);
         assertEquals("0x0", actualStatus);
     }
+    @Test
+    void testTypeField() {
+        RskAddress rskAddress = RskAddress.nullAddress();
+        Keccak256 hash = Keccak256.ZERO_HASH;
+        Bloom bloom = new Bloom();
+
+        Block block = mock(Block.class);
+        when(block.getHash()).thenReturn(hash);
+
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getHash()).thenReturn(hash);
+        when(transaction.getSender(any(SignatureCache.class))).thenReturn(rskAddress);
+        when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+
+        TransactionReceipt txReceipt = mock(TransactionReceipt.class);
+        when(txReceipt.getTransaction()).thenReturn(transaction);
+        when(txReceipt.getLogInfoList()).thenReturn(Collections.emptyList());
+        when(txReceipt.getBloomFilter()).thenReturn(bloom);
+        when(txReceipt.getStatus()).thenReturn(ByteUtil.EMPTY_BYTE_ARRAY);
+
+        TransactionInfo txInfo = new TransactionInfo(txReceipt, hash.getBytes(), 0);
+
+        TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
+
+        String actualType = transactionReceiptDTO.getType();
+
+        assertNotNull(actualType);
+        assertEquals("0x0", actualType);
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
@@ -115,5 +115,19 @@ class TransactionResultDTOTest {
         Assertions.assertEquals(HEX_ZERO, dto.getR());
         Assertions.assertEquals(HEX_ZERO, dto.getS());
     }
+
+    @Test
+    void transactionResultHasType() {
+        Transaction originalTransaction = CallTransaction.createCallTransaction(
+                1, 0, 100000000000000L,
+                new RskAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), 0,
+                CallTransaction.Function.fromSignature("get"), chainId);
+
+        originalTransaction.sign(new byte[]{});
+
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 42, originalTransaction, false, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
+
+        Assertions.assertEquals("0x0", dto.getType());
+    }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To be backwards compatible with Ethereum we need to extend our transaction receipt DTO and transaction result DTO in the RPC response with new the new field “type”, and return “0x0” as its value. - following EIP-2718

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
