### PR TITLE
Fixed parsing of --import cli flag

### DIFF
--- a/rskj-core/src/main/java/co/rsk/cli/RskCli.java
+++ b/rskj-core/src/main/java/co/rsk/cli/RskCli.java
@@ -53,8 +53,8 @@ public class RskCli implements Runnable {
     @CommandLine.Option(names = {"-r", "--reset"}, description = "Reset the database")
     private boolean dbReset;
 
-    @CommandLine.Option(names = {"--import"}, description = "Import database")
-    private String dbImport;
+    @CommandLine.Option(names = {"-i", "--import"}, description = "Import database")
+    private boolean dbImport;
 
     // config flags
     @CommandLine.Option(names = {"--verify-config"}, description = "Verify configuration")
@@ -110,9 +110,8 @@ public class RskCli implements Runnable {
             activatedFlags.add(NodeCliFlags.DB_RESET);
         }
 
-        if (dbImport != null) {
+        if (dbImport) {
             activatedFlags.add(NodeCliFlags.DB_IMPORT);
-            paramValueMap.put("import", dbImport);
         }
 
         if (verifyConfig) {
@@ -129,12 +128,10 @@ public class RskCli implements Runnable {
 
         if (rpcCors != null) {
             activatedOptions.put(NodeCliOptions.RPC_CORS, rpcCors);
-            paramValueMap.put("rpc-cors", rpcCors);
         }
 
         if (basePath != null) {
             activatedOptions.put(NodeCliOptions.BASE_PATH, basePath);
-            paramValueMap.put("base-path", basePath);
         }
 
         if (xArguments != null) {

--- a/rskj-core/src/test/java/co/rsk/cli/RskCliTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/RskCliTest.java
@@ -25,13 +25,43 @@ public class RskCliTest {
         rskCli.load(args);
         assertTrue(rskCli.getCliArgs().getFlags().contains(NodeCliFlags.VERSION));
     }
+
     @Test
     void argsAreParsedCorrectly() {
         RskCli rskCli = new RskCli();
-        String[] args = {"--main", "--skip-java-check", "--print-system-info", "--verify-config", "--reset"};
-        rskCli.load(args);
+        String[] mainnetArgs = {"--main", "--skip-java-check", "--print-system-info", "--verify-config", "--reset", "--import", "-rpccors=*", "-base-path=./test-db", "-Xdatabase.dir="};
+        rskCli.load(mainnetArgs);
         CliArgs<NodeCliOptions, NodeCliFlags> parsedArgs = rskCli.getCliArgs();
-        assertEquals(5, parsedArgs.getFlags().size());
+        assertEquals(6, parsedArgs.getFlags().size());
+        assertEquals(2, parsedArgs.getOptions().size());
+        assertEquals(1, parsedArgs.getParamValueMap().size());
+
+        assertEquals("*", parsedArgs.getOptions().get(NodeCliOptions.RPC_CORS));
+        assertEquals("./test-db", parsedArgs.getOptions().get(NodeCliOptions.BASE_PATH));
+
+        rskCli = new RskCli();
+        String[] shortArgs = {"-r", "-i"};
+        rskCli.load(shortArgs);
+        parsedArgs = rskCli.getCliArgs();
+        assertEquals(2, parsedArgs.getFlags().size());
+        assertTrue(parsedArgs.getFlags().contains(NodeCliFlags.DB_RESET));
+        assertTrue(parsedArgs.getFlags().contains(NodeCliFlags.DB_IMPORT));
+
+        rskCli = new RskCli();
+        String[] testnetArgs = {"--testnet", "--skip-java-check", "--print-system-info", "--verify-config", "--reset", "--import", "-rpccors=*", "-base-path=./test-db", "-Xdatabase.dir="};
+        rskCli.load(testnetArgs);
+        parsedArgs = rskCli.getCliArgs();
+        assertEquals(6, parsedArgs.getFlags().size());
+        assertEquals(2, parsedArgs.getOptions().size());
+        assertEquals(1, parsedArgs.getParamValueMap().size());
+
+        rskCli = new RskCli();
+        String[] regtestArgs = {"--regtest", "--skip-java-check", "--print-system-info", "--verify-config", "--reset", "--import", "-rpccors=*", "-base-path=./test-db", "-Xdatabase.dir="};
+        rskCli.load(regtestArgs);
+        parsedArgs = rskCli.getCliArgs();
+        assertEquals(6, parsedArgs.getFlags().size());
+        assertEquals(2, parsedArgs.getOptions().size());
+        assertEquals(1, parsedArgs.getParamValueMap().size());
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Right now `--import` flag requires a value to be provided. This PR fixes this and returns how it was before.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


*ci:fingerroot530-modifier*
