### PR TITLE
Add input to CallArguments class

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -39,7 +39,6 @@ public class Constants {
     public static final byte TESTNET_CHAIN_ID = (byte) 31;
     public static final byte DEVNET_CHAIN_ID = (byte) 32;
     public static final byte REGTEST_CHAIN_ID = (byte) 33;
-    public static final String TEST_DATA = "0x603d80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463c6888fa18114602d57005b6007600435028060005260206000f3";
 
     private static final byte[] FALLBACKMINING_PUBKEY_0 = Hex.decode("041e2b148c024770e19c4f31db2233cac791583df95b4d14a5e9fd4b38dc8254b3048f937f169446b19d2eca40db1dd93fab34c0cd8a310afd6e6211f9a89e4bca");
     private static final byte[] FALLBACKMINING_PUBKEY_1 = Hex.decode("04b55031870df5de88bdb84f65bd1c6f8331c633e759caa5ac7cad3fa4f8a36791e995804bba1558ddcf330a67ff5bfa253fa1d8789735f97a97e849686527976e");

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -39,6 +39,7 @@ public class Constants {
     public static final byte TESTNET_CHAIN_ID = (byte) 31;
     public static final byte DEVNET_CHAIN_ID = (byte) 32;
     public static final byte REGTEST_CHAIN_ID = (byte) 33;
+    public static final String TEST_DATA = "0x603d80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463c6888fa18114602d57005b6007600435028060005260206000f3";
 
     private static final byte[] FALLBACKMINING_PUBKEY_0 = Hex.decode("041e2b148c024770e19c4f31db2233cac791583df95b4d14a5e9fd4b38dc8254b3048f937f169446b19d2eca40db1dd93fab34c0cd8a310afd6e6211f9a89e4bca");
     private static final byte[] FALLBACKMINING_PUBKEY_1 = Hex.decode("04b55031870df5de88bdb84f65bd1c6f8331c633e759caa5ac7cad3fa4f8a36791e995804bba1558ddcf330a67ff5bfa253fa1d8789735f97a97e849686527976e");

--- a/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
@@ -18,6 +18,8 @@
 
 package org.ethereum.rpc;
 
+import java.util.Optional;
+
 /**
  * Wraps call arguments for several json-rpc methods.
  * Take account to fill up the arguments using the right hex value encoding (QUANTITY and UNFORMATTED DATA),
@@ -36,6 +38,7 @@ public class CallArguments {
     private String nonce;
     private String chainId;
     private String type; // ignore, see https://github.com/rsksmart/rskj/pull/1601
+    private String input;
 
     public String getFrom() {
         return from;
@@ -86,7 +89,7 @@ public class CallArguments {
     }
 
     public String getData() {
-        return data;
+        return getInputOrData();
     }
 
     public void setData(String data) {
@@ -115,6 +118,18 @@ public class CallArguments {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getInput() {
+        return getInputOrData();
+    }
+
+    public void setInput(String input) {
+        this.input = input;
+    }
+
+    private String getInputOrData() {
+        return Optional.ofNullable(input).filter(i -> !i.isEmpty()).orElse(data);
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
@@ -38,7 +38,6 @@ public class CallArguments {
     private String nonce;
     private String chainId;
     private String type; // ignore, see https://github.com/rsksmart/rskj/pull/1601
-    private String input;
 
     public String getFrom() {
         return from;
@@ -89,7 +88,7 @@ public class CallArguments {
     }
 
     public String getData() {
-        return getInputOrData();
+        return this.data;
     }
 
     public void setData(String data) {
@@ -121,15 +120,11 @@ public class CallArguments {
     }
 
     public String getInput() {
-        return getInputOrData();
+        return this.data;
     }
 
     public void setInput(String input) {
-        this.input = input;
-    }
-
-    private String getInputOrData() {
-        return Optional.ofNullable(input).filter(i -> !i.isEmpty()).orElse(data);
+        this.data = input;
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/CallArguments.java
@@ -18,8 +18,6 @@
 
 package org.ethereum.rpc;
 
-import java.util.Optional;
-
 /**
  * Wraps call arguments for several json-rpc methods.
  * Take account to fill up the arguments using the right hex value encoding (QUANTITY and UNFORMATTED DATA),

--- a/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3RskImplTest.java
@@ -116,4 +116,13 @@ class Web3RskImplTest {
 
         assertEquals("FilterRequest{fromBlock='1', toBlock='2', address=0x0000000001, topics=[2], blockHash='0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2'}", filterRequest.toString());
     }
+
+    @Test
+    void whenSetInput_DataAndInputAreEquals() {
+        CallArguments callArguments = new CallArguments();
+
+        callArguments.setInput("data");
+
+        assertEquals(callArguments.getData(), callArguments.getInput());
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -43,9 +43,12 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -62,7 +65,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class EthModuleTest {
-
     private final TestSystemProperties config = new TestSystemProperties();
     private SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
 
@@ -352,5 +354,360 @@ class EthModuleTest {
                 config.getCallGasCap()
         );
         assertThat(eth.chainId(), is("0x21"));
+    }
+
+    @Test
+    void whenExecuteCallWithDataParameter_callExecutorWithData() {
+        CallArguments args = new CallArguments();
+        args.setData(Constants.TEST_DATA);
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        when(retriever.retrieveExecutionBlock("latest"))
+                .thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(block);
+
+        byte[] hReturn = HexUtils.stringToByteArray("hello");
+        ProgramResult executorResult = mock(ProgramResult.class);
+        when(executorResult.getHReturn())
+                .thenReturn(hReturn);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(executorResult);
+
+        EthModule eth = new EthModule(
+                null,
+                anyByte(),
+                null,
+                null,
+                executor,
+                retriever,
+                null,
+                null,
+                null,
+                new BridgeSupportFactory(
+                        null, null, null, signatureCache),
+                config.getGasEstimationCap(),
+                config.getCallGasCap());
+
+        eth.call(args, "latest");
+
+        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(executor, times(1))
+                .executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getData()), dataCaptor.getValue());
+    }
+
+    @Test
+    void whenExecuteCallWithInputParameter_callExecutorWithInput() {
+        CallArguments args = new CallArguments();
+        args.setInput(Constants.TEST_DATA);
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        when(retriever.retrieveExecutionBlock("latest"))
+                .thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(block);
+
+        byte[] hReturn = HexUtils.stringToByteArray("hello");
+        ProgramResult executorResult = mock(ProgramResult.class);
+        when(executorResult.getHReturn())
+                .thenReturn(hReturn);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(executorResult);
+
+        EthModule eth = new EthModule(
+                null,
+                anyByte(),
+                null,
+                null,
+                executor,
+                retriever,
+                null,
+                null,
+                null,
+                new BridgeSupportFactory(
+                        null, null, null, signatureCache),
+                config.getGasEstimationCap(),
+                config.getCallGasCap());
+
+        eth.call(args, "latest");
+
+        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(executor, times(1))
+                .executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), dataCaptor.getValue());
+    }
+
+    @Test
+    void whenExecuteCallWithInputAndDataParameters_callExecutorWithInput() {
+        CallArguments args = new CallArguments();
+        args.setData(Constants.TEST_DATA);
+        args.setInput(Constants.TEST_DATA);
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        when(retriever.retrieveExecutionBlock("latest"))
+                .thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(block);
+
+        byte[] hReturn = HexUtils.stringToByteArray("hello");
+        ProgramResult executorResult = mock(ProgramResult.class);
+        when(executorResult.getHReturn())
+                .thenReturn(hReturn);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(executorResult);
+
+        EthModule eth = new EthModule(
+                null,
+                anyByte(),
+                null,
+                null,
+                executor,
+                retriever,
+                null,
+                null,
+                null,
+                new BridgeSupportFactory(
+                        null, null, null, signatureCache),
+                config.getGasEstimationCap(),
+                config.getCallGasCap());
+
+
+        eth.call(args, "latest");
+
+        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(executor, times(1))
+                .executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), dataCaptor.getValue());
+    }
+
+    @Test
+    void whenExecuteEstimateGasWithDataParameter_callExecutorWithData() {
+        CallArguments args = new CallArguments();
+        args.setData(Constants.TEST_DATA);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        Block block = mock(Block.class);
+        Blockchain blockchain = mock(Blockchain.class);
+        when(blockchain.getBestBlock())
+                .thenReturn(block);
+
+        ProgramResult executorResult = mock(ProgramResult.class);
+        TransactionExecutor transactionExecutor = mock(TransactionExecutor.class);
+        when(transactionExecutor.getResult())
+                .thenReturn(executorResult);
+
+        ReversibleTransactionExecutor reversibleTransactionExecutor = mock(ReversibleTransactionExecutor.class);
+        when(reversibleTransactionExecutor.estimateGas(eq(blockchain.getBestBlock()), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(transactionExecutor);
+
+        EthModule eth = new EthModule(
+                null,
+                Constants.REGTEST_CHAIN_ID,
+                blockchain,
+                null,
+                reversibleTransactionExecutor,
+                retriever,
+                null,
+                null,
+                null,
+                new BridgeSupportFactory(
+                        null, null, null, signatureCache),
+                config.getGasEstimationCap(),
+                config.getCallGasCap());
+
+        eth.estimateGas(args);
+
+        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(reversibleTransactionExecutor, times(1))
+                .estimateGas(eq(blockchain.getBestBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getData()), dataCaptor.getValue());
+    }
+
+    @Test
+    void whenExecuteEstimateGasWithInputParameter_callExecutorWithInput() {
+        CallArguments args = new CallArguments();
+        args.setInput(Constants.TEST_DATA);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        Block block = mock(Block.class);
+        Blockchain blockchain = mock(Blockchain.class);
+        when(blockchain.getBestBlock())
+                .thenReturn(block);
+
+        ProgramResult executorResult = mock(ProgramResult.class);
+        TransactionExecutor transactionExecutor = mock(TransactionExecutor.class);
+        when(transactionExecutor.getResult())
+                .thenReturn(executorResult);
+
+        ReversibleTransactionExecutor reversibleTransactionExecutor = mock(ReversibleTransactionExecutor.class);
+        when(reversibleTransactionExecutor.estimateGas(eq(blockchain.getBestBlock()), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(transactionExecutor);
+
+        EthModule eth = new EthModule(
+                null,
+                Constants.REGTEST_CHAIN_ID,
+                blockchain,
+                null,
+                reversibleTransactionExecutor,
+                retriever,
+                null,
+                null,
+                null,
+                new BridgeSupportFactory(
+                        null, null, null, signatureCache),
+                config.getGasEstimationCap(),
+                config.getCallGasCap());
+
+        eth.estimateGas(args);
+
+        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(reversibleTransactionExecutor, times(1))
+                .estimateGas(eq(blockchain.getBestBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), dataCaptor.getValue());
+    }
+
+    @Test
+    void whenExecuteEstimateGasWithInputAndDataParameters_callExecutorWithInput() {
+        CallArguments args = new CallArguments();
+        args.setData(Constants.TEST_DATA);
+        args.setInput(Constants.TEST_DATA);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        Block block = mock(Block.class);
+        Blockchain blockchain = mock(Blockchain.class);
+        when(blockchain.getBestBlock())
+                .thenReturn(block);
+
+        ProgramResult executorResult = mock(ProgramResult.class);
+        TransactionExecutor transactionExecutor = mock(TransactionExecutor.class);
+        when(transactionExecutor.getResult())
+                .thenReturn(executorResult);
+
+        ReversibleTransactionExecutor reversibleTransactionExecutor = mock(ReversibleTransactionExecutor.class);
+        when(reversibleTransactionExecutor.estimateGas(eq(blockchain.getBestBlock()), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(transactionExecutor);
+
+        EthModule eth = new EthModule(
+                null,
+                Constants.REGTEST_CHAIN_ID,
+                blockchain,
+                null,
+                reversibleTransactionExecutor,
+                retriever,
+                null,
+                null,
+                null,
+                new BridgeSupportFactory(
+                        null, null, null, signatureCache),
+                config.getGasEstimationCap(),
+                config.getCallGasCap());
+
+        eth.estimateGas(args);
+
+        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(reversibleTransactionExecutor, times(1))
+                .estimateGas(eq(blockchain.getBestBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), dataCaptor.getValue());
+    }
+
+    @Test
+    void whenExecuteSendTransactionWithDataParameter_callExecutorWithData() {
+        Constants constants = Constants.regtest();
+
+        Wallet wallet = new Wallet(new HashMapDB());
+        RskAddress sender = wallet.addAccount();
+        RskAddress receiver = wallet.addAccount();
+
+        // Hash of the expected transaction
+        CallArguments args = TransactionFactoryHelper.createArguments(sender, receiver);
+        args.setData(Constants.TEST_DATA);
+
+        String expectedDataValue = args.getData().substring(2);
+
+        TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+        when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+
+        TransactionGateway transactionGateway = mock(TransactionGateway.class);
+        when(transactionGateway.receiveTransaction(any(Transaction.class))).thenReturn(transactionPoolAddResult);
+
+        TransactionPool transactionPool = mock(TransactionPool.class);
+
+        EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
+
+        ethModuleTransaction.sendTransaction(args);
+
+        ArgumentCaptor<Transaction> transactionCaptor = ArgumentCaptor.forClass(Transaction.class);
+        verify(transactionGateway, times(1))
+                .receiveTransaction(transactionCaptor.capture());
+        assertArrayEquals(Hex.decode(expectedDataValue), transactionCaptor.getValue().getData());
+    }
+
+    @Test
+    void whenExecuteSendTransactionWithInputParameter_callExecutorWithInput() {
+        Constants constants = Constants.regtest();
+
+        Wallet wallet = new Wallet(new HashMapDB());
+        RskAddress sender = wallet.addAccount();
+        RskAddress receiver = wallet.addAccount();
+
+        // Hash of the expected transaction
+        CallArguments args = TransactionFactoryHelper.createArguments(sender, receiver);
+        args.setInput(Constants.TEST_DATA);
+
+        String expectedDataValue = args.getInput().substring(2);
+
+        TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+        when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+
+        TransactionGateway transactionGateway = mock(TransactionGateway.class);
+        when(transactionGateway.receiveTransaction(any(Transaction.class))).thenReturn(transactionPoolAddResult);
+
+        TransactionPool transactionPool = mock(TransactionPool.class);
+
+        EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
+
+        ethModuleTransaction.sendTransaction(args);
+
+        ArgumentCaptor<Transaction> transactionCaptor = ArgumentCaptor.forClass(Transaction.class);
+        verify(transactionGateway, times(1))
+                .receiveTransaction(transactionCaptor.capture());
+        assertArrayEquals(Hex.decode(expectedDataValue), transactionCaptor.getValue().getData());
+    }
+
+    @Test
+    void whenExecuteSendTransactionWithInputAndDataParameters_callExecutorWithInput() {
+        Constants constants = Constants.regtest();
+
+        Wallet wallet = new Wallet(new HashMapDB());
+        RskAddress sender = wallet.addAccount();
+        RskAddress receiver = wallet.addAccount();
+
+        // Hash of the expected transaction
+        CallArguments args = TransactionFactoryHelper.createArguments(sender, receiver);
+        args.setData(Constants.TEST_DATA);
+        args.setInput(Constants.TEST_DATA);
+
+        String expectedDataValue = args.getInput().substring(2);
+
+        TransactionPoolAddResult transactionPoolAddResult = mock(TransactionPoolAddResult.class);
+        when(transactionPoolAddResult.transactionsWereAdded()).thenReturn(true);
+
+        TransactionGateway transactionGateway = mock(TransactionGateway.class);
+        when(transactionGateway.receiveTransaction(any(Transaction.class))).thenReturn(transactionPoolAddResult);
+
+        TransactionPool transactionPool = mock(TransactionPool.class);
+
+        EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
+
+        ethModuleTransaction.sendTransaction(args);
+
+        ArgumentCaptor<Transaction> transactionCaptor = ArgumentCaptor.forClass(Transaction.class);
+        verify(transactionGateway, times(1))
+                .receiveTransaction(transactionCaptor.capture());
+        assertArrayEquals(Hex.decode(expectedDataValue), transactionCaptor.getValue().getData());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -65,6 +65,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class EthModuleTest {
+
+    public static final String TEST_DATA = "0x603d80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463c6888fa18114602d57005b6007600435028060005260206000f3";
+    
     private final TestSystemProperties config = new TestSystemProperties();
     private SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
 
@@ -359,7 +362,7 @@ class EthModuleTest {
     @Test
     void whenExecuteCallWithDataParameter_callExecutorWithData() {
         CallArguments args = new CallArguments();
-        args.setData(Constants.TEST_DATA);
+        args.setData(TEST_DATA);
         ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
@@ -402,7 +405,7 @@ class EthModuleTest {
     @Test
     void whenExecuteCallWithInputParameter_callExecutorWithInput() {
         CallArguments args = new CallArguments();
-        args.setInput(Constants.TEST_DATA);
+        args.setInput(TEST_DATA);
         ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
@@ -445,8 +448,8 @@ class EthModuleTest {
     @Test
     void whenExecuteCallWithInputAndDataParameters_callExecutorWithInput() {
         CallArguments args = new CallArguments();
-        args.setData(Constants.TEST_DATA);
-        args.setInput(Constants.TEST_DATA);
+        args.setData(TEST_DATA);
+        args.setInput(TEST_DATA);
         ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
         Block block = mock(Block.class);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
@@ -490,7 +493,7 @@ class EthModuleTest {
     @Test
     void whenExecuteEstimateGasWithDataParameter_callExecutorWithData() {
         CallArguments args = new CallArguments();
-        args.setData(Constants.TEST_DATA);
+        args.setData(TEST_DATA);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
         Block block = mock(Block.class);
         Blockchain blockchain = mock(Blockchain.class);
@@ -532,7 +535,7 @@ class EthModuleTest {
     @Test
     void whenExecuteEstimateGasWithInputParameter_callExecutorWithInput() {
         CallArguments args = new CallArguments();
-        args.setInput(Constants.TEST_DATA);
+        args.setInput(TEST_DATA);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
         Block block = mock(Block.class);
         Blockchain blockchain = mock(Blockchain.class);
@@ -574,8 +577,8 @@ class EthModuleTest {
     @Test
     void whenExecuteEstimateGasWithInputAndDataParameters_callExecutorWithInput() {
         CallArguments args = new CallArguments();
-        args.setData(Constants.TEST_DATA);
-        args.setInput(Constants.TEST_DATA);
+        args.setData(TEST_DATA);
+        args.setInput(TEST_DATA);
         ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
         Block block = mock(Block.class);
         Blockchain blockchain = mock(Blockchain.class);
@@ -624,7 +627,7 @@ class EthModuleTest {
 
         // Hash of the expected transaction
         CallArguments args = TransactionFactoryHelper.createArguments(sender, receiver);
-        args.setData(Constants.TEST_DATA);
+        args.setData(TEST_DATA);
 
         String expectedDataValue = args.getData().substring(2);
 
@@ -656,7 +659,7 @@ class EthModuleTest {
 
         // Hash of the expected transaction
         CallArguments args = TransactionFactoryHelper.createArguments(sender, receiver);
-        args.setInput(Constants.TEST_DATA);
+        args.setInput(TEST_DATA);
 
         String expectedDataValue = args.getInput().substring(2);
 
@@ -688,8 +691,8 @@ class EthModuleTest {
 
         // Hash of the expected transaction
         CallArguments args = TransactionFactoryHelper.createArguments(sender, receiver);
-        args.setData(Constants.TEST_DATA);
-        args.setInput(Constants.TEST_DATA);
+        args.setData(TEST_DATA);
+        args.setInput(TEST_DATA);
 
         String expectedDataValue = args.getInput().substring(2);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added `input` field to CallArguments
- Added new test for RPC methods that acccept a CallArguments object as argument.

## Motivation and Context
Following the investigation done in [CORE-2939](https://rsklabs.atlassian.net/browse/CORE-2939), regarding an issue with some of the RPC methods we use in rskj, we found that both Web3js and Geth now have a parameter called `input`  which currently is not supported by our code, this parameter seems to behave similar to the `data` parameter given that Web3js automatically add `input` in the payload if it is missing add sets its value to a copy from `data`'s. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
