### PR TITLE
Return properly encoded value by eth_getStorageAt RPC method for non-existing keys

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1198,6 +1198,9 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         closed = true;
 
+        final long startTime = System.currentTimeMillis();
+        logger.info("Closing RSK context");
+
         // as RskContext creates PeerExplorer and manages its lifecycle, dispose it here
         if (peerExplorer != null) {
             peerExplorer.dispose();
@@ -1246,6 +1249,9 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             wallet.close();
             logger.trace("wallet closed.");
         }
+
+        final long endTime = System.currentTimeMillis();
+        logger.info("RSK context closed (after {} ms)", endTime - startTime);
     }
 
     public synchronized DbKind getDbKind(String dbPath) {

--- a/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
@@ -239,7 +239,7 @@ public class PeerExplorer {
                 this.addConnection(message, request.getAddress().getHostString(), request.getAddress().getPort());
             }
         } else {
-            logger.warn("handlePong - Peer discovery request with id [{}] is either null or invalid", message.getMessageId());
+            logger.debug("handlePong - Peer discovery request with id [{}] is either null or invalid", message.getMessageId());
         }
     }
 
@@ -254,7 +254,7 @@ public class PeerExplorer {
             this.sendNeighbors(connectedNode.getAddress(), nodesToSend, message.getMessageId());
             updateEntry(connectedNode);
         } else {
-            logger.warn("handleFindNode - Node with id: [{}] is not connected. Ignored", nodeId);
+            logger.debug("handleFindNode - Node with id: [{}] is not connected. Ignored", nodeId);
         }
     }
 
@@ -282,7 +282,7 @@ public class PeerExplorer {
             }
             updateEntry(connectedNode);
         } else {
-            logger.warn("handleFindNode - Node with id: [{}] is not connected. Ignored", nodeId);
+            logger.debug("handleNeighborsMessage - Node with id: [{}] is not connected. Ignored", nodeId);
         }
     }
 
