### PR TITLE
Make rocksdb the default DB instead of leveldb

### DIFF
--- a/rskj-core/src/integrationTest/java/co/rsk/cli/tools/CliToolsIntegrationTest.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/cli/tools/CliToolsIntegrationTest.java
@@ -421,7 +421,7 @@ class CliToolsIntegrationTest {
     }
 
     @Test
-    void whenDbMigrateRuns_shouldMigrateLevelDbToRocksDbAndShouldNotStartNodeWithPrevDbKind() throws Exception {
+    void whenDbMigrateRuns_shouldMigrateLevelDbToRocksDbAndShouldStartNodeWithPrevDbKind() throws Exception {
         String cmd = String.format("%s -cp %s/%s co.rsk.Start --reset %s", baseJavaCmd, buildLibsPath, jarName, strBaseArgs);
         TestUtils.runCommand(cmd, 1, TimeUnit.MINUTES, false);
 
@@ -434,7 +434,8 @@ class CliToolsIntegrationTest {
         List<String> logLines = Arrays.asList(proc.getOutput().split("\\n"));
 
         Assertions.assertTrue(dbMigrateProc.getOutput().contains("DbMigrate finished"));
-        Assertions.assertTrue(logLines.stream().anyMatch(l -> l.equals("java.lang.IllegalStateException: DbKind mismatch. You have selected LEVEL_DB when the previous detected DbKind was ROCKS_DB.")));
+        Assertions.assertTrue(logLines.stream().anyMatch(l -> l.contains("[minerserver] [miner client]  Mined block import result is IMPORTED_BEST")));
+        Assertions.assertTrue(logLines.stream().noneMatch(l -> l.contains("Exception:")));
     }
 
     @Test

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -319,7 +319,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 FileUtil.recursiveDelete(rskSystemProperties.databaseDir());
             }
 
-            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
+            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir());
 
             if (rskSystemProperties.importEnabled()) {
                 getBootstrapImporter().importData();

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -319,7 +319,6 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 FileUtil.recursiveDelete(rskSystemProperties.databaseDir());
             }
 
-            logger.warn("keyvalue.datasource is used the first time the node is run or or db is created from scratch.");
             KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             if (rskSystemProperties.importEnabled()) {

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -318,6 +318,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 FileUtil.recursiveDelete(rskSystemProperties.databaseDir());
             }
 
+            logger.warn("keyvalue.datasource is used the first time the node is run or or db is created from scratch.");
             KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             if (rskSystemProperties.importEnabled()) {

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1160,7 +1160,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         DB indexDB = DBMaker.fileDB(dbFile)
                 .make();
 
-        DbKind currentDbKind = getRskSystemProperties().databaseKind();
+        DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(databaseDir);
         KeyValueDataSource blocksDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "blocks"), currentDbKind);
 
         return new IndexedBlockStore(getBlockFactory(), blocksDB, new MapDBBlocksIndex(indexDB));
@@ -1260,7 +1260,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         int bloomsCacheSize = getRskSystemProperties().getBloomsCacheSize();
         Path bloomsStorePath = Paths.get(getRskSystemProperties().databaseDir(), "blooms");
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(bloomsStorePath, getRskSystemProperties().databaseKind());
+        DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(getRskSystemProperties().databaseDir());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(bloomsStorePath, currentDbKind);
 
         if (bloomsCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = getRskSystemProperties().shouldPersistBloomsCacheSnapshot()
@@ -1341,7 +1342,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int receiptsCacheSize = rskSystemProperties.getReceiptsCacheSize();
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "receipts"), rskSystemProperties.databaseKind());
+        DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(rskSystemProperties.databaseDir());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "receipts"), currentDbKind);
 
         if (receiptsCacheSize != 0) {
             ds = new DataSourceWithCache(ds, receiptsCacheSize);
@@ -1382,7 +1384,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int statesCacheSize = rskSystemProperties.getStatesCacheSize();
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, rskSystemProperties.databaseKind());
+        DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(rskSystemProperties.databaseDir());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, currentDbKind);
 
         if (statesCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = rskSystemProperties.shouldPersistStatesCacheSnapshot()
@@ -1411,7 +1414,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int stateRootsCacheSize = rskSystemProperties.getStateRootsCacheSize();
-        KeyValueDataSource stateRootsDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "stateRoots"), rskSystemProperties.databaseKind());
+        DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(rskSystemProperties.databaseDir());
+        KeyValueDataSource stateRootsDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "stateRoots"), currentDbKind);
 
         if (stateRootsCacheSize > 0) {
             stateRootsDB = new DataSourceWithCache(stateRootsDB, stateRootsCacheSize);
@@ -1463,7 +1467,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             return null;
         }
 
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "wallet"), rskSystemProperties.databaseKind());
+        DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(rskSystemProperties.databaseDir());
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(Paths.get(rskSystemProperties.databaseDir(), "wallet"), currentDbKind);
 
         return new Wallet(ds);
     }
@@ -1503,7 +1508,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
                 boolean gcWasEnabled = !multiTrieStorePaths.isEmpty();
                 if (gcWasEnabled) {
-                    KeyValueDataSourceUtils.mergeDataSources(trieStorePath, multiTrieStorePaths, rskSystemProperties.databaseKind());
+                    DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(rskSystemProperties.databaseDir());
+                    KeyValueDataSourceUtils.mergeDataSources(trieStorePath, multiTrieStorePaths, currentDbKind);
                     // cleanup MultiTrieStore data sources
                     multiTrieStorePaths.stream()
                             .map(Path::toString)

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -122,7 +122,6 @@ import org.ethereum.util.FileUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactory;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
-import org.ethereum.datasource.KeyValueDataSourceUtils.DbKindValueFromDbKindFileResponse;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
 import org.slf4j.Logger;

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1251,7 +1251,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         }
     }
 
