### PR TITLE
Improve error handling in JSON-RPC Interface

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3FilterHandler.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/netty/JsonRpcWeb3FilterHandler.java
@@ -126,7 +126,7 @@ public class JsonRpcWeb3FilterHandler extends SimpleChannelInboundHandler<FullHt
                 return;
             }
         } else {
-            response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_IMPLEMENTED);
+            response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.METHOD_NOT_ALLOWED);
         }
 
         ctx.write(response).addListener(ChannelFutureListener.CLOSE);

--- a/rskj-core/src/main/java/co/rsk/util/HexUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/HexUtils.java
@@ -282,7 +282,7 @@ public class HexUtils {
         for (int i = startAt; i < data.length(); i++) {
             char c = data.charAt(i);
 
-            if (!(c >= '0' && c <= '9' || c >= 'a' && c <= 'f')) {
+            if (!(c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F')) {
                 return false;
             }
         }

--- a/rskj-core/src/main/java/co/rsk/util/HexUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/HexUtils.java
@@ -282,7 +282,7 @@ public class HexUtils {
         for (int i = startAt; i < data.length(); i++) {
             char c = data.charAt(i);
 
-            if (!(c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F')) {
+            if (!(c >= '0' && c <= '9' || c >= 'a' && c <= 'f')) {
                 return false;
             }
         }

--- a/rskj-core/src/main/java/org/ethereum/core/genesis/BlockTag.java
+++ b/rskj-core/src/main/java/org/ethereum/core/genesis/BlockTag.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2023 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.core.genesis;
+
+import javax.annotation.Nullable;
+
+public enum BlockTag {
+    PENDING("pending"), LATEST("latest"), EARLIEST("earliest"), FINALIZED("finalized"), SAFE("safe");
+
+    private final String tag;
+
+    BlockTag(String tag) {
+        this.tag = tag;
+    }
+
+    @Nullable
+    public static BlockTag fromString(String text) {
+        for (BlockTag b : BlockTag.values()) {
+            if (b.tag.equalsIgnoreCase(text)) {
+                return b;
+            }
+        }
+        return null;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public boolean tagEquals(String tagName) {
+        return tag.contentEquals(tagName);
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/FilterManager.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/FilterManager.java
@@ -23,6 +23,7 @@ import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.listener.EthereumListenerAdapter;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.util.*;
@@ -71,6 +72,11 @@ public class FilterManager {
 
     public boolean removeFilter(int id) {
         synchronized (filterLock) {
+
+            Filter filter = installedFilters.get(id);
+            if (filter == null) {
+                throw new RskJsonRpcRequestException(-32000, "filter not found");
+            }
             return installedFilters.remove(id) != null;
         }
     }
@@ -82,7 +88,7 @@ public class FilterManager {
             Filter filter = installedFilters.get(id);
 
             if (filter == null) {
-                return null;
+                throw new RskJsonRpcRequestException(-32000, "filter not found");
             }
 
             if (newevents) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/FilterRequest.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/FilterRequest.java
@@ -19,6 +19,7 @@
 package org.ethereum.rpc;
 
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.validation.BlockHashValidator;
 import org.ethereum.rpc.validation.BnTagOrNumberValidator;
 import org.ethereum.rpc.validation.EthAddressValidator;
 
@@ -93,6 +94,9 @@ public class FilterRequest {
         }
         validateAddress();
         validateTopics();
+        if (blockHash != null) {
+            BlockHashValidator.isValid(blockHash);
+        }
         return true;
     }
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/FilterRequest.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/FilterRequest.java
@@ -103,7 +103,9 @@ public class FilterRequest {
     private boolean validateTopics() {
         if (topics != null) {
             for (Object topic : topics) {
-                if (topic instanceof String) {
+                if (topic == null) {
+                    continue;
+                } else if (topic instanceof String) {
                     new Topic((String) topic);
                 } else if (topic instanceof Collection) {
                     Collection<?> iterable = (Collection<?>) topic;

--- a/rskj-core/src/main/java/org/ethereum/rpc/LogFilter.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/LogFilter.java
@@ -243,7 +243,7 @@ public class LogFilter extends Filter {
         Keccak256 keccak256BlockHash = new Keccak256(HexUtils.stringHexToByteArray(blockHash));
         Block blockByHash = blockchain.getBlockByHash(keccak256BlockHash.getBytes());
         if (blockByHash == null) {
-            return;
+            throw RskJsonRpcRequestException.unknownBlock("unknown block");
         }
 
         processBlocks(blockByHash, blockByHash, filter, blockchain, blocksBloomStore);

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -76,9 +76,7 @@ import java.util.function.UnaryOperator;
 
 import static co.rsk.util.HexUtils.*;
 import static java.lang.Math.max;
-import static org.ethereum.rpc.exception.RskJsonRpcRequestException.blockNotFound;
-import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
-import static org.ethereum.rpc.exception.RskJsonRpcRequestException.unimplemented;
+import static org.ethereum.rpc.exception.RskJsonRpcRequestException.*;
 
 public class Web3Impl implements Web3 {
     private static final Logger logger = LoggerFactory.getLogger("web3");
@@ -870,6 +868,7 @@ public class Web3Impl implements Web3 {
 
     @Override
     public String eth_newFilter(FilterRequest fr) throws Exception {
+        fr.isValid();
         String str = null;
         try {
             Filter filter = LogFilter.fromFilterRequest(fr, blockchain, blocksBloomStore, config.getRpcEthGetLogsMaxBlockToQuery(),config.getRpcEthGetLogsMaxLogsToReturn());
@@ -916,10 +915,8 @@ public class Web3Impl implements Web3 {
 
     @Override
     public boolean eth_uninstallFilter(String id) {
+        HexValueValidator.isValid(id);
         Boolean s = null;
-
-        id = HexValueValidator.getValidHex(id);
-
         try {
             if (id == null) {
                 return false;
@@ -938,8 +935,7 @@ public class Web3Impl implements Web3 {
     @Override
     public Object[] eth_getFilterChanges(String id) {
         logger.debug("eth_getFilterChanges ...");
-
-        id = HexValueValidator.getValidHex(id);
+        HexValueValidator.isValid(id);
 
         // TODO(mc): this is a quick solution that seems to work with OpenZeppelin tests, but needs to be reviewed
         // We do the same as in Ganache: mine a block in each request to getFilterChanges so block filters work
@@ -964,8 +960,7 @@ public class Web3Impl implements Web3 {
     @Override
     public Object[] eth_getFilterLogs(String id) {
         logger.debug("eth_getFilterLogs ...");
-
-        id = HexValueValidator.getValidHex(id);
+        HexValueValidator.isValid(id);
 
         Object[] s = null;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -59,7 +59,7 @@ import org.ethereum.rpc.dto.BlockResultDTO;
 import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
-import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.validation.HexValueValidator;
 import org.ethereum.util.BuildInfo;
 import org.ethereum.vm.DataWord;
 import org.slf4j.Logger;
@@ -972,6 +972,7 @@ public class Web3Impl implements Web3 {
     @Override
     public Object[] eth_getFilterLogs(String id) {
         logger.debug("eth_getFilterLogs ...");
+        HexValueValidator.isValid(id);
 
 //        if (!id.matches("-?[0-9a-fA-F]+")) {
 //            throw new InvalidParameterException("Invalid id: not a hex number");
@@ -1002,6 +1003,7 @@ public class Web3Impl implements Web3 {
     @Override
     public Object[] eth_getLogs(FilterRequest fr) throws Exception {
         logger.debug("eth_getLogs ...");
+        fr.isValid();
         String id = eth_newFilter(fr);
         Object[] ret = eth_getFilterLogs(id);
         eth_uninstallFilter(id);

--- a/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/exception/RskJsonRpcRequestException.java
@@ -57,4 +57,8 @@ public class RskJsonRpcRequestException extends RuntimeException {
     public static RskJsonRpcRequestException stateNotFound(String message) {
         return new RskJsonRpcRequestException(-32600, message);
     }
+
+    public static RskJsonRpcRequestException unknownBlock(String message) {
+        return new RskJsonRpcRequestException(-32000, message);
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
@@ -21,8 +21,8 @@ package org.ethereum.rpc.validation;
 import co.rsk.util.HexUtils;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
-public class BlockHashValidator {
-    private static int BLOCK_HASH_BYTE_LENGTH = 32;
+public final class BlockHashValidator {
+    private static final int BLOCK_HASH_BYTE_LENGTH = 32;
     private BlockHashValidator() {
 
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
@@ -21,20 +21,21 @@ package org.ethereum.rpc.validation;
 import co.rsk.util.HexUtils;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
-public class HexTopicValidator {
-    private static final int TOPIC_BYTE_LENGTH = 32;
+public class BlockHashValidator {
+    private static int BLOCK_HASH_BYTE_LENGTH = 32;
+    private BlockHashValidator() { }
 
-    public static boolean isValid(String topic) {
-        byte[] topicBytes = null;
-        try {
-            topicBytes = HexUtils.stringHexToByteArray(topic);
+    public static boolean isValid(String blockHash) {
+        byte[] blockHashBytes = null;
+        try{
+            blockHashBytes = HexUtils.stringHexToByteArray(blockHash);
         } catch (Exception e) {
-            throw RskJsonRpcRequestException.invalidParamError("Invalid topic format. " + e.getMessage());
+            throw RskJsonRpcRequestException.invalidParamError("Invalid block hash format. " + e.getMessage());
         }
-        if (TOPIC_BYTE_LENGTH != topicBytes.length) {
-            throw RskJsonRpcRequestException.invalidParamError("Invalid topic: incorrect length.");
+        if(BLOCK_HASH_BYTE_LENGTH != blockHashBytes.length){
+            throw RskJsonRpcRequestException.invalidParamError("Invalid block hash: incorrect length.");
         }
+
         return true;
     }
-
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
@@ -27,7 +27,7 @@ public final class BlockHashValidator {
 
     }
 
-    public static boolean isValid(String blockHash) {
+    public static void isValid(String blockHash) {
         byte[] blockHashBytes;
 
         try {
@@ -40,6 +40,5 @@ public final class BlockHashValidator {
             throw RskJsonRpcRequestException.invalidParamError("Invalid block hash: incorrect length.");
         }
 
-        return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
@@ -23,16 +23,20 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
 public class BlockHashValidator {
     private static int BLOCK_HASH_BYTE_LENGTH = 32;
-    private BlockHashValidator() { }
+    private BlockHashValidator() {
+
+    }
 
     public static boolean isValid(String blockHash) {
-        byte[] blockHashBytes = null;
-        try{
+        byte[] blockHashBytes;
+
+        try {
             blockHashBytes = HexUtils.stringHexToByteArray(blockHash);
         } catch (Exception e) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid block hash format. " + e.getMessage());
         }
-        if(BLOCK_HASH_BYTE_LENGTH != blockHashBytes.length){
+
+        if (BLOCK_HASH_BYTE_LENGTH != blockHashBytes.length) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid block hash: incorrect length.");
         }
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BlockHashValidator.java
@@ -23,10 +23,18 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
 public final class BlockHashValidator {
     private static final int BLOCK_HASH_BYTE_LENGTH = 32;
+
     private BlockHashValidator() {
 
     }
 
+    /**
+     * Validates if the given block hash is a valid Hexadecimal string of 32 bytes length.
+     *
+     * @param blockHash The string representation of the block hash to be validated.
+     * @return Nothing.
+     * @throws RskJsonRpcRequestException If the block hash format is invalid or the length is incorrect.
+     */
     public static void isValid(String blockHash) {
         byte[] blockHashBytes;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -27,6 +27,15 @@ public final class BnTagOrNumberValidator {
 
     }
 
+    /**
+     * Validates if the given parameter is a valid block number or tag.
+     * The tags can be one of the following: "earliest", "finalized", "safe", "latest", "pending".
+     * If the parameter is not a tag, it checks if the parameter is a hexadecimal number with prefix.
+     *
+     * @param parameter The string representation of the block number or tag to be validated.
+     * @return Nothing.
+     * @throws RskJsonRpcRequestException If the parameter is null or it's neither a valid tag nor a hexadecimal number with prefix.
+     */
     public static void isValid(String parameter) {
         if (parameter == null) {
             throw RskJsonRpcRequestException.invalidParamError("Cannot process null parameter");

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -27,7 +27,7 @@ public final class BnTagOrNumberValidator {
 
     }
 
-    public static boolean isValid(String parameter) {
+    public static void isValid(String parameter) {
         if (parameter == null) {
             throw RskJsonRpcRequestException.invalidParamError("Cannot process null parameter");
         }
@@ -37,7 +37,5 @@ public final class BnTagOrNumberValidator {
         if (!StringUtils.equalsAny(parameter, "earliest", "finalized", "safe", "latest", "pending") && !HexUtils.isHexWithPrefix(parameter)) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid block number: " + parameter);
         }
-
-        return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -19,7 +19,6 @@
 package org.ethereum.rpc.validation;
 
 import co.rsk.util.HexUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.ethereum.core.genesis.BlockTag;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -24,10 +24,16 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
 public class BnTagOrNumberValidator {
     private BnTagOrNumberValidator() {
+
     }
 
     public static boolean isValid(String parameter) {
+        if (parameter == null) {
+            throw RskJsonRpcRequestException.invalidParamError("Cannot process null parameter");
+        }
+
         parameter = parameter.toLowerCase();
+
         if (StringUtils.equalsAny(parameter, "earliest", "finalized", "safe", "latest", "pending")) {
             return true;
         }
@@ -35,6 +41,7 @@ public class BnTagOrNumberValidator {
         if (HexUtils.isHexWithPrefix(parameter)) {
             return true;
         }
+
         throw RskJsonRpcRequestException.invalidParamError("Invalid block number: " + parameter);
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -22,7 +22,7 @@ import co.rsk.util.HexUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
-public class BnTagOrNumberValidator {
+public final class BnTagOrNumberValidator {
     private BnTagOrNumberValidator() {
 
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -34,14 +34,10 @@ public class BnTagOrNumberValidator {
 
         parameter = parameter.toLowerCase();
 
-        if (StringUtils.equalsAny(parameter, "earliest", "finalized", "safe", "latest", "pending")) {
-            return true;
+        if (!StringUtils.equalsAny(parameter, "earliest", "finalized", "safe", "latest", "pending") && !HexUtils.isHexWithPrefix(parameter)) {
+            throw RskJsonRpcRequestException.invalidParamError("Invalid block number: " + parameter);
         }
 
-        if (HexUtils.isHexWithPrefix(parameter)) {
-            return true;
-        }
-
-        throw RskJsonRpcRequestException.invalidParamError("Invalid block number: " + parameter);
+        return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -20,6 +20,7 @@ package org.ethereum.rpc.validation;
 
 import co.rsk.util.HexUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.ethereum.core.genesis.BlockTag;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
 public final class BnTagOrNumberValidator {
@@ -43,7 +44,7 @@ public final class BnTagOrNumberValidator {
 
         parameter = parameter.toLowerCase();
 
-        if (!StringUtils.equalsAny(parameter, "earliest", "finalized", "safe", "latest", "pending") && !HexUtils.isHexWithPrefix(parameter)) {
+        if (BlockTag.fromString(parameter) == null && !HexUtils.isHexWithPrefix(parameter)) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid block number: " + parameter);
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -1,0 +1,19 @@
+package org.ethereum.rpc.validation;
+
+import co.rsk.util.HexUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BnTagOrNumberValidator {
+    private static final String HEX_BN_OR_ID_REGEX = "^(?:0x[0-9a-fA-F]+$|earliest$|finalized$|safe$|latest$|pending$)";
+    private static final Pattern HEX_BN_OR_ID_PATTERN = Pattern.compile(HEX_BN_OR_ID_REGEX);
+    private BnTagOrNumberValidator() { }
+
+    public static boolean isValid(String parameter) {
+        Matcher matcher = HEX_BN_OR_ID_PATTERN.matcher(parameter);
+        HexUtils.isHex(parameter);
+        return matcher.matches();
+    }
+
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/BnTagOrNumberValidator.java
@@ -1,19 +1,40 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2023 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.ethereum.rpc.validation;
 
 import co.rsk.util.HexUtils;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
 public class BnTagOrNumberValidator {
-    private static final String HEX_BN_OR_ID_REGEX = "^(?:0x[0-9a-fA-F]+$|earliest$|finalized$|safe$|latest$|pending$)";
-    private static final Pattern HEX_BN_OR_ID_PATTERN = Pattern.compile(HEX_BN_OR_ID_REGEX);
-    private BnTagOrNumberValidator() { }
-
-    public static boolean isValid(String parameter) {
-        Matcher matcher = HEX_BN_OR_ID_PATTERN.matcher(parameter);
-        HexUtils.isHex(parameter);
-        return matcher.matches();
+    private BnTagOrNumberValidator() {
     }
 
+    public static boolean isValid(String parameter) {
+        parameter = parameter.toLowerCase();
+        if (StringUtils.equalsAny(parameter, "earliest", "finalized", "safe", "latest", "pending")) {
+            return true;
+        }
+
+        if (HexUtils.isHexWithPrefix(parameter)) {
+            return true;
+        }
+        throw RskJsonRpcRequestException.invalidParamError("Invalid block number: " + parameter);
+    }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
@@ -1,0 +1,20 @@
+package org.ethereum.rpc.validation;
+
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+
+import java.util.regex.Pattern;
+
+public class EthAddressValidator {
+    private static final String ETH_ADDRESS_PATTERN = "^0x[a-fA-F0-9]{40}$";
+    private static final Pattern PATTERN = Pattern.compile(ETH_ADDRESS_PATTERN, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+    private static final String MESSAGE = "Invalid address: ";
+
+    private EthAddressValidator() { }
+
+    public static boolean isValid(String parameter){
+        if (!PATTERN.matcher(parameter).matches()) {
+            throw RskJsonRpcRequestException.invalidParamError(MESSAGE + parameter);
+        }
+        return true;
+    }
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
@@ -21,7 +21,7 @@ package org.ethereum.rpc.validation;
 import co.rsk.util.HexUtils;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
-public class EthAddressValidator {
+public final class EthAddressValidator {
     private static final int ETH_ADDRESS_BYTE_LENGTH = 20;
     private EthAddressValidator() { }
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
@@ -27,14 +27,17 @@ public class EthAddressValidator {
 
     public static boolean isValid(String parameter){
         byte[] addressBytes = null;
+
         try {
             addressBytes = HexUtils.stringHexToByteArray(parameter);
-        }catch (Exception e){
+        } catch (Exception e) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid address format. " + e.getMessage());
         }
-        if(ETH_ADDRESS_BYTE_LENGTH != addressBytes.length ){
+
+        if (ETH_ADDRESS_BYTE_LENGTH != addressBytes.length ) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid address: incorrect length.");
         }
+
         return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
@@ -25,6 +25,13 @@ public final class EthAddressValidator {
     private static final int ETH_ADDRESS_BYTE_LENGTH = 20;
     private EthAddressValidator() { }
 
+    /**
+     * Validates if the given parameter is a valid RSK address.
+     *
+     * @param parameter The string representation of the RSK address to be validated.
+     * @return True if the address is valid, otherwise false.
+     * @throws RskJsonRpcRequestException If the address format is invalid or incorrect length.
+     */
     public static void isValid(String parameter){
         byte[] addressBytes = null;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
@@ -25,7 +25,7 @@ public final class EthAddressValidator {
     private static final int ETH_ADDRESS_BYTE_LENGTH = 20;
     private EthAddressValidator() { }
 
-    public static boolean isValid(String parameter){
+    public static void isValid(String parameter){
         byte[] addressBytes = null;
 
         try {
@@ -37,7 +37,5 @@ public final class EthAddressValidator {
         if (ETH_ADDRESS_BYTE_LENGTH != addressBytes.length ) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid address: incorrect length.");
         }
-
-        return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/EthAddressValidator.java
@@ -1,19 +1,39 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2023 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.ethereum.rpc.validation;
 
+import co.rsk.util.HexUtils;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
-import java.util.regex.Pattern;
-
 public class EthAddressValidator {
-    private static final String ETH_ADDRESS_PATTERN = "^0x[a-fA-F0-9]{40}$";
-    private static final Pattern PATTERN = Pattern.compile(ETH_ADDRESS_PATTERN, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
-    private static final String MESSAGE = "Invalid address: ";
-
+    private static final int ETH_ADDRESS_BYTE_LENGTH = 20;
     private EthAddressValidator() { }
 
     public static boolean isValid(String parameter){
-        if (!PATTERN.matcher(parameter).matches()) {
-            throw RskJsonRpcRequestException.invalidParamError(MESSAGE + parameter);
+        byte[] addressBytes = null;
+        try {
+            addressBytes = HexUtils.stringHexToByteArray(parameter);
+        }catch (Exception e){
+            throw RskJsonRpcRequestException.invalidParamError("Invalid address format. " + e.getMessage());
+        }
+        if(ETH_ADDRESS_BYTE_LENGTH != addressBytes.length ){
+            throw RskJsonRpcRequestException.invalidParamError("Invalid address: incorrect length.");
         }
         return true;
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
@@ -21,7 +21,7 @@ package org.ethereum.rpc.validation;
 import co.rsk.util.HexUtils;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
-public class HexTopicValidator {
+public final class HexTopicValidator {
     private static final int TOPIC_BYTE_LENGTH = 32;
 
     private HexTopicValidator() {

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
@@ -24,6 +24,10 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 public class HexTopicValidator {
     private static final int TOPIC_BYTE_LENGTH = 32;
 
+    private HexTopicValidator() {
+
+    }
+
     public static boolean isValid(String topic) {
         byte[] topicBytes = null;
         try {

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
@@ -1,0 +1,18 @@
+package org.ethereum.rpc.validation;
+
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+
+import java.util.regex.Pattern;
+
+public class HexTopicValidator {
+    private static final String HEX_TOPIC_REGEX = "^0x[a-fA-F0-9]{64}$";
+    private static final Pattern HEX_TOPIC_PATTERN = Pattern.compile(HEX_TOPIC_REGEX);
+
+    public static boolean isValid(String topic){
+        if(!HEX_TOPIC_PATTERN.matcher(topic).matches()){
+            throw RskJsonRpcRequestException.invalidParamError("Invalid topic: " + topic);
+        }
+        return true;
+    }
+
+}

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
@@ -28,6 +28,13 @@ public final class HexTopicValidator {
 
     }
 
+    /**
+     * Validates if the given topic is a valid Hexadecimal string of 32 bytes length.
+     *
+     * @param topic The string representation of the Hexadecimal topic to be validated.
+     * @return Nothing.
+     * @throws RskJsonRpcRequestException If the topic format is invalid or the length is incorrect.
+     */
     public static void isValid(String topic) {
         byte[] topicBytes = null;
         try {

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexTopicValidator.java
@@ -28,7 +28,7 @@ public final class HexTopicValidator {
 
     }
 
-    public static boolean isValid(String topic) {
+    public static void isValid(String topic) {
         byte[] topicBytes = null;
         try {
             topicBytes = HexUtils.stringHexToByteArray(topic);
@@ -38,7 +38,6 @@ public final class HexTopicValidator {
         if (TOPIC_BYTE_LENGTH != topicBytes.length) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid topic: incorrect length.");
         }
-        return true;
     }
 
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
@@ -21,7 +21,7 @@ package org.ethereum.rpc.validation;
 import co.rsk.util.HexUtils;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 
-public class HexValueValidator {
+public final class HexValueValidator {
     private HexValueValidator(){}
 
     public static boolean isValid(String input){

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
@@ -26,7 +26,7 @@ public final class HexValueValidator {
 
     public static void isValid(String input){
         if (!HexUtils.isHexWithPrefix(input)) {
-            throw RskJsonRpcRequestException.invalidParamError("Invalid argument: " + input + ": param should be a hex value string.");
+            throw RskJsonRpcRequestException.invalidParamError("Invalid argument: " + input + ": param should be a hexadecimal value string.");
         }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2023 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.ethereum.rpc.validation;
 
 import co.rsk.util.HexUtils;
@@ -6,20 +24,10 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 public class HexValueValidator {
     private HexValueValidator(){}
 
-    private static boolean isValid(String input){
-        if (!HexUtils.isHex(input) && !HexUtils.isHexWithPrefix(input)) {
+    public static boolean isValid(String input){
+        if (!HexUtils.isHexWithPrefix(input)) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid argument: " + input + ": param should be a hex value string.");
         }
         return true;
     }
-
-    public static String getValidHex(String input) {
-        isValid(input);
-
-        if (HexUtils.isHex(input) && !HexUtils.hasHexPrefix(input)) {
-             return "0x" + input;
-        }
-        return input;
-    }
-
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
@@ -6,11 +6,20 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 public class HexValueValidator {
     private HexValueValidator(){}
 
-    public static boolean isValid(String hexNumber){
-        if (HexUtils.isHex(hexNumber)) {
-            throw RskJsonRpcRequestException.invalidParamError("Invalid block number: " + hexNumber);
+    private static boolean isValid(String input){
+        if (!HexUtils.isHex(input) && !HexUtils.isHexWithPrefix(input)) {
+            throw RskJsonRpcRequestException.invalidParamError("Invalid argument: " + input + ": param should be a hex value string.");
         }
         return true;
+    }
+
+    public static String getValidHex(String input) {
+        isValid(input);
+
+        if (HexUtils.isHex(input) && !HexUtils.hasHexPrefix(input)) {
+             return "0x" + input;
+        }
+        return input;
     }
 
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
@@ -24,10 +24,9 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 public final class HexValueValidator {
     private HexValueValidator(){}
 
-    public static boolean isValid(String input){
+    public static void isValid(String input){
         if (!HexUtils.isHexWithPrefix(input)) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid argument: " + input + ": param should be a hex value string.");
         }
-        return true;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
@@ -24,6 +24,13 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 public final class HexValueValidator {
     private HexValueValidator(){}
 
+    /**
+     * Validates if the given input is a valid hexadecimal value string with a prefix.
+     *
+     * @param input The string representation of the hexadecimal value to be validated.
+     * @return Nothing.
+     * @throws RskJsonRpcRequestException If the input is not a valid hexadecimal value string with a prefix.
+     */
     public static void isValid(String input){
         if (!HexUtils.isHexWithPrefix(input)) {
             throw RskJsonRpcRequestException.invalidParamError("Invalid argument: " + input + ": param should be a hexadecimal value string.");

--- a/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/validation/HexValueValidator.java
@@ -1,0 +1,16 @@
+package org.ethereum.rpc.validation;
+
+import co.rsk.util.HexUtils;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+
+public class HexValueValidator {
+    private HexValueValidator(){}
+
+    public static boolean isValid(String hexNumber){
+        if (HexUtils.isHex(hexNumber)) {
+            throw RskJsonRpcRequestException.invalidParamError("Invalid block number: " + hexNumber);
+        }
+        return true;
+    }
+
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
@@ -1,10 +1,28 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2023 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.ethereum.rpc;
 
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.validation.BnTagOrNumberValidator;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class BnTagOrNumberValidatorTest {
 
@@ -22,10 +40,18 @@ class BnTagOrNumberValidatorTest {
 
     @Test
     void testInvalidParameters() {
-        assertFalse(BnTagOrNumberValidator.isValid("0x"));
-        assertFalse(BnTagOrNumberValidator.isValid("0x12j"));
-        assertFalse(BnTagOrNumberValidator.isValid("0xGHI"));
-        assertFalse(BnTagOrNumberValidator.isValid("invalid"));
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            BnTagOrNumberValidator.isValid("0x");
+        });
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            BnTagOrNumberValidator.isValid("0x12j");
+        });
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            BnTagOrNumberValidator.isValid("0xGHI");
+        });
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            BnTagOrNumberValidator.isValid("invalid");
+        });
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
@@ -27,13 +27,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class BnTagOrNumberValidatorTest {
     @Test
     void testValidHexBlockNumberOrId() {
-        assertTrue(BnTagOrNumberValidator.isValid("0x123"));
-        assertTrue(BnTagOrNumberValidator.isValid("0x0123"));
-        assertTrue(BnTagOrNumberValidator.isValid("earliest"));
-        assertTrue(BnTagOrNumberValidator.isValid("finalized"));
-        assertTrue(BnTagOrNumberValidator.isValid("safe"));
-        assertTrue(BnTagOrNumberValidator.isValid("latest"));
-        assertTrue(BnTagOrNumberValidator.isValid("pending"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("0x123"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("0x0123"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("earliest"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("finalized"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("safe"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("latest"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("pending"));
     }
 
     @Test
@@ -54,20 +54,20 @@ class BnTagOrNumberValidatorTest {
 
     @Test
     void testValidBlockTagPascalCase() {
-        assertTrue(BnTagOrNumberValidator.isValid("Earliest"));
-        assertTrue(BnTagOrNumberValidator.isValid("Finalized"));
-        assertTrue(BnTagOrNumberValidator.isValid("Safe"));
-        assertTrue(BnTagOrNumberValidator.isValid("Latest"));
-        assertTrue(BnTagOrNumberValidator.isValid("Pending"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("Earliest"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("Finalized"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("Safe"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("Latest"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("Pending"));
     }
 
     @Test
     void testValidBlockTagUppercase() {
-        assertTrue(BnTagOrNumberValidator.isValid("EARLIEST"));
-        assertTrue(BnTagOrNumberValidator.isValid("FINALIZED"));
-        assertTrue(BnTagOrNumberValidator.isValid("SAFE"));
-        assertTrue(BnTagOrNumberValidator.isValid("LATEST"));
-        assertTrue(BnTagOrNumberValidator.isValid("PENDING"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("EARLIEST"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("FINALIZED"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("SAFE"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("LATEST"));
+        assertDoesNotThrow(() -> BnTagOrNumberValidator.isValid("PENDING"));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
@@ -1,0 +1,31 @@
+package org.ethereum.rpc;
+
+import org.ethereum.rpc.validation.BnTagOrNumberValidator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BnTagOrNumberValidatorTest {
+
+
+    @Test
+    void testValidHexBlockNumberOrId() {
+        assertTrue(BnTagOrNumberValidator.isValid("0x123"));
+        assertTrue(BnTagOrNumberValidator.isValid("0x0123"));
+        assertTrue(BnTagOrNumberValidator.isValid("earliest"));
+        assertTrue(BnTagOrNumberValidator.isValid("finalized"));
+        assertTrue(BnTagOrNumberValidator.isValid("safe"));
+        assertTrue(BnTagOrNumberValidator.isValid("latest"));
+        assertTrue(BnTagOrNumberValidator.isValid("pending"));
+    }
+
+    @Test
+    void testInvalidParameters() {
+        assertFalse(BnTagOrNumberValidator.isValid("0x"));
+        assertFalse(BnTagOrNumberValidator.isValid("0x12j"));
+        assertFalse(BnTagOrNumberValidator.isValid("0xGHI"));
+        assertFalse(BnTagOrNumberValidator.isValid("invalid"));
+    }
+
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class BnTagOrNumberValidatorTest {
-
-
     @Test
     void testValidHexBlockNumberOrId() {
         assertTrue(BnTagOrNumberValidator.isValid("0x123"));
@@ -52,6 +50,39 @@ class BnTagOrNumberValidatorTest {
         assertThrows(RskJsonRpcRequestException.class, () -> {
             BnTagOrNumberValidator.isValid("invalid");
         });
+    }
+
+    @Test
+    void testValidBlockTagPascalCase() {
+        assertTrue(BnTagOrNumberValidator.isValid("Earliest"));
+        assertTrue(BnTagOrNumberValidator.isValid("Finalized"));
+        assertTrue(BnTagOrNumberValidator.isValid("Safe"));
+        assertTrue(BnTagOrNumberValidator.isValid("Latest"));
+        assertTrue(BnTagOrNumberValidator.isValid("Pending"));
+    }
+
+    @Test
+    void testValidBlockTagUppercase() {
+        assertTrue(BnTagOrNumberValidator.isValid("EARLIEST"));
+        assertTrue(BnTagOrNumberValidator.isValid("FINALIZED"));
+        assertTrue(BnTagOrNumberValidator.isValid("SAFE"));
+        assertTrue(BnTagOrNumberValidator.isValid("LATEST"));
+        assertTrue(BnTagOrNumberValidator.isValid("PENDING"));
+    }
+
+    @Test
+    void testWhitespaceString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> BnTagOrNumberValidator.isValid(" "));
+    }
+
+    @Test
+    void testEmptyString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> BnTagOrNumberValidator.isValid(""));
+    }
+
+    @Test
+    void testNullString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> BnTagOrNumberValidator.isValid(null));
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/BnTagOrNumberValidatorTest.java
@@ -22,6 +22,7 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.validation.BnTagOrNumberValidator;
 import org.junit.jupiter.api.Test;
 
+import static org.ethereum.TestUtils.assertThrows;
 import static org.junit.jupiter.api.Assertions.*;
 
 class BnTagOrNumberValidatorTest {
@@ -85,4 +86,9 @@ class BnTagOrNumberValidatorTest {
         assertThrows(RskJsonRpcRequestException.class, () -> BnTagOrNumberValidator.isValid(null));
     }
 
+    @Test
+    void testValidErrorCodeOnException() {
+        RskJsonRpcRequestException exception = assertThrows(RskJsonRpcRequestException.class, () -> BnTagOrNumberValidator.isValid("123456"));
+        assertEquals(-32602, exception.getCode());
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -903,10 +903,7 @@ class Web3ImplLogsTest {
         FilterRequest fr = new FilterRequest();
         fr.setBlockHash(blockHash);
 
-        Object[] logs = web3.eth_getLogs(fr);
-
-        assertNotNull(logs);
-        assertEquals(0, logs.length);
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> web3.eth_getLogs(fr));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -1,34 +1,22 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2023 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.ethereum.rpc;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.ethereum.TestUtils;
-import org.ethereum.core.*;
-import org.ethereum.db.BlockStore;
-import org.ethereum.db.ReceiptStore;
-import org.ethereum.facade.Ethereum;
-import org.ethereum.net.client.ConfigCapabilities;
-import org.ethereum.net.server.ChannelManager;
-import org.ethereum.net.server.PeerServer;
-import org.ethereum.rpc.exception.RskJsonRpcRequestException;
-import org.ethereum.util.BuildInfo;
-import org.ethereum.vm.DataWord;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
@@ -49,6 +37,28 @@ import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.PeerScoringManager;
 import co.rsk.util.HexUtils;
+import org.ethereum.TestUtils;
+import org.ethereum.core.*;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.net.client.ConfigCapabilities;
+import org.ethereum.net.server.ChannelManager;
+import org.ethereum.net.server.PeerServer;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.util.BuildInfo;
+import org.ethereum.vm.DataWord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 class Web3ImplUnitTest {
 
@@ -335,5 +345,19 @@ class Web3ImplUnitTest {
         String result = target.eth_getUncleCountByBlockNumber(identifier);
 
         assertEquals("0x2", result);
+    }
+
+    @Test
+    void eth_uninstallFilter_with_noHexId() {
+        String id = "id";
+        RskJsonRpcRequestException exception = assertThrows(RskJsonRpcRequestException.class, () -> target.eth_uninstallFilter(id));
+        assertEquals(-32602,  exception.getCode());
+    }
+
+    @Test
+    void eth_uninstallFilter_with_WrongHexId() {
+        String id = "0x123j";
+        RskJsonRpcRequestException exception = assertThrows(RskJsonRpcRequestException.class, () -> target.eth_uninstallFilter(id));
+        assertEquals(-32602,  exception.getCode());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/BlockHashValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/BlockHashValidatorTest.java
@@ -23,8 +23,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.ethereum.TestUtils.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class BlockHashValidatorTest {
     @Test
@@ -81,5 +80,11 @@ class BlockHashValidatorTest {
     @Test
     void testNullString() {
         assertThrows(RskJsonRpcRequestException.class, () -> BlockHashValidator.isValid(null));
+    }
+
+    @Test
+    void testValidErrorCodeOnException() {
+        RskJsonRpcRequestException exception = assertThrows(RskJsonRpcRequestException.class, () -> BlockHashValidator.isValid("123456"));
+        assertEquals(-32602, exception.getCode());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/BlockHashValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/BlockHashValidatorTest.java
@@ -22,41 +22,38 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class HexTopicValidatorTest {
+class BlockHashValidatorTest {
     @Test
-    void testValidHexTopicWithPrefix() {
-        String validHexTopic = "0x1ABF1234567890ABCdEF01234167890ABCDeF01234567890ABCDEF0123456789";
-        Assertions.assertTrue(HexTopicValidator.isValid(validHexTopic));
-    }
-
-    @Test
-    void testValidHexTopicWithoutPrefix() {
-        String validHexTopic = "1ABF1234567890ABCDEF01234567890ABCDEF01234567890ABCDEF0123456789";
-        boolean result = HexTopicValidator.isValid(validHexTopic);
+    void testValidBlockHash() {
+        boolean result = BlockHashValidator.isValid("0xae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909");
         Assertions.assertTrue(result);
     }
 
     @Test
-    void testInvalidHexTopicTooShort() {
-        String invalidHexTopic = "0x12345";
+    void testValidBlockHashWithoutOx() {
+        boolean result = BlockHashValidator.isValid("ae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909");
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    void testInvalidBlockHashFormat() {
         Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
-            HexTopicValidator.isValid(invalidHexTopic);
+            BlockHashValidator.isValid("0zae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909");
         });
     }
 
     @Test
-    void testInvalidHexTopicTooLong() {
-        String invalidHexTopic = "0x1ABF1234567890ABCDEF01234567890ABCDEF01234567890ABCDEF0123456789FF";
+    void testInvalidLargerBlockHashLength() {
         Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
-            HexTopicValidator.isValid(invalidHexTopic);
+            BlockHashValidator.isValid("1234567890abcdef1234567890abcqasdfasdfdef1234567890abcdef1234567890abcde");
         });
     }
 
     @Test
-    void testInvalidHexTopicWithInvalidCharacters() {
-        String invalidHexTopic = "0x1ABF1234567890ABCDEF01234567890ABGDEF01234567890ABCDEF0123456789";
+    void testInvalidShorterBlockHashLength() {
         Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
-            HexTopicValidator.isValid(invalidHexTopic);
+            BlockHashValidator.isValid("1234567890abcdef1234564567890abcdef1234567890abcde");
         });
     }
+
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/BlockHashValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/BlockHashValidatorTest.java
@@ -22,38 +22,66 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.ethereum.TestUtils.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class BlockHashValidatorTest {
     @Test
     void testValidBlockHash() {
         boolean result = BlockHashValidator.isValid("0xae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909");
-        Assertions.assertTrue(result);
+        assertTrue(result);
     }
 
     @Test
     void testValidBlockHashWithoutOx() {
         boolean result = BlockHashValidator.isValid("ae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909");
-        Assertions.assertTrue(result);
+        assertTrue(result);
     }
 
     @Test
     void testInvalidBlockHashFormat() {
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
+        assertThrows(RskJsonRpcRequestException.class, () -> {
             BlockHashValidator.isValid("0zae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909");
         });
     }
 
     @Test
     void testInvalidLargerBlockHashLength() {
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
+        assertThrows(RskJsonRpcRequestException.class, () -> {
             BlockHashValidator.isValid("1234567890abcdef1234567890abcqasdfasdfdef1234567890abcdef1234567890abcde");
         });
     }
 
     @Test
     void testInvalidShorterBlockHashLength() {
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
+        assertThrows(RskJsonRpcRequestException.class, () -> {
             BlockHashValidator.isValid("1234567890abcdef1234564567890abcdef1234567890abcde");
         });
+    }
+
+    @Test
+    void testValidBlockHashMixedCase() {
+        assertTrue(BlockHashValidator.isValid("0xAe3Bd321D09D559C148A2Eb85A1B395383D176368Fac8Fdf2A3BabF346461909"));
+    }
+
+    @Test
+    void testValidBlockHashUppercase() {
+        assertTrue(BlockHashValidator.isValid("0xAE3BD321D09D559C148A2EB85A1B395383D176368FAC8FDF2A3BABF346461909"));
+    }
+
+    @Test
+    void testWhitespaceString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> BlockHashValidator.isValid(" "));
+    }
+
+    @Test
+    void testEmptyString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> BlockHashValidator.isValid(""));
+    }
+
+    @Test
+    void testNullString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> BlockHashValidator.isValid(null));
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/BlockHashValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/BlockHashValidatorTest.java
@@ -23,19 +23,18 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.ethereum.TestUtils.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BlockHashValidatorTest {
     @Test
     void testValidBlockHash() {
-        boolean result = BlockHashValidator.isValid("0xae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909");
-        assertTrue(result);
+        assertDoesNotThrow(() -> BlockHashValidator.isValid("0xae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909"));
     }
 
     @Test
     void testValidBlockHashWithoutOx() {
-        boolean result = BlockHashValidator.isValid("ae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909");
-        assertTrue(result);
+        assertDoesNotThrow(() -> BlockHashValidator.isValid("ae3bd321d09d559c148a2eb85a1b395383d176368fac8fdf2a3babf346461909"));
     }
 
     @Test
@@ -61,12 +60,12 @@ class BlockHashValidatorTest {
 
     @Test
     void testValidBlockHashMixedCase() {
-        assertTrue(BlockHashValidator.isValid("0xAe3Bd321D09D559C148A2Eb85A1B395383D176368Fac8Fdf2A3BabF346461909"));
+        assertDoesNotThrow(() -> BlockHashValidator.isValid("0xAe3Bd321D09D559C148A2Eb85A1B395383D176368Fac8Fdf2A3BabF346461909"));
     }
 
     @Test
     void testValidBlockHashUppercase() {
-        assertTrue(BlockHashValidator.isValid("0xAE3BD321D09D559C148A2EB85A1B395383D176368FAC8FDF2A3BABF346461909"));
+        assertDoesNotThrow(() -> BlockHashValidator.isValid("0xAE3BD321D09D559C148A2EB85A1B395383D176368FAC8FDF2A3BABF346461909"));
     }
 
     @Test
@@ -83,5 +82,4 @@ class BlockHashValidatorTest {
     void testNullString() {
         assertThrows(RskJsonRpcRequestException.class, () -> BlockHashValidator.isValid(null));
     }
-
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
@@ -1,0 +1,39 @@
+package org.ethereum.rpc.validation;
+
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EthAddressValidatorTest {
+    @Test
+    void testValidAddress() {
+        assertTrue(EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693c"));
+
+    }
+
+    @Test
+    void testInvalidAddress() {
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            EthAddressValidator.isValid("0x12345");
+        });
+
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693");
+        });
+
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            EthAddressValidator.isValid("0x02382771475f8c232ed8856049dc6dd42a693c");
+        });
+
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            EthAddressValidator.isValid("0x0y3827714750bf8c232ed8856049dc6dd42a693c");
+        });
+
+        assertThrows(RskJsonRpcRequestException.class, () -> {
+            EthAddressValidator.isValid("013827714750bf8c232ed8856049dc6dd42a693c");
+        });
+    }
+
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
@@ -21,14 +21,13 @@ package org.ethereum.rpc.validation;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class EthAddressValidatorTest {
     @Test
     void testValidAddress() {
-        assertTrue(EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693c"));
-        assertTrue(EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693"));
+        assertDoesNotThrow(() -> EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693c"));
+        assertDoesNotThrow(() -> EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693"));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2023 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.ethereum.rpc.validation;
 
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
@@ -10,7 +28,7 @@ class EthAddressValidatorTest {
     @Test
     void testValidAddress() {
         assertTrue(EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693c"));
-
+        assertTrue(EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693"));
     }
 
     @Test
@@ -20,19 +38,10 @@ class EthAddressValidatorTest {
         });
 
         assertThrows(RskJsonRpcRequestException.class, () -> {
-            EthAddressValidator.isValid("0x023827714750bf8c232ed8856049dc6dd42a693");
+            EthAddressValidator.isValid("0x02382771475f2ed8856049dc6dd42a693c");
         });
-
-        assertThrows(RskJsonRpcRequestException.class, () -> {
-            EthAddressValidator.isValid("0x02382771475f8c232ed8856049dc6dd42a693c");
-        });
-
         assertThrows(RskJsonRpcRequestException.class, () -> {
             EthAddressValidator.isValid("0x0y3827714750bf8c232ed8856049dc6dd42a693c");
-        });
-
-        assertThrows(RskJsonRpcRequestException.class, () -> {
-            EthAddressValidator.isValid("013827714750bf8c232ed8856049dc6dd42a693c");
         });
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
@@ -45,4 +45,28 @@ class EthAddressValidatorTest {
         });
     }
 
+    @Test
+    void testValidAddressWithoutPrefix() {
+        assertThrows(RskJsonRpcRequestException.class, () -> EthAddressValidator.isValid("123456"));
+    }
+
+    @Test
+    void testInvalidAddressWithPrefix() {
+        assertThrows(RskJsonRpcRequestException.class, () -> EthAddressValidator.isValid("0x1234g6"));
+    }
+
+    @Test
+    void testWhitespaceString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> EthAddressValidator.isValid(" "));
+    }
+
+    @Test
+    void testEmptyString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> EthAddressValidator.isValid(""));
+    }
+
+    @Test
+    void testNullString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> EthAddressValidator.isValid(null));
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/EthAddressValidatorTest.java
@@ -21,6 +21,7 @@ package org.ethereum.rpc.validation;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.jupiter.api.Test;
 
+import static org.ethereum.TestUtils.assertThrows;
 import static org.junit.jupiter.api.Assertions.*;
 
 class EthAddressValidatorTest {
@@ -67,5 +68,11 @@ class EthAddressValidatorTest {
     @Test
     void testNullString() {
         assertThrows(RskJsonRpcRequestException.class, () -> EthAddressValidator.isValid(null));
+    }
+
+    @Test
+    void testValidErrorCodeOnException() {
+        RskJsonRpcRequestException exception = assertThrows(RskJsonRpcRequestException.class, () -> EthAddressValidator.isValid("123456"));
+        assertEquals(-32602, exception.getCode());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexTopicValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexTopicValidatorTest.java
@@ -22,6 +22,8 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.ethereum.TestUtils.assertThrows;
+
 class HexTopicValidatorTest {
     @Test
     void testValidHexTopicWithPrefix() {
@@ -58,5 +60,30 @@ class HexTopicValidatorTest {
         Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
             HexTopicValidator.isValid(invalidHexTopic);
         });
+    }
+
+    @Test
+    void testNullString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexTopicValidator.isValid(null));
+    }
+
+    @Test
+    void testEmptyString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexTopicValidator.isValid(""));
+    }
+
+    @Test
+    void testWhitespaceString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexTopicValidator.isValid(" "));
+    }
+
+    @Test
+    void testInvalidHexadecimalWithPrefix() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexTopicValidator.isValid("0x1234g6"));
+    }
+
+    @Test
+    void testValidHexadecimalWithoutPrefix() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexTopicValidator.isValid("123456"));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexTopicValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexTopicValidatorTest.java
@@ -1,0 +1,44 @@
+package org.ethereum.rpc.validation;
+
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HexTopicValidatorTest {
+    @Test
+    void testValidHexTopicWithPrefix() {
+        String validHexTopic = "0x1ABF1234567890ABCdEF01234167890ABCDeF01234567890ABCDEF0123456789";
+        Assertions.assertTrue(HexTopicValidator.isValid(validHexTopic));
+    }
+
+    @Test
+    void testValidHexTopicWithoutPrefix() {
+        String validHexTopic = "1ABF1234567890ABCDEF01234567890ABCDEF01234567890ABCDEF0123456789";
+        boolean result = HexTopicValidator.isValid(validHexTopic);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    void testInvalidHexTopicTooShort() {
+        String invalidHexTopic = "0x12345";
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
+            HexTopicValidator.isValid(invalidHexTopic);
+        });
+    }
+
+    @Test
+    void testInvalidHexTopicTooLong() {
+        String invalidHexTopic = "0x1ABF1234567890ABCDEF01234567890ABCDEF01234567890ABCDEF0123456789FF";
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
+            HexTopicValidator.isValid(invalidHexTopic);
+        });
+    }
+
+    @Test
+    void testInvalidHexTopicWithInvalidCharacters() {
+        String invalidHexTopic = "0x1ABF1234567890ABCDEF01234567890ABGDEF01234567890ABCDEF0123456789";
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> {
+            HexTopicValidator.isValid(invalidHexTopic);
+        });
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexTopicValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexTopicValidatorTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.ethereum.TestUtils.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class HexTopicValidatorTest {
     @Test
@@ -86,4 +87,11 @@ class HexTopicValidatorTest {
     void testValidHexadecimalWithoutPrefix() {
         assertThrows(RskJsonRpcRequestException.class, () -> HexTopicValidator.isValid("123456"));
     }
+
+    @Test
+    void testValidErrorCodeOnException() {
+        RskJsonRpcRequestException exception = assertThrows(RskJsonRpcRequestException.class, () -> HexTopicValidator.isValid("123456"));
+        assertEquals(-32602, exception.getCode());
+    }
+
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexTopicValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexTopicValidatorTest.java
@@ -23,19 +23,19 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.ethereum.TestUtils.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class HexTopicValidatorTest {
     @Test
     void testValidHexTopicWithPrefix() {
         String validHexTopic = "0x1ABF1234567890ABCdEF01234167890ABCDeF01234567890ABCDEF0123456789";
-        Assertions.assertTrue(HexTopicValidator.isValid(validHexTopic));
+        assertDoesNotThrow(() -> HexTopicValidator.isValid(validHexTopic));
     }
 
     @Test
     void testValidHexTopicWithoutPrefix() {
         String validHexTopic = "1ABF1234567890ABCDEF01234567890ABCDEF01234567890ABCDEF0123456789";
-        boolean result = HexTopicValidator.isValid(validHexTopic);
-        Assertions.assertTrue(result);
+        assertDoesNotThrow(() -> HexTopicValidator.isValid(validHexTopic));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
@@ -1,0 +1,30 @@
+package org.ethereum.rpc.validation;
+
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HexValueValidatorTest {
+
+    @Test
+    void testValidHexadecimals() {
+        assertTrue(HexValueValidator.isValid("0x0"));
+        assertTrue(HexValueValidator.isValid("0x123"));
+        assertTrue(HexValueValidator.isValid("0xabcdef"));
+        assertTrue(HexValueValidator.isValid("0x0000000000000000000000000000000001000008"));
+        assertTrue(HexValueValidator.isValid("0xABCDEF")); // Uppercase are not allowed in Ethereum
+        assertTrue(HexValueValidator.isValid("0x0123456789")); //Numbers staring by 0x0 is not allowed in Ethereum
+    }
+
+    @Test
+    void testInvalidHexadecimals() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("0x"));
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("0xGHIJKLMNOPQRSTUVWXYZ"));
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("123456"));
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("abcdef"));
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("invalid"));
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("0x1234g6"));
+    }
+
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
@@ -45,4 +45,28 @@ class HexValueValidatorTest {
         assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("0x1234g6"));
     }
 
+    @Test
+    void testValidHexadecimalWithoutPrefix() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("123456"));
+    }
+
+    @Test
+    void testInvalidHexadecimalWithPrefix() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("0x1234g6"));
+    }
+
+    @Test
+    void testWhitespaceString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid(" "));
+    }
+
+    @Test
+    void testEmptyString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid(""));
+    }
+
+    @Test
+    void testNullString() {
+        assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid(null));
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
@@ -21,6 +21,7 @@ package org.ethereum.rpc.validation;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.junit.jupiter.api.Test;
 
+import static org.ethereum.TestUtils.assertThrows;
 import static org.junit.jupiter.api.Assertions.*;
 
 class HexValueValidatorTest {
@@ -68,5 +69,11 @@ class HexValueValidatorTest {
     @Test
     void testNullString() {
         assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid(null));
+    }
+
+    @Test
+    void testValidErrorCodeOnException() {
+        RskJsonRpcRequestException exception = assertThrows(RskJsonRpcRequestException.class, () -> HexValueValidator.isValid("123456"));
+        assertEquals(-32602, exception.getCode());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2023 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.ethereum.rpc.validation;
 
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;

--- a/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/validation/HexValueValidatorTest.java
@@ -27,12 +27,12 @@ class HexValueValidatorTest {
 
     @Test
     void testValidHexadecimals() {
-        assertTrue(HexValueValidator.isValid("0x0"));
-        assertTrue(HexValueValidator.isValid("0x123"));
-        assertTrue(HexValueValidator.isValid("0xabcdef"));
-        assertTrue(HexValueValidator.isValid("0x0000000000000000000000000000000001000008"));
-        assertTrue(HexValueValidator.isValid("0xABCDEF")); // Uppercase are not allowed in Ethereum
-        assertTrue(HexValueValidator.isValid("0x0123456789")); //Numbers staring by 0x0 is not allowed in Ethereum
+        assertDoesNotThrow(() -> HexValueValidator.isValid("0x0"));
+        assertDoesNotThrow(() -> HexValueValidator.isValid("0x123"));
+        assertDoesNotThrow(() -> HexValueValidator.isValid("0xabcdef"));
+        assertDoesNotThrow(() -> HexValueValidator.isValid("0x0000000000000000000000000000000001000008"));
+        assertDoesNotThrow(() -> HexValueValidator.isValid("0xABCDEF")); // Uppercase are not allowed in Ethereum
+        assertDoesNotThrow(() -> HexValueValidator.isValid("0x0123456789")); //Numbers staring by 0x0 is not allowed in Ethereum
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improve Error Handling in JSON-RPC Interface - Part 1

## Description
<!--- Describe your changes in detail -->
This PR focuses on aligning the RSKj node behaviour with the Eth Spec (geth) for JSON-RPC requests. Specifically, it improves the error handling for `eth_newFilter`, `eth_getFilterChanges`, `eth_getFilterLogs`, `eth_uninstallFilter`, and `eth_getLogs`. Prior to this, the error handling for these methods was not aligned with GETH, leading to discrepancies in the responses for failed RPC requests.

The changes primarily involve proper handling of input validation. This results in an error object being returned (`RskJsonRpcRequestException`), rather than a successful result with a null value or an internal server error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These changes are necessary to provide clear and consistent error handling in line with GETH. This will enhance the user experience and bring better compatibility between GETH and RSKJ.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Changes were tested by sending RPC requests with different invalid inputs and ensuring that the responses align with GETH. 

In addition to these manual tests, we added unit tests to ensure everything was working as intended. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