@@ -298,7 +298,7 @@ public class PeerExplorer {
         PingPeerMessage nodeMessage = checkPendingPeerToAddress(nodeAddress);
 
         if (nodeMessage != null) {
-            logger.warn("sendPing - No ping message has been sent to address: [{}/{}], as there's pending one", nodeAddress.getHostName(), nodeAddress.getPort());
+            logger.trace("sendPing - No ping message has been sent to address: [{}/{}], as there's pending one", nodeAddress.getHostName(), nodeAddress.getPort());
 
             return nodeMessage;
         }

--- a/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
@@ -486,15 +486,11 @@ public class PeerExplorer {
     }
 
     private void removeConnection(Node node) {
-        if (logger.isDebugEnabled()) {
-            InetSocketAddress address = node.getAddress();
-            logger.debug("removeConnection - Removing node: [{}], " +
-                    "nodeAddress address: [{}/{}]", node.getHexId(), address.getHostName(), address.getPort());
-        }
-
         this.establishedConnections.remove(node.getId());
         this.distanceTable.removeNode(node);
         this.knownHosts.remove(node.getAddressAsString());
+
+        logger.info("removeConnection - Removed peer: [{}]. Total num of peers: [{}]", node, this.establishedConnections.size());
     }
 
     private void addConnection(PongPeerMessage message, String ip, int port) {
@@ -523,7 +519,7 @@ public class PeerExplorer {
         if (result.isSuccess()) {
             this.knownHosts.put(senderNode.getAddressAsString(), senderNode.getId());
             this.establishedConnections.put(senderNode.getId(), senderNode);
-            logger.debug("New Peer found or id changed: ip[{}] port[{}] id [{}]", ip, port, senderNode.getId());
+            logger.info("New Peer found or id changed: ip[{}] port[{}] id [{}]. Total num of peers: [{}]", ip, port, senderNode.getId(), this.establishedConnections.size());
         } else {
             this.challengeManager.startChallenge(result.getAffectedEntry().getNode(), senderNode, this);
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -582,12 +582,12 @@ public class BridgeSupport {
                 btcTx.getHash(),
                 e.getMessage()
             );
-            logger.warn("[processPegIn] {}", message);
+            logger.warn("[legacyProcessPegin] {}", message);
             throw new RegisterBtcTransactionException(message);
         }
 
         int protocolVersion = peginInformation.getProtocolVersion();
-        logger.debug("[processPegIn] Protocol version: {}", protocolVersion);
+        logger.debug("[legacyProcessPegin] Protocol version: {}", protocolVersion);
         switch (protocolVersion) {
             case 0:
                 processPegInVersionLegacy(btcTx, rskTxHash, height, peginInformation, totalAmount);
@@ -598,7 +598,7 @@ public class BridgeSupport {
             default:
                 markTxAsProcessed(btcTx);
                 String message = String.format("Invalid peg-in protocol version: %d", protocolVersion);
-                logger.warn("[processPegIn] {}", message);
+                logger.warn("[legacyProcessPegin] {}", message);
                 throw new RegisterBtcTransactionException(message);
         }
 

--- a/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/Web3RskModule.java
@@ -19,6 +19,9 @@
 package co.rsk.rpc;
 
 import co.rsk.rpc.modules.rsk.RskModule;
+import org.ethereum.rpc.parameters.BlockRefParam;
+import org.ethereum.rpc.parameters.HexAddressParam;
+import org.ethereum.rpc.parameters.HexNumberParam;
 
 public interface Web3RskModule {
 
@@ -47,4 +50,7 @@ public interface Web3RskModule {
     }
 
     RskModule getRskModule();
+
+    String rsk_getStorageBytesAt(HexAddressParam address, HexNumberParam storageIdx, BlockRefParam blockRefParam);
+
 }

--- a/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/LevelDbDataSource.java
@@ -62,7 +62,7 @@ public class LevelDbDataSource implements KeyValueDataSource {
     public LevelDbDataSource(String name, String databaseDir) {
         this.databaseDir = databaseDir;
         this.name = name;
-        logger.debug("New LevelDbDataSource: {}", name);
+        logger.info("New LevelDbDataSource: {}", name);
     }
 
     public static KeyValueDataSource makeDataSource(Path datasourcePath) {

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
@@ -66,7 +66,7 @@ public class RocksDbDataSource implements KeyValueDataSource {
     public RocksDbDataSource(String name, String databaseDir) {
         this.databaseDir = databaseDir;
         this.name = name;
-        logger.debug("New RocksDbDataSource: {}", name);
+        logger.info("New RocksDbDataSource: {}", name);
     }
 
     public static KeyValueDataSource makeDataSource(Path datasourcePath) {
@@ -74,8 +74,6 @@ public class RocksDbDataSource implements KeyValueDataSource {
         ds.init();
         return ds;
     }
-
-
 
     @Override
     public void init() {

--- a/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/net/server/ChannelManagerImpl.java
@@ -179,6 +179,8 @@ public class ChannelManagerImpl implements ChannelManager {
             syncPool.add(peer);
             synchronized (activePeersLock) {
                 activePeers.put(peer.getNodeId(), peer);
+
+                logger.info("Added new peer: {}. Total num of active peers: {}", peer, activePeers.size());
             }
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/rpc/parameters/HexAddressParam.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/parameters/HexAddressParam.java
@@ -49,6 +49,11 @@ public class HexAddressParam implements Serializable {
         return address;
     }
 
+    @Override
+    public String toString() {
+        return address.toString();
+    }
+    
     public static class Deserializer extends StdDeserializer<HexAddressParam> {
         private static final long serialVersionUID = 1L;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/parameters/HexNumberParam.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/parameters/HexNumberParam.java
@@ -51,6 +51,11 @@ public class HexNumberParam implements Serializable {
         return this.hexNumber;
     }
 
+    @Override
+    public String toString() {
+        return this.hexNumber;
+    }
+
     public static class Deserializer extends StdDeserializer<HexNumberParam> {
         private static final long serialVersionUID = 1L;
 

--- a/rskj-core/src/main/resources/logback.xml
+++ b/rskj-core/src/main/resources/logback.xml
@@ -107,6 +107,8 @@
     <logger name="btcBlockStore" level="INFO" />
     <logger name="secp256k1" level="INFO" />
     <logger name="altbn128" level="INFO" />
+    <logger name="co.rsk.net.discovery.PeerExplorer" level="INFO" />
+    <logger name="co.rsk.net.discovery.NodeChallengeManager" level="INFO" />
 
     <!-- Use INFO or upper levels for production environments. -->
     <logger name="com.googlecode.jsonrpc4j" level="INFO" />

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -428,7 +428,7 @@ rpc {
             version: "1.0",
             enabled: "true",
             methods: {
-                disabled: [ "rsk_shutdown", "rsk_flush" ]
+                disabled: [ "rsk_shutdown", "rsk_flush", "rsk_getStorageBytesAt" ]
             }
         }
     }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -110,7 +110,7 @@ class Web3ImplTest {
 
     private static final String BALANCE_10K_HEX = "0x2710"; //10.000
     private static final String CALL_RESPOND = "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000";
-
+    private static final String NON_EXISTING_KEY_RESPONSE = "0x0000000000000000000000000000000000000000000000000000000000000000";
     private final TestSystemProperties config = new TestSystemProperties();
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
     private final SyncProcessor syncProcessor = mock(SyncProcessor.class);
@@ -367,7 +367,7 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockNumber": "0x0" } -> return storage at given address in genesis block
     void getStorageAtAccountAndBlockNumber() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertByBlockNumber("0x0", blockRef -> chain.web3.eth_getStorageAt(
+        assertByBlockNumber(NON_EXISTING_KEY_RESPONSE, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -377,7 +377,7 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" } -> return storage at given address in genesis block
     void getStorageAtAccountAndBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertByBlockHash("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertByBlockHash(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -428,7 +428,7 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": true } -> return storage at given address in genesis block
     void getStorageAtAccountAndCanonicalBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertCanonicalBlockHashWhenCanonical("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertCanonicalBlockHashWhenCanonical(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -438,7 +438,7 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": false } -> return storage at given address in genesis block
     void getStorageAtAccountAndCanonicalBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertCanonicalBlockHashWhenNotCanonical("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertCanonicalBlockHashWhenNotCanonical(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -448,7 +448,7 @@ class Web3ImplTest {
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>", "requireCanonical": false } -> return storage at given address in specified block
     void getStorageAtAccountAndNonCanonicalBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = chainWithAccount10kBalance(true);
-        assertNonCanonicalBlockHashWhenNotCanonical("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertNonCanonicalBlockHashWhenNotCanonical(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -458,7 +458,7 @@ class Web3ImplTest {
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>" } -> return storage at given address in specified bloc
     void getStorageAtAccountAndNonCanonicalBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(true);
-        assertNonCanonicalBlockHash("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertNonCanonicalBlockHash(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -209,7 +209,7 @@ class Web3ImplUnitTest {
                 .thenReturn(null);
 
         String result = target.eth_getStorageAt(hexAddressParam, hexNumberParam, blockRefParam);
-        assertEquals("0x0",
+        assertEquals("0x0000000000000000000000000000000000000000000000000000000000000000",
                 result);
     }
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -1,41 +1,5 @@
 package org.ethereum.rpc;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.ethereum.TestUtils;
-import org.ethereum.core.*;
-import org.ethereum.db.BlockStore;
-import org.ethereum.db.ReceiptStore;
-import org.ethereum.facade.Ethereum;
-import org.ethereum.net.client.ConfigCapabilities;
-import org.ethereum.net.server.ChannelManager;
-import org.ethereum.net.server.PeerServer;
-import org.ethereum.rpc.exception.RskJsonRpcRequestException;
-import org.ethereum.rpc.parameters.BlockHashParam;
-import org.ethereum.rpc.parameters.BlockIdentifierParam;
-import org.ethereum.rpc.parameters.BlockRefParam;
-import org.ethereum.rpc.parameters.HexAddressParam;
-import org.ethereum.rpc.parameters.HexNumberParam;
-import org.ethereum.util.BuildInfo;
-import org.ethereum.util.TransactionFactoryHelper;
-import org.ethereum.vm.DataWord;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import co.rsk.config.RskSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
@@ -55,6 +19,29 @@ import co.rsk.rpc.modules.rsk.RskModule;
 import co.rsk.rpc.modules.txpool.TxPoolModule;
 import co.rsk.scoring.PeerScoringManager;
 import co.rsk.util.HexUtils;
+import org.ethereum.TestUtils;
+import org.ethereum.core.*;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.facade.Ethereum;
+import org.ethereum.net.client.ConfigCapabilities;
+import org.ethereum.net.server.ChannelManager;
+import org.ethereum.net.server.PeerServer;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.*;
+import org.ethereum.util.BuildInfo;
+import org.ethereum.util.TransactionFactoryHelper;
+import org.ethereum.vm.DataWord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 class Web3ImplUnitTest {
 
@@ -222,6 +209,53 @@ class Web3ImplUnitTest {
                 .thenReturn(null);
 
         String result = target.eth_getStorageAt(hexAddressParam, hexNumberParam, blockRefParam);
+        assertEquals("0x0",
+                result);
+    }
+
+    @Test
+    void rsk_getStorageBytesAt() {
+        String id = "0x00";
+        String addr = "0x0011223344556677880011223344556677889900";
+        RskAddress expectedAddress = new RskAddress(addr);
+        String storageIdx = "0x01";
+        DataWord expectedIdx = DataWord.valueOf(HexUtils.stringHexToByteArray(storageIdx));
+
+        HexAddressParam hexAddressParam =  new HexAddressParam(addr);
+        HexNumberParam hexNumberParam = new HexNumberParam(storageIdx);
+        BlockRefParam blockRefParam = new BlockRefParam(id);
+        byte[] resultBytes = TestUtils.generateBytes("result",64);
+
+        AccountInformationProvider aip = mock(AccountInformationProvider.class);
+        when(retriever.getInformationProvider(id)).thenReturn(aip);
+        when(aip.getStorageBytes(expectedAddress, expectedIdx))
+                .thenReturn(resultBytes);
+
+        String expectedResult = HexUtils.toUnformattedJsonHex(resultBytes);
+
+        String result = target.rsk_getStorageBytesAt(hexAddressParam, hexNumberParam, blockRefParam);
+        assertEquals(expectedResult,
+                result);
+    }
+
+    @Test
+    void rsk_getStorageBytesAtEmptyCell() {
+        String id = "0x00";
+        String addr = "0x0011223344556677880011223344556677889900";
+        RskAddress expectedAddress = new RskAddress(addr);
+        String storageIdx = "0x01";
+        DataWord expectedIdx = DataWord.valueOf(HexUtils.stringHexToByteArray(storageIdx));
+
+        HexAddressParam hexAddressParam =  new HexAddressParam(addr);
+        HexNumberParam hexNumberParam = new HexNumberParam(storageIdx);
+        BlockRefParam blockRefParam = new BlockRefParam(id);
+
+        AccountInformationProvider aip = mock(AccountInformationProvider.class);
+        when(retriever.getInformationProvider(id)).thenReturn(aip);
+        when(aip.getStorageValue(expectedAddress, expectedIdx))
+                .thenReturn(null);
+
+        String result = target.rsk_getStorageBytesAt(hexAddressParam, hexNumberParam, blockRefParam);
         assertEquals("0x0",
                 result);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated eth_getStorageAt to return a 32-byte zero value for non-existing keys, aligning with geth client behavior.

## Motivation and Context
Ensures compatibility with Ethers.js and other clients like Geth, which expect a 32-byte zero value for non-existing keys.

## How Has This Been Tested?
Tested in local development environment; unit tests updated to reflect new return value.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
