### PR TITLE
Move pending federation serializer behaviour to PendingFederation class so it can be moved into federation package. Move PendingFederation class into federation package

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -393,17 +393,6 @@ public class BridgeSerializationUtils {
         return new FederationMember(btcKey, rskKey, mstKey);
     }
 
-    /**
-     * A pending federation is serialized as the
-     * public keys conforming it.
-     * This is a legacy format for blocks before the Wasabi
-     * network upgrade.
-     * See BridgeSerializationUtils::serializeBtcPublicKeys
-     */
-    public static byte[] serializePendingFederationOnlyBtcKeys(PendingFederation pendingFederation) {
-        return serializeBtcPublicKeys(pendingFederation.getBtcPublicKeys());
-    }
-
     // For the serialization format, see BridgeSerializationUtils::serializePendingFederationOnlyBtcKeys
     // and serializePublicKeys::deserializeBtcPublicKeys
     public static PendingFederation deserializePendingFederationOnlyBtcKeys(byte[] data) {
@@ -413,19 +402,6 @@ public class BridgeSerializationUtils {
         ).collect(Collectors.toList());
 
         return new PendingFederation(members);
-    }
-
-    /**
-     * A pending federation is serialized as the
-     * list of its sorted members serialized.
-     * For the member serialization format, see BridgeSerializationUtils::serializeFederationMember
-     */
-    public static byte[] serializePendingFederation(PendingFederation pendingFederation) {
-        List<byte[]> encodedMembers = pendingFederation.getMembers().stream()
-                .sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR)
-                .map(BridgeSerializationUtils::serializeFederationMember)
-                .collect(Collectors.toList());
-        return RLP.encodeList(encodedMembers.toArray(new byte[0][]));
     }
 
     // For the serialization format, see BridgeSerializationUtils::serializePendingFederation
@@ -889,18 +865,6 @@ public class BridgeSerializationUtils {
         }
 
         return new ABICallSpec(function, arguments);
-    }
-
-    // A list of btc public keys is serialized as
-    // [pubkey1, pubkey2, ..., pubkeyn], sorted
-    // using the lexicographical order of the public keys
-    // (see BtcECKey.PUBKEY_COMPARATOR).
-    private static byte[] serializeBtcPublicKeys(List<BtcECKey> keys) {
-        List<byte[]> encodedKeys = keys.stream()
-                .sorted(BtcECKey.PUBKEY_COMPARATOR)
-                .map(key -> RLP.encodeElement(key.getPubKey()))
-                .collect(Collectors.toList());
-        return RLP.encodeList(encodedKeys.toArray(new byte[0][]));
     }
 
     // For the serialization format, see BridgeSerializationUtils::serializePublicKeys

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -443,10 +443,10 @@ public class BridgeStorageProvider {
                     return null;
                 }
                 if (storageVersion.isPresent()) {
-                    return BridgeSerializationUtils.deserializePendingFederation(data); // Assume this is the multi-key version
+                    return PendingFederation.deserialize(data); // Assume this is the multi-key version
                 }
 
-                return BridgeSerializationUtils.deserializePendingFederationOnlyBtcKeys(data);
+                return PendingFederation.deserializeOnlyBtcKeys(data);
             }
         );
 