-    public DbKind getDbKind(String dbPath) {
+    public synchronized DbKind getDbKind(String dbPath) {
+        checkIfNotClosed();
         return dbPathToDbKindMap.computeIfAbsent(dbPath, KeyValueDataSourceUtils::getDbKindValueFromDbKindFile);
     }
 

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1253,7 +1253,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
     public synchronized DbKind getDbKind(String dbPath) {
         checkIfNotClosed();
         return dbPathToDbKindMap.computeIfAbsent(dbPath,
-                k -> KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(k).getDbKind());
+                KeyValueDataSourceUtils::getDbKindValueFromDbKindFile);
     }
 
     /***** Protected Methods ******************************************************************************************/

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -122,6 +122,7 @@ import org.ethereum.util.FileUtil;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactory;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
+import org.ethereum.datasource.KeyValueDataSourceUtils.DbKindValueFromDbKindFileResponse;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
 import org.slf4j.Logger;
@@ -1162,7 +1163,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 .make();
 
         Path blocksDbPath = Paths.get(databaseDir, "blocks");
-        DbKind currentDbKind = getDbKind(blocksDbPath.getParent().toString());
+        DbKind currentDbKind = getDbKind(databaseDir);
         KeyValueDataSource blocksDB = KeyValueDataSourceUtils.makeDataSource(blocksDbPath, currentDbKind);
 
         return new IndexedBlockStore(getBlockFactory(), blocksDB, new MapDBBlocksIndex(indexDB));
@@ -1252,7 +1253,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
     public synchronized DbKind getDbKind(String dbPath) {
         checkIfNotClosed();
-        return dbPathToDbKindMap.computeIfAbsent(dbPath, KeyValueDataSourceUtils::getDbKindValueFromDbKindFile);
+        return dbPathToDbKindMap.computeIfAbsent(dbPath,
+                k -> KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(k).getDbKind());
     }
 
     /***** Protected Methods ******************************************************************************************/
@@ -1267,7 +1269,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         int bloomsCacheSize = getRskSystemProperties().getBloomsCacheSize();
         Path bloomsStorePath = Paths.get(getRskSystemProperties().databaseDir(), "blooms");
