### PR TITLE
Add error message in body of Unsupported Media Type response

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3FilterHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3FilterHandler.java
@@ -1,11 +1,14 @@
 package co.rsk.rpc.netty;
 
 import co.rsk.rpc.OriginValidator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.*;
+import io.netty.util.CharsetUtil;
 import org.ethereum.rpc.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,7 +117,9 @@ public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHt
 
             if (!"application/json".equals(mimeType) && !"application/json-rpc".equals(mimeType)) {
                 logger.debug("Unsupported content type");
-                response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE);
+                String errorMessage = "invalid content type, only application/json is supported";
+                ByteBuf errorContent = Unpooled.copiedBuffer(errorMessage, CharsetUtil.UTF_8);
+                response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE, errorContent);
             } else if (origin != null && !this.originValidator.isValidOrigin(origin)) {
                 logger.debug("Invalid origin");
                 response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added message content to the Unsupported Media Type error response in order to match GETH's reponse.

## Motivation and Context
Related slack [thread](https://iov-labs.slack.com/archives/C747J6HN3/p1688557455365629).

As of now, RSKj’s JSON-RPC interface allows only application/json Content-Type in requests. As other Evm compatible RPC endpoints do allow any content type, the idea of this ticket is to do same in RSKj.

At the moment RSKj returns this:

```
curl -i -X POST -H "Content-Type: applications/x-www-form-urlencoded" --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' http://localhost:4444

HTTP/1.1 415 Unsupported Media Type
```

Align how GETH is working in relation of other contentTypes different than application/json 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
