### PR TITLE
Add Environment contract check and init call to Program

### DIFF
--- a/rskj-core/src/main/java/co/rsk/pcc/environment/GetCallStackDepth.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/environment/GetCallStackDepth.java
@@ -45,7 +45,7 @@ public class GetCallStackDepth extends NativeMethod {
 
     @Override
     public Object execute(Object[] arguments) throws NativeContractIllegalArgumentException {
-        return ByteUtil.intToBytes(programInvoke.getCallDeep());
+        return ByteUtil.intToBytes(programInvoke == null ? 1 : programInvoke.getCallDeep());
     }
 
     @Override

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1086,6 +1086,10 @@ public class Program {
         return result;
     }
 
+    public ProgramInvoke getInvoke() {
+        return this.invoke;
+    }
+
     public void setRuntimeFailure(RuntimeException e) {
         getResult().setException(e);
     }
@@ -1408,6 +1412,14 @@ public class Program {
             );
 
             contract.init(internalTx, executionBlock, track, this.invoke.getBlockStore(), null, result.getLogInfoList());
+        }
+
+        if (contract instanceof PrecompiledContracts.Environment) {
+            PrecompiledContractArgs args = PrecompiledContractArgsBuilder.builder()
+                    .programInvoke(this.invoke)
+                    .build();
+
+            contract.init(args);
         }
 
         long requiredGas = contract.getGasForData(data);

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -1411,11 +1411,12 @@ public class Program {
                     Collections.emptyList()
             );
 