-        DbKind currentDbKind = getDbKind(bloomsStorePath.getParent().toString());
+        DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
         KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(bloomsStorePath, currentDbKind);
 
         if (bloomsCacheSize != 0) {
@@ -1350,7 +1352,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int receiptsCacheSize = rskSystemProperties.getReceiptsCacheSize();
         Path receiptsDbPath = Paths.get(rskSystemProperties.databaseDir(), "receipts");
-        DbKind currentDbKind = getDbKind(receiptsDbPath.getParent().toString());
+        DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
         KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(receiptsDbPath, currentDbKind);
 
         if (receiptsCacheSize != 0) {
@@ -1392,7 +1394,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int statesCacheSize = rskSystemProperties.getStatesCacheSize();
-        DbKind currentDbKind = getDbKind(trieStorePath.getParent().toString());
+        DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
         KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, currentDbKind);
 
         if (statesCacheSize != 0) {
@@ -1423,7 +1425,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int stateRootsCacheSize = rskSystemProperties.getStateRootsCacheSize();
         Path stateRootsDbPath = Paths.get(rskSystemProperties.databaseDir(), "stateRoots");
-        DbKind currentDbKind = getDbKind(stateRootsDbPath.getParent().toString());
+        DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
         KeyValueDataSource stateRootsDB = KeyValueDataSourceUtils.makeDataSource(stateRootsDbPath, currentDbKind);
 
         if (stateRootsCacheSize > 0) {
@@ -1477,7 +1479,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         }
 
         Path walletDbPath = Paths.get(rskSystemProperties.databaseDir(), "wallet");
-        DbKind currentDbKind = getDbKind(walletDbPath.getParent().toString());
+        DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
         KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(walletDbPath, currentDbKind);
 
         return new Wallet(ds);
@@ -1518,7 +1520,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
                 boolean gcWasEnabled = !multiTrieStorePaths.isEmpty();
                 if (gcWasEnabled) {
-                    DbKind currentDbKind = getDbKind(trieStorePath.getParent().toString());
+                    DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
                     KeyValueDataSourceUtils.mergeDataSources(trieStorePath, multiTrieStorePaths, currentDbKind);
                     // cleanup MultiTrieStore data sources
                     multiTrieStorePaths.stream()

--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -88,7 +88,6 @@ public abstract class CliToolRskContextAware {
 
             RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
 
-            logger.warn("keyvalue.datasource is used the first time the node is run or or db is created from scratch.");
             KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             onExecute(args, ctx);

--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -88,6 +88,7 @@ public abstract class CliToolRskContextAware {
 
             RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
 
+            logger.warn("keyvalue.datasource is used the first time the node is run or or db is created from scratch.");
             KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
 
             onExecute(args, ctx);

--- a/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
+++ b/rskj-core/src/main/java/co/rsk/cli/CliToolRskContextAware.java
@@ -88,7 +88,7 @@ public abstract class CliToolRskContextAware {
 
             RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
 
-            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir(), rskSystemProperties.databaseReset() || rskSystemProperties.importEnabled());
+            KeyValueDataSourceUtils.validateDbKind(rskSystemProperties.databaseKind(), rskSystemProperties.databaseDir());
 
             onExecute(args, ctx);
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -132,7 +132,7 @@ public class DbMigrate extends PicoCliToolRskContextAware {
                     .forEach(this::migrate);
         }
 
-        KeyValueDataSourceUtils.validateDbKind(targetDbKind, targetDbDir, true);
+        KeyValueDataSourceUtils.validateDbKind(targetDbKind, targetDbDir);
 
         String nodeIdFilePath = "/" + NODE_ID_FILE;
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -107,7 +107,7 @@ public class DbMigrate extends PicoCliToolRskContextAware {
             throw new IllegalArgumentException("Db to migrate not specified. Please specify in the first argument.");
         }
 
-        DbKind sourceDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(ctx.getRskSystemProperties().databaseDir());
+        DbKind sourceDbKind = ctx.getCurrentDbKind();
         DbKind targetDbKind = DbKind.ofName(this.targetdb);
 
         if (sourceDbKind == targetDbKind) {

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -107,7 +107,7 @@ public class DbMigrate extends PicoCliToolRskContextAware {
             throw new IllegalArgumentException("Db to migrate not specified. Please specify in the first argument.");
         }
 
-        DbKind sourceDbKind = ctx.getRskSystemProperties().databaseKind();
+        DbKind sourceDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(ctx.getRskSystemProperties().databaseDir());
         DbKind targetDbKind = DbKind.ofName(this.targetdb);
 
         if (sourceDbKind == targetDbKind) {

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -107,7 +107,7 @@ public class DbMigrate extends PicoCliToolRskContextAware {
             throw new IllegalArgumentException("Db to migrate not specified. Please specify in the first argument.");
         }
 
-        DbKind sourceDbKind = ctx.getCurrentDbKind();
+        DbKind sourceDbKind = ctx.getDbKind(ctx.getRskSystemProperties().databaseDir());
         DbKind targetDbKind = DbKind.ofName(this.targetdb);
 
         if (sourceDbKind == targetDbKind) {

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -54,7 +54,7 @@ public class ImportState extends PicoCliToolRskContextAware {
     public Integer call() throws IOException {
         RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
-        DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(databaseDir);
+        DbKind currentDbKind = ctx.getCurrentDbKind(databaseDir);
 
         KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), currentDbKind);
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -22,6 +22,7 @@ import co.rsk.config.RskSystemProperties;
 import co.rsk.crypto.Keccak256;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.Keccak256Helper;
+import org.ethereum.datasource.DbKind;
 import org.ethereum.datasource.KeyValueDataSource;
 import picocli.CommandLine;
 import org.ethereum.datasource.KeyValueDataSourceUtils;
@@ -53,8 +54,9 @@ public class ImportState extends PicoCliToolRskContextAware {
     public Integer call() throws IOException {
         RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
+        DbKind currentDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(databaseDir);
 
-        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), rskSystemProperties.databaseKind());
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), currentDbKind);
 
         try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
             importState(reader, trieDB);

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -31,6 +31,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
@@ -54,9 +55,10 @@ public class ImportState extends PicoCliToolRskContextAware {
     public Integer call() throws IOException {
         RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
-        DbKind currentDbKind = ctx.getCurrentDbKind();
+        Path unitrieDbPath = Paths.get(databaseDir, "unitrie");
+        DbKind currentDbKind = ctx.getDbKind(unitrieDbPath.getParent().toString());
 
-        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), currentDbKind);
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(unitrieDbPath, currentDbKind);
 
         try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
             importState(reader, trieDB);

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -56,7 +56,7 @@ public class ImportState extends PicoCliToolRskContextAware {
         RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
         Path unitrieDbPath = Paths.get(databaseDir, "unitrie");
-        DbKind currentDbKind = ctx.getDbKind(unitrieDbPath.getParent().toString());
+        DbKind currentDbKind = ctx.getDbKind(databaseDir);
 
         KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(unitrieDbPath, currentDbKind);
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -54,7 +54,7 @@ public class ImportState extends PicoCliToolRskContextAware {
     public Integer call() throws IOException {
         RskSystemProperties rskSystemProperties = ctx.getRskSystemProperties();
         String databaseDir = rskSystemProperties.databaseDir();
-        DbKind currentDbKind = ctx.getCurrentDbKind(databaseDir);
+        DbKind currentDbKind = ctx.getCurrentDbKind();
 
         KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(Paths.get(databaseDir, "unitrie"), currentDbKind);
 

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -111,7 +111,7 @@ public class KeyValueDataSourceUtils {
             return;
         }
 
-        if (!dbKindFileExists || !dbKindFile.canRead()) { // use LEVEL_DB (for backward compatibility), if db folder is not empty and dbKind file doesn't exist
+        if (!dbKindFileExists) { // use LEVEL_DB (for backward compatibility), if db folder is not empty and dbKind file doesn't exist
             KeyValueDataSourceUtils.generatedDbKindFile(DbKind.LEVEL_DB, databaseDir);
             return;
         }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -134,10 +134,9 @@ public class KeyValueDataSourceUtils {
             if (databaseReset) {
                 KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
             } else {
-                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).warn(String
-                        .format("Current Db kind %s does not match with db kind %s from properties file, using value from properties file." +
+                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).warn("Current Db kind {} does not match with db kind {} from properties file, using value from properties file." +
                                 " keyvalue.datasource from .conf file is used the first time the node is run or db is created from scratch.",
-                                currentDbKind.name(), prevDbKind.name()));
+                                currentDbKind.name(), prevDbKind.name());
             }
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -104,12 +104,8 @@ public class KeyValueDataSourceUtils {
             return;
         }
 
-        DbKind prevDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(databaseDir);
-
-        if (prevDbKind != currentDbKind) {
-            if (databaseReset) {
-                KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
-            }
+        if (databaseReset) {
+            KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
         }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -67,7 +67,7 @@ public class KeyValueDataSourceUtils {
                 return DbKind.ofName(props.getProperty(KEYVALUE_DATASOURCE_PROP_NAME));
             }
 
-            return DbKind.LEVEL_DB;
+            return DbKind.ROCKS_DB;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -109,9 +109,6 @@ public class KeyValueDataSourceUtils {
         if (prevDbKind != currentDbKind) {
             if (databaseReset) {
                 KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
-            } else {
-                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).warn("Use the flag --reset when running the application if you are using a different datasource. Also you can use the cli tool DbMigrate, in order to migrate data between databases.");
-                throw new IllegalStateException("DbKind mismatch. You have selected " + currentDbKind.name() + " when the previous detected DbKind was " + prevDbKind.name() + ".");
             }
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -110,7 +110,10 @@ public class KeyValueDataSourceUtils {
             if (databaseReset) {
                 KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
             } else {
-                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).warn("keyvalue.datasource is used the first time the node is run or or db is created from scratch.");
+                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).warn(String
+                        .format("Current Db kind %s does not match with db kind %s from properties file, using value from properties file." +
+                                " keyvalue.datasource from .conf file is used the first time the node is run or db is created from scratch.",
+                                currentDbKind.name(), prevDbKind.name()));
             }
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -104,8 +104,14 @@ public class KeyValueDataSourceUtils {
             return;
         }
 
-        if (databaseReset) {
-            KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
+        DbKind prevDbKind = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(databaseDir);
+
+        if (prevDbKind != currentDbKind) {
+            if (databaseReset) {
+                KeyValueDataSourceUtils.generatedDbKindFile(currentDbKind, databaseDir);
+            } else {
+                LoggerFactory.getLogger(KEYVALUE_DATASOURCE).warn("keyvalue.datasource is used the first time the node is run or or db is created from scratch.");
+            }
         }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -89,7 +89,7 @@ public class KeyValueDataSourceUtils {
         }
     }
 
-    public static void validateDbKind(DbKind currentDbKind, String databaseDir, boolean databaseReset) {
+    public static void validateDbKind(DbKind currentDbKind, String databaseDir) {
         File dbDir = new File(databaseDir);
         boolean dbDirExists = dbDir.exists();
 

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -271,6 +271,31 @@ vm {
     }
 }
 
+# This configuration sets up the db kind for both general and specific/individual data sources.
+# General db kind selection helps to identify the default db kind, when the db kind file is not found
+# and when a specific db kind is not set in the configuration file.
+# This property is used the first time the node is run or db is created from scratch.
+#
+# A specific db kind configuration is a priority over the general one, that means
+# specific db kind configuration will override the general db kind configuration
+# for that specific datasource.
+#
+# Example 1:
+# keyvalue.datasource = leveldb and keyvalue.datasources = null
+# All data sources will use leveldb
+#
+# Example 2:
+# keyvalue.datasource = rocksdb and keyvalue.datasources = null
+# All data sources will use rocksdb
+#
+# Example 3:
+# keyvalue.datasource = rocksdb and keyvalue.datasources.blocks = leveldb
+# All data sources will use rocksdb except by blocks DB that will use leveldb
+#
+# Example 4:
+# keyvalue.datasource = leveldb, keyvalue.datasources.blocks = rocksdb and keyvalue.datasources.blooms = rocksdb
+# All data sources will use leveldb except by blocks and blooms DBs that will use rocksdb
+#
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = rocksdb
 

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -270,7 +270,8 @@ vm {
         initStorageLimit = 10000
     }
 }
-
+# This configuration value defines db kind which is used one time on db creation.
+# To change db kind of an existing database, you will have to make a proper change in the configuration as well as drop the db.
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = rocksdb
 

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -272,7 +272,7 @@ vm {
 }
 
 # Key value data source values: [leveldb/rocksdb]
-keyvalue.datasource = leveldb
+keyvalue.datasource = rocksdb
 
 sync {
     # block chain synchronization can be: [true/false]

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -271,31 +271,6 @@ vm {
     }
 }
 
-# This configuration sets up the db kind for both general and specific/individual data sources.
-# General db kind selection helps to identify the default db kind, when the db kind file is not found
-# and when a specific db kind is not set in the configuration file.
-# This property is used the first time the node is run or db is created from scratch.
-#
-# A specific db kind configuration is a priority over the general one, that means
-# specific db kind configuration will override the general db kind configuration
-# for that specific datasource.
-#
-# Example 1:
-# keyvalue.datasource = leveldb and keyvalue.datasources = null
-# All data sources will use leveldb
-#
-# Example 2:
-# keyvalue.datasource = rocksdb and keyvalue.datasources = null
-# All data sources will use rocksdb
-#
-# Example 3:
-# keyvalue.datasource = rocksdb and keyvalue.datasources.blocks = leveldb
-# All data sources will use rocksdb except by blocks DB that will use leveldb
-#
-# Example 4:
-# keyvalue.datasource = leveldb, keyvalue.datasources.blocks = rocksdb and keyvalue.datasources.blooms = rocksdb
-# All data sources will use leveldb except by blocks and blooms DBs that will use rocksdb
-#
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = rocksdb
 

--- a/rskj-core/src/test/java/co/rsk/RskContextTest.java
+++ b/rskj-core/src/test/java/co/rsk/RskContextTest.java
@@ -244,7 +244,7 @@ class RskContextTest {
             add("resolveCacheSnapshotPath");
             add("isClosed");
             add("close");
-            add("getCurrentDbKind");
+            add("getDbKind");
         }};
 
         for (Method method : RskContext.class.getDeclaredMethods()) {

--- a/rskj-core/src/test/java/co/rsk/RskContextTest.java
+++ b/rskj-core/src/test/java/co/rsk/RskContextTest.java
@@ -244,7 +244,6 @@ class RskContextTest {
             add("resolveCacheSnapshotPath");
             add("isClosed");
             add("close");
-            add("getDbKind");
         }};
 
         for (Method method : RskContext.class.getDeclaredMethods()) {

--- a/rskj-core/src/test/java/co/rsk/RskContextTest.java
+++ b/rskj-core/src/test/java/co/rsk/RskContextTest.java
@@ -244,6 +244,7 @@ class RskContextTest {
             add("resolveCacheSnapshotPath");
             add("isClosed");
             add("close");
+            add("getCurrentDbKind");
         }};
 
         for (Method method : RskContext.class.getDeclaredMethods()) {

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -381,7 +381,7 @@ class CliToolsTest {
         RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
         doReturn(databaseDir).when(rskSystemProperties).databaseDir();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
-        doReturn(DbKind.ROCKS_DB).when(rskContext).getDbKind(Mockito.eq(unitrieDbPath.getParent().toString()));
+        doReturn(DbKind.ROCKS_DB).when(rskContext).getDbKind(Mockito.eq(databaseDir));
         doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         NodeStopper stopper = mock(NodeStopper.class);
 

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -293,7 +293,7 @@ class CliToolsTest {
         doReturn(world.getTrieStore()).when(rskContext).getTrieStore();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
         doReturn(tempDir.toString()).when(rskSystemProperties).databaseDir();
-        doReturn(DbKind.LEVEL_DB).when(rskSystemProperties).databaseKind();
+        doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         NodeStopper stopper = mock(NodeStopper.class);
 
         ConnectBlocks connectBlocksCliTool = new ConnectBlocks();
@@ -346,7 +346,7 @@ class CliToolsTest {
         doReturn(new BlockFactory(ActivationConfigsForTest.all())).when(rskContext).getBlockFactory();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
         doReturn(tempDir.toString()).when(rskSystemProperties).databaseDir();
-        doReturn(DbKind.LEVEL_DB).when(rskSystemProperties).databaseKind();
+        doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         NodeStopper stopper = mock(NodeStopper.class);
 
         ImportBlocks importBlocksCliTool = new ImportBlocks();
@@ -519,7 +519,7 @@ class CliToolsTest {
         RskContext rskContext = mock(RskContext.class);
         RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
 
-        doReturn(DbKind.LEVEL_DB).when(rskSystemProperties).databaseKind();
+        doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         doReturn(tempDir.toString()).when(rskSystemProperties).databaseDir();
         doReturn(true).when(rskSystemProperties).databaseReset();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
@@ -527,7 +527,7 @@ class CliToolsTest {
         NodeStopper stopper = mock(NodeStopper.class);
 
         DbMigrate dbMigrateCliTool = new DbMigrate();
-        dbMigrateCliTool.execute(new String[]{"-t", "rocksdb"}, () -> rskContext, stopper);
+        dbMigrateCliTool.execute(new String[]{"-t", "leveldb"}, () -> rskContext, stopper);
 
         String nodeIdPropsFileLine = null;
 
@@ -548,9 +548,7 @@ class CliToolsTest {
         }
 
         Assertions.assertEquals("nodeId=testing", nodeIdPropsFileLine);
-        Assertions.assertEquals("keyvalue.datasource=ROCKS_DB", dbKindPropsFileLine);
-        Assertions.assertEquals("nodeId=testing", nodeIdPropsFileLine);
-        Assertions.assertEquals("keyvalue.datasource=ROCKS_DB", dbKindPropsFileLine);
+        Assertions.assertEquals("keyvalue.datasource=LEVEL_DB", dbKindPropsFileLine);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -526,6 +526,7 @@ class CliToolsTest {
         doReturn(tempDir.toString()).when(rskSystemProperties).databaseDir();
         doReturn(true).when(rskSystemProperties).databaseReset();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
+        doReturn(DbKind.ROCKS_DB).when(rskContext).getDbKind(Mockito.anyString());
 
         NodeStopper stopper = mock(NodeStopper.class);
 
@@ -551,7 +552,7 @@ class CliToolsTest {
         }
 
         Assertions.assertEquals("nodeId=testing", nodeIdPropsFileLine);
-        Assertions.assertEquals("keyvalue.datasource=ROCKS_DB", dbKindPropsFileLine);
+        Assertions.assertEquals("keyvalue.datasource=LEVEL_DB", dbKindPropsFileLine);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -375,11 +375,13 @@ class CliToolsTest {
 
         String databaseDir = tempDir.resolve("db").toAbsolutePath().toString();
         String[] args = new String[]{"--file", stateFile.getAbsolutePath()};
+        Path unitrieDbPath = Paths.get(databaseDir, "unitrie");
 
         RskContext rskContext = mock(RskContext.class);
         RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
         doReturn(databaseDir).when(rskSystemProperties).databaseDir();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
+        doReturn(DbKind.ROCKS_DB).when(rskContext).getDbKind(Mockito.eq(unitrieDbPath.getParent().toString()));
         doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         NodeStopper stopper = mock(NodeStopper.class);
 

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import picocli.CommandLine;
 
 import java.io.*;
@@ -379,7 +380,9 @@ class CliToolsTest {
         RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
         doReturn(databaseDir).when(rskSystemProperties).databaseDir();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
-        doReturn(DbKind.LEVEL_DB).when(rskSystemProperties).databaseKind();
+        doReturn(DbKind.ROCKS_DB).when(rskContext).getCurrentDbKind();
+        doReturn(DbKind.ROCKS_DB).when(rskContext).getCurrentDbKind(Mockito.eq(databaseDir));
+        doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         NodeStopper stopper = mock(NodeStopper.class);
 
         ImportState importStateCliTool = new ImportState();
@@ -548,7 +551,7 @@ class CliToolsTest {
         }
 
         Assertions.assertEquals("nodeId=testing", nodeIdPropsFileLine);
-        Assertions.assertEquals("keyvalue.datasource=LEVEL_DB", dbKindPropsFileLine);
+        Assertions.assertEquals("keyvalue.datasource=ROCKS_DB", dbKindPropsFileLine);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -380,8 +380,6 @@ class CliToolsTest {
         RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
         doReturn(databaseDir).when(rskSystemProperties).databaseDir();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
-        doReturn(DbKind.ROCKS_DB).when(rskContext).getCurrentDbKind();
-        doReturn(DbKind.ROCKS_DB).when(rskContext).getCurrentDbKind();
         doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         NodeStopper stopper = mock(NodeStopper.class);
 

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -381,7 +381,7 @@ class CliToolsTest {
         doReturn(databaseDir).when(rskSystemProperties).databaseDir();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
         doReturn(DbKind.ROCKS_DB).when(rskContext).getCurrentDbKind();
-        doReturn(DbKind.ROCKS_DB).when(rskContext).getCurrentDbKind(Mockito.eq(databaseDir));
+        doReturn(DbKind.ROCKS_DB).when(rskContext).getCurrentDbKind();
         doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         NodeStopper stopper = mock(NodeStopper.class);
 

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -381,7 +381,7 @@ class CliToolsTest {
         RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
         doReturn(databaseDir).when(rskSystemProperties).databaseDir();
         doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
-        doReturn(DbKind.ROCKS_DB).when(rskContext).getDbKind(Mockito.eq(databaseDir));
+        doReturn(DbKind.ROCKS_DB).when(rskContext).getDbKind(databaseDir);
         doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
         NodeStopper stopper = mock(NodeStopper.class);
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
@@ -61,18 +61,18 @@ class NotParameterizedKeyValueDataSourceTest {
         BufferedWriter writer = new BufferedWriter(new FileWriter(dbKindFile));
         writer.write(propName + DbKind.LEVEL_DB);
         writer.close();
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When DbKind file is LEVEL_DB, calculated should too");
 
         dbKindFile.delete();
         writer = new BufferedWriter(new FileWriter(dbKindFile));
         writer.write(propName + DbKind.ROCKS_DB);
         writer.close();
-        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindRocks, "When DbKind file is ROCKS_DB, calculated should too");
 
         dbKindFile.delete();
-        DbKind dbKindFallback = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindFallback = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindFallback, "When missing DbKind, LEVEL_DB should be returned as fallback");
     }
 
@@ -82,13 +82,13 @@ class NotParameterizedKeyValueDataSourceTest {
         File dbKindFile = tempDir.resolve(KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE).toFile();
 
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.LEVEL_DB, dbPath);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When LEVEL_DB is provided on generate, that should be the value when requested");
 
         dbKindFile.delete();
 
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindRocks, "When ROCKS_DB is provided on generate, that should be the value when requested");
     }
 
@@ -102,7 +102,7 @@ class NotParameterizedKeyValueDataSourceTest {
     void validateDbKindMissingFolder() {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When DbKind file is missing validation should create it with the provided value");
     }
 
@@ -118,7 +118,7 @@ class NotParameterizedKeyValueDataSourceTest {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
         KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath, true);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When DbKind changes and reset flag is specified on validation, new DbKind file should be generated");
     }
 
@@ -127,7 +127,7 @@ class NotParameterizedKeyValueDataSourceTest {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
         KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When same DB without reset specified on validation, nothing changes on DbKind file");
     }
 
@@ -136,7 +136,7 @@ class NotParameterizedKeyValueDataSourceTest {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
         KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, true);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When same DB and reset specified on validation, nothing changes on DbKind file");
     }
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
@@ -24,12 +24,12 @@ class NotParameterizedKeyValueDataSourceTest {
     }
 
     @Test()
-    void testShouldThrowErrorWhenValidatingDifferentKinds() throws IOException {
+    void testShouldNotThrowErrorWhenValidatingDifferentKinds() throws IOException {
         FileWriter fileWriter = new FileWriter(new File(tempDir.toString(), KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE));
         fileWriter.write("keyvalue.datasource=ROCKS_DB\n");
         fileWriter.close();
         String path = tempDir.toString();
-        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, path, false));
+        Assertions.assertDoesNotThrow(() -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, path, false));
     }
 
     @Test()
@@ -73,7 +73,7 @@ class NotParameterizedKeyValueDataSourceTest {
 
         dbKindFile.delete();
         DbKind dbKindFallback = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
-        Assertions.assertEquals(DbKind.LEVEL_DB, dbKindFallback, "When missing DbKind, LEVEL_DB should be returned as fallback");
+        Assertions.assertEquals(DbKind.ROCKS_DB, dbKindFallback, "When missing DbKind, LEVEL_DB should be returned as fallback");
     }
 
     @Test
@@ -107,16 +107,10 @@ class NotParameterizedKeyValueDataSourceTest {
     }
 
     @Test
-    void validateDbKindExistingFolderDifferentDbWithoutResetThrows() {
+    void validateDbKindExistingFolderDifferentDbWithoutResetShouldNotThrowError() {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-
-        try {
-            KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath, false);
-            Assertions.fail("Should've thrown exception due to already existing dbKind file without reset flag");
-        } catch (RuntimeException re) {
-            Assertions.assertTrue(re.getMessage().startsWith("DbKind mismatch. You have selected"));
-        }
+        Assertions.assertDoesNotThrow(() -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath, false));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
@@ -61,18 +61,18 @@ class NotParameterizedKeyValueDataSourceTest {
         BufferedWriter writer = new BufferedWriter(new FileWriter(dbKindFile));
         writer.write(propName + DbKind.LEVEL_DB);
         writer.close();
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When DbKind file is LEVEL_DB, calculated should too");
 
         dbKindFile.delete();
         writer = new BufferedWriter(new FileWriter(dbKindFile));
         writer.write(propName + DbKind.ROCKS_DB);
         writer.close();
-        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindRocks, "When DbKind file is ROCKS_DB, calculated should too");
 
         dbKindFile.delete();
-        DbKind dbKindFallback = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindFallback = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindFallback, "When missing DbKind, LEVEL_DB should be returned as fallback");
     }
 
@@ -82,13 +82,13 @@ class NotParameterizedKeyValueDataSourceTest {
         File dbKindFile = tempDir.resolve(KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE).toFile();
 
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.LEVEL_DB, dbPath);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When LEVEL_DB is provided on generate, that should be the value when requested");
 
         dbKindFile.delete();
 
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindRocks = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindRocks, "When ROCKS_DB is provided on generate, that should be the value when requested");
     }
 
@@ -102,7 +102,7 @@ class NotParameterizedKeyValueDataSourceTest {
     void validateDbKindMissingFolder() {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When DbKind file is missing validation should create it with the provided value");
     }
 
@@ -118,7 +118,7 @@ class NotParameterizedKeyValueDataSourceTest {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
         KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath, true);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When DbKind changes and reset flag is specified on validation, new DbKind file should be generated");
     }
 
@@ -127,7 +127,7 @@ class NotParameterizedKeyValueDataSourceTest {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
         KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When same DB without reset specified on validation, nothing changes on DbKind file");
     }
 
@@ -136,7 +136,7 @@ class NotParameterizedKeyValueDataSourceTest {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
         KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, true);
-        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath).getDbKind();
+        DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When same DB and reset specified on validation, nothing changes on DbKind file");
     }
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
@@ -20,7 +20,7 @@ class NotParameterizedKeyValueDataSourceTest {
 
     @Test
     void testShouldValidateKindWithEmptyDbDirAndResetDbFalseSuccessfully() {
-        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, tempDir.toString(), false);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, tempDir.toString());
     }
 
     @Test()
@@ -29,7 +29,7 @@ class NotParameterizedKeyValueDataSourceTest {
         fileWriter.write("keyvalue.datasource=ROCKS_DB\n");
         fileWriter.close();
         String path = tempDir.toString();
-        Assertions.assertDoesNotThrow(() -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, path, false));
+        Assertions.assertDoesNotThrow(() -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, path));
     }
 
     @Test()
@@ -39,7 +39,7 @@ class NotParameterizedKeyValueDataSourceTest {
         fileWriter.write("keyvalue.datasource=ROCKS_DB\n");
         fileWriter.close();
         String path = file.getPath();
-        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, path, false));
+        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, path));
     }
 
     @Test
@@ -95,13 +95,13 @@ class NotParameterizedKeyValueDataSourceTest {
     @Test
     void validateDbKindNoFolder() throws IOException {
         String dbPathNoDir = Files.createFile(Paths.get(tempDir.toString(), "no_file")).toAbsolutePath().toString();
-        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPathNoDir, false));
+        Assertions.assertThrows(IllegalStateException.class, () -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPathNoDir));
     }
 
     @Test
     void validateDbKindMissingFolder() {
         String dbPath = tempDir.toString();
-        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath);
         DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When DbKind file is missing validation should create it with the provided value");
     }
