### PR TITLE
Ignore LevelDB-related unit tests when running on ARM CPUs

### DIFF
--- a/rskj-core/src/main/java/co/rsk/util/SystemUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/SystemUtils.java
@@ -17,6 +17,7 @@
  */
 package co.rsk.util;
 
+import co.rsk.altbn128.cloudflare.Utils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 
@@ -35,6 +36,13 @@ public class SystemUtils {
     );
 
     private SystemUtils() { /* hidden */ }
+
+    /**
+    * Wrapper for {@link Utils::isArm()} from external library
+    */
+    public static boolean isArm() {
+        return Utils.isArm();
+    }
 
     /**
      * Helper method that prints some system and runtime properties available to JVM.

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CliToolsTest.java
@@ -37,6 +37,7 @@ import co.rsk.trie.Trie;
 import co.rsk.util.NodeStopper;
 import co.rsk.util.PreflightCheckException;
 import co.rsk.util.PreflightChecksUtils;
+import co.rsk.util.SystemUtils;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -79,6 +80,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.*;
 
 /**
@@ -508,6 +510,8 @@ class CliToolsTest {
 
     @Test
     void dbMigrate() throws IOException {
+        assumeTrue(!SystemUtils.isArm()); // db migration assumes that one of the data sources is leveldb, which doesn't support ARM cpu
+
         File nodeIdPropsFile = tempDir.resolve("nodeId.properties").toFile();
         File dbKindPropsFile = tempDir.resolve(KeyValueDataSourceUtils.DB_KIND_PROPERTIES_FILE).toFile();
 

--- a/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/KeyValueDataSourceTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.datasource;
 
+import co.rsk.util.SystemUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.db.ByteArrayWrapper;
 import org.ethereum.util.ByteUtil;
@@ -272,18 +273,26 @@ class KeyValueDataSourceTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws IOException {
             Path tmpDir = Files.createTempDirectory("rskj");
-            return Stream.of(
+            Stream<Arguments> argumentsStream = Stream.of(
                     Arguments.of(initHashmapDB(), HashMapDB.class.getSimpleName(), true),
-                    Arguments.of(initLevelDBDatasource(tmpDir), LevelDbDataSource.class.getSimpleName(), true),
                     Arguments.of(initRocksDBDatasource(tmpDir), RocksDbDataSource.class.getSimpleName(), true),
                     Arguments.of(initHashmapDBWithCache(), String.format("Cache with %s", HashMapDB.class.getSimpleName()), true),
                     Arguments.of(initDatasourceWithCache(tmpDir), String.format("Cache with %s", RocksDbDataSource.class.getSimpleName()), true),
                     Arguments.of(initHashmapDB(), HashMapDB.class.getSimpleName(), false),
-                    Arguments.of(initLevelDBDatasource(tmpDir), LevelDbDataSource.class.getSimpleName(), true),
                     Arguments.of(initRocksDBDatasource(tmpDir), RocksDbDataSource.class.getSimpleName(), false),
                     Arguments.of(initHashmapDBWithCache(), String.format("Cache with %s", HashMapDB.class.getSimpleName()), false),
                     Arguments.of(initDatasourceWithCache(tmpDir), String.format("Cache with %s", RocksDbDataSource.class.getSimpleName()), false)
             );
+
+            if (SystemUtils.isArm()) {
+                return argumentsStream;
+            }
+
+            // if not arm, then add LevelDB data sources
+            return Stream.concat(argumentsStream, Stream.of(
+                    Arguments.of(initLevelDBDatasource(tmpDir), LevelDbDataSource.class.getSimpleName(), true),
+                    Arguments.of(initLevelDBDatasource(tmpDir), LevelDbDataSource.class.getSimpleName(), true)
+            ));
         }
 
         private static HashMapDB initHashmapDB() {

--- a/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/LevelDbDataSourceTest.java
@@ -19,6 +19,7 @@
 
 package org.ethereum.datasource;
 
+import co.rsk.util.SystemUtils;
 import com.google.common.collect.ImmutableSet;
 import org.awaitility.Awaitility;
 import org.ethereum.TestUtils;
@@ -28,10 +29,7 @@ import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.DBIterator;
 import org.iq80.leveldb.WriteBatch;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
@@ -45,6 +43,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.ethereum.TestUtils.generateBytes;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.*;
 
 class LevelDbDataSourceTest {
@@ -52,6 +51,11 @@ class LevelDbDataSourceTest {
     public Path databaseDir;
 
     private LevelDbDataSource dataSource;
+
+    @BeforeAll
+    static void setUpBeforeClass() {
+        assumeTrue(!SystemUtils.isArm());
+    }
 
     @BeforeEach
     void setUp() {

--- a/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/NotParameterizedKeyValueDataSourceTest.java
@@ -1,5 +1,6 @@
 package org.ethereum.datasource;
 
+import co.rsk.util.SystemUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -12,6 +13,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class NotParameterizedKeyValueDataSourceTest {
 
@@ -44,6 +47,8 @@ class NotParameterizedKeyValueDataSourceTest {
 
     @Test
     void mergeDataSourceLevelDb() {
+        assumeTrue(!SystemUtils.isArm()); // LevelDB doesn't support ARM cpu
+
         testMergeDataSource(DbKind.LEVEL_DB);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As of now, LevelDB database engine doesn't support Apple or any other ARM-based silicons which causes unit tests check to fail when triggered on such cpu's

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
