### PR TITLE
Configurable eth get logs limits

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -33,12 +33,7 @@ import org.ethereum.crypto.HashUtil;
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Created by ajlopez on 3/3/2016.
@@ -57,6 +52,9 @@ public class RskSystemProperties extends SystemProperties {
     private static final String MINER_REWARD_ADDRESS_CONFIG = "miner.reward.address";
     private static final String MINER_COINBASE_SECRET_CONFIG = "miner.coinbase.secret";
     private static final String RPC_MODULES_PATH = "rpc.modules";
+    private static final String RPC_ETH_GET_LOGS_MAX_BLOCKS_TO_QUERY = "rpc.eth_getLogs.maxBlocksToQuery";
+    private static final String RPC_ETH_GET_LOGS_MAX_LOGS_TO_RETURN = "rpc.eth_getLogs.maxLogsToReturn";
+
     private static final int CHUNK_SIZE = 192;
 
     public static final String PROPERTY_SYNC_TOP_BEST = "sync.topBest";
@@ -294,6 +292,7 @@ public class RskSystemProperties extends SystemProperties {
         }
         return modules;
     }
+
     private ModuleDescription getModule(Config configElement, String name) {
 
         String version = configElement.getString("version");
@@ -321,6 +320,7 @@ public class RskSystemProperties extends SystemProperties {
         }
         return new ModuleDescription(name, version, enabled, enabledMethods, disabledMethods, timeout, methodTimeoutMap);
     }
+
     public boolean hasMessageRecorderEnabled() {
         return getBoolean("messages.recorder.enabled", false);
     }