@@ -110,14 +110,13 @@ class NotParameterizedKeyValueDataSourceTest {
     void validateDbKindExistingFolderDifferentDbWithoutResetShouldNotThrowError() {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        Assertions.assertDoesNotThrow(() -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath, false));
+        Assertions.assertDoesNotThrow(() -> KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath));
     }
 
     @Test
     void validateDbKindExistingFolderDifferentDbWithResetGeneratesNewFileThrows() {
         String dbPath = tempDir.toString();
-        KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath, true);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.LEVEL_DB, dbPath);
         DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.LEVEL_DB, dbKindLevel, "When DbKind changes and reset flag is specified on validation, new DbKind file should be generated");
     }
@@ -126,7 +125,7 @@ class NotParameterizedKeyValueDataSourceTest {
     void validateDbKindExistingFolderSameDbWithoutResetDoesNothing() {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, false);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath);
         DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When same DB without reset specified on validation, nothing changes on DbKind file");
     }
@@ -135,7 +134,7 @@ class NotParameterizedKeyValueDataSourceTest {
     void validateDbKindExistingFolderSameDbWithResetDoesNothing() {
         String dbPath = tempDir.toString();
         KeyValueDataSourceUtils.generatedDbKindFile(DbKind.ROCKS_DB, dbPath);
-        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath, true);
+        KeyValueDataSourceUtils.validateDbKind(DbKind.ROCKS_DB, dbPath);
         DbKind dbKindLevel = KeyValueDataSourceUtils.getDbKindValueFromDbKindFile(dbPath);
         Assertions.assertEquals(DbKind.ROCKS_DB, dbKindLevel, "When same DB and reset specified on validation, nothing changes on DbKind file");
     }

