### PR TITLE
Change rpc.modules config from array to object

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
+++ b/rskj-core/src/main/java/co/rsk/config/ConfigLoader.java
@@ -197,6 +197,9 @@ public class ConfigLoader {
                 ConfigValue expectedEntryValue = expectedObject.get(actualEntryKey);
                 String entryKeyPath = prefix + actualEntryKey;
                 if (expectedEntryValue == null) {
+                    expectedEntryValue = expectedObject.get("<fallback>");
+                }
+                if (expectedEntryValue == null) {
                     logger.warn("Unexpected config value {} for key path `{}`. See expected.conf for the expected settings", actualEntryValue, entryKeyPath);
                     valid = false;
                 } else {

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -301,7 +301,7 @@ public class RskSystemProperties extends SystemProperties {
             timeout = configElement.getInt("timeout");
         }
 
-        if (configElement.hasPath("methodTimeout")) {
+        if (configElement.hasPath("methods.timeout")) {
             fetchMethodTimeout(configElement, methodTimeoutMap);
         }
 

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -51,6 +51,7 @@ public class RskSystemProperties extends SystemProperties {
 
     private static final String MINER_REWARD_ADDRESS_CONFIG = "miner.reward.address";
     private static final String MINER_COINBASE_SECRET_CONFIG = "miner.coinbase.secret";
+    private static final String RPC_MODULES_PATH = "rpc.modules";
     private static final int CHUNK_SIZE = 192;
 
     //TODO: REMOVE THIS WHEN THE LocalBLockTests starts working with REMASC
@@ -250,16 +251,16 @@ public class RskSystemProperties extends SystemProperties {
 
         List<ModuleDescription> modules = new ArrayList<>();
 
-        if (!configFromFiles.hasPath("rpc.modules")) {
+        if (!configFromFiles.hasPath(RPC_MODULES_PATH)) {
             return modules;
         }
 
-        ConfigValue modulesConfig = configFromFiles.getValue("rpc.modules");
+        ConfigValue modulesConfig = configFromFiles.getValue(RPC_MODULES_PATH);
         if (modulesConfig.valueType() == ConfigValueType.LIST) {
-            List<? extends ConfigObject> list = configFromFiles.getObjectList("rpc.modules");
+            List<? extends ConfigObject> list = configFromFiles.getObjectList(RPC_MODULES_PATH);
             modules = getModulesFromListFormat(list);
         } else {
-            ConfigObject configObject = configFromFiles.getObject("rpc.modules");
+            ConfigObject configObject = configFromFiles.getObject(RPC_MODULES_PATH);
             modules = getModulesFromObjectFormat(configObject);
         }
         this.moduleDescriptions = modules;

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -22,6 +22,8 @@ import co.rsk.core.RskAddress;
 import co.rsk.rpc.ModuleDescription;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
 import org.ethereum.config.Constants;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.core.Account;
@@ -252,40 +254,15 @@ public class RskSystemProperties extends SystemProperties {
             return modules;
         }
 
-        List<? extends ConfigObject> list = configFromFiles.getObjectList("rpc.modules");
-
-        for (ConfigObject configObject : list) {
-            Config configElement = configObject.toConfig();
-            String name = configElement.getString("name");
-            String version = configElement.getString("version");
-            boolean enabled = configElement.getBoolean("enabled");
-            long timeout = 0;
-            Map<String, Long> methodTimeoutMap = new HashMap<>();
-
-            if (configElement.hasPath("timeout")) {
-                timeout = configElement.getLong("timeout");
-            }
-
-            if (configElement.hasPath("methods.timeout")) {
-                fetchMethodTimeout(configElement, methodTimeoutMap);
-            }
-
-            List<String> enabledMethods = null;
-            List<String> disabledMethods = null;
-
-            if (configElement.hasPath("methods.enabled")) {
-                enabledMethods = configElement.getStringList("methods.enabled");
-            }
-
-            if (configElement.hasPath("methods.disabled")) {
-                disabledMethods = configElement.getStringList("methods.disabled");
-            }
-
-            modules.add(new ModuleDescription(name, version, enabled, enabledMethods, disabledMethods, timeout, methodTimeoutMap));
+        ConfigValue modulesConfig = configFromFiles.getValue("rpc.modules");
+        if (modulesConfig.valueType() == ConfigValueType.LIST) {
+            List<? extends ConfigObject> list = configFromFiles.getObjectList("rpc.modules");
+            modules = getModulesFromListFormat(list);
+        } else {
+            ConfigObject configObject = configFromFiles.getObject("rpc.modules");
+            modules = getModulesFromObjectFormat(configObject);
         }
-
         this.moduleDescriptions = modules;
-
         return modules;
     }
 

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -289,6 +289,53 @@ public class RskSystemProperties extends SystemProperties {
         return modules;
     }
 
+    private List<ModuleDescription> getModulesFromObjectFormat(ConfigObject modulesConfigObject) {
+        List<ModuleDescription> modules = new ArrayList<>();
+
+        for (String configKey : modulesConfigObject.keySet()) {
+            String name = configKey;
+            Config configElement = ((ConfigObject) modulesConfigObject.get(configKey)).toConfig();
+            modules.add(getModule(configElement, name));
+        }
+        return modules;
+    }
+
+    private List<ModuleDescription> getModulesFromListFormat(List<? extends ConfigObject> list) {
+        List<ModuleDescription> modules = new ArrayList<>();
+        for (ConfigObject configObject : list) {
+            Config configElement = configObject.toConfig();
+            String name = configElement.getString("name");
+            modules.add(getModule(configElement, name));
+        }
+        return modules;
+    }
+    private ModuleDescription getModule(Config configElement, String name) {
+
+        String version = configElement.getString("version");
+        boolean enabled = configElement.getBoolean("enabled");
+        List<String> enabledMethods = null;
+        List<String> disabledMethods = null;
+        int timeout = 0;
+        Map<String, Long> methodTimeoutMap = new HashMap<>();
+
+
+        if (configElement.hasPath("timeout")) {
+            timeout = configElement.getInt("timeout");
+        }
+
+        if (configElement.hasPath("methodTimeout")) {
+            fetchMethodTimeout(configElement, methodTimeoutMap);
+        }
+
+        if (configElement.hasPath("methods.enabled")) {
+            enabledMethods = configElement.getStringList("methods.enabled");
+        }
+
+        if (configElement.hasPath("methods.disabled")) {
+            disabledMethods = configElement.getStringList("methods.disabled");
+        }
+        return new ModuleDescription(name, version, enabled, enabledMethods, disabledMethods, timeout, methodTimeoutMap);
+    }
     public boolean hasMessageRecorderEnabled() {
         return getBoolean("messages.recorder.enabled", false);
     }

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -258,21 +258,20 @@ rpc = {
             }
         }
     }
-    modules = [
-        {
-            name = <name>
-            version = <version>
+    modules = {
+        <fallback> {
+            version = <string>
             enabled = <enabled>
             timeout = <number>
             methods = {
                 enabled = [<string>]
-                disabled = [<disabled>]
+                disabled = [<string>]
                 timeout = {
                     # <method> = <number>
                 }
             }
         }
-    ]
+    }
     skipRemasc: <enabled>
     zeroSignatureIfRemasc = <enabled>
     gasEstimationCap = <gas>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -357,10 +357,9 @@ rpc {
             }
         }
     }
-    # Enabled RPC Modules. If the module is NOT in the list, and mark as "enabled", the rpc calls will be discard.
+    # Enabled RPC Modules. If the module is NOT in the object, and mark as "enabled", the rpc calls will be discard.
     # It is possible to enable/disable a particular method in a module
-    # {
-    #  name: "evm",
+    # evm {
     #  version: "1.0",
     #  enabled: "true",
     #  methods: {
@@ -368,66 +367,55 @@ rpc {
     #      disabled: [ "evm_reset", "evm_increaseTime" ]
     #  }
     # }
-    modules = [
-        {
-            name: "eth",
+    modules = {
+        eth {
             version: "1.0",
             enabled: "true",
         },
-        {
-            name: "net",
+        net {
             version: "1.0",
             enabled: "true",
         },
-        {
-            name: "rpc",
+        rpc {
             version: "1.0",
             enabled: "true",
         },
-        {
-            name: "web3",
+        web3 {
             version: "1.0",
             enabled: "true",
         },
-        {
-            name: "evm",
+        evm {
             version: "1.0",
             enabled: "true",
         },
-        {
-            name: "sco",
+        sco {
             version: "1.0",
             enabled: "false",
         },
-        {
-            name: "txpool",
+        txpool {
             version: "1.0",
             enabled: "true",
         },
-        {
-            name: "personal",
+        personal {
             version: "1.0",
             enabled: "true"
         },
-        {
-            name: "debug",
+        debug {
             version: "1.0",
             enabled: "false"
         },
-        {
-            name: "trace",
+        trace {
             version: "1.0",
             enabled: "false"
         },
-        {
-            name: "rsk",
+        rsk {
             version: "1.0",
             enabled: "true",
             methods: {
                 disabled: [ "rsk_shutdown" ]
             }
         }
-    ]
+    }
     skipRemasc: false
     # set signature to zero (instead of null) for Remasc transaction on RPC DTOs
     zeroSignatureIfRemasc = true

--- a/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/RskSystemPropertiesTest.java
@@ -146,6 +146,7 @@ class RskSystemPropertiesTest {
                         "    name: \"web\", \n" +
                         "    version: \"2.0\",\n" +
                         "    enabled: false,\n" +
+                        "    timeout: 1000,\n" +
                         "  }\n" +
                         "  {\n" +
                         "    name: \"net\", \n" +
@@ -154,6 +155,7 @@ class RskSystemPropertiesTest {
                         "    methods: {\n" +
                         "       enabled: [ \"evm_snapshot\", \"evm_revert\" ],\n" +
                         "       disabled: [ \"evm_reset\"]\n" +
+                        "       timeout: { \"eth_getBlockByHash\" = 5000}\n" +
                         "    }\n" +
                         "  }\n" +
                         "]\n" +
@@ -170,9 +172,11 @@ class RskSystemPropertiesTest {
         ModuleDescription webModule = moduleDescriptionMap.get("web");
         assertEquals("2.0", webModule.getVersion());
         assertEquals(false, webModule.isEnabled());
+        assertEquals(1000, webModule.getTimeout());
         ModuleDescription netModule = moduleDescriptionMap.get("net");
         assertEquals(2, netModule.getEnabledMethods().size());
         assertEquals(1, netModule.getDisabledMethods().size());
+        assertEquals(5000, netModule.getMethodTimeout("eth_getBlockByHash"));
     }
     @Test
     void testGetRpcModulesWithObject() {
@@ -190,9 +194,11 @@ class RskSystemPropertiesTest {
                         "  net {\n" +
                         "    version: \"3.0\",\n" +
                         "    enabled: true,\n" +
+                        "    timeout: 9000,\n" +
                         "    methods: {\n" +
                         "       enabled: [ \"evm_snapshot\", \"evm_revert\" ],\n" +
                         "       disabled: [ \"evm_reset\"]\n" +
+                        "       timeout: { \"eth_getBlockByHash\" = 30000}\n" +
                         "    }\n" +
                         "  }\n" +
                         "}\n" +
@@ -213,5 +219,7 @@ class RskSystemPropertiesTest {
         ModuleDescription netModule = moduleDescriptionMap.get("net");
         assertEquals(2, netModule.getEnabledMethods().size());
         assertEquals(1, netModule.getDisabledMethods().size());
+        assertEquals(9000, netModule.getTimeout());
+        assertEquals(30000, netModule.getMethodTimeout("eth_getBlockByHash"));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Currently, rpc.modules is an array. Changing only one value (in DevOps case, enabling debug module in order to get access to queue size thru RPC) implies redefining rpc.modules in its totality.

Given that each entry of rpc.modules does include an unique name property, a better approach could be to change modules into an object.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
