### PR TITLE
Move the tests that spend from an ERP federation to it's own utils class

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/P2shErpFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/P2shErpFederation.java
@@ -44,7 +44,7 @@ public class P2shErpFederation extends ErpFederation {
     public final Script getStandardRedeemScript() {
         if (standardRedeemScript == null) {
             standardRedeemScript = P2shErpFederationRedeemScriptParser.extractStandardRedeemScript(
-                    getRedeemScript().getChunks()
+                getRedeemScript().getChunks()
             );
         }
         return standardRedeemScript;

--- a/rskj-core/src/test/java/co/rsk/peg/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BitcoinTestUtils.java
@@ -3,6 +3,8 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -27,5 +29,12 @@ public class BitcoinTestUtils {
     public static Address createP2PKHAddress(NetworkParameters networkParameters, String seed) {
         BtcECKey key = BtcECKey.fromPrivate(HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8)));
         return key.toAddress(networkParameters);
+    }
+
+    public static Address createP2SHMultisigAddress(NetworkParameters networkParameters, List<BtcECKey> keys) {
+        Script redeemScript = ScriptBuilder.createRedeemScript((keys.size() / 2) + 1, keys);
+        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
+
+        return Address.fromP2SHScript(networkParameters, outputScript);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BitcoinTestUtils.java
@@ -1,0 +1,24 @@
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.ethereum.crypto.HashUtil;
+
+public class BitcoinTestUtils {
+
+    public static List<BtcECKey> getBtcEcKeysFromSeeds(String[] seeds, boolean sorted) {
+        List<BtcECKey> keys = Arrays
+            .stream(seeds)
+            .map(seed -> BtcECKey.fromPrivate(HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8))))
+            .collect(Collectors.toList());
+
+        if (sorted) {
+            keys.sort(BtcECKey.PUBKEY_COMPARATOR);
+        }
+
+        return keys;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BitcoinTestUtils.java
@@ -1,6 +1,8 @@
 package co.rsk.peg;
 
+import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -20,5 +22,10 @@ public class BitcoinTestUtils {
         }
 
         return keys;
+    }
+
+    public static Address createP2PKHAddress(NetworkParameters networkParameters, String seed) {
+        BtcECKey key = BtcECKey.fromPrivate(HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8)));
+        return key.toAddress(networkParameters);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -24,6 +24,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.MutableTrieCache;
 import co.rsk.db.MutableTrieImpl;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.utils.BridgeEventLoggerImpl;
 import co.rsk.peg.utils.RejectedPegoutReason;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -965,7 +965,7 @@ class BridgeSupportReleaseBtcTest {
         for (int i = 0; i < entriesSizeAboveMaxIterations; i++) {
             entries.add(
                 new ReleaseRequestQueue.Entry(
-                    PegTestUtils.createP2PKHBtcAddress(bridgeConstants.getBtcParams(), i+2),
+                    BitcoinTestUtils.createP2PKHAddress(bridgeConstants.getBtcParams(), String.valueOf(i)),
                     Coin.COIN.multiply(5)
                 )
             );

--- a/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
@@ -19,6 +19,7 @@ import co.rsk.bitcoinj.script.ScriptOpCodes;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeTestNetConstants;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.resources.TestConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
@@ -1,6 +1,5 @@
 package co.rsk.peg;
 
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -12,13 +11,10 @@ import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.ScriptException;
-import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.core.VerificationException;
-import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.ErpFederationRedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
-import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptOpCodes;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
@@ -29,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -39,7 +36,7 @@ import java.util.stream.Collectors;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -704,113 +701,6 @@ class ErpFederationTest {
         ));
     }
 