@@ -458,6 +458,14 @@ public class RskSystemProperties extends SystemProperties {
 
     public boolean rpcZeroSignatureIfRemasc() {
         return configFromFiles.getBoolean("rpc.zeroSignatureIfRemasc");
+    }
+
+    public long getRpcEthGetLogsMaxBlockToQuery() {
+        return configFromFiles.getLong(RPC_ETH_GET_LOGS_MAX_BLOCKS_TO_QUERY);
+    }
+
+    public long getRpcEthGetLogsMaxLogsToReturn() {
+        return configFromFiles.getLong(RPC_ETH_GET_LOGS_MAX_LOGS_TO_RETURN);
     }
 
     public double getTopBest() {

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -52,8 +52,8 @@ public class RskSystemProperties extends SystemProperties {
     private static final String MINER_REWARD_ADDRESS_CONFIG = "miner.reward.address";
     private static final String MINER_COINBASE_SECRET_CONFIG = "miner.coinbase.secret";
     private static final String RPC_MODULES_PATH = "rpc.modules";
-    private static final String RPC_ETH_GET_LOGS_MAX_BLOCKS_TO_QUERY = "rpc.eth_getLogs.maxBlocksToQuery";
-    private static final String RPC_ETH_GET_LOGS_MAX_LOGS_TO_RETURN = "rpc.eth_getLogs.maxLogsToReturn";
+    private static final String RPC_ETH_GET_LOGS_MAX_BLOCKS_TO_QUERY = "rpc.logs.maxBlocksToQuery";
+    private static final String RPC_ETH_GET_LOGS_MAX_LOGS_TO_RETURN = "rpc.logs.maxLogsToReturn";
 
     private static final int CHUNK_SIZE = 192;
 

--- a/rskj-core/src/main/java/co/rsk/jsonrpc/JsonRpcError.java
+++ b/rskj-core/src/main/java/co/rsk/jsonrpc/JsonRpcError.java
@@ -30,7 +30,7 @@ public class JsonRpcError implements JsonRpcResultOrError {
 	public static final int INVALID_PARAMS = -32602;
 	public static final int INTERNAL_ERROR = -32603;
 	public static final int RPC_LIMIT_ERROR = -32011;
-
+	public static final int MAX_ETH_GET_LOGS_LIMIT = -32012;
 
 	private final int code;
 	private final String message;

--- a/rskj-core/src/main/java/org/ethereum/rpc/Filter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Filter.java
@@ -18,11 +18,9 @@
 
 package org.ethereum.rpc;
 
-import co.rsk.jsonrpc.JsonRpcError;
 import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
-import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,15 +36,8 @@ public class Filter {
     private List<FilterEvent> events = new ArrayList<>();
     private int processedEvents = 0;
     private long accessTime = System.currentTimeMillis();
-    private final long maxLogsToReturn;
 
-    public Filter() {
-        this.maxLogsToReturn = 0;
-    }
-
-    public Filter(long maxLogsToReturn) {
-        this.maxLogsToReturn = maxLogsToReturn;
-    }
+    public Filter() {}
 
     public boolean hasExpired(long timeout) {
         long nowTime = System.currentTimeMillis();
@@ -83,9 +74,6 @@ public class Filter {
     }
 
     protected synchronized void add(FilterEvent evt) {
-        if (maxLogsToReturn > 0 && events.size() + 1 > maxLogsToReturn) {
-            throw new RskJsonRpcRequestException(JsonRpcError.MAX_ETH_GET_LOGS_LIMIT, "Filter returned more than " + maxLogsToReturn + " logs.");
-        }
         events.add(evt);
     }
 
@@ -102,5 +90,9 @@ public class Filter {
 
     public interface FilterEvent {
         Object getJsonEventObject();
+    }
+
+    protected int eventsSize() {
+        return events.size();
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/Filter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Filter.java
@@ -37,8 +37,6 @@ public class Filter {
     private int processedEvents = 0;
     private long accessTime = System.currentTimeMillis();
 
-    public Filter() {}
-
     public boolean hasExpired(long timeout) {
         long nowTime = System.currentTimeMillis();
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/LogFilter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/LogFilter.java
@@ -46,11 +46,6 @@ public class LogFilter extends Filter {
     private final long maxBlocksToQuery;
     private final long maxLogsToReturn;
 
-    @Deprecated
-    public LogFilter(AddressesTopicsFilter addressesTopicsFilter, Blockchain blockchain, boolean fromLatestBlock, boolean toLatestBlock) {
-        this(addressesTopicsFilter, blockchain, fromLatestBlock, toLatestBlock, 0, 0);
-    }
-
     private LogFilter(AddressesTopicsFilter addressesTopicsFilter, Blockchain blockchain, boolean fromLatestBlock, boolean toLatestBlock, long maxBlocksToQuery, long maxLogsToReturn) {
         this.maxLogsToReturn = maxLogsToReturn;
         this.addressesTopicsFilter = addressesTopicsFilter;
@@ -198,7 +193,9 @@ public class LogFilter extends Filter {
             maxBlocksToReturn = 0L;
         }
 
-        LogFilter filter = new LogFilterBuilder(addressesTopicsFilter, blockchain)
+        LogFilter filter = new LogFilterBuilder()
+                .addressesTopicsFilter(addressesTopicsFilter)
+                .blockchain(blockchain)
                 .fromLatestBlock(fromLatestBlock)
                 .toLatestBlock(toLatestBlock)
                 .maxBlocksToQuery(maxBlocksToQuery)
@@ -344,20 +341,30 @@ public class LogFilter extends Filter {
 
     public static class LogFilterBuilder {
 
-        private final AddressesTopicsFilter addressesTopicsFilter;
-        private final Blockchain blockchain;
+        private AddressesTopicsFilter addressesTopicsFilter;
+        private Blockchain blockchain;
         private boolean fromLatestBlock;
         private boolean toLatestBlock;
         private long maxBlocksToQuery;
         private long maxBlocksToReturn;
 
-        public LogFilterBuilder(AddressesTopicsFilter addressesTopicsFilter, Blockchain blockchain) {
-            this.addressesTopicsFilter = addressesTopicsFilter;
-            this.blockchain = blockchain;
+        public LogFilterBuilder() {
+            this.addressesTopicsFilter = null;
+            this.blockchain = null;
             this.fromLatestBlock = false;
             this.toLatestBlock = false;
             this.maxBlocksToQuery = 0;
             this.maxBlocksToReturn = 0;
+        }
+
+        public LogFilterBuilder addressesTopicsFilter(AddressesTopicsFilter addressesTopicsFilter) {
+            this.addressesTopicsFilter = addressesTopicsFilter;
+            return this;
+        }
+
+        public LogFilterBuilder blockchain(Blockchain blockchain) {
+            this.blockchain = blockchain;
+            return this;
         }
 
         public LogFilterBuilder fromLatestBlock(boolean fromLatestBlock) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/LogFilter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/LogFilter.java
@@ -333,9 +333,6 @@ public class LogFilter extends Filter {
         }
     }
 
-    //Builder pattern class
-    //Builder pattern class
-
     public static class LogFilterBuilder {
 
         private final AddressesTopicsFilter addressesTopicsFilter;

--- a/rskj-core/src/main/java/org/ethereum/rpc/NewBlockFilter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/NewBlockFilter.java
@@ -27,7 +27,7 @@ import co.rsk.util.HexUtils;
  */
 
 public class NewBlockFilter extends Filter {
-    class NewBlockFilterEvent extends FilterEvent {
+    static class NewBlockFilterEvent implements FilterEvent {
         public final Block b;
 
         NewBlockFilterEvent(Block b) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/PendingTransactionFilter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/PendingTransactionFilter.java
@@ -25,7 +25,7 @@ import org.ethereum.core.Transaction;
  */
 
 public class PendingTransactionFilter extends Filter {
-    class PendingTransactionFilterEvent extends FilterEvent {
+    static class PendingTransactionFilterEvent implements FilterEvent {
         private final Transaction tx;
 
         PendingTransactionFilterEvent(Transaction tx) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -17,55 +17,6 @@
  */
 package org.ethereum.rpc;
 
-import static co.rsk.util.HexUtils.jsonHexToInt;
-import static co.rsk.util.HexUtils.jsonHexToLong;
-import static co.rsk.util.HexUtils.stringHexToBigInteger;
-import static co.rsk.util.HexUtils.stringHexToByteArray;
-import static co.rsk.util.HexUtils.toQuantityJsonHex;
-import static co.rsk.util.HexUtils.toUnformattedJsonHex;
-import static java.lang.Math.max;
-import static org.ethereum.rpc.exception.RskJsonRpcRequestException.blockNotFound;
-import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
-import static org.ethereum.rpc.exception.RskJsonRpcRequestException.unimplemented;
-
-import java.math.BigInteger;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.UnaryOperator;
-
-import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.core.*;
-import org.ethereum.crypto.HashUtil;
-import org.ethereum.db.BlockInformation;
-import org.ethereum.db.BlockStore;
-import org.ethereum.db.ReceiptStore;
-import org.ethereum.db.TransactionInfo;
-import org.ethereum.facade.Ethereum;
-import org.ethereum.net.client.Capability;
-import org.ethereum.net.client.ConfigCapabilities;
-import org.ethereum.net.server.ChannelManager;
-import org.ethereum.net.server.PeerServer;
-import org.ethereum.rpc.dto.BlockResultDTO;
-import org.ethereum.rpc.dto.CompilationResultDTO;
-import org.ethereum.rpc.dto.TransactionReceiptDTO;
-import org.ethereum.rpc.dto.TransactionResultDTO;
-import org.ethereum.util.BuildInfo;
-import org.ethereum.vm.DataWord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
-
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
@@ -89,12 +40,44 @@ import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.trace.TraceModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
-import co.rsk.scoring.InvalidInetAddressException;
-import co.rsk.scoring.PeerScoringInformation;
-import co.rsk.scoring.PeerScoringManager;
-import co.rsk.scoring.PeerScoringReporterUtil;
-import co.rsk.scoring.PeerScoringReputationSummary;
+import co.rsk.scoring.*;
 import co.rsk.util.HexUtils;
+import com.google.common.annotations.VisibleForTesting;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.ethereum.core.*;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.db.BlockInformation;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.db.TransactionInfo;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.net.client.Capability;
+import org.ethereum.net.client.ConfigCapabilities;
+import org.ethereum.net.server.ChannelManager;
+import org.ethereum.net.server.PeerServer;
+import org.ethereum.rpc.dto.BlockResultDTO;
+import org.ethereum.rpc.dto.CompilationResultDTO;
+import org.ethereum.rpc.dto.TransactionReceiptDTO;
+import org.ethereum.rpc.dto.TransactionResultDTO;
+import org.ethereum.util.BuildInfo;
+import org.ethereum.vm.DataWord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import static co.rsk.util.HexUtils.*;
+import static java.lang.Math.max;
+import static org.ethereum.rpc.exception.RskJsonRpcRequestException.blockNotFound;
+import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
+import static org.ethereum.rpc.exception.RskJsonRpcRequestException.unimplemented;
 
 public class Web3Impl implements Web3 {
     private static final Logger logger = LoggerFactory.getLogger("web3");
@@ -265,7 +248,8 @@ public class Web3Impl implements Web3 {
         String s = null;
         try {
             int n = channelManager.getActivePeers().size();
-            return s = HexUtils.toQuantityJsonHex(n);
+            s = HexUtils.toQuantityJsonHex(n);
+            return s;
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug("net_peerCount(): {}", s);
@@ -664,8 +648,8 @@ public class Web3Impl implements Web3 {
         BlockResultDTO s = null;
         try {
             Block b = getBlockByJSonHash(blockHash);
-
-            return s = (b == null ? null : getBlockResult(b, fullTransactionObjects));
+            s = (b == null ? null : getBlockResult(b, fullTransactionObjects));
+            return s;
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug("eth_getBlockByHash({}, {}): {}", blockHash, fullTransactionObjects, s);
@@ -704,7 +688,8 @@ public class Web3Impl implements Web3 {
 
                 for (Transaction tx : txs) {
                     if (tx.getHash().equals(txHash)) {
-                        return s = new TransactionResultDTO(null, null, tx, config.rpcZeroSignatureIfRemasc(), signatureCache);
+                        s = new TransactionResultDTO(null, null, tx, config.rpcZeroSignatureIfRemasc(), signatureCache);
+                        return s;
                     }
                 }
             } else {
@@ -720,8 +705,8 @@ public class Web3Impl implements Web3 {
             if (txInfo == null) {
                 return null;
             }
-
-            return s = new TransactionResultDTO(block, txInfo.getIndex(), txInfo.getReceipt().getTransaction(), config.rpcZeroSignatureIfRemasc(), signatureCache);
+            s = new TransactionResultDTO(block, txInfo.getIndex(), txInfo.getReceipt().getTransaction(), config.rpcZeroSignatureIfRemasc(), signatureCache);
+            return s;
         } finally {
             logger.debug("eth_getTransactionByHash({}): {}", transactionHash, s);
         }
@@ -744,8 +729,8 @@ public class Web3Impl implements Web3 {
             }
 
             Transaction tx = b.getTransactionsList().get(idx);
-
-            return s = new TransactionResultDTO(b, idx, tx, config.rpcZeroSignatureIfRemasc(), signatureCache);
+            s = new TransactionResultDTO(b, idx, tx, config.rpcZeroSignatureIfRemasc(), signatureCache);
+            return s;
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug("eth_getTransactionByBlockHashAndIndex({}, {}): {}", blockHash, index, s);
@@ -885,9 +870,8 @@ public class Web3Impl implements Web3 {
     @Override
     public String eth_newFilter(FilterRequest fr) throws Exception {
         String str = null;
-
         try {
-            Filter filter = LogFilter.fromFilterRequest(fr, blockchain, blocksBloomStore);
+            Filter filter = LogFilter.fromFilterRequest(fr, blockchain, blocksBloomStore, config.getRpcEthGetLogsMaxBlockToQuery(),config.getRpcEthGetLogsMaxLogsToReturn());
             int id = filterManager.registerFilter(filter);
 
             str = toQuantityJsonHex(id);

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -282,10 +282,10 @@ rpc = {
     skipRemasc: <enabled>
     zeroSignatureIfRemasc = <enabled>
     gasEstimationCap = <gas>
-    eth_getLogs =  {
-            maxBlocksToQuery = <number>
-            maxLogsToReturn = <number>
-        }
+    logs = {
+        maxBlocksToQuery = <number>
+        maxLogsToReturn = <number>
+    }
 }
 wire = {
     protocol = <protocol>

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -282,6 +282,10 @@ rpc = {
     skipRemasc: <enabled>
     zeroSignatureIfRemasc = <enabled>
     gasEstimationCap = <gas>
+    eth_getLogs =  {
+            maxBlocksToQuery = <number>
+            maxLogsToReturn = <number>
+        }
 }
 wire = {
     protocol = <protocol>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -431,7 +431,7 @@ rpc {
     zeroSignatureIfRemasc = true
     gasEstimationCap = 6800000 # block gasLimit, rpc DoS protection for gas estimation
     logs {
-        # maximum number of logs to query
+        # maximum number of blocks to query
         maxBlocksToQuery = 0
         # maximum number of logs to return
         maxLogsToReturn = 0

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -434,7 +434,7 @@ rpc {
         # maximum number of logs to query
         maxBlocksToQuery = 0
         # maximum number of logs to return
-        maxBlocksToReturn = 0
+        maxLogsToReturn = 0
     }
 }
 

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -430,6 +430,12 @@ rpc {
     # set signature to zero (instead of null) for Remasc transaction on RPC DTOs
     zeroSignatureIfRemasc = true
     gasEstimationCap = 6800000 # block gasLimit, rpc DoS protection for gas estimation
+    eth_getLogs {
+        # maximum number of logs to query
+        maxBlocksToQuery = 0
+        # maximum number of logs to return
+        maxBlocksToReturn = 0
+    }
 }
 
 wire {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -430,7 +430,7 @@ rpc {
     # set signature to zero (instead of null) for Remasc transaction on RPC DTOs
     zeroSignatureIfRemasc = true
     gasEstimationCap = 6800000 # block gasLimit, rpc DoS protection for gas estimation
-    eth_getLogs {
+    logs {
         # maximum number of logs to query
         maxBlocksToQuery = 0
         # maximum number of logs to return

--- a/rskj-core/src/test/java/org/ethereum/rpc/FilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/FilterTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2018 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.ethereum.rpc;
+
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FilterTest {
+
+    private Filter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new Filter();
+    }
+
+    @Test
+    void testGetEvents() {
+        Filter.FilterEvent mockEvent1 = new FilterEventMock();
+        Filter.FilterEvent mockEvent2 = new FilterEventMock();
+        Filter.FilterEvent mockEvent3 = new FilterEventMock();
+        filter.add(mockEvent1);
+        filter.add(mockEvent2);
+        filter.add(mockEvent3);
+
+        Object[] events = filter.getEvents();
+        assertArrayEquals(new Object[] { mockEvent1.getJsonEventObject(), mockEvent2.getJsonEventObject(), mockEvent3.getJsonEventObject() }, events);
+    }
+
+    @Test
+    void addFilter_mustFail_whenLimitIsReached(){
+        int limit = 2;
+        Filter filter = new Filter(limit);
+        assertTrue(filter.getEventsInternal().isEmpty());
+        filter.add(new FilterEventMock());
+        filter.add(new FilterEventMock());
+
+        // the limit is reached
+        assertEquals(limit,filter.getEvents().length);
+
+        FilterEventMock thirdEvent = new FilterEventMock();
+        assertThrows(RskJsonRpcRequestException.class, () -> filter.add(thirdEvent));
+    }
+
+    @Test
+    @DisplayName("Test getEventsInternal() method")
+    void testGetEventsInternal() {
+        Filter.FilterEvent mockEvent1 = new FilterEventMock();
+        Filter.FilterEvent mockEvent2 = new FilterEventMock();
+        filter.add(mockEvent1);
+        filter.add(mockEvent2);
+
+        // get the internal events list and make sure it's a copy of the original list
+        List<Filter.FilterEvent> events = filter.getEventsInternal();
+        assertNotSame(events, filter.getEventsInternal());
+        assertArrayEquals(new Object[] { mockEvent1, mockEvent2 }, events.toArray());
+    }
+
+
+    @Test
+    void testHasExpired_mustFailIfExpired() {
+        assertFalse(filter.hasExpired(1000));
+
+        filter = new Filter();
+        filter.hasExpired(1000); // to set the accessTime
+        try {
+            //TODO replace with TestUtils.waitFor when the other PR is merged
+            Thread.sleep(1500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        assertTrue(filter.hasExpired(1000));
+    }
+
+    @Test
+    void testGetNewEvents() {
+        Filter.FilterEvent mockEvent = new FilterEventMock();
+        filter.add(mockEvent);
+
+        // call getNewEvents() twice, the first time it should return the mock event, the second time it should return an empty array
+        Object[] events1 = filter.getNewEvents();
+        Object[] events2 = filter.getNewEvents();
+
+        assertArrayEquals(new Object[] { mockEvent.getJsonEventObject() }, events1);
+        assertArrayEquals(new Object[] {}, events2);
+    }
+
+
+
+    static class FilterEventMock implements Filter.FilterEvent {
+
+        @Override
+        public Object getJsonEventObject() {
+            return "MockObject";
+        }
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/FilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/FilterTest.java
@@ -18,14 +18,16 @@
 
 package org.ethereum.rpc;
 
-import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FilterTest {
 
@@ -47,21 +49,6 @@ class FilterTest {
 
         Object[] events = filter.getEvents();
         assertArrayEquals(new Object[] { mockEvent1.getJsonEventObject(), mockEvent2.getJsonEventObject(), mockEvent3.getJsonEventObject() }, events);
-    }
-
-    @Test
-    void addFilter_mustFail_whenLimitIsReached(){
-        int limit = 2;
-        Filter filter = new Filter(limit);
-        assertTrue(filter.getEventsInternal().isEmpty());
-        filter.add(new FilterEventMock());
-        filter.add(new FilterEventMock());
-
-        // the limit is reached
-        assertEquals(limit,filter.getEvents().length);
-
-        FilterEventMock thirdEvent = new FilterEventMock();
-        assertThrows(RskJsonRpcRequestException.class, () -> filter.add(thirdEvent));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/FilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/FilterTest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of RskJ
- * Copyright (C) 2018 RSK Labs Ltd.
+ * Copyright (C) 2023 RSK Labs Ltd.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
@@ -226,6 +226,23 @@ class LogFilterTest {
         assertEquals(-32012,ex.getCode());
     }
 
+    @Test
+    void addFilter_mustFail_whenLimitIsReached(){
+        int limit = 2;
+        LogFilter filter = new LogFilter.LogFilterBuilder(null, null)
+                .maxBlocksToReturn(limit)
+                .build();
+        assertTrue(filter.getEventsInternal().isEmpty());
+        filter.add(new FilterTest.FilterEventMock());
+        filter.add(new FilterTest.FilterEventMock());
+
+        // the limit is reached
+        assertEquals(limit,filter.getEvents().length);
+
+        FilterTest.FilterEventMock thirdEvent = new FilterTest.FilterEventMock();
+        assertThrows(RskJsonRpcRequestException.class, () -> filter.add(thirdEvent));
+    }
+
     private void createBlocksTo(int blockNumber, BlockBuilder blockBuilder, Blockchain blockchain, Account acc1) {
 
         Block parent = blockchain.getBlockByNumber(0);

--- a/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
@@ -40,7 +40,9 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by ajlopez on 17/01/2018.

--- a/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
@@ -49,7 +49,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Created by ajlopez on 17/01/2018.
  */
-class LogFilterTest {
+class
+LogFilterTest {
 
     @TempDir
     public Path tempDir;
@@ -211,7 +212,7 @@ class LogFilterTest {
     @Test
     void testLogFilterExceptionIsThrownWhenLimitIsReached(){
         //TODO RskTestFactory is deprecated but RskTestContext is not working in the same way
-        RskTestFactory rskTestContext = new RskTestFactory();
+        RskTestFactory rskTestContext = new RskTestFactory(tempDir);
         Blockchain blockchain = rskTestContext.getBlockchain();
         BlockStore blockStore = rskTestContext.getBlockStore();
         BlocksBloomStore blocksBloomStore = rskTestContext.getBlocksBloomStore();

--- a/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/LogFilterTest.java
@@ -56,8 +56,7 @@ class LogFilterTest {
 
     @Test
     void noEvents() {
-        LogFilter filter = new LogFilter(null, null, false, false);
-
+        LogFilter filter = new LogFilter.LogFilterBuilder().build();
         Object[] result = filter.getEvents();
 
         Assertions.assertNotNull(result);
@@ -66,7 +65,7 @@ class LogFilterTest {
 
     @Test
     void noEventsAfterEmptyBlock() {
-        LogFilter filter = new LogFilter(null, null, false, false);
+        LogFilter filter =new LogFilter.LogFilterBuilder().build();
 
         Block block = new BlockGenerator().getBlock(1);
 
@@ -89,7 +88,12 @@ class LogFilterTest {
 
         AddressesTopicsFilter atfilter = new AddressesTopicsFilter(new RskAddress[0], null);
 
-        LogFilter filter = new LogFilter(atfilter, blockchain, false, true);
+        LogFilter filter = new LogFilter.LogFilterBuilder()
+                .addressesTopicsFilter(atfilter)
+                .blockchain(blockchain)
+                .fromLatestBlock(false)
+                .toLatestBlock(true)
+                .build();
 
         filter.newBlockReceived(block);
 
@@ -110,7 +114,12 @@ class LogFilterTest {
 
         AddressesTopicsFilter atfilter = new AddressesTopicsFilter(new RskAddress[0], null);
 
-        LogFilter filter = new LogFilter(atfilter, blockchain, false, true);
+        LogFilter filter = new LogFilter.LogFilterBuilder()
+                .addressesTopicsFilter(atfilter)
+                .blockchain(blockchain)
+                .fromLatestBlock(false)
+                .toLatestBlock(true)
+                .build();
 
         filter.newBlockReceived(block);
         filter.newBlockReceived(block);
@@ -132,8 +141,12 @@ class LogFilterTest {
 
         AddressesTopicsFilter atfilter = new AddressesTopicsFilter(new RskAddress[0], null);
 
-        LogFilter filter = new LogFilter(atfilter, blockchain, true, true);
-
+        LogFilter filter = new LogFilter.LogFilterBuilder()
+                .addressesTopicsFilter(atfilter)
+                .blockchain(blockchain)
+                .fromLatestBlock(true)
+                .toLatestBlock(true)
+                .build();
         filter.newBlockReceived(block);
         filter.newBlockReceived(block);
 
@@ -229,7 +242,7 @@ class LogFilterTest {
     @Test
     void addFilter_mustFail_whenLimitIsReached(){
         int limit = 2;
-        LogFilter filter = new LogFilter.LogFilterBuilder(null, null)
+        LogFilter filter = new LogFilter.LogFilterBuilder()
                 .maxBlocksToReturn(limit)
                 .build();
         assertTrue(filter.getEventsInternal().isEmpty());


### PR DESCRIPTION
Create two configurable limits for the JSON RPC request eth_getLogs

## Description
We are adding two configurable limits related with the amount of blocks to query and another one to limit the max number of logs to be return. 

By default they are deactivated with the default value = 0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
