### PR TITLE
Convert rsk_protocalVersion return value to hex

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -281,7 +281,7 @@ public class Web3Impl implements Web3 {
                 }
             }
 
-            return s = Integer.toString(version);
+            return s = HexUtils.toQuantityJsonHex(version);
         } finally {
             if (logger.isDebugEnabled()) {
                 logger.debug("rsk_protocolVersion(): {}", s);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -153,7 +153,7 @@ class Web3ImplTest {
 
         String netVersion = web3.eth_protocolVersion();
 
-        assertEquals(0, netVersion.compareTo("1"), "RSK net version different than one");
+        assertEquals(0, netVersion.compareTo("0x1"), "RSK net version different than one");
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the `eth_protocolVersion` method so its return value is a hexadecimal String instead of an Integer.

## Motivation and Context
As per the Rootstock [documentation](https://dev.rootstock.io/rsk/node/architecture/json-rpc/) the `eth_protocolVersion` method should return the current ethereum protocl version number as a hexadecimal, but it currently returns it as a decimal number.

## How Has This Been Tested?
```
curl --location 'http://localhost:4444' \
--header 'Content-Type: application/json' \
--data '{
	"jsonrpc":"2.0",
	"id":666,
	"method":"eth_protocolVersion"
}'

// Should return
{"jsonrpc":"2.0","id":666,"result":"0x32"}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