-    private void spendFromErpFed(
-        NetworkParameters networkParameters,
-        long activationDelay,
-        boolean isRskip293Active,
-        boolean signWithEmergencyMultisig) {
-
-        // Created with GenNodeKeyId using seed 'fed1'
-        byte[] publicKeyBytes = Hex.decode("043267e382e076cbaa199d49ea7362535f95b135de181caf66b391f541bf39ab0e75b8577faac2183782cb0d76820cf9f356831d216e99d886f8a6bc47fe696939");
-        BtcECKey btcKey = BtcECKey.fromPublicOnly(publicKeyBytes);
-        ECKey rskKey = ECKey.fromPublicOnly(publicKeyBytes);
-        FederationMember fed1 = new FederationMember(btcKey, rskKey, rskKey);
-        BtcECKey fed1PrivKey = BtcECKey.fromPrivate(Hex.decode("529822842595a3a6b3b3e51e9cffa0db66452599f7beec542382a02b1e42be4b"));
-
-        // Created with GenNodeKeyId using seed 'fed3', used for fed2 to keep keys sorted
-        publicKeyBytes = Hex.decode("0443e106d90183e2eef7d5cb7538a634439bf1301d731787c6736922ff19e750ed39e74a76731fed620aeedbcd77e4de403fc4148efd3b5dbfc6cef550aa63c377");
-        btcKey = BtcECKey.fromPublicOnly(publicKeyBytes);
-        rskKey = ECKey.fromPublicOnly(publicKeyBytes);
-        FederationMember fed2 = new FederationMember(btcKey, rskKey, rskKey);
-        BtcECKey fed2PrivKey = BtcECKey.fromPrivate(Hex.decode("b2889610e66cd3f7de37c81c20c786b576349b80b3f844f8409e3a29d95c0c7c"));
-
-        // Created with GenNodeKeyId using seed 'fed2', used for fed3 to keep keys sorted
-        publicKeyBytes = Hex.decode("04bd5b51b1c5d799da190285c8078a2712b8e5dc6f73c799751e6256bb89a4bd04c6444b00289fc76ee853fcfa52b3083d66c42e84f8640f53a4cdf575e4d4a399");
-        btcKey = BtcECKey.fromPublicOnly(publicKeyBytes);
-        rskKey = ECKey.fromPublicOnly(publicKeyBytes);
-        FederationMember fed3 = new FederationMember(btcKey, rskKey, rskKey);
-        BtcECKey fed3PrivKey = BtcECKey.fromPrivate(Hex.decode("fa013890aa14dd269a0ca16003cabde1688021358b662d17b1e8c555f5cccc6e"));
-
-        // Created with GenNodeKeyId using seed 'erp1'
-        publicKeyBytes = Hex.decode("048f5a88b08d75765b36951254e68060759de5be7e559972c37c67fc8cedafeb2643a4a8a618125530e275fe310c72dbdd55fa662cdcf8e134012f8a8d4b7e8400");
-        BtcECKey erp1Key = BtcECKey.fromPublicOnly(publicKeyBytes);
-        BtcECKey erp1PrivKey = BtcECKey.fromPrivate(Hex.decode("1f28656deb5f108f8cdf14af34ac4ff7a5643a7ac3f77b8de826b9ad9775f0ca"));
-
-        // Created with GenNodeKeyId using seed 'erp2'
-        publicKeyBytes = Hex.decode("04deba35a96add157b6de58f48bb6e23bcb0a17037bed1beb8ba98de6b0a0d71d60f3ce246954b78243b41337cf8f93b38563c3bcd6a5329f1d68c057d0e5146e8");
-        BtcECKey erp2Key = BtcECKey.fromPublicOnly(publicKeyBytes);
-        BtcECKey erp2PrivKey = BtcECKey.fromPrivate(Hex.decode("4e58ebe9cd04ffea5ab81dd2aded3ab8a63e44f3b47aef334e369d895c351646"));
-
-        // Created with GenNodeKeyId using seed 'erp3'
-        publicKeyBytes = Hex.decode("04c34fcd05cef2733ea7337c37f50ae26245646aba124948c6ff8dcdf82128499808fc9148dfbc0e0ab510b4f4a78bf7a58f8b6574e03dae002533c5059973b61f");
-        BtcECKey erp3Key = BtcECKey.fromPublicOnly(publicKeyBytes);
-        BtcECKey erp3PrivKey = BtcECKey.fromPrivate(Hex.decode("57e8d2cd51c3b076ca96a1043c8c6d32c6c18447e411a6279cda29d70650977b"));
-
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(isRskip293Active);
-        ErpFederation erpFed = new ErpFederation(
-            Arrays.asList(fed1, fed2, fed3),
-            ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
-            0L,
-            networkParameters,
-            Arrays.asList(erp1Key, erp2Key, erp3Key),
-            activationDelay,
-            activations
-        );
-
-        // Below code can be used to create a transaction spending from the emergency multisig in testnet or mainnet
-//        String RAW_FUND_TX = "";
-//        BtcTransaction pegInTx = new BtcTransaction(networkParameters, Hex.decode(RAW_FUND_TX));
-        int outputIndex = 0; // Remember to change this value accordingly in case of using an existing raw tx
-        BtcTransaction pegInTx = new BtcTransaction(networkParameters);
-        pegInTx.addOutput(Coin.valueOf(990_000), erpFed.getAddress());
-
-        Address destinationAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
-        BtcTransaction pegOutTx = new BtcTransaction(networkParameters);
-        pegOutTx.addInput(pegInTx.getOutput(outputIndex));
-        pegOutTx.addOutput(Coin.valueOf(900_000), destinationAddress);
-        pegOutTx.setVersion(BTC_TX_VERSION_2);
-        pegOutTx.getInput(0).setSequenceNumber(activationDelay);
-
-        // Create signatures
-        Sha256Hash sigHash = pegOutTx.hashForSignature(
-            0,
-            erpFed.getRedeemScript(),
-            BtcTransaction.SigHash.ALL,
-            false
-        );
-
-        BtcECKey.ECDSASignature signature1;
-        BtcECKey.ECDSASignature signature2;
-        BtcECKey.ECDSASignature signature3;
-        if (signWithEmergencyMultisig) {
-            signature1 = erp1PrivKey.sign(sigHash);
-            signature2 = erp2PrivKey.sign(sigHash);
-            signature3 = erp3PrivKey.sign(sigHash);
-        } else {
-            signature1 = fed1PrivKey.sign(sigHash);
-            signature2 = fed2PrivKey.sign(sigHash);
-            signature3 = fed3PrivKey.sign(sigHash);
-        }
-
-        // Try different signature permutations
-        Script inputScript = createInputScript(erpFed.getRedeemScript(), signature1, signature2, signWithEmergencyMultisig);
-        pegOutTx.getInput(0).setScriptSig(inputScript);
-        inputScript.correctlySpends(pegOutTx,0, pegInTx.getOutput(outputIndex).getScriptPubKey());
-
-        inputScript = createInputScript(erpFed.getRedeemScript(), signature1, signature3, signWithEmergencyMultisig);
-        pegOutTx.getInput(0).setScriptSig(inputScript);
-        inputScript.correctlySpends(pegOutTx,0, pegInTx.getOutput(outputIndex).getScriptPubKey());
-
-        inputScript = createInputScript(erpFed.getRedeemScript(), signature2, signature3, signWithEmergencyMultisig);
-        pegOutTx.getInput(0).setScriptSig(inputScript);
-        inputScript.correctlySpends(pegOutTx,0, pegInTx.getOutput(outputIndex).getScriptPubKey());
-
-        // Uncomment to print the raw tx in console and broadcast https://blockstream.info/testnet/tx/push
-//        System.out.println(Hex.toHexString(pegOutTx.bitcoinSerialize()));
-    }
-
     private void createErpFederation(BridgeConstants constants, boolean isRskip293Active) {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(isRskip293Active);
 
@@ -833,35 +723,66 @@ class ErpFederationTest {
         );
     }
 