@@ -461,7 +461,7 @@ public class BridgeStorageProvider {
     /**
      * Save the pending federation
      */
-    public void savePendingFederation() throws IOException {
+    protected void savePendingFederation() throws IOException {
         if (shouldSavePendingFederation) {
             if (activations.isActive(RSKIP123)) {
                 // we only need to save the standard part of the fed since the emergency part is constant
@@ -470,19 +470,15 @@ public class BridgeStorageProvider {
                     STANDARD_MULTISIG_FEDERATION.getFormatVersion()
                 );
             }
-            savePendingFederation(pendingFederation);
+            savePendingFederationToRepository(pendingFederation);
         }
     }
-
-    /**
-     * Save the pending federation
-     */
-    private void savePendingFederation(PendingFederation pendingFederation) throws IOException {
+    private void savePendingFederationToRepository(PendingFederation pendingFederation) throws IOException {
         byte[] fedSerialized = null;
         if (pendingFederation != null) {
              fedSerialized = pendingFederation.serialize(activations);
         }
-        savePendingFederationToRepository(fedSerialized);
+        saveSerializedPendingFederationToRepository(fedSerialized);
     }
 
     /**
@@ -1145,12 +1141,12 @@ public class BridgeStorageProvider {
         repository.addStorageBytes(contractAddress, addressKey, data);
     }
 
-    private void savePendingFederationToRepository(byte[] federationSerialized) throws IOException {
+    private void saveSerializedPendingFederationToRepository(byte[] federationSerialized) throws IOException {
         try {
             DataWord pendingFederationKey = PENDING_FEDERATION_KEY.getKey();
             repository.addStorageBytes(contractAddress, pendingFederationKey, federationSerialized);
         } catch (RuntimeException e) {
-            throw new IOException("Unable to save to repository: " + Arrays.toString(federationSerialized), e);
+            throw new IOException("Unable to save pending federation to repository: " + Arrays.toString(federationSerialized), e);
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -480,7 +480,7 @@ public class BridgeStorageProvider {
         if (pendingFederation != null) {
             fedSerialized = pendingFederation.serializeOnlyBtcKeys();
         }
-        safeSavePendingFederationToRepository(PENDING_FEDERATION_KEY, fedSerialized);
+        safeSavePendingFederationToRepository(fedSerialized);
     }
 
     /**
@@ -497,7 +497,7 @@ public class BridgeStorageProvider {
         if (pendingFederation != null) {
              fedSerialized = pendingFederation.serialize();
         }
-        safeSavePendingFederationToRepository(PENDING_FEDERATION_KEY, fedSerialized);
+        safeSavePendingFederationToRepository(fedSerialized);
     }
 
     /**
@@ -1160,17 +1160,17 @@ public class BridgeStorageProvider {
         repository.addStorageBytes(contractAddress, addressKey, data);
     }
 
-    private void safeSavePendingFederationToRepository(BridgeStorageIndexKey addressKey, byte[] federationSerialized) {
+    private void safeSavePendingFederationToRepository(byte[] federationSerialized) {
         try {
-            savePendingFederationToRepository(addressKey, federationSerialized);
+            savePendingFederationToRepository(federationSerialized);
         } catch (IOException ioe) {
-            throw new RuntimeException("Unable to save to repository: " + addressKey, ioe);
+            throw new RuntimeException("Unable to save to repository: " + Arrays.toString(federationSerialized), ioe);
         }
     }
 
-    private void savePendingFederationToRepository(BridgeStorageIndexKey addressKey, byte[] federationSerialized) throws IOException {
-        DataWord keyFromAddressKey = addressKey.getKey();
-        repository.addStorageBytes(contractAddress, keyFromAddressKey, federationSerialized);
+    private void savePendingFederationToRepository(byte[] federationSerialized) throws IOException {
+        DataWord pendingFederationKey = PENDING_FEDERATION_KEY.getKey();
+        repository.addStorageBytes(contractAddress, pendingFederationKey, federationSerialized);
     }
 
     private interface RepositoryDeserializer<T> {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -446,7 +446,7 @@ public class BridgeStorageProvider {
                     return PendingFederation.deserialize(data); // Assume this is the multi-key version
                 }
 
-                return PendingFederation.deserializeOnlyBtcKeys(data);
+                return PendingFederation.deserializeFromBtcKeys(data);
             }
         );
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -464,38 +464,23 @@ public class BridgeStorageProvider {
     public void savePendingFederation() throws IOException {
         if (shouldSavePendingFederation) {
             if (activations.isActive(RSKIP123)) {
-                savePendingFederation(pendingFederation);
+                // we only need to save the standard part of the fed since the emergency part is constant
+                saveStorageVersion(
+                    PENDING_FEDERATION_FORMAT_VERSION.getKey(),
+                    STANDARD_MULTISIG_FEDERATION.getFormatVersion()
+                );
             }
-            else {
-                savePendingFederationOnlyBtcKeys(pendingFederation);
-            }
+            savePendingFederation(pendingFederation);
         }
-    }
-
-    /**
-     * Save the pending federation before RSKIP123
-     */
-    private void savePendingFederationOnlyBtcKeys(PendingFederation pendingFederation) throws IOException {
-        byte[] fedSerialized = null;
-        if (pendingFederation != null) {
-            fedSerialized = pendingFederation.serializeOnlyBtcKeys();
-        }
-        savePendingFederationToRepository(fedSerialized);
     }
 
     /**
      * Save the pending federation
      */
     private void savePendingFederation(PendingFederation pendingFederation) throws IOException {
-        // we only need to save the standard part of the fed since the emergency part is constant
-        saveStorageVersion(
-            PENDING_FEDERATION_FORMAT_VERSION.getKey(),
-            STANDARD_MULTISIG_FEDERATION.getFormatVersion()
-        );
-
         byte[] fedSerialized = null;
         if (pendingFederation != null) {
-             fedSerialized = pendingFederation.serialize();
+             fedSerialized = pendingFederation.serialize(activations);
         }
         savePendingFederationToRepository(fedSerialized);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationMember.java
@@ -21,6 +21,7 @@ package co.rsk.peg.federation;
 import co.rsk.bitcoinj.core.BtcECKey;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RLP;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +38,10 @@ import java.util.stream.Collectors;
  */
 public final class FederationMember {
     public static final FederationMemberPubKeysComparator BTC_RSK_MST_PUBKEYS_COMPARATOR = new FederationMemberPubKeysComparator();
+    private static final int FEDERATION_MEMBER_LIST_SIZE = 3;
+    private static final int FEDERATION_MEMBER_BTC_KEY_INDEX = 0;
+    private static final int FEDERATION_MEMBER_RSK_KEY_INDEX = 1;
+    private static final int FEDERATION_MEMBER_MST_KEY_INDEX = 2;
     private final BtcECKey btcPublicKey;
     private final ECKey rskPublicKey;
     private final ECKey mstPublicKey;
@@ -153,5 +158,15 @@ public final class FederationMember {
                 rskPublicKey,
                 mstPublicKey
         );
+    }
+
+    public byte[] serialize() {
+        byte[][] rlpElements = new byte[FEDERATION_MEMBER_LIST_SIZE][];
+        rlpElements[FEDERATION_MEMBER_BTC_KEY_INDEX] = RLP.encodeElement(
+            this.getBtcPublicKey().getPubKeyPoint().getEncoded(true)
+        );
+        rlpElements[FEDERATION_MEMBER_RSK_KEY_INDEX] = RLP.encodeElement(this.getRskPublicKey().getPubKey(true));
+        rlpElements[FEDERATION_MEMBER_MST_KEY_INDEX] = RLP.encodeElement(this.getMstPublicKey().getPubKey(true));
+        return RLP.encodeList(rlpElements);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationMember.java
@@ -39,8 +39,7 @@ import java.util.stream.Collectors;
  */
 public final class FederationMember {
     public static final FederationMemberPubKeysComparator BTC_RSK_MST_PUBKEYS_COMPARATOR = new FederationMemberPubKeysComparator();
-    private static final int FEDERATION_RLP_LIST_SIZE = 3;
-    private static final int LIST_SIZE = 3;
+    private static final int KEYS_QUANTITY = 3;
     private static final int BTC_KEY_INDEX = 0;
     private static final int RSK_KEY_INDEX = 1;
     private static final int MST_KEY_INDEX = 2;
@@ -163,7 +162,7 @@ public final class FederationMember {
     }
 
     public byte[] serialize() {
-        byte[][] rlpElements = new byte[LIST_SIZE][];
+        byte[][] rlpElements = new byte[KEYS_QUANTITY][];
         byte[] btcPublicKeyBytes = this.getBtcPublicKey().getPubKeyPoint().getEncoded(true);
         byte[] rskPublicKeyBytes = this.getRskPublicKey().getPubKey(true);
         byte[] mstPublicKeyBytes = this.getMstPublicKey().getPubKey(true);
@@ -176,15 +175,19 @@ public final class FederationMember {
 
     public static FederationMember deserialize(byte[] data) {
         RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
-
-        if (rlpList.size() != FEDERATION_RLP_LIST_SIZE) {
-            throw new RuntimeException(String.format("Invalid serialized FederationMember. Expected %d elements but got %d", LIST_SIZE, rlpList.size()));
+        if (rlpList.size() != KEYS_QUANTITY) {
+            throw new RuntimeException(String.format(
+                "Invalid serialized FederationMember. Expected %d elements but got %d", KEYS_QUANTITY, rlpList.size())
+            );
         }
 
-        BtcECKey btcKey = BtcECKey.fromPublicOnly(rlpList.get(BTC_KEY_INDEX).getRLPData());
-        ECKey rskKey = ECKey.fromPublicOnly(rlpList.get(RSK_KEY_INDEX).getRLPData());
-        ECKey mstKey = ECKey.fromPublicOnly(rlpList.get(MST_KEY_INDEX).getRLPData());
+        byte[] btcKeyData = rlpList.get(BTC_KEY_INDEX).getRLPData();
+        byte[] rskKeyData = rlpList.get(RSK_KEY_INDEX).getRLPData();
+        byte[] mstKeyData = rlpList.get(MST_KEY_INDEX).getRLPData();
 
+        BtcECKey btcKey = BtcECKey.fromPublicOnly(btcKeyData);
+        ECKey rskKey = ECKey.fromPublicOnly(rskKeyData);
+        ECKey mstKey = ECKey.fromPublicOnly(mstKeyData);
         return new FederationMember(btcKey, rskKey, mstKey);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationMember.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,10 +39,11 @@ import java.util.stream.Collectors;
  */
 public final class FederationMember {
     public static final FederationMemberPubKeysComparator BTC_RSK_MST_PUBKEYS_COMPARATOR = new FederationMemberPubKeysComparator();
-    private static final int FEDERATION_MEMBER_LIST_SIZE = 3;
-    private static final int FEDERATION_MEMBER_BTC_KEY_INDEX = 0;
-    private static final int FEDERATION_MEMBER_RSK_KEY_INDEX = 1;
-    private static final int FEDERATION_MEMBER_MST_KEY_INDEX = 2;
+    private static final int FEDERATION_RLP_LIST_SIZE = 3;
+    private static final int LIST_SIZE = 3;
+    private static final int BTC_KEY_INDEX = 0;
+    private static final int RSK_KEY_INDEX = 1;
+    private static final int MST_KEY_INDEX = 2;
     private final BtcECKey btcPublicKey;
     private final ECKey rskPublicKey;
     private final ECKey mstPublicKey;
@@ -161,12 +163,28 @@ public final class FederationMember {
     }
 
     public byte[] serialize() {
-        byte[][] rlpElements = new byte[FEDERATION_MEMBER_LIST_SIZE][];
-        rlpElements[FEDERATION_MEMBER_BTC_KEY_INDEX] = RLP.encodeElement(
-            this.getBtcPublicKey().getPubKeyPoint().getEncoded(true)
-        );
-        rlpElements[FEDERATION_MEMBER_RSK_KEY_INDEX] = RLP.encodeElement(this.getRskPublicKey().getPubKey(true));
-        rlpElements[FEDERATION_MEMBER_MST_KEY_INDEX] = RLP.encodeElement(this.getMstPublicKey().getPubKey(true));
+        byte[][] rlpElements = new byte[LIST_SIZE][];
+        byte[] btcPublicKeyBytes = this.getBtcPublicKey().getPubKeyPoint().getEncoded(true);
+        byte[] rskPublicKeyBytes = this.getRskPublicKey().getPubKey(true);
+        byte[] mstPublicKeyBytes = this.getMstPublicKey().getPubKey(true);
+
+        rlpElements[BTC_KEY_INDEX] = RLP.encodeElement(btcPublicKeyBytes);
+        rlpElements[RSK_KEY_INDEX] = RLP.encodeElement(rskPublicKeyBytes);
+        rlpElements[MST_KEY_INDEX] = RLP.encodeElement(mstPublicKeyBytes);
         return RLP.encodeList(rlpElements);
+    }
+
+    public static FederationMember deserialize(byte[] data) {
+        RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
+
+        if (rlpList.size() != FEDERATION_RLP_LIST_SIZE) {
+            throw new RuntimeException(String.format("Invalid serialized FederationMember. Expected %d elements but got %d", LIST_SIZE, rlpList.size()));
+        }
+
+        BtcECKey btcKey = BtcECKey.fromPublicOnly(rlpList.get(BTC_KEY_INDEX).getRLPData());
+        ECKey rskKey = ECKey.fromPublicOnly(rlpList.get(RSK_KEY_INDEX).getRLPData());
+        ECKey mstKey = ECKey.fromPublicOnly(rlpList.get(MST_KEY_INDEX).getRLPData());
+
+        return new FederationMember(btcKey, rskKey, mstKey);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -16,14 +16,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package co.rsk.peg;
+package co.rsk.peg.federation;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.config.BridgeConstants;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationMember;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.HashUtil;
@@ -34,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.ethereum.util.RLP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +48,11 @@ public final class PendingFederation {
     private static final int MIN_MEMBERS_REQUIRED = 2;
 
     private final List<FederationMember> members;
+
+    private static final int FEDERATION_MEMBER_LIST_SIZE = 3;
+    private static final int FEDERATION_MEMBER_BTC_KEY_INDEX = 0;
+    private static final int FEDERATION_MEMBER_RSK_KEY_INDEX = 1;
+    private static final int FEDERATION_MEMBER_MST_KEY_INDEX = 2;
 
     public PendingFederation(List<FederationMember> members) {
         // Sorting members ensures same order for members
@@ -160,7 +163,7 @@ public final class PendingFederation {
     }
 
     public Keccak256 getHash() {
-        byte[] encoded = BridgeSerializationUtils.serializePendingFederationOnlyBtcKeys(this);
+        byte[] encoded = serializeOnlyBtcKeys();
         return new Keccak256(HashUtil.keccak256(encoded));
     }
 
@@ -169,5 +172,53 @@ public final class PendingFederation {
         // Can use java.util.Objects.hash since List<BtcECKey> has a
         // well-defined hashCode()
         return Objects.hash(getBtcPublicKeys());
+    }
+
+    /**
+     * A pending federation is serialized as the
+     * public keys conforming it.
+     * A list of btc public keys is serialized as
+     * [pubkey1, pubkey2, ..., pubkeyn], sorted
+     * using the lexicographical order of the public keys
+     * (see BtcECKey.PUBKEY_COMPARATOR).
+     * This is a legacy format for blocks before the Wasabi
+     * network upgrade.
+     */
+    public byte[] serializeOnlyBtcKeys() {
+        return serializeBtcPublicKeys(this.getBtcPublicKeys());
+    }
+    private static byte[] serializeBtcPublicKeys(List<BtcECKey> keys) {
+        List<byte[]> encodedKeys = keys.stream()
+            .sorted(BtcECKey.PUBKEY_COMPARATOR)
+            .map(key -> RLP.encodeElement(key.getPubKey()))
+            .collect(Collectors.toList());
+        return RLP.encodeList(encodedKeys.toArray(new byte[0][]));
+    }
+
+    /**
+     * A pending federation is serialized as the
+     * list of its sorted members serialized.
+     * A FederationMember is serialized as a list in the following order:
+     * - BTC public key
+     * - RSK public key
+     * - MST public key
+     * All keys are stored in their COMPRESSED versions.
+     */
+    public byte[] serialize() {
+        List<byte[]> encodedMembers = this.getMembers().stream()
+            .sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR)
+            .map(PendingFederation::serializeMember)
+            .collect(Collectors.toList());
+        return RLP.encodeList(encodedMembers.toArray(new byte[0][]));
+    }
+
+    private static byte[] serializeMember(FederationMember federationMember) {
+        byte[][] rlpElements = new byte[FEDERATION_MEMBER_LIST_SIZE][];
+        rlpElements[FEDERATION_MEMBER_BTC_KEY_INDEX] = RLP.encodeElement(
+            federationMember.getBtcPublicKey().getPubKeyPoint().getEncoded(true)
+        );
+        rlpElements[FEDERATION_MEMBER_RSK_KEY_INDEX] = RLP.encodeElement(federationMember.getRskPublicKey().getPubKey(true));
+        rlpElements[FEDERATION_MEMBER_MST_KEY_INDEX] = RLP.encodeElement(federationMember.getMstPublicKey().getPubKey(true));
+        return RLP.encodeList(rlpElements);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.ethereum.util.RLP;
+import org.ethereum.util.RLPElement;
+import org.ethereum.util.RLPList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -169,11 +171,23 @@ public final class PendingFederation {
     }
 
     public byte[] serialize(ActivationConfig.ForBlock activations) {
-        if (activations.isActive(ConsensusRule.RSKIP123)) {
-            return serializeFromMembers();
-        } else {
+        if (!activations.isActive(ConsensusRule.RSKIP123)) {
             return serializeOnlyBtcKeys();
         }
+        return serializeFromMembers();
+    }
+
+    public static PendingFederation deserialize(byte[] data) {
+        RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
+        List<FederationMember> deserializedMembers = new ArrayList<>();
+
+        for (int k = 0; k < rlpList.size(); k++) {
+            RLPElement element = rlpList.get(k);
+            FederationMember member = FederationMember.deserialize(element.getRLPData());
+            deserializedMembers.add(member);
+        }
+
+        return new PendingFederation(deserializedMembers);
     }
 
     /**
@@ -203,11 +217,32 @@ public final class PendingFederation {
      * This is a legacy format for blocks before the Wasabi
      * network upgrade.
      */
-    public byte[] serializeOnlyBtcKeys() {
+    protected byte[] serializeOnlyBtcKeys() {
         List<byte[]> encodedKeys = this.getBtcPublicKeys().stream()
             .sorted(BtcECKey.PUBKEY_COMPARATOR)
             .map(key -> RLP.encodeElement(key.getPubKey()))
             .collect(Collectors.toList());
         return RLP.encodeList(encodedKeys.toArray(new byte[0][]));
+    }
+
+    public static PendingFederation deserializeOnlyBtcKeys(byte[] data) {
+        // BTC, RSK and MST keys are the same
+        List<FederationMember> deserializedMembers = deserializeBtcPublicKeys(data).stream()
+            .map(FederationMember::getFederationMemberFromKey)
+            .collect(Collectors.toList());
+
+        return new PendingFederation(deserializedMembers);
+    }
+
+    private static List<BtcECKey> deserializeBtcPublicKeys(byte[] data) {
+        RLPList rlpList = (RLPList)RLP.decode2(data).get(0);
+
+        List<BtcECKey> keys = new ArrayList<>();
+        for (int k = 0; k < rlpList.size(); k++) {
+            RLPElement element = rlpList.get(k);
+            BtcECKey key = BtcECKey.fromPublicOnly(element.getRLPData());
+            keys.add(key);
+        }
+        return keys;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -46,13 +46,12 @@ import org.slf4j.LoggerFactory;
 public final class PendingFederation {
     private static final Logger logger = LoggerFactory.getLogger("PendingFederation");
     private static final int MIN_MEMBERS_REQUIRED = 2;
-
-    private final List<FederationMember> members;
-
     private static final int FEDERATION_MEMBER_LIST_SIZE = 3;
     private static final int FEDERATION_MEMBER_BTC_KEY_INDEX = 0;
     private static final int FEDERATION_MEMBER_RSK_KEY_INDEX = 1;
     private static final int FEDERATION_MEMBER_MST_KEY_INDEX = 2;
+    private final List<FederationMember> members;
+
 
     public PendingFederation(List<FederationMember> members) {
         // Sorting members ensures same order for members

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -46,10 +46,6 @@ import org.slf4j.LoggerFactory;
 public final class PendingFederation {
     private static final Logger logger = LoggerFactory.getLogger("PendingFederation");
     private static final int MIN_MEMBERS_REQUIRED = 2;
-    private static final int FEDERATION_MEMBER_LIST_SIZE = 3;
-    private static final int FEDERATION_MEMBER_BTC_KEY_INDEX = 0;
-    private static final int FEDERATION_MEMBER_RSK_KEY_INDEX = 1;
-    private static final int FEDERATION_MEMBER_MST_KEY_INDEX = 2;
     private final List<FederationMember> members;
 
 
@@ -162,7 +158,7 @@ public final class PendingFederation {
     }
 
     public Keccak256 getHash() {
-        byte[] encoded = serializeOnlyBtcKeys();
+        byte[] encoded = this.serializeOnlyBtcKeys();
         return new Keccak256(HashUtil.keccak256(encoded));
     }
 
@@ -184,10 +180,7 @@ public final class PendingFederation {
      * network upgrade.
      */
     public byte[] serializeOnlyBtcKeys() {
-        return serializeBtcPublicKeys(this.getBtcPublicKeys());
-    }
-    private static byte[] serializeBtcPublicKeys(List<BtcECKey> keys) {
-        List<byte[]> encodedKeys = keys.stream()
+        List<byte[]> encodedKeys = this.getBtcPublicKeys().stream()
             .sorted(BtcECKey.PUBKEY_COMPARATOR)
             .map(key -> RLP.encodeElement(key.getPubKey()))
             .collect(Collectors.toList());
@@ -206,18 +199,8 @@ public final class PendingFederation {
     public byte[] serialize() {
         List<byte[]> encodedMembers = this.getMembers().stream()
             .sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR)
-            .map(PendingFederation::serializeMember)
+            .map(FederationMember::serialize)
             .collect(Collectors.toList());
         return RLP.encodeList(encodedMembers.toArray(new byte[0][]));
-    }
-
-    private static byte[] serializeMember(FederationMember federationMember) {
-        byte[][] rlpElements = new byte[FEDERATION_MEMBER_LIST_SIZE][];
-        rlpElements[FEDERATION_MEMBER_BTC_KEY_INDEX] = RLP.encodeElement(
-            federationMember.getBtcPublicKey().getPubKeyPoint().getEncoded(true)
-        );
-        rlpElements[FEDERATION_MEMBER_RSK_KEY_INDEX] = RLP.encodeElement(federationMember.getRskPublicKey().getPubKey(true));
-        rlpElements[FEDERATION_MEMBER_MST_KEY_INDEX] = RLP.encodeElement(federationMember.getMstPublicKey().getPubKey(true));
-        return RLP.encodeList(rlpElements);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -48,7 +48,6 @@ public final class PendingFederation {
     private static final int MIN_MEMBERS_REQUIRED = 2;
     private final List<FederationMember> members;
 
-
     public PendingFederation(List<FederationMember> members) {
         // Sorting members ensures same order for members
         // Immutability provides protection against unwanted modification, thus making the Pending Federation instance

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -225,7 +225,7 @@ public final class PendingFederation {
         return RLP.encodeList(encodedKeys.toArray(new byte[0][]));
     }
 
-    public static PendingFederation deserializeOnlyBtcKeys(byte[] data) {
+    public static PendingFederation deserializeFromBtcKeys(byte[] data) {
         // BTC, RSK and MST keys are the same
         List<FederationMember> deserializedMembers = deserializeBtcPublicKeys(data).stream()
             .map(FederationMember::getFederationMemberFromKey)

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -217,7 +217,7 @@ public final class PendingFederation {
      * This is a legacy format for blocks before the Wasabi
      * network upgrade.
      */
-    protected byte[] serializeOnlyBtcKeys() {
+    private byte[] serializeOnlyBtcKeys() {
         List<byte[]> encodedKeys = this.getBtcPublicKeys().stream()
             .sorted(BtcECKey.PUBKEY_COMPARATOR)
             .map(key -> RLP.encodeElement(key.getPubKey()))

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -353,6 +353,10 @@ class BridgeSerializationUtilsTest {
 
     @Test
     void serializeAndDeserializePendingFederation() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        // we want serialization from members
+        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
+
         final int NUM_CASES = 20;
 
         for (int i = 0; i < NUM_CASES; i++) {
@@ -363,7 +367,7 @@ class BridgeSerializationUtilsTest {
             }
             PendingFederation testPendingFederation = new PendingFederation(members);
 
-            byte[] serializedTestPendingFederation = testPendingFederation.serialize();
+            byte[] serializedTestPendingFederation = testPendingFederation.serialize(activations);
 
             PendingFederation deserializedTestPendingFederation = BridgeSerializationUtils.deserializePendingFederation(
                 serializedTestPendingFederation);
@@ -374,6 +378,10 @@ class BridgeSerializationUtilsTest {
 
     @Test
     void serializePendingFederation_serializedKeysAreCompressedAndThree() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        // we want serialization from members
+        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
+
         final int NUM_MEMBERS = 10;
         final int EXPECTED_NUM_KEYS = 3;
         final int EXPECTED_PUBLICKEY_SIZE = 33;
@@ -385,7 +393,7 @@ class BridgeSerializationUtilsTest {
 
         PendingFederation testPendingFederation = new PendingFederation(members);
 
-        byte[] serializedPendingFederation = testPendingFederation.serialize();
+        byte[] serializedPendingFederation = testPendingFederation.serialize(activations);
 
         RLPList memberList = (RLPList) RLP.decode2(serializedPendingFederation).get(0);
 
@@ -417,6 +425,10 @@ class BridgeSerializationUtilsTest {
 
     @Test
     void serializePendingFederationOnlyBtcKeys() throws Exception {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        // we want serialization from pub keys
+        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(false);
+
         byte[][] publicKeyBytes = new byte[][]{
             BtcECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey(),
             BtcECKey.fromPrivate(BigInteger.valueOf(200)).getPubKey(),
@@ -438,7 +450,7 @@ class BridgeSerializationUtilsTest {
             }))
         );
 
-        byte[] result = pendingFederation.serializeOnlyBtcKeys();
+        byte[] result = pendingFederation.serialize(activations);
         StringBuilder expectedBuilder = new StringBuilder();
         expectedBuilder.append("f8cc");
         pendingFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -363,7 +363,7 @@ class BridgeSerializationUtilsTest {
             }
             PendingFederation testPendingFederation = new PendingFederation(members);
 
-            byte[] serializedTestPendingFederation = BridgeSerializationUtils.serializePendingFederation(testPendingFederation);
+            byte[] serializedTestPendingFederation = testPendingFederation.serialize();
 
             PendingFederation deserializedTestPendingFederation = BridgeSerializationUtils.deserializePendingFederation(
                 serializedTestPendingFederation);
@@ -385,7 +385,7 @@ class BridgeSerializationUtilsTest {
 
         PendingFederation testPendingFederation = new PendingFederation(members);
 
-        byte[] serializedPendingFederation = BridgeSerializationUtils.serializePendingFederation(testPendingFederation);
+        byte[] serializedPendingFederation = testPendingFederation.serialize();
 
         RLPList memberList = (RLPList) RLP.decode2(serializedPendingFederation).get(0);
 
@@ -438,7 +438,7 @@ class BridgeSerializationUtilsTest {
             }))
         );
 
-        byte[] result = BridgeSerializationUtils.serializePendingFederationOnlyBtcKeys(pendingFederation);
+        byte[] result = pendingFederation.serializeOnlyBtcKeys();
         StringBuilder expectedBuilder = new StringBuilder();
         expectedBuilder.append("f8cc");
         pendingFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -26,8 +26,6 @@ import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.bitcoin.CoinbaseInformation;
-import co.rsk.peg.bitcoin.ErpRedeemScriptBuilder;
-import co.rsk.peg.bitcoin.NonStandardErpRedeemScriptBuilderFactory;
 import co.rsk.peg.federation.*;
 import co.rsk.peg.resources.TestConstants;
 import co.rsk.peg.utils.MerkleTreeUtils;
@@ -345,145 +343,9 @@ class BridgeSerializationUtilsTest {
             RLP.encodeList(RLP.encodeList(RLP.encodeElement(new byte[0]), RLP.encodeElement(new byte[0])))
         );
 
-
         NetworkParameters networkParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         Exception ex = Assertions.assertThrows(RuntimeException.class, () -> BridgeSerializationUtils.deserializeStandardMultisigFederation(serialized, networkParameters));
         Assertions.assertTrue(ex.getMessage().contains("Invalid serialized FederationMember"));
-    }
-
-    @Test
-    void serializeAndDeserializePendingFederation() {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        // we want serialization from members
-        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
-
-        final int NUM_CASES = 20;
-
-        for (int i = 0; i < NUM_CASES; i++) {
-            int numMembers = randomInRange(2, 14);
-            List<FederationMember> members = new ArrayList<>();
-            for (int j = 0; j < numMembers; j++) {
-                members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
-            }
-            PendingFederation testPendingFederation = new PendingFederation(members);
-
-            byte[] serializedTestPendingFederation = testPendingFederation.serialize(activations);
-
-            PendingFederation deserializedTestPendingFederation = BridgeSerializationUtils.deserializePendingFederation(
-                serializedTestPendingFederation);
-
-            Assertions.assertEquals(testPendingFederation, deserializedTestPendingFederation);
-        }
-    }
-
-    @Test
-    void serializePendingFederation_serializedKeysAreCompressedAndThree() {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        // we want serialization from members
-        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
-
-        final int NUM_MEMBERS = 10;
-        final int EXPECTED_NUM_KEYS = 3;
-        final int EXPECTED_PUBLICKEY_SIZE = 33;
-
-        List<FederationMember> members = new ArrayList<>();
-        for (int j = 0; j < NUM_MEMBERS; j++) {
-            members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
-        }
-
-        PendingFederation testPendingFederation = new PendingFederation(members);
-
-        byte[] serializedPendingFederation = testPendingFederation.serialize(activations);
-
-        RLPList memberList = (RLPList) RLP.decode2(serializedPendingFederation).get(0);
-
-        Assertions.assertEquals(NUM_MEMBERS, memberList.size());
-
-        for (int i = 0; i < NUM_MEMBERS; i++) {
-            RLPList memberKeys = (RLPList) RLP.decode2(memberList.get(i).getRLPData()).get(0);
-            Assertions.assertEquals(EXPECTED_NUM_KEYS, memberKeys.size());
-            for (int j = 0; j < EXPECTED_NUM_KEYS; j++) {
-                Assertions.assertEquals(EXPECTED_PUBLICKEY_SIZE, memberKeys.get(j).getRLPData().length);
-            }
-
-        }
-    }
-
-    @Test
-    void deserializePendingFederation_invalidFederationMember() {
-        byte[] serialized = RLP.encodeList(
-            RLP.encodeList(RLP.encodeElement(new byte[0]), RLP.encodeElement(new byte[0]))
-        );
-
-        try {
-            BridgeSerializationUtils.deserializePendingFederation(serialized);
-            Assertions.fail();
-        } catch (RuntimeException e) {
-            Assertions.assertTrue(e.getMessage().contains("Invalid serialized FederationMember"));
-        }
-    }
-
-    @Test
-    void serializePendingFederationOnlyBtcKeys() throws Exception {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        // we want serialization from pub keys
-        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(false);
-
-        byte[][] publicKeyBytes = new byte[][]{
-            BtcECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(200)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(300)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(400)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(500)).getPubKey(),
-            BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
-        };
-
-        // Only actual keys serialized are BTC keys, so we don't really care about RSK or MST keys
-        PendingFederation pendingFederation = new PendingFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPublicOnly(publicKeyBytes[0]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[1]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[2]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[3]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[4]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[5]),
-            }))
-        );
-
-        byte[] result = pendingFederation.serialize(activations);
-        StringBuilder expectedBuilder = new StringBuilder();
-        expectedBuilder.append("f8cc");
-        pendingFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
-            expectedBuilder.append("a1");
-            expectedBuilder.append(ByteUtil.toHexString(key.getPubKey()));
-        });
-
-        String expected = expectedBuilder.toString();
-        Assertions.assertEquals(expected, ByteUtil.toHexString(result));
-    }
-
-    @Test
-    void deserializePendingFederationOnlyBtcKeys() throws Exception {
-        byte[][] publicKeyBytes = Arrays.asList(100, 200, 300, 400, 500, 600).stream()
-            .map(k -> BtcECKey.fromPrivate(BigInteger.valueOf(k)))
-            .sorted(BtcECKey.PUBKEY_COMPARATOR)
-            .map(k -> k.getPubKey())
-            .toArray(byte[][]::new);
-
-        byte[][] rlpBytes = new byte[publicKeyBytes.length][];
-
-        for (int k = 0; k < publicKeyBytes.length; k++) {
-            rlpBytes[k] = RLP.encodeElement(publicKeyBytes[k]);
-        }
-
-        byte[] data = RLP.encodeList(rlpBytes);
-
-        PendingFederation deserializedPendingFederation = BridgeSerializationUtils.deserializePendingFederationOnlyBtcKeys(data);
-
-        Assertions.assertEquals(6, deserializedPendingFederation.getBtcPublicKeys().size());
-        for (int i = 0; i < 6; i++) {
-            Assertions.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedPendingFederation.getBtcPublicKeys().get(i).getPubKey()));
-        }
     }
 
     @Test
@@ -1252,9 +1114,6 @@ class BridgeSerializationUtilsTest {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(isRskip284Active);
         when(activations.isActive(ConsensusRule.RSKIP353)).thenReturn(isRskip353Active);
-
-        ErpRedeemScriptBuilder erpRedeemScriptBuilder =
-            NonStandardErpRedeemScriptBuilderFactory.getNonStandardErpRedeemScriptBuilder(activations, bridgeConstants.getBtcParams());
 
         for (int i = 0; i < NUM_CASES; i++) {
             int numMembers = randomInRange(2, 14);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -1126,7 +1126,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void savePendingFederation_preMultikey() {
+    void savePendingFederation_preMultikey() throws IOException {
         PendingFederation pendingFederation = buildMockPendingFederation(100, 200, 300);
         List<Integer> storageBytesCalls = new ArrayList<>();
         List<Integer> serializeCalls = new ArrayList<>();
@@ -1156,7 +1156,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void savePendingFederation_preMultikey_setToNull() {
+    void savePendingFederation_preMultikey_setToNull() throws IOException {
         List<Integer> storageBytesCalls = new ArrayList<>();
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), bridgeTestnetInstance, activationsBeforeFork);
@@ -1182,7 +1182,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void savePendingFederation_postMultikey() {
+    void savePendingFederation_postMultikey() throws IOException {
         PendingFederation pendingFederation = buildMockPendingFederation(100, 200, 300);
         List<Integer> storageBytesCalls = new ArrayList<>();
         Repository repositoryMock = mock(Repository.class);
@@ -1219,7 +1219,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void savePendingFederation_postMultikey_setToNull() {
+    void savePendingFederation_postMultikey_setToNull() throws IOException {
         try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class, Mockito.CALLS_REAL_METHODS)) {
             List<Integer> storageBytesCalls = new ArrayList<>();
             Repository repositoryMock = mock(Repository.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -1151,36 +1151,34 @@ class BridgeStorageProviderTest {
         storageProvider.setPendingFederation(pendingFederation);
         // Should save the pending federation because is now set
         storageProvider.savePendingFederation();
-        // Should have called storage one time since RSKIP123 is not activated
+        // Should have called storage one time
         assertEquals(1, storageBytesCalls.size());
     }
 
     @Test
     void savePendingFederation_preMultikey_setToNull() {
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class)) {
-            List<Integer> storageBytesCalls = new ArrayList<>();
-            Repository repositoryMock = mock(Repository.class);
-            BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), bridgeTestnetInstance, activationsBeforeFork);
+        List<Integer> storageBytesCalls = new ArrayList<>();
+        Repository repositoryMock = mock(Repository.class);
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), bridgeTestnetInstance, activationsBeforeFork);
 
-            Mockito.doAnswer((InvocationOnMock invocation) -> {
-                storageBytesCalls.add(0);
-                RskAddress contractAddress = invocation.getArgument(0);
-                DataWord address = invocation.getArgument(1);
-                byte[] data = invocation.getArgument(2);
-                // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
-                assertArrayEquals(new byte[]{(byte) 0xaa, (byte) 0xbb, (byte) 0xcc, (byte) 0xdd}, contractAddress.getBytes());
-                Assertions.assertEquals(PENDING_FEDERATION_KEY.getKey(), address);
-                assertNull(data);
-                return null;
-            }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any());
+        Mockito.doAnswer((InvocationOnMock invocation) -> {
+            storageBytesCalls.add(0);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
+            byte[] data = invocation.getArgument(2);
+            // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
+            assertArrayEquals(new byte[]{(byte) 0xaa, (byte) 0xbb, (byte) 0xcc, (byte) 0xdd}, contractAddress.getBytes());
+            Assertions.assertEquals(PENDING_FEDERATION_KEY.getKey(), address);
+            assertNull(data);
+            return null;
+        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any());
 
-            storageProvider.savePendingFederation();
-            // Shouldn't have tried to save nor serialize anything
-            Assertions.assertEquals(0, storageBytesCalls.size());
-            storageProvider.setPendingFederation(null);
-            storageProvider.savePendingFederation();
-            Assertions.assertEquals(1, storageBytesCalls.size());
-        }
+        storageProvider.savePendingFederation();
+        // Shouldn't have tried to save nor serialize anything
+        Assertions.assertEquals(0, storageBytesCalls.size());
+        storageProvider.setPendingFederation(null);
+        storageProvider.savePendingFederation();
+        Assertions.assertEquals(1, storageBytesCalls.size());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -1213,7 +1213,7 @@ class BridgeStorageProviderTest {
         storageProvider.setPendingFederation(pendingFederation);
         // Should save the pending federation because is now set
         storageProvider.savePendingFederation();
-        // Should have called storage two times
+        // Should have called storage two times since RSKIP123 is activated
         Assertions.assertEquals(2, storageBytesCalls.size());
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -997,8 +997,8 @@ class BridgeStorageProviderTest {
             }
         });
 
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class)) {
-            bridgeSerializationUtilsMocked.when(() -> BridgeSerializationUtils.deserializePendingFederationOnlyBtcKeys(any(byte[].class))).then((InvocationOnMock invocation) -> {
+        try (MockedStatic<PendingFederation> pendingFederationMocked = mockStatic(PendingFederation.class)) {
+            pendingFederationMocked.when(() -> PendingFederation.deserializeOnlyBtcKeys(any(byte[].class))).then((InvocationOnMock invocation) -> {
                 deserializeCalls.add(0);
                 byte[] data = invocation.getArgument(0);
                 // Make sure we're deserializing what just came from the repo with the correct BTC context
@@ -1014,7 +1014,7 @@ class BridgeStorageProviderTest {
 
     @Test
     void getPendingFederation_initialVersion_nullBytes() {
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class)) {
+        try (MockedStatic<PendingFederation> pendingFederationMocked = mockStatic(PendingFederation.class)) {
 
             List<Integer> storageCalls = new ArrayList<>();
             Repository repositoryMock = mock(Repository.class);
@@ -1042,7 +1042,7 @@ class BridgeStorageProviderTest {
             assertNull(storageProvider.getPendingFederation());
             Assertions.assertEquals(2, storageCalls.size());
 
-            bridgeSerializationUtilsMocked.verify(() -> BridgeSerializationUtils.deserializePendingFederation(any(byte[].class)), never());
+            pendingFederationMocked.verify(() -> PendingFederation.deserialize(any(byte[].class)), never());
         }
     }
 
@@ -1073,8 +1073,8 @@ class BridgeStorageProviderTest {
             }
         });
 
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class)) {
-            bridgeSerializationUtilsMocked.when(() -> BridgeSerializationUtils.deserializePendingFederation(any(byte[].class))).then((InvocationOnMock invocation) -> {
+        try (MockedStatic<PendingFederation> pendingFederationMocked = mockStatic(PendingFederation.class)) {
+            pendingFederationMocked.when(() -> PendingFederation.deserialize(any(byte[].class))).then((InvocationOnMock invocation) -> {
                 deserializeCalls.add(0);
                 byte[] data = invocation.getArgument(0);
                 // Make sure we're deserializing what just came from the repo with the correct BTC context
@@ -1090,7 +1090,7 @@ class BridgeStorageProviderTest {
 
     @Test
     void getPendingFederation_multiKeyVersion_nullBytes() {
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class)) {
+        try (MockedStatic<PendingFederation> pendingFederationMocked = mockStatic(PendingFederation.class)) {
             List<Integer> storageCalls = new ArrayList<>();
             Repository repositoryMock = mock(Repository.class);
             BridgeStorageProvider storageProvider = new BridgeStorageProvider(
@@ -1121,7 +1121,7 @@ class BridgeStorageProviderTest {
 
             assertNull(storageProvider.getPendingFederation());
             assertEquals(2, storageCalls.size());
-            bridgeSerializationUtilsMocked.verify(() -> BridgeSerializationUtils.deserializePendingFederation(any(byte[].class)), never());
+            pendingFederationMocked.verify(() -> PendingFederation.deserialize(any(byte[].class)), never());
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -1133,35 +1133,26 @@ class BridgeStorageProviderTest {
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), bridgeTestnetInstance, activationsBeforeFork);
 
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class)) {
-            bridgeSerializationUtilsMocked.when(() -> BridgeSerializationUtils.serializePendingFederationOnlyBtcKeys(any(PendingFederation.class))).then((InvocationOnMock invocation) -> {
-                PendingFederation federation = invocation.getArgument(0);
-                Assertions.assertEquals(pendingFederation, federation);
-                serializeCalls.add(0);
-                return new byte[]{(byte) 0xbb};
-            });
+        doAnswer((InvocationOnMock invocation) -> {
+            storageBytesCalls.add(0);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
 
-            doAnswer((InvocationOnMock invocation) -> {
-                storageBytesCalls.add(0);
-                RskAddress contractAddress = invocation.getArgument(0);
-                DataWord address = invocation.getArgument(1);
-                byte[] data = invocation.getArgument(2);
-                // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
-                assertArrayEquals(new byte[]{(byte) 0xaa, (byte) 0xbb, (byte) 0xcc, (byte) 0xdd}, contractAddress.getBytes());
-                Assertions.assertEquals(PENDING_FEDERATION_KEY.getKey(), address);
-                assertArrayEquals(new byte[]{(byte) 0xbb}, data);
-                return null;
-            }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
+            // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
+            assertArrayEquals(new byte[]{(byte) 0xaa, (byte) 0xbb, (byte) 0xcc, (byte) 0xdd}, contractAddress.getBytes());
+            Assertions.assertEquals(PENDING_FEDERATION_KEY.getKey(), address);
+            return null;
+        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
 
-            storageProvider.savePendingFederation();
-            // Shouldn't have tried to save nor serialize anything
-            assertEquals(0, storageBytesCalls.size());
-            assertEquals(0, serializeCalls.size());
-            storageProvider.setPendingFederation(pendingFederation);
-            storageProvider.savePendingFederation();
-            assertEquals(1, storageBytesCalls.size());
-            assertEquals(1, serializeCalls.size());
-        }
+        storageProvider.savePendingFederation();
+        // Shouldn't have tried to save anything since pending federation is not set
+        assertEquals(0, storageBytesCalls.size());
+
+        storageProvider.setPendingFederation(pendingFederation);
+        // Should save the pending federation because is now set
+        storageProvider.savePendingFederation();
+        // Should have called storage one time since RSKIP123 is not activated
+        assertEquals(1, storageBytesCalls.size());
     }
 
     @Test
@@ -1189,9 +1180,6 @@ class BridgeStorageProviderTest {
             storageProvider.setPendingFederation(null);
             storageProvider.savePendingFederation();
             Assertions.assertEquals(1, storageBytesCalls.size());
-
-            bridgeSerializationUtilsMocked.verify(() -> BridgeSerializationUtils.serializePendingFederationOnlyBtcKeys(any(PendingFederation.class)), never());
-            bridgeSerializationUtilsMocked.verify(() -> BridgeSerializationUtils.serializePendingFederation(any(PendingFederation.class)), never());
         }
     }
 
@@ -1199,47 +1187,37 @@ class BridgeStorageProviderTest {
     void savePendingFederation_postMultikey() {
         PendingFederation pendingFederation = buildMockPendingFederation(100, 200, 300);
         List<Integer> storageBytesCalls = new ArrayList<>();
-        List<Integer> serializeCalls = new ArrayList<>();
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), bridgeTestnetInstance, activationsAllForks);
 
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class, Mockito.CALLS_REAL_METHODS)) {
-            bridgeSerializationUtilsMocked.when(() -> BridgeSerializationUtils.serializePendingFederation(any(PendingFederation.class))).then((InvocationOnMock invocation) -> {
-                PendingFederation federation = invocation.getArgument(0);
-                Assertions.assertEquals(pendingFederation, federation);
-                serializeCalls.add(0);
-                return new byte[]{(byte) 0xbb};
-            });
+        Mockito.doAnswer((InvocationOnMock invocation) -> {
+            storageBytesCalls.add(0);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
+            byte[] data = invocation.getArgument(2);
 
-            Mockito.doAnswer((InvocationOnMock invocation) -> {
-                storageBytesCalls.add(0);
-                RskAddress contractAddress = invocation.getArgument(0);
-                DataWord address = invocation.getArgument(1);
-                byte[] data = invocation.getArgument(2);
+            assertArrayEquals(Hex.decode("aabbccdd"), contractAddress.getBytes());
 
-                assertArrayEquals(Hex.decode("aabbccdd"), contractAddress.getBytes());
+            if (storageBytesCalls.size() == 1) {
+                Assertions.assertEquals(PENDING_FEDERATION_FORMAT_VERSION.getKey(), address);
+                Assertions.assertEquals(BigInteger.valueOf(1000), RLP.decodeBigInteger(data, 0));
+            } else {
+                Assertions.assertEquals(2, storageBytesCalls.size());
+                // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
+                Assertions.assertEquals(PENDING_FEDERATION_KEY.getKey(), address);
+            }
+            return null;
+        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
 
-                if (storageBytesCalls.size() == 1) {
-                    Assertions.assertEquals(PENDING_FEDERATION_FORMAT_VERSION.getKey(), address);
-                    Assertions.assertEquals(BigInteger.valueOf(1000), RLP.decodeBigInteger(data, 0));
-                } else {
-                    Assertions.assertEquals(2, storageBytesCalls.size());
-                    // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
-                    Assertions.assertEquals(PENDING_FEDERATION_KEY.getKey(), address);
-                    assertArrayEquals(new byte[]{(byte) 0xbb}, data);
-                }
-                return null;
-            }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any(byte[].class));
+        storageProvider.savePendingFederation();
+        // Shouldn't have tried to save anything since pending federation is not set
+        Assertions.assertEquals(0, storageBytesCalls.size());
 
-            storageProvider.savePendingFederation();
-            // Shouldn't have tried to save nor serialize anything
-            Assertions.assertEquals(0, storageBytesCalls.size());
-            Assertions.assertEquals(0, serializeCalls.size());
-            storageProvider.setPendingFederation(pendingFederation);
-            storageProvider.savePendingFederation();
-            Assertions.assertEquals(2, storageBytesCalls.size());
-            Assertions.assertEquals(1, serializeCalls.size());
-        }
+        storageProvider.setPendingFederation(pendingFederation);
+        // Should save the pending federation because is now set
+        storageProvider.savePendingFederation();
+        // Should have called storage two times since RSKIP123 is activated
+        Assertions.assertEquals(2, storageBytesCalls.size());
     }
 
     @Test
@@ -1275,9 +1253,6 @@ class BridgeStorageProviderTest {
             storageProvider.setPendingFederation(null);
             storageProvider.savePendingFederation();
             Assertions.assertEquals(2, storageBytesCalls.size());
-
-            bridgeSerializationUtilsMocked.verify(() -> BridgeSerializationUtils.serializePendingFederationOnlyBtcKeys(any(PendingFederation.class)), never());
-            bridgeSerializationUtilsMocked.verify(() -> BridgeSerializationUtils.serializePendingFederation(any(PendingFederation.class)), never());
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -1213,7 +1213,7 @@ class BridgeStorageProviderTest {
         storageProvider.setPendingFederation(pendingFederation);
         // Should save the pending federation because is now set
         storageProvider.savePendingFederation();
-        // Should have called storage two times since RSKIP123 is activated
+        // Should have called storage two times
         Assertions.assertEquals(2, storageBytesCalls.size());
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -998,7 +998,7 @@ class BridgeStorageProviderTest {
         });
 
         try (MockedStatic<PendingFederation> pendingFederationMocked = mockStatic(PendingFederation.class)) {
-            pendingFederationMocked.when(() -> PendingFederation.deserializeOnlyBtcKeys(any(byte[].class))).then((InvocationOnMock invocation) -> {
+            pendingFederationMocked.when(() -> PendingFederation.deserializeFromBtcKeys(any(byte[].class))).then((InvocationOnMock invocation) -> {
                 deserializeCalls.add(0);
                 byte[] data = invocation.getArgument(0);
                 // Make sure we're deserializing what just came from the repo with the correct BTC context

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -1129,7 +1129,6 @@ class BridgeStorageProviderTest {
     void savePendingFederation_preMultikey() throws IOException {
         PendingFederation pendingFederation = buildMockPendingFederation(100, 200, 300);
         List<Integer> storageBytesCalls = new ArrayList<>();
-        List<Integer> serializeCalls = new ArrayList<>();
         Repository repositoryMock = mock(Repository.class);
         BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), bridgeTestnetInstance, activationsBeforeFork);
 
@@ -1220,38 +1219,36 @@ class BridgeStorageProviderTest {
 
     @Test
     void savePendingFederation_postMultikey_setToNull() throws IOException {
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class, Mockito.CALLS_REAL_METHODS)) {
-            List<Integer> storageBytesCalls = new ArrayList<>();
-            Repository repositoryMock = mock(Repository.class);
-            BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), bridgeTestnetInstance, activationsAllForks);
+        List<Integer> storageBytesCalls = new ArrayList<>();
+        Repository repositoryMock = mock(Repository.class);
+        BridgeStorageProvider storageProvider = new BridgeStorageProvider(repositoryMock, mockAddress("aabbccdd"), bridgeTestnetInstance, activationsAllForks);
 
-            Mockito.doAnswer((InvocationOnMock invocation) -> {
-                storageBytesCalls.add(0);
-                RskAddress contractAddress = invocation.getArgument(0);
-                DataWord address = invocation.getArgument(1);
-                byte[] data = invocation.getArgument(2);
+        Mockito.doAnswer((InvocationOnMock invocation) -> {
+            storageBytesCalls.add(0);
+            RskAddress contractAddress = invocation.getArgument(0);
+            DataWord address = invocation.getArgument(1);
+            byte[] data = invocation.getArgument(2);
 
-                assertArrayEquals(Hex.decode("aabbccdd"), contractAddress.getBytes());
+            assertArrayEquals(Hex.decode("aabbccdd"), contractAddress.getBytes());
 
-                if (storageBytesCalls.size() == 1) {
-                    Assertions.assertEquals(PENDING_FEDERATION_FORMAT_VERSION.getKey(), address);
-                    Assertions.assertEquals(BigInteger.valueOf(1000), RLP.decodeBigInteger(data, 0));
-                } else {
-                    Assertions.assertEquals(2, storageBytesCalls.size());
-                    // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
-                    Assertions.assertEquals(PENDING_FEDERATION_KEY.getKey(), address);
-                    assertNull(data);
-                }
-                return null;
-            }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any());
+            if (storageBytesCalls.size() == 1) {
+                Assertions.assertEquals(PENDING_FEDERATION_FORMAT_VERSION.getKey(), address);
+                Assertions.assertEquals(BigInteger.valueOf(1000), RLP.decodeBigInteger(data, 0));
+            } else {
+                Assertions.assertEquals(2, storageBytesCalls.size());
+                // Make sure the bytes are set to the correct address in the repo and that what's saved is what was serialized
+                Assertions.assertEquals(PENDING_FEDERATION_KEY.getKey(), address);
+                assertNull(data);
+            }
+            return null;
+        }).when(repositoryMock).addStorageBytes(any(RskAddress.class), any(DataWord.class), any());
 
-            storageProvider.savePendingFederation();
-            // Shouldn't have tried to save nor serialize anything
-            Assertions.assertEquals(0, storageBytesCalls.size());
-            storageProvider.setPendingFederation(null);
-            storageProvider.savePendingFederation();
-            Assertions.assertEquals(2, storageBytesCalls.size());
-        }
+        storageProvider.savePendingFederation();
+        // Shouldn't have tried to save nor serialize anything
+        Assertions.assertEquals(0, storageBytesCalls.size());
+        storageProvider.setPendingFederation(null);
+        storageProvider.savePendingFederation();
+        Assertions.assertEquals(2, storageBytesCalls.size());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -24,10 +24,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.federation.FederationTestUtils;
+import co.rsk.peg.federation.*;
 import co.rsk.peg.resources.TestConstants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -246,8 +243,8 @@ class PendingFederationTest {
 
     @Test
     void getHash() {
-        try (MockedStatic<BridgeSerializationUtils> bridgeSerializationUtilsMocked = mockStatic(BridgeSerializationUtils.class)) {
-            bridgeSerializationUtilsMocked.when(() -> BridgeSerializationUtils.serializePendingFederationOnlyBtcKeys(pendingFederation)).thenReturn(new byte[]{(byte) 0xaa});
+        try (MockedStatic<PendingFederation> pendingFederationMocked = mockStatic(PendingFederation.class)) {
+            pendingFederationMocked.when(() -> pendingFederation.serializeOnlyBtcKeys()).thenReturn(new byte[]{(byte) 0xaa});
 
             Keccak256 expectedHash = new Keccak256(HashUtil.keccak256(new byte[]{(byte) 0xaa}));
 

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -241,12 +240,12 @@ class PendingFederationTest {
         fail();
     }
 
-/*    @Test
+    @Test
     void getHash() {
-        byte[] pendingFederationBytes = {39, 127, 53, -79, -61, -73, 66, -15, 94, -22, -69, 36, 57, 103, 121, 77, -112, -93, -110, 109, 74, 74, -111, -53, -7, -41, -39, -20, -22, -59, 74, 86};
-        Keccak256 expectedHash = new Keccak256(HashUtil.keccak256(pendingFederationBytes));
+        byte[] pendingFederationData = pendingFederation.serializeOnlyBtcKeys();
+        Keccak256 expectedHash = new Keccak256(HashUtil.keccak256(pendingFederationData));
         assertEquals(expectedHash, pendingFederation.getHash());
-    }*/
+    }
 
     private void testBuildFederation(
         boolean isRskip201Active,

--- a/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PendingFederationTest.java
@@ -241,16 +241,12 @@ class PendingFederationTest {
         fail();
     }
 
-    @Test
+/*    @Test
     void getHash() {
-        try (MockedStatic<PendingFederation> pendingFederationMocked = mockStatic(PendingFederation.class)) {
-            pendingFederationMocked.when(() -> pendingFederation.serializeOnlyBtcKeys()).thenReturn(new byte[]{(byte) 0xaa});
-
-            Keccak256 expectedHash = new Keccak256(HashUtil.keccak256(new byte[]{(byte) 0xaa}));
-
-            assertEquals(expectedHash, pendingFederation.getHash());
-        }
-    }
+        byte[] pendingFederationBytes = {39, 127, 53, -79, -61, -73, 66, -15, 94, -22, -69, 36, 57, 103, 121, 77, -112, -93, -110, 109, 74, 74, -111, -53, -7, -41, -39, -20, -22, -59, 74, 86};
+        Keccak256 expectedHash = new Keccak256(HashUtil.keccak256(pendingFederationBytes));
+        assertEquals(expectedHash, pendingFederation.getHash());
+    }*/
 
     private void testBuildFederation(
         boolean isRskip201Active,

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationMemberTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationMemberTest.java
@@ -115,4 +115,12 @@ class FederationMemberTest {
             Assertions.fail();
         } catch (IllegalArgumentException e) {}
     }
+
+    @Test
+    void serializeAndDeserializeFederationMember() {
+        byte[] serializedMember = member.serialize();
+        FederationMember deserializedSerializedMember = FederationMember.deserialize(serializedMember);
+
+        Assertions.assertEquals(deserializedSerializedMember, member);
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package co.rsk.peg;
+package co.rsk.peg.federation;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
@@ -24,12 +24,15 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.federation.*;
 import co.rsk.peg.resources.TestConstants;
+import org.ethereum.TestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +43,8 @@ import org.mockito.quality.Strictness;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -247,6 +252,137 @@ class PendingFederationTest {
         assertEquals(expectedHash, pendingFederation.getHash());
     }
 
+    @Test
+    void serializeAndDeserializePendingFederation() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        // we want serialization from members
+        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
+
+        final int NUM_CASES = 20;
+
+        for (int i = 0; i < NUM_CASES; i++) {
+            int numMembers = randomInRange(2, 14);
+            List<FederationMember> members = new ArrayList<>();
+            for (int j = 0; j < numMembers; j++) {
+                members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
+            }
+            PendingFederation testPendingFederation = new PendingFederation(members);
+
+            byte[] serializedTestPendingFederation = testPendingFederation.serialize(activations);
+            PendingFederation deserializedTestPendingFederation = PendingFederation.deserialize(serializedTestPendingFederation);
+
+            Assertions.assertEquals(testPendingFederation, deserializedTestPendingFederation);
+        }
+    }
+
+    @Test
+    void serializePendingFederation_serializedKeysAreCompressedAndThree() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        // we want serialization from members
+        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
+
+        final int NUM_MEMBERS = 10;
+        final int EXPECTED_NUM_KEYS = 3;
+        final int EXPECTED_PUBLICKEY_SIZE = 33;
+
+        List<FederationMember> members = new ArrayList<>();
+        for (int j = 0; j < NUM_MEMBERS; j++) {
+            members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
+        }
+
+        PendingFederation testPendingFederation = new PendingFederation(members);
+        byte[] serializedPendingFederation = testPendingFederation.serialize(activations);
+
+        RLPList memberList = (RLPList) RLP.decode2(serializedPendingFederation).get(0);
+        Assertions.assertEquals(NUM_MEMBERS, memberList.size());
+
+        for (int i = 0; i < NUM_MEMBERS; i++) {
+            RLPList memberKeys = (RLPList) RLP.decode2(memberList.get(i).getRLPData()).get(0);
+            Assertions.assertEquals(EXPECTED_NUM_KEYS, memberKeys.size());
+            for (int j = 0; j < EXPECTED_NUM_KEYS; j++) {
+                Assertions.assertEquals(EXPECTED_PUBLICKEY_SIZE, memberKeys.get(j).getRLPData().length);
+            }
+
+        }
+    }
+
+    @Test
+    void deserializePendingFederation_invalidFederationMember() {
+        byte[] serialized = RLP.encodeList(
+            RLP.encodeList(RLP.encodeElement(new byte[0]), RLP.encodeElement(new byte[0]))
+        );
+
+        try {
+            PendingFederation.deserialize(serialized);
+            Assertions.fail();
+        } catch (RuntimeException e) {
+            Assertions.assertTrue(e.getMessage().contains("Invalid serialized FederationMember"));
+        }
+    }
+
+    @Test
+    void serializePendingFederationOnlyBtcKeys() throws Exception {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        // we want serialization from pub keys
+        when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(false);
+
+        byte[][] publicKeyBytes = new byte[][]{
+            BtcECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey(),
+            BtcECKey.fromPrivate(BigInteger.valueOf(200)).getPubKey(),
+            BtcECKey.fromPrivate(BigInteger.valueOf(300)).getPubKey(),
+            BtcECKey.fromPrivate(BigInteger.valueOf(400)).getPubKey(),
+            BtcECKey.fromPrivate(BigInteger.valueOf(500)).getPubKey(),
+            BtcECKey.fromPrivate(BigInteger.valueOf(600)).getPubKey(),
+        };
+
+        // Only actual keys serialized are BTC keys, so we don't really care about RSK or MST keys
+        List<BtcECKey> keys = Arrays.asList(new BtcECKey[]{
+            BtcECKey.fromPublicOnly(publicKeyBytes[0]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[1]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[2]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[3]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[4]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[5]),
+        });
+        List<FederationMember> members = FederationTestUtils.getFederationMembersWithBtcKeys(keys);
+        PendingFederation pendingFederation = new PendingFederation(members);
+
+        byte[] result = pendingFederation.serialize(activations);
+        StringBuilder expectedBuilder = new StringBuilder();
+        expectedBuilder.append("f8cc");
+        pendingFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
+            expectedBuilder.append("a1");
+            expectedBuilder.append(ByteUtil.toHexString(key.getPubKey()));
+        });
+
+        String expected = expectedBuilder.toString();
+        Assertions.assertEquals(expected, ByteUtil.toHexString(result));
+    }
+
+    @Test
+    void deserializePendingFederationOnlyBtcKeys() throws Exception {
+        byte[][] publicKeyBytes = Arrays.asList(100, 200, 300, 400, 500, 600).stream()
+            .map(k -> BtcECKey.fromPrivate(BigInteger.valueOf(k)))
+            .sorted(BtcECKey.PUBKEY_COMPARATOR)
+            .map(k -> k.getPubKey())
+            .toArray(byte[][]::new);
+
+        byte[][] rlpBytes = new byte[publicKeyBytes.length][];
+
+        for (int k = 0; k < publicKeyBytes.length; k++) {
+            rlpBytes[k] = RLP.encodeElement(publicKeyBytes[k]);
+        }
+
+        byte[] data = RLP.encodeList(rlpBytes);
+
+        PendingFederation deserializedPendingFederation = PendingFederation.deserializeOnlyBtcKeys(data);
+
+        Assertions.assertEquals(6, deserializedPendingFederation.getBtcPublicKeys().size());
+        for (int i = 0; i < 6; i++) {
+            Assertions.assertTrue(Arrays.equals(publicKeyBytes[i], deserializedPendingFederation.getBtcPublicKeys().get(i).getPubKey()));
+        }
+    }
+
     private void testBuildFederation(
         boolean isRskip201Active,
         boolean isRskip284Active,
@@ -315,5 +451,9 @@ class PendingFederationTest {
         if (isRskip201Active && !isRskip284Active && networkId.equals(NetworkParameters.ID_TESTNET)) {
             assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, builtFederation.getRedeemScript());
         }
+    }
+
+    private int randomInRange(int min, int max) {
+        return TestUtils.generateInt(PendingFederationTest.class.toString(),max - min + 1) + min;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
@@ -374,7 +374,7 @@ class PendingFederationTest {
 
         byte[] data = RLP.encodeList(rlpBytes);
 
-        PendingFederation deserializedPendingFederation = PendingFederation.deserializeOnlyBtcKeys(data);
+        PendingFederation deserializedPendingFederation = PendingFederation.deserializeFromBtcKeys(data);
 
         Assertions.assertEquals(6, deserializedPendingFederation.getBtcPublicKeys().size());
         for (int i = 0; i < 6; i++) {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
@@ -247,8 +247,7 @@ class PendingFederationTest {
 
     @Test
     void getHash() {
-        byte[] pendingFederationData = pendingFederation.serializeOnlyBtcKeys();
-        Keccak256 expectedHash = new Keccak256(HashUtil.keccak256(pendingFederationData));
+        Keccak256 expectedHash = new Keccak256("277f35b1c3b742f15eeabb243967794d90a3926d4a4a91cbf9d7d9eceac54a56");
         assertEquals(expectedHash, pendingFederation.getHash());
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/FederationChangeTest.java
@@ -23,7 +23,7 @@ import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.*;
 import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.PendingFederation;
+import co.rsk.peg.federation.PendingFederation;
 import org.ethereum.core.Repository;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PendingFederationTest.java
@@ -21,7 +21,7 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
-import co.rsk.peg.PendingFederation;
+import co.rsk.peg.federation.PendingFederation;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.exception.VMException;


### PR DESCRIPTION
PendingFederation class needed to be moved into ./federation package. For that reason, the serialization and deserialization methods that belonged to BridgeSerializationUtils had to be moved into PendingFederation class, to avoid circular dependency between ./peg/federation and ./peg packages.
And the serialization and deserialization methods related to FederationMember class are moved into its class too.

Also, the tests were moved following the new structure