### PR TITLE
Ignore replaced transaction on total pending tx cost calculation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -272,7 +272,7 @@ public class TransactionPoolImpl implements TransactionPool {
 
         if (!senderCanPayPendingTransactionsAndNewTx(tx, currentRepository)) {
             // discard this tx to prevent spam
-            return TransactionPoolAddResult.withError("insufficient funds to pay for pending and new transaction");
+            return TransactionPoolAddResult.withError("insufficient funds to pay for pending and new transactions");
         }
 
         pendingTransactions.addTransaction(tx);
@@ -469,7 +469,11 @@ public class TransactionPoolImpl implements TransactionPool {
 
         Coin accumTxCost = Coin.ZERO;
         for (Transaction t : transactions) {
-            accumTxCost = accumTxCost.add(getTxBaseCost(t));
+            boolean isReplacedTx = Arrays.equals(t.getNonce(), newTx.getNonce());
+            // do not consider replaced transaction for the calculations
+            if (!isReplacedTx) {
+                accumTxCost = accumTxCost.add(getTxBaseCost(t));
+            }
         }
 
         Coin costWithNewTx = accumTxCost.add(getTxBaseCost(newTx));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Do not consider replaced transaction for pending transactions cost calculation.

## Description
<!--- Describe your changes in detail -->

On the transaction pool, when a pending transaction is replaced by another one (with a gasPrice bump), the original (replaced) transaction should not count for the total pending transactions costs calculation, as it is being replaced, and just the new one (replacement) should.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