-            contract.init(internalTx, executionBlock, track, this.invoke.getBlockStore(), null, result.getLogInfoList());
-        }
-
-        if (contract instanceof PrecompiledContracts.Environment) {
             PrecompiledContractArgs args = PrecompiledContractArgsBuilder.builder()
+                    .transaction(internalTx)
+                    .executionBlock(executionBlock)
+                    .repository(track)
+                    .blockStore(this.invoke.getBlockStore())
+                    .logs(result.getLogInfoList())
                     .programInvoke(this.invoke)
                     .build();
 

--- a/rskj-core/src/test/java/co/rsk/pcc/environment/GetCallStackDepthTest.java
+++ b/rskj-core/src/test/java/co/rsk/pcc/environment/GetCallStackDepthTest.java
@@ -33,10 +33,10 @@ import static org.mockito.Mockito.when;
 
 class GetCallStackDepthTest {
     private GetCallStackDepth method;
+    ExecutionEnvironment executionEnvironment = mock(ExecutionEnvironment.class);
 
     @BeforeEach
     void createMethod() {
-        ExecutionEnvironment executionEnvironment = mock(ExecutionEnvironment.class);
         ProgramInvoke programInvoke = mock(ProgramInvoke.class);
         when(programInvoke.getCallDeep()).thenReturn(1);
         method = new GetCallStackDepth(executionEnvironment, programInvoke);
@@ -68,5 +68,14 @@ class GetCallStackDepthTest {
         Assertions.assertArrayEquals(
                 ByteUtil.intToBytes(1),
                 (byte[]) method.execute(new Object[]{}));
+    }
+
+    @Test
+    void executesWithNullProgramInvoke() throws NativeContractIllegalArgumentException {
+        GetCallStackDepth methodWithNullProgramInvoke = new GetCallStackDepth(executionEnvironment, null);
+
+        Assertions.assertArrayEquals(
+                ByteUtil.intToBytes(1),
+                (byte[]) methodWithNullProgramInvoke.execute(new Object[]{}));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/vm/program/ProgramTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/ProgramTest.java
@@ -28,7 +28,6 @@ import org.ethereum.core.*;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.MessageCall;
 import org.ethereum.vm.PrecompiledContractArgs;
-import org.ethereum.vm.PrecompiledContractArgsBuilder;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.exception.VMException;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
@@ -63,9 +62,10 @@ class ProgramTest {
     protected long gasCost;
     protected Program program;
 
+    private final ActivationConfig.ForBlock activations = getBlockchainConfig();
+
     @BeforeEach
     void setup() {
-        final ActivationConfig.ForBlock activations = getBlockchainConfig();
         precompiledContract = spy(precompiledContracts.getContractForAddress(activations, PrecompiledContracts.ECRECOVER_ADDR_DW));
         gasCost = precompiledContract.getGasForData(DataWord.ONE.getData());
 
@@ -165,11 +165,7 @@ class ProgramTest {
 
     @Test
     void testCallToPrecompiledAddress_callEnvironmentInit() {
-        ActivationConfig.ForBlock environmentActivations = getBlockchainConfig();
-        PrecompiledContracts.PrecompiledContract environmentContract = spy(precompiledContracts.getContractForAddress(environmentActivations, PrecompiledContracts.ENVIRONMENT_ADDR_DW));
-        PrecompiledContractArgs args = PrecompiledContractArgsBuilder.builder()
-                        .programInvoke(programInvoke)
-                        .build();
+        PrecompiledContracts.PrecompiledContract environmentContract = spy(precompiledContracts.getContractForAddress(activations, PrecompiledContracts.ENVIRONMENT_ADDR_DW));
 
         program.callToPrecompiledAddress(msg, environmentContract);
 

--- a/rskj-core/src/test/java/org/ethereum/vm/program/ProgramTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/ProgramTest.java
@@ -153,25 +153,16 @@ class ProgramTest {
 
         program.callToPrecompiledAddress(msg, bridge);
 
-        verify(bridge, atLeastOnce()).init(
-            any(Transaction.class),
-            any(Block.class),
-            any(Repository.class),
-            isNull(),
-            isNull(),
-            anyList()
-        );
-    }
-
-    @Test
-    void testCallToPrecompiledAddress_callEnvironmentInit() {
-        PrecompiledContracts.PrecompiledContract environmentContract = spy(precompiledContracts.getContractForAddress(activations, PrecompiledContracts.ENVIRONMENT_ADDR_DW));
-
-        program.callToPrecompiledAddress(msg, environmentContract);
-
         ArgumentCaptor<PrecompiledContractArgs> argsCaptor = ArgumentCaptor.forClass(PrecompiledContractArgs.class);
 
-        verify(environmentContract, times(1)).init(argsCaptor.capture());
+        verify(bridge, atLeastOnce()).init(argsCaptor.capture());
+
+        assertNotNull(argsCaptor.getValue().getTransaction());
+        assertNotNull(argsCaptor.getValue().getExecutionBlock());
+        assertNotNull(argsCaptor.getValue().getRepository());
+        assertNull(argsCaptor.getValue().getBlockStore());
+        assertNull(argsCaptor.getValue().getReceiptStore());
+        assertNotNull(argsCaptor.getValue().getLogs());
         assertNotNull(argsCaptor.getValue().getProgramInvoke());
     }
 

--- a/rskj-core/src/test/java/org/ethereum/vm/program/ProgramTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/ProgramTest.java
@@ -27,6 +27,8 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.*;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.MessageCall;
+import org.ethereum.vm.PrecompiledContractArgs;
+import org.ethereum.vm.PrecompiledContractArgsBuilder;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.exception.VMException;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigInteger;
@@ -158,6 +161,22 @@ class ProgramTest {
             isNull(),
             anyList()
         );
+    }
+
+    @Test
+    void testCallToPrecompiledAddress_callEnvironmentInit() {
+        ActivationConfig.ForBlock environmentActivations = getBlockchainConfig();
+        PrecompiledContracts.PrecompiledContract environmentContract = spy(precompiledContracts.getContractForAddress(environmentActivations, PrecompiledContracts.ENVIRONMENT_ADDR_DW));
+        PrecompiledContractArgs args = PrecompiledContractArgsBuilder.builder()
+                        .programInvoke(programInvoke)
+                        .build();
+
+        program.callToPrecompiledAddress(msg, environmentContract);
+
+        ArgumentCaptor<PrecompiledContractArgs> argsCaptor = ArgumentCaptor.forClass(PrecompiledContractArgs.class);
+
+        verify(environmentContract, times(1)).init(argsCaptor.capture());
+        assertNotNull(argsCaptor.getValue().getProgramInvoke());
     }
 
     /*********************************


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the `Program#callToPrecompiledAddress` method to check if the contract beign called is `Environment` and if so, call its `init` method by passing a `PrecompiledContractArgs` instance with just its `programInvoke` variable set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