--- a/rskj-core/src/test/resources/rskj.conf
+++ b/rskj-core/src/test/resources/rskj.conf
@@ -240,30 +240,8 @@ hello.phrase = Dev
 #        [hex hash 32 bytes] root hash
 root.hash.start = null
 
-# This configuration sets up the db kind for both general and specific/individual data sources.
-# General db kind selection helps to identify the default db kind, when the db kind file is not found
-# and when a specific db kind is not set in the configuration file.
-# This property is used the first time the node is run or db is created from scratch.
-#
-# A specific db kind configuration is a priority over the general one, that means
-# specific db kind configuration will override the general db kind configuration
-# for that specific datasource.
-#
-# Example 1:
-# keyvalue.datasource = leveldb and keyvalue.datasources = null
-# All data sources will use leveldb
-#
-# Example 2:
-# keyvalue.datasource = rocksdb and keyvalue.datasources = null
-# All data sources will use rocksdb
-#
-# Example 3:
-# keyvalue.datasource = rocksdb and keyvalue.datasources.blocks = leveldb
-# All data sources will use rocksdb except by blocks DB that will use leveldb
-#
-# Example 4:
-# keyvalue.datasource = leveldb, keyvalue.datasources.blocks = rocksdb and keyvalue.datasources.blooms = rocksdb
-# All data sources will use leveldb except by blocks and blooms DBs that will use rocksdb
+# This configuration value defines db kind which is used one time on db creation.
+# To change db kind of an existing database, you will have to make a proper change in the configuration as well as drop the db.
 #
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = leveldb