-    private Script createInputScript(
-        Script fedRedeemScript,
-        BtcECKey.ECDSASignature signature1,
-        BtcECKey.ECDSASignature signature2,
-        boolean signWithTheEmergencyMultisig) {
+    private void spendFromErpFed(
+        NetworkParameters networkParameters,
+        long activationDelay,
+        boolean isRskip293Active,
+        boolean signWithEmergencyMultisig) {
 
-        TransactionSignature txSignature1 = new TransactionSignature(
-            signature1,
-            BtcTransaction.SigHash.ALL,
-            false
+        List<BtcECKey> standardKeys = Arrays.stream(new String[]{
+            "fed1",
+            "fed2",
+            "fed3",
+            "fed4",
+            "fed5",
+            "fed6",
+            "fed7",
+            "fed8",
+            "fed9",
+            "fed10",
+        }).map(seed -> BtcECKey.fromPrivate(HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8))))
+            .sorted(BtcECKey.PUBKEY_COMPARATOR)
+            .collect(Collectors.toList());
+
+        List<BtcECKey> emergencyKeys = Arrays.stream(new String[]{
+            "erp1",
+            "erp2",
+            "erp3",
+            "erp4"
+        }).map(seed -> BtcECKey.fromPrivate(HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8))))
+            .sorted(BtcECKey.PUBKEY_COMPARATOR)
+            .collect(Collectors.toList());
+
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(isRskip293Active);
+        ErpFederation erpFed = new ErpFederation(
+            FederationMember.getFederationMembersFromKeys(standardKeys),
+            ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
+            0L,
+            networkParameters,
+            emergencyKeys,
+            activationDelay,
+            activations
         );
