### PR TITLE
Renamed methods, logs and tests and refactored co.rsk.peg.ReleaseTransactionSet.Entry class

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -682,8 +682,8 @@ public class BridgeSerializationUtils {
         int n = 0;
 
         for (ReleaseTransactionSet.Entry entry : entries) {
-            bytes[n++] = RLP.encodeElement(entry.getTransaction().bitcoinSerialize());
-            bytes[n++] = RLP.encodeBigInteger(BigInteger.valueOf(entry.getRskBlockNumber()));
+            bytes[n++] = RLP.encodeElement(entry.getPegoutCreationBtcTx().bitcoinSerialize());
+            bytes[n++] = RLP.encodeBigInteger(BigInteger.valueOf(entry.getPegoutCreationRskBlockNumber()));
         }
 
         return RLP.encodeList(bytes);
@@ -697,9 +697,9 @@ public class BridgeSerializationUtils {
         int n = 0;
 
         for (ReleaseTransactionSet.Entry entry : entries) {
-            bytes[n++] = RLP.encodeElement(entry.getTransaction().bitcoinSerialize());
-            bytes[n++] = RLP.encodeBigInteger(BigInteger.valueOf(entry.getRskBlockNumber()));
-            bytes[n++] = RLP.encodeElement(entry.getRskTxHash().getBytes());
+            bytes[n++] = RLP.encodeElement(entry.getPegoutCreationBtcTx().bitcoinSerialize());
+            bytes[n++] = RLP.encodeBigInteger(BigInteger.valueOf(entry.getPegoutCreationRskBlockNumber()));
+            bytes[n++] = RLP.encodeElement(entry.getPegoutCreationRskTxHash().getBytes());
         }
 
         return RLP.encodeList(bytes);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1253,7 +1253,7 @@ public class BridgeSupport {
 
         ReleaseTransactionSet.Entry entry = nextPegoutWithEnoughConfirmations.get();
 
-        Keccak256 txWaitingForSignatureKey = getTxWaitingForSignatureKey(rskTx, entry);
+        Keccak256 txWaitingForSignatureKey = getPegoutWaitingForSignatureKey(rskTx, entry);
         if (activations.isActive(ConsensusRule.RSKIP375)){
             /*
              This check aims to prevent entry overriding. Currently, we do not accept more than one peg-out
@@ -1275,7 +1275,7 @@ public class BridgeSupport {
         }
     }
 
-    private Keccak256 getTxWaitingForSignatureKey(Transaction rskTx, ReleaseTransactionSet.Entry entry) {
+    private Keccak256 getPegoutWaitingForSignatureKey(Transaction rskTx, ReleaseTransactionSet.Entry entry) {
         if (activations.isActive(ConsensusRule.RSKIP375)){
             return entry.getPegoutCreationRskTxHash();
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1267,23 +1267,23 @@ public class BridgeSupport {
             checkIfEntryExistsInPegoutsWaitingForSignatures(txWaitingForSignatureKey, pegoutsWaitingForSignatures);
         }
 
-        pegoutsWaitingForSignatures.put(txWaitingForSignatureKey, entry.getTransaction());
+        pegoutsWaitingForSignatures.put(txWaitingForSignatureKey, entry.getPegoutCreationBtcTx());
         pegoutsWaitingForConfirmations.removeEntry(entry);
 
         if(activations.isActive(ConsensusRule.RSKIP326)) {
-            eventLogger.logPegoutConfirmed(entry.getTransaction().getHash(), entry.getRskBlockNumber());
+            eventLogger.logPegoutConfirmed(entry.getPegoutCreationBtcTx().getHash(), entry.getPegoutCreationRskBlockNumber());
         }
     }
 
     private Keccak256 getTxWaitingForSignatureKey(Transaction rskTx, ReleaseTransactionSet.Entry entry) {
         if (activations.isActive(ConsensusRule.RSKIP375)){
-            return entry.getRskTxHash();
+            return entry.getPegoutCreationRskTxHash();
         }
         // Since RSKIP176 we are moving back to using the updateCollections related txHash as the set key
         if (activations.isActive(ConsensusRule.RSKIP146) && !activations.isActive(ConsensusRule.RSKIP176)) {
             // The pegout waiting for confirmations may have been created prior to the Consensus Rule activation
             // therefore it won't have a rskTxHash value, fallback to this transaction's hash
-            return entry.getRskTxHash() == null ? rskTx.getHash() : entry.getRskTxHash();
+            return entry.getPegoutCreationRskTxHash() == null ? rskTx.getHash() : entry.getPegoutCreationRskTxHash();
         }
         return rskTx.getHash();
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -902,8 +902,8 @@ public class BridgeSupport {
      * Executed every now and then.
      * Performs a few tasks: processing of any pending btc funds
      * migrations from retiring federations;
-     * processing of any outstanding btc release requests; and
-     * processing of any outstanding release btc transactions.
+     * processing of any outstanding pegout requests; and
+     * processing of any outstanding confirmed pegouts.
      * @throws IOException
      * @param rskTx current RSK transaction
      */
@@ -914,9 +914,9 @@ public class BridgeSupport {
 
         processFundsMigration(rskTx);
 
-        processReleaseRequests(rskTx);
+        processPegoutRequests(rskTx);
 
-        processReleaseTransactions(rskTx);
+        processConfirmedPegouts(rskTx);
 
         updateFederationCreationBlockHeights();
     }
@@ -1053,25 +1053,24 @@ public class BridgeSupport {
      *
      * @param rskTx
      */
-    private void processReleaseRequests(Transaction rskTx) {
+    private void processPegoutRequests(Transaction rskTx) {
         final Wallet activeFederationWallet;
-        final ReleaseRequestQueue releaseRequestQueue;
+        final ReleaseRequestQueue pegoutRequests;
         final List<UTXO> availableUTXOs;
-        final ReleaseTransactionSet releaseTransactionSet;
+        final ReleaseTransactionSet pegoutsWaitingForConfirmations;
 
         try {
             // (any of these could fail and would invalidate both the tx build and utxo selection, so treat as atomic)
             activeFederationWallet = getActiveFederationWallet(true);
-            releaseRequestQueue = provider.getReleaseRequestQueue();
+            pegoutRequests = provider.getReleaseRequestQueue();
             availableUTXOs = getActiveFederationBtcUTXOs();
-            releaseTransactionSet = provider.getReleaseTransactionSet();
+            pegoutsWaitingForConfirmations = provider.getReleaseTransactionSet();
         } catch (IOException e) {
-            logger.error("Unexpected error accessing storage while attempting to process release requests", e);
+            logger.error("Unexpected error accessing storage while attempting to process pegout requests", e);
             return;
         }
 
-        // Releases are attempted using the currently active federation
-        // wallet.
+        // Pegouts are attempted using the currently active federation wallet.
         final ReleaseTransactionBuilder txBuilder = new ReleaseTransactionBuilder(
                 btcContext.getParams(),
                 activeFederationWallet,
@@ -1081,84 +1080,83 @@ public class BridgeSupport {
         );
 
         if (activations.isActive(RSKIP271)) {
-            processPegoutsInBatch(releaseRequestQueue, txBuilder, availableUTXOs, releaseTransactionSet, activeFederationWallet, rskTx);
+            processPegoutsInBatch(pegoutRequests, txBuilder, availableUTXOs, pegoutsWaitingForConfirmations, activeFederationWallet, rskTx);
         } else {
-            processPegoutsIndividually(releaseRequestQueue, txBuilder, availableUTXOs, releaseTransactionSet, activeFederationWallet);
+            processPegoutsIndividually(pegoutRequests, txBuilder, availableUTXOs, pegoutsWaitingForConfirmations, activeFederationWallet);
         }
     }
 
-    private void addPegoutTxToReleaseTransactionSet(
+    private void addPegoutBtcTxToPegoutWaitingForConfirmationsSet(
         BtcTransaction generatedTransaction,
-        ReleaseTransactionSet releaseTransactionSet,
-        Keccak256 rskTxHash,
+        ReleaseTransactionSet pegoutWaitingForConfirmations,
+        Keccak256 pegoutCreationRskTxHash,
         Coin amount
     ) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             // Add the TX
-            releaseTransactionSet.add(generatedTransaction, rskExecutionBlock.getNumber(), rskTxHash);
-            // For a short time period, there could be items in the release request queue that don't have the rskTxHash
-            // (these are releases created right before the consensus rule activation, that weren't processed before its activation)
-            // We shouldn't generate the event for those releases
-            if (rskTxHash != null) {
-                // Log the Release request
-                eventLogger.logReleaseBtcRequested(rskTxHash.getBytes(), generatedTransaction, amount);
+            pegoutWaitingForConfirmations.add(generatedTransaction, rskExecutionBlock.getNumber(), pegoutCreationRskTxHash);
+            // For a short time period, there could be items in the pegout request queue that don't have the pegoutCreationRskTxHash
+            // (these are pegouts created right before the consensus rule activation, that weren't processed before its activation)
+            // We shouldn't generate the event for those pegouts
+            if (pegoutCreationRskTxHash != null) {
+                eventLogger.logReleaseBtcRequested(pegoutCreationRskTxHash.getBytes(), generatedTransaction, amount);
             }
         } else {
-            releaseTransactionSet.add(generatedTransaction, rskExecutionBlock.getNumber());
+            pegoutWaitingForConfirmations.add(generatedTransaction, rskExecutionBlock.getNumber());
         }
     }
 
     private void processPegoutsIndividually(
-        ReleaseRequestQueue releaseRequestQueue,
+        ReleaseRequestQueue pegoutRequests,
         ReleaseTransactionBuilder txBuilder,
         List<UTXO> availableUTXOs,
-        ReleaseTransactionSet releaseTransactionSet,
+        ReleaseTransactionSet pegoutsWaitingForConfirmations,
         Wallet wallet
     ) {
-        releaseRequestQueue.process(MAX_RELEASE_ITERATIONS, (ReleaseRequestQueue.Entry releaseRequest) -> {
+        pegoutRequests.process(MAX_RELEASE_ITERATIONS, (ReleaseRequestQueue.Entry pegoutRequest) -> {
             ReleaseTransactionBuilder.BuildResult result = txBuilder.buildAmountTo(
-                releaseRequest.getDestination(),
-                releaseRequest.getAmount()
+                pegoutRequest.getDestination(),
+                pegoutRequest.getAmount()
             );
 
             if (result.getResponseCode() != ReleaseTransactionBuilder.Response.SUCCESS) {
-            // Couldn't build a transaction to release these funds
+            // Couldn't build a pegout transaction to release these funds
             // Log the event and return false so that the request remains in the
             // queue for future processing.
             // Further logging is done at the tx builder level.
                 logger.warn(
-                    "Couldn't build a release BTC tx for <{}, {}>. Reason: {}",
-                    releaseRequest.getDestination().toBase58(),
-                    releaseRequest.getAmount(),
+                    "Couldn't build a pegout transaction for <{}, {}>. Reason: {}",
+                    pegoutRequest.getDestination().toBase58(),
+                    pegoutRequest.getAmount(),
                     result.getResponseCode());
                 return false;
             }
 
             BtcTransaction generatedTransaction = result.getBtcTx();
-            addPegoutTxToReleaseTransactionSet(generatedTransaction, releaseTransactionSet, releaseRequest.getRskTxHash(), releaseRequest.getAmount());
+            addPegoutBtcTxToPegoutWaitingForConfirmationsSet(generatedTransaction, pegoutsWaitingForConfirmations, pegoutRequest.getRskTxHash(), pegoutRequest.getAmount());
 
             // Mark UTXOs as spent
             List<UTXO> selectedUTXOs = result.getSelectedUTXOs();
             availableUTXOs.removeAll(selectedUTXOs);
 
-            adjustBalancesIfChangeOutputWasDust(generatedTransaction, releaseRequest.getAmount(), wallet);
+            adjustBalancesIfChangeOutputWasDust(generatedTransaction, pegoutRequest.getAmount(), wallet);
 
             return true;
         });
     }
 
     private void processPegoutsInBatch(
-        ReleaseRequestQueue releaseRequestQueue,
+        ReleaseRequestQueue pegoutRequests,
         ReleaseTransactionBuilder txBuilder,
         List<UTXO> availableUTXOs,
-        ReleaseTransactionSet releaseTransactionSet,
+        ReleaseTransactionSet pegoutsWaitingForConfirmations,
         Wallet wallet,
         Transaction rskTx) {
         long currentBlockNumber = rskExecutionBlock.getNumber();
         long nextPegoutCreationBlockNumber = getNextPegoutCreationBlockNumber();
 
         if (currentBlockNumber >= nextPegoutCreationBlockNumber) {
-            List<ReleaseRequestQueue.Entry> pegoutEntries = releaseRequestQueue.getEntries();
+            List<ReleaseRequestQueue.Entry> pegoutEntries = pegoutRequests.getEntries();
             Coin totalPegoutValue = pegoutEntries
                 .stream()
                 .map(ReleaseRequestQueue.Entry::getAmount)
@@ -1183,7 +1181,7 @@ public class BridgeSupport {
                 if (result.getResponseCode() != ReleaseTransactionBuilder.Response.SUCCESS) {
                     logger.warn(
                         "Couldn't build a pegout BTC tx for {} pending requests (total amount: {}), Reason: {}",
-                        releaseRequestQueue.getEntries().size(),
+                        pegoutRequests.getEntries().size(),
                         totalPegoutValue,
                         result.getResponseCode());
                     return;
@@ -1192,10 +1190,10 @@ public class BridgeSupport {
                 logger.info("[processPegoutsInBatch] pegouts processed with btcTx hash {} and response code {}", result.getBtcTx().getHash(), result.getResponseCode());
 
                 BtcTransaction generatedTransaction = result.getBtcTx();
-                addPegoutTxToReleaseTransactionSet(generatedTransaction, releaseTransactionSet, rskTx.getHash(), totalPegoutValue);
+                addPegoutBtcTxToPegoutWaitingForConfirmationsSet(generatedTransaction, pegoutsWaitingForConfirmations, rskTx.getHash(), totalPegoutValue);
 
                 // Remove batched requests from the queue after successfully batching pegouts
-                releaseRequestQueue.removeEntries(pegoutEntries);
+                pegoutRequests.removeEntries(pegoutEntries);
 
                 // Mark UTXOs as spent
                 List<UTXO> selectedUTXOs = result.getSelectedUTXOs();
@@ -1209,7 +1207,7 @@ public class BridgeSupport {
             }
 
             // update next Pegout height even if there were no request in queue
-            if (releaseRequestQueue.getEntries().isEmpty()) {
+            if (pegoutRequests.getEntries().isEmpty()) {
                 long nextPegoutHeight = currentBlockNumber + bridgeConstants.getNumberOfBlocksBetweenPegouts();
                 provider.setNextPegoutHeight(nextPegoutHeight);
                 logger.info("[processPegoutsInBatch] Next Pegout Height updated from {} to {}", currentBlockNumber, nextPegoutHeight);
@@ -1218,32 +1216,32 @@ public class BridgeSupport {
     }
 
     /**
-     * Processes the current btc release transaction set.
-     * It basically looks for transactions with enough confirmations
+     * Processes pegout waiting for confirmations.
+     * It basically looks for pegout transactions with enough confirmations
      * and marks them as ready for signing as well as removes them
      * from the set.
      * @param rskTx the RSK transaction that is causing this processing.
      */
-    private void processReleaseTransactions(Transaction rskTx) {
-        final Map<Keccak256, BtcTransaction> txsWaitingForSignatures;
-        final ReleaseTransactionSet releaseTransactionSet;
+    private void processConfirmedPegouts(Transaction rskTx) {
+        final Map<Keccak256, BtcTransaction> pegoutsWaitingForSignatures;
+        final ReleaseTransactionSet pegoutsWaitingForConfirmations;
 
         try {
-            txsWaitingForSignatures = provider.getRskTxsWaitingForSignatures();
-            releaseTransactionSet = provider.getReleaseTransactionSet();
+            pegoutsWaitingForSignatures = provider.getRskTxsWaitingForSignatures();
+            pegoutsWaitingForConfirmations = provider.getReleaseTransactionSet();
         } catch (IOException e) {
-            logger.error("Unexpected error accessing storage while attempting to process release btc transactions", e);
+            logger.error("Unexpected error accessing storage while attempting to process confirmed pegouts", e);
             return;
         }
 
         // TODO: (Ariel Mendelzon - 07/12/2017)
         // TODO: at the moment, there can only be one btc transaction
-        // TODO: per rsk transaction in the txsWaitingForSignatures
+        // TODO: per rsk transaction in the pegoutsWaitingForSignatures
         // TODO: map, and the rest of the processing logic is
         // TODO: dependant upon this. That is the reason we
         // TODO: add only one btc transaction at a time
         // TODO: (at least at this stage).
-        Optional<ReleaseTransactionSet.Entry> nextPegoutWithEnoughConfirmations = releaseTransactionSet
+        Optional<ReleaseTransactionSet.Entry> nextPegoutWithEnoughConfirmations = pegoutsWaitingForConfirmations
             .getNextPegoutWithEnoughConfirmations(
                 rskExecutionBlock.getNumber(),
                 bridgeConstants.getRsk2BtcMinimumAcceptableConfirmations()
@@ -1266,11 +1264,11 @@ public class BridgeSupport {
              entries to have the same key. So, informing on time the existence of this critical bug to pursue
              awareness and hint to rethink the changes being added.
              */
-            checkIfEntryExistsInTxsWaitingForSignatures(txWaitingForSignatureKey, txsWaitingForSignatures);
+            checkIfEntryExistsInPegoutsWaitingForSignatures(txWaitingForSignatureKey, pegoutsWaitingForSignatures);
         }
 
-        txsWaitingForSignatures.put(txWaitingForSignatureKey, entry.getTransaction());
-        releaseTransactionSet.removeEntry(entry);
+        pegoutsWaitingForSignatures.put(txWaitingForSignatureKey, entry.getTransaction());
+        pegoutsWaitingForConfirmations.removeEntry(entry);
 
         if(activations.isActive(ConsensusRule.RSKIP326)) {
             eventLogger.logPegoutConfirmed(entry.getTransaction().getHash(), entry.getRskBlockNumber());
@@ -1283,17 +1281,17 @@ public class BridgeSupport {
         }
         // Since RSKIP176 we are moving back to using the updateCollections related txHash as the set key
         if (activations.isActive(ConsensusRule.RSKIP146) && !activations.isActive(ConsensusRule.RSKIP176)) {
-            // The release transaction may have been created prior to the Consensus Rule activation
+            // The pegout waiting for confirmations may have been created prior to the Consensus Rule activation
             // therefore it won't have a rskTxHash value, fallback to this transaction's hash
             return entry.getRskTxHash() == null ? rskTx.getHash() : entry.getRskTxHash();
         }
         return rskTx.getHash();
     }
 
-    private void checkIfEntryExistsInTxsWaitingForSignatures(Keccak256 rskTxHash, Map<Keccak256, BtcTransaction> txsWaitingForSignatures) {
-        if (txsWaitingForSignatures.containsKey(rskTxHash)) {
+    private void checkIfEntryExistsInPegoutsWaitingForSignatures(Keccak256 rskTxHash, Map<Keccak256, BtcTransaction> pegoutsWaitingForSignatures) {
+        if (pegoutsWaitingForSignatures.containsKey(rskTxHash)) {
             String message = String.format(
-                "An entry for the given rskTxHash %s already exists. Entry overriding is not allowed for txsWaitingForSignatures map.",
+                "An entry for the given rskTxHash %s already exists. Entry overriding is not allowed for pegoutsWaitingForSignatures map.",
                 rskTxHash
             );
             logger.error("[checkIfEntryExistsInTxsWaitingForSignatures] {}", message);
@@ -3182,7 +3180,7 @@ public class BridgeSupport {
     private boolean verifyLockSenderIsWhitelisted(Address senderBtcAddress, Coin totalAmount, int height) {
         // If the address is not whitelisted, then return the funds
         // using the exact same utxos sent to us.
-        // That is, build a release transaction and get it in the release transaction set.
+        // That is, build a pegout waiting for confirmations and get it in the pegoutWaitingForConfirmations set.
         // Otherwise, transfer SBTC to the sender of the BTC
         // The RSK account to update is the one that matches the pubkey "spent" on the first bitcoin tx input
         LockWhitelist lockWhitelist = provider.getLockWhitelist();

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
@@ -78,7 +78,7 @@ public class ReleaseTransactionSet {
 
         @Override
         public int hashCode() {
-            return pegoutCreationBtcTx.hashCode();
+            return Objects.hash(getPegoutCreationBtcTx());
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionSet.java
@@ -40,31 +40,31 @@ public class ReleaseTransactionSet {
 
             @Override
             public int compare(Entry e1, Entry e2) {
-                return comparator.compare(e1.getTransaction().bitcoinSerialize(), e2.getTransaction().bitcoinSerialize());
+                return comparator.compare(e1.getPegoutCreationBtcTx().bitcoinSerialize(), e2.getPegoutCreationBtcTx().bitcoinSerialize());
             }
         };
 
-        private BtcTransaction transaction;
-        private Long rskBlockNumber;
-        private Keccak256 rskTxHash;
+        private BtcTransaction pegoutCreationBtcTx;
+        private Long pegoutCreationRskBlockNumber;
+        private Keccak256 pegoutCreationRskTxHash;
 
-        public Entry(BtcTransaction transaction, Long rskBlockNumber, Keccak256 rskTxHash) {
-            this.transaction = transaction;
-            this.rskBlockNumber = rskBlockNumber;
-            this.rskTxHash = rskTxHash;
+        public Entry(BtcTransaction pegoutCreationBtcTx, Long pegoutCreationRskBlockNumber, Keccak256 pegoutCreationRskTxHash) {
+            this.pegoutCreationBtcTx = pegoutCreationBtcTx;
+            this.pegoutCreationRskBlockNumber = pegoutCreationRskBlockNumber;
+            this.pegoutCreationRskTxHash = pegoutCreationRskTxHash;
         }
 
-        public Entry(BtcTransaction transaction, Long rskBlockNumber) { this(transaction, rskBlockNumber, null); }
+        public Entry(BtcTransaction pegoutCreationBtcTx, Long pegoutCreationRskBlockNumber) { this(pegoutCreationBtcTx, pegoutCreationRskBlockNumber, null); }
 
-        public BtcTransaction getTransaction() {
-            return transaction;
+        public BtcTransaction getPegoutCreationBtcTx() {
+            return pegoutCreationBtcTx;
         }
 
-        public Long getRskBlockNumber() {
-            return rskBlockNumber;
+        public Long getPegoutCreationRskBlockNumber() {
+            return pegoutCreationRskBlockNumber;
         }
 
-        public Keccak256 getRskTxHash() { return rskTxHash; }
+        public Keccak256 getPegoutCreationRskTxHash() { return pegoutCreationRskTxHash; }
 
         @Override
         public boolean equals(Object o) {
@@ -73,15 +73,12 @@ public class ReleaseTransactionSet {
             }
 
             Entry otherEntry = (Entry) o;
-            return otherEntry.getTransaction().equals(getTransaction()) &&
-                    otherEntry.getRskBlockNumber().equals(getRskBlockNumber()) &&
-                            (otherEntry.getRskTxHash() == null && getRskTxHash() == null ||
-                                    otherEntry.getRskTxHash() != null && otherEntry.getRskTxHash().equals(getRskTxHash()));
+            return otherEntry.getPegoutCreationBtcTx().equals(getPegoutCreationBtcTx());
          }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getTransaction(), getRskBlockNumber());
+            return pegoutCreationBtcTx.hashCode();
         }
     }
 
@@ -92,11 +89,11 @@ public class ReleaseTransactionSet {
     }
 
     public Set<Entry> getEntriesWithoutHash() {
-        return entries.stream().filter(e -> e.getRskTxHash() == null).collect(Collectors.toSet());
+        return entries.stream().filter(e -> e.getPegoutCreationRskTxHash() == null).collect(Collectors.toSet());
     }
 
     public Set<Entry> getEntriesWithHash() {
-        return entries.stream().filter(e -> e.getRskTxHash() != null).collect(Collectors.toSet());
+        return entries.stream().filter(e -> e.getPegoutCreationRskTxHash() != null).collect(Collectors.toSet());
     }
 
     public Set<Entry> getEntries() {
@@ -108,10 +105,7 @@ public class ReleaseTransactionSet {
     }
 
     public void add(BtcTransaction transaction, Long blockNumber, Keccak256 rskTxHash) {
-        // Disallow duplicate transactions
-        if (entries.stream().noneMatch(e -> e.getTransaction().equals(transaction))) {
-            entries.add(new Entry(transaction, blockNumber, rskTxHash));
-        }
+        entries.add(new Entry(transaction, blockNumber, rskTxHash));
     }
 
     /**
@@ -134,6 +128,6 @@ public class ReleaseTransactionSet {
     }
 
     private boolean hasEnoughConfirmations(Entry entry, Long currentBlockNumber, Integer minimumConfirmations) {
-        return (currentBlockNumber - entry.getRskBlockNumber()) >= minimumConfirmations;
+        return (currentBlockNumber - entry.getPegoutCreationRskBlockNumber()) >= minimumConfirmations;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -814,7 +814,7 @@ class BridgeSupportFlyoverTest {
         if (result.longValue() == FlyoverTxResponseCodes.REFUNDED_LP_ERROR.value() || result.longValue() == FlyoverTxResponseCodes.REFUNDED_USER_ERROR.value()){
             List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
                 .stream()
-                .map(ReleaseTransactionSet.Entry::getTransaction)
+                .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
                 .collect(Collectors.toList());
 
             assertEquals(1, releaseTxs.size());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -238,7 +238,7 @@ class BridgeSupportProcessFundsMigrationTest {
                 .toArray()[0];
             verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(
                 updateCollectionsTx.getHash().getBytes(),
-                entry.getTransaction(),
+                entry.getPegoutCreationBtcTx(),
                 Coin.COIN
             );
         } else {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -680,7 +680,7 @@ class BridgeSupportReleaseBtcTest {
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
 
-        ReleaseRequestQueue releaseRequestQueue = new ReleaseRequestQueue(
+        ReleaseRequestQueue pegoutRequests = new ReleaseRequestQueue(
             Arrays.asList(
                 new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.MILLICOIN),
                 new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.MILLICOIN),
@@ -688,15 +688,15 @@ class BridgeSupportReleaseBtcTest {
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
-        when(provider.getReleaseRequestQueue()).thenReturn(releaseRequestQueue);
+        when(provider.getReleaseRequestQueue()).thenReturn(pegoutRequests);
         when(provider.getReleaseTransactionSet()).thenReturn(new ReleaseTransactionSet(Collections.emptySet()));
 
-        Coin totalValue = releaseRequestQueue.getEntries()
+        Coin totalValue = pegoutRequests.getEntries()
             .stream()
             .map(ReleaseRequestQueue.Entry::getAmount)
             .reduce(Coin.ZERO, Coin::add);
 
-        List<Keccak256> rskHashesList = releaseRequestQueue.getEntries()
+        List<Keccak256> rskHashesList = pegoutRequests.getEntries()
             .stream()
             .map(ReleaseRequestQueue.Entry::getRskTxHash)
             .collect(Collectors.toList());
@@ -929,13 +929,13 @@ class BridgeSupportReleaseBtcTest {
             new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.COIN.multiply(3))
         );
 
-        ReleaseRequestQueue originalReleaseRequestQueue = new ReleaseRequestQueue(entries);
-        ReleaseRequestQueue releaseRequestQueue = new ReleaseRequestQueue(entries);
+        ReleaseRequestQueue originalPegoutRequests = new ReleaseRequestQueue(entries);
+        ReleaseRequestQueue pegoutRequests = new ReleaseRequestQueue(entries);
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
         when(provider.getReleaseRequestQueue())
-            .thenReturn(releaseRequestQueue);
+            .thenReturn(pegoutRequests);
         when(provider.getReleaseTransactionSet()).thenReturn(new ReleaseTransactionSet(Collections.emptySet()));
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
@@ -947,7 +947,7 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        Assertions.assertEquals(originalReleaseRequestQueue, provider.getReleaseRequestQueue());
+        Assertions.assertEquals(originalPegoutRequests, provider.getReleaseRequestQueue());
         Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
     }
 
@@ -975,14 +975,14 @@ class BridgeSupportReleaseBtcTest {
         expectedEntries.addAll(entries.subList(BridgeSupport.MAX_RELEASE_ITERATIONS, entries.size()));
         expectedEntries.addAll(entries.subList(0, BridgeSupport.MAX_RELEASE_ITERATIONS));
 
-        ReleaseRequestQueue expectedReleaseRequestQueue = new ReleaseRequestQueue(expectedEntries);
-        ReleaseRequestQueue originalReleaseRequestQueue = new ReleaseRequestQueue(entries);
-        ReleaseRequestQueue releaseRequestQueue = new ReleaseRequestQueue(entries);
+        ReleaseRequestQueue expectedPegoutRequests = new ReleaseRequestQueue(expectedEntries);
+        ReleaseRequestQueue originalPegoutRequests = new ReleaseRequestQueue(entries);
+        ReleaseRequestQueue pegoutRequests = new ReleaseRequestQueue(entries);
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
         when(provider.getReleaseRequestQueue())
-            .thenReturn(releaseRequestQueue);
+            .thenReturn(pegoutRequests);
         when(provider.getReleaseTransactionSet()).thenReturn(new ReleaseTransactionSet(Collections.emptySet()));
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
@@ -994,9 +994,9 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        Assertions.assertNotEquals(originalReleaseRequestQueue, provider.getReleaseRequestQueue());
+        Assertions.assertNotEquals(originalPegoutRequests, provider.getReleaseRequestQueue());
 
-        Assertions.assertEquals(expectedReleaseRequestQueue, provider.getReleaseRequestQueue());
+        Assertions.assertEquals(expectedPegoutRequests, provider.getReleaseRequestQueue());
 
         Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntries().size());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -714,7 +714,7 @@ class BridgeSupportReleaseBtcTest {
         Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
-        BtcTransaction generatedTransaction = provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction();
+        BtcTransaction generatedTransaction = provider.getReleaseTransactionSet().getEntries().iterator().next().getPegoutCreationBtcTx();
 
         verify(provider, times(1)).getNextPegoutHeight();
         verify(provider, times(1)).setNextPegoutHeight(any(Long.class));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1086,7 +1086,7 @@ class BridgeSupportTest {
 
         List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
-            .map(ReleaseTransactionSet.Entry::getTransaction)
+            .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .sorted(Comparator.comparing(BtcTransaction::getOutputSum))
             .collect(Collectors.toList());
 
@@ -1257,7 +1257,7 @@ class BridgeSupportTest {
 
         List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
-            .map(ReleaseTransactionSet.Entry::getTransaction)
+            .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .sorted(Comparator.comparing(BtcTransaction::getOutputSum))
             .collect(Collectors.toList());
 
@@ -1533,7 +1533,7 @@ class BridgeSupportTest {
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntriesWithHash().size());
         ReleaseTransactionSet.Entry entry = (ReleaseTransactionSet.Entry) provider.getReleaseTransactionSet().getEntriesWithHash().toArray()[0];
         // Should have been logged with the migrated UTXO
-        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(tx.getHash().getBytes(), entry.getTransaction(), Coin.COIN);
+        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(tx.getHash().getBytes(), entry.getPegoutCreationBtcTx(), Coin.COIN);
     }
 
     @Test
@@ -1660,7 +1660,7 @@ class BridgeSupportTest {
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntriesWithHash().size());
         ReleaseTransactionSet.Entry entry = (ReleaseTransactionSet.Entry) provider.getReleaseTransactionSet().getEntriesWithHash().toArray()[0];
         // Should have been logged with the migrated UTXO
-        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(tx.getHash().getBytes(), entry.getTransaction(), Coin.COIN);
+        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(tx.getHash().getBytes(), entry.getPegoutCreationBtcTx(), Coin.COIN);
     }
 
     @Test
@@ -2593,7 +2593,7 @@ class BridgeSupportTest {
 
         List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
-            .map(ReleaseTransactionSet.Entry::getTransaction)
+            .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .sorted(Comparator.comparing(BtcTransaction::getOutputSum))
             .collect(Collectors.toList());
 
@@ -2945,7 +2945,7 @@ class BridgeSupportTest {
 
         List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
-            .map(ReleaseTransactionSet.Entry::getTransaction)
+            .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .sorted(Comparator.comparing(BtcTransaction::getOutputSum))
             .collect(Collectors.toList());
 
@@ -3114,7 +3114,7 @@ class BridgeSupportTest {
 
         List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
-            .map(ReleaseTransactionSet.Entry::getTransaction)
+            .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
@@ -3288,7 +3288,7 @@ class BridgeSupportTest {
 
         List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
-            .map(ReleaseTransactionSet.Entry::getTransaction)
+            .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
@@ -4170,7 +4170,7 @@ class BridgeSupportTest {
 
         List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
-            .map(ReleaseTransactionSet.Entry::getTransaction)
+            .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
@@ -6277,7 +6277,7 @@ class BridgeSupportTest {
             // Check rejection tx input was created from btc tx and sent to the btc refund address indicated by the user
             boolean successfulRejection = false;
             for (ReleaseTransactionSet.Entry e : releaseTransactionSet.getEntries()) {
-                BtcTransaction refundTx = e.getTransaction();
+                BtcTransaction refundTx = e.getPegoutCreationBtcTx();
                 if (refundTx.getInput(0).getOutpoint().getHash() == btcTx.getHash() &&
                     refundTx.getOutput(0).getScriptPubKey().getToAddress(btcRegTestParams).equals(btcSenderAddress)) {
                     successfulRejection = true;
@@ -6609,7 +6609,7 @@ class BridgeSupportTest {
         // Check rejection tx input was created from btc tx
         boolean successfulRejection = false;
         for (ReleaseTransactionSet.Entry e : releaseTransactionSet.getEntries()) {
-            if (e.getTransaction().getInput(0).getOutpoint().getHash() == btcTx.getHash()) {
+            if (e.getPegoutCreationBtcTx().getInput(0).getOutpoint().getHash() == btcTx.getHash()) {
                 successfulRejection = true;
                 break;
             }
@@ -6734,7 +6734,7 @@ class BridgeSupportTest {
         }
 
         releaseTransactionSet.getEntries().forEach(e -> {
-            Integer inputsSize = e.getTransaction().getInputs().size();
+            Integer inputsSize = e.getPegoutCreationBtcTx().getInputs().size();
             expectedInputSizes.remove(inputsSize);
         });
 
@@ -6981,7 +6981,7 @@ class BridgeSupportTest {
             // Check rejection tx input was created from btc tx and sent to the btc refund address indicated by the user
             boolean successfulRejection = false;
             for (ReleaseTransactionSet.Entry e : releaseTransactionSet.getEntries()) {
-                BtcTransaction refundTx = e.getTransaction();
+                BtcTransaction refundTx = e.getPegoutCreationBtcTx();
                 if (refundTx.getInput(0).getOutpoint().getHash() == btcTx.getHash() &&
                     refundTx.getOutput(0).getScriptPubKey().getToAddress(btcRegTestParams).equals(btcRefundAddress.get())) {
                     successfulRejection = true;
@@ -7174,7 +7174,7 @@ class BridgeSupportTest {
 
         if (!shouldLock) {
             // Release tx should have been created directly to the signatures stack
-            BtcTransaction releaseTx = provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction();
+            BtcTransaction releaseTx = provider.getReleaseTransactionSet().getEntries().iterator().next().getPegoutCreationBtcTx();
             Assertions.assertNotNull(releaseTx);
             // returns the funds to the sender
             Assertions.assertEquals(1, releaseTx.getOutputs().size());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1084,29 +1084,29 @@ class BridgeSupportTest {
         Assertions.assertEquals(3, provider.getReleaseTransactionSet().getEntriesWithoutHash().size());
         Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntriesWithHash().size());
 
-        List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
+        List<BtcTransaction> pegoutBtcTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
             .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .sorted(Comparator.comparing(BtcTransaction::getOutputSum))
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
-        BtcTransaction releaseTx = releaseTxs.get(0);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(Coin.COIN.multiply(5).subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(srcKey1.toAddress(btcRegTestParams), releaseTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx1.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        BtcTransaction pegoutBtcTx = pegoutBtcTxs.get(0);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(Coin.COIN.multiply(5).subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(srcKey1.toAddress(btcRegTestParams), pegoutBtcTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx1.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx1.getHash()).isPresent());
 
         // Second release tx should correspond to the 7 (3+4) BTC lock tx
-        releaseTx = releaseTxs.get(1);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(Coin.COIN.multiply(7).subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(srcKey3.toAddress(btcRegTestParams), releaseTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
-        Assertions.assertEquals(2, releaseTx.getInputs().size());
-        List<TransactionOutPoint> releaseOutpoints = releaseTx.getInputs().stream().map(TransactionInput::getOutpoint).sorted(Comparator.comparing(TransactionOutPoint::getIndex)).collect(Collectors.toList());
+        pegoutBtcTx = pegoutBtcTxs.get(1);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(Coin.COIN.multiply(7).subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(srcKey3.toAddress(btcRegTestParams), pegoutBtcTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
+        Assertions.assertEquals(2, pegoutBtcTx.getInputs().size());
+        List<TransactionOutPoint> releaseOutpoints = pegoutBtcTx.getInputs().stream().map(TransactionInput::getOutpoint).sorted(Comparator.comparing(TransactionOutPoint::getIndex)).collect(Collectors.toList());
         Assertions.assertEquals(tx3.getHash(), releaseOutpoints.get(0).getHash());
         Assertions.assertEquals(tx3.getHash(), releaseOutpoints.get(1).getHash());
         Assertions.assertEquals(0, releaseOutpoints.get(0).getIndex());
@@ -1114,13 +1114,13 @@ class BridgeSupportTest {
         assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx3.getHash()).isPresent());
 
         // Third release tx should correspond to the 10 BTC lock tx
-        releaseTx = releaseTxs.get(2);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(Coin.COIN.multiply(10).subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(srcKey2.toAddress(btcRegTestParams), releaseTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx2.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        pegoutBtcTx = pegoutBtcTxs.get(2);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(Coin.COIN.multiply(10).subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(srcKey2.toAddress(btcRegTestParams), pegoutBtcTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx2.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx2.getHash()).isPresent());
 
         Assertions.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
@@ -1255,50 +1255,50 @@ class BridgeSupportTest {
         Assertions.assertEquals(0, provider.getReleaseTransactionSet().getEntriesWithoutHash().size());
         Assertions.assertEquals(3, provider.getReleaseTransactionSet().getEntriesWithHash().size());
 
-        List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
+        List<BtcTransaction> pegoutBtcTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
             .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .sorted(Comparator.comparing(BtcTransaction::getOutputSum))
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
-        BtcTransaction releaseTx = releaseTxs.get(0);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(Coin.COIN.multiply(5).subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(srcKey1.toAddress(btcRegTestParams), releaseTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx1.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        BtcTransaction pegoutBtcTx = pegoutBtcTxs.get(0);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(Coin.COIN.multiply(5).subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(srcKey1.toAddress(btcRegTestParams), pegoutBtcTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx1.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx1.getHash()).isPresent());
         // First Rsk tx corresponds to this release
-        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(rskTx1.getHash().getBytes(), releaseTx, Coin.COIN.multiply(5));
+        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(rskTx1.getHash().getBytes(), pegoutBtcTx, Coin.COIN.multiply(5));
 
         // Second release tx should correspond to the 7 (3+4) BTC lock tx
-        releaseTx = releaseTxs.get(1);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(Coin.COIN.multiply(7).subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(srcKey3.toAddress(btcRegTestParams), releaseTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
-        Assertions.assertEquals(2, releaseTx.getInputs().size());
-        List<TransactionOutPoint> releaseOutpoints = releaseTx.getInputs().stream().map(TransactionInput::getOutpoint).sorted(Comparator.comparing(TransactionOutPoint::getIndex)).collect(Collectors.toList());
+        pegoutBtcTx = pegoutBtcTxs.get(1);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(Coin.COIN.multiply(7).subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(srcKey3.toAddress(btcRegTestParams), pegoutBtcTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
+        Assertions.assertEquals(2, pegoutBtcTx.getInputs().size());
+        List<TransactionOutPoint> releaseOutpoints = pegoutBtcTx.getInputs().stream().map(TransactionInput::getOutpoint).sorted(Comparator.comparing(TransactionOutPoint::getIndex)).collect(Collectors.toList());
         Assertions.assertEquals(tx3.getHash(), releaseOutpoints.get(0).getHash());
         Assertions.assertEquals(tx3.getHash(), releaseOutpoints.get(1).getHash());
         Assertions.assertEquals(0, releaseOutpoints.get(0).getIndex());
         Assertions.assertEquals(1, releaseOutpoints.get(1).getIndex());
         assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx3.getHash()).isPresent());
         // third Rsk tx corresponds to this release
-        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(rskTx3.getHash().getBytes(), releaseTx, Coin.COIN.multiply(7));
+        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(rskTx3.getHash().getBytes(), pegoutBtcTx, Coin.COIN.multiply(7));
 
         // Third release tx should correspond to the 10 BTC lock tx
-        releaseTx = releaseTxs.get(2);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(Coin.COIN.multiply(10).subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(srcKey2.toAddress(btcRegTestParams), releaseTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx2.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        pegoutBtcTx = pegoutBtcTxs.get(2);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(Coin.COIN.multiply(10).subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(srcKey2.toAddress(btcRegTestParams), pegoutBtcTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx2.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx2.getHash()).isPresent());
         // Second Rsk tx corresponds to this release
-        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(rskTx2.getHash().getBytes(), releaseTx, Coin.COIN.multiply(10));
+        verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(rskTx2.getHash().getBytes(), pegoutBtcTx, Coin.COIN.multiply(10));
 
         Assertions.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
     }
@@ -2591,20 +2591,20 @@ class BridgeSupportTest {
         Assertions.assertEquals(0, provider.getNewFederationBtcUTXOs().size());
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
-        List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
+        List<BtcTransaction> pegoutBtcTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
             .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .sorted(Comparator.comparing(BtcTransaction::getOutputSum))
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
-        BtcTransaction releaseTx = releaseTxs.get(0);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(amountToLock.subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(btcAddress, releaseTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx1.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        BtcTransaction pegoutBtcTx = pegoutBtcTxs.get(0);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(amountToLock.subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(btcAddress, pegoutBtcTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx1.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         Assertions.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
         Assertions.assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx1.getHash()).isPresent());
     }
@@ -2943,20 +2943,20 @@ class BridgeSupportTest {
         Assertions.assertEquals(0, provider.getNewFederationBtcUTXOs().size());
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
-        List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
+        List<BtcTransaction> pegoutBtcTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
             .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .sorted(Comparator.comparing(BtcTransaction::getOutputSum))
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
-        BtcTransaction releaseTx = releaseTxs.get(0);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(amountToLock.subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(btcAddress, releaseTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx1.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        BtcTransaction pegoutBtcTx = pegoutBtcTxs.get(0);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(amountToLock.subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(btcAddress, pegoutBtcTx.getOutput(0).getAddressFromP2PKHScript(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx1.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         Assertions.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
         Assertions.assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx1.getHash()).isPresent());
     }
@@ -3112,19 +3112,19 @@ class BridgeSupportTest {
         Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
-        List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
+        List<BtcTransaction> pegoutBtcTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
             .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
-        BtcTransaction releaseTx = releaseTxs.get(0);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(amountToLock.subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(btcAddress, releaseTx.getOutput(0).getScriptPubKey().getToAddress(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx1.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        BtcTransaction pegoutBtcTx = pegoutBtcTxs.get(0);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(amountToLock.subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(btcAddress, pegoutBtcTx.getOutput(0).getScriptPubKey().getToAddress(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx1.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         Assertions.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
         Assertions.assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx1.getHash()).isPresent());
     }
@@ -3286,19 +3286,19 @@ class BridgeSupportTest {
         Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
-        List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
+        List<BtcTransaction> pegoutBtcTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
             .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
-        BtcTransaction releaseTx = releaseTxs.get(0);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(amountToLock.subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(btcAddress, releaseTx.getOutput(0).getScriptPubKey().getToAddress(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx1.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        BtcTransaction pegoutBtcTx = pegoutBtcTxs.get(0);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(amountToLock.subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(btcAddress, pegoutBtcTx.getOutput(0).getScriptPubKey().getToAddress(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx1.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         Assertions.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
         Assertions.assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx1.getHash()).isPresent());
     }
@@ -4168,19 +4168,19 @@ class BridgeSupportTest {
         Assertions.assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
 
-        List<BtcTransaction> releaseTxs = provider.getReleaseTransactionSet().getEntries()
+        List<BtcTransaction> pegoutBtcTxs = provider.getReleaseTransactionSet().getEntries()
             .stream()
             .map(ReleaseTransactionSet.Entry::getPegoutCreationBtcTx)
             .collect(Collectors.toList());
 
         // First release tx should correspond to the 5 BTC lock tx
-        BtcTransaction releaseTx = releaseTxs.get(0);
-        Assertions.assertEquals(1, releaseTx.getOutputs().size());
-        MatcherAssert.assertThat(amountToLock.subtract(releaseTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
-        Assertions.assertEquals(btcAddressFromBtcLockSender, releaseTx.getOutput(0).getScriptPubKey().getToAddress(btcRegTestParams));
-        Assertions.assertEquals(1, releaseTx.getInputs().size());
-        Assertions.assertEquals(tx1.getHash(), releaseTx.getInput(0).getOutpoint().getHash());
-        Assertions.assertEquals(0, releaseTx.getInput(0).getOutpoint().getIndex());
+        BtcTransaction pegoutBtcTx = pegoutBtcTxs.get(0);
+        Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+        MatcherAssert.assertThat(amountToLock.subtract(pegoutBtcTx.getOutput(0).getValue()), is(lessThanOrEqualTo(Coin.MILLICOIN)));
+        Assertions.assertEquals(btcAddressFromBtcLockSender, pegoutBtcTx.getOutput(0).getScriptPubKey().getToAddress(btcRegTestParams));
+        Assertions.assertEquals(1, pegoutBtcTx.getInputs().size());
+        Assertions.assertEquals(tx1.getHash(), pegoutBtcTx.getInput(0).getOutpoint().getHash());
+        Assertions.assertEquals(0, pegoutBtcTx.getInput(0).getOutpoint().getIndex());
         Assertions.assertTrue(provider.getRskTxsWaitingForSignatures().isEmpty());
         Assertions.assertTrue(provider.getHeightIfBtcTxhashIsAlreadyProcessed(tx1.getHash()).isPresent());
     }
@@ -5677,11 +5677,11 @@ class BridgeSupportTest {
         );
 
         // Create a tx from the Fed to a random btc address
-        BtcTransaction releaseTx1 = new BtcTransaction(btcRegTestParams);
-        releaseTx1.addOutput(Coin.COIN, randomAddress);
+        BtcTransaction pegoutBtcTx = new BtcTransaction(btcRegTestParams);
+        pegoutBtcTx.addOutput(Coin.COIN, randomAddress);
         TransactionInput releaseInput1 = new TransactionInput(
             btcRegTestParams,
-            releaseTx1,
+            pegoutBtcTx,
             new byte[]{},
             new TransactionOutPoint(
                 btcRegTestParams,
@@ -5690,14 +5690,14 @@ class BridgeSupportTest {
             )
         );
 
-        releaseTx1.addInput(releaseInput1);
+        pegoutBtcTx.addInput(releaseInput1);
 
         // Sign it using the Federation members
         Script redeemScript = createBaseRedeemScriptThatSpendsFromTheFederation(federation);
         Script inputScript = createBaseInputScriptThatSpendsFromTheFederation(federation);
         releaseInput1.setScriptSig(inputScript);
 
-        Sha256Hash sighash = releaseTx1.hashForSignature(
+        Sha256Hash sighash = pegoutBtcTx.hashForSignature(
             0,
             redeemScript,
             BtcTransaction.SigHash.ALL,
@@ -5722,7 +5722,7 @@ class BridgeSupportTest {
         }
         releaseInput1.setScriptSig(inputScript);
 
-        Assertions.assertEquals(TxType.PEGOUT, bridgeSupport.getTransactionType(releaseTx1));
+        Assertions.assertEquals(TxType.PEGOUT, bridgeSupport.getTransactionType(pegoutBtcTx));
     }
 
     @Test
@@ -7174,16 +7174,16 @@ class BridgeSupportTest {
 
         if (!shouldLock) {
             // Release tx should have been created directly to the signatures stack
-            BtcTransaction releaseTx = provider.getReleaseTransactionSet().getEntries().iterator().next().getPegoutCreationBtcTx();
-            Assertions.assertNotNull(releaseTx);
+            BtcTransaction pegoutBtcTx = provider.getReleaseTransactionSet().getEntries().iterator().next().getPegoutCreationBtcTx();
+            Assertions.assertNotNull(pegoutBtcTx);
             // returns the funds to the sender
-            Assertions.assertEquals(1, releaseTx.getOutputs().size());
-            Assertions.assertEquals(address, releaseTx.getOutputs().get(0).getAddressFromP2PKHScript(bridgeConstants.getBtcParams()));
-            Assertions.assertEquals(lockValue, releaseTx.getOutputs().get(0).getValue().add(releaseTx.getFee()));
+            Assertions.assertEquals(1, pegoutBtcTx.getOutputs().size());
+            Assertions.assertEquals(address, pegoutBtcTx.getOutputs().get(0).getAddressFromP2PKHScript(bridgeConstants.getBtcParams()));
+            Assertions.assertEquals(lockValue, pegoutBtcTx.getOutputs().get(0).getValue().add(pegoutBtcTx.getFee()));
             // Uses the same UTXO(s)
-            Assertions.assertEquals(newUtxos, releaseTx.getInputs().size());
+            Assertions.assertEquals(newUtxos, pegoutBtcTx.getInputs().size());
             for (int i = 0; i < newUtxos; i++) {
-                TransactionInput input = releaseTx.getInput(i);
+                TransactionInput input = pegoutBtcTx.getInput(i);
                 Assertions.assertEquals(tx.getHash(), input.getOutpoint().getHash());
                 Assertions.assertEquals(i, input.getOutpoint().getIndex());
             }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -413,7 +413,7 @@ public class BridgeSupportTestIntegration {
         Assertions.assertEquals(1, provider.getReleaseTransactionSet().getEntries().size());
         Assertions.assertEquals(0, provider.getRskTxsWaitingForSignatures().size());
         // Check value sent to user is 10 BTC minus fee
-        Assertions.assertEquals(Coin.valueOf(999962800L), provider.getReleaseTransactionSet().getEntries().iterator().next().getTransaction().getOutput(0).getValue());
+        Assertions.assertEquals(Coin.valueOf(999962800L), provider.getReleaseTransactionSet().getEntries().iterator().next().getPegoutCreationBtcTx().getOutput(0).getValue());
         // Check the wallet has been emptied
         Assertions.assertTrue(provider.getNewFederationBtcUTXOs().isEmpty());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 
+import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.test.builders.BlockChainBuilder;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
@@ -215,9 +216,9 @@ public class BridgeTestIntegration {
 
     @Test
     void callUpdateCollectionsWithTransactionsWaitingForConfirmation() throws IOException, VMException {
-        BtcTransaction tx1 = createTransaction(2, Coin.valueOf(150));
-        BtcTransaction tx2 = createTransaction(3, Coin.valueOf(200));
-        BtcTransaction tx3 = createTransaction(4, Coin.valueOf(250));
+        BtcTransaction tx1 = createTransaction(2, bridgeConstants.getMinimumPegoutTxValueInSatoshis());
+        BtcTransaction tx2 = createTransaction(3, bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN));
+        BtcTransaction tx3 = createTransaction(4, bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -271,9 +272,9 @@ public class BridgeTestIntegration {
 
     @Test
     void callUpdateCollectionsWithTransactionsWaitingForConfirmationWithEnoughConfirmations() throws IOException, VMException {
-        BtcTransaction tx1 = createTransaction(2, Coin.valueOf(150));
-        BtcTransaction tx2 = createTransaction(3, Coin.valueOf(200));
-        BtcTransaction tx3 = createTransaction(4, Coin.valueOf(250));
+        BtcTransaction tx1 = createTransaction(2, bridgeConstants.getMinimumPegoutTxValueInSatoshis());
+        BtcTransaction tx2 = createTransaction(3, bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN));
+        BtcTransaction tx3 = createTransaction(4, bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -3292,11 +3293,11 @@ public class BridgeTestIntegration {
         return new SimpleBtcTransaction(networkParameters, hash);
     }
 
-    private BtcTransaction createTransaction(int toPk, Coin value) {
+    /*private BtcTransaction createTransaction(int toPk, Coin value) {
         return createTransaction(toPk, value, BtcECKey.fromPrivate(BigInteger.valueOf(123456)));
-    }
+    }*/
 
-    private BtcTransaction createUniqueTransaction(int toPk, Coin value) {
+    private BtcTransaction createTransaction(int toPk, Coin value) {
         return createTransaction(toPk, value, new BtcECKey());
     }
 
@@ -3304,7 +3305,7 @@ public class BridgeTestIntegration {
         NetworkParameters params = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         BtcTransaction input = new BtcTransaction(params);
 
-        input.addOutput(Coin.FIFTY_COINS, btcECKey.toAddress(params));
+        input.addOutput(Coin.COIN, btcECKey.toAddress(params));
 
         Address to = BtcECKey.fromPrivate(BigInteger.valueOf(toPk)).toAddress(params);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -3293,10 +3293,6 @@ public class BridgeTestIntegration {
         return new SimpleBtcTransaction(networkParameters, hash);
     }
 
-    /*private BtcTransaction createTransaction(int toPk, Coin value) {
-        return createTransaction(toPk, value, BtcECKey.fromPrivate(BigInteger.valueOf(123456)));
-    }*/
-
     private BtcTransaction createTransaction(int toPk, Coin value) {
         return createTransaction(toPk, value, new BtcECKey());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -215,9 +215,9 @@ public class BridgeTestIntegration {
 
     @Test
     void callUpdateCollectionsWithTransactionsWaitingForConfirmation() throws IOException, VMException {
-        BtcTransaction tx1 = createTransaction();
-        BtcTransaction tx2 = createTransaction();
-        BtcTransaction tx3 = createTransaction();
+        BtcTransaction tx1 = createTransaction(2, Coin.valueOf(150));
+        BtcTransaction tx2 = createTransaction(3, Coin.valueOf(200));
+        BtcTransaction tx3 = createTransaction(4, Coin.valueOf(250));
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -271,9 +271,9 @@ public class BridgeTestIntegration {
 
     @Test
     void callUpdateCollectionsWithTransactionsWaitingForConfirmationWithEnoughConfirmations() throws IOException, VMException {
-        BtcTransaction tx1 = createTransaction();
-        BtcTransaction tx2 = createTransaction();
-        BtcTransaction tx3 = createTransaction();
+        BtcTransaction tx1 = createTransaction(2, Coin.valueOf(150));
+        BtcTransaction tx2 = createTransaction(3, Coin.valueOf(200));
+        BtcTransaction tx3 = createTransaction(4, Coin.valueOf(250));
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -3285,7 +3285,34 @@ public class BridgeTestIntegration {
     }
 
     private BtcTransaction createTransaction() {
-        return new SimpleBtcTransaction(networkParameters, PegTestUtils.createHash());
+        return createTransaction(PegTestUtils.createHash());
+    }
+
+    private BtcTransaction createTransaction(Sha256Hash hash) {
+        return new SimpleBtcTransaction(networkParameters, hash);
+    }
+
+    private BtcTransaction createTransaction(int toPk, Coin value) {
+        return createTransaction(toPk, value, BtcECKey.fromPrivate(BigInteger.valueOf(123456)));
+    }
+
+    private BtcTransaction createUniqueTransaction(int toPk, Coin value) {
+        return createTransaction(toPk, value, new BtcECKey());
+    }
+
+    private BtcTransaction createTransaction(int toPk, Coin value, BtcECKey btcECKey) {
+        NetworkParameters params = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+        BtcTransaction input = new BtcTransaction(params);
+
+        input.addOutput(Coin.FIFTY_COINS, btcECKey.toAddress(params));
+
+        Address to = BtcECKey.fromPrivate(BigInteger.valueOf(toPk)).toAddress(params);
+
+        BtcTransaction result = new BtcTransaction(params);
+        result.addInput(input.getOutput(0));
+        result.getInput(0).disconnect();
+        result.addOutput(value, to);
+        return result;
     }
 
     private Block getGenesisBlock() {

--- a/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
@@ -382,7 +382,7 @@ class PowpegMigrationTest {
         );
 
         for (ReleaseTransactionSet.Entry entry : bridgeStorageProvider.getReleaseTransactionSet().getEntries()) {
-            BtcTransaction pegout = entry.getTransaction();
+            BtcTransaction pegout = entry.getPegoutCreationBtcTx();
             // This would fail if we were to implement UTXO expansion at some point
             assertEquals(1, pegout.getOutputs().size());
             assertEquals(
@@ -556,7 +556,7 @@ class PowpegMigrationTest {
         Federation retiringFederation = bridgeStorageProvider.getOldFederation();
 
         for (ReleaseTransactionSet.Entry pegoutEntry : bridgeStorageProvider.getReleaseTransactionSet().getEntries()) {
-            BtcTransaction pegoutBtcTransaction = pegoutEntry.getTransaction();
+            BtcTransaction pegoutBtcTransaction = pegoutEntry.getPegoutCreationBtcTx();
             for (TransactionInput input : pegoutBtcTransaction.getInputs()) {
                 // Each input should contain the right scriptsig
                 List<ScriptChunk> inputScriptChunks = input.getScriptSig().getChunks();
@@ -669,12 +669,12 @@ class PowpegMigrationTest {
             lastPegout = collectionItr.next();
         }
 
-        if (lastPegout == null || lastPegout.getTransaction() == null) {
+        if (lastPegout == null || lastPegout.getPegoutCreationBtcTx() == null) {
             fail("Couldn't find the recently created pegout in the release transaction set");
         }
 
         // Verify the recipients are the expected ones
-        for (TransactionOutput output : lastPegout.getTransaction().getOutputs()) {
+        for (TransactionOutput output : lastPegout.getPegoutCreationBtcTx().getOutputs()) {
             switch (output.getScriptPubKey().getScriptType()) {
                 case P2PKH: // Output for the pegout receiver
                     assertEquals(

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionSetTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionSetTest.java
@@ -66,7 +66,7 @@ class ReleaseTransactionSetTest {
         Assertions.assertNotEquals(e1, e3);
         Assertions.assertNotEquals(e1, e4);
         Assertions.assertEquals(e5, e6);
-        Assertions.assertNotEquals(e5, e7);
+        Assertions.assertEquals(e5, e7);
         Assertions.assertEquals(e7, e8);
     }
 
@@ -74,8 +74,8 @@ class ReleaseTransactionSetTest {
     void entryGetters() {
         ReleaseTransactionSet.Entry entry = new ReleaseTransactionSet.Entry(createTransaction(5, Coin.valueOf(100)), 7L);
 
-        Assertions.assertEquals(createTransaction(5, Coin.valueOf(100)), entry.getTransaction());
-        Assertions.assertEquals(7L, entry.getRskBlockNumber().longValue());
+        Assertions.assertEquals(createTransaction(5, Coin.valueOf(100)), entry.getPegoutCreationBtcTx());
+        Assertions.assertEquals(7L, entry.getPegoutCreationRskBlockNumber().longValue());
     }
 
     @Test
@@ -131,11 +131,11 @@ class ReleaseTransactionSetTest {
     @Test
     void add_existing() {
         Assertions.assertTrue(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 32L)));
-        Assertions.assertEquals(1, set.getEntries().stream().filter(e -> e.getTransaction().equals(createTransaction(2, Coin.valueOf(150)))).count());
+        Assertions.assertEquals(1, set.getEntries().stream().filter(e -> e.getPegoutCreationBtcTx().equals(createTransaction(2, Coin.valueOf(150)))).count());
         set.add(createTransaction(2, Coin.valueOf(150)), 23L);
         Assertions.assertTrue(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 32L)));
-        Assertions.assertFalse(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 23L)));
-        Assertions.assertEquals(1, set.getEntries().stream().filter(e -> e.getTransaction().equals(createTransaction(2, Coin.valueOf(150)))).count());
+        Assertions.assertTrue(set.getEntries().contains(new ReleaseTransactionSet.Entry(createTransaction(2, Coin.valueOf(150)), 23L)));
+        Assertions.assertEquals(1, set.getEntries().stream().filter(e -> e.getPegoutCreationBtcTx().equals(createTransaction(2, Coin.valueOf(150)))).count());
     }
 
     @Test


### PR DESCRIPTION
Renamed methods:

- processReleaseRequests -> processPegoutRequests
- processReleaseTransactions -> processConfirmedPegouts
- addPegoutTxToReleaseTransactionSet -> addPegoutBtcTxToPegoutWaitingForConfirmationsSet
- checkIfEntryExistsInTxsWaitingForSignatures -> checkIfEntryExistsInPegoutsWaitingForSignatures

Also, renamed logs 'release' to 'pegout' on methods renamed and refactored co.rsk.peg.ReleaseTransactionSet.Entry class