### PR TITLE
Fixed tests by mocking NodeStopper and RskContext in CliToolTests

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -56,7 +56,11 @@ public abstract class CliToolRskContextAware {
     }
 
     public void execute(@Nonnull String[] args) {
-        execute(args, () -> new RskContext(args, true), System::exit);
+        execute(args, System::exit);
+    }
+
+    public void execute(@Nonnull String[] args, @Nonnull NodeStopper nodeStopper) {
+        execute(args, () -> new RskContext(args, true), nodeStopper);
     }
 
     public void execute(@Nonnull String[] args, @Nonnull Factory<RskContext> contextFactory, @Nonnull NodeStopper nodeStopper) {

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -91,7 +91,8 @@ class CliToolsTest {
         private String target;
 
         public static void main(String[] args) {
-            create(MethodHandles.lookup().lookupClass()).execute(args);
+            NodeStopper stopper = mock(NodeStopper.class);
+            create(MethodHandles.lookup().lookupClass()).execute(args, stopper);
         }
 
         @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed tests by mocking NodeStopper and RskContext in CliToolTests

## Description
Multiple tests were ignored due to the `System::exit` execution within `CliToolRskContextAware`. So we mocked RSK

## Motivation and Context
Multiple tests were ignored due to the `System::exit` execution within `CliToolRskContextAware`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