--- a/rskj-core/src/test/resources/rskj.conf
+++ b/rskj-core/src/test/resources/rskj.conf
@@ -240,6 +240,31 @@ hello.phrase = Dev
 #        [hex hash 32 bytes] root hash
 root.hash.start = null
 
+# This configuration sets up the db kind for both general and specific/individual data sources.
+# General db kind selection helps to identify the default db kind, when the db kind file is not found
+# and when a specific db kind is not set in the configuration file.
+# This property is used the first time the node is run or db is created from scratch.
+#
+# A specific db kind configuration is a priority over the general one, that means
+# specific db kind configuration will override the general db kind configuration
+# for that specific datasource.
+#
+# Example 1:
+# keyvalue.datasource = leveldb and keyvalue.datasources = null
+# All data sources will use leveldb
+#
+# Example 2:
+# keyvalue.datasource = rocksdb and keyvalue.datasources = null
+# All data sources will use rocksdb
+#
+# Example 3:
+# keyvalue.datasource = rocksdb and keyvalue.datasources.blocks = leveldb
+# All data sources will use rocksdb except by blocks DB that will use leveldb
+#
+# Example 4:
+# keyvalue.datasource = leveldb, keyvalue.datasources.blocks = rocksdb and keyvalue.datasources.blooms = rocksdb
+# All data sources will use leveldb except by blocks and blooms DBs that will use rocksdb
+#
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = leveldb
 