-        byte[] txSignature1Encoded = txSignature1.encodeToBitcoin();
 
-        TransactionSignature txSignature2 = new TransactionSignature(
-            signature2,
-            BtcTransaction.SigHash.ALL,
-            false
+        Coin value = Coin.valueOf(1_000_000);
+        Coin fee = Coin.valueOf(10_000);
+        BtcTransaction fundTx = new BtcTransaction(networkParameters);
+        fundTx.addOutput(value, erpFed.getAddress());
+
+        Address destinationAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+
+        FederationTestUtils.spendFromErpFed(
+            networkParameters,
+            erpFed,
+            signWithEmergencyMultisig ? emergencyKeys : standardKeys,
+            fundTx.getHash(),
+            0,
+            destinationAddress,
+            value.minus(fee),
+            signWithEmergencyMultisig
         );
-        byte[] txSignature2Encoded = txSignature2.encodeToBitcoin();
-
-        int flowOpCode = signWithTheEmergencyMultisig ? 1 : 0;
-        ScriptBuilder scriptBuilder = new ScriptBuilder();
-        return scriptBuilder
-            .number(0)
-            .data(txSignature1Encoded)
-            .data(txSignature2Encoded)
-            .number(flowOpCode)
-            .data(fedRedeemScript.getProgram())
-            .build();
     }
 
     private ErpFederation createDefaultErpFederation() {

--- a/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
@@ -31,10 +31,12 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -737,9 +739,11 @@ class ErpFederationTest {
             true
         );
 
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(isRskip293Active);
+        List<ConsensusRule> except = isRskip293Active ?
+            Collections.emptyList() :
+            Collections.singletonList(ConsensusRule.RSKIP293);
+        ActivationConfig activations = ActivationConfigsForTest.hop400(except);
+
         ErpFederation erpFed = new ErpFederation(
             FederationMember.getFederationMembersFromKeys(standardKeys),
             ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
@@ -747,7 +751,7 @@ class ErpFederationTest {
             networkParameters,
             emergencyKeys,
             activationDelay,
-            activations
+            activations.forBlock(0)
         );
 
         Coin value = Coin.valueOf(1_000_000);

--- a/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
@@ -79,7 +79,6 @@ class ErpFederationTest {
             activationDelayValue,
             false
         );
-
     }
 
     @Test
@@ -755,7 +754,10 @@ class ErpFederationTest {
         BtcTransaction fundTx = new BtcTransaction(networkParameters);
         fundTx.addOutput(value, erpFed.getAddress());
 
-        Address destinationAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+        Address destinationAddress = BitcoinTestUtils.createP2PKHAddress(
+            networkParameters,
+            "destination"
+        );
 
         FederationTestUtils.spendFromErpFed(
             networkParameters,

--- a/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ErpFederationTest.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -36,7 +35,6 @@ import java.util.stream.Collectors;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.crypto.HashUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -729,29 +727,15 @@ class ErpFederationTest {
         boolean isRskip293Active,
         boolean signWithEmergencyMultisig) {
 
-        List<BtcECKey> standardKeys = Arrays.stream(new String[]{
-            "fed1",
-            "fed2",
-            "fed3",
-            "fed4",
-            "fed5",
-            "fed6",
-            "fed7",
-            "fed8",
-            "fed9",
-            "fed10",
-        }).map(seed -> BtcECKey.fromPrivate(HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8))))
-            .sorted(BtcECKey.PUBKEY_COMPARATOR)
-            .collect(Collectors.toList());
+        List<BtcECKey> standardKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
+            new String[]{"fed1", "fed2", "fed3", "fed4", "fed5", "fed6", "fed7", "fed8", "fed9", "fed10"},
+            true
+        );
 
-        List<BtcECKey> emergencyKeys = Arrays.stream(new String[]{
-            "erp1",
-            "erp2",
-            "erp3",
-            "erp4"
-        }).map(seed -> BtcECKey.fromPrivate(HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8))))
-            .sorted(BtcECKey.PUBKEY_COMPARATOR)
-            .collect(Collectors.toList());
+        List<BtcECKey> emergencyKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
+            new String[]{"erp1", "erp2", "erp3", "erp4"},
+            true
+        );
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
@@ -126,7 +126,12 @@ public class FederationTestUtils {
             List<BtcECKey.ECDSASignature> signatures = allSignatures.subList(i, requiredSignatures + i);
             Script inputScript = createInputScript(federation.getRedeemScript(), signatures, signWithEmergencyMultisig);
             spendTx.getInput(0).setScriptSig(inputScript);
-            inputScript.correctlySpends(spendTx,0, federation.getP2SHScript());
+            inputScript.correctlySpends(
+                spendTx,
+                0,
+                federation.getP2SHScript(),
+                Script.ALL_VERIFY_FLAGS
+            );
         }
 
         // Uncomment to print the raw tx in console and broadcast https://blockstream.info/testnet/tx/push

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
@@ -124,7 +124,7 @@ public class FederationTestUtils {
         int permutations = totalSigners % 2 == 0 ? requiredSignatures - 1 : requiredSignatures;
         for (int i = 0; i < permutations; i++) {
             List<BtcECKey.ECDSASignature> signatures = allSignatures.subList(i, requiredSignatures + i);
-            Script inputScript = createInputScript(federation.getRedeemScript(), signatures, signWithEmergencyMultisig);
+            Script inputScript = createInputScriptSig(federation.getRedeemScript(), signatures, signWithEmergencyMultisig);
             spendTx.getInput(0).setScriptSig(inputScript);
             inputScript.correctlySpends(
                 spendTx,
@@ -138,7 +138,7 @@ public class FederationTestUtils {
 //        System.out.println(Hex.toHexString(spendTx.bitcoinSerialize()));
     }
 
-    private static Script createInputScript(
+    private static Script createInputScriptSig(
         Script fedRedeemScript,
         List<BtcECKey.ECDSASignature> signatures,
         boolean signWithTheEmergencyMultisig) {

--- a/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationTestUtils.java
@@ -18,16 +18,24 @@
 
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import org.ethereum.crypto.ECKey;
+import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
 
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.crypto.TransactionSignature;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
 import java.math.BigInteger;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.ethereum.crypto.ECKey;
 
 public class FederationTestUtils {
 
@@ -62,9 +70,9 @@ public class FederationTestUtils {
     }
 
     public static List<FederationMember> getFederationMembersWithBtcKeys(List<BtcECKey> keys) {
-        return keys.stream().map(btcKey ->
-                new FederationMember(btcKey, new ECKey(), new ECKey())
-        ).collect(Collectors.toList());
+        return keys.stream()
+            .map(btcKey -> new FederationMember(btcKey, new ECKey(), new ECKey()))
+            .collect(Collectors.toList());
     }
 
     public static List<FederationMember> getFederationMembersWithKeys(List<BtcECKey> pks) {
@@ -74,5 +82,80 @@ public class FederationTestUtils {
     public static FederationMember getFederationMemberWithKey(BtcECKey pk) {
         ECKey ethKey = ECKey.fromPublicOnly(pk.getPubKey());
         return new FederationMember(pk, ethKey, ethKey);
+    }
+
+    public static void spendFromErpFed(
+        NetworkParameters networkParameters,
+        ErpFederation federation,
+        List<BtcECKey> signers,
+        Sha256Hash fundTxHash,
+        int outputIndex,
+        Address receiver,
+        Coin value,
+        boolean signWithEmergencyMultisig) {
+
+        BtcTransaction spendTx = new BtcTransaction(networkParameters);
+        spendTx.addInput(fundTxHash, outputIndex, new Script(new byte[]{}));
+        spendTx.addOutput(value, receiver);
+
+        if (signWithEmergencyMultisig) {
+            spendTx.setVersion(BTC_TX_VERSION_2);
+            spendTx.getInput(0).setSequenceNumber(federation.getActivationDelay());
+        }
+
+        // Create signatures
+        Sha256Hash sigHash = spendTx.hashForSignature(
+            0,
+            federation.getRedeemScript(),
+            BtcTransaction.SigHash.ALL,
+            false
+        );
+
+        int totalSigners = signers.size();
+        List<BtcECKey.ECDSASignature> allSignatures = new ArrayList<>();
+        for (int i = 0; i < totalSigners; i++) {
+            BtcECKey keyToSign = signers.get(i);
+            BtcECKey.ECDSASignature signature = keyToSign.sign(sigHash);
+            allSignatures.add(signature);
+        }
+
+        // Try different signature permutations
+        int requiredSignatures = totalSigners / 2 + 1;
+        int permutations = totalSigners % 2 == 0 ? requiredSignatures - 1 : requiredSignatures;
+        for (int i = 0; i < permutations; i++) {
+            List<BtcECKey.ECDSASignature> signatures = allSignatures.subList(i, requiredSignatures + i);
+            Script inputScript = createInputScript(federation.getRedeemScript(), signatures, signWithEmergencyMultisig);
+            spendTx.getInput(0).setScriptSig(inputScript);
+            inputScript.correctlySpends(spendTx,0, federation.getP2SHScript());
+        }
+
+        // Uncomment to print the raw tx in console and broadcast https://blockstream.info/testnet/tx/push
+//        System.out.println(Hex.toHexString(spendTx.bitcoinSerialize()));
+    }
+
+    private static Script createInputScript(
+        Script fedRedeemScript,
+        List<BtcECKey.ECDSASignature> signatures,
+        boolean signWithTheEmergencyMultisig) {
+
+        ScriptBuilder scriptBuilder = new ScriptBuilder();
+
+        scriptBuilder = scriptBuilder.number(0);
+        for (BtcECKey.ECDSASignature signature : signatures) {
+            TransactionSignature txSignature = new TransactionSignature(
+                signature,
+                BtcTransaction.SigHash.ALL,
+                false
+            );
+            byte[] txSignatureEncoded = txSignature.encodeToBitcoin();
+
+            scriptBuilder = scriptBuilder.data(txSignatureEncoded);
+        }
+        int flowOpCode = signWithTheEmergencyMultisig ? 1 : 0;
+
+        return scriptBuilder
+            .number(flowOpCode)
+            .data(fedRedeemScript.getProgram())
+            .build();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
@@ -16,6 +16,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.config.BridgeTestNetConstants;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Arrays;

--- a/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
@@ -37,14 +37,14 @@ class P2shErpFederationTest {
     @ParameterizedTest
     @MethodSource("getRedeemScriptArgsProvider")
     void getRedeemScript(BridgeConstants bridgeConstants) {
-        List<BtcECKey> defaultKeys = bridgeConstants.getGenesisFederation().getBtcPublicKeys();
+        List<BtcECKey> standardKeys = bridgeConstants.getGenesisFederation().getBtcPublicKeys();
         List<BtcECKey> emergencyKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
 
         Federation p2shErpFederation = new P2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(defaultKeys),
+            FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys),
             ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
             0L,
             bridgeConstants.getBtcParams(),
@@ -55,7 +55,7 @@ class P2shErpFederationTest {
 
         validateP2shErpRedeemScript(
             p2shErpFederation.getRedeemScript(),
-            defaultKeys,
+            standardKeys,
             emergencyKeys,
             activationDelay
         );
@@ -177,7 +177,7 @@ class P2shErpFederationTest {
             true
         );
 
-        P2shErpFederation pshErpFed = new P2shErpFederation(
+        P2shErpFederation p2shErpFed = new P2shErpFederation(
             FederationMember.getFederationMembersFromKeys(standardKeys),
             ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
             0L,
@@ -190,7 +190,7 @@ class P2shErpFederationTest {
         Coin value = Coin.valueOf(1_000_000);
         Coin fee = Coin.valueOf(10_000);
         BtcTransaction fundTx = new BtcTransaction(networkParameters);
-        fundTx.addOutput(value, pshErpFed.getAddress());
+        fundTx.addOutput(value, p2shErpFed.getAddress());
 
         Address destinationAddress = BitcoinTestUtils.createP2PKHAddress(
             networkParameters,
@@ -199,7 +199,7 @@ class P2shErpFederationTest {
 
         assertDoesNotThrow(() -> FederationTestUtils.spendFromErpFed(
             networkParameters,
-            pshErpFed,
+            p2shErpFed,
             signWithEmergencyMultisig ? emergencyKeys : standardKeys,
             fundTx.getHash(),
             0,

--- a/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
@@ -1,5 +1,6 @@
 package co.rsk.peg;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -195,7 +196,7 @@ class P2shErpFederationTest {
             "destination"
         );
 
-        FederationTestUtils.spendFromErpFed(
+        assertDoesNotThrow(() -> FederationTestUtils.spendFromErpFed(
             networkParameters,
             pshErpFed,
             signWithEmergencyMultisig ? emergencyKeys : standardKeys,
@@ -204,7 +205,7 @@ class P2shErpFederationTest {
             destinationAddress,
             value.minus(fee),
             signWithEmergencyMultisig
-        );
+        ));
     }
 
     private void validateP2shErpRedeemScript(

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -170,7 +170,7 @@ public final class PegTestUtils {
     }
 
     /**
-     * @deprecated Use co.rsk.peg.BitcoinTestUtils#createP2PKHAddress(co.rsk.bitcoinj.core.NetworkParameters, java.lang.String) instead.
+     * @deprecated Use co.rsk.peg.bitcoin.BitcoinTestUtils#createP2PKHAddress(co.rsk.bitcoinj.core.NetworkParameters, java.lang.String) instead.
      * Avoid using random values in tests
      */
     @Deprecated

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -34,16 +34,13 @@ import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.config.BridgeConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
-
-import java.math.BigInteger;
+import co.rsk.peg.simples.SimpleRskTransaction;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import co.rsk.peg.simples.SimpleRskTransaction;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
@@ -170,10 +167,6 @@ public final class PegTestUtils {
         System.arraycopy(customPayload, 0, payloadBytes, index, customPayload.length);
 
         return ScriptBuilder.createOpReturnScript(payloadBytes);
-    }
-
-    public static Address createP2PKHBtcAddress(NetworkParameters networkParameters, int pk) {
-        return BtcECKey.fromPrivate(BigInteger.valueOf(pk)).toAddress(networkParameters);
     }
 
     /**

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -179,14 +179,6 @@ public final class PegTestUtils {
         return key.toAddress(networkParameters);
     }
 
-    public static Address createRandomP2SHMultisigAddress(NetworkParameters networkParameters, int keysCount) {
-        List<BtcECKey> keys = createRandomBtcECKeys(keysCount);
-        Script redeemScript = ScriptBuilder.createRedeemScript((keys.size() / 2) + 1, keys);
-        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-
-        return Address.fromP2SHScript(networkParameters, outputScript);
-    }
-
     public static List<BtcECKey> createRandomBtcECKeys(int keysCount) {
         List<BtcECKey> keys = new ArrayList<>();
         for (int i = 0; i < keysCount; i++) {

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -176,6 +176,11 @@ public final class PegTestUtils {
         return BtcECKey.fromPrivate(BigInteger.valueOf(pk)).toAddress(networkParameters);
     }
 
+    /**
+     * @deprecated Use co.rsk.peg.BitcoinTestUtils#createP2PKHAddress(co.rsk.bitcoinj.core.NetworkParameters, java.lang.String) instead.
+     * Avoid using random values in tests
+     */
+    @Deprecated
     public static Address createRandomP2PKHBtcAddress(NetworkParameters networkParameters) {
         BtcECKey key = new BtcECKey();
         return key.toAddress(networkParameters);

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -18,13 +18,39 @@
 
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.Context;
+import co.rsk.bitcoinj.core.InsufficientMoneyException;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.TransactionOutput;
+import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.core.UTXOProvider;
+import co.rsk.bitcoinj.core.UTXOProviderException;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.SendRequest;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeRegTestConstants;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.junit.jupiter.api.Assertions;
@@ -32,14 +58,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.*;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 class ReleaseTransactionBuilderTest {
     private Wallet wallet;
@@ -544,8 +562,17 @@ class ReleaseTransactionBuilderTest {
     @Test
     void test_BuildBatchedPegouts_ok_P2SHAddress() {
         ReleaseRequestQueue.Entry testEntry1 = createTestEntry(123, 2);
-        ReleaseRequestQueue.Entry testEntry2 = new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2SHMultisigAddress(networkParameters, 3), Coin.COIN);
-        ReleaseRequestQueue.Entry testEntry3 = new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2SHMultisigAddress(networkParameters, 3), Coin.COIN);
+
+        List<BtcECKey> keys = BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"k1", "k2", "k3"}, true);
+        ReleaseRequestQueue.Entry testEntry2 = new ReleaseRequestQueue.Entry(
+            BitcoinTestUtils.createP2SHMultisigAddress(networkParameters, keys),
+            Coin.COIN
+        );
+        keys = BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"k4", "k5", "k6"}, true);
+        ReleaseRequestQueue.Entry testEntry3 = new ReleaseRequestQueue.Entry(
+            BitcoinTestUtils.createP2SHMultisigAddress(networkParameters, keys),
+            Coin.COIN
+        );
         List<ReleaseRequestQueue.Entry> pegoutRequests = Arrays.asList(testEntry1, testEntry2, testEntry3);
 
         List<UTXO> utxos = Arrays.asList(

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -44,6 +44,7 @@ import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -1,4 +1,4 @@
-package co.rsk.peg;
+package co.rsk.peg.bitcoin;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
There is currently a method in ErpFederationTest that builds an ERP federation and signs a transaction with it. This is useful for unit testing, but also useful to try creating new federations with different keys and spending from it. Also useful to test spending using the emergency keys since it simplifies the signing process.

The way the method is set up now is not very flexible, it has a few keys hardcoded and they need to be put manually in order for it work.

Move the method to a utils class, make it so that a federation can be created simply by passing the seed for the different keys and the public and private keys can be derived from them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
