### PR TITLE
Increase the new federation activation age to 40,320

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeConstants.java
@@ -46,6 +46,7 @@ public abstract class BridgeConstants {
     protected Coin minimumPegoutTxValueInSatoshis;
 
     protected long federationActivationAge;
+    protected long federationActivationAgeLegacy;
 
     protected long fundsMigrationAgeSinceActivationBegin;
     protected long fundsMigrationAgeSinceActivationEnd;
@@ -119,8 +120,8 @@ public abstract class BridgeConstants {
 
     public Coin getMinimumPegoutTxValueInSatoshis() { return minimumPegoutTxValueInSatoshis; }
 
-    public long getFederationActivationAge() {
-        return federationActivationAge;
+    public long getFederationActivationAge(ActivationConfig.ForBlock activations) {
+        return activations.isActive(ConsensusRule.RSKIP383)? federationActivationAge: federationActivationAgeLegacy;
     }
 
     public long getFundsMigrationAgeSinceActivationBegin() {

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -104,7 +104,8 @@ public class BridgeDevNetConstants extends BridgeConstants {
             AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
 
-        federationActivationAge = 10L;
+        federationActivationAgeLegacy = 10L;
+        federationActivationAge = 20L;
 
         fundsMigrationAgeSinceActivationBegin = 15L;
         fundsMigrationAgeSinceActivationEnd = 100L;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -93,7 +93,8 @@ public class BridgeMainNetConstants extends BridgeConstants {
             AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
 
-        federationActivationAge = 18500L;
+        federationActivationAgeLegacy = 18500L;
+        federationActivationAge = 40320L;
 
         fundsMigrationAgeSinceActivationBegin = 0L;
         fundsMigrationAgeSinceActivationEnd = 10585L;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -90,7 +90,8 @@ public class BridgeRegTestConstants extends BridgeConstants {
             AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY
         );
 
-        federationActivationAge = 10L;
+        federationActivationAgeLegacy = 10L;
+        federationActivationAge = 20L;
 
         fundsMigrationAgeSinceActivationBegin = 15L;
         fundsMigrationAgeSinceActivationEnd = 150L;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -103,7 +103,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
             AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
 
-        federationActivationAge = 60L;
+        federationActivationAgeLegacy = 60L;
+        federationActivationAge = 120L;
 
         fundsMigrationAgeSinceActivationBegin = 60L;
         fundsMigrationAgeSinceActivationEnd = 900L;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -998,7 +998,7 @@ public class BridgeSupport {
     }
 
     private boolean federationIsInMigrationAge(Federation federation) {
-        long federationActivationAge = bridgeConstants.getFederationActivationAge();
+        long federationActivationAge = bridgeConstants.getFederationActivationAge(activations);
         long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
         long ageBegin = federationActivationAge + bridgeConstants.getFundsMigrationAgeSinceActivationBegin();
         long ageEnd = federationActivationAge + bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
@@ -1008,7 +1008,7 @@ public class BridgeSupport {
 
     private boolean federationIsPastMigrationAge(Federation federation) {
         long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
-        long ageEnd = bridgeConstants.getFederationActivationAge() +
+        long ageEnd = bridgeConstants.getFederationActivationAge(activations) +
             bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
 
         return federationAge >= ageEnd;
@@ -1327,7 +1327,7 @@ public class BridgeSupport {
             long nextFederationCreationBlockHeight = nextFederationCreationBlockHeightOpt.get();
             long curBlockHeight = rskExecutionBlock.getNumber();
 
-            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge()) {
+            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge(activations)) {
                 provider.setActiveFederationCreationBlockHeight(nextFederationCreationBlockHeight);
                 provider.clearNextFederationCreationBlockHeight();
             }
@@ -2678,7 +2678,7 @@ public class BridgeSupport {
         if (nextFederationCreationBlockHeightOpt.isPresent()) {
             long nextFederationCreationBlockHeight = nextFederationCreationBlockHeightOpt.get();
             long curBlockHeight = rskExecutionBlock.getNumber();
-            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge()) {
+            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge(activations)) {
                 return nextFederationCreationBlockHeight;
             }
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupportFactory.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupportFactory.java
@@ -67,7 +67,7 @@ public class BridgeSupportFactory {
             activations
         );
 
-        FederationSupport federationSupport = new FederationSupport(bridgeConstants, provider, executionBlock);
+        FederationSupport federationSupport = new FederationSupport(bridgeConstants, provider, executionBlock, activations);
 
         BridgeEventLogger eventLogger;
         if (logs == null) {

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -20,6 +20,7 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.config.BridgeConstants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
 
 import javax.annotation.Nullable;
@@ -34,11 +35,13 @@ public class FederationSupport {
     private final BridgeStorageProvider provider;
     private final BridgeConstants bridgeConstants;
     private final Block executionBlock;
+    private final ActivationConfig.ForBlock activations;
 
-    public FederationSupport(BridgeConstants bridgeConstants, BridgeStorageProvider provider, Block executionBlock) {
+    public FederationSupport(BridgeConstants bridgeConstants, BridgeStorageProvider provider, Block executionBlock, ActivationConfig.ForBlock activations) {
         this.provider = provider;
         this.bridgeConstants = bridgeConstants;
         this.executionBlock = executionBlock;
+        this.activations = activations;
     }
 
     /**
@@ -226,6 +229,6 @@ public class FederationSupport {
 
     private boolean shouldFederationBeActive(Federation federation) {
         long federationAge = executionBlock.getNumber() - federation.getCreationBlockNumber();
-        return federationAge >= bridgeConstants.getFederationActivationAge();
+        return federationAge >= bridgeConstants.getFederationActivationAge(activations);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -106,7 +106,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
         String oldFederationBtcAddress = oldFederation.getAddress().toBase58();
         byte[] newFederationFlatPubKeys = flatKeysAsByteArray(newFederation.getBtcPublicKeys());
         String newFederationBtcAddress = newFederation.getAddress().toBase58();
-        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge();
+        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge(activations);
 
         CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION.getEvent();
         byte[][] encodedTopicsInBytes = event.encodeEventTopics();

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
@@ -119,7 +119,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
         byte[] newFedFlatPubKeys = flatKeysAsRlpCollection(newFederation.getBtcPublicKeys());
         byte[] newFedData = RLP.encodeList(RLP.encodeElement(newFederation.getAddress().getHash160()), RLP.encodeList(newFedFlatPubKeys));
 
-        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge();
+        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge(activations);
 
         byte[] data = RLP.encodeList(oldFedData, newFedData, RLP.encodeString(Long.toString(newFedActivationBlockNumber)));
 

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
@@ -38,13 +38,15 @@ public class RemascFederationProvider {
             BridgeConstants bridgeConstants,
             Repository repository,
             Block processingBlock) {
+
+        ActivationConfig.ForBlock activations = activationConfig.forBlock(processingBlock.getNumber());
         BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
                 repository,
                 PrecompiledContracts.BRIDGE_ADDR,
                 bridgeConstants,
-                activationConfig.forBlock(processingBlock.getNumber())
+                activations
         );
-        this.federationSupport = new FederationSupport(bridgeConstants, bridgeStorageProvider, processingBlock);
+        this.federationSupport = new FederationSupport(bridgeConstants, bridgeStorageProvider, processingBlock, activations);
     }
 
     public int getFederationSize() {

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -83,6 +83,7 @@ public enum ConsensusRule {
     RSKIP374("rskip374"),
     RSKIP375("rskip375"),
     RSKIP377("rskip377"),
+    RSKIP383("rskip383"),
     ;
 
     private String configKey;

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -81,6 +81,7 @@ blockchain = {
              rskip374 = <hardforkName>
              rskip375 = <hardforkName>
              rskip377 = <hardforkName>
+             rskip383 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -69,6 +69,7 @@ blockchain = {
             rskip374 = fingerroot500
             rskip375 = fingerroot500
             rskip377 = fingerroot500
+            rskip383 = fingerroot500
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/config/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/BridgeConstantsTest.java
@@ -13,8 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BridgeConstantsTest {
-
-    private static Stream<Arguments> generator() {
+    private static Stream<Arguments> fundsMigrationAgeSinceActivationEndArgsProvider() {
         return Stream.of(
             Arguments.of(BridgeMainNetConstants.getInstance(), false),
             Arguments.of(BridgeTestNetConstants.getInstance(), true),
@@ -23,8 +22,8 @@ class BridgeConstantsTest {
     }
 
     @ParameterizedTest()
-    @MethodSource("generator")
-    void test_getFundsMigrationAgeSinceActivationEnd(BridgeConstants bridgeConstants, boolean hasSameValueForBothMigrationAges) {
+    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
+    void test_getFundsMigrationAgeSinceActivationEnd(BridgeConstants bridgeConstants, boolean hasSameValueForBothFields) {
         // Arrange
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
 
@@ -33,11 +32,11 @@ class BridgeConstantsTest {
 
         // assert
         assertEquals(fundsMigrationAgeSinceActivationEnd, bridgeConstants.fundsMigrationAgeSinceActivationEnd);
-        assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
+        assertEquals(hasSameValueForBothFields,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
     }
 
     @ParameterizedTest()
-    @MethodSource("generator")
+    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
     void test_getFundsMigrationAgeSinceActivationEnd_post_RSKIP357(BridgeConstants bridgeConstants, boolean hasSameValueForBothMigrationAges) {
         // Arrange
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -52,7 +51,7 @@ class BridgeConstantsTest {
     }
 
     @ParameterizedTest()
-    @MethodSource("generator")
+    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
     void test_getFundsMigrationAgeSinceActivationEnd_post_RSKIP374(BridgeConstants bridgeConstants, boolean hasSameValueForBothMigrationAges) {
         // Arrange
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -65,5 +64,33 @@ class BridgeConstantsTest {
         // assert
         assertEquals(fundsMigrationAgeSinceActivationEnd, bridgeConstants.fundsMigrationAgeSinceActivationEnd);
         assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
+    }
+
+    private static Stream<Arguments> federationActivationAgeArgProvider() {
+        return Stream.of(
+            Arguments.of(BridgeMainNetConstants.getInstance(), false),
+            Arguments.of(BridgeTestNetConstants.getInstance(), false),
+            Arguments.of(BridgeRegTestConstants.getInstance(), false),
+            Arguments.of(BridgeMainNetConstants.getInstance(), true),
+            Arguments.of(BridgeTestNetConstants.getInstance(), true),
+            Arguments.of(BridgeRegTestConstants.getInstance(), true)
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("federationActivationAgeArgProvider")
+    void test_getFederationActivationAge(BridgeConstants bridgeConstants, boolean isRSKIP383Active) {
+        // Arrange
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP383)).thenReturn(isRSKIP383Active);
+        // Act
+        long federationActivationAge = bridgeConstants.getFederationActivationAge(activations);
+
+        // assert
+        if (isRSKIP383Active){
+            assertEquals(bridgeConstants.federationActivationAge, federationActivationAge);
+        } else {
+            assertEquals(bridgeConstants.federationActivationAgeLegacy, federationActivationAge);
+        }
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -117,7 +117,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -259,7 +259,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -403,7 +403,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -571,7 +571,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -1607,7 +1607,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -1791,7 +1791,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -1985,7 +1985,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -2179,7 +2179,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -2346,7 +2346,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();
@@ -2528,7 +2528,7 @@ class BridgeSupportFlyoverTest {
         // For the sake of simplicity, this set the fed activation age value equal to the value in the bridgeRegTestConstants
         // in order to be able to always get the current retiring federation when it's been mock with no need of creating
         // unnecessary blocks when testing on mainnet.
-        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge()).when(bridgeConstants).getFederationActivationAge();
+        doReturn(BridgeRegTestConstants.getInstance().getFederationActivationAge(activations)).when(bridgeConstants).getFederationActivationAge(activations);
 
         Context btcContext = mock(Context.class);
         doReturn(bridgeConstants.getBtcParams()).when(btcContext).getParams();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -16,6 +16,9 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Transaction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -23,157 +26,84 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 class BridgeSupportProcessFundsMigrationTest {
 
-    @Test
-    void processFundsMigration_in_migration_age_before_rskip_146_activation_testnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, true);
+    private static Stream<Arguments> processFundMigrationArgsProvider() {
+        BridgeMainNetConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
+        BridgeTestNetConstants bridgeTestNetConstants = BridgeTestNetConstants.getInstance();
+
+        ActivationConfig.ForBlock activationsBeforeRSKIP146 = mock(ActivationConfig.ForBlock.class);
+
+        Stream<Arguments> beforeRskip146Tests = Stream.of(
+            Arguments.of(bridgeTestNetConstants, activationsBeforeRSKIP146, false),
+            Arguments.of(bridgeTestNetConstants, activationsBeforeRSKIP146, true),
+            Arguments.of(bridgeMainNetConstants, activationsBeforeRSKIP146, false),
+            Arguments.of(bridgeMainNetConstants, activationsBeforeRSKIP146, true)
+        );
+
+        ActivationConfig.ForBlock activationsAfterRSKIP146 = mock(ActivationConfig.ForBlock.class);
+        when(activationsAfterRSKIP146.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+
+        Stream<Arguments> afterRskip146Tests = Stream.of(
+            Arguments.of(bridgeTestNetConstants, activationsAfterRSKIP146, false),
+            Arguments.of(bridgeTestNetConstants, activationsAfterRSKIP146, true),
+            Arguments.of(bridgeMainNetConstants, activationsAfterRSKIP146, false),
+            Arguments.of(bridgeMainNetConstants, activationsAfterRSKIP146, true)
+        );
+
+        ActivationConfig.ForBlock activationsAfterRSKIP357 = mock(ActivationConfig.ForBlock.class);
+        when(activationsAfterRSKIP357.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activationsAfterRSKIP357.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+
+        Stream<Arguments> afterRskip357Tests = Stream.of(
+            Arguments.of(bridgeTestNetConstants, activationsAfterRSKIP357, false),
+            Arguments.of(bridgeTestNetConstants, activationsAfterRSKIP357, true),
+            Arguments.of(bridgeMainNetConstants, activationsAfterRSKIP357, false),
+            Arguments.of(bridgeMainNetConstants, activationsAfterRSKIP357, true)
+        );
+
+        ActivationConfig.ForBlock activationsAfterRSKIP374 = mock(ActivationConfig.ForBlock.class);
+        when(activationsAfterRSKIP374.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activationsAfterRSKIP374.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activationsAfterRSKIP374.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
+
+        Stream<Arguments> afterRskip374Tests = Stream.of(
+            Arguments.of(bridgeTestNetConstants, activationsAfterRSKIP374, false),
+            Arguments.of(bridgeTestNetConstants, activationsAfterRSKIP374, true),
+            Arguments.of(bridgeMainNetConstants, activationsAfterRSKIP374, false),
+            Arguments.of(bridgeMainNetConstants, activationsAfterRSKIP374, true)
+        );
+
+        ActivationConfig.ForBlock activationsAfterRSKIP383 = mock(ActivationConfig.ForBlock.class);
+        when(activationsAfterRSKIP383.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
+        when(activationsAfterRSKIP383.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activationsAfterRSKIP383.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
+        when(activationsAfterRSKIP383.isActive(ConsensusRule.RSKIP383)).thenReturn(true);
+
+        Stream<Arguments> afterRskip383Tests = Stream.of(
+            Arguments.of(bridgeTestNetConstants, activationsAfterRSKIP383, false),
+            Arguments.of(bridgeTestNetConstants, activationsAfterRSKIP383, true),
+            Arguments.of(bridgeMainNetConstants, activationsAfterRSKIP383, false),
+            Arguments.of(bridgeMainNetConstants, activationsAfterRSKIP383, true)
+        );
+        return Stream.of(
+            beforeRskip146Tests,
+            afterRskip146Tests,
+            afterRskip357Tests,
+            afterRskip374Tests,
+            afterRskip383Tests
+        ).flatMap(Function.identity());
     }
 
-    @Test
-    void processFundsMigration_in_migration_age_after_rskip_146_activation_testnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, true);
-    }
-
-    @Test
-    void processFundsMigration_in_migration_age_after_rskip_357_activation_testnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, true);
-    }
-
-    @Test
-    void processFundsMigration_in_migration_age_after_rskip_374_activation_testnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, true);
-    }
-
-    @Test
-    void processFundsMigration_past_migration_age_before_rskip_146_activation_testnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, false);
-    }
-
-    @Test
-    void processFundsMigration_past_migration_age_after_rskip_146_activation_testnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, false);
-    }
-
-    @Test
-    void processFundsMigration_past_migration_age_after_rskip_357_activation_testnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, false);
-    }
-
-    @Test
-    void processFundsMigration_past_migration_age_after_rskip_374_activation_testnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
-        test_processFundsMigration(BridgeTestNetConstants.getInstance(), activations, false);
-    }
-
-    @Test
-    void processFundsMigration_in_migration_age_before_rskip_146_activation_mainnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, true);
-    }
-
-    @Test
-    void processFundsMigration_in_migration_age_after_rskip_146_activation_mainnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, true);
-    }
-
-    @Test
-    void processFundsMigration_in_migration_age_after_rskip_357_activation_mainnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, true);
-    }
-
-    @Test
-    void processFundsMigration_in_migration_age_after_rskip_374_activation_mainnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, true);
-    }
-
-    @Test
-    void processFundsMigration_past_migration_age_before_rskip_146_activation_mainnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, false);
-    }
-
-    @Test
-    void processFundsMigration_past_migration_age_after_rskip_146_activation_mainnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(false);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, false);
-    }
-
-    @Test
-    void processFundsMigration_past_migration_age_after_rskip_357_activation_mainnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(false);
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, false);
-    }
-
-    @Test
-    void processFundsMigration_past_migration_age_after_rskip_374_activation_mainnet() throws IOException {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
-        test_processFundsMigration(BridgeMainNetConstants.getInstance(), activations, false);
-    }
-
-    private void test_processFundsMigration(
+    @ParameterizedTest
+    @MethodSource("processFundMigrationArgsProvider")
+    void test_processFundsMigration(
         BridgeConstants bridgeConstants,
         ActivationConfig.ForBlock activations,
         boolean inMigrationAge
@@ -181,13 +111,13 @@ class BridgeSupportProcessFundsMigrationTest {
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
         Federation oldFederation = bridgeConstants.getGenesisFederation();
+        long federationActivationAge = bridgeConstants.getFederationActivationAge(activations);
 
         long federationCreationBlockNumber = 5L;
-        long federationInMigrationAgeHeight = federationCreationBlockNumber +
-            bridgeConstants.getFederationActivationAge() +
+        long federationInMigrationAgeHeight = federationCreationBlockNumber + federationActivationAge +
             bridgeConstants.getFundsMigrationAgeSinceActivationBegin() + 1;
         long federationPastMigrationAgeHeight = federationCreationBlockNumber +
-            bridgeConstants.getFederationActivationAge() +
+            federationActivationAge +
             bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations) + 1;
 
         Federation newFederation = new Federation(
@@ -229,7 +159,14 @@ class BridgeSupportProcessFundsMigrationTest {
         bridgeSupport.updateCollections(updateCollectionsTx);
 
         Assertions.assertEquals(activations.isActive(ConsensusRule.RSKIP146)? 0 : 1, provider.getPegoutsWaitingForConfirmations().getEntriesWithoutHash().size());
-        Assertions.assertEquals(activations.isActive(ConsensusRule.RSKIP146) ? 1 : 0, provider.getPegoutsWaitingForConfirmations().getEntriesWithHash().size());
+        Assertions.assertEquals(activations.isActive(ConsensusRule.RSKIP146)? 1 : 0, provider.getPegoutsWaitingForConfirmations().getEntriesWithHash().size());
+
+        Assertions.assertTrue(sufficientUTXOsForMigration.isEmpty());
+        if (inMigrationAge){
+            verify(provider, never()).setOldFederation(null);
+        } else {
+            verify(provider, times(1)).setOldFederation(null);
+        }
 
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             // Should have been logged with the migrated UTXO

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -2107,6 +2107,7 @@ class BridgeSupportTest {
     private static Stream<BridgeConstants> provideBridgeConstants() {
         return Stream.of(BridgeRegTestConstants.getInstance(), BridgeTestNetConstants.getInstance(), BridgeMainNetConstants.getInstance());
     }
+
     @ParameterizedTest
     @MethodSource("provideBridgeConstants")
     void rskTxWaitingForSignature_uses_pegoutCreation_rskTxHash_after_rskip_375_activation(BridgeConstants bridgeConstants) throws IOException {
@@ -6675,7 +6676,7 @@ class BridgeSupportTest {
         Block block = mock(Block.class);
         // Set block right after the migration should start
         long blockNumber = newFed.getCreationBlockNumber() +
-            bridgeConstantsRegtest.getFederationActivationAge() +
+            bridgeConstantsRegtest.getFederationActivationAge(activations) +
             bridgeConstantsRegtest.getFundsMigrationAgeSinceActivationBegin() +
             1;
         when(block.getNumber()).thenReturn(blockNumber);
@@ -7237,7 +7238,7 @@ class BridgeSupportTest {
             track,
             executionBlock,
             new Context(constants.getBtcParams()),
-            new FederationSupport(constants, provider, executionBlock),
+            new FederationSupport(constants, provider, executionBlock, activations),
             blockStoreFactory,
             activations,
             signatureCache

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -227,7 +227,7 @@ public class BridgeSupportTestIntegration {
             track,
             null,
             new Context(bridgeConstants.getBtcParams()),
-            new FederationSupport(bridgeConstants, provider, null),
+            new FederationSupport(bridgeConstants, provider, null, activationsBeforeForks),
             btcBlockStoreFactory,
             mock(ActivationConfig.ForBlock.class),
             signatureCache
@@ -3750,8 +3750,9 @@ public class BridgeSupportTestIntegration {
         when(constantsMock.getBtcParams()).thenReturn(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         when(constantsMock.getFederationChangeAuthorizer()).thenReturn(bridgeConstants.getFederationChangeAuthorizer());
 
-        long federationActivationAge = bridgeConstants.getFederationActivationAge();
-        when(constantsMock.getFederationActivationAge()).thenReturn(federationActivationAge);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        long federationActivationAge = bridgeConstants.getFederationActivationAge(activations);
+        when(constantsMock.getFederationActivationAge(any())).thenReturn(federationActivationAge);
 
         class FederationHolder {
             private PendingFederation pendingFederation;
@@ -3968,7 +3969,7 @@ public class BridgeSupportTestIntegration {
                 track,
                 executionBlock,
                 new Context(constants.getBtcParams()),
-                new FederationSupport(constants, provider, executionBlock),
+                new FederationSupport(constants, provider, executionBlock, activations),
                 blockStoreFactory,
                 activations,
                 signatureCache

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
@@ -45,6 +45,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -105,7 +106,7 @@ class BridgeEventLoggerLegacyImplTest {
     void testLogUpdateCollectionsAfterRskip146() {
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
         Transaction anyTx = any();
-        Assertions.assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logUpdateCollections(anyTx));
+        assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logUpdateCollections(anyTx));
     }
 
     @Test
@@ -147,7 +148,7 @@ class BridgeEventLoggerLegacyImplTest {
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
         BtcECKey federatorPublicKey = new BtcECKey();
         byte[] bytes = rskTxHash.getBytes();
-        Assertions.assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logAddSignature(federatorPublicKey, btcTxMock, bytes));
+        assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logAddSignature(federatorPublicKey, btcTxMock, bytes));
     }
 
     @Test
@@ -185,7 +186,7 @@ class BridgeEventLoggerLegacyImplTest {
 
         // Act
         byte[] bytes = rskTxHash.getBytes();
-        Assertions.assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logReleaseBtc(btcTxMock, bytes));
+        assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logReleaseBtc(btcTxMock, bytes));
     }
 
     @Test
@@ -269,7 +270,7 @@ class BridgeEventLoggerLegacyImplTest {
         }
 
         // Assert new federation activation block number
-        Assertions.assertEquals(15L + constantsMock.getFederationActivationAge(), Long.valueOf(new String(dataList.get(2).getRLPData(), StandardCharsets.UTF_8)).longValue());
+        Assertions.assertEquals(15L + constantsMock.getFederationActivationAge(activations), Long.valueOf(new String(dataList.get(2).getRLPData(), StandardCharsets.UTF_8)).longValue());
     }
 
     @Test
@@ -278,7 +279,7 @@ class BridgeEventLoggerLegacyImplTest {
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
 
         // Act
-        Assertions.assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logCommitFederation(mock(Block.class), mock(Federation.class), mock(Federation.class)));
+        assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logCommitFederation(mock(Block.class), mock(Federation.class), mock(Federation.class)));
     }
 
     /**********************************

--- a/rskj-core/src/test/java/co/rsk/test/builders/BridgeSupportBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BridgeSupportBuilder.java
@@ -99,7 +99,7 @@ public class BridgeSupportBuilder {
             repository,
             executionBlock,
             new Context(bridgeConstants.getBtcParams()),
-            new FederationSupport(bridgeConstants, provider, executionBlock),
+            new FederationSupport(bridgeConstants, provider, executionBlock, activations),
             btcBlockStoreFactory,
             activations,
             signatureCache

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -108,6 +108,7 @@ class ActivationConfigTest {
             "    rskip374: fingerroot500",
             "    rskip375: fingerroot500",
             "    rskip377: fingerroot500",
+            "    rskip383: fingerroot500",
             "}"
     ));
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -167,7 +167,8 @@ public class ActivationConfigsForTest {
             ConsensusRule.RSKIP326,
             ConsensusRule.RSKIP374,
             ConsensusRule.RSKIP375,
-            ConsensusRule.RSKIP377
+            ConsensusRule.RSKIP377,
+            ConsensusRule.RSKIP383
         ));
 
         return rskips;


### PR DESCRIPTION
Since RSKIP383 after a commit_federation event is emitted we expect the new federation to activate after 40,320 blocks instead of the current 18,500 blocks.

Changed made:

- Created new federationActivationAgeLegacy bridge constants variable and set it with the old value 18,500.
- Set federationActivationAge bridge constants with the new value: 40320.
- Refactored method BridgeConstants.getFederationActivationAge.
- Added new tests and updated existence tests based on the changes.

*fed:FINGERROOT-5.0.0-rc*
*fit:FINGERROOT-5.0.0-rc*
*ci:FINGERROOT-5.0.0-rc*