--- a/rskj-core/src/test/resources/test-rskj.conf
+++ b/rskj-core/src/test/resources/test-rskj.conf
@@ -143,7 +143,7 @@ root.hash.start = null
 GitHubTests.VMTest.loadLocal = false
 
 # Key value data source values: [leveldb/rocksdb]
-keyvalue.datasource = leveldb
+keyvalue.datasource = rocksdb
 
 # structured trace
 # is the trace being

--- a/rskj-core/src/test/resources/test-rskj.conf
+++ b/rskj-core/src/test/resources/test-rskj.conf
@@ -142,6 +142,31 @@ root.hash.start = null
 # if set true, json tests will be loaded from local repository
 GitHubTests.VMTest.loadLocal = false
 
+# This configuration sets up the db kind for both general and specific/individual data sources.
+# General db kind selection helps to identify the default db kind, when the db kind file is not found
+# and when a specific db kind is not set in the configuration file.
+# This property is used the first time the node is run or db is created from scratch.
+#
+# A specific db kind configuration is a priority over the general one, that means
+# specific db kind configuration will override the general db kind configuration
+# for that specific datasource.
+#
+# Example 1:
+# keyvalue.datasource = leveldb and keyvalue.datasources = null
+# All data sources will use leveldb
+#
+# Example 2:
+# keyvalue.datasource = rocksdb and keyvalue.datasources = null
+# All data sources will use rocksdb
+#
+# Example 3:
+# keyvalue.datasource = rocksdb and keyvalue.datasources.blocks = leveldb
+# All data sources will use rocksdb except by blocks DB that will use leveldb
+#
+# Example 4:
+# keyvalue.datasource = leveldb, keyvalue.datasources.blocks = rocksdb and keyvalue.datasources.blooms = rocksdb
+# All data sources will use leveldb except by blocks and blooms DBs that will use rocksdb
+#
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = rocksdb
 

