### PR TITLE
Fix response format on eth_hashrate()

### DIFF
--- a/doc/rpc/methods/eth_hashrate.json
+++ b/doc/rpc/methods/eth_hashrate.json
@@ -4,7 +4,7 @@
   "params": [],
   "result": {
     "name": "hashesPerSecond",
-    "description": "Integer (hex) of the number of hashes per second",
+    "description": "hex value of the number of hashes per second",
     "schema": {
       "$ref": "#/components/schemas/IntegerHex"
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -64,7 +64,7 @@ public interface Web3EthModule {
 
     boolean eth_mining();
 
-    BigInteger eth_hashrate();
+    String eth_hashrate();
 
     String eth_gasPrice();
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -343,13 +343,13 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
-    public BigInteger eth_hashrate() {
+    public String eth_hashrate() {
         BigInteger hashesPerHour = hashRateCalculator.calculateNodeHashRate(Duration.ofHours(1));
         BigInteger hashesPerSecond = hashesPerHour.divide(BigInteger.valueOf(Duration.ofHours(1).getSeconds()));
 
         logger.debug("eth_hashrate(): {}", hashesPerSecond);
 
-        return hashesPerSecond;
+        return hashesPerSecond.toString(16);
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -349,7 +349,7 @@ public class Web3Impl implements Web3 {
 
         logger.debug("eth_hashrate(): {}", hashesPerSecond);
 
-        return hashesPerSecond.toString(16);
+        return HexUtils.toQuantityJsonHex(hashesPerSecond);
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3EthModuleTest.java
@@ -33,6 +33,7 @@ import co.rsk.rpc.modules.personal.PersonalModule;
 import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.PeerScoringManager;
+import co.rsk.util.HexUtils;
 import org.ethereum.core.BlockTxSignatureCache;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.ReceivedTxSignatureCache;
@@ -44,6 +45,8 @@ import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
 import org.ethereum.util.BuildInfo;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -84,5 +87,44 @@ class Web3EthModuleTest {
                 new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
 
         assertThat(web3.eth_chainId(), is("0x21"));
+    }
+
+    @Test
+    void eth_hasrate() {
+        EthModule ethModule = mock(EthModule.class);
+        HashRateCalculator hc = mock(HashRateCalculator.class);
+        when(hc.calculateNodeHashRate(any())).thenReturn(BigInteger.valueOf(0));
+
+        Web3EthModule web3 = new Web3RskImpl(
+                mock(Ethereum.class),
+                mock(Blockchain.class, RETURNS_DEEP_STUBS),
+                mock(RskSystemProperties.class),
+                mock(MinerClient.class),
+                mock(MinerServer.class),
+                mock(PersonalModule.class),
+                ethModule,
+                mock(EvmModule.class),
+                mock(TxPoolModule.class),
+                mock(MnrModule.class),
+                mock(DebugModule.class),
+                null, mock(RskModule.class),
+                mock(ChannelManager.class),
+                mock(PeerScoringManager.class),
+                mock(NetworkStateExporter.class),
+                mock(BlockStore.class),
+                mock(ReceiptStore.class),
+                mock(PeerServer.class),
+                mock(BlockProcessor.class),
+                hc,
+                mock(ConfigCapabilities.class),
+                mock(BuildInfo.class),
+                mock(BlocksBloomStore.class),
+                mock(Web3InformationRetriever.class),
+                mock(SyncProcessor.class),
+                new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
+
+        String expectedValue = HexUtils.toQuantityJsonHex(BigInteger.ZERO);
+        String result = web3.eth_hashrate();
+        assertThat(expectedValue, is(result));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the response of the `eth_hashrate` method from a plain decimal number to a hexadecimal string. The change is in line with the behavior of the Geth.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required to align the behavior of the RSKj client with the Ethereum clients, which return the hashrate as a hex-encoded string. This change fixes [issue #1837](https://github.com/rsksmart/rskj/issues/1837), where the `eth_hashrate` method in RSKj was returning a plain decimal number.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The changes have been tested by running the RSKj node with the changes applied. I checked the response format of the `eth_hashrate` method, and it now returns the hashrate as a hex-encoded string, which aligns with the behavior of geth.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
