### PR TITLE
Implement json param validation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -26,6 +26,11 @@ import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
 import org.ethereum.rpc.parameters.BlockHashParam;
 import org.ethereum.rpc.parameters.FilterRequestParam;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.BlockRefParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexAddressParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.rpc.parameters.HexIndexParam;
 import org.ethereum.rpc.parameters.TxHashParam;
 
@@ -37,15 +42,15 @@ public interface Web3EthModule {
         return getEthModule().accounts();
     }
 
-    default String eth_sign(String addr, String data) {
+    default String eth_sign(HexAddressParam addr, HexDataParam data) {
         return getEthModule().sign(addr, data);
     }
 
-    default String eth_call(CallArguments args, String bnOrId) {
+    default String eth_call(CallArgumentsParam args, BlockIdentifierParam bnOrId) {
         return getEthModule().call(args, bnOrId);
     }
 
-    default String eth_estimateGas(CallArguments args) {
+    default String eth_estimateGas(CallArgumentsParam args) {
         return getEthModule().estimateGas(args);
     }
 
@@ -75,19 +80,15 @@ public interface Web3EthModule {
 
     String eth_call(CallArguments args, Map<String, String> blockRef) throws Exception; // NOSONAR
 
-    String eth_getBalance(String address, String block) throws Exception;
+    String eth_getBalance(HexAddressParam address, BlockRefParam blockRefParam) throws Exception;
 
-    String eth_getBalance(String address) throws Exception;
-
-    String eth_getBalance(String address, Map<String, String> blockRef) throws Exception; // NOSONAR
+    String eth_getBalance(HexAddressParam address) throws Exception;
 
     String eth_getStorageAt(String address, String storageIdx, Map<String, String> blockRef) throws Exception; // NOSONAR
 
     String eth_getStorageAt(String address, String storageIdx, String blockId) throws Exception;
 
-    String eth_getTransactionCount(String address, Map<String, String> blockRef) throws Exception; // NOSONAR
-
-    String eth_getTransactionCount(String address, String blockId) throws Exception ;
+    String eth_getTransactionCount(HexAddressParam address, BlockRefParam blockRefParam) throws Exception;
 
     String eth_getBlockTransactionCountByHash(BlockHashParam blockHash)throws Exception;
 
@@ -103,11 +104,11 @@ public interface Web3EthModule {
 
     String eth_getCode(String address, Map<String, String> blockRef) throws Exception; // NOSONAR
 
-    default String eth_sendRawTransaction(String rawData) {
+    default String eth_sendRawTransaction(HexDataParam rawData) {
         return getEthModule().sendRawTransaction(rawData);
     }
 
-    default String eth_sendTransaction(CallArguments args) {
+    default String eth_sendTransaction(CallArgumentsParam args) {
         return getEthModule().sendTransaction(args);
     }
 
@@ -121,7 +122,7 @@ public interface Web3EthModule {
 
     TransactionResultDTO eth_getTransactionByBlockNumberAndIndex(String bnOrId, String index) throws Exception;
 
-    TransactionReceiptDTO eth_getTransactionReceipt(String transactionHash) throws Exception;
+    TransactionReceiptDTO eth_getTransactionReceipt(TxHashParam transactionHash) throws Exception;
 
     BlockResultDTO eth_getUncleByBlockHashAndIndex(BlockHashParam blockHash, HexIndexParam uncleIdx) throws Exception;
 

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -36,6 +36,7 @@ import org.ethereum.rpc.parameters.TxHashParam;
 import java.math.BigInteger;
 import java.util.Map;
 
+@SuppressWarnings({"java:S100", "java:S112"})
 public interface Web3EthModule {
     default String[] eth_accounts() {
         return getEthModule().accounts();

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3EthModule.java
@@ -19,7 +19,6 @@
 package co.rsk.rpc;
 
 import co.rsk.rpc.modules.eth.EthModule;
-import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.dto.BlockResultDTO;
 import org.ethereum.rpc.dto.CompilationResultDTO;
 import org.ethereum.rpc.dto.TransactionReceiptDTO;
@@ -78,7 +77,7 @@ public interface Web3EthModule {
 
     String eth_blockNumber();
 
-    String eth_call(CallArguments args, Map<String, String> blockRef) throws Exception; // NOSONAR
+    String eth_call(CallArgumentsParam args, Map<String, String> blockRef) throws Exception; // NOSONAR
 
     String eth_getBalance(HexAddressParam address, BlockRefParam blockRefParam) throws Exception;
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -126,7 +126,7 @@ public class EthModule
 
     public String call(CallArgumentsParam argsParam, BlockIdentifierParam bnOrId) {
         String hReturn = null;
-        CallArguments args = argsParam.getCallArguments();
+        CallArguments args = argsParam.toCallArguments();
         try {
             ExecutionBlockRetriever.Result result = executionBlockRetriever.retrieveExecutionBlock(bnOrId.getIdentifier());
             Block block = result.getBlock();
@@ -159,7 +159,7 @@ public class EthModule
         String estimation = null;
         Block bestBlock = blockchain.getBestBlock();
         try {
-            CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args.getCallArguments());
+            CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args.toCallArguments());
 
             TransactionExecutor executor = reversibleTransactionExecutor.estimateGas(
                     bestBlock,

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -38,6 +38,10 @@ import org.ethereum.db.MutableRepository;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.converters.CallArgumentsToByteArray;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexAddressParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.vm.GasCost;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
@@ -120,10 +124,11 @@ public class EthModule
         return state.stateToMap();
     }
 
-    public String call(CallArguments args, String bnOrId) {
+    public String call(CallArgumentsParam argsParam, BlockIdentifierParam bnOrId) {
         String hReturn = null;
+        CallArguments args = argsParam.getCallArguments();
         try {
-            ExecutionBlockRetriever.Result result = executionBlockRetriever.retrieveExecutionBlock(bnOrId);
+            ExecutionBlockRetriever.Result result = executionBlockRetriever.retrieveExecutionBlock(bnOrId.getIdentifier());
             Block block = result.getBlock();
             Trie finalState = result.getFinalState();
             ProgramResult res;
@@ -150,11 +155,11 @@ public class EthModule
         }
     }
 
-    public String estimateGas(CallArguments args) {
+    public String estimateGas(CallArgumentsParam args) {
         String estimation = null;
         Block bestBlock = blockchain.getBestBlock();
         try {
-            CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args);
+            CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args.getCallArguments());
 
             TransactionExecutor executor = reversibleTransactionExecutor.estimateGas(
                     bestBlock,
@@ -194,17 +199,17 @@ public class EthModule
     }
 
     @Override
-    public String sendTransaction(CallArguments args) {
+    public String sendTransaction(CallArgumentsParam args) {
         return ethModuleTransaction.sendTransaction(args);
     }
 
     @Override
-    public String sendRawTransaction(String rawData) {
+    public String sendRawTransaction(HexDataParam rawData) {
         return ethModuleTransaction.sendRawTransaction(rawData);
     }
 
     @Override
-    public String sign(String addr, String data) {
+    public String sign(HexAddressParam addr, HexDataParam data) {
         return ethModuleWallet.sign(addr, data);
     }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransaction.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransaction.java
@@ -18,10 +18,11 @@
 
 package co.rsk.rpc.modules.eth;
 
-import org.ethereum.rpc.CallArguments;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 
 public interface EthModuleTransaction {
-    String sendTransaction(CallArguments args);
+    String sendTransaction(CallArgumentsParam args);
 
-    String sendRawTransaction(String rawData);
+    String sendRawTransaction(HexDataParam rawData);
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -30,6 +30,8 @@ import org.ethereum.core.TransactionPool;
 import org.ethereum.core.TransactionPoolAddResult;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.util.TransactionArgumentsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +39,6 @@ import org.slf4j.LoggerFactory;
 import co.rsk.core.RskAddress;
 import co.rsk.core.Wallet;
 import co.rsk.net.TransactionGateway;
-import co.rsk.util.HexUtils;
 
 public class EthModuleTransactionBase implements EthModuleTransaction {
 
@@ -56,7 +57,12 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
     }
 
     @Override
-    public synchronized String sendTransaction(CallArguments args) {
+    public synchronized String sendTransaction(CallArgumentsParam argsParam) {
+        CallArguments args = argsParam.getCallArguments();
+
+        if(args.getFrom() == null) {
+            throw invalidParamError("from is null");
+        }
 
         Account senderAccount = this.wallet.getAccount(new RskAddress(args.getFrom()));
 
@@ -97,10 +103,10 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
     }
 
     @Override
-    public String sendRawTransaction(String rawData) {
+    public String sendRawTransaction(HexDataParam rawData) {
         String s = null;
         try {
-            Transaction tx = new ImmutableTransaction(HexUtils.stringHexToByteArray(rawData));
+            Transaction tx = new ImmutableTransaction(rawData.getRawDataBytes());
 
             if (null == tx.getGasLimit() || null == tx.getGasPrice() || null == tx.getValue()) {
                 throw invalidParamError("Missing parameter, gasPrice, gas or value");

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionBase.java
@@ -58,7 +58,7 @@ public class EthModuleTransactionBase implements EthModuleTransaction {
 
     @Override
     public synchronized String sendTransaction(CallArgumentsParam argsParam) {
-        CallArguments args = argsParam.getCallArguments();
+        CallArguments args = argsParam.toCallArguments();
 
         if(args.getFrom() == null) {
             throw invalidParamError("from is null");

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionDisabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionDisabled.java
@@ -21,7 +21,6 @@ package co.rsk.rpc.modules.eth;
 import co.rsk.net.TransactionGateway;
 import org.ethereum.config.Constants;
 import org.ethereum.core.TransactionPool;
-import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.parameters.CallArgumentsParam;
 
 import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
@@ -37,7 +36,7 @@ public class EthModuleTransactionDisabled extends EthModuleTransactionBase {
     }
 
     @Override
-    public String sendTransaction(CallArgumentsParam args) { // lgtm [java/non-sync-override]
+    public synchronized String sendTransaction(CallArgumentsParam args) { // lgtm [java/non-sync-override]
         LOGGER.debug("eth_sendTransaction({}): {}", args, null);
         throw invalidParamError("Local wallet is disabled in this node");
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionDisabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionDisabled.java
@@ -22,6 +22,7 @@ import co.rsk.net.TransactionGateway;
 import org.ethereum.config.Constants;
 import org.ethereum.core.TransactionPool;
 import org.ethereum.rpc.CallArguments;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
 
 import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
 
@@ -36,7 +37,7 @@ public class EthModuleTransactionDisabled extends EthModuleTransactionBase {
     }
 
     @Override
-    public String sendTransaction(CallArguments args) { // lgtm [java/non-sync-override]
+    public String sendTransaction(CallArgumentsParam args) { // lgtm [java/non-sync-override]
         LOGGER.debug("eth_sendTransaction({}): {}", args, null);
         throw invalidParamError("Local wallet is disabled in this node");
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionInstant.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleTransactionInstant.java
@@ -27,8 +27,9 @@ import org.ethereum.config.Constants;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.TransactionPool;
 import org.ethereum.db.TransactionInfo;
-import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.vm.program.ProgramResult;
 
 import co.rsk.core.Wallet;
@@ -64,7 +65,7 @@ public class EthModuleTransactionInstant extends EthModuleTransactionBase {
     }
 
     @Override
-    public synchronized String sendTransaction(CallArguments args) {
+    public synchronized String sendTransaction(CallArgumentsParam args) {
         try {
             this.blockExecutor.setRegisterProgramResults(true);
 
@@ -80,7 +81,7 @@ public class EthModuleTransactionInstant extends EthModuleTransactionBase {
     }
 
     @Override
-    public String sendRawTransaction(String rawData) {
+    public String sendRawTransaction(HexDataParam rawData) {
         try {
             this.blockExecutor.setRegisterProgramResults(true);
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWallet.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWallet.java
@@ -18,9 +18,12 @@
 
 package co.rsk.rpc.modules.eth;
 
+import org.ethereum.rpc.parameters.HexAddressParam;
+import org.ethereum.rpc.parameters.HexDataParam;
+
 public interface EthModuleWallet {
 
     String[] accounts();
 
-    String sign(String addr, String data);
+    String sign(HexAddressParam addr, HexDataParam data);
 }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletDisabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletDisabled.java
@@ -18,6 +18,8 @@
 
 package co.rsk.rpc.modules.eth;
 
+import org.ethereum.rpc.parameters.HexAddressParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +39,7 @@ public class EthModuleWalletDisabled implements EthModuleWallet {
     }
 
     @Override
-    public String sign(String addr, String data) {
+    public String sign(HexAddressParam addr, HexDataParam data) {
         LOGGER.debug("eth_sign({}, {}): {}", addr, data, null);
         throw invalidParamError("Local wallet is disabled in this node");
     }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
@@ -56,7 +56,9 @@ public class EthModuleWalletEnabled implements EthModuleWallet {
                 throw invalidParamError("Account not found");
             }
 
-            return s = this.sign(data.getRawDataBytes(), account.getEcKey());
+            s = this.sign(data.getRawDataBytes(), account.getEcKey());
+
+            return s;
         } finally {
             LOGGER.debug("eth_sign({}, {}): {}", addr, data, s);
         }

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModuleWalletEnabled.java
@@ -28,11 +28,12 @@ import org.ethereum.core.Account;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.signature.ECDSASignature;
+import org.ethereum.rpc.parameters.HexAddressParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import co.rsk.core.RskAddress;
 import co.rsk.core.Wallet;
 import co.rsk.util.HexUtils;
 
@@ -47,15 +48,15 @@ public class EthModuleWalletEnabled implements EthModuleWallet {
     }
 
     @Override
-    public String sign(String addr, String data) {
+    public String sign(HexAddressParam addr, HexDataParam data) {
         String s = null;
         try {
-            Account account = this.wallet.getAccount(new RskAddress(addr));
+            Account account = this.wallet.getAccount(addr.getAddress());
             if (account == null) {
                 throw invalidParamError("Account not found");
             }
 
-            return s = this.sign(data, account.getEcKey());
+            return s = this.sign(data.getRawDataBytes(), account.getEcKey());
         } finally {
             LOGGER.debug("eth_sign({}, {}): {}", addr, data, s);
         }
@@ -71,8 +72,7 @@ public class EthModuleWalletEnabled implements EthModuleWallet {
         }
     }
 
-    private String sign(String data, ECKey ecKey) {
-        byte[] dataHash = HexUtils.stringHexToByteArray(data);
+    private String sign(byte[] dataHash, ECKey ecKey) {
         // 0x19 = 25, length should be an ascii decimals, message - original
         String prefix = (char) 25 + "Ethereum Signed Message:\n" + dataHash.length;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -404,8 +404,8 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
-    public String eth_call(CallArguments args, Map<String, String> inputs) {
-        return invokeByBlockRef(inputs, blockNumber -> this.eth_call(new CallArgumentsParam(args), new BlockIdentifierParam(blockNumber)));
+    public String eth_call(CallArgumentsParam args, Map<String, String> inputs) {
+        return invokeByBlockRef(inputs, blockNumber -> this.eth_call(args, new BlockIdentifierParam(blockNumber)));
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -85,6 +85,7 @@ import static co.rsk.util.HexUtils.*;
 import static java.lang.Math.max;
 import static org.ethereum.rpc.exception.RskJsonRpcRequestException.*;
 
+@SuppressWarnings("java:S100")
 public class Web3Impl implements Web3 {
     private static final Logger logger = LoggerFactory.getLogger("web3");
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -61,6 +61,10 @@ import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
 import org.ethereum.rpc.parameters.BlockHashParam;
 import org.ethereum.rpc.parameters.FilterRequestParam;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.BlockRefParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexAddressParam;
 import org.ethereum.rpc.parameters.HexIndexParam;
 import org.ethereum.rpc.parameters.TxHashParam;
 import org.ethereum.util.BuildInfo;
@@ -401,7 +405,7 @@ public class Web3Impl implements Web3 {
 
     @Override
     public String eth_call(CallArguments args, Map<String, String> inputs) {
-        return invokeByBlockRef(inputs, blockNumber -> this.eth_call(args, blockNumber));
+        return invokeByBlockRef(inputs, blockNumber -> this.eth_call(new CallArgumentsParam(args), new BlockIdentifierParam(blockNumber)));
     }
 
     @Override
@@ -410,7 +414,15 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
-    public String eth_getBalance(String address, String block) {
+    public String eth_getBalance(HexAddressParam address, BlockRefParam blockRefParam) {
+        if(blockRefParam.getIdentifier() != null) {
+            return this.eth_getBalance(address, blockRefParam.getIdentifier());
+        } else {
+            return this.eth_getBalance(address, blockRefParam.getInputs());
+        }
+    }
+
+    private String eth_getBalance(HexAddressParam address, String block) {
         /* HEX String  - an integer block number
          *  String "earliest"  for the earliest/genesis block
          *  String "latest"  - for the latest mined block
@@ -419,14 +431,14 @@ public class Web3Impl implements Web3 {
 
         AccountInformationProvider accountInformationProvider = web3InformationRetriever.getInformationProvider(block);
 
-        RskAddress addr = new RskAddress(address);
+        RskAddress addr = address.getAddress();
         Coin balance = accountInformationProvider.getBalance(addr);
 
         return toQuantityJsonHex(balance.asBigInteger());
     }
 
-    @Override
-    public String eth_getBalance(String address, Map<String, String> inputs) {
+
+    private String eth_getBalance(HexAddressParam address, Map<String, String> inputs) {
         return invokeByBlockRef(inputs, blockNumber -> this.eth_getBalance(address, blockNumber));
     }
 
@@ -440,7 +452,7 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
-    public String eth_getBalance(String address) {
+    public String eth_getBalance(HexAddressParam address) {
         return eth_getBalance(address, "latest");
     }
 
@@ -477,7 +489,15 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
-    public String eth_getTransactionCount(String address, Map<String, String> inputs) {
+    public String eth_getTransactionCount(HexAddressParam address, BlockRefParam blockRefParam) {
+        if(blockRefParam.getIdentifier() != null) {
+            return this.eth_getTransactionCount(address, blockRefParam.getIdentifier());
+        } else {
+            return this.eth_getTransactionCount(address, blockRefParam.getInputs());
+        }
+    }
+
+    private String eth_getTransactionCount(HexAddressParam address, Map<String, String> inputs) {
         return invokeByBlockRef(inputs, blockNumber -> this.eth_getTransactionCount(address, blockNumber));
     }
 
@@ -511,11 +531,10 @@ public class Web3Impl implements Web3 {
         return toInvokeByBlockNumber.apply(toQuantityJsonHex(block.getNumber()));
     }
 
-    @Override
-    public String eth_getTransactionCount(String address, String blockId) {
+    private String eth_getTransactionCount(HexAddressParam address, String blockId) {
         String s = null;
         try {
-            RskAddress addr = new RskAddress(address);
+            RskAddress addr = address.getAddress();
             AccountInformationProvider accountInformationProvider = web3InformationRetriever
                     .getInformationProvider(blockId);
             BigInteger nonce = accountInformationProvider.getNonce(addr);
@@ -777,10 +796,10 @@ public class Web3Impl implements Web3 {
     }
 
     @Override
-    public TransactionReceiptDTO eth_getTransactionReceipt(String transactionHash) {
+    public TransactionReceiptDTO eth_getTransactionReceipt(TxHashParam transactionHash) {
         logger.trace("eth_getTransactionReceipt({})", transactionHash);
 
-        byte[] hash = stringHexToByteArray(transactionHash);
+        byte[] hash = stringHexToByteArray(transactionHash.getHash().toHexString());
         TransactionInfo txInfo = receiptStore.getInMainChain(hash, blockStore).orElse(null);
 
         if (txInfo == null) {

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -67,6 +67,8 @@ import org.ethereum.rpc.Simples.SimpleChannelManager;
 import org.ethereum.rpc.Simples.SimpleConfigCapabilities;
 import org.ethereum.rpc.Web3Impl;
 import org.ethereum.rpc.Web3Mocks;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.sync.SyncPool;
 import org.ethereum.util.BuildInfo;
 import org.ethereum.util.ByteUtil;
@@ -306,7 +308,7 @@ class TransactionModuleTest {
         Assertions.assertNotEquals(expectedValue, gasLimit);
 
         CallArguments args = getContractCallTransactionParameters(method, gasLimit, srcAddr, contractAddress, repository);
-        String gas = web3.eth_estimateGas(args);
+        String gas = web3.eth_estimateGas(new CallArgumentsParam(args));
         byte[] gasReturnedBytes = Hex.decode(gas.substring("0x".length()));
         BigInteger gasReturned = BigIntegers.fromUnsignedByteArray(gasReturnedBytes);
         int gasReturnedInt = gasReturned.intValueExact();
@@ -332,7 +334,7 @@ class TransactionModuleTest {
 
         String rawData = ByteUtil.toHexString(tx.getEncoded());
 
-        return web3.eth_sendRawTransaction(rawData);
+        return web3.eth_sendRawTransaction(new HexDataParam(rawData));
     }
 
     private Transaction getTransactionFromBlockWhichWasSend(BlockChainImpl blockchain, String tx) {
@@ -350,13 +352,13 @@ class TransactionModuleTest {
     private String sendContractCreationTransaction(RskAddress srcaddr, Web3Impl web3, RepositorySnapshot repository) {
         CallArguments args = getContractCreationTransactionParameters(srcaddr, web3, repository);
 
-        return web3.eth_sendTransaction(args);
+        return web3.eth_sendTransaction(new CallArgumentsParam(args));
     }
 
     private String sendTransaction(Web3Impl web3, RepositorySnapshot repository) {
         CallArguments args = getTransactionParameters(web3, repository);
 
-        return web3.eth_sendTransaction(args);
+        return web3.eth_sendTransaction(new CallArgumentsParam(args));
     }
 
     ////////////////////////////////////////////////

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -67,11 +67,11 @@ import org.ethereum.rpc.Simples.SimpleChannelManager;
 import org.ethereum.rpc.Simples.SimpleConfigCapabilities;
 import org.ethereum.rpc.Web3Impl;
 import org.ethereum.rpc.Web3Mocks;
-import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.sync.SyncPool;
 import org.ethereum.util.BuildInfo;
 import org.ethereum.util.ByteUtil;
+import org.ethereum.util.TransactionFactoryHelper;
 import org.ethereum.vm.GasCost;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
@@ -308,7 +308,7 @@ class TransactionModuleTest {
         Assertions.assertNotEquals(expectedValue, gasLimit);
 
         CallArguments args = getContractCallTransactionParameters(method, gasLimit, srcAddr, contractAddress, repository);
-        String gas = web3.eth_estimateGas(new CallArgumentsParam(args));
+        String gas = web3.eth_estimateGas(TransactionFactoryHelper.toCallArgumentsParam(args));
         byte[] gasReturnedBytes = Hex.decode(gas.substring("0x".length()));
         BigInteger gasReturned = BigIntegers.fromUnsignedByteArray(gasReturnedBytes);
         int gasReturnedInt = gasReturned.intValueExact();
@@ -352,13 +352,13 @@ class TransactionModuleTest {
     private String sendContractCreationTransaction(RskAddress srcaddr, Web3Impl web3, RepositorySnapshot repository) {
         CallArguments args = getContractCreationTransactionParameters(srcaddr, web3, repository);
 
-        return web3.eth_sendTransaction(new CallArgumentsParam(args));
+        return web3.eth_sendTransaction(TransactionFactoryHelper.toCallArgumentsParam(args));
     }
 
     private String sendTransaction(Web3Impl web3, RepositorySnapshot repository) {
         CallArguments args = getTransactionParameters(web3, repository);
 
-        return web3.eth_sendTransaction(new CallArgumentsParam(args));
+        return web3.eth_sendTransaction(TransactionFactoryHelper.toCallArgumentsParam(args));
     }
 
     ////////////////////////////////////////////////

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
@@ -27,6 +27,7 @@ import org.ethereum.core.TransactionReceipt;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.util.EthModuleTestUtils;
 import org.ethereum.util.TransactionFactoryHelper;
 import org.hamcrest.MatcherAssert;
@@ -64,8 +65,10 @@ class EthModuleDSLTest {
         args.setValue("0");
         args.setNonce("1");
         args.setGas("10000000");
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("0x2");
         try {
-            eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("0x2"));
+            eth.call(callArgumentsParam, blockIdentifierParam);
             fail();
         } catch (RskJsonRpcRequestException e) {
             MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("Negative value."));

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
@@ -27,8 +27,8 @@ import org.ethereum.core.TransactionReceipt;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.BlockIdentifierParam;
-import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.util.EthModuleTestUtils;
+import org.ethereum.util.TransactionFactoryHelper;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -65,14 +65,14 @@ class EthModuleDSLTest {
         args.setNonce("1");
         args.setGas("10000000");
         try {
-            eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("0x2"));
+            eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("0x2"));
             fail();
         } catch (RskJsonRpcRequestException e) {
             MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("Negative value."));
         }
 
         args.setData("0xd96a094a0000000000000000000000000000000000000000000000000000000000000001"); // call to contract with param value = 1
-        final String call = eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("0x2"));
+        final String call = eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("0x2"));
         assertEquals("0x", call);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
@@ -26,6 +26,8 @@ import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.util.EthModuleTestUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -63,14 +65,14 @@ class EthModuleDSLTest {
         args.setNonce("1");
         args.setGas("10000000");
         try {
-            eth.call(args, "0x2");
+            eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("0x2"));
             fail();
         } catch (RskJsonRpcRequestException e) {
             MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("Negative value."));
         }
 
         args.setData("0xd96a094a0000000000000000000000000000000000000000000000000000000000000001"); // call to contract with param value = 1
-        final String call = eth.call(args, "0x2");
+        final String call = eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("0x2"));
         assertEquals("0x", call);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleGasEstimationDSLTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleGasEstimationDSLTest.java
@@ -30,6 +30,7 @@ import org.ethereum.core.CallTransaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.rpc.CallArguments;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.EthModuleTestUtils;
 import org.ethereum.vm.GasCost;
@@ -288,7 +289,7 @@ class EthModuleGasEstimationDSLTest {
         callArguments.setGas(HexUtils.toQuantityJsonHex(gasEstimationCap + 1_000_000_000)); // exceeding the gas cap
         callArguments.setData("0x31fe52e8"); // call outOfGas()
 
-        String estimatedGas = eth.estimateGas(callArguments);
+        String estimatedGas = eth.estimateGas(new CallArgumentsParam(callArguments));
         assertEquals("0x67c280", estimatedGas);
 
         assertEquals(gasEstimationCap, Long.decode(estimatedGas).longValue());
@@ -785,7 +786,7 @@ class EthModuleGasEstimationDSLTest {
     }
 
     private long estimateGas(EthModuleTestUtils.EthModuleGasEstimation eth, CallArguments args) {
-        return Long.parseLong(eth.estimateGas(args).substring("0x".length()), 16);
+        return Long.parseLong(eth.estimateGas(new CallArgumentsParam(args)).substring("0x".length()), 16);
     }
 
     // todo this is duplicated code, should be extracted into a test util

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleGasEstimationDSLTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleGasEstimationDSLTest.java
@@ -30,9 +30,9 @@ import org.ethereum.core.CallTransaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.rpc.CallArguments;
-import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.EthModuleTestUtils;
+import org.ethereum.util.TransactionFactoryHelper;
 import org.ethereum.vm.GasCost;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.program.InternalTransaction;
@@ -289,7 +289,7 @@ class EthModuleGasEstimationDSLTest {
         callArguments.setGas(HexUtils.toQuantityJsonHex(gasEstimationCap + 1_000_000_000)); // exceeding the gas cap
         callArguments.setData("0x31fe52e8"); // call outOfGas()
 
-        String estimatedGas = eth.estimateGas(new CallArgumentsParam(callArguments));
+        String estimatedGas = eth.estimateGas(TransactionFactoryHelper.toCallArgumentsParam(callArguments));
         assertEquals("0x67c280", estimatedGas);
 
         assertEquals(gasEstimationCap, Long.decode(estimatedGas).longValue());
@@ -786,7 +786,7 @@ class EthModuleGasEstimationDSLTest {
     }
 
     private long estimateGas(EthModuleTestUtils.EthModuleGasEstimation eth, CallArguments args) {
-        return Long.parseLong(eth.estimateGas(new CallArgumentsParam(args)).substring("0x".length()), 16);
+        return Long.parseLong(eth.estimateGas(TransactionFactoryHelper.toCallArgumentsParam(args)).substring("0x".length()), 16);
     }
 
     // todo this is duplicated code, should be extracted into a test util

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -37,6 +37,7 @@ import org.ethereum.datasource.HashMapDB;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.TransactionFactoryHelper;
@@ -246,7 +247,8 @@ class EthModuleTest {
 
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendTransaction(TransactionFactoryHelper.toCallArgumentsParam(args)));
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendTransaction(callArgumentsParam));
     }
 
     @Test
@@ -275,7 +277,8 @@ class EthModuleTest {
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
         String rawData = ByteUtil.toHexString(tx.getEncoded());
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendRawTransaction(new HexDataParam(rawData)));
+        HexDataParam hexDataParam = new HexDataParam(rawData);
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendRawTransaction(hexDataParam));
     }
 
     @Test
@@ -292,9 +295,10 @@ class EthModuleTest {
 
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPoolMock, transactionGatewayMock);
 
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(argsMock);
         // Then
         try {
-            ethModuleTransaction.sendTransaction(TransactionFactoryHelper.toCallArgumentsParam(argsMock));
+            ethModuleTransaction.sendTransaction(callArgumentsParam);
             fail("RskJsonRpcRequestException should be thrown");
         } catch (RskJsonRpcRequestException ex) {
             assertEquals("Could not find account for address: " + addressFrom.toJsonString(), ex.getMessage());

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -36,6 +36,9 @@ import org.ethereum.crypto.ECKey;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.TransactionFactoryHelper;
 import org.ethereum.vm.program.ProgramResult;
@@ -106,7 +109,7 @@ class EthModuleTest {
                 config.getCallGasCap());
 
         String expectedResult = HexUtils.toUnformattedJsonHex(hReturn);
-        String actualResult = eth.call(args, "latest");
+        String actualResult = eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
 
         assertEquals(expectedResult, actualResult);
     }
@@ -146,7 +149,7 @@ class EthModuleTest {
                 config.getCallGasCap());
 
         String expectedResult = HexUtils.toUnformattedJsonHex(hReturn);
-        String actualResult = eth.call(args, "latest");
+        String actualResult = eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
 
         assertEquals(expectedResult, actualResult);
     }
@@ -191,7 +194,7 @@ class EthModuleTest {
                 config.getCallGasCap());
 
         try {
-            eth.call(args, "latest");
+            eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
         } catch (RskJsonRpcRequestException e) {
             assertThat(e.getMessage(), Matchers.containsString("deposit too big"));
         }
@@ -222,7 +225,7 @@ class EthModuleTest {
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
         // Hash of the actual transaction builded inside the sendTransaction
-        String txResult = ethModuleTransaction.sendTransaction(args);
+        String txResult = ethModuleTransaction.sendTransaction(new CallArgumentsParam(args));
 
         assertEquals(txExpectedResult, txResult);
     }
@@ -250,7 +253,7 @@ class EthModuleTest {
 
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendTransaction(args));
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendTransaction(new CallArgumentsParam(args)));
     }
 
     @Test
@@ -279,7 +282,7 @@ class EthModuleTest {
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
         String rawData = ByteUtil.toHexString(tx.getEncoded());
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendRawTransaction(rawData));
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendRawTransaction(new HexDataParam(rawData)));
     }
 
     @Test
@@ -298,10 +301,10 @@ class EthModuleTest {
 
         // Then
         try {
-            ethModuleTransaction.sendTransaction(argsMock);
+            ethModuleTransaction.sendTransaction(new CallArgumentsParam(argsMock));
             fail("RskJsonRpcRequestException should be thrown");
         } catch (RskJsonRpcRequestException ex) {
-            verify(argsMock, times(2)).getFrom();
+            verify(argsMock, times(4)).getFrom();
             assertEquals("Could not find account for address: " + addressFrom.toJsonString(), ex.getMessage());
         }
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -37,7 +37,6 @@ import org.ethereum.datasource.HashMapDB;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.BlockIdentifierParam;
-import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.TransactionFactoryHelper;
@@ -59,13 +58,7 @@ import static org.mockito.ArgumentMatchers.anyByte;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class EthModuleTest {
 
@@ -109,7 +102,7 @@ class EthModuleTest {
                 config.getCallGasCap());
 
         String expectedResult = HexUtils.toUnformattedJsonHex(hReturn);
-        String actualResult = eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
+        String actualResult = eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
 
         assertEquals(expectedResult, actualResult);
     }
@@ -149,7 +142,7 @@ class EthModuleTest {
                 config.getCallGasCap());
 
         String expectedResult = HexUtils.toUnformattedJsonHex(hReturn);
-        String actualResult = eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
+        String actualResult = eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
 
         assertEquals(expectedResult, actualResult);
     }
@@ -194,7 +187,7 @@ class EthModuleTest {
                 config.getCallGasCap());
 
         try {
-            eth.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
+            eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
         } catch (RskJsonRpcRequestException e) {
             assertThat(e.getMessage(), Matchers.containsString("deposit too big"));
         }
@@ -225,7 +218,7 @@ class EthModuleTest {
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
         // Hash of the actual transaction builded inside the sendTransaction
-        String txResult = ethModuleTransaction.sendTransaction(new CallArgumentsParam(args));
+        String txResult = ethModuleTransaction.sendTransaction(TransactionFactoryHelper.toCallArgumentsParam(args));
 
         assertEquals(txExpectedResult, txResult);
     }
@@ -253,7 +246,7 @@ class EthModuleTest {
 
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
-        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendTransaction(new CallArgumentsParam(args)));
+        Assertions.assertThrows(RskJsonRpcRequestException.class, () -> ethModuleTransaction.sendTransaction(TransactionFactoryHelper.toCallArgumentsParam(args)));
     }
 
     @Test
@@ -301,10 +294,9 @@ class EthModuleTest {
 
         // Then
         try {
-            ethModuleTransaction.sendTransaction(new CallArgumentsParam(argsMock));
+            ethModuleTransaction.sendTransaction(TransactionFactoryHelper.toCallArgumentsParam(argsMock));
             fail("RskJsonRpcRequestException should be thrown");
         } catch (RskJsonRpcRequestException ex) {
-            verify(argsMock, times(4)).getFrom();
             assertEquals("Could not find account for address: " + addressFrom.toJsonString(), ex.getMessage());
         }
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -47,7 +47,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -59,6 +58,8 @@ import static org.mockito.ArgumentMatchers.anyByte;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class EthModuleTest {
@@ -393,7 +394,10 @@ class EthModuleTest {
                 config.getGasEstimationCap(),
                 config.getCallGasCap());
 
-        eth.call(args, "latest");
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("latest");
+
+        eth.call(callArgumentsParam, blockIdentifierParam);
 
         ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
         verify(executor, times(1))
@@ -436,7 +440,10 @@ class EthModuleTest {
                 config.getGasEstimationCap(),
                 config.getCallGasCap());
 
-        eth.call(args, "latest");
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("latest");
+
+        eth.call(callArgumentsParam, blockIdentifierParam);
 
         ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
         verify(executor, times(1))
@@ -481,7 +488,10 @@ class EthModuleTest {
                 config.getCallGasCap());
 
 
-        eth.call(args, "latest");
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("latest");
+
+        eth.call(callArgumentsParam, blockIdentifierParam);
 
         ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
         verify(executor, times(1))
@@ -523,7 +533,9 @@ class EthModuleTest {
                 config.getGasEstimationCap(),
                 config.getCallGasCap());
 
-        eth.estimateGas(args);
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        eth.estimateGas(callArgumentsParam);
 
         ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
         verify(reversibleTransactionExecutor, times(1))
@@ -565,7 +577,9 @@ class EthModuleTest {
                 config.getGasEstimationCap(),
                 config.getCallGasCap());
 
-        eth.estimateGas(args);
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        eth.estimateGas(callArgumentsParam);
 
         ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
         verify(reversibleTransactionExecutor, times(1))
@@ -608,7 +622,9 @@ class EthModuleTest {
                 config.getGasEstimationCap(),
                 config.getCallGasCap());
 
-        eth.estimateGas(args);
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        eth.estimateGas(callArgumentsParam);
 
         ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
         verify(reversibleTransactionExecutor, times(1))
@@ -640,7 +656,9 @@ class EthModuleTest {
 
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
-        ethModuleTransaction.sendTransaction(args);
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        ethModuleTransaction.sendTransaction(callArgumentsParam);
 
         ArgumentCaptor<Transaction> transactionCaptor = ArgumentCaptor.forClass(Transaction.class);
         verify(transactionGateway, times(1))
@@ -672,7 +690,9 @@ class EthModuleTest {
 
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
-        ethModuleTransaction.sendTransaction(args);
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        ethModuleTransaction.sendTransaction(callArgumentsParam);
 
         ArgumentCaptor<Transaction> transactionCaptor = ArgumentCaptor.forClass(Transaction.class);
         verify(transactionGateway, times(1))
@@ -705,7 +725,9 @@ class EthModuleTest {
 
         EthModuleTransactionBase ethModuleTransaction = new EthModuleTransactionBase(constants, wallet, transactionPool, transactionGateway);
 
-        ethModuleTransaction.sendTransaction(args);
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        ethModuleTransaction.sendTransaction(callArgumentsParam);
 
         ArgumentCaptor<Transaction> transactionCaptor = ArgumentCaptor.forClass(Transaction.class);
         verify(transactionGateway, times(1))

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplLogsTest.java
@@ -18,6 +18,29 @@
 
 package org.ethereum.rpc;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import java.math.BigInteger;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.ethereum.core.*;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.rpc.Simples.SimpleConfigCapabilities;
+import org.ethereum.rpc.dto.TransactionReceiptDTO;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.TxHashParam;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RskTestFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.Wallet;
@@ -362,7 +385,7 @@ class Web3ImplLogsTest {
         assertEquals(1, logs.length);
 
         String txhash = ((LogFilterElement) logs[0]).transactionHash;
-        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
+        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(new TxHashParam(txhash));
 
         assertEquals(txdto.getContractAddress(), ((LogFilterElement) logs[0]).address);
     }
@@ -380,7 +403,7 @@ class Web3ImplLogsTest {
         assertEquals(1, logs.length);
 
         String txhash = ((LogFilterElement) logs[0]).transactionHash;
-        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
+        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(new TxHashParam(txhash));
 
         assertEquals(txdto.getContractAddress(), ((LogFilterElement) logs[0]).address);
     }
@@ -397,7 +420,7 @@ class Web3ImplLogsTest {
         assertEquals(2, logs.length);
 
         String txhash = ((LogFilterElement) logs[0]).transactionHash;
-        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
+        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(new TxHashParam(txhash));
 
         assertEquals(txdto.getContractAddress(), ((LogFilterElement) logs[0]).address);
         assertEquals(txdto.getContractAddress(), ((LogFilterElement) logs[1]).address);
@@ -415,7 +438,7 @@ class Web3ImplLogsTest {
         assertEquals(3, logs.length);
 
         String txHash1 = "0x" + transactions.get(0).getHash().toHexString();
-        TransactionReceiptDTO txReceipt1 = web3.eth_getTransactionReceipt(txHash1);
+        TransactionReceiptDTO txReceipt1 = web3.eth_getTransactionReceipt(new TxHashParam(txHash1));
         String contractAddress = txReceipt1.getContractAddress();
         LogFilterElement logs1 = (LogFilterElement) logs[0];
         assertEquals(contractAddress, logs1.address);
@@ -426,7 +449,7 @@ class Web3ImplLogsTest {
         assertArrayEquals(receipt1Logs.topics, logs1.topics);
 
         String txHash2 = "0x" + transactions.get(1).getHash().toHexString();
-        TransactionReceiptDTO txReceipt2 = web3.eth_getTransactionReceipt(txHash2);
+        TransactionReceiptDTO txReceipt2 = web3.eth_getTransactionReceipt(new TxHashParam(txHash2));
         LogFilterElement logs2 = (LogFilterElement) logs[1];
         assertEquals(contractAddress, logs2.address);
         assertEquals(txHash2, logs2.transactionHash);
@@ -436,7 +459,7 @@ class Web3ImplLogsTest {
         assertArrayEquals(receipt2Logs.topics, logs2.topics);
 
         String txHash3 = "0x" + transactions.get(2).getHash().toHexString();
-        TransactionReceiptDTO txReceipt3 = web3.eth_getTransactionReceipt(txHash3);
+        TransactionReceiptDTO txReceipt3 = web3.eth_getTransactionReceipt(new TxHashParam(txHash3));
         LogFilterElement logs3 = (LogFilterElement) logs[2];
         assertEquals(contractAddress, logs3.address);
         assertEquals(txHash3, logs3.transactionHash);
@@ -465,7 +488,7 @@ class Web3ImplLogsTest {
         assertEquals(2, logs.length);
 
         String txhash = ((LogFilterElement) logs[0]).transactionHash;
-        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
+        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(new TxHashParam(txhash));
 
         assertEquals(txdto.getContractAddress(), ((LogFilterElement) logs[0]).address);
         assertEquals(txdto.getContractAddress(), ((LogFilterElement) logs[1]).address);
@@ -850,7 +873,7 @@ class Web3ImplLogsTest {
         assertEquals(1, logs.length);
         assertEquals(blockHash, ((LogFilterElement) logs[0]).blockHash);
         String txhash = ((LogFilterElement) logs[0]).transactionHash;
-        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(txhash);
+        TransactionReceiptDTO txdto = web3.eth_getTransactionReceipt(new TxHashParam(txhash));
         assertEquals(txdto.getContractAddress(), ((LogFilterElement) logs[0]).address);
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -87,6 +87,7 @@ import org.ethereum.rpc.parameters.HexIndexParam;
 import org.ethereum.rpc.parameters.TxHashParam;
 import org.ethereum.util.BuildInfo;
 import org.ethereum.util.ByteUtil;
+import org.ethereum.util.TransactionFactoryHelper;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
@@ -513,70 +514,70 @@ class Web3ImplTest {
         //[ {argsForCall}, { "blockNumber": "0x0" } -> return contract call respond at given args for call in genesis block
     void callByBlockNumber() {
         final ChainParams chain = createChainWithACall(false);
-        assertByBlockNumber(CALL_RESPOND, blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertByBlockNumber(CALL_RESPOND, blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         //[ {argsForCall}, { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" } -> return  contract call respond at given address in genesis block
     void callByBlockHash() {
         final ChainParams chain = createChainWithACall(false);
-        assertByBlockHash(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertByBlockHash(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         //[ {argsForCall}, { "blockHash": "0x<non-existent-block-hash>" } -> raise block-not-found error
     void callByNonExistentBlockHash() {
         final ChainParams chain = createChainWithACall(false);
-        assertNonExistentBlockHash(blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertNonExistentBlockHash(blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         //[ {argsForCall}, { "blockHash": "0x<non-existent-block-hash>", "requireCanonical": true } -> raise block-not-found error
     void callByNonExistentBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = createChainWithACall(false);
-        assertNonBlockHashWhenCanonical(blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertNonBlockHashWhenCanonical(blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         //[ {argsForCall}, { "blockHash": "0x<non-existent-block-hash>", "requireCanonical": false } -> raise block-not-found error
     void callByNonExistentBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = createChainWithACall(false);
-        assertNonBlockHashWhenIsNotCanonical(blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertNonBlockHashWhenIsNotCanonical(blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         // [ {argsForCall} { "blockHash": "0x<non-canonical-block-hash>", "requireCanonical": true } -> raise block-not-canonical error
     void callByNonCanonicalBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = createChainWithACall(true);
-        assertNonCanonicalBlockHashWhenCanonical(chain.block, blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertNonCanonicalBlockHashWhenCanonical(chain.block, blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         //[ {argsForCall}, { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": true } -> return  contract call respond at given address in genesis block
     void callByCanonicalBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = createChainWithACall(false);
-        assertCanonicalBlockHashWhenCanonical(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertCanonicalBlockHashWhenCanonical(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         //[ {argsForCall}, { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": false } -> return  contract call respond at given address in genesis block
     void callByCanonicalBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = createChainWithACall(false);
-        assertCanonicalBlockHashWhenNotCanonical(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertCanonicalBlockHashWhenNotCanonical(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         // [ {argsForCall}, { "blockHash": "0x<non-canonical-block-hash>", "requireCanonical": false } -> return  contract call respond at given address in specified block
     void callByNonCanonicalBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = createChainWithACall(true);
-        assertNonCanonicalBlockHashWhenNotCanonical(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertNonCanonicalBlockHashWhenNotCanonical(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
         // [ {argsForCall}, { "blockHash": "0x<non-canonical-block-hash>" } -> return  contract call respond at given address in specified bloc
     void callByNonCanonicalBlockHash() {
         final ChainParams chain = createChainWithACall(true);
-        assertNonCanonicalBlockHash(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(chain.argsForCall, blockRef));
+        assertNonCanonicalBlockHash(CALL_RESPOND, chain.block, blockRef -> chain.web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(chain.argsForCall), blockRef));
     }
 
     @Test
@@ -1787,7 +1788,7 @@ class Web3ImplTest {
         argsForCall.setTo(HexUtils.toJsonHex(tx.getContractAddress().getBytes()));
         argsForCall.setData("0xead710c40000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000");
 
-        String result = web3.eth_call(new CallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
+        String result = web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
 
         assertEquals("0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000", result);
     }
@@ -1834,7 +1835,7 @@ class Web3ImplTest {
         argsForCall.setTo(HexUtils.toJsonHex(tx.getContractAddress().getBytes()));
         argsForCall.setData("0xead710c40000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000");
 
-        String result = web3.eth_call(new CallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
+        String result = web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
 
         assertEquals("0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000", result);
     }
@@ -1867,7 +1868,7 @@ class Web3ImplTest {
         argsForCall.setTo(HexUtils.toUnformattedJsonHex(tx.getContractAddress().getBytes()));
         argsForCall.setData(HexUtils.toUnformattedJsonHex(func.encode()));
 
-        String result = web3.eth_call(new CallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
+        String result = web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
 
         assertEquals("0x", result);
     }
@@ -2340,8 +2341,9 @@ class Web3ImplTest {
         if (chainId != null) {
             args.setChainId(HexUtils.toJsonHex(new byte[]{chainId}));
         }
+        CallArgumentsParam argsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
 
-        String txHash = web3.eth_sendTransaction(new CallArgumentsParam(args));
+        String txHash = web3.eth_sendTransaction(argsParam);
 
         // ***** Verifies tx hash
         String to = toAddress.substring(2);
@@ -2351,7 +2353,7 @@ class Web3ImplTest {
                 .gasPrice(gasPrice)
                 .gasLimit(gasLimit)
                 .destination(Hex.decode(to))
-                .data(args.getData() == null ? null : Hex.decode(args.getData()))
+                .data(args.getData() == null ? null : Hex.decode(args.getData().substring(2)))
                 .chainId(config.getNetworkConstants().getChainId())
                 .value(value)
                 .build();
@@ -2410,7 +2412,7 @@ class Web3ImplTest {
         argsForCall.setTo(HexUtils.toJsonHex(tx.getContractAddress().getBytes()));
         argsForCall.setData(HexUtils.toJsonHex(noreturn.functions.get("noreturn").encodeSignature()));
 
-        String result = web3.eth_call(new CallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
+        String result = web3.eth_call(TransactionFactoryHelper.toCallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
 
         Assertions.assertEquals("0x", result);
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -78,6 +78,11 @@ import org.ethereum.rpc.dto.TransactionReceiptDTO;
 import org.ethereum.rpc.dto.TransactionResultDTO;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.BlockHashParam;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.BlockRefParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexAddressParam;
+import org.ethereum.rpc.parameters.HexDataParam;
 import org.ethereum.rpc.parameters.HexIndexParam;
 import org.ethereum.rpc.parameters.TxHashParam;
 import org.ethereum.util.BuildInfo;
@@ -217,7 +222,7 @@ class Web3ImplTest {
 
         Web3Impl web3 = createWeb3(world);
 
-        assertEquals(BALANCE_10K_HEX, web3.eth_getBalance(ByteUtil.toHexString(acc1.getAddress().getBytes())));
+        assertEquals(BALANCE_10K_HEX, web3.eth_getBalance(new HexAddressParam(ByteUtil.toHexString(acc1.getAddress().getBytes()))));
     }
 
     @Test
@@ -227,7 +232,9 @@ class Web3ImplTest {
 
         Web3Impl web3 = createWeb3(world);
 
-        assertEquals(BALANCE_10K_HEX, web3.eth_getBalance(ByteUtil.toHexString(acc1.getAddress().getBytes()), "latest"));
+        assertEquals(BALANCE_10K_HEX, web3.eth_getBalance(
+                new HexAddressParam(ByteUtil.toHexString(acc1.getAddress().getBytes())),
+                new BlockRefParam(new BlockRef("latest"))));
     }
 
     @Test
@@ -239,7 +246,7 @@ class Web3ImplTest {
 
         String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
 
-        assertEquals(BALANCE_10K_HEX, web3.eth_getBalance(accountAddress, "0x0"));
+        assertEquals(BALANCE_10K_HEX, web3.eth_getBalance(new HexAddressParam(accountAddress), new BlockRefParam(new BlockRef("0x0"))));
     }
 
     @Test
@@ -252,42 +259,42 @@ class Web3ImplTest {
 
         String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
 
-        assertEquals(BALANCE_10K_HEX, web3.eth_getBalance(accountAddress, "0x1"));
+        assertEquals(BALANCE_10K_HEX, web3.eth_getBalance(new HexAddressParam(accountAddress), new BlockRefParam(new BlockRef("0x1"))));
     }
 
     @Test
         //[ "0x<address>", { "blockNumber": "0x0" } -> return balance at given address in genesis block
     void getBalanceWithAccountAndBlockNumber() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertByBlockNumber(BALANCE_10K_HEX, blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertByBlockNumber(BALANCE_10K_HEX, blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         //[ "0x<address>", { "invalidInput": "0x0" } -> throw RskJsonRpcRequestException
     void getBalanceWithAccountAndInvalidInputThrowsException() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertInvalidInput(blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertInvalidInput(blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" } -> return balance at given address in genesis block
     void getBalanceWithAccountAndBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertByBlockHash(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertByBlockHash(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         //[ "0x<address>", { "blockHash": "0x<non-existent-block-hash>" } -> raise block-not-found error
     void getBalanceWithAccountAndNonExistentBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertNonExistentBlockHash(blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertNonExistentBlockHash(blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         //[ "0x<address>", { "blockHash": "0x<non-existent-block-hash>", "requireCanonical": true } -> raise block-not-found error
     void getBalanceWithAccountAndNonExistentBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertNonBlockHashWhenCanonical(blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertNonBlockHashWhenCanonical(blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
 
@@ -295,14 +302,14 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockHash": "0x<non-existent-block-hash>", "requireCanonical": false } -> raise block-not-found error
     void getBalanceWithAccountAndNonExistentBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertNonBlockHashWhenIsNotCanonical(blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertNonBlockHashWhenIsNotCanonical(blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>", "requireCanonical": true } -> raise block-not-canonical error
     void getBalanceWithAccountAndNonCanonicalBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = chainWithAccount10kBalance(true);
-        assertNonCanonicalBlockHashWhenCanonical(chain.block, blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertNonCanonicalBlockHashWhenCanonical(chain.block, blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
 
@@ -310,28 +317,28 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": true } -> return balance at given address in genesis block
     void getBalanceWithAccountAndCanonicalBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertCanonicalBlockHashWhenCanonical(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertCanonicalBlockHashWhenCanonical(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": false } -> return balance at given address in genesis block
     void getBalanceWithAccountAndCanonicalBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertCanonicalBlockHashWhenNotCanonical(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertCanonicalBlockHashWhenNotCanonical(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>", "requireCanonical": false } -> return balance at given address in specified block
     void getBalanceWithAccountAndNonCanonicalBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = chainWithAccount10kBalance(true);
-        assertNonCanonicalBlockHashWhenNotCanonical(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertNonCanonicalBlockHashWhenNotCanonical(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>" } -> return balance at given address in specified bloc
     void getBalanceWithAccountAndNonCanonicalBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(true);
-        assertNonCanonicalBlockHash(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(chain.accountAddress, blockRef));
+        assertNonCanonicalBlockHash(BALANCE_10K_HEX, chain.block, blockRef -> chain.web3.eth_getBalance(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
@@ -355,9 +362,9 @@ class Web3ImplTest {
         String accountAddress = ByteUtil.toHexString(acc2.getAddress().getBytes());
         String balanceString = BALANCE_10K_HEX;
 
-        assertEquals("0x0", web3.eth_getBalance(accountAddress, "0x0"));
-        assertEquals(balanceString, web3.eth_getBalance(accountAddress, "0x1"));
-        assertEquals(balanceString, web3.eth_getBalance(accountAddress, "pending"));
+        assertEquals("0x0", web3.eth_getBalance(new HexAddressParam(accountAddress), new BlockRefParam(new BlockRef("0x0"))));
+        assertEquals(balanceString, web3.eth_getBalance(new HexAddressParam(accountAddress), new BlockRefParam(new BlockRef("0x1"))));
+        assertEquals(balanceString, web3.eth_getBalance(new HexAddressParam(accountAddress), new BlockRefParam(new BlockRef("pending"))));
     }
 
     @Test
@@ -719,7 +726,7 @@ class Web3ImplTest {
 
         String hashString = tx.getHash().toHexString();
 
-        Assertions.assertNull(web3.eth_getTransactionReceipt(hashString));
+        Assertions.assertNull(web3.eth_getTransactionReceipt(new TxHashParam(hashString)));
         Assertions.assertNull(web3.rsk_getRawTransactionReceiptByHash(hashString));
     }
 
@@ -738,7 +745,7 @@ class Web3ImplTest {
 
         String hashString = tx.getHash().toHexString();
 
-        TransactionReceiptDTO tr = web3.eth_getTransactionReceipt(hashString);
+        TransactionReceiptDTO tr = web3.eth_getTransactionReceipt(new TxHashParam(hashString));
 
         assertNotNull(tr);
         assertEquals("0x" + hashString, tr.getTransactionHash());
@@ -789,7 +796,7 @@ class Web3ImplTest {
 
         String hashString = tx.getHash().toHexString();
 
-        TransactionReceiptDTO tr = web3.eth_getTransactionReceipt(hashString);
+        TransactionReceiptDTO tr = web3.eth_getTransactionReceipt(new TxHashParam(hashString));
 
         Assertions.assertNull(tr);
     }
@@ -989,12 +996,12 @@ class Web3ImplTest {
 
         String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
 
-        String count = web3.eth_getTransactionCount(accountAddress, "0x1");
+        String count = web3.eth_getTransactionCount(new HexAddressParam(accountAddress), new BlockRefParam(new BlockRef("0x1")));
 
         assertNotNull(count);
         assertEquals("0x1", count);
 
-        count = web3.eth_getTransactionCount(accountAddress, "0x0");
+        count = web3.eth_getTransactionCount(new HexAddressParam(accountAddress), new BlockRefParam(new BlockRef("0x0")));
 
         assertNotNull(count);
         assertEquals("0x0", count);
@@ -1004,42 +1011,42 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockNumber": "0x0" } -> return tx count at given address in genesis block
     void getTransactionCountByBlockNumber() {
         final ChainParams chain = createChainWithATransaction(false);
-        assertByBlockNumber("0x1", blockRef -> chain.web3.eth_getTransactionCount(chain.accountAddress, blockRef));
+        assertByBlockNumber("0x1", blockRef -> chain.web3.eth_getTransactionCount(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         //[ "0x<address>", { "invalidInput": "0x0" } -> throw RskJsonRpcRequestException
     void getTransactionCountAndInvalidInputThrowsException() {
         final ChainParams chain = createChainWithATransaction(false);
-        assertInvalidInput(blockRef -> chain.web3.eth_getTransactionCount(chain.accountAddress, blockRef));
+        assertInvalidInput(blockRef -> chain.web3.eth_getTransactionCount(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" } -> return tx count at given address in genesis block
     void getTransactionCountByBlockHash() {
         final ChainParams chain = createChainWithATransaction(false);
-        assertByBlockHash("0x1", chain.block, blockRef -> chain.web3.eth_getTransactionCount(chain.accountAddress, blockRef));
+        assertByBlockHash("0x1", chain.block, blockRef -> chain.web3.eth_getTransactionCount(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         //[ "0x<address>", { "blockHash": "0x<non-existent-block-hash>" } -> raise block-not-found error
     void getTransactionCountByNonExistentBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertNonExistentBlockHash(blockRef -> chain.web3.eth_getTransactionCount(chain.accountAddress, blockRef));
+        assertNonExistentBlockHash(blockRef -> chain.web3.eth_getTransactionCount(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>", "requireCanonical": true } -> raise block-not-canonical error
     void getTransactionCountByNonCanonicalBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = createChainWithATransaction(true);
-        assertNonCanonicalBlockHashWhenCanonical(chain.block, blockRef -> chain.web3.eth_getTransactionCount(chain.accountAddress, blockRef));
+        assertNonCanonicalBlockHashWhenCanonical(chain.block, blockRef -> chain.web3.eth_getTransactionCount(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>" } -> return tx count at given address in specified bloc
     void getTransactionCountByNonCanonicalBlockHash() {
         final ChainParams chain = createChainWithATransaction(true);
-        assertNonCanonicalBlockHash("0x1", chain.block, blockRef -> chain.web3.eth_getTransactionCount(chain.accountAddress, blockRef));
+        assertNonCanonicalBlockHash("0x1", chain.block, blockRef -> chain.web3.eth_getTransactionCount(new HexAddressParam(chain.accountAddress), new BlockRefParam(new BlockRef(blockRef))));
     }
 
     @Test
@@ -1780,7 +1787,7 @@ class Web3ImplTest {
         argsForCall.setTo(HexUtils.toJsonHex(tx.getContractAddress().getBytes()));
         argsForCall.setData("0xead710c40000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000");
 
-        String result = web3.eth_call(argsForCall, "latest");
+        String result = web3.eth_call(new CallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
 
         assertEquals("0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000", result);
     }
@@ -1827,7 +1834,7 @@ class Web3ImplTest {
         argsForCall.setTo(HexUtils.toJsonHex(tx.getContractAddress().getBytes()));
         argsForCall.setData("0xead710c40000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000");
 
-        String result = web3.eth_call(argsForCall, "latest");
+        String result = web3.eth_call(new CallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
 
         assertEquals("0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000", result);
     }
@@ -1860,7 +1867,7 @@ class Web3ImplTest {
         argsForCall.setTo(HexUtils.toUnformattedJsonHex(tx.getContractAddress().getBytes()));
         argsForCall.setData(HexUtils.toUnformattedJsonHex(func.encode()));
 
-        String result = web3.eth_call(argsForCall, "latest");
+        String result = web3.eth_call(new CallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
 
         assertEquals("0x", result);
     }
@@ -1964,7 +1971,7 @@ class Web3ImplTest {
 
         byte[] hash = Keccak256Helper.keccak256("this is the data to hash".getBytes());
 
-        String signature = web3.eth_sign(addr1, "0x" + ByteUtil.toHexString(hash));
+        String signature = web3.eth_sign(new HexAddressParam(addr1), new HexDataParam("0x" + ByteUtil.toHexString(hash)));
 
         MatcherAssert.assertThat(
                 signature,
@@ -1990,7 +1997,7 @@ class Web3ImplTest {
 
             byte[] hash = Keccak256Helper.keccak256("this is the data to hash".getBytes());
 
-            String signature = web3.eth_sign(addr1, "0x" + ByteUtil.toHexString(hash));
+            String signature = web3.eth_sign(new HexAddressParam(addr1), new HexDataParam("0x" + ByteUtil.toHexString(hash)));
 
             MatcherAssert.assertThat(
                     signature,
@@ -2334,7 +2341,7 @@ class Web3ImplTest {
             args.setChainId(HexUtils.toJsonHex(new byte[]{chainId}));
         }
 
-        String txHash = web3.eth_sendTransaction(args);
+        String txHash = web3.eth_sendTransaction(new CallArgumentsParam(args));
 
         // ***** Verifies tx hash
         String to = toAddress.substring(2);
@@ -2403,7 +2410,7 @@ class Web3ImplTest {
         argsForCall.setTo(HexUtils.toJsonHex(tx.getContractAddress().getBytes()));
         argsForCall.setData(HexUtils.toJsonHex(noreturn.functions.get("noreturn").encodeSignature()));
 
-        String result = web3.eth_call(argsForCall, "latest");
+        String result = web3.eth_call(new CallArgumentsParam(argsForCall), new BlockIdentifierParam("latest"));
 
         Assertions.assertEquals("0x", result);
     }
@@ -3040,7 +3047,7 @@ class Web3ImplTest {
 
         String hashString = tx.getHash().toHexString();
         TxHashParam txHashParam = new TxHashParam(hashString);
-        TransactionReceiptDTO txReceipt = web3.eth_getTransactionReceipt(hashString);
+        TransactionReceiptDTO txReceipt = web3.eth_getTransactionReceipt(new TxHashParam(hashString));
         TransactionResultDTO txResult = web3.eth_getTransactionByHash(txHashParam);
 
         assertEquals("0x0", txReceipt.getType());

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -25,6 +25,8 @@ import org.ethereum.net.client.ConfigCapabilities;
 import org.ethereum.net.server.ChannelManager;
 import org.ethereum.net.server.PeerServer;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.BlockRefParam;
+import org.ethereum.rpc.parameters.HexAddressParam;
 import org.ethereum.util.BuildInfo;
 import org.ethereum.vm.DataWord;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,12 +103,12 @@ class Web3ImplUnitTest {
         when(retriever.getInformationProvider(id))
                 .thenThrow(RskJsonRpcRequestException.blockNotFound("Block not found"));
         TestUtils.assertThrows(RskJsonRpcRequestException.class,
-                () -> target.eth_getBalance(addr, id));
+                () -> target.eth_getBalance(new HexAddressParam(addr), new BlockRefParam(new BlockRef(id))));
     }
 
     @Test
     void eth_getBalance() {
-        String id = "id";
+        String id = "0x00";
         String addr = "0x0011223344556677880011223344556677889900";
         RskAddress expectedAddress = new RskAddress(addr);
 
@@ -115,7 +117,7 @@ class Web3ImplUnitTest {
         when(aip.getBalance(expectedAddress))
                 .thenReturn(new Coin(BigInteger.ONE));
 
-        String result = target.eth_getBalance(addr, id);
+        String result = target.eth_getBalance(new HexAddressParam(addr),new BlockRefParam(new BlockRef(id)));
         assertEquals("0x1", result);
     }
 
@@ -130,7 +132,7 @@ class Web3ImplUnitTest {
         };
         final Web3Impl spyTarget = spy(target);
         doReturn("0x1").when(spyTarget).invokeByBlockRef(eq(blockRef),any());
-        String result = spyTarget.eth_getBalance(addr, blockRef);
+        String result = spyTarget.eth_getBalance(new HexAddressParam(addr), new BlockRefParam(new BlockRef(blockRef)));
         assertEquals("0x1", result);
         verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
     }
@@ -276,7 +278,7 @@ class Web3ImplUnitTest {
         };
         final Web3Impl spyTarget = spy(target);
         doReturn("0x1").when(spyTarget).invokeByBlockRef(eq(blockRef),any());
-        String result = spyTarget.eth_getTransactionCount(addr, blockRef);
+        String result = spyTarget.eth_getTransactionCount(new HexAddressParam(addr), new BlockRefParam(new BlockRef(blockRef)));
         assertEquals("0x1", result);
         verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -28,6 +28,7 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.BlockRefParam;
 import org.ethereum.rpc.parameters.HexAddressParam;
 import org.ethereum.util.BuildInfo;
+import org.ethereum.util.TransactionFactoryHelper;
 import org.ethereum.vm.DataWord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -262,7 +263,7 @@ class Web3ImplUnitTest {
         final String expectedData = "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000";
 
         doReturn(expectedData).when(spyTarget).invokeByBlockRef(eq(blockRef),any());
-        String result = spyTarget.eth_call(argsForCall,blockRef);
+        String result = spyTarget.eth_call(TransactionFactoryHelper.toCallArgumentsParam(argsForCall),blockRef);
         assertEquals(expectedData, result);
         verify(spyTarget).invokeByBlockRef(eq(blockRef),any());
     }

--- a/rskj-core/src/test/java/org/ethereum/util/TransactionFactoryHelper.java
+++ b/rskj-core/src/test/java/org/ethereum/util/TransactionFactoryHelper.java
@@ -1,6 +1,7 @@
 package org.ethereum.util;
 
 import java.math.BigInteger;
+import java.util.Optional;
 
 import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
@@ -10,6 +11,10 @@ import co.rsk.core.RskAddress;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.TransactionBuilder;
 import co.rsk.util.HexUtils;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.rpc.parameters.HexAddressParam;
+import org.ethereum.rpc.parameters.HexDataParam;
+import org.ethereum.rpc.parameters.HexNumberParam;
 
 /**
  * Created by ajlopez on 28/02/2018.
@@ -114,6 +119,20 @@ public class TransactionFactoryHelper {
         tx.sign(senderAccount.getEcKey().getPrivKeyBytes());
 
         return tx;
+    }
+
+    public static CallArgumentsParam toCallArgumentsParam(CallArguments args) {
+        return new CallArgumentsParam(
+                Optional.ofNullable(args.getFrom()).filter(p -> !p.isEmpty()).map(HexAddressParam::new).orElse(null),
+                Optional.ofNullable(args.getTo()).filter(p -> !p.isEmpty()).map(HexAddressParam::new).orElse(null),
+                Optional.ofNullable(args.getGas()).filter(p -> !p.isEmpty()).map(HexNumberParam::new).orElse(null),
+                Optional.ofNullable(args.getGasPrice()).filter(p -> !p.isEmpty()).map(HexNumberParam::new).orElse(null),
+                Optional.ofNullable(args.getGasLimit()).filter(p -> !p.isEmpty()).map(HexNumberParam::new).orElse(null),
+                Optional.ofNullable(args.getNonce()).filter(p -> !p.isEmpty()).map(HexNumberParam::new).orElse(null),
+                Optional.ofNullable(args.getChainId()).filter(p -> !p.isEmpty()).map(HexNumberParam::new).orElse(null),
+                Optional.ofNullable(args.getValue()).filter(p -> !p.isEmpty()).map(HexNumberParam::new).orElse(null),
+                Optional.ofNullable(args.getData()).filter(p -> !p.isEmpty()).map(HexDataParam::new).orElse(null)
+        );
     }
 
 }

--- a/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
@@ -35,7 +35,7 @@ import org.ethereum.core.ReceivedTxSignatureCache;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.BlockIdentifierParam;
-import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.util.TransactionFactoryHelper;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
@@ -113,7 +113,7 @@ class NestedContractsTest {
         final String contractA = getContractAddressString(TX_CONTRACTA);
         CallArguments args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(0)));
         try {
-            ethModule.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
+            ethModule.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
             fail();
         } catch (RskJsonRpcRequestException e) {
             MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("Negative value"));
@@ -121,7 +121,7 @@ class NestedContractsTest {
 
         //Success Call -> 2 > 0
         args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(2)));
-        final String call = ethModule.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
+        final String call = ethModule.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
         //assertEquals("0x" + DataWord.valueOf(2).toString(), call);
     }
 
@@ -153,12 +153,12 @@ class NestedContractsTest {
         //Failed Call ContractA.buy(0) -> 0 > 0
         final String contractA = getContractAddressString("tx03");
         CallArguments args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(0)));
-        String call = ethModule.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
+        String call = ethModule.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
         assertEquals("0x" + DataWord.valueOf(0).toString(), call);
 
         //Success Call -> 2 > 0
         args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(2)));
-        call = ethModule.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
+        call = ethModule.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
         assertEquals("0x" + DataWord.valueOf(2).toString(), call);
 
     }

--- a/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
@@ -34,6 +34,8 @@ import org.ethereum.core.CallTransaction;
 import org.ethereum.core.ReceivedTxSignatureCache;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
@@ -111,7 +113,7 @@ class NestedContractsTest {
         final String contractA = getContractAddressString(TX_CONTRACTA);
         CallArguments args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(0)));
         try {
-            ethModule.call(args, "latest");
+            ethModule.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
             fail();
         } catch (RskJsonRpcRequestException e) {
             MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("Negative value"));
@@ -119,7 +121,7 @@ class NestedContractsTest {
 
         //Success Call -> 2 > 0
         args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(2)));
-        final String call = ethModule.call(args, "latest");
+        final String call = ethModule.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
         //assertEquals("0x" + DataWord.valueOf(2).toString(), call);
     }
 
@@ -151,12 +153,12 @@ class NestedContractsTest {
         //Failed Call ContractA.buy(0) -> 0 > 0
         final String contractA = getContractAddressString("tx03");
         CallArguments args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(0)));
-        String call = ethModule.call(args, "latest");
+        String call = ethModule.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
         assertEquals("0x" + DataWord.valueOf(0).toString(), call);
 
         //Success Call -> 2 > 0
         args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(2)));
-        call = ethModule.call(args, "latest");
+        call = ethModule.call(new CallArgumentsParam(args), new BlockIdentifierParam("latest"));
         assertEquals("0x" + DataWord.valueOf(2).toString(), call);
 
     }

--- a/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
@@ -35,6 +35,7 @@ import org.ethereum.core.ReceivedTxSignatureCache;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.util.TransactionFactoryHelper;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
@@ -112,8 +113,10 @@ class NestedContractsTest {
         //Failed Call ContractA.buy(0) -> 0 > 0
         final String contractA = getContractAddressString(TX_CONTRACTA);
         CallArguments args = buildArgs(contractA, Hex.toHexString(BUY_FUNCTION.encode(0)));
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("latest");
         try {
-            ethModule.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
+            ethModule.call(callArgumentsParam, blockIdentifierParam);
             fail();
         } catch (RskJsonRpcRequestException e) {
             MatcherAssert.assertThat(e.getMessage(), Matchers.containsString("Negative value"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Implemented deserializers added in [#2097](https://github.com/rsksmart/rskj/pull/2097).
- Updated affected tests.

## Motivation and Context
We want to align GETH's and RSKJ's behavior when handling requests errors to avoid returning "Internal server error" from RSKJ.

## How Has This Been Tested?
Using the payloads from the notion document linked in the ticket CORE-3026 for the methods, for the payloads that should return an error, said error should not be "Internal server error". For example:

```
curl --location 'http://localhost:4444' \
--header 'Content-Type: application/json' \
--data '{
	"jsonrpc":"2.0",
	"method":"eth_getTransactionCount",
	"params":[
		"0xefd2de7da3e0cc04fa07654f34b8bcb8ebbf1015",
		"first" 
	],
	"id":1
}'
```
Should return:
`{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Invalid block identifier 'first'"}}`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
