### PR TITLE
Allow specifying VM options when running RSKj in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,14 @@ USER rsk
 WORKDIR /var/lib/rsk
 COPY --from=build --chown=rsk:rsk /home/rsk/rsk.jar ./
 
-ENV JAVA_OPTS=""
+ENV DEFAULT_JVM_OPTS="-Xms3G -Xmx5G"
+ENV RSKJ_SYS_PROPS="-Drpc.providers.web.http.bind_address=0.0.0.0 -Drpc.providers.web.http.hosts.0=localhost -Drpc.providers.web.http.hosts.1=127.0.0.1 -Drpc.providers.web.http.hosts.2=::1"
 ENV RSKJ_CLASS=co.rsk.Start
 ENV RSKJ_OPTS=""
 
 ENTRYPOINT java \
-    $JAVA_OPTS \
-    -Drpc.providers.web.http.bind_address=0.0.0.0 \
-    -Drpc.providers.web.http.hosts.0=localhost \
-    -Drpc.providers.web.http.hosts.1=127.0.0.1 \
-    -Drpc.providers.web.http.hosts.2=::1 \
+    $DEFAULT_JVM_OPTS \
+    $RSKJ_SYS_PROPS \
     -cp rsk.jar \
     $RSKJ_CLASS \
     $RSKJ_OPTS

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ USER rsk
 WORKDIR /var/lib/rsk
 COPY --from=build --chown=rsk:rsk /home/rsk/rsk.jar ./
 
-ENV DEFAULT_JVM_OPTS="-Xms3G -Xmx5G"
+ENV DEFAULT_JVM_OPTS="-Xms4G"
 ENV RSKJ_SYS_PROPS="-Drpc.providers.web.http.bind_address=0.0.0.0 -Drpc.providers.web.http.hosts.0=localhost -Drpc.providers.web.http.hosts.1=127.0.0.1 -Drpc.providers.web.http.hosts.2=::1"
 ENV RSKJ_CLASS=co.rsk.Start
 ENV RSKJ_OPTS=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,16 @@ USER rsk
 WORKDIR /var/lib/rsk
 COPY --from=build --chown=rsk:rsk /home/rsk/rsk.jar ./
 
-ENTRYPOINT ["java", \
-    "-Drpc.providers.web.http.bind_address=0.0.0.0", \
-    "-Drpc.providers.web.http.hosts.0=localhost", \
-    "-Drpc.providers.web.http.hosts.1=127.0.0.1", \
-    "-Drpc.providers.web.http.hosts.2=::1", \
-    "-cp", "rsk.jar", "co.rsk.Start"]
+ENV JAVA_OPTS=""
+ENV RSKJ_CLASS=co.rsk.Start
+ENV RSKJ_OPTS=""
+
+ENTRYPOINT java \
+    $JAVA_OPTS \
+    -Drpc.providers.web.http.bind_address=0.0.0.0 \
+    -Drpc.providers.web.http.hosts.0=localhost \
+    -Drpc.providers.web.http.hosts.1=127.0.0.1 \
+    -Drpc.providers.web.http.hosts.2=::1 \
+    -cp rsk.jar \
+    $RSKJ_CLASS \
+    $RSKJ_OPTS

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,5 @@ ENV RSKJ_SYS_PROPS="-Drpc.providers.web.http.bind_address=0.0.0.0 -Drpc.provider
 ENV RSKJ_CLASS=co.rsk.Start
 ENV RSKJ_OPTS=""
 
-ENTRYPOINT java \
-    $DEFAULT_JVM_OPTS \
-    $RSKJ_SYS_PROPS \
-    -cp rsk.jar \
-    $RSKJ_CLASS \
-    $RSKJ_OPTS
+ENTRYPOINT ["/bin/sh", "-c", "java $DEFAULT_JVM_OPTS $RSKJ_SYS_PROPS -cp rsk.jar $RSKJ_CLASS $RSKJ_OPTS \"${@}\"", "--"]
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow JAVA_OPTS env variable when running docker container.

## Motivation and Context
In the rskj repo we have a GitHub workflow that builds and pushes a docker image to DockerHub. Here’s a docker [file](https://github.com/rsksmart/rskj/blob/9c14a23e49de1b4729c8ab226c9e68445a8437a3/Dockerfile#L31-L36) for that

As of now, only a specific set of sys args is specified in the entrypoint statement and there’s no way to override or add extra vm args, eg. -Xmx or -Xss.

The idea is to define an env. var. in the Dockerfile, which would allow us to do that.

## How Has This Been Tested?
Running the follwoing commands:
```
docker build -t rskj-node -f Dockerfile . 
docker run --name rskj-node -e DEFAULT_JVM_OPTS="-Xms3G -Xmx5G" rskj-node
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