--- a/rskj-core/src/test/resources/test-rskj.conf
+++ b/rskj-core/src/test/resources/test-rskj.conf
@@ -142,30 +142,8 @@ root.hash.start = null
 # if set true, json tests will be loaded from local repository
 GitHubTests.VMTest.loadLocal = false
 
-# This configuration sets up the db kind for both general and specific/individual data sources.
-# General db kind selection helps to identify the default db kind, when the db kind file is not found
-# and when a specific db kind is not set in the configuration file.
-# This property is used the first time the node is run or db is created from scratch.
-#
-# A specific db kind configuration is a priority over the general one, that means
-# specific db kind configuration will override the general db kind configuration
-# for that specific datasource.
-#
-# Example 1:
-# keyvalue.datasource = leveldb and keyvalue.datasources = null
-# All data sources will use leveldb
-#
-# Example 2:
-# keyvalue.datasource = rocksdb and keyvalue.datasources = null
-# All data sources will use rocksdb
-#
-# Example 3:
-# keyvalue.datasource = rocksdb and keyvalue.datasources.blocks = leveldb
-# All data sources will use rocksdb except by blocks DB that will use leveldb
-#
-# Example 4:
-# keyvalue.datasource = leveldb, keyvalue.datasources.blocks = rocksdb and keyvalue.datasources.blooms = rocksdb
-# All data sources will use leveldb except by blocks and blooms DBs that will use rocksdb
+# This configuration value defines db kind which is used one time on db creation.
+# To change db kind of an existing database, you will have to make a proper change in the configuration as well as drop the db.
 #
 # Key value data source values: [leveldb/rocksdb]
 keyvalue.datasource = rocksdb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Added rocksdb as default in the .conf files.
* Updated the default return type of `getDbKindValueFromDbKindFile`

## Motivation and Context
Currently, RSKj default library storage is LevelDb. 

We want to make RocksDb the default db. 

Nodes running on LevelDb should keep using LevelDb, same with RocksDb. But nodes started from scratch will use RocksDb.

## How Has This Been Tested?

1. Running node from scratch and then stop it.
2. Run the node again.
3. Run node from scratch selecting non-default DB and then stop it.
4. Run the node again.
5. Run the node again with a different db selected and make sure it was running fine as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
