### PR TITLE
Add filterNotFound exception to RskJsonRpcRequestException class

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/FilterManager.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/FilterManager.java
@@ -72,13 +72,7 @@ public class FilterManager {
 
     public boolean removeFilter(int id) {
         synchronized (filterLock) {
-            Filter filter = installedFilters.remove(id);
-
-            if (filter == null) {
-                throw filterNotFound("filter not found");
-            }
-
-            return true;
+            return installedFilters.remove(id) != null;
         }
     }
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/FilterManager.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/FilterManager.java
@@ -18,6 +18,7 @@
 
 package org.ethereum.rpc;
 
+import static org.ethereum.rpc.exception.RskJsonRpcRequestException.filterNotFound;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
@@ -71,7 +72,13 @@ public class FilterManager {
 
     public boolean removeFilter(int id) {
         synchronized (filterLock) {
-            return installedFilters.remove(id) != null;
+            Filter filter = installedFilters.remove(id);
+
+            if (filter == null) {
+                throw filterNotFound("filter not found");
+            }
+
+            return true;
         }
     }
 
@@ -82,7 +89,7 @@ public class FilterManager {
             Filter filter = installedFilters.get(id);
 
             if (filter == null) {
-                return null;
+                throw filterNotFound("filter not found");
             }
 
             if (newevents) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
@@ -57,4 +57,8 @@ public class RskJsonRpcRequestException extends RuntimeException {
     public static RskJsonRpcRequestException stateNotFound(String message) {
         return new RskJsonRpcRequestException(-32600, message);
     }
+
+    public static RskJsonRpcRequestException filterNotFound(String message) {
+        return new RskJsonRpcRequestException(-32000, message);
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/FilterManagerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/FilterManagerTest.java
@@ -18,17 +18,4 @@ public class FilterManagerTest {
                 "filter not found"
         );
     }
-
-    @Test
-    void whenRemoveFilter_throwFilterNotFoundException() {
-        Ethereum ethMock = Web3Mocks.getMockEthereum();
-        FilterManager filterManager = new FilterManager(ethMock);
-
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> filterManager.removeFilter(1));
-        Assertions.assertThrowsExactly(
-                RskJsonRpcRequestException.class,
-                () -> filterManager.removeFilter(1),
-                "filter not found"
-        );
-    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/FilterManagerTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/FilterManagerTest.java
@@ -1,0 +1,34 @@
+package org.ethereum.rpc;
+
+import org.ethereum.facade.Ethereum;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FilterManagerTest {
+
+    @Test
+    void whenGetFilterEvent_throwFilterNotFoundException() {
+        Ethereum ethMock = Web3Mocks.getMockEthereum();
+        FilterManager filterManager = new FilterManager(ethMock);
+
+        Assertions.assertThrowsExactly(
+                RskJsonRpcRequestException.class,
+                () -> filterManager.getFilterEvents(1, false),
+                "filter not found"
+        );
+    }
+
+    @Test
+    void whenRemoveFilter_throwFilterNotFoundException() {
+        Ethereum ethMock = Web3Mocks.getMockEthereum();
+        FilterManager filterManager = new FilterManager(ethMock);
+
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> filterManager.removeFilter(1));
+        Assertions.assertThrowsExactly(
+                RskJsonRpcRequestException.class,
+                () -> filterManager.removeFilter(1),
+                "filter not found"
+        );
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -2406,15 +2406,17 @@ class Web3ImplTest {
         when(config.isMinerClientEnabled()).thenReturn(false);
         when(config.minerClientAutoMine()).thenReturn(false);
 
+        RskJsonRpcRequestException expectedException = RskJsonRpcRequestException.filterNotFound("filter not found");
+
         Web3RskImpl web3 = (Web3RskImpl) createWeb3();
 
         RskJsonRpcRequestException exception = Assertions.assertThrowsExactly(
-                RskJsonRpcRequestException.class,
+                expectedException.getClass(),
                 () -> web3.eth_getFilterChanges("0x01"),
                 "filter not found"
         );
 
-        assertEquals(-32000, exception.getCode());
+        assertEquals(expectedException.getCode(), exception.getCode());
     }
 
     @Test
@@ -2424,15 +2426,17 @@ class Web3ImplTest {
         when(config.isMinerClientEnabled()).thenReturn(false);
         when(config.minerClientAutoMine()).thenReturn(false);
 
+        RskJsonRpcRequestException expectedException = RskJsonRpcRequestException.filterNotFound("filter not found");
+
         Web3RskImpl web3 = (Web3RskImpl) createWeb3();
 
         RskJsonRpcRequestException exception = Assertions.assertThrowsExactly(
-                RskJsonRpcRequestException.class,
+                expectedException.getClass(),
                 () -> web3.eth_getFilterLogs("0x01"),
                 "filter not found"
         );
 
-        assertEquals(-32000, exception.getCode());
+        assertEquals(expectedException.getCode(), exception.getCode());
     }
 
     private Web3Impl createWeb3() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -2408,11 +2408,13 @@ class Web3ImplTest {
 
         Web3RskImpl web3 = (Web3RskImpl) createWeb3();
 
-        Assertions.assertThrowsExactly(
+        RskJsonRpcRequestException exception = Assertions.assertThrowsExactly(
                 RskJsonRpcRequestException.class,
                 () -> web3.eth_getFilterChanges("0x01"),
                 "filter not found"
         );
+
+        assertEquals(-32000, exception.getCode());
     }
 
     @Test
@@ -2424,11 +2426,13 @@ class Web3ImplTest {
 
         Web3RskImpl web3 = (Web3RskImpl) createWeb3();
 
-        Assertions.assertThrowsExactly(
+        RskJsonRpcRequestException exception = Assertions.assertThrowsExactly(
                 RskJsonRpcRequestException.class,
                 () -> web3.eth_getFilterLogs("0x01"),
                 "filter not found"
         );
+
+        assertEquals(-32000, exception.getCode());
     }
 
     private Web3Impl createWeb3() {

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -2431,22 +2431,6 @@ class Web3ImplTest {
         );
     }
 
-    @Test
-    void whenEthUninstallFilter_throwFilterNotFoundException() {
-        RskSystemProperties config = mock(RskSystemProperties.class);
-
-        when(config.isMinerClientEnabled()).thenReturn(false);
-        when(config.minerClientAutoMine()).thenReturn(false);
-
-        Web3RskImpl web3 = (Web3RskImpl) createWeb3();
-
-        Assertions.assertThrowsExactly(
-                RskJsonRpcRequestException.class,
-                () -> web3.eth_uninstallFilter("0x01"),
-                "filter not found"
-        );
-    }
-
     private Web3Impl createWeb3() {
         return createWeb3(
                 Web3Mocks.getMockEthereum(), Web3Mocks.getMockBlockchain(), Web3Mocks.getMockRepositoryLocator(), Web3Mocks.getMockTransactionPool(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added the `filterNotFound` method to the `RskJsonRpcRequestException` class.
- Updated `getFilterEvents` and `removeFilter` method in `FilterManager` so they will throw the `filterNotFound` exception instead of returning null.
- Added unit tests fort the updated methods in `FilterManager` and integration tests for the affected eth methods.

## Motivation and Context
The reponse for the eth filter method in rskj when a filter is not found is different from the response GETH returns. For example, when calling the endpoint `eth_getFilterChanges`:

Example call:

```
curl --location 'http://localhost:4444' \
--header 'Content-Type: application/json' \
--data '{
	"jsonrpc":"2.0",
	"method":"eth_getFilterChanges",
	"params":[
		"0x16"
	],
	"id":73
}'
```

The filter does not exist, GETH is returning;

```
{
    "jsonrpc": "2.0",
    "id": 73,
    "error": {
        "code": -32000,
        "message": "filter not found"
    }
}
```
while RSKJ is returning null



```
{
    "jsonrpc": "2.0",
    "id": 73,
    "result": null
}
```

This also happens for the `eth_getFilterLogs` and `eth_unistallFilter` endpoints.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
