### PR TITLE
Rebase create federation args

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.federation.FederationFactory;
 import java.time.Instant;
@@ -57,10 +58,9 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
         // Expected federation address is:
         // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
+        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L);
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationMembers,
-            genesisFederationAddressCreatedAt,
-            1L,
+            args,
             getBtcParams()
         );
 

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -49,6 +49,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
     public BridgeDevNetConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_TESTNET;
+        NetworkParameters btcParams = NetworkParameters.fromID(btcParamsString);
 
         List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPublicKeys);
 
@@ -58,11 +59,8 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
         // Expected federation address is:
         // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
-        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L);
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            getBtcParams()
-        );
+        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
+        genesisFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         btc2RskMinimumAcceptableConfirmations = 1;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -49,7 +49,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
     public BridgeDevNetConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_TESTNET;
-        NetworkParameters btcParams = NetworkParameters.fromID(btcParamsString);
 
         List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPublicKeys);
 
@@ -59,7 +58,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
         // Expected federation address is:
         // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, getBtcParams());
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         btc2RskMinimumAcceptableConfirmations = 1;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeDevNetConstants.java
@@ -59,8 +59,8 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
         // Expected federation address is:
         // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
-        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
+        genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         btc2RskMinimumAcceptableConfirmations = 1;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -54,8 +54,8 @@ public class BridgeMainNetConstants extends BridgeConstants {
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400L);
 
-        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
+        genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         btc2RskMinimumAcceptableConfirmations = 100;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 1000;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -20,7 +20,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
 
     BridgeMainNetConstants() {
         btcParamsString = NetworkParameters.ID_MAINNET;
-        NetworkParameters btcParams = NetworkParameters.fromID(btcParamsString);
 
         BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2"));
         BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("027319afb15481dbeb3c426bcc37f9a30e7f51ceff586936d85548d9395bcc2344"));
@@ -54,7 +53,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400L);
 
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, getBtcParams());
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         btc2RskMinimumAcceptableConfirmations = 100;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -4,6 +4,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.federation.FederationFactory;
 import com.google.common.collect.Lists;
@@ -52,10 +53,9 @@ public class BridgeMainNetConstants extends BridgeConstants {
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400L);
 
+        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L);
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationMembers,
-            genesisFederationAddressCreatedAt,
-            1L,
+            args,
             getBtcParams()
         );
 

--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -20,6 +20,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
 
     BridgeMainNetConstants() {
         btcParamsString = NetworkParameters.ID_MAINNET;
+        NetworkParameters btcParams = NetworkParameters.fromID(btcParamsString);
 
         BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2"));
         BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("027319afb15481dbeb3c426bcc37f9a30e7f51ceff586936d85548d9395bcc2344"));
@@ -53,11 +54,8 @@ public class BridgeMainNetConstants extends BridgeConstants {
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400L);
 
-        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L);
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            getBtcParams()
-        );
+        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
+        genesisFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         btc2RskMinimumAcceptableConfirmations = 100;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 1000;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -57,8 +57,8 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
-        FederationArgs args = new FederationArgs(federationMembers, genesisFederationCreatedAt, 1L, btcParams);
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreatedAt, 1L, btcParams);
+        genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -51,16 +51,14 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;
+        NetworkParameters btcParams = NetworkParameters.fromID(btcParamsString);
 
         List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPublicKeys);
 
         Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
-        FederationArgs args = new FederationArgs(federationMembers, genesisFederationCreatedAt, 1L);
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            getBtcParams()
-        );
+        FederationArgs args = new FederationArgs(federationMembers, genesisFederationCreatedAt, 1L, btcParams);
+        genesisFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.federation.FederationFactory;
 import java.nio.charset.StandardCharsets;
@@ -55,10 +56,9 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
+        FederationArgs args = new FederationArgs(federationMembers, genesisFederationCreatedAt, 1L);
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationMembers,
-            genesisFederationCreatedAt,
-            1L,
+            args,
             getBtcParams()
         );
 

--- a/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeRegTestConstants.java
@@ -51,13 +51,12 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;
-        NetworkParameters btcParams = NetworkParameters.fromID(btcParamsString);
 
         List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPublicKeys);
 
         Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreatedAt, 1L, btcParams);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreatedAt, 1L, getBtcParams());
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         btc2RskMinimumAcceptableConfirmations = 3;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -67,10 +67,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
         // Currently set to: Monday, October 8, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1538967600l);
 
-        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
+        genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         btc2RskMinimumAcceptableConfirmations = 10;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.federation.FederationFactory;
 import java.time.Instant;
@@ -65,10 +66,9 @@ public class BridgeTestNetConstants extends BridgeConstants {
         // Currently set to: Monday, October 8, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1538967600l);
 
+        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L);
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationMembers,
-            genesisFederationAddressCreatedAt,
-            1L,
+            args,
             getBtcParams()
         );
 

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -37,7 +37,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
     BridgeTestNetConstants() {
         btcParamsString = NetworkParameters.ID_TESTNET;
-        NetworkParameters btcParams = NetworkParameters.fromID(btcParamsString);
 
         BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(
             Hex.decode("039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9")
@@ -67,7 +66,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
         // Currently set to: Monday, October 8, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1538967600l);
 
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, getBtcParams());
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         btc2RskMinimumAcceptableConfirmations = 10;

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -37,6 +37,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
     BridgeTestNetConstants() {
         btcParamsString = NetworkParameters.ID_TESTNET;
+        NetworkParameters btcParams = NetworkParameters.fromID(btcParamsString);
 
         BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(
             Hex.decode("039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9")
@@ -66,10 +67,9 @@ public class BridgeTestNetConstants extends BridgeConstants {
         // Currently set to: Monday, October 8, 2018 12:00:00 AM GMT-03:00
         Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1538967600l);
 
-        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L);
+        FederationArgs args = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, btcParams);
         genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            getBtcParams()
+            args
         );
 
         btc2RskMinimumAcceptableConfirmations = 10;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -268,10 +268,9 @@ public class BridgeSerializationUtils {
             federationMembers.add(member);
         }
 
+        FederationArgs args = new FederationArgs(federationMembers, creationTime, creationBlockNumber);
         return FederationFactory.buildStandardMultiSigFederation(
-            federationMembers,
-            creationTime,
-            creationBlockNumber,
+            args,
             networkParameters
         );
     }
@@ -325,10 +324,9 @@ public class BridgeSerializationUtils {
             FederationMember::deserialize
         );
 
+        FederationArgs args = new FederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber());
         return FederationFactory.buildNonStandardErpFederation(
-            federation.getMembers(),
-            federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
+            args,
             federation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay(),
@@ -345,10 +343,10 @@ public class BridgeSerializationUtils {
             bridgeConstants.getBtcParams(),
             FederationMember::deserialize
         );
+
+        FederationArgs args = new FederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber());
         return FederationFactory.buildP2shErpFederation(
-            federation.getMembers(),
-            federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
+            args,
             federation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -312,7 +312,7 @@ public class BridgeSerializationUtils {
             FederationMember::deserialize
         );
     }
-    public static ErpFederation deserializeLegacyErpFederation(
+    public static ErpFederation deserializeNonStandardErpFederation(
         byte[] data,
         BridgeConstants bridgeConstants,
         ActivationConfig.ForBlock activations

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -268,10 +268,9 @@ public class BridgeSerializationUtils {
             federationMembers.add(member);
         }
 
-        FederationArgs args = new FederationArgs(federationMembers, creationTime, creationBlockNumber);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters);
         return FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            federationArgs
         );
     }
 
@@ -324,14 +323,16 @@ public class BridgeSerializationUtils {
             FederationMember::deserialize
         );
 
-        FederationArgs args = new FederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber());
-        return FederationFactory.buildNonStandardErpFederation(
-            args,
-            federation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
-            activations
-        );
+        List<FederationMember> fedMembers = federation.getMembers();
+        Instant creationTime = federation.getCreationTime();
+        long creationBlockNumber = federation.getCreationBlockNumber();
+        NetworkParameters btcParams = federation.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
+        return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
     }
 
     public static ErpFederation deserializeP2shErpFederation(
@@ -344,13 +345,16 @@ public class BridgeSerializationUtils {
             FederationMember::deserialize
         );
 
-        FederationArgs args = new FederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber());
-        return FederationFactory.buildP2shErpFederation(
-            args,
-            federation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay()
-        );
+        List<FederationMember> fedMembers = federation.getMembers();
+        Instant creationTime = federation.getCreationTime();
+        long creationBlockNumber = federation.getCreationBlockNumber();
+        NetworkParameters btcParams = federation.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
+        return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
 
     // An ABI call election is serialized as a list of the votes, like so:

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -323,15 +323,11 @@ public class BridgeSerializationUtils {
             FederationMember::deserialize
         );
 
-        List<FederationMember> fedMembers = federation.getMembers();
-        Instant creationTime = federation.getCreationTime();
-        long creationBlockNumber = federation.getCreationBlockNumber();
-        NetworkParameters btcParams = federation.getBtcParams();
+        FederationArgs federationArgs = federation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
         return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
     }
 
@@ -345,15 +341,11 @@ public class BridgeSerializationUtils {
             FederationMember::deserialize
         );
 
-        List<FederationMember> fedMembers = federation.getMembers();
-        Instant creationTime = federation.getCreationTime();
-        long creationBlockNumber = federation.getCreationBlockNumber();
-        NetworkParameters btcParams = federation.getBtcParams();
+        FederationArgs federationArgs = federation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
         return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -446,7 +446,7 @@ public class BridgeStorageProvider {
                     return PendingFederation.deserialize(data); // Assume this is the multi-key version
                 }
 
-                return PendingFederation.deserializeFromBtcKeys(data);
+                return PendingFederation.deserializeFromBtcKeysOnly(data);
             }
         );
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -1078,7 +1078,7 @@ public class BridgeStorageProvider {
             );
         }
         if (version == NON_STANDARD_ERP_FEDERATION.getFormatVersion()) {
-            return BridgeSerializationUtils.deserializeLegacyErpFederation(
+            return BridgeSerializationUtils.deserializeNonStandardErpFederation(
                 data,
                 bridgeConstants,
                 activations

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
@@ -10,7 +10,6 @@ import co.rsk.bitcoinj.script.ScriptChunk;
 import co.rsk.peg.bitcoin.ErpRedeemScriptBuilder;
 import co.rsk.peg.bitcoin.RedeemScriptCreationException;
 import co.rsk.peg.utils.EcKeyUtils;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,9 +24,7 @@ public class ErpFederation extends Federation {
     private ErpRedeemScriptBuilder erpRedeemScriptBuilder;
 
     protected ErpFederation(
-        List<FederationMember> members,
-        Instant creationTime,
-        long creationBlockNumber,
+        FederationArgs args,
         NetworkParameters btcParams,
         List<BtcECKey> erpPubKeys,
         long activationDelay,
@@ -35,7 +32,7 @@ public class ErpFederation extends Federation {
         int formatVersion
     ) {
 
-        super(members, creationTime, creationBlockNumber, btcParams, formatVersion);
+        super(args, btcParams, formatVersion);
         validateEmergencyKeys(erpPubKeys);
 
         this.erpPubKeys = EcKeyUtils.getCompressedPubKeysList(erpPubKeys);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
@@ -1,7 +1,6 @@
 package co.rsk.peg.federation;
 
 import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.script.RedeemScriptParser;
 import co.rsk.bitcoinj.script.RedeemScriptParserFactory;
 import co.rsk.bitcoinj.script.Script;
@@ -13,7 +12,6 @@ import co.rsk.peg.utils.EcKeyUtils;
 import java.util.Collections;
 import java.util.List;
 
-import static co.rsk.peg.federation.ErpFederationCreationException.Reason.NULL_OR_EMPTY_EMERGENCY_KEYS;
 import static co.rsk.peg.federation.ErpFederationCreationException.Reason.REDEEM_SCRIPT_CREATION_FAILED;
 
 public class ErpFederation extends Federation {
@@ -21,31 +19,20 @@ public class ErpFederation extends Federation {
     private final long activationDelay;
     private Script defaultRedeemScript;
     private Script defaultP2SHScript;
-    private ErpRedeemScriptBuilder erpRedeemScriptBuilder;
+    private final ErpRedeemScriptBuilder erpRedeemScriptBuilder;
 
     protected ErpFederation(
-        FederationArgs args,
-        NetworkParameters btcParams,
-        List<BtcECKey> erpPubKeys,
-        long activationDelay,
+        ErpFederationArgs erpFederationArgs,
         ErpRedeemScriptBuilder erpRedeemScriptBuilder,
         int formatVersion
     ) {
+        super(erpFederationArgs, formatVersion);
 
-        super(args, btcParams, formatVersion);
-        validateEmergencyKeys(erpPubKeys);
-
-        this.erpPubKeys = EcKeyUtils.getCompressedPubKeysList(erpPubKeys);
-        this.activationDelay = activationDelay;
+        this.erpPubKeys = EcKeyUtils.getCompressedPubKeysList(erpFederationArgs.erpPubKeys);
+        this.activationDelay = erpFederationArgs.activationDelay;
         this.erpRedeemScriptBuilder = erpRedeemScriptBuilder;
     }
 
-    private void validateEmergencyKeys(List<BtcECKey> erpPubKeys) {
-        if (erpPubKeys == null || erpPubKeys.isEmpty()) {
-            String message = "Emergency keys are not provided";
-            throw new ErpFederationCreationException(message, NULL_OR_EMPTY_EMERGENCY_KEYS);
-        }
-    }
 
     public ErpRedeemScriptBuilder getErpRedeemScriptBuilder() { return erpRedeemScriptBuilder; }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
@@ -28,8 +28,8 @@ public class ErpFederation extends Federation {
     ) {
         super(erpFederationArgs, formatVersion);
 
-        this.erpPubKeys = EcKeyUtils.getCompressedPubKeysList(erpFederationArgs.erpPubKeys);
-        this.activationDelay = erpFederationArgs.activationDelay;
+        this.erpPubKeys = EcKeyUtils.getCompressedPubKeysList(erpFederationArgs.getErpPubKeys());
+        this.activationDelay = erpFederationArgs.getActivationDelay();
         this.erpRedeemScriptBuilder = erpRedeemScriptBuilder;
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
@@ -26,6 +26,11 @@ public class ErpFederationArgs extends FederationArgs{
         this.activationDelay = activationDelay;
     }
 
+    public static ErpFederationArgs fromFederationArgs(FederationArgs federationArgs, List<BtcECKey> erpPubKeys, long activationDelay){
+        return new ErpFederationArgs(federationArgs.members, federationArgs.creationTime,
+            federationArgs.creationBlockNumber, federationArgs.btcParams, erpPubKeys, activationDelay);
+    }
+
     private void validateEmergencyKeys(List<BtcECKey> erpPubKeys) {
         if (erpPubKeys == null || erpPubKeys.isEmpty()) {
             String message = "Emergency keys are not provided";

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
@@ -1,0 +1,35 @@
+package co.rsk.peg.federation;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+
+import java.time.Instant;
+import java.util.List;
+
+import static co.rsk.peg.federation.ErpFederationCreationException.Reason.NULL_OR_EMPTY_EMERGENCY_KEYS;
+
+public class ErpFederationArgs extends FederationArgs{
+    protected final List<BtcECKey> erpPubKeys;
+    protected final long activationDelay;
+    public ErpFederationArgs(
+        List<FederationMember> members,
+        Instant creationTime,
+        long blockNumber,
+        NetworkParameters btcParams,
+        List<BtcECKey> erpPubKeys,
+        long activationDelay
+    ) {
+        super(members, creationTime, blockNumber, btcParams);
+
+        validateEmergencyKeys(erpPubKeys);
+        this.erpPubKeys = erpPubKeys;
+        this.activationDelay = activationDelay;
+    }
+
+    private void validateEmergencyKeys(List<BtcECKey> erpPubKeys) {
+        if (erpPubKeys == null || erpPubKeys.isEmpty()) {
+            String message = "Emergency keys are not provided";
+            throw new ErpFederationCreationException(message, NULL_OR_EMPTY_EMERGENCY_KEYS);
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
@@ -14,12 +14,12 @@ public class ErpFederationArgs extends FederationArgs{
     public ErpFederationArgs(
         List<FederationMember> members,
         Instant creationTime,
-        long blockNumber,
+        long creationBlockNumber,
         NetworkParameters btcParams,
         List<BtcECKey> erpPubKeys,
         long activationDelay
     ) {
-        super(members, creationTime, blockNumber, btcParams);
+        super(members, creationTime, creationBlockNumber, btcParams);
 
         validateEmergencyKeys(erpPubKeys);
         this.erpPubKeys = erpPubKeys;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
@@ -9,8 +9,9 @@ import java.util.List;
 import static co.rsk.peg.federation.ErpFederationCreationException.Reason.NULL_OR_EMPTY_EMERGENCY_KEYS;
 
 public class ErpFederationArgs extends FederationArgs{
-    protected final List<BtcECKey> erpPubKeys;
-    protected final long activationDelay;
+    private final List<BtcECKey> erpPubKeys;
+    private final long activationDelay;
+
     public ErpFederationArgs(
         List<FederationMember> members,
         Instant creationTime,
@@ -26,9 +27,13 @@ public class ErpFederationArgs extends FederationArgs{
         this.activationDelay = activationDelay;
     }
 
+    public List<BtcECKey> getErpPubKeys() { return erpPubKeys; }
+
+    public long getActivationDelay() { return activationDelay; }
+
     public static ErpFederationArgs fromFederationArgs(FederationArgs federationArgs, List<BtcECKey> erpPubKeys, long activationDelay){
-        return new ErpFederationArgs(federationArgs.members, federationArgs.creationTime,
-            federationArgs.creationBlockNumber, federationArgs.btcParams, erpPubKeys, activationDelay);
+        return new ErpFederationArgs(federationArgs.getMembers(), federationArgs.getCreationTime(),
+            federationArgs.getCreationBlockNumber(), federationArgs.getBtcParams(), erpPubKeys, activationDelay);
     }
 
     private void validateEmergencyKeys(List<BtcECKey> erpPubKeys) {

--- a/rskj-core/src/main/java/co/rsk/peg/federation/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/Federation.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
  */
 
 public abstract class Federation {
+    protected final FederationArgs federationArgs;
     protected final List<FederationMember> members;
     protected final Instant creationTime;
     protected final long creationBlockNumber;
@@ -56,6 +57,7 @@ public abstract class Federation {
         // Sorting members ensures same order of federation members for same members
         // Immutability provides protection against unwanted modification, thus making the Federation instance
         // effectively immutable
+        this.federationArgs = federationArgs;
         this.members = Collections.unmodifiableList(federationArgs.members.stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
         this.creationTime = federationArgs.creationTime.truncatedTo(ChronoUnit.MILLIS);
         this.creationBlockNumber = federationArgs.creationBlockNumber;
@@ -67,6 +69,9 @@ public abstract class Federation {
         return formatVersion;
     }
 
+    public FederationArgs getArgs() {
+        return federationArgs;
+    }
     public List<FederationMember> getMembers() {
         // Safe to return members since
         // both list and instances are immutable

--- a/rskj-core/src/main/java/co/rsk/peg/federation/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/Federation.java
@@ -50,18 +50,16 @@ public abstract class Federation {
     protected Address address;
 
     protected Federation(
-        List<FederationMember> members,
-        Instant creationTime,
-        long creationBlockNumber,
+        FederationArgs args,
         NetworkParameters btcParams,
         int formatVersion
     ) {
         // Sorting members ensures same order of federation members for same members
         // Immutability provides protection against unwanted modification, thus making the Federation instance
         // effectively immutable
-        this.members = Collections.unmodifiableList(members.stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
-        this.creationTime = creationTime.truncatedTo(ChronoUnit.MILLIS);
-        this.creationBlockNumber = creationBlockNumber;
+        this.members = Collections.unmodifiableList(args.members.stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
+        this.creationTime = args.creationTime.truncatedTo(ChronoUnit.MILLIS);
+        this.creationBlockNumber = args.creationBlockNumber;
         this.btcParams = btcParams;
         this.formatVersion = formatVersion;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/Federation.java
@@ -50,17 +50,16 @@ public abstract class Federation {
     protected Address address;
 
     protected Federation(
-        FederationArgs args,
-        NetworkParameters btcParams,
+        FederationArgs federationArgs,
         int formatVersion
     ) {
         // Sorting members ensures same order of federation members for same members
         // Immutability provides protection against unwanted modification, thus making the Federation instance
         // effectively immutable
-        this.members = Collections.unmodifiableList(args.members.stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
-        this.creationTime = args.creationTime.truncatedTo(ChronoUnit.MILLIS);
-        this.creationBlockNumber = args.creationBlockNumber;
-        this.btcParams = btcParams;
+        this.members = Collections.unmodifiableList(federationArgs.members.stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
+        this.creationTime = federationArgs.creationTime.truncatedTo(ChronoUnit.MILLIS);
+        this.creationBlockNumber = federationArgs.creationBlockNumber;
+        this.btcParams = federationArgs.btcParams;
         this.formatVersion = formatVersion;
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/Federation.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
  */
 
 public abstract class Federation {
-    protected final FederationArgs federationArgs;
     protected final List<FederationMember> members;
     protected final Instant creationTime;
     protected final long creationBlockNumber;
@@ -57,11 +56,10 @@ public abstract class Federation {
         // Sorting members ensures same order of federation members for same members
         // Immutability provides protection against unwanted modification, thus making the Federation instance
         // effectively immutable
-        this.federationArgs = federationArgs;
-        this.members = Collections.unmodifiableList(federationArgs.members.stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
-        this.creationTime = federationArgs.creationTime.truncatedTo(ChronoUnit.MILLIS);
-        this.creationBlockNumber = federationArgs.creationBlockNumber;
-        this.btcParams = federationArgs.btcParams;
+        this.members = Collections.unmodifiableList(federationArgs.getMembers().stream().sorted(FederationMember.BTC_RSK_MST_PUBKEYS_COMPARATOR).collect(Collectors.toList()));
+        this.creationTime = federationArgs.getCreationTime().truncatedTo(ChronoUnit.MILLIS);
+        this.creationBlockNumber = federationArgs.getCreationBlockNumber();
+        this.btcParams = federationArgs.getBtcParams();
         this.formatVersion = formatVersion;
     }
 
@@ -70,7 +68,7 @@ public abstract class Federation {
     }
 
     public FederationArgs getArgs() {
-        return federationArgs;
+        return new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
     }
     public List<FederationMember> getMembers() {
         // Safe to return members since

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
@@ -12,10 +12,10 @@ public class FederationArgs {
     protected final NetworkParameters btcParams;
 
     public FederationArgs(List<FederationMember> members, Instant creationTime,
-                          long blockNumber, NetworkParameters btcParams) {
+                          long creationBlockNumber, NetworkParameters btcParams) {
         this.members = members;
         this.creationTime = creationTime;
-        this.creationBlockNumber = blockNumber;
+        this.creationBlockNumber = creationBlockNumber;
         this.btcParams = btcParams;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
@@ -6,10 +6,10 @@ import java.time.Instant;
 import java.util.List;
 
 public class FederationArgs {
-    protected final List<FederationMember> members;
-    protected final Instant creationTime;
-    protected final long creationBlockNumber;
-    protected final NetworkParameters btcParams;
+    private final List<FederationMember> members;
+    private final Instant creationTime;
+    private final long creationBlockNumber;
+    private final NetworkParameters btcParams;
 
     public FederationArgs(List<FederationMember> members, Instant creationTime,
                           long creationBlockNumber, NetworkParameters btcParams) {
@@ -18,4 +18,16 @@ public class FederationArgs {
         this.creationBlockNumber = creationBlockNumber;
         this.btcParams = btcParams;
     }
+
+    public List<FederationMember> getMembers() {
+        return members;
+    }
+
+    public Instant getCreationTime() {
+        return creationTime;
+    }
+
+    public long getCreationBlockNumber() { return creationBlockNumber; }
+    public NetworkParameters getBtcParams() { return btcParams; }
+
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
@@ -1,5 +1,7 @@
 package co.rsk.peg.federation;
 
+import co.rsk.bitcoinj.core.NetworkParameters;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -7,10 +9,13 @@ public class FederationArgs {
     protected final List<FederationMember> members;
     protected final Instant creationTime;
     protected final long creationBlockNumber;
+    protected final NetworkParameters btcParams;
 
-    public FederationArgs(List<FederationMember> members, Instant creationTime, long blockNumber) {
+    public FederationArgs(List<FederationMember> members, Instant creationTime,
+                          long blockNumber, NetworkParameters btcParams) {
         this.members = members;
         this.creationTime = creationTime;
         this.creationBlockNumber = blockNumber;
+        this.btcParams = btcParams;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
@@ -1,0 +1,16 @@
+package co.rsk.peg.federation;
+
+import java.time.Instant;
+import java.util.List;
+
+public class FederationArgs {
+    protected final List<FederationMember> members;
+    protected final Instant creationTime;
+    protected final long creationBlockNumber;
+
+    public FederationArgs(List<FederationMember> members, Instant creationTime, long blockNumber) {
+        this.members = members;
+        this.creationTime = creationTime;
+        this.creationBlockNumber = blockNumber;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationFactory.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationFactory.java
@@ -7,7 +7,6 @@ import co.rsk.peg.bitcoin.NonStandardErpRedeemScriptBuilderFactory;
 import co.rsk.peg.bitcoin.P2shErpRedeemScriptBuilder;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 
-import java.time.Instant;
 import java.util.List;
 
 import static co.rsk.peg.federation.FederationFormatVersion.*;
@@ -16,22 +15,16 @@ public class FederationFactory {
 
     private FederationFactory() {}
 
-    public static StandardMultisigFederation buildStandardMultiSigFederation(List<FederationMember> members,
-                                                                      Instant creationTime,
-                                                                      long creationBlockNumber,
+    public static StandardMultisigFederation buildStandardMultiSigFederation(FederationArgs args,
                                                                       NetworkParameters btcParams) {
         return new StandardMultisigFederation(
-            members,
-            creationTime,
-            creationBlockNumber,
+            args,
             btcParams,
             STANDARD_MULTISIG_FEDERATION.getFormatVersion()
         );
     }
 
-    public static ErpFederation buildNonStandardErpFederation(List<FederationMember> members,
-                                                       Instant creationTime,
-                                                       long creationBlockNumber,
+    public static ErpFederation buildNonStandardErpFederation(FederationArgs args,
                                                        NetworkParameters btcParams,
                                                        List<BtcECKey> erpPubKeys,
                                                        long activationDelay,
@@ -40,9 +33,7 @@ public class FederationFactory {
             NonStandardErpRedeemScriptBuilderFactory.getNonStandardErpRedeemScriptBuilder(activations, btcParams);
 
         return new ErpFederation(
-            members,
-            creationTime,
-            creationBlockNumber,
+            args,
             btcParams,
             erpPubKeys,
             activationDelay,
@@ -51,18 +42,14 @@ public class FederationFactory {
         );
     }
 
-    public static ErpFederation buildP2shErpFederation(List<FederationMember> members,
-                                                       Instant creationTime,
-                                                       long creationBlockNumber,
+    public static ErpFederation buildP2shErpFederation(FederationArgs args,
                                                        NetworkParameters btcParams,
                                                        List<BtcECKey> erpPubKeys,
                                                        long activationDelay) {
 
         ErpRedeemScriptBuilder erpRedeemScriptBuilder = new P2shErpRedeemScriptBuilder();
         return new ErpFederation(
-            members,
-            creationTime,
-            creationBlockNumber,
+            args,
             btcParams,
             erpPubKeys,
             activationDelay,

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationFactory.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationFactory.java
@@ -21,7 +21,7 @@ public class FederationFactory {
 
     public static ErpFederation buildNonStandardErpFederation(ErpFederationArgs erpFederationArgs,
                                                               ActivationConfig.ForBlock activations) {
-        NetworkParameters btcParams = erpFederationArgs.btcParams;
+        NetworkParameters btcParams = erpFederationArgs.getBtcParams();
         ErpRedeemScriptBuilder erpRedeemScriptBuilder =
             NonStandardErpRedeemScriptBuilderFactory.getNonStandardErpRedeemScriptBuilder(activations, btcParams);
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationFactory.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationFactory.java
@@ -1,13 +1,10 @@
 package co.rsk.peg.federation;
 
-import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.bitcoin.ErpRedeemScriptBuilder;
 import co.rsk.peg.bitcoin.NonStandardErpRedeemScriptBuilderFactory;
 import co.rsk.peg.bitcoin.P2shErpRedeemScriptBuilder;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
-
-import java.util.List;
 
 import static co.rsk.peg.federation.FederationFormatVersion.*;
 
@@ -15,47 +12,26 @@ public class FederationFactory {
 
     private FederationFactory() {}
 
-    public static StandardMultisigFederation buildStandardMultiSigFederation(FederationArgs args,
-                                                                      NetworkParameters btcParams) {
+    public static StandardMultisigFederation buildStandardMultiSigFederation(FederationArgs federationArgs) {
         return new StandardMultisigFederation(
-            args,
-            btcParams,
+            federationArgs,
             STANDARD_MULTISIG_FEDERATION.getFormatVersion()
         );
     }
 
-    public static ErpFederation buildNonStandardErpFederation(FederationArgs args,
-                                                       NetworkParameters btcParams,
-                                                       List<BtcECKey> erpPubKeys,
-                                                       long activationDelay,
-                                                       ActivationConfig.ForBlock activations) {
+    public static ErpFederation buildNonStandardErpFederation(ErpFederationArgs erpFederationArgs,
+                                                              ActivationConfig.ForBlock activations) {
+        NetworkParameters btcParams = erpFederationArgs.btcParams;
         ErpRedeemScriptBuilder erpRedeemScriptBuilder =
             NonStandardErpRedeemScriptBuilderFactory.getNonStandardErpRedeemScriptBuilder(activations, btcParams);
 
-        return new ErpFederation(
-            args,
-            btcParams,
-            erpPubKeys,
-            activationDelay,
-            erpRedeemScriptBuilder,
-            NON_STANDARD_ERP_FEDERATION.getFormatVersion()
+        return new ErpFederation(erpFederationArgs, erpRedeemScriptBuilder, NON_STANDARD_ERP_FEDERATION.getFormatVersion()
         );
     }
 
-    public static ErpFederation buildP2shErpFederation(FederationArgs args,
-                                                       NetworkParameters btcParams,
-                                                       List<BtcECKey> erpPubKeys,
-                                                       long activationDelay) {
-
+    public static ErpFederation buildP2shErpFederation(ErpFederationArgs erpFederationArgs) {
         ErpRedeemScriptBuilder erpRedeemScriptBuilder = new P2shErpRedeemScriptBuilder();
-        return new ErpFederation(
-            args,
-            btcParams,
-            erpPubKeys,
-            activationDelay,
-            erpRedeemScriptBuilder,
-            P2SH_ERP_FEDERATION.getFormatVersion()
+        return new ErpFederation(erpFederationArgs, erpRedeemScriptBuilder, P2SH_ERP_FEDERATION.getFormatVersion()
         );
     }
-
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -98,29 +98,29 @@ public final class PendingFederation {
      * @return a Federation
      */
     public Federation buildFederation(
-            Instant creationTime,
-            long blockNumber,
-            BridgeConstants bridgeConstants,
-            ActivationConfig.ForBlock activations
+        Instant creationTime,
+        long creationBlockNumber,
+        BridgeConstants bridgeConstants,
+        ActivationConfig.ForBlock activations
         ) {
         if (!this.isComplete()) {
             throw new IllegalStateException("PendingFederation is incomplete");
         }
 
         NetworkParameters btcParams = bridgeConstants.getBtcParams();
-        FederationArgs federationArgs = new FederationArgs(members, creationTime, blockNumber, btcParams);
+        FederationArgs federationArgs = new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
 
         if (shouldBuildStandardMultisigFederation(activations)){
             return FederationFactory.buildStandardMultiSigFederation(federationArgs);
         }
 
-        // should build and erp federation due to activations
+        // should build an erp federation due to activations
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
 
         if (shouldBuildNonStandardErpFederation(activations)) {
-            logger.info("[buildFederation] Going to create an ERP Federation");
+            logger.info("[buildFederation] Going to create a Non-Standard ERP Federation");
             return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         }
 
@@ -221,7 +221,7 @@ public final class PendingFederation {
         return RLP.encodeList(encodedKeys.toArray(new byte[0][]));
     }
 
-    public static PendingFederation deserializeFromBtcKeys(byte[] data) {
+    public static PendingFederation deserializeFromBtcKeysOnly(byte[] data) {
         // BTC, RSK and MST keys are the same
         List<FederationMember> deserializedMembers = deserializeBtcPublicKeys(data).stream()
             .map(FederationMember::getFederationMemberFromKey)

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -98,30 +98,41 @@ public final class PendingFederation {
      * @return a Federation
      */
     public Federation buildFederation(
-        Instant creationTime,
-        long blockNumber,
-        BridgeConstants bridgeConstants,
-        ActivationConfig.ForBlock activations
+            Instant creationTime,
+            long blockNumber,
+            BridgeConstants bridgeConstants,
+            ActivationConfig.ForBlock activations
         ) {
         if (!this.isComplete()) {
             throw new IllegalStateException("PendingFederation is incomplete");
         }
 
         NetworkParameters btcParams = bridgeConstants.getBtcParams();
-        if (!activations.isActive(ConsensusRule.RSKIP201)){
+
+        if (shouldBuildStandardMultisigFederation(activations)){
             FederationArgs federationArgs = new FederationArgs(members, creationTime, blockNumber, btcParams);
             return FederationFactory.buildStandardMultiSigFederation(federationArgs);
         }
 
+        // should build and erp federation due to activations
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(members, creationTime, blockNumber, btcParams, erpPubKeys, activationDelay);
-        if (!activations.isActive(ConsensusRule.RSKIP353)) {
+        if (shouldBuildNonStandardErpFederation(activations)) {
             logger.info("[buildFederation] Going to create an ERP Federation");
             return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         }
+
         logger.info("[buildFederation] Going to create a P2SH ERP Federation");
         return FederationFactory.buildP2shErpFederation(erpFederationArgs);
+    }
+
+    private boolean shouldBuildStandardMultisigFederation(ActivationConfig.ForBlock activations) {
+        return !activations.isActive(ConsensusRule.RSKIP201);
+    }
+
+    private boolean shouldBuildNonStandardErpFederation(ActivationConfig.ForBlock activations) {
+        return !activations.isActive(ConsensusRule.RSKIP353);
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -108,8 +108,8 @@ public final class PendingFederation {
         }
 
         NetworkParameters btcParams = bridgeConstants.getBtcParams();
-        FederationArgs federationArgs = new FederationArgs(members, creationTime, blockNumber, btcParams);
         if (!activations.isActive(ConsensusRule.RSKIP201)){
+            FederationArgs federationArgs = new FederationArgs(members, creationTime, blockNumber, btcParams);
             return FederationFactory.buildStandardMultiSigFederation(federationArgs);
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -106,12 +106,11 @@ public final class PendingFederation {
             throw new IllegalStateException("PendingFederation is incomplete");
         }
 
+        FederationArgs args = new FederationArgs(members, creationTime, blockNumber);
         if (activations.isActive(ConsensusRule.RSKIP353)) {
             logger.info("[buildFederation] Going to create a P2SH ERP Federation");
             return FederationFactory.buildP2shErpFederation(
-                members,
-                creationTime,
-                blockNumber,
+                args,
                 bridgeConstants.getBtcParams(),
                 bridgeConstants.getErpFedPubKeysList(),
                 bridgeConstants.getErpFedActivationDelay()
@@ -122,9 +121,7 @@ public final class PendingFederation {
             logger.info("[buildFederation] Going to create an ERP Federation");
 
             return FederationFactory.buildNonStandardErpFederation(
-                members,
-                creationTime,
-                blockNumber,
+                args,
                 bridgeConstants.getBtcParams(),
                 bridgeConstants.getErpFedPubKeysList(),
                 bridgeConstants.getErpFedActivationDelay(),
@@ -133,9 +130,7 @@ public final class PendingFederation {
         }
 
         return FederationFactory.buildStandardMultiSigFederation(
-                members,
-                creationTime,
-                blockNumber,
+                args,
                 bridgeConstants.getBtcParams()
         );
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -108,16 +108,17 @@ public final class PendingFederation {
         }
 
         NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        FederationArgs federationArgs = new FederationArgs(members, creationTime, blockNumber, btcParams);
 
         if (shouldBuildStandardMultisigFederation(activations)){
-            FederationArgs federationArgs = new FederationArgs(members, creationTime, blockNumber, btcParams);
             return FederationFactory.buildStandardMultiSigFederation(federationArgs);
         }
 
         // should build and erp federation due to activations
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(members, creationTime, blockNumber, btcParams, erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
+
         if (shouldBuildNonStandardErpFederation(activations)) {
             logger.info("[buildFederation] Going to create an ERP Federation");
             return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/StandardMultisigFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/StandardMultisigFederation.java
@@ -23,9 +23,6 @@ import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.peg.bitcoin.ScriptValidations;
 
-import java.time.Instant;
-import java.util.List;
-
 /**
  * Immutable representation of an RSK Federation in the context of
  * a specific BTC network.
@@ -35,13 +32,11 @@ import java.util.List;
 public class StandardMultisigFederation extends Federation {
 
     protected StandardMultisigFederation(
-        List<FederationMember> members,
-        Instant creationTime,
-        long creationBlockNumber,
+        FederationArgs args,
         NetworkParameters btcParams,
         int formatVersion) {
 
-        super(members, creationTime, creationBlockNumber, btcParams, formatVersion);
+        super(args, btcParams, formatVersion);
 
         validateRedeemScriptSize();
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/StandardMultisigFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/StandardMultisigFederation.java
@@ -18,7 +18,6 @@
 
 package co.rsk.peg.federation;
 
-import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.peg.bitcoin.ScriptValidations;
@@ -32,11 +31,10 @@ import co.rsk.peg.bitcoin.ScriptValidations;
 public class StandardMultisigFederation extends Federation {
 
     protected StandardMultisigFederation(
-        FederationArgs args,
-        NetworkParameters btcParams,
+        FederationArgs federationArgs,
         int formatVersion) {
 
-        super(args, btcParams, formatVersion);
+        super(federationArgs, formatVersion);
 
         validateRedeemScriptSize();
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -163,11 +163,11 @@ class BridgeSerializationUtilsTest {
         FederationArgs args = new FederationArgs(
             members,
             Instant.ofEpochMilli(0xabcdef),
-            42L
+            42L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
 
         byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(federation);
@@ -307,10 +307,10 @@ class BridgeSerializationUtilsTest {
             members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
         }
 
-        FederationArgs args = new FederationArgs(members, Instant.now(), 123);
+        FederationArgs args = new FederationArgs(members, Instant.now(), 123,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Federation testFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
 
         byte[] serializedFederation = BridgeSerializationUtils.serializeFederation(testFederation);
@@ -659,7 +659,8 @@ class BridgeSerializationUtilsTest {
 
     @Test
     void serializeAndDeserializeFederationOnlyBtcKeysWithRealRLP() {
-        NetworkParameters networkParms = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+        NetworkParameters networkParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+
         byte[][] publicKeyBytes = new byte[][]{
             BtcECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey(),
             BtcECKey.fromPrivate(BigInteger.valueOf(200)).getPubKey(),
@@ -678,14 +679,14 @@ class BridgeSerializationUtilsTest {
             BtcECKey.fromPublicOnly(publicKeyBytes[4]),
             BtcECKey.fromPublicOnly(publicKeyBytes[5])
         ));
-        FederationArgs args = new FederationArgs(members, Instant.ofEpochMilli(0xabcdef), 42L);
+        FederationArgs args = new FederationArgs(members, Instant.ofEpochMilli(0xabcdef), 42L,
+            networkParams);
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParms
+            args
         );
 
         byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(federation);
-        Federation deserializedFederation = BridgeSerializationUtils.deserializeStandardMultisigFederationOnlyBtcKeys(result, networkParms);
+        Federation deserializedFederation = BridgeSerializationUtils.deserializeStandardMultisigFederationOnlyBtcKeys(result, networkParams);
         MatcherAssert.assertThat(federation, is(deserializedFederation));
     }
 
@@ -1129,10 +1130,10 @@ class BridgeSerializationUtilsTest {
                 members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
             }
 
-            FederationArgs args = new FederationArgs(members, Instant.now(), 123);
+            FederationArgs args = new FederationArgs(members, Instant.now(), 123,
+                bridgeConstants.getBtcParams());
             Federation testFederation = FederationFactory.buildStandardMultiSigFederation(
-                args,
-                bridgeConstants.getBtcParams()
+                args
             );
             byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testFederation);
 
@@ -1141,11 +1142,13 @@ class BridgeSerializationUtilsTest {
                 bridgeConstants.getBtcParams()
             );
 
-            Federation testErpFederation = FederationFactory.buildNonStandardErpFederation(
-                args,
+            ErpFederationArgs erpArgs = new ErpFederationArgs(members, Instant.now(), 123,
                 bridgeConstants.getBtcParams(),
                 bridgeConstants.getErpFedPubKeysList(),
-                bridgeConstants.getErpFedActivationDelay(),
+                bridgeConstants.getErpFedActivationDelay()
+            );
+            Federation testErpFederation = FederationFactory.buildNonStandardErpFederation(
+                erpArgs,
                 activations
             );
             byte[] serializedTestErpFederation = BridgeSerializationUtils.serializeFederation(testErpFederation);
@@ -1166,12 +1169,7 @@ class BridgeSerializationUtilsTest {
             }
 
             if (isRskip353Active) {
-                Federation testP2shErpFederation = FederationFactory.buildP2shErpFederation(
-                    args,
-                    bridgeConstants.getBtcParams(),
-                    bridgeConstants.getErpFedPubKeysList(),
-                    bridgeConstants.getErpFedActivationDelay()
-                );
+                Federation testP2shErpFederation = FederationFactory.buildP2shErpFederation(erpArgs);
                 byte[] serializedTestP2shErpFederation = BridgeSerializationUtils.serializeFederation(testP2shErpFederation);
 
                 Federation deserializedTestP2shErpFederation = BridgeSerializationUtils.deserializeP2shErpFederation(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1136,30 +1136,30 @@ class BridgeSerializationUtilsTest {
             FederationArgs federationArgs =
                 new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
             Federation testStandardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-            byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testStandardMultisigFederation);
+            byte[] serializedTestStandardMultisigFederation = BridgeSerializationUtils.serializeFederation(testStandardMultisigFederation);
 
-            Federation deserializedTestFederation =
-                BridgeSerializationUtils.deserializeStandardMultisigFederation(serializedTestFederation, bridgeConstants.getBtcParams());
-            FederationArgs deserializedTestFederationArgs = deserializedTestFederation.getArgs();
+            Federation deserializedTestStandardMultisigFederation =
+                BridgeSerializationUtils.deserializeStandardMultisigFederation(serializedTestStandardMultisigFederation, bridgeConstants.getBtcParams());
+            FederationArgs deserializedTestStandardMultisigFederationArgs = deserializedTestStandardMultisigFederation.getArgs();
 
             ErpFederationArgs erpFederationArgs =
-                ErpFederationArgs.fromFederationArgs(deserializedTestFederationArgs, bridgeConstants.getErpFedPubKeysList(), bridgeConstants.getErpFedActivationDelay());
+                ErpFederationArgs.fromFederationArgs(deserializedTestStandardMultisigFederationArgs, bridgeConstants.getErpFedPubKeysList(), bridgeConstants.getErpFedActivationDelay());
             Federation testNonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
                 erpFederationArgs,
                 activations
             );
-            byte[] serializedTestErpFederation = BridgeSerializationUtils.serializeFederation(testNonStandardErpFederation);
+            byte[] serializedTestNonStandardErpFederation = BridgeSerializationUtils.serializeFederation(testNonStandardErpFederation);
 
-            Federation deserializedTestErpFederation = BridgeSerializationUtils.deserializeNonStandardErpFederation(
-                serializedTestErpFederation,
+            ErpFederation deserializedTestNonStandardErpFederation = BridgeSerializationUtils.deserializeNonStandardErpFederation(
+                serializedTestNonStandardErpFederation,
                 bridgeConstants,
                 activations
             );
 
-            Assertions.assertEquals(testStandardMultisigFederation, deserializedTestFederation);
-            Assertions.assertEquals(testNonStandardErpFederation, deserializedTestErpFederation);
-            assertNotEquals(testStandardMultisigFederation, deserializedTestErpFederation);
-            assertNotEquals(testNonStandardErpFederation, deserializedTestFederation);
+            Assertions.assertEquals(testStandardMultisigFederation, deserializedTestStandardMultisigFederation);
+            Assertions.assertEquals(testNonStandardErpFederation, deserializedTestNonStandardErpFederation);
+            assertNotEquals(testStandardMultisigFederation, deserializedTestNonStandardErpFederation);
+            assertNotEquals(testNonStandardErpFederation, deserializedTestStandardMultisigFederation);
 
             if (!isRskip284Active && networkId.equals(NetworkParameters.ID_TESTNET)) {
                 Assertions.assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, testNonStandardErpFederation.getRedeemScript());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -160,15 +160,13 @@ class BridgeSerializationUtilsTest {
             BtcECKey.fromPublicOnly(publicKeyBytes[4]),
             BtcECKey.fromPublicOnly(publicKeyBytes[5]),
         }));
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             members,
             Instant.ofEpochMilli(0xabcdef),
             42L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(federation);
         StringBuilder expectedBuilder = new StringBuilder();
@@ -307,11 +305,9 @@ class BridgeSerializationUtilsTest {
             members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
         }
 
-        FederationArgs args = new FederationArgs(members, Instant.now(), 123,
+        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), 123,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
-        Federation testFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+        Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         byte[] serializedFederation = BridgeSerializationUtils.serializeFederation(testFederation);
 
@@ -679,11 +675,9 @@ class BridgeSerializationUtilsTest {
             BtcECKey.fromPublicOnly(publicKeyBytes[4]),
             BtcECKey.fromPublicOnly(publicKeyBytes[5])
         ));
-        FederationArgs args = new FederationArgs(members, Instant.ofEpochMilli(0xabcdef), 42L,
+        FederationArgs federationArgs = new FederationArgs(members, Instant.ofEpochMilli(0xabcdef), 42L,
             networkParams);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(federation);
         Federation deserializedFederation = BridgeSerializationUtils.deserializeStandardMultisigFederationOnlyBtcKeys(result, networkParams);
@@ -1130,11 +1124,9 @@ class BridgeSerializationUtilsTest {
                 members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
             }
 
-            FederationArgs args = new FederationArgs(members, Instant.now(), 123,
+            FederationArgs federationArgs = new FederationArgs(members, Instant.now(), 123,
                 bridgeConstants.getBtcParams());
-            Federation testFederation = FederationFactory.buildStandardMultiSigFederation(
-                args
-            );
+            Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
             byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testFederation);
 
             Federation deserializedTestFederation = BridgeSerializationUtils.deserializeStandardMultisigFederation(
@@ -1142,13 +1134,13 @@ class BridgeSerializationUtilsTest {
                 bridgeConstants.getBtcParams()
             );
 
-            ErpFederationArgs erpArgs = new ErpFederationArgs(members, Instant.now(), 123,
+            ErpFederationArgs erpFederationArgs = new ErpFederationArgs(members, Instant.now(), 123,
                 bridgeConstants.getBtcParams(),
                 bridgeConstants.getErpFedPubKeysList(),
                 bridgeConstants.getErpFedActivationDelay()
             );
             Federation testErpFederation = FederationFactory.buildNonStandardErpFederation(
-                erpArgs,
+                erpFederationArgs,
                 activations
             );
             byte[] serializedTestErpFederation = BridgeSerializationUtils.serializeFederation(testErpFederation);
@@ -1169,7 +1161,7 @@ class BridgeSerializationUtilsTest {
             }
 
             if (isRskip353Active) {
-                Federation testP2shErpFederation = FederationFactory.buildP2shErpFederation(erpArgs);
+                Federation testP2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
                 byte[] serializedTestP2shErpFederation = BridgeSerializationUtils.serializeFederation(testP2shErpFederation);
 
                 Federation deserializedTestP2shErpFederation = BridgeSerializationUtils.deserializeP2shErpFederation(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -152,17 +152,21 @@ class BridgeSerializationUtilsTest {
         };
 
         // Only actual keys serialized are BTC keys, so we don't really care about RSK or MST keys
+        List<FederationMember> members = FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
+            BtcECKey.fromPublicOnly(publicKeyBytes[0]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[1]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[2]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[3]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[4]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[5]),
+        }));
+        FederationArgs args = new FederationArgs(
+            members,
+            Instant.ofEpochMilli(0xabcdef),
+            42L
+        );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
-                BtcECKey.fromPublicOnly(publicKeyBytes[0]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[1]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[2]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[3]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[4]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[5]),
-            })),
-            Instant.ofEpochMilli(0xabcdef), //
-            42L,
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -303,8 +307,10 @@ class BridgeSerializationUtilsTest {
             members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
         }
 
+        FederationArgs args = new FederationArgs(members, Instant.now(), 123);
         Federation testFederation = FederationFactory.buildStandardMultiSigFederation(
-            members, Instant.now(), 123, NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         byte[] serializedFederation = BridgeSerializationUtils.serializeFederation(testFederation);
@@ -664,17 +670,17 @@ class BridgeSerializationUtilsTest {
         };
 
         // Only actual keys serialized are BTC keys, so deserialization will fill RSK and MST keys with those
+        List<FederationMember> members = FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
+            BtcECKey.fromPublicOnly(publicKeyBytes[0]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[1]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[2]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[3]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[4]),
+            BtcECKey.fromPublicOnly(publicKeyBytes[5])
+        ));
+        FederationArgs args = new FederationArgs(members, Instant.ofEpochMilli(0xabcdef), 42L);
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
-                BtcECKey.fromPublicOnly(publicKeyBytes[0]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[1]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[2]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[3]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[4]),
-                BtcECKey.fromPublicOnly(publicKeyBytes[5])
-            )),
-            Instant.ofEpochMilli(0xabcdef),
-            42L,
+            args,
             networkParms
         );
 
@@ -1123,10 +1129,9 @@ class BridgeSerializationUtilsTest {
                 members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
             }
 
+            FederationArgs args = new FederationArgs(members, Instant.now(), 123);
             Federation testFederation = FederationFactory.buildStandardMultiSigFederation(
-                members,
-                Instant.now(),
-                123,
+                args,
                 bridgeConstants.getBtcParams()
             );
             byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testFederation);
@@ -1137,9 +1142,7 @@ class BridgeSerializationUtilsTest {
             );
 
             Federation testErpFederation = FederationFactory.buildNonStandardErpFederation(
-                members,
-                Instant.now(),
-                123,
+                args,
                 bridgeConstants.getBtcParams(),
                 bridgeConstants.getErpFedPubKeysList(),
                 bridgeConstants.getErpFedActivationDelay(),
@@ -1164,9 +1167,7 @@ class BridgeSerializationUtilsTest {
 
             if (isRskip353Active) {
                 Federation testP2shErpFederation = FederationFactory.buildP2shErpFederation(
-                    members,
-                    Instant.now(),
-                    123,
+                    args,
                     bridgeConstants.getBtcParams(),
                     bridgeConstants.getErpFedPubKeysList(),
                     bridgeConstants.getErpFedActivationDelay()

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1138,16 +1138,12 @@ class BridgeSerializationUtilsTest {
             Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
             byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testFederation);
 
-            Federation deserializedTestFederation = BridgeSerializationUtils.deserializeStandardMultisigFederation(
-                serializedTestFederation,
-                bridgeConstants.getBtcParams()
-            );
+            Federation deserializedTestFederation =
+                BridgeSerializationUtils.deserializeStandardMultisigFederation(serializedTestFederation, bridgeConstants.getBtcParams());
+            FederationArgs deserializedTestFederationArgs = deserializedTestFederation.getArgs();
 
             ErpFederationArgs erpFederationArgs =
-                new ErpFederationArgs(members, creationTime, creationBlockNumber, btcParams,
-                bridgeConstants.getErpFedPubKeysList(),
-                bridgeConstants.getErpFedActivationDelay()
-            );
+                ErpFederationArgs.fromFederationArgs(deserializedTestFederationArgs, bridgeConstants.getErpFedPubKeysList(), bridgeConstants.getErpFedActivationDelay());
             Federation testErpFederation = FederationFactory.buildNonStandardErpFederation(
                 erpFederationArgs,
                 activations

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -160,11 +160,15 @@ class BridgeSerializationUtilsTest {
             BtcECKey.fromPublicOnly(publicKeyBytes[4]),
             BtcECKey.fromPublicOnly(publicKeyBytes[5]),
         }));
+        Instant creationTime = Instant.ofEpochMilli(0xabcdef);
+        long creationBlockNumber = 42L;
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+
         FederationArgs federationArgs = new FederationArgs(
             members,
-            Instant.ofEpochMilli(0xabcdef),
-            42L,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            creationTime,
+            creationBlockNumber,
+            btcParams
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
@@ -305,18 +309,19 @@ class BridgeSerializationUtilsTest {
             members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
         }
 
-        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), 123,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
-        Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        Instant creationTime = Instant.now();
+        long creationBlockNumber = 123;
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
+        FederationArgs federationArgs =
+            new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
+        Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
         byte[] serializedFederation = BridgeSerializationUtils.serializeFederation(testFederation);
 
         RLPList serializedList = (RLPList) RLP.decode2(serializedFederation).get(0);
-
         Assertions.assertEquals(3, serializedList.size());
 
         RLPList memberList = (RLPList) serializedList.get(2);
-
         Assertions.assertEquals(NUM_MEMBERS, memberList.size());
 
         for (int i = 0; i < NUM_MEMBERS; i++) {
@@ -1124,8 +1129,12 @@ class BridgeSerializationUtilsTest {
                 members.add(new FederationMember(new BtcECKey(), new ECKey(), new ECKey()));
             }
 
-            FederationArgs federationArgs = new FederationArgs(members, Instant.now(), 123,
-                bridgeConstants.getBtcParams());
+            Instant creationTime = Instant.now();
+            long creationBlockNumber = 123;
+            NetworkParameters btcParams = bridgeConstants.getBtcParams();
+
+            FederationArgs federationArgs =
+                new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
             Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
             byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testFederation);
 
@@ -1134,8 +1143,8 @@ class BridgeSerializationUtilsTest {
                 bridgeConstants.getBtcParams()
             );
 
-            ErpFederationArgs erpFederationArgs = new ErpFederationArgs(members, Instant.now(), 123,
-                bridgeConstants.getBtcParams(),
+            ErpFederationArgs erpFederationArgs =
+                new ErpFederationArgs(members, creationTime, creationBlockNumber, btcParams,
                 bridgeConstants.getErpFedPubKeysList(),
                 bridgeConstants.getErpFedActivationDelay()
             );

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -170,16 +170,16 @@ class BridgeSerializationUtilsTest {
             creationBlockNumber,
             btcParams
         );
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-        byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(federation);
+        byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(standardMultisigFederation);
         StringBuilder expectedBuilder = new StringBuilder();
         expectedBuilder.append("f8d3"); // Outer list
         expectedBuilder.append("83abcdef"); // Creation time
         expectedBuilder.append("2a"); // Creation block number
         expectedBuilder.append("f8cc"); // Inner list
 
-        federation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
+        standardMultisigFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
             expectedBuilder.append("a1");
             expectedBuilder.append(ByteUtil.toHexString(key.getPubKey()));
         });
@@ -315,8 +315,8 @@ class BridgeSerializationUtilsTest {
 
         FederationArgs federationArgs =
             new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
-        Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-        byte[] serializedFederation = BridgeSerializationUtils.serializeFederation(testFederation);
+        Federation testStandardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        byte[] serializedFederation = BridgeSerializationUtils.serializeFederation(testStandardMultisigFederation);
 
         RLPList serializedList = (RLPList) RLP.decode2(serializedFederation).get(0);
         Assertions.assertEquals(3, serializedList.size());
@@ -682,11 +682,11 @@ class BridgeSerializationUtilsTest {
         ));
         FederationArgs federationArgs = new FederationArgs(members, Instant.ofEpochMilli(0xabcdef), 42L,
             networkParams);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-        byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(federation);
+        byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(standardMultisigFederation);
         Federation deserializedFederation = BridgeSerializationUtils.deserializeStandardMultisigFederationOnlyBtcKeys(result, networkParams);
-        MatcherAssert.assertThat(federation, is(deserializedFederation));
+        MatcherAssert.assertThat(standardMultisigFederation, is(deserializedFederation));
     }
 
     @Test
@@ -1135,8 +1135,8 @@ class BridgeSerializationUtilsTest {
 
             FederationArgs federationArgs =
                 new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
-            Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-            byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testFederation);
+            Federation testStandardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+            byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testStandardMultisigFederation);
 
             Federation deserializedTestFederation =
                 BridgeSerializationUtils.deserializeStandardMultisigFederation(serializedTestFederation, bridgeConstants.getBtcParams());
@@ -1144,25 +1144,25 @@ class BridgeSerializationUtilsTest {
 
             ErpFederationArgs erpFederationArgs =
                 ErpFederationArgs.fromFederationArgs(deserializedTestFederationArgs, bridgeConstants.getErpFedPubKeysList(), bridgeConstants.getErpFedActivationDelay());
-            Federation testErpFederation = FederationFactory.buildNonStandardErpFederation(
+            Federation testNonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
                 erpFederationArgs,
                 activations
             );
-            byte[] serializedTestErpFederation = BridgeSerializationUtils.serializeFederation(testErpFederation);
+            byte[] serializedTestErpFederation = BridgeSerializationUtils.serializeFederation(testNonStandardErpFederation);
 
-            Federation deserializedTestErpFederation = BridgeSerializationUtils.deserializeLegacyErpFederation(
+            Federation deserializedTestErpFederation = BridgeSerializationUtils.deserializeNonStandardErpFederation(
                 serializedTestErpFederation,
                 bridgeConstants,
                 activations
             );
 
-            Assertions.assertEquals(testFederation, deserializedTestFederation);
-            Assertions.assertEquals(testErpFederation, deserializedTestErpFederation);
-            assertNotEquals(testFederation, deserializedTestErpFederation);
-            assertNotEquals(testErpFederation, deserializedTestFederation);
+            Assertions.assertEquals(testStandardMultisigFederation, deserializedTestFederation);
+            Assertions.assertEquals(testNonStandardErpFederation, deserializedTestErpFederation);
+            assertNotEquals(testStandardMultisigFederation, deserializedTestErpFederation);
+            assertNotEquals(testNonStandardErpFederation, deserializedTestFederation);
 
             if (!isRskip284Active && networkId.equals(NetworkParameters.ID_TESTNET)) {
-                Assertions.assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, testErpFederation.getRedeemScript());
+                Assertions.assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, testNonStandardErpFederation.getRedeemScript());
             }
 
             if (isRskip353Active) {
@@ -1175,8 +1175,8 @@ class BridgeSerializationUtilsTest {
                 );
 
                 assertEquals(testP2shErpFederation, deserializedTestP2shErpFederation);
-                assertNotEquals(testFederation, deserializedTestP2shErpFederation);
-                assertNotEquals(testErpFederation, deserializedTestP2shErpFederation);
+                assertNotEquals(testStandardMultisigFederation, deserializedTestP2shErpFederation);
+                assertNotEquals(testNonStandardErpFederation, deserializedTestP2shErpFederation);
             }
         }
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderFederationTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderFederationTests.java
@@ -36,7 +36,7 @@ class BridgeStorageProviderFederationTests {
     private ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
 
     @Test
-    void getNewFederation_should_return_P2shErpFederation() {
+    void getNewFederation_should_return_p2sh_erp_federation() {
         Federation federation = createFederation(P2SH_ERP_FEDERATION_FORMAT_VERSION);
 
         testGetNewFederation(
@@ -46,7 +46,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getNewFederation_should_return_erp_federation() {
+    void getNewFederation_should_return_non_standard_erp_federation() {
         Federation federation = createFederation(NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION);
         testGetNewFederation(
             NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION,
@@ -55,7 +55,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getNewFederation_should_return_legacy_federation() {
+    void getNewFederation_should_return_standard_multisig_federation() {
         Federation federation = createFederation(STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION);
         testGetNewFederation(
             STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION,
@@ -141,7 +141,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getOldFederation_should_return_P2shErpFederation() {
+    void getOldFederation_should_return_p2sh_erp_federation() {
         Federation federation = createFederation(P2SH_ERP_FEDERATION_FORMAT_VERSION);
 
         testGetOldFederation(
@@ -151,7 +151,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getOldFederation_should_return_erp_federation() {
+    void getOldFederation_should_return_non_standard_erp_federation() {
         Federation federation = createFederation(NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION);
         testGetOldFederation(
             NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION,
@@ -160,7 +160,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getOldFederation_should_return_legacy_fed() {
+    void getOldFederation_should_return_standard_multisig_fed() {
         Federation federation = createFederation(STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION);
         testGetOldFederation(
             STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION,
@@ -264,7 +264,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP123_should_save_legacy_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP123_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(ConsensusRule.RSKIP123).forBlock(0);
         testSaveNewFederation(
             STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION,
@@ -273,7 +273,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP201_should_save_legacy_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP201_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201
@@ -285,7 +285,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP353_should_save_legacy_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP353_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201,
@@ -298,7 +298,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP201_should_save_erp_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP201_should_save_non_standard_erp_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201
@@ -310,7 +310,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP353_should_save_erp_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP353_should_save_non_standard_erp_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201,
@@ -437,7 +437,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP123_should_save_legacy_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP123_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(ConsensusRule.RSKIP123).forBlock(0);
         testSaveOldFederation(
             STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION,
@@ -446,7 +446,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP201_should_save_legacy_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP201_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201
@@ -458,7 +458,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP353_should_save_legacy_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP353_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201,
@@ -471,7 +471,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP201_should_save_erp_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP201_should_save_non_standard_erp_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201
@@ -483,7 +483,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP353_should_save_erp_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP353_should_save_non_standard_erp_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderFederationTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderFederationTests.java
@@ -604,19 +604,19 @@ class BridgeStorageProviderFederationTests {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
+        FederationArgs args = new FederationArgs(members,
+            Instant.now(),
+            1L);
+
         if (version == STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION) {
             return FederationFactory.buildStandardMultiSigFederation(
-                members,
-                Instant.now(),
-                1L,
+                args,
                 bridgeConstantsRegtest.getBtcParams()
             );
         }
         if (version == NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION) {
             return FederationFactory.buildNonStandardErpFederation(
-                members,
-                Instant.now(),
-                1L,
+                args,
                 bridgeConstantsRegtest.getBtcParams(),
                 bridgeConstantsRegtest.getErpFedPubKeysList(),
                 bridgeConstantsRegtest.getErpFedActivationDelay(),
@@ -625,9 +625,7 @@ class BridgeStorageProviderFederationTests {
         }
         if (version == P2SH_ERP_FEDERATION_FORMAT_VERSION) {
             return FederationFactory.buildP2shErpFederation(
-                members,
-                Instant.now(),
-                1L,
+                args,
                 bridgeConstantsRegtest.getBtcParams(),
                 bridgeConstantsRegtest.getErpFedPubKeysList(),
                 bridgeConstantsRegtest.getErpFedActivationDelay()
@@ -635,9 +633,7 @@ class BridgeStorageProviderFederationTests {
         }
         // To keep backwards compatibility
         return FederationFactory.buildStandardMultiSigFederation(
-            members,
-            Instant.now(),
-            1L,
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderFederationTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderFederationTests.java
@@ -612,10 +612,11 @@ class BridgeStorageProviderFederationTests {
             return FederationFactory.buildStandardMultiSigFederation(federationArgs);
         }
 
+        // version should be erp
         List<BtcECKey> erpPubKeys = bridgeConstantsRegtest.getErpFedPubKeysList();
         long activationDelay = bridgeConstantsRegtest.getErpFedActivationDelay();
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(members, Instant.now(), 1L, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
+
         if (version == NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION) {
             return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -407,10 +407,11 @@ class BridgeStorageProviderTest {
         Federation newFederation = buildMockFederation(100, 200, 300);
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
 
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            newFederation.getMembers(),
+        FederationArgs args = new FederationArgs(newFederation.getMembers(),
             newFederation.getCreationTime(),
-            newFederation.getCreationBlockNumber(),
+            newFederation.getCreationBlockNumber());
+        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
+            args,
             newFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay(),
@@ -423,10 +424,12 @@ class BridgeStorageProviderTest {
     @Test
     void getNewFederation_p2sh_erp_fed() {
         Federation newFederation = buildMockFederation(100, 200, 300);
-        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            newFederation.getMembers(),
+        FederationArgs args = new FederationArgs(newFederation.getMembers(),
             newFederation.getCreationTime(),
-            newFederation.getCreationBlockNumber(),
+            newFederation.getCreationBlockNumber());
+
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
+            args,
             newFederation.getBtcParams(),
             bridgeTestnetInstance.getErpFedPubKeysList(),
             bridgeTestnetInstance.getErpFedActivationDelay()
@@ -546,11 +549,12 @@ class BridgeStorageProviderTest {
 
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation newFederation = buildMockFederation(100, 200, 300);
+        FederationArgs args = new FederationArgs(newFederation.getMembers(),
+            newFederation.getCreationTime(),
+            newFederation.getCreationBlockNumber());
 
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            newFederation.getMembers(),
-            newFederation.getCreationTime(),
-            newFederation.getCreationBlockNumber(),
+            args,
             newFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay(),
@@ -564,11 +568,12 @@ class BridgeStorageProviderTest {
     void saveNewFederation_postMultiKey_RSKIP_353_active_p2sh_erp_fed() {
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation newFederation = buildMockFederation(100, 200, 300);
+        FederationArgs args = new FederationArgs(newFederation.getMembers(),
+            newFederation.getCreationTime(),
+            newFederation.getCreationBlockNumber());
 
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            newFederation.getMembers(),
-            newFederation.getCreationTime(),
-            newFederation.getCreationBlockNumber(),
+            args,
             newFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()
@@ -678,13 +683,14 @@ class BridgeStorageProviderTest {
     void getOldFederation_nonStandardHardcoded_fed() {
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
+        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
+            oldFederation.getCreationTime(),
+            oldFederation.getCreationBlockNumber());
 
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
 
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber(),
+            args,
             oldFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay(),
@@ -698,14 +704,15 @@ class BridgeStorageProviderTest {
     void getOldFederation_nonStandardWithUnsignedBE_fed() {
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
+        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
+            oldFederation.getCreationTime(),
+            oldFederation.getCreationBlockNumber());
 
         List<ConsensusRule> rulesToDisable = Arrays.asList(ConsensusRule.RSKIP293);
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.hop400(rulesToDisable).forBlock(0);
 
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber(),
+            args,
             oldFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay(),
@@ -719,13 +726,14 @@ class BridgeStorageProviderTest {
     void getOldFederation_nonStandard_fed() {
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
+        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
+            oldFederation.getCreationTime(),
+            oldFederation.getCreationBlockNumber());
 
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.hop400().forBlock(0);
 
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber(),
+            args,
             oldFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay(),
@@ -739,12 +747,13 @@ class BridgeStorageProviderTest {
     void getOldFederation_RSKIP_353_active_p2sh_erp_fed() {
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
+        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
+            oldFederation.getCreationTime(),
+            oldFederation.getCreationBlockNumber());
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber(),
+            args,
             oldFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()
@@ -863,10 +872,12 @@ class BridgeStorageProviderTest {
 
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            oldFederation.getMembers(),
+        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
             oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber(),
+            oldFederation.getCreationBlockNumber());
+
+        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
+            args,
             oldFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay(),
@@ -881,10 +892,12 @@ class BridgeStorageProviderTest {
 
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            oldFederation.getMembers(),
+        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
             oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber(),
+            oldFederation.getCreationBlockNumber());
+
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
+            args,
             oldFederation.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()
@@ -3893,10 +3906,11 @@ class BridgeStorageProviderTest {
     }
 
     private Federation buildMockFederation(Integer... pks) {
-        return FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersFromPks(pks),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersFromPks(pks),
             Instant.ofEpochMilli(1000),
-            1,
+            1);
+        return FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -544,9 +544,26 @@ class BridgeStorageProviderTest {
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
             erpPubKeys, activationDelay);
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         testSaveNewFederationPostMultiKey(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
+    }
+
+    @Test
+    void saveNewFederation_postMultiKey_RSKIP_353_active_p2sh_erp_fed() {
+        Federation newFederation = buildMockFederation(100, 200, 300);
+
+        List<FederationMember> fedMembers = newFederation.getMembers();
+        Instant creationTime = newFederation.getCreationTime();
+        long creationBlockNumber = newFederation.getCreationBlockNumber();
+        BridgeConstants bridgeConstants = bridgeTestnetInstance;
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
+        
         testSaveNewFederationPostMultiKey(p2shErpFederation, P2SH_ERP_FEDERATION_FORMAT_VERSION, activationsAllForks);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -402,39 +402,24 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void getNewFederation_erp_fed() {
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        Federation newFederation = buildMockFederation(100, 200, 300);
+    void getNewFederation_erp_and_p2sh_erp_feds() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
+        Federation newFederation = buildMockFederation(100, 200, 300);
 
-        FederationArgs args = new FederationArgs(newFederation.getMembers(),
-            newFederation.getCreationTime(),
-            newFederation.getCreationBlockNumber());
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            newFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
-            activations
-        );
+        List<FederationMember> fedMembers = newFederation.getMembers();
+        Instant creationTime = newFederation.getCreationTime();
+        long creationBlockNumber = newFederation.getCreationBlockNumber();
+        BridgeConstants bridgeConstants = bridgeTestnetInstance;
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
+        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         testGetNewFederationPostMultiKey(erpFederation);
-    }
-
-    @Test
-    void getNewFederation_p2sh_erp_fed() {
-        Federation newFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(newFederation.getMembers(),
-            newFederation.getCreationTime(),
-            newFederation.getCreationBlockNumber());
-
-        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            args,
-            newFederation.getBtcParams(),
-            bridgeTestnetInstance.getErpFedPubKeysList(),
-            bridgeTestnetInstance.getErpFedActivationDelay()
-        );
-
         testGetNewFederationPostMultiKey(p2shErpFederation);
     }
 
@@ -544,41 +529,24 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void saveNewFederation_postMultiKey_RSKIP_201_active_erp_fed() {
+    void saveNewFederation_postMultiKey_RSKIP_201_active_erp_and_p2sh_erp_feds() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
-
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation newFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(newFederation.getMembers(),
-            newFederation.getCreationTime(),
-            newFederation.getCreationBlockNumber());
 
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            newFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
-            activations
-        );
+        List<FederationMember> fedMembers = newFederation.getMembers();
+        Instant creationTime = newFederation.getCreationTime();
+        long creationBlockNumber = newFederation.getCreationBlockNumber();
+        BridgeConstants bridgeConstants = bridgeTestnetInstance;
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
+        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         testSaveNewFederationPostMultiKey(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
-    }
-
-    @Test
-    void saveNewFederation_postMultiKey_RSKIP_353_active_p2sh_erp_fed() {
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        Federation newFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(newFederation.getMembers(),
-            newFederation.getCreationTime(),
-            newFederation.getCreationBlockNumber());
-
-        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            args,
-            newFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay()
-        );
-
         testSaveNewFederationPostMultiKey(p2shErpFederation, P2SH_ERP_FEDERATION_FORMAT_VERSION, activationsAllForks);
     }
 
@@ -681,25 +649,33 @@ class BridgeStorageProviderTest {
 
     @Test
     void getOldFederation_nonStandardHardcoded_fed() {
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber());
+        List<FederationMember> fedMembers = oldFederation.getMembers();
+        Instant creationTime = oldFederation.getCreationTime();
+        long creationBlockNumber = oldFederation.getCreationBlockNumber();
+        BridgeConstants bridgeConstants = bridgeTestnetInstance;
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
 
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
-
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            oldFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
-            activations
-        );
-
+        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         testGetOldFederation(erpFederation, activations);
-    }
 
+        List<ConsensusRule> rulesToDisable = Arrays.asList(ConsensusRule.RSKIP293);
+        activations = ActivationConfigsForTest.hop400(rulesToDisable).forBlock(0);
+        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testGetOldFederation(erpFederation, activations);
+
+        activations = ActivationConfigsForTest.hop400().forBlock(0);
+        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testGetOldFederation(erpFederation, activations);
+
+    }
+/*
     @Test
     void getOldFederation_nonStandardWithUnsignedBE_fed() {
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
@@ -720,8 +696,8 @@ class BridgeStorageProviderTest {
         );
 
         testGetOldFederation(erpFederation, activations);
-    }
-
+    }*/
+/*
     @Test
     void getOldFederation_nonStandard_fed() {
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
@@ -741,24 +717,25 @@ class BridgeStorageProviderTest {
         );
 
         testGetOldFederation(erpFederation, activations);
-    }
+    }*/
 
     @Test
     void getOldFederation_RSKIP_353_active_p2sh_erp_fed() {
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber());
+
+        List<FederationMember> fedMembers = oldFederation.getMembers();
+        Instant creationTime = oldFederation.getCreationTime();
+        long creationBlockNumber = oldFederation.getCreationBlockNumber();
+        BridgeConstants bridgeConstants = bridgeTestnetInstance;
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            args,
-            oldFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay()
-        );
-
         testGetOldFederation(p2shErpFederation, activations);
     }
 
@@ -870,39 +847,38 @@ class BridgeStorageProviderTest {
         when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber());
+        List<FederationMember> fedMembers = oldFederation.getMembers();
+        Instant creationTime = oldFederation.getCreationTime();
+        long creationBlockNumber = oldFederation.getCreationBlockNumber();
+        BridgeConstants bridgeConstants = bridgeTestnetInstance;
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            oldFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
-            activations
-        );
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
 
+        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         testSaveOldFederation(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
     }
 
     @Test
     void saveOldFederation_postMultikey_RSKIP_353_active_p2sh_erp_fed() {
 
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber());
+        List<FederationMember> fedMembers = oldFederation.getMembers();
+        Instant creationTime = oldFederation.getCreationTime();
+        long creationBlockNumber = oldFederation.getCreationBlockNumber();
+        BridgeConstants bridgeConstants = bridgeTestnetInstance;
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            args,
-            oldFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay()
-        );
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
+            erpPubKeys, activationDelay);
 
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
         testSaveOldFederation(p2shErpFederation, P2SH_ERP_FEDERATION_FORMAT_VERSION, activationsAllForks);
     }
 
@@ -3908,11 +3884,8 @@ class BridgeStorageProviderTest {
     private Federation buildMockFederation(Integer... pks) {
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersFromPks(pks),
             Instant.ofEpochMilli(1000),
-            1);
-        return FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
-        );
+            1, networkParameters);
+        return FederationFactory.buildStandardMultiSigFederation(args);
     }
 
     private PendingFederation buildMockPendingFederation(Integer... pks) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -684,8 +684,6 @@ class BridgeStorageProviderTest {
         testGetOldFederation(erpFederation, activations);
 
         // this should get non-standard with csv unsigned BE fed
-        List<ConsensusRule> rulesToDisable = Collections.singletonList(ConsensusRule.RSKIP293);
-        activations = ActivationConfigsForTest.hop400(rulesToDisable).forBlock(0);
         erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         testGetOldFederation(erpFederation, activations);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -529,7 +529,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void saveNewFederation_postMultiKey_RSKIP_201_active_erp_and_p2sh_erp_feds() {
+    void saveNewFederation_postMultiKey_RSKIP_201_active_erp_fed() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
         Federation newFederation = buildMockFederation(100, 200, 300);
 
@@ -563,7 +563,7 @@ class BridgeStorageProviderTest {
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
             erpPubKeys, activationDelay);
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
-        
+
         testSaveNewFederationPostMultiKey(p2shErpFederation, P2SH_ERP_FEDERATION_FORMAT_VERSION, activationsAllForks);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -665,7 +665,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void getOldFederation_nonStandardHardcoded_fed() {
+    void getOldFederation_nonStandard_feds() {
         Federation oldFederation = buildMockFederation(100, 200, 300);
         List<FederationMember> fedMembers = oldFederation.getMembers();
         Instant creationTime = oldFederation.getCreationTime();
@@ -678,15 +678,18 @@ class BridgeStorageProviderTest {
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
             erpPubKeys, activationDelay);
 
+        // this should get non-standard hardcoded fed
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         testGetOldFederation(erpFederation, activations);
 
-        List<ConsensusRule> rulesToDisable = Arrays.asList(ConsensusRule.RSKIP293);
+        // this should get non-standard with csv unsigned BE fed
+        List<ConsensusRule> rulesToDisable = Collections.singletonList(ConsensusRule.RSKIP293);
         activations = ActivationConfigsForTest.hop400(rulesToDisable).forBlock(0);
         erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         testGetOldFederation(erpFederation, activations);
 
+        // this should get non-standard fed
         activations = ActivationConfigsForTest.hop400().forBlock(0);
         erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         testGetOldFederation(erpFederation, activations);
@@ -3855,10 +3858,10 @@ class BridgeStorageProviderTest {
     }
 
     private Federation buildMockFederation(Integer... pks) {
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersFromPks(pks),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembersFromPks(pks),
             Instant.ofEpochMilli(1000),
             1, networkParameters);
-        return FederationFactory.buildStandardMultiSigFederation(args);
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
     private PendingFederation buildMockPendingFederation(Integer... pks) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -653,7 +653,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void getOldFederation_nonStandard_feds() {
+    void getOldFederation_non_standard_erp_feds() {
         Federation oldFederation = buildMockFederation(100, 200, 300);
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -934,7 +934,7 @@ class BridgeStorageProviderTest {
         });
 
         try (MockedStatic<PendingFederation> pendingFederationMocked = mockStatic(PendingFederation.class)) {
-            pendingFederationMocked.when(() -> PendingFederation.deserializeFromBtcKeys(any(byte[].class))).then((InvocationOnMock invocation) -> {
+            pendingFederationMocked.when(() -> PendingFederation.deserializeFromBtcKeysOnly(any(byte[].class))).then((InvocationOnMock invocation) -> {
                 deserializeCalls.add(0);
                 byte[] data = invocation.getArgument(0);
                 // Make sure we're deserializing what just came from the repo with the correct BTC context

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -402,7 +402,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void getNewFederation_erp_and_p2sh_erp_feds() {
+    void getNewFederation_non_standard_erp_and_p2sh_erp_feds() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
         Federation newFederation = buildMockFederation(100, 200, 300);
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
@@ -412,10 +412,10 @@ class BridgeStorageProviderTest {
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
-        testGetNewFederationPostMultiKey(erpFederation);
+        testGetNewFederationPostMultiKey(nonStandardErpFederation);
         testGetNewFederationPostMultiKey(p2shErpFederation);
     }
 
@@ -525,7 +525,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void saveNewFederation_postMultiKey_RSKIP_201_active_erp_fed() {
+    void saveNewFederation_postMultiKey_RSKIP_201_active_non_standard_erp_fed() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
         Federation newFederation = buildMockFederation(100, 200, 300);
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
@@ -535,9 +535,9 @@ class BridgeStorageProviderTest {
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        testSaveNewFederationPostMultiKey(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
+        testSaveNewFederationPostMultiKey(nonStandardErpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
     }
 
     @Test
@@ -665,17 +665,17 @@ class BridgeStorageProviderTest {
 
         // this should get non-standard hardcoded fed
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        testGetOldFederation(erpFederation, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testGetOldFederation(nonStandardErpFederation, activations);
 
         // this should get non-standard with csv unsigned BE fed
-        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        testGetOldFederation(erpFederation, activations);
+        nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testGetOldFederation(nonStandardErpFederation, activations);
 
         // this should get non-standard fed
         activations = ActivationConfigsForTest.hop400().forBlock(0);
-        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        testGetOldFederation(erpFederation, activations);
+        nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testGetOldFederation(nonStandardErpFederation, activations);
     }
 
     @Test
@@ -797,7 +797,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void saveOldFederation_postMultikey_RSKIP_201_active_erp_fed() {
+    void saveOldFederation_postMultikey_RSKIP_201_active_non_standard_erp_fed() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -811,8 +811,8 @@ class BridgeStorageProviderTest {
 
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
 
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        testSaveOldFederation(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testSaveOldFederation(nonStandardErpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -673,51 +673,7 @@ class BridgeStorageProviderTest {
         activations = ActivationConfigsForTest.hop400().forBlock(0);
         erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         testGetOldFederation(erpFederation, activations);
-
     }
-/*
-    @Test
-    void getOldFederation_nonStandardWithUnsignedBE_fed() {
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        Federation oldFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber());
-
-        List<ConsensusRule> rulesToDisable = Arrays.asList(ConsensusRule.RSKIP293);
-        ActivationConfig.ForBlock activations = ActivationConfigsForTest.hop400(rulesToDisable).forBlock(0);
-
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            oldFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
-            activations
-        );
-
-        testGetOldFederation(erpFederation, activations);
-    }*/
-/*
-    @Test
-    void getOldFederation_nonStandard_fed() {
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        Federation oldFederation = buildMockFederation(100, 200, 300);
-        FederationArgs args = new FederationArgs(oldFederation.getMembers(),
-            oldFederation.getCreationTime(),
-            oldFederation.getCreationBlockNumber());
-
-        ActivationConfig.ForBlock activations = ActivationConfigsForTest.hop400().forBlock(0);
-
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            oldFederation.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
-            activations
-        );
-
-        testGetOldFederation(erpFederation, activations);
-    }*/
 
     @Test
     void getOldFederation_RSKIP_353_active_p2sh_erp_fed() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -405,17 +405,13 @@ class BridgeStorageProviderTest {
     void getNewFederation_erp_and_p2sh_erp_feds() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
         Federation newFederation = buildMockFederation(100, 200, 300);
-
-        List<FederationMember> fedMembers = newFederation.getMembers();
-        Instant creationTime = newFederation.getCreationTime();
-        long creationBlockNumber = newFederation.getCreationBlockNumber();
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+
+        FederationArgs federationArgs = newFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
@@ -532,17 +528,13 @@ class BridgeStorageProviderTest {
     void saveNewFederation_postMultiKey_RSKIP_201_active_erp_fed() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
         Federation newFederation = buildMockFederation(100, 200, 300);
-
-        List<FederationMember> fedMembers = newFederation.getMembers();
-        Instant creationTime = newFederation.getCreationTime();
-        long creationBlockNumber = newFederation.getCreationBlockNumber();
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+
+        FederationArgs federationArgs = newFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         testSaveNewFederationPostMultiKey(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
@@ -551,17 +543,13 @@ class BridgeStorageProviderTest {
     @Test
     void saveNewFederation_postMultiKey_RSKIP_353_active_p2sh_erp_fed() {
         Federation newFederation = buildMockFederation(100, 200, 300);
-
-        List<FederationMember> fedMembers = newFederation.getMembers();
-        Instant creationTime = newFederation.getCreationTime();
-        long creationBlockNumber = newFederation.getCreationBlockNumber();
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+
+        FederationArgs federationArgs = newFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         testSaveNewFederationPostMultiKey(p2shErpFederation, P2SH_ERP_FEDERATION_FORMAT_VERSION, activationsAllForks);
@@ -667,16 +655,13 @@ class BridgeStorageProviderTest {
     @Test
     void getOldFederation_nonStandard_feds() {
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        List<FederationMember> fedMembers = oldFederation.getMembers();
-        Instant creationTime = oldFederation.getCreationTime();
-        long creationBlockNumber = oldFederation.getCreationBlockNumber();
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+
+        FederationArgs federationArgs = oldFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
 
         // this should get non-standard hardcoded fed
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
@@ -696,17 +681,13 @@ class BridgeStorageProviderTest {
     @Test
     void getOldFederation_RSKIP_353_active_p2sh_erp_fed() {
         Federation oldFederation = buildMockFederation(100, 200, 300);
-
-        List<FederationMember> fedMembers = oldFederation.getMembers();
-        Instant creationTime = oldFederation.getCreationTime();
-        long creationBlockNumber = oldFederation.getCreationBlockNumber();
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+
+        FederationArgs federationArgs = oldFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
@@ -822,16 +803,13 @@ class BridgeStorageProviderTest {
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        List<FederationMember> fedMembers = oldFederation.getMembers();
-        Instant creationTime = oldFederation.getCreationTime();
-        long creationBlockNumber = oldFederation.getCreationBlockNumber();
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+
+        FederationArgs federationArgs = oldFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
 
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         testSaveOldFederation(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
@@ -839,18 +817,13 @@ class BridgeStorageProviderTest {
 
     @Test
     void saveOldFederation_postMultikey_RSKIP_353_active_p2sh_erp_fed() {
-
         Federation oldFederation = buildMockFederation(100, 200, 300);
-        List<FederationMember> fedMembers = oldFederation.getMembers();
-        Instant creationTime = oldFederation.getCreationTime();
-        long creationBlockNumber = oldFederation.getCreationBlockNumber();
         BridgeConstants bridgeConstants = bridgeTestnetInstance;
-        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+
+        FederationArgs federationArgs = oldFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
-
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
 
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
         testSaveOldFederation(p2shErpFederation, P2SH_ERP_FEDERATION_FORMAT_VERSION, activationsAllForks);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -79,10 +79,10 @@ class BridgeSupportAddSignatureTest {
         );
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
             0L, btcRegTestParams);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(activeFedArgs);
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         BridgeSupport bridgeSupport = new BridgeSupport(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -5,10 +5,7 @@ import java.math.BigInteger;
 import java.util.*;
 
 import co.rsk.config.BridgeConstants;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationArgs;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationTestUtils;
+import co.rsk.peg.federation.*;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
@@ -59,6 +56,8 @@ class BridgeSupportAddSignatureTest {
     private BridgeSupportBuilder bridgeSupportBuilder;
     private final BridgeConstants bridgeConstantsRegtest = BridgeRegTestConstants.getInstance();
     private final NetworkParameters btcRegTestParams = bridgeConstantsRegtest.getBtcParams();
+    private final Instant creationTime = Instant.ofEpochMilli(1000L);
+    private final long creationBlockNumber = 0L;
 
     @BeforeEach
     void setUpOnEachTest() {
@@ -73,15 +72,15 @@ class BridgeSupportAddSignatureTest {
         FederationSupport mockFederationSupport = mock(FederationSupport.class);
 
         // Creates new federation
-        List<BtcECKey> federation1Keys = Arrays.asList(
+        List<BtcECKey> activeFedKeys = Arrays.asList(
                 BtcECKey.fromPrivate(Hex.decode("fa01")),
                 BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
-        federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
+        activeFedKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-            Instant.ofEpochMilli(1000L),
-            0L, btcRegTestParams);
+        List<FederationMember> activeFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFedKeys);
+        FederationArgs activeFedArgs =
+            new FederationArgs(activeFedMembers, creationTime, creationBlockNumber, btcRegTestParams);
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(activeFedArgs);
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -130,14 +129,14 @@ class BridgeSupportAddSignatureTest {
         );
 
         // Creates retiring federation
-        List<BtcECKey> federation1Keys = Arrays.asList(
+        List<BtcECKey> retiringFedKeys = Arrays.asList(
                 BtcECKey.fromPrivate(Hex.decode("fa01")),
                 BtcECKey.fromPrivate(Hex.decode("fa02")));
-        federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
+        retiringFedKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-            Instant.ofEpochMilli(1000L),
-            0L, btcRegTestParams);
+        List<FederationMember> retiringFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys);
+        FederationArgs retiringFedArgs =
+            new FederationArgs(retiringFedMembers, creationTime, creationBlockNumber, btcRegTestParams);
         Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(retiringFedArgs);
 
         // Creates active federation
@@ -146,12 +145,9 @@ class BridgeSupportAddSignatureTest {
                 BtcECKey.fromPrivate(Hex.decode("fa04"))
         );
         activeFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-
-        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            btcRegTestParams
-        );
+        List<FederationMember> activeFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys);
+        FederationArgs activeFedArgs =
+            new FederationArgs(activeFedMembers, creationTime, creationBlockNumber, btcRegTestParams);
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(activeFedArgs);
 
         when(mockFederationSupport.getActiveFederation()).thenReturn(activeFederation);
@@ -185,14 +181,14 @@ class BridgeSupportAddSignatureTest {
         );
 
         // Creates retiring federation
-        List<BtcECKey> federation1Keys = Arrays.asList(
+        List<BtcECKey> retiringFedKeys = Arrays.asList(
                 BtcECKey.fromPrivate(Hex.decode("fa01")),
                 BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
-        federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-
-        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-            Instant.ofEpochMilli(1000L), 0L, btcRegTestParams);
+        retiringFedKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
+        List<FederationMember> retiringFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys);
+        FederationArgs retiringFedArgs =
+            new FederationArgs(retiringFedMembers, creationTime, creationBlockNumber, btcRegTestParams);
         Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(retiringFedArgs);
 
         // Creates active federation
@@ -202,9 +198,9 @@ class BridgeSupportAddSignatureTest {
         );
         activeFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        FederationArgs activeFedArgs = new FederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L), 0L, btcRegTestParams);
+        List<FederationMember> activeFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys);
+        FederationArgs activeFedArgs =
+            new FederationArgs(activeFedMembers, creationTime, creationBlockNumber, btcRegTestParams);
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(activeFedArgs);
 
         when(mockFederationSupport.getActiveFederation()).thenReturn(activeFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 import co.rsk.config.BridgeConstants;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -78,10 +79,11 @@ class BridgeSupportAddSignatureTest {
         );
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
+            Instant.ofEpochMilli(1000L),
+            0L);
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-                Instant.ofEpochMilli(1000L),
-                0L,
+                args,
                 btcRegTestParams
         );
 
@@ -136,10 +138,11 @@ class BridgeSupportAddSignatureTest {
                 BtcECKey.fromPrivate(Hex.decode("fa02")));
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
+        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
+            Instant.ofEpochMilli(1000L),
+            0L);
         Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-                Instant.ofEpochMilli(1000L),
-                0L,
+            retiringFedArgs,
                 btcRegTestParams
         );
 
@@ -150,10 +153,11 @@ class BridgeSupportAddSignatureTest {
         );
         activeFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+            Instant.ofEpochMilli(1000L),
+            0L);
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-                Instant.ofEpochMilli(1000L),
-                0L,
+                activeFedArgs,
                 btcRegTestParams
         );
 
@@ -194,10 +198,11 @@ class BridgeSupportAddSignatureTest {
         );
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
+        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
+            Instant.ofEpochMilli(1000L),
+            0L);
         Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-                Instant.ofEpochMilli(1000L),
-                0L,
+                retiringFedArgs,
                 btcRegTestParams
         );
 
@@ -208,10 +213,13 @@ class BridgeSupportAddSignatureTest {
         );
         activeFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
+        FederationArgs activeFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+            Instant.ofEpochMilli(1000L),
+            0L
+        );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-                Instant.ofEpochMilli(1000L),
-                0L,
+                activeFedArgs,
                 btcRegTestParams);
 
         when(mockFederationSupport.getActiveFederation()).thenReturn(activeFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -81,11 +81,8 @@ class BridgeSupportAddSignatureTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
-            0L);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                args,
-                btcRegTestParams
-        );
+            0L, btcRegTestParams);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         BridgeSupport bridgeSupport = new BridgeSupport(
@@ -140,11 +137,8 @@ class BridgeSupportAddSignatureTest {
 
         FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
-            0L);
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            retiringFedArgs,
-                btcRegTestParams
-        );
+            0L, btcRegTestParams);
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(retiringFedArgs);
 
         // Creates active federation
         List<BtcECKey> activeFederationKeys = Arrays.asList(
@@ -155,11 +149,10 @@ class BridgeSupportAddSignatureTest {
 
         FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                activeFedArgs,
-                btcRegTestParams
+            0L,
+            btcRegTestParams
         );
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(activeFedArgs);
 
         when(mockFederationSupport.getActiveFederation()).thenReturn(activeFederation);
         when(mockFederationSupport.getRetiringFederation()).thenReturn(retiringFederation);
@@ -199,12 +192,8 @@ class BridgeSupportAddSignatureTest {
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-            Instant.ofEpochMilli(1000L),
-            0L);
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-                retiringFedArgs,
-                btcRegTestParams
-        );
+            Instant.ofEpochMilli(1000L), 0L, btcRegTestParams);
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(retiringFedArgs);
 
         // Creates active federation
         List<BtcECKey> activeFederationKeys = Arrays.asList(
@@ -215,12 +204,8 @@ class BridgeSupportAddSignatureTest {
 
         FederationArgs activeFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L
-        );
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                activeFedArgs,
-                btcRegTestParams);
+            Instant.ofEpochMilli(1000L), 0L, btcRegTestParams);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(activeFedArgs);
 
         when(mockFederationSupport.getActiveFederation()).thenReturn(activeFederation);
         when(mockFederationSupport.getRetiringFederation()).thenReturn(retiringFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -8,6 +8,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.utils.BridgeEventLogger;
@@ -130,10 +131,13 @@ class BridgeSupportProcessFundsMigrationTest {
             federationActivationAge +
             bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations) + 1;
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            federationCreationBlockNumber,
+            federationCreationBlockNumber
+        );
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstants.getBtcParams()
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -131,14 +131,14 @@ class BridgeSupportProcessFundsMigrationTest {
             federationActivationAge +
             bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations) + 1;
 
-        FederationArgs args = new FederationArgs(
+        FederationArgs newFederationArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             federationCreationBlockNumber,
             bridgeConstants.getBtcParams()
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -134,11 +134,11 @@ class BridgeSupportProcessFundsMigrationTest {
         FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            federationCreationBlockNumber
+            federationCreationBlockNumber,
+            bridgeConstants.getBtcParams()
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstants.getBtcParams()
+            args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -25,6 +25,7 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.util.MapSnapshot;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -351,10 +352,13 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         retiringFedSigners.sort(BtcECKey.PUBKEY_COMPARATOR);
         List<FederationMember> retiringFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedSigners);
+        Instant creationTime = Instant.ofEpochMilli(1000L);
+        long retiringFedCreationBlockNumber = 1;
         List<BtcECKey> erpPubKeys = bridgeMainnetConstants.getErpFedPubKeysList();
         long activationDelay = bridgeMainnetConstants.getErpFedActivationDelay();
-        ErpFederationArgs retiringFedArgs = new ErpFederationArgs(retiringFedMembers, Instant.ofEpochMilli(1000L), 1, btcParams,
-            erpPubKeys, activationDelay);
+
+        ErpFederationArgs retiringFedArgs =
+            new ErpFederationArgs(retiringFedMembers, creationTime, retiringFedCreationBlockNumber, btcParams, erpPubKeys, activationDelay);
         retiringFederation = FederationFactory.buildP2shErpFederation(retiringFedArgs);
 
         activeFedSigners = BitcoinTestUtils.getBtcEcKeysFromSeeds(
@@ -362,8 +366,9 @@ class BridgeSupportRegisterBtcTransactionTest {
         );
         activeFedSigners.sort(BtcECKey.PUBKEY_COMPARATOR);
         List<FederationMember> activeFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFedSigners);
-        ErpFederationArgs activeFedArgs = new ErpFederationArgs(activeFedMembers, Instant.ofEpochMilli(1000L), 2L, btcParams,
-            erpPubKeys, activationDelay);
+        long activeFedCreationBlockNumber = 2L;
+        ErpFederationArgs activeFedArgs =
+            new ErpFederationArgs(activeFedMembers, creationTime, activeFedCreationBlockNumber, btcParams, erpPubKeys, activationDelay);
         activeFederation = FederationFactory.buildP2shErpFederation(activeFedArgs);
 
         mockFactory = mock(BtcBlockStoreWithCache.Factory.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -12,10 +12,7 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.bitcoin.CoinbaseInformation;
 import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationArgs;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationTestUtils;
+import co.rsk.peg.federation.*;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import co.rsk.peg.utils.BridgeEventLogger;
@@ -341,6 +338,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         registerHeader = null;
 
         userAddress = BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "userAddress");
+        NetworkParameters btcParams = bridgeMainnetConstants.getBtcParams();
 
         retiredFedSigners = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
@@ -352,31 +350,21 @@ class BridgeSupportRegisterBtcTransactionTest {
         );
 
         retiringFedSigners.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs retiringFedArgs = new FederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedSigners),
-            Instant.ofEpochMilli(1000L),
-            1
-        );
-        retiringFederation = FederationFactory.buildP2shErpFederation(
-            retiringFedArgs,
-            bridgeMainnetConstants.getBtcParams(),
-            bridgeMainnetConstants.getErpFedPubKeysList(),
-            bridgeMainnetConstants.getErpFedActivationDelay()
-        );
+        List<FederationMember> retiringFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedSigners);
+        List<BtcECKey> erpPubKeys = bridgeMainnetConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeMainnetConstants.getErpFedActivationDelay();
+        ErpFederationArgs retiringFedArgs = new ErpFederationArgs(retiringFedMembers, Instant.ofEpochMilli(1000L), 1, btcParams,
+            erpPubKeys, activationDelay);
+        retiringFederation = FederationFactory.buildP2shErpFederation(retiringFedArgs);
 
         activeFedSigners = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa07", "fa08", "fa09", "fa10", "fa11"}, true
         );
         activeFedSigners.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFedSigners),
-            Instant.ofEpochMilli(1000L),
-            2L);
-        activeFederation = FederationFactory.buildP2shErpFederation(
-            activeFedArgs,
-            bridgeMainnetConstants.getBtcParams(),
-            bridgeMainnetConstants.getErpFedPubKeysList(),
-            bridgeMainnetConstants.getErpFedActivationDelay()
-        );
+        List<FederationMember> activeFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFedSigners);
+        ErpFederationArgs activeFedArgs = new ErpFederationArgs(activeFedMembers, Instant.ofEpochMilli(1000L), 2L, btcParams,
+            erpPubKeys, activationDelay);
+        activeFederation = FederationFactory.buildP2shErpFederation(activeFedArgs);
 
         mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -25,7 +25,6 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
-import org.ethereum.util.MapSnapshot;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -13,6 +13,7 @@ import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.bitcoin.CoinbaseInformation;
 import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.pegin.RejectedPeginReason;
@@ -351,10 +352,13 @@ class BridgeSupportRegisterBtcTransactionTest {
         );
 
         retiringFedSigners.sort(BtcECKey.PUBKEY_COMPARATOR);
-        retiringFederation = FederationFactory.buildP2shErpFederation(
+        FederationArgs retiringFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedSigners),
             Instant.ofEpochMilli(1000L),
-            1,
+            1
+        );
+        retiringFederation = FederationFactory.buildP2shErpFederation(
+            retiringFedArgs,
             bridgeMainnetConstants.getBtcParams(),
             bridgeMainnetConstants.getErpFedPubKeysList(),
             bridgeMainnetConstants.getErpFedActivationDelay()
@@ -364,10 +368,11 @@ class BridgeSupportRegisterBtcTransactionTest {
             new String[]{"fa07", "fa08", "fa09", "fa10", "fa11"}, true
         );
         activeFedSigners.sort(BtcECKey.PUBKEY_COMPARATOR);
-        activeFederation = FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFedSigners),
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFedSigners),
             Instant.ofEpochMilli(1000L),
-            2L,
+            2L);
+        activeFederation = FederationFactory.buildP2shErpFederation(
+            activeFedArgs,
             bridgeMainnetConstants.getBtcParams(),
             bridgeMainnetConstants.getErpFedPubKeysList(),
             bridgeMainnetConstants.getErpFedActivationDelay()

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -26,6 +26,7 @@ import co.rsk.db.MutableTrieCache;
 import co.rsk.db.MutableTrieImpl;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.utils.BridgeEventLogger;
@@ -1253,10 +1254,11 @@ class BridgeSupportReleaseBtcTest {
     }
 
     private static Federation getFederation() {
-        return FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(3),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L,
+            0L);
+        return FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1254,13 +1254,11 @@ class BridgeSupportReleaseBtcTest {
     }
 
     private static Federation getFederation() {
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(3),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
             0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
-        return FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1256,10 +1256,10 @@ class BridgeSupportReleaseBtcTest {
     private static Federation getFederation() {
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         return FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
@@ -12,6 +12,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.test.builders.BridgeSupportBuilder;
@@ -122,10 +123,12 @@ class BridgeSupportSigHashTest {
 
         Federation oldFederation = bridgeMainnetConstants.getGenesisFederation();
         long newFedCreationBlockNumber = 5L;
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            newFedCreationBlockNumber,
+            newFedCreationBlockNumber);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             btcMainnetParams
         );
         when(provider.getOldFederation())
@@ -191,10 +194,11 @@ class BridgeSupportSigHashTest {
         Federation oldFederation = bridgeMainnetConstants.getGenesisFederation();
 
         long newFedCreationBlockNumber = 5L;
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            newFedCreationBlockNumber,
+            newFedCreationBlockNumber);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             btcMainnetParams
         );
         when(provider.getOldFederation())

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
@@ -125,12 +125,8 @@ class BridgeSupportSigHashTest {
         long newFedCreationBlockNumber = 5L;
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
-            Instant.EPOCH,
-            newFedCreationBlockNumber);
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            btcMainnetParams
-        );
+            Instant.EPOCH, newFedCreationBlockNumber, btcMainnetParams);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(args);
         when(provider.getOldFederation())
             .thenReturn(oldFederation);
         when(provider.getNewFederation())
@@ -195,12 +191,9 @@ class BridgeSupportSigHashTest {
 
         long newFedCreationBlockNumber = 5L;
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
-            Instant.EPOCH,
-            newFedCreationBlockNumber);
+            Instant.EPOCH, newFedCreationBlockNumber, btcMainnetParams);
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            btcMainnetParams
-        );
+            args);
         when(provider.getOldFederation())
             .thenReturn(oldFederation);
         when(provider.getNewFederation())

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
@@ -124,9 +124,9 @@ class BridgeSupportSigHashTest {
         Federation oldFederation = bridgeMainnetConstants.getGenesisFederation();
         long newFedCreationBlockNumber = 5L;
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH, newFedCreationBlockNumber, btcMainnetParams);
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(newFederationArgs);
         when(provider.getOldFederation())
             .thenReturn(oldFederation);
         when(provider.getNewFederation())
@@ -190,10 +190,10 @@ class BridgeSupportSigHashTest {
         Federation oldFederation = bridgeMainnetConstants.getGenesisFederation();
 
         long newFedCreationBlockNumber = 5L;
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH, newFedCreationBlockNumber, btcMainnetParams);
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args);
+            newFederationArgs);
         when(provider.getOldFederation())
             .thenReturn(oldFederation);
         when(provider.getNewFederation())

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1428,13 +1428,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationArgs
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1493,13 +1493,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationArgs
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1560,13 +1560,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationArgs
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1625,13 +1625,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationArgs
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1691,13 +1691,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationArgs
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1756,13 +1756,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationArgs
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -2139,13 +2139,13 @@ class BridgeSupportTest {
 
         // Set state to make concur a pegout migration tx and pegout batch creation on the same updateCollection
         Federation oldFederation = bridgeConstants.getGenesisFederation();
-        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             bridgeConstants.getBtcParams()
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            federationArgs
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -6593,7 +6593,7 @@ class BridgeSupportTest {
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(false);
 
-        ErpFederationArgs federationArgs = new ErpFederationArgs(members,
+        ErpFederationArgs p2shFedArgs = new ErpFederationArgs(members,
             Instant.now(),
             1L,
             bridgeConstants.getBtcParams(),
@@ -6601,7 +6601,7 @@ class BridgeSupportTest {
             bridgeConstants.getErpFedActivationDelay()
         );
         Federation p2shFed = FederationFactory.buildP2shErpFederation(
-            federationArgs
+            p2shFedArgs
         );
 
         Stream<Arguments> preRskip271 = Stream.of(
@@ -6662,7 +6662,7 @@ class BridgeSupportTest {
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(false);
 
-        ErpFederationArgs federationArgs = new ErpFederationArgs(members,
+        ErpFederationArgs p2shFedArgs = new ErpFederationArgs(members,
             Instant.now(),
             1L,
             bridgeConstants.getBtcParams(),
@@ -6670,7 +6670,7 @@ class BridgeSupportTest {
             bridgeConstants.getErpFedActivationDelay()
         );
         Federation p2shFed = FederationFactory.buildP2shErpFederation(
-            federationArgs
+            p2shFedArgs
         );
 
         Stream<Arguments> preRskip385 = Stream.of(
@@ -6730,7 +6730,7 @@ class BridgeSupportTest {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
-        ErpFederationArgs federationArgs = new ErpFederationArgs(members,
+        ErpFederationArgs p2shFedArgs = new ErpFederationArgs(members,
             Instant.now(),
             1L,
             bridgeConstants.getBtcParams(),
@@ -6738,7 +6738,7 @@ class BridgeSupportTest {
             bridgeConstants.getErpFedActivationDelay()
         );
         ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(
-            federationArgs
+            p2shFedArgs
         );
 
         Stream<Arguments> postRskip385 = Stream.of(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -1334,13 +1334,13 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
             0L,
             btcRegTestParams
         );
         Federation fed = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         txWithWitness.addOutput(Coin.COIN.multiply(5), fed.getAddress());
@@ -1428,13 +1428,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1493,13 +1493,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1560,13 +1560,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1625,13 +1625,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1691,13 +1691,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1756,13 +1756,13 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             btcRegTestParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -2139,13 +2139,13 @@ class BridgeSupportTest {
 
         // Set state to make concur a pegout migration tx and pegout batch creation on the same updateCollection
         Federation oldFederation = bridgeConstants.getGenesisFederation();
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
             bridgeConstants.getBtcParams()
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -6595,7 +6595,7 @@ class BridgeSupportTest {
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(false);
 
-        ErpFederationArgs args = new ErpFederationArgs(members,
+        ErpFederationArgs federationArgs = new ErpFederationArgs(members,
             Instant.now(),
             1L,
             bridgeConstants.getBtcParams(),
@@ -6603,7 +6603,7 @@ class BridgeSupportTest {
             bridgeConstants.getErpFedActivationDelay()
         );
         Federation p2shFed = FederationFactory.buildP2shErpFederation(
-            args
+            federationArgs
         );
 
         Stream<Arguments> preRskip271 = Stream.of(
@@ -6664,7 +6664,7 @@ class BridgeSupportTest {
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(false);
 
-        ErpFederationArgs args = new ErpFederationArgs(members,
+        ErpFederationArgs federationArgs = new ErpFederationArgs(members,
             Instant.now(),
             1L,
             bridgeConstants.getBtcParams(),
@@ -6672,7 +6672,7 @@ class BridgeSupportTest {
             bridgeConstants.getErpFedActivationDelay()
         );
         Federation p2shFed = FederationFactory.buildP2shErpFederation(
-            args
+            federationArgs
         );
 
         Stream<Arguments> preRskip385 = Stream.of(
@@ -6732,7 +6732,7 @@ class BridgeSupportTest {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
-        ErpFederationArgs args = new ErpFederationArgs(members,
+        ErpFederationArgs federationArgs = new ErpFederationArgs(members,
             Instant.now(),
             1L,
             bridgeConstants.getBtcParams(),
@@ -6740,7 +6740,7 @@ class BridgeSupportTest {
             bridgeConstants.getErpFedActivationDelay()
         );
         ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(
-            args
+            federationArgs
         );
 
         Stream<Arguments> postRskip385 = Stream.of(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -969,14 +969,14 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
 
-        FederationArgs args1 = new FederationArgs(
+        FederationArgs federation1Args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
             0L,
             btcParams
         );
         Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            args1
+            federation1Args
         );
 
         //Creates federation 2
@@ -985,14 +985,14 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fb02")),
             BtcECKey.fromPrivate(Hex.decode("fb03")));
 
-        FederationArgs args2 = new FederationArgs(
+        FederationArgs federation2Args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
             Instant.ofEpochMilli(2000L),
             0L,
             btcParams
         );
         Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            args2
+            federation2Args
         );
 
         Repository repository = createRepository();
@@ -1146,13 +1146,13 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
 
-        FederationArgs args1 = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
+        FederationArgs federation1Args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
             0L,
             btcParams
         );
         Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            args1
+            federation1Args
         );
 
         //Creates federation 2
@@ -1161,13 +1161,13 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fb02")),
             BtcECKey.fromPrivate(Hex.decode("fb03")));
 
-        FederationArgs args2 = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
+        FederationArgs federation2Args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
             Instant.ofEpochMilli(2000L),
             0L,
             btcParams
         );
         Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            args2
+            federation2Args
         );
 
         Repository repository = createRepository();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -968,10 +968,13 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
 
-        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args1 = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+            args1,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -981,10 +984,13 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fb02")),
             BtcECKey.fromPrivate(Hex.decode("fb03")));
 
-        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args2 = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
             Instant.ofEpochMilli(2000L),
-            0L,
+            0L
+        );
+        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
+            args2,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -1138,10 +1144,11 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
 
-        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
+        FederationArgs args1 = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+            args1,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -1151,10 +1158,11 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fb02")),
             BtcECKey.fromPrivate(Hex.decode("fb03")));
 
-        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
+        FederationArgs args2 = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
             Instant.ofEpochMilli(2000L),
-            0L,
+            0L);
+        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
+            args2,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -1322,10 +1330,11 @@ class BridgeSupportTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
 
-        Federation fed = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation fed = FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -1414,10 +1423,11 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L,
+            5L);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 
@@ -1477,10 +1487,11 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L,
+            5L);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 
@@ -1542,10 +1553,11 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L,
+            5L);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 
@@ -1605,10 +1617,11 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L,
+            5L);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 
@@ -1669,10 +1682,11 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L,
+            5L);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 
@@ -1732,10 +1746,11 @@ class BridgeSupportTest {
 
         Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L,
+            5L);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 
@@ -2113,10 +2128,11 @@ class BridgeSupportTest {
 
         // Set state to make concur a pegout migration tx and pegout batch creation on the same updateCollection
         Federation oldFederation = bridgeConstants.getGenesisFederation();
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(1),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L,
+            5L);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstants.getBtcParams()
         );
 
@@ -6405,20 +6421,22 @@ class BridgeSupportTest {
             oldFedMembers.add(FederationMember.getFederationMemberFromKey(new BtcECKey()));
         }
 
-        Federation oldFed = FederationFactory.buildStandardMultiSigFederation(
-            oldFedMembers,
+        FederationArgs oldFedArgs = new FederationArgs(oldFedMembers,
             Instant.now(),
-            0,
+            0);
+        Federation oldFed = FederationFactory.buildStandardMultiSigFederation(
+            oldFedArgs,
             btcRegTestParams
         );
+
+        List<FederationMember> members = Arrays.asList(
+            FederationMember.getFederationMemberFromKey(new BtcECKey()),
+            FederationMember.getFederationMemberFromKey(new BtcECKey()),
+            FederationMember.getFederationMemberFromKey(new BtcECKey())
+        );
+        FederationArgs newFedArgs = new FederationArgs(members, Instant.now(), 1);
         Federation newFed = FederationFactory.buildStandardMultiSigFederation(
-            Arrays.asList(
-                FederationMember.getFederationMemberFromKey(new BtcECKey()),
-                FederationMember.getFederationMemberFromKey(new BtcECKey()),
-                FederationMember.getFederationMemberFromKey(new BtcECKey())
-            ),
-            Instant.now(),
-            1,
+            newFedArgs,
             btcRegTestParams
         );
 
@@ -6563,10 +6581,11 @@ class BridgeSupportTest {
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(false);
 
-        Federation p2shFed = FederationFactory.buildP2shErpFederation(
-            members,
+        FederationArgs args = new FederationArgs(members,
             Instant.now(),
-            1L,
+            1L);
+        Federation p2shFed = FederationFactory.buildP2shErpFederation(
+            args,
             bridgeConstants.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()
@@ -6630,10 +6649,11 @@ class BridgeSupportTest {
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(false);
 
-        Federation p2shFed = FederationFactory.buildP2shErpFederation(
-            members,
+        FederationArgs args = new FederationArgs(members,
             Instant.now(),
-            1L,
+            1L);
+        Federation p2shFed = FederationFactory.buildP2shErpFederation(
+            args,
             bridgeConstants.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()
@@ -6696,10 +6716,11 @@ class BridgeSupportTest {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
-        ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(
-            members,
+        FederationArgs args = new FederationArgs(members,
             Instant.now(),
-            1L,
+            1L);
+        ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(
+            args,
             bridgeConstants.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -960,6 +960,7 @@ class BridgeSupportTest {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
 
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
         //Creates federation 1
@@ -971,11 +972,11 @@ class BridgeSupportTest {
         FederationArgs args1 = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
-            0L
+            0L,
+            btcParams
         );
         Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            args1,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args1
         );
 
         //Creates federation 2
@@ -987,11 +988,11 @@ class BridgeSupportTest {
         FederationArgs args2 = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
             Instant.ofEpochMilli(2000L),
-            0L
+            0L,
+            btcParams
         );
         Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            args2,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args2
         );
 
         Repository repository = createRepository();
@@ -1136,6 +1137,7 @@ class BridgeSupportTest {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
 
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
         //Creates federation 1
@@ -1146,10 +1148,11 @@ class BridgeSupportTest {
 
         FederationArgs args1 = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
-            0L);
+            0L,
+            btcParams
+        );
         Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            args1,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args1
         );
 
         //Creates federation 2
@@ -1160,10 +1163,11 @@ class BridgeSupportTest {
 
         FederationArgs args2 = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
             Instant.ofEpochMilli(2000L),
-            0L);
+            0L,
+            btcParams
+        );
         Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            args2,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args2
         );
 
         Repository repository = createRepository();
@@ -1332,10 +1336,11 @@ class BridgeSupportTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
-            0L);
+            0L,
+            btcRegTestParams
+        );
         Federation fed = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
 
         txWithWitness.addOutput(Coin.COIN.multiply(5), fed.getAddress());
@@ -1425,10 +1430,11 @@ class BridgeSupportTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L);
+            5L,
+            btcRegTestParams
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
+            args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1489,10 +1495,11 @@ class BridgeSupportTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L);
+            5L,
+            btcRegTestParams
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
+            args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1555,10 +1562,11 @@ class BridgeSupportTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L);
+            5L,
+            btcRegTestParams
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
+            args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1619,10 +1627,11 @@ class BridgeSupportTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L);
+            5L,
+            btcRegTestParams
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
+            args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1684,10 +1693,11 @@ class BridgeSupportTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L);
+            5L,
+            btcRegTestParams
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
+            args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1748,10 +1758,11 @@ class BridgeSupportTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L);
+            5L,
+            btcRegTestParams
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
+            args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -2130,10 +2141,11 @@ class BridgeSupportTest {
         Federation oldFederation = bridgeConstants.getGenesisFederation();
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
-            5L);
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
+            5L,
             bridgeConstants.getBtcParams()
+        );
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -6423,10 +6435,11 @@ class BridgeSupportTest {
 
         FederationArgs oldFedArgs = new FederationArgs(oldFedMembers,
             Instant.now(),
-            0);
-        Federation oldFed = FederationFactory.buildStandardMultiSigFederation(
-            oldFedArgs,
+            0,
             btcRegTestParams
+        );
+        Federation oldFed = FederationFactory.buildStandardMultiSigFederation(
+            oldFedArgs
         );
 
         List<FederationMember> members = Arrays.asList(
@@ -6434,10 +6447,11 @@ class BridgeSupportTest {
             FederationMember.getFederationMemberFromKey(new BtcECKey()),
             FederationMember.getFederationMemberFromKey(new BtcECKey())
         );
-        FederationArgs newFedArgs = new FederationArgs(members, Instant.now(), 1);
-        Federation newFed = FederationFactory.buildStandardMultiSigFederation(
-            newFedArgs,
+        FederationArgs newFedArgs = new FederationArgs(members, Instant.now(), 1,
             btcRegTestParams
+        );
+        Federation newFed = FederationFactory.buildStandardMultiSigFederation(
+            newFedArgs
         );
 
         Block block = mock(Block.class);
@@ -6581,14 +6595,15 @@ class BridgeSupportTest {
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(false);
 
-        FederationArgs args = new FederationArgs(members,
+        ErpFederationArgs args = new ErpFederationArgs(members,
             Instant.now(),
-            1L);
-        Federation p2shFed = FederationFactory.buildP2shErpFederation(
-            args,
+            1L,
             bridgeConstants.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()
+        );
+        Federation p2shFed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         Stream<Arguments> preRskip271 = Stream.of(
@@ -6649,14 +6664,15 @@ class BridgeSupportTest {
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(false);
 
-        FederationArgs args = new FederationArgs(members,
+        ErpFederationArgs args = new ErpFederationArgs(members,
             Instant.now(),
-            1L);
-        Federation p2shFed = FederationFactory.buildP2shErpFederation(
-            args,
+            1L,
             bridgeConstants.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()
+        );
+        Federation p2shFed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         Stream<Arguments> preRskip385 = Stream.of(
@@ -6716,14 +6732,15 @@ class BridgeSupportTest {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
-        FederationArgs args = new FederationArgs(members,
+        ErpFederationArgs args = new ErpFederationArgs(members,
             Instant.now(),
-            1L);
-        ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(
-            args,
+            1L,
             bridgeConstants.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()
+        );
+        ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         Stream<Arguments> postRskip385 = Stream.of(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -6442,14 +6442,12 @@ class BridgeSupportTest {
             oldFedArgs
         );
 
-        List<FederationMember> members = Arrays.asList(
+        List<FederationMember> newFedMembers = Arrays.asList(
             FederationMember.getFederationMemberFromKey(new BtcECKey()),
             FederationMember.getFederationMemberFromKey(new BtcECKey()),
             FederationMember.getFederationMemberFromKey(new BtcECKey())
         );
-        FederationArgs newFedArgs = new FederationArgs(members, Instant.now(), 1,
-            btcRegTestParams
-        );
+        FederationArgs newFedArgs = new FederationArgs(newFedMembers, Instant.now(), 1, btcRegTestParams);
         Federation newFed = FederationFactory.buildStandardMultiSigFederation(
             newFedArgs
         );

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -630,11 +630,11 @@ public class BridgeSupportTestIntegration {
         FederationArgs args = new FederationArgs(
             Collections.singletonList(member),
             Instant.EPOCH,
-            5L
+            5L,
+            bridgeConstants.getBtcParams()
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                args,
-                bridgeConstants.getBtcParams()
+                args
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1395,10 +1395,11 @@ public class BridgeSupportTestIntegration {
         List<FederationMember> activeFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys);
         FederationArgs activeFedArgs = new FederationArgs(activeFederationMembers,
             Instant.ofEpochMilli(2000L),
-            2L);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            activeFedArgs,
+            2L,
             parameters
+        );
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            activeFedArgs
         );
 
         List<BtcECKey> retiringFederationKeys = Stream.of(
@@ -1409,10 +1410,10 @@ public class BridgeSupportTestIntegration {
         List<FederationMember> retiringFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys);
         FederationArgs retiringFedArgs = new FederationArgs(retiringFederationMembers,
             Instant.ofEpochMilli(1000L),
-            1L);
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            retiringFedArgs,
-            parameters);
+            1L,
+            parameters
+        );
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(retiringFedArgs);
 
         Repository repository = createRepository();
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
@@ -1521,11 +1522,11 @@ public class BridgeSupportTestIntegration {
         FederationArgs activeFedArgs = new FederationArgs(
             activeFederationMembers,
             Instant.ofEpochMilli(1000L),
-            5L
+            5L,
+            params
         );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            activeFedArgs,
-            params
+            activeFedArgs
         );
 
         final List<BtcECKey> retiringFedPrivateKeys = Arrays.asList(
@@ -1621,10 +1622,11 @@ public class BridgeSupportTestIntegration {
         List<FederationMember> federation1Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys);
         FederationArgs args1 = new FederationArgs(federation1Members,
             Instant.ofEpochMilli(1000L),
-            0L);
-        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            args1,
+            0L,
             btcParams
+        );
+        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+            args1
         );
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
@@ -1637,10 +1639,10 @@ public class BridgeSupportTestIntegration {
         List<FederationMember> federation2Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys);
         FederationArgs args2 = new FederationArgs(federation2Members,
             Instant.ofEpochMilli(2000L),
-            0L);
+            0L,
+            btcParams);
         Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            args2,
-            btcParams
+            args2
         );
 
         Repository repository = createRepository();
@@ -1794,18 +1796,20 @@ public class BridgeSupportTestIntegration {
     void getFederationMethods_genesis() throws IOException {
         FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                activeFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                activeFedArgs
         );
 
         FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
         Federation genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-                genesisFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                genesisFedArgs
         );
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, activeFederation, genesisFederation, null, null, null, null);
 
@@ -1825,18 +1829,20 @@ public class BridgeSupportTestIntegration {
     void getFederationMethods_active() throws IOException {
         FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                activeFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                activeFedArgs
         );
 
         FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
         Federation genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-                genesisFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                genesisFedArgs
         );
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
@@ -1865,19 +1871,20 @@ public class BridgeSupportTestIntegration {
         FederationArgs newFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            15L
+            15L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                newFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                newFedArgs
         );
 
         FederationArgs oldFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
         Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-                oldFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                oldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -1907,22 +1914,24 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getFederationMethods_newNotActivated() throws IOException {
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         FederationArgs newFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            15L
+            15L,
+            btcParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                newFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                newFedArgs
         );
 
         FederationArgs oldFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            btcParams
+        );
         Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-                oldFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                oldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -1965,22 +1974,25 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getRetiringFederationMethods_presentNewInactive() throws IOException {
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         FederationArgs mockedNewFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(2),
             Instant.ofEpochMilli(1000),
-            10L);
+            10L,
+            btcParams
+        );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedNewFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedNewFedArgs
         );
 
         FederationArgs mockedOldFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(4),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            btcParams
+        );
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedOldFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedOldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -2006,22 +2018,25 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getRetiringFederationMethods_presentNewActive() throws IOException {
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         FederationArgs mockedNewFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(2),
             Instant.ofEpochMilli(1000),
-            10L);
+            10L,
+            btcParams
+        );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedNewFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedNewFedArgs
         );
 
         FederationArgs mockedOldFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(4),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            btcParams
+        );
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedOldFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedOldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -2226,23 +2241,26 @@ public class BridgeSupportTestIntegration {
     @Test
     void createFederation_withPendingActivation() throws IOException, BridgeIllegalArgumentException {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
         FederationArgs mockedNewFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(2),
             Instant.ofEpochMilli(2000),
-            10L);
+            10L,
+            btcParams
+        );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedNewFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedNewFedArgs
         );
 
         FederationArgs mockedOldFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(4),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            btcParams
+        );
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedOldFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedOldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -2271,23 +2289,26 @@ public class BridgeSupportTestIntegration {
     @Test
     void createFederation_withExistingRetiringFederation() throws IOException, BridgeIllegalArgumentException {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
         FederationArgs mockedNewFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(2),
             Instant.ofEpochMilli(2000),
-            10L);
+            10L,
+            btcParams
+        );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedNewFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedNewFedArgs
         );
 
         FederationArgs mockedOldFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(4),
             Instant.ofEpochMilli(1000),
-            0L);
+            0L,
+            btcParams
+        );
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedOldFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedOldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -2805,7 +2826,7 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void commitFederation_ok() throws IOException, BridgeIllegalArgumentException {
-
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         PendingFederation pendingFederation = new PendingFederation(FederationTestUtils.getFederationMembersWithKeys(Arrays.asList(
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
                 BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
@@ -2832,10 +2853,11 @@ public class BridgeSupportTestIntegration {
             );
         FederationArgs expectedFedArgs = new FederationArgs(expectedFederationMembers,
             Instant.ofEpochMilli(15005L),
-            15L);
+            15L,
+            btcParams
+        );
         Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
-            expectedFedArgs,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            expectedFedArgs
         );
 
         List<FederationMember> newFederationMembers =
@@ -2848,10 +2870,11 @@ public class BridgeSupportTestIntegration {
             );
         FederationArgs newFedArgs = new FederationArgs(newFederationMembers,
             Instant.ofEpochMilli(5005L),
-            0L);
+            0L,
+            btcParams
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            newFedArgs,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            newFedArgs
         );
 
         BridgeEventLogger eventLoggerMock = mock(BridgeEventLogger.class);
@@ -3004,10 +3027,11 @@ public class BridgeSupportTestIntegration {
             );
         FederationArgs args = new FederationArgs(expectedFederationMembers,
             Instant.ofEpochMilli(5005L),
-            0L);
-        Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
+            0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
+        Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
+            args
         );
 
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
@@ -3041,10 +3065,11 @@ public class BridgeSupportTestIntegration {
     void getRetiringFederationWallet_nonEmpty() throws IOException {
         FederationArgs mockedFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(2),
             Instant.ofEpochMilli(2000),
-            10L);
+            10L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedFedArgs,
-                NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+                mockedFedArgs
         );
 
         List<FederationMember> expectedFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(
@@ -3055,11 +3080,11 @@ public class BridgeSupportTestIntegration {
         FederationArgs expectedFederationArgs = new FederationArgs(
             expectedFederationMembers,
             Instant.ofEpochMilli(5005L),
-            0L
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
-            expectedFederationArgs,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            expectedFederationArgs
         );
 
         Block mockedBlock = mock(Block.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -627,14 +627,14 @@ public class BridgeSupportTestIntegration {
         Federation oldFederation = bridgeConstants.getGenesisFederation();
         BtcECKey key = new BtcECKey(new SecureRandom());
         FederationMember member = new FederationMember(key, new ECKey(), new ECKey());
-        FederationArgs args = new FederationArgs(
+        FederationArgs newFederationArgs = new FederationArgs(
             Collections.singletonList(member),
             Instant.EPOCH,
             5L,
             bridgeConstants.getBtcParams()
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                args
+            newFederationArgs
         );
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -1620,13 +1620,13 @@ public class BridgeSupportTestIntegration {
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         List<FederationMember> federation1Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys);
-        FederationArgs args1 = new FederationArgs(federation1Members,
+        FederationArgs federation1Args = new FederationArgs(federation1Members,
             Instant.ofEpochMilli(1000L),
             0L,
             btcParams
         );
         Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            args1
+            federation1Args
         );
 
         List<BtcECKey> federation2Keys = Arrays.asList(new BtcECKey[]{
@@ -1637,12 +1637,12 @@ public class BridgeSupportTestIntegration {
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         List<FederationMember> federation2Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys);
-        FederationArgs args2 = new FederationArgs(federation2Members,
+        FederationArgs federation2Args = new FederationArgs(federation2Members,
             Instant.ofEpochMilli(2000L),
             0L,
             btcParams);
         Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            args2
+            federation2Args
         );
 
         Repository repository = createRepository();
@@ -1800,7 +1800,7 @@ public class BridgeSupportTestIntegration {
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                activeFedArgs
+            activeFedArgs
         );
 
         FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
@@ -1809,7 +1809,7 @@ public class BridgeSupportTestIntegration {
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-                genesisFedArgs
+            genesisFedArgs
         );
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, activeFederation, genesisFederation, null, null, null, null);
 
@@ -1833,7 +1833,7 @@ public class BridgeSupportTestIntegration {
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                activeFedArgs
+            activeFedArgs
         );
 
         FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
@@ -1842,7 +1842,7 @@ public class BridgeSupportTestIntegration {
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-                genesisFedArgs
+            genesisFedArgs
         );
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
                 false,
@@ -1868,14 +1868,14 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getFederationMethods_newActivated() throws IOException {
-        FederationArgs newFedArgs = new FederationArgs(
+        FederationArgs newFederationArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
             15L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                newFedArgs
+            newFederationArgs
         );
 
         FederationArgs oldFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
@@ -1884,7 +1884,7 @@ public class BridgeSupportTestIntegration {
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-                oldFedArgs
+            oldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -1915,14 +1915,14 @@ public class BridgeSupportTestIntegration {
     @Test
     void getFederationMethods_newNotActivated() throws IOException {
         NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        FederationArgs newFedArgs = new FederationArgs(
+        FederationArgs newFederationArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
             15L,
             btcParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                newFedArgs
+            newFederationArgs
         );
 
         FederationArgs oldFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
@@ -1931,7 +1931,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-                oldFedArgs
+            oldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -1982,7 +1982,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedNewFedArgs
+            mockedNewFedArgs
         );
 
         FederationArgs mockedOldFedArgs = new FederationArgs(
@@ -1992,7 +1992,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedOldFedArgs
+            mockedOldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -2026,7 +2026,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedNewFedArgs
+            mockedNewFedArgs
         );
 
         FederationArgs mockedOldFedArgs = new FederationArgs(
@@ -2036,7 +2036,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedOldFedArgs
+            mockedOldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -2250,7 +2250,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedNewFedArgs
+            mockedNewFedArgs
         );
 
         FederationArgs mockedOldFedArgs = new FederationArgs(
@@ -2260,7 +2260,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedOldFedArgs
+            mockedOldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -2298,7 +2298,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedNewFedArgs
+            mockedNewFedArgs
         );
 
         FederationArgs mockedOldFedArgs = new FederationArgs(
@@ -2308,7 +2308,7 @@ public class BridgeSupportTestIntegration {
             btcParams
         );
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedOldFedArgs
+            mockedOldFedArgs
         );
 
         Block mockedBlock = mock(Block.class);
@@ -2868,13 +2868,13 @@ public class BridgeSupportTestIntegration {
                     BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
                 )
             );
-        FederationArgs newFedArgs = new FederationArgs(newFederationMembers,
+        FederationArgs newFederationArgs = new FederationArgs(newFederationMembers,
             Instant.ofEpochMilli(5005L),
             0L,
             btcParams
         );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            newFedArgs
+            newFederationArgs
         );
 
         BridgeEventLogger eventLoggerMock = mock(BridgeEventLogger.class);
@@ -3025,13 +3025,13 @@ public class BridgeSupportTestIntegration {
                     BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
                 )
             );
-        FederationArgs args = new FederationArgs(expectedFederationMembers,
+        FederationArgs expectedFederationArgs = new FederationArgs(expectedFederationMembers,
             Instant.ofEpochMilli(5005L),
             0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            expectedFederationArgs
         );
 
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
@@ -3069,7 +3069,7 @@ public class BridgeSupportTestIntegration {
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                mockedFedArgs
+            mockedFedArgs
         );
 
         List<FederationMember> expectedFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -627,10 +627,13 @@ public class BridgeSupportTestIntegration {
         Federation oldFederation = bridgeConstants.getGenesisFederation();
         BtcECKey key = new BtcECKey(new SecureRandom());
         FederationMember member = new FederationMember(key, new ECKey(), new ECKey());
+        FederationArgs args = new FederationArgs(
+            Collections.singletonList(member),
+            Instant.EPOCH,
+            5L
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                Collections.singletonList(member),
-                Instant.EPOCH,
-                5L,
+                args,
                 bridgeConstants.getBtcParams()
         );
 
@@ -1390,10 +1393,11 @@ public class BridgeSupportTestIntegration {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         List<FederationMember> activeFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            activeFederationMembers,
+        FederationArgs activeFedArgs = new FederationArgs(activeFederationMembers,
             Instant.ofEpochMilli(2000L),
-            2L,
+            2L);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            activeFedArgs,
             parameters
         );
 
@@ -1403,10 +1407,11 @@ public class BridgeSupportTestIntegration {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         List<FederationMember> retiringFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys);
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            retiringFederationMembers,
+        FederationArgs retiringFedArgs = new FederationArgs(retiringFederationMembers,
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+            retiringFedArgs,
             parameters);
 
         Repository repository = createRepository();
@@ -1513,10 +1518,13 @@ public class BridgeSupportTestIntegration {
                 .collect(Collectors.toList());
 
         List<FederationMember> activeFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs activeFedArgs = new FederationArgs(
             activeFederationMembers,
             Instant.ofEpochMilli(1000L),
-            5L,
+            5L
+        );
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            activeFedArgs,
             params
         );
 
@@ -1611,10 +1619,11 @@ public class BridgeSupportTestIntegration {
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         List<FederationMember> federation1Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys);
-        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            federation1Members,
+        FederationArgs args1 = new FederationArgs(federation1Members,
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+            args1,
             btcParams
         );
 
@@ -1626,10 +1635,11 @@ public class BridgeSupportTestIntegration {
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         List<FederationMember> federation2Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys);
-        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            federation2Members,
+        FederationArgs args2 = new FederationArgs(federation2Members,
             Instant.ofEpochMilli(2000L),
-            0L,
+            0L);
+        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
+            args2,
             btcParams
         );
 
@@ -1782,16 +1792,19 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getFederationMethods_genesis() throws IOException {
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(3),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(3),
-                Instant.ofEpochMilli(1000),
-                0L,
+                activeFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
+
+        FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(6),
-                Instant.ofEpochMilli(1000),
-                0L,
+                genesisFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, activeFederation, genesisFederation, null, null, null, null);
@@ -1810,16 +1823,19 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getFederationMethods_active() throws IOException {
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(3),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(3),
-                Instant.ofEpochMilli(1000),
-                0L,
+                activeFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
+
+        FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation genesisFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(6),
-                Instant.ofEpochMilli(1000),
-                0L,
+                genesisFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(
@@ -1846,16 +1862,21 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getFederationMethods_newActivated() throws IOException {
+        FederationArgs newFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(3),
+            Instant.ofEpochMilli(1000),
+            15L
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(3),
-                Instant.ofEpochMilli(1000),
-                15L,
+                newFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
+
+        FederationArgs oldFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(6),
-                Instant.ofEpochMilli(1000),
-                0L,
+                oldFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -1886,16 +1907,21 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getFederationMethods_newNotActivated() throws IOException {
+        FederationArgs newFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(3),
+            Instant.ofEpochMilli(1000),
+            15L
+        );
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(3),
-                Instant.ofEpochMilli(1000),
-                15L,
+                newFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
+
+        FederationArgs oldFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(6),
-                Instant.ofEpochMilli(1000),
-                0L,
+                oldFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -1939,17 +1965,21 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getRetiringFederationMethods_presentNewInactive() throws IOException {
+        FederationArgs mockedNewFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(2),
+            Instant.ofEpochMilli(1000),
+            10L);
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(2),
-                Instant.ofEpochMilli(2000),
-                10L,
+                mockedNewFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
+        FederationArgs mockedOldFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(4),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(4),
-                Instant.ofEpochMilli(1000),
-                0L,
+                mockedOldFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -1976,17 +2006,21 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getRetiringFederationMethods_presentNewActive() throws IOException {
+        FederationArgs mockedNewFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(2),
+            Instant.ofEpochMilli(1000),
+            10L);
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(2),
-                Instant.ofEpochMilli(2000),
-                10L,
+                mockedNewFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
+        FederationArgs mockedOldFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(4),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(4),
-                Instant.ofEpochMilli(1000),
-                0L,
+                mockedOldFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -2193,17 +2227,21 @@ public class BridgeSupportTestIntegration {
     void createFederation_withPendingActivation() throws IOException, BridgeIllegalArgumentException {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
 
+        FederationArgs mockedNewFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(2),
+            Instant.ofEpochMilli(2000),
+            10L);
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(2),
-                Instant.ofEpochMilli(2000),
-                10L,
+                mockedNewFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
+        FederationArgs mockedOldFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(4),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(4),
-                Instant.ofEpochMilli(1000),
-                0L,
+                mockedOldFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -2234,17 +2272,21 @@ public class BridgeSupportTestIntegration {
     void createFederation_withExistingRetiringFederation() throws IOException, BridgeIllegalArgumentException {
         VotingMocksProvider mocksProvider = new VotingMocksProvider("create", new byte[][]{}, false);
 
+        FederationArgs mockedNewFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(2),
+            Instant.ofEpochMilli(2000),
+            10L);
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(2),
-                Instant.ofEpochMilli(2000),
-                10L,
+                mockedNewFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
+        FederationArgs mockedOldFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembers(4),
+            Instant.ofEpochMilli(1000),
+            0L);
         Federation mockedOldFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(4),
-                Instant.ofEpochMilli(1000),
-                0L,
+                mockedOldFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -2788,10 +2830,11 @@ public class BridgeSupportTestIntegration {
                     BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))
                 )
             );
-        Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
-            expectedFederationMembers,
+        FederationArgs expectedFedArgs = new FederationArgs(expectedFederationMembers,
             Instant.ofEpochMilli(15005L),
-            15L,
+            15L);
+        Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
+            expectedFedArgs,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -2803,10 +2846,11 @@ public class BridgeSupportTestIntegration {
                     BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
                 )
             );
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            newFederationMembers,
+        FederationArgs newFedArgs = new FederationArgs(newFederationMembers,
             Instant.ofEpochMilli(5005L),
-            0L,
+            0L);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
+            newFedArgs,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -2958,10 +3002,11 @@ public class BridgeSupportTestIntegration {
                     BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
                 )
             );
-        Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
-            expectedFederationMembers,
+        FederationArgs args = new FederationArgs(expectedFederationMembers,
             Instant.ofEpochMilli(5005L),
-            0L,
+            0L);
+        Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -2994,17 +3039,28 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void getRetiringFederationWallet_nonEmpty() throws IOException {
+        FederationArgs mockedFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(2),
+            Instant.ofEpochMilli(2000),
+            10L);
         Federation mockedNewFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembers(2),
-                Instant.ofEpochMilli(2000),
-                10L,
+                mockedFedArgs,
                 NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
-        Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(FederationTestUtils.getFederationMembersWithBtcKeys(Arrays.asList(new BtcECKey[]{
+        List<FederationMember> expectedFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(
+            Arrays.asList(new BtcECKey[]{
                 BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
-                BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
-        })), Instant.ofEpochMilli(5005L), 0L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+            BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
+        }));
+        FederationArgs expectedFederationArgs = new FederationArgs(
+            expectedFederationMembers,
+            Instant.ofEpochMilli(5005L),
+            0L
+        );
+        Federation expectedFederation = FederationFactory.buildStandardMultiSigFederation(
+            expectedFederationArgs,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
 
         Block mockedBlock = mock(Block.class);
         when(mockedBlock.getNumber()).thenReturn(25L);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -8,6 +8,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
@@ -241,10 +242,11 @@ class BridgeTest {
         ActivationConfig activations = spy(ActivationConfigsForTest.genesis());
         doReturn(false).when(activations).isActive(eq(RSKIP199), anyLong());
 
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(3),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L,
+            0L);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -287,10 +289,11 @@ class BridgeTest {
         List<BtcECKey> federationKeys = Arrays.asList(fed1Key, new BtcECKey(), new BtcECKey());
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithKeys(federationKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithKeys(federationKeys),
             Instant.ofEpochMilli(1000),
-            0L,
+            0L);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -243,10 +243,10 @@ class BridgeTest {
         doReturn(false).when(activations).isActive(eq(RSKIP199), anyLong());
         NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(3),
+        FederationArgs activeFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
             0L, btcParams);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(activeFederationArgs);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getActiveFederation()).thenReturn(activeFederation);
@@ -288,11 +288,11 @@ class BridgeTest {
         List<BtcECKey> federationKeys = Arrays.asList(fed1Key, new BtcECKey(), new BtcECKey());
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithKeys(federationKeys),
+        FederationArgs activeFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithKeys(federationKeys),
             Instant.ofEpochMilli(1000),
             0L,
             btcParams);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(activeFederationArgs);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getActiveFederation()).thenReturn(activeFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -241,14 +241,12 @@ class BridgeTest {
 
         ActivationConfig activations = spy(ActivationConfigsForTest.genesis());
         doReturn(false).when(activations).isActive(eq(RSKIP199), anyLong());
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
+            0L, btcParams);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getActiveFederation()).thenReturn(activeFederation);
@@ -283,6 +281,7 @@ class BridgeTest {
 
         ActivationConfig activations = spy(ActivationConfigsForTest.genesis());
         doReturn(false).when(activations).isActive(eq(RSKIP199), anyLong());
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
         BtcECKey fed1Key = new BtcECKey();
         RskAddress fed1Address = new RskAddress(ECKey.fromPublicOnly(fed1Key.getPubKey()).getAddress());
@@ -291,11 +290,9 @@ class BridgeTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithKeys(federationKeys),
             Instant.ofEpochMilli(1000),
-            0L);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
+            0L,
+            btcParams);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getActiveFederation()).thenReturn(activeFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
@@ -461,9 +461,9 @@ class BridgeUtilsLegacyTest {
         NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
+        FederationArgs federationArgs = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(), 0, btcParams);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         int pegoutTxSize = BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 2, 2);
 
@@ -482,9 +482,9 @@ class BridgeUtilsLegacyTest {
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
 
-        FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
+        FederationArgs federationArgs = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(), 0, btcParams);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         Assertions.assertThrows(DeprecatedMethodCallException.class, () -> BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 2, 2));
     }
@@ -495,9 +495,9 @@ class BridgeUtilsLegacyTest {
         NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
+        FederationArgs federationArgs = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(), 0, btcParams);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 0, 0));
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
@@ -458,15 +458,12 @@ class BridgeUtilsLegacyTest {
     @Test
     void calculatePegoutTxSize_before_rskip_271() {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
+        NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
         FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
-            Instant.now(),
-            0);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
-        );
+            Instant.now(), 0, btcParams);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(args);
 
         int pegoutTxSize = BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 2, 2);
 
@@ -481,16 +478,13 @@ class BridgeUtilsLegacyTest {
     @Test
     void calculatePegoutTxSize_after_rskip_271() {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
+        NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
 
         FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
-            Instant.now(),
-            0);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
-        );
+            Instant.now(), 0, btcParams);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(args);
 
         Assertions.assertThrows(DeprecatedMethodCallException.class, () -> BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 2, 2));
     }
@@ -498,15 +492,12 @@ class BridgeUtilsLegacyTest {
     @Test
     void calculatePegoutTxSize_ZeroInput_ZeroOutput() {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
+        NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
         FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
-            Instant.now(),
-            0);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstantsRegtest.getBtcParams()
-        );
+            Instant.now(), 0, btcParams);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(args);
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 0, 0));
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
@@ -7,6 +7,7 @@ import co.rsk.config.BridgeRegTestConstants;
 import java.time.Instant;
 import java.util.List;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationMember;
 import org.bouncycastle.util.encoders.Hex;
@@ -459,10 +460,11 @@ class BridgeUtilsLegacyTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationMember.getFederationMembersFromKeys(keys),
+        FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 
@@ -481,10 +483,12 @@ class BridgeUtilsLegacyTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationMember.getFederationMembersFromKeys(keys),
+
+        FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 
@@ -496,10 +500,11 @@ class BridgeUtilsLegacyTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationMember.getFederationMembersFromKeys(keys),
+        FederationArgs args = new FederationArgs(FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0);
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1615,17 +1615,6 @@ class BridgeUtilsTest {
         return privKey;
     }
 
-    private void signWithErpFederation(Federation erpFederation, List<BtcECKey> privateKeys, TransactionInput txIn, BtcTransaction tx) {
-        signWithNecessaryKeys(erpFederation, privateKeys, txIn, tx);
-        // Add OP_0 prefix to make it a valid erp federation script
-        Script erpInputScript = new ScriptBuilder()
-            .number(ScriptOpCodes.OP_0)
-            .addChunks(txIn.getScriptSig().getChunks())
-            .build();
-
-        txIn.setScriptSig(erpInputScript);
-    }
-
     private void signWithNecessaryKeys(
         Federation federation,
         List<BtcECKey> privateKeys,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -470,14 +470,14 @@ class BridgeUtilsTest {
         // Arrange
         BtcECKey federator1Key = new BtcECKey();
         BtcECKey federator2Key = new BtcECKey();
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         // Create a tx from the Fed to a random btc address
@@ -521,14 +521,14 @@ class BridgeUtilsTest {
         // Arrange
         BtcECKey federator1Key = new BtcECKey();
         BtcECKey federator2Key = new BtcECKey();
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         // Create a tx from the Fed to a random btc address
@@ -572,14 +572,14 @@ class BridgeUtilsTest {
         // Arrange
         BtcECKey federator1Key = new BtcECKey();
         BtcECKey federator2Key = new BtcECKey();
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         // Create a tx from the Fed to a random btc address
@@ -921,14 +921,14 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> BridgeUtils.calculatePegoutTxSize(activations, federation, 0, 0));
@@ -940,14 +940,14 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         int inputSize = 2;
@@ -968,14 +968,14 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         int inputSize = 9;
@@ -996,14 +996,14 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         // Create a pegout tx with 10 inputs and 20 outputs
@@ -1027,14 +1027,14 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         // Create a pegout tx with 50 inputs and 200 outputs
@@ -1071,7 +1071,7 @@ class BridgeUtilsTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        ErpFederationArgs args = new ErpFederationArgs(
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
             Instant.ofEpochMilli(1000L),
             0L,
@@ -1080,7 +1080,7 @@ class BridgeUtilsTest {
             500L
         );
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
+            erpFederationArgs,
             activations
         );
 
@@ -1118,7 +1118,7 @@ class BridgeUtilsTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        ErpFederationArgs args = new ErpFederationArgs(
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
             Instant.ofEpochMilli(1000L),
             0L,
@@ -1127,7 +1127,7 @@ class BridgeUtilsTest {
             500L
         );
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
+            erpFederationArgs,
             activations
         );
 
@@ -1155,14 +1155,14 @@ class BridgeUtilsTest {
         BtcECKey key2 = new BtcECKey();
         BtcECKey key3 = new BtcECKey();
         List<BtcECKey> keys = Arrays.asList(key1, key2, key3);
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
             0,
             networkParameters
         );
         Federation fed = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         // Create a pegout tx with two inputs and two outputs
@@ -1202,14 +1202,14 @@ class BridgeUtilsTest {
                     BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
                 )
             );
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             federationMembers,
             Instant.ofEpochMilli(5005L),
             0L,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(networkParameters);
@@ -1243,14 +1243,14 @@ class BridgeUtilsTest {
                     BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
                 )
             );
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             federationMembers,
             Instant.ofEpochMilli(5005L),
             0L,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args);
+            federationArgs);
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(networkParameters);
 
@@ -1474,7 +1474,7 @@ class BridgeUtilsTest {
 
     private ErpFederation createErpFederation() {
         Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
-        ErpFederationArgs args = new ErpFederationArgs(
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
             genesisFederation.getMembers(),
             genesisFederation.getCreationTime(),
             genesisFederation.getCreationBlockNumber(),
@@ -1483,7 +1483,7 @@ class BridgeUtilsTest {
             bridgeConstantsRegtest.getErpFedActivationDelay()
         );
         return FederationFactory.buildNonStandardErpFederation(
-            args,
+            erpFederationArgs,
             activations
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -473,11 +473,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         // Create a tx from the Fed to a random btc address
@@ -524,11 +524,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         // Create a tx from the Fed to a random btc address
@@ -575,11 +575,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         // Create a tx from the Fed to a random btc address
@@ -924,11 +924,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> BridgeUtils.calculatePegoutTxSize(activations, federation, 0, 0));
@@ -943,11 +943,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         int inputSize = 2;
@@ -971,11 +971,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         int inputSize = 9;
@@ -999,11 +999,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         // Create a pegout tx with 10 inputs and 20 outputs
@@ -1030,11 +1030,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         // Create a pegout tx with 50 inputs and 200 outputs
@@ -1071,16 +1071,16 @@ class BridgeUtilsTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        FederationArgs args = new FederationArgs(
+        ErpFederationArgs args = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L
+            0L,
+            networkParameters,
+            erpFederationPublicKeys,
+            500L
         );
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
             args,
-            networkParameters,
-            erpFederationPublicKeys,
-            500L,
             activations
         );
 
@@ -1118,16 +1118,16 @@ class BridgeUtilsTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        FederationArgs args = new FederationArgs(
+        ErpFederationArgs args = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L
+            0L,
+            networkParameters,
+            erpFederationPublicKeys,
+            500L
         );
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
             args,
-            networkParameters,
-            erpFederationPublicKeys,
-            500L,
             activations
         );
 
@@ -1158,11 +1158,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation fed = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         // Create a pegout tx with two inputs and two outputs
@@ -1205,11 +1205,12 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             federationMembers,
             Instant.ofEpochMilli(5005L),
-            0L
+            0L,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters);
+            args
+        );
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(networkParameters);
 
@@ -1245,11 +1246,11 @@ class BridgeUtilsTest {
         FederationArgs args = new FederationArgs(
             federationMembers,
             Instant.ofEpochMilli(5005L),
-            0L
+            0L,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters);
+            args);
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(networkParameters);
 
@@ -1473,16 +1474,16 @@ class BridgeUtilsTest {
 
     private ErpFederation createErpFederation() {
         Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
-        FederationArgs args = new FederationArgs(
+        ErpFederationArgs args = new ErpFederationArgs(
             genesisFederation.getMembers(),
             genesisFederation.getCreationTime(),
-            genesisFederation.getCreationBlockNumber()
+            genesisFederation.getCreationBlockNumber(),
+            genesisFederation.getBtcParams(),
+            bridgeConstantsRegtest.getErpFedPubKeysList(),
+            bridgeConstantsRegtest.getErpFedActivationDelay()
         );
         return FederationFactory.buildNonStandardErpFederation(
             args,
-            genesisFederation.getBtcParams(),
-            bridgeConstantsRegtest.getErpFedPubKeysList(),
-            bridgeConstantsRegtest.getErpFedActivationDelay(),
             activations
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -470,10 +470,13 @@ class BridgeUtilsTest {
         // Arrange
         BtcECKey federator1Key = new BtcECKey();
         BtcECKey federator2Key = new BtcECKey();
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -518,10 +521,13 @@ class BridgeUtilsTest {
         // Arrange
         BtcECKey federator1Key = new BtcECKey();
         BtcECKey federator2Key = new BtcECKey();
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -566,10 +572,13 @@ class BridgeUtilsTest {
         // Arrange
         BtcECKey federator1Key = new BtcECKey();
         BtcECKey federator2Key = new BtcECKey();
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1Key, federator2Key)),
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -912,10 +921,13 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -928,10 +940,13 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -953,10 +968,13 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -978,10 +996,13 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -1006,10 +1027,13 @@ class BridgeUtilsTest {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -1047,10 +1071,13 @@ class BridgeUtilsTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+            args,
             networkParameters,
             erpFederationPublicKeys,
             500L,
@@ -1091,10 +1118,13 @@ class BridgeUtilsTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+            args,
             networkParameters,
             erpFederationPublicKeys,
             500L,
@@ -1125,10 +1155,13 @@ class BridgeUtilsTest {
         BtcECKey key2 = new BtcECKey();
         BtcECKey key3 = new BtcECKey();
         List<BtcECKey> keys = Arrays.asList(key1, key2, key3);
-        Federation fed = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(keys),
             Instant.now(),
-            0,
+            0
+        );
+        Federation fed = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -1169,10 +1202,13 @@ class BridgeUtilsTest {
                     BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
                 )
             );
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             federationMembers,
             Instant.ofEpochMilli(5005L),
-            0L,
+            0L
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters);
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(networkParameters);
@@ -1206,10 +1242,13 @@ class BridgeUtilsTest {
                     BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"))
                 )
             );
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             federationMembers,
             Instant.ofEpochMilli(5005L),
-            0L,
+            0L
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters);
         Context mockedBtcContext = mock(Context.class);
         when(mockedBtcContext.getParams()).thenReturn(networkParameters);
@@ -1434,10 +1473,13 @@ class BridgeUtilsTest {
 
     private ErpFederation createErpFederation() {
         Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
-        return FederationFactory.buildNonStandardErpFederation(
+        FederationArgs args = new FederationArgs(
             genesisFederation.getMembers(),
             genesisFederation.getCreationTime(),
-            genesisFederation.getCreationBlockNumber(),
+            genesisFederation.getCreationBlockNumber()
+        );
+        return FederationFactory.buildNonStandardErpFederation(
+            args,
             genesisFederation.getBtcParams(),
             bridgeConstantsRegtest.getErpFedPubKeysList(),
             bridgeConstantsRegtest.getErpFedActivationDelay(),

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1474,14 +1474,11 @@ class BridgeUtilsTest {
 
     private ErpFederation createErpFederation() {
         Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
-            genesisFederation.getMembers(),
-            genesisFederation.getCreationTime(),
-            genesisFederation.getCreationBlockNumber(),
-            genesisFederation.getBtcParams(),
-            bridgeConstantsRegtest.getErpFedPubKeysList(),
-            bridgeConstantsRegtest.getErpFedActivationDelay()
-        );
+        FederationArgs genesisFederationArgs = genesisFederation.getArgs();
+        List<BtcECKey> erpPubKeys = bridgeConstantsRegtest.getErpFedPubKeysList();
+        long activationDelay = bridgeConstantsRegtest.getErpFedActivationDelay();
+
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(genesisFederationArgs, erpPubKeys, activationDelay);
         return FederationFactory.buildNonStandardErpFederation(
             erpFederationArgs,
             activations

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -163,12 +163,12 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void hasEnoughSignatures_several_inputs_all_signed_erp_fed() {
+    void hasEnoughSignatures_several_inputs_all_signed_non_standard_erp_fed() {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createErpFederation();
+        Federation erpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTx(
             Arrays.asList(sign1, sign2),
             3,
@@ -195,12 +195,12 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void hasEnoughSignatures_several_inputs_all_signed_erp_fast_bridge() {
+    void hasEnoughSignatures_several_inputs_all_signed_non_standard_erp_fast_bridge() {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createErpFederation();
+        Federation erpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTxForFlyover(
             Arrays.asList(sign1, sign2),
             3,
@@ -256,12 +256,12 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void countMissingSignatures_several_inputs_all_signed_erp_fed() {
+    void countMissingSignatures_several_inputs_all_signed_non_standard_erp_fed() {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createErpFederation();
+        Federation erpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTx(
             Arrays.asList(sign1, sign2),
             3,
@@ -288,12 +288,12 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void countMissingSignatures_several_inputs_all_signed_erp_fast_bridge() {
+    void countMissingSignatures_several_inputs_all_signed_non_standard_erp_fast_bridge() {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createErpFederation();
+        Federation erpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTxForFlyover(
             Arrays.asList(sign1, sign2),
             3,
@@ -1053,7 +1053,7 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void testCalculatePegoutTxSize_50Inputs_200Outputs_erpFederation() {
+    void testCalculatePegoutTxSize_50Inputs_200Outputs_nonStandardErpFederation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
@@ -1079,7 +1079,7 @@ class BridgeUtilsTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpFederationArgs,
             activations
         );
@@ -1087,9 +1087,9 @@ class BridgeUtilsTest {
         // Create a pegout tx with 50 inputs and 200 outputs
         int inputSize = 50;
         int outputSize = 200;
-        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, erpFederation, defaultFederationKeys);
+        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, nonStandardErpFederation, defaultFederationKeys);
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, erpFederation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, nonStandardErpFederation, inputSize, outputSize);
 
         // The difference between the calculated size and a real tx size should be smaller than 3% in any direction
         int origTxSize = pegoutTx.bitcoinSerialize().length;
@@ -1100,7 +1100,7 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void testCalculatePegoutTxSize_100Inputs_50Outputs_erpFederation() {
+    void testCalculatePegoutTxSize_100Inputs_50Outputs_nonStandardErpFederation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
@@ -1126,7 +1126,7 @@ class BridgeUtilsTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpFederationArgs,
             activations
         );
@@ -1134,9 +1134,9 @@ class BridgeUtilsTest {
         // Create a pegout tx with 100 inputs and 50 outputs
         int inputSize = 100;
         int outputSize = 50;
-        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, erpFederation, defaultFederationKeys);
+        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, nonStandardErpFederation, defaultFederationKeys);
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, erpFederation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, nonStandardErpFederation, inputSize, outputSize);
 
         // The difference between the calculated size and a real tx size should be smaller than 3% in any direction
         int origTxSize = pegoutTx.bitcoinSerialize().length;
@@ -1472,7 +1472,7 @@ class BridgeUtilsTest {
         return new TestGenesisLoader(trieStore, "frontier.json", constants.getInitialNonce(), false, true, true).load();
     }
 
-    private ErpFederation createErpFederation() {
+    private ErpFederation createNonStandardErpFederation() {
         Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
         FederationArgs genesisFederationArgs = genesisFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstantsRegtest.getErpFedPubKeysList();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -168,11 +168,11 @@ class BridgeUtilsTest {
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createNonStandardErpFederation();
+        ErpFederation nonStandardErpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTx(
             Arrays.asList(sign1, sign2),
             3,
-            erpFederation,
+            nonStandardErpFederation,
             false
         );
 
@@ -200,11 +200,11 @@ class BridgeUtilsTest {
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createNonStandardErpFederation();
+        ErpFederation nonStandardErpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTxForFlyover(
             Arrays.asList(sign1, sign2),
             3,
-            erpFederation
+            nonStandardErpFederation
         );
 
         Assertions.assertTrue(BridgeUtils.hasEnoughSignatures(mock(Context.class), btcTx));
@@ -261,11 +261,11 @@ class BridgeUtilsTest {
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createNonStandardErpFederation();
+        ErpFederation nonStandardErpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTx(
             Arrays.asList(sign1, sign2),
             3,
-            erpFederation,
+            nonStandardErpFederation,
             false
         );
 
@@ -293,11 +293,11 @@ class BridgeUtilsTest {
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createNonStandardErpFederation();
+        ErpFederation nonStandardErpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTxForFlyover(
             Arrays.asList(sign1, sign2),
             3,
-            erpFederation
+            nonStandardErpFederation
         );
 
         Assertions.assertEquals(0, BridgeUtils.countMissingSignatures(mock(Context.class), btcTx));

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -171,10 +171,10 @@ class FederationSupportTest {
             new FederationMember(btcKey0, rskKey0, mstKey0),
             new FederationMember(btcKey1, rskKey1, mstKey1)
         );
-        FederationArgs args = new FederationArgs(members, Instant.ofEpochMilli(123), 456,
+        FederationArgs federationArgs = new FederationArgs(members, Instant.ofEpochMilli(123), 456,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Federation theFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
         when(provider.getNewFederation()).thenReturn(theFederation);
 
@@ -244,14 +244,14 @@ class FederationSupportTest {
             true
         );
         List<FederationMember> members = FederationTestUtils.getFederationMembersWithBtcKeys(keys);
-        FederationArgs args = new FederationArgs(members,
+        FederationArgs federationArgs = new FederationArgs(members,
             Instant.ofEpochMilli(123),
             creationBlockNumber,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         return FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -23,10 +23,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.federation.FederationTestUtils;
+import co.rsk.peg.federation.*;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
@@ -170,11 +167,13 @@ class FederationSupportTest {
         ECKey rskKey1 = new ECKey();
         ECKey mstKey1 = new ECKey();
 
+        List<FederationMember> members = Arrays.asList(
+            new FederationMember(btcKey0, rskKey0, mstKey0),
+            new FederationMember(btcKey1, rskKey1, mstKey1)
+        );
+        FederationArgs args = new FederationArgs(members, Instant.ofEpochMilli(123), 456);
         Federation theFederation = FederationFactory.buildStandardMultiSigFederation(
-            Arrays.asList(
-                new FederationMember(btcKey0, rskKey0, mstKey0),
-                new FederationMember(btcKey1, rskKey1, mstKey1)
-            ), Instant.ofEpochMilli(123), 456,
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         when(provider.getNewFederation()).thenReturn(theFederation);
@@ -245,11 +244,12 @@ class FederationSupportTest {
             true
         );
         List<FederationMember> members = FederationTestUtils.getFederationMembersWithBtcKeys(keys);
+        FederationArgs args = new FederationArgs(members,
+            Instant.ofEpochMilli(123),
+            creationBlockNumber);
 
         return FederationFactory.buildStandardMultiSigFederation(
-            members,
-            Instant.ofEpochMilli(123),
-            creationBlockNumber,
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -171,10 +171,10 @@ class FederationSupportTest {
             new FederationMember(btcKey0, rskKey0, mstKey0),
             new FederationMember(btcKey1, rskKey1, mstKey1)
         );
-        FederationArgs args = new FederationArgs(members, Instant.ofEpochMilli(123), 456);
+        FederationArgs args = new FederationArgs(members, Instant.ofEpochMilli(123), 456,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         Federation theFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
         when(provider.getNewFederation()).thenReturn(theFederation);
 
@@ -246,11 +246,12 @@ class FederationSupportTest {
         List<FederationMember> members = FederationTestUtils.getFederationMembersWithBtcKeys(keys);
         FederationArgs args = new FederationArgs(members,
             Instant.ofEpochMilli(123),
-            creationBlockNumber);
+            creationBlockNumber,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
 
         return FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -36,8 +36,8 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
     }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
     private Federation federation;
-    private ErpFederation erpFederation;
-    private List<Federation> federationList;
+    private ErpFederation nonStandardErpFederation;
+    private List<Federation> nonStandardErpFederationList;
     private List<Federation> erpFederationList;
 
     @BeforeEach
@@ -51,10 +51,10 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         long activationDelay = 5063;
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, activationDelay);
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        federationList = Collections.singletonList(federation);
-        erpFederationList = Collections.singletonList(erpFederation);
+        nonStandardErpFederationList = Collections.singletonList(federation);
+        erpFederationList = Collections.singletonList(nonStandardErpFederation);
     }
 
     @Test
@@ -63,7 +63,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         when(provider.getFlyoverFederationInformation(any(byte[].class))).thenReturn(Optional.empty());
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage = new FlyoverCompatibleBtcWalletWithStorage(
-            mock(Context.class), federationList, provider);
+            mock(Context.class), nonStandardErpFederationList, provider);
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(
             federation.getP2SHScript().getPubKeyHash());
@@ -93,7 +93,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
             .thenReturn(Optional.of(flyoverFederationInformation));
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage = new FlyoverCompatibleBtcWalletWithStorage(
-            mock(Context.class), federationList, provider
+            mock(Context.class), nonStandardErpFederationList, provider
         );
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(flyoverFederationP2SH);
@@ -103,13 +103,13 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
     }
 
     @Test
-    void findRedeemDataFromScriptHash_with_flyoverInformation_in_storage_and_erp_fed() {
+    void findRedeemDataFromScriptHash_with_flyoverInformation_in_storage_and_non_standard_erp_fed() {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Keccak256 derivationArgumentsHash = PegTestUtils.createHash3(1);
 
         Script flyoverRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
-            Sha256Hash.wrap(derivationArgumentsHash.getBytes()
+                nonStandardErpFederation.getRedeemScript(),
+                Sha256Hash.wrap(derivationArgumentsHash.getBytes()
             )
         );
 
@@ -119,7 +119,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         FlyoverFederationInformation flyoverFederationInformation =
             new FlyoverFederationInformation(
                 derivationArgumentsHash,
-                erpFederation.getP2SHScript().getPubKeyHash(),
+                nonStandardErpFederation.getP2SHScript().getPubKeyHash(),
                 flyoverFederationP2SH);
 
         when(provider.getFlyoverFederationInformation(flyoverFederationP2SH))
@@ -154,7 +154,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         );
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage =
-            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), federationList, provider);
+            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), nonStandardErpFederationList, provider);
 
         Assertions.assertNull(flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(new byte[]{1}));
     }
@@ -174,7 +174,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         );
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage =
-            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), federationList, provider);
+            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), nonStandardErpFederationList, provider);
 
         Optional<FlyoverFederationInformation> result = flyoverCompatibleBtcWalletWithStorage.
             getFlyoverFederationInformation(flyoverScriptHash);
@@ -191,7 +191,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         );
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage =
-            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), federationList, provider);
+            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), nonStandardErpFederationList, provider);
 
         Optional<FlyoverFederationInformation> result = flyoverCompatibleBtcWalletWithStorage.
             getFlyoverFederationInformation(new byte[1]);

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -49,8 +49,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         long activationDelay = 5063;
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000), 0L, btcParams,
-            erpFedKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, activationDelay);
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -42,22 +42,17 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
 
     @BeforeEach
     void setup() {
+        List<FederationMember> fedMembers = FederationTestUtils.getFederationMembers(3);
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(3),
-            Instant.ofEpochMilli(1000),
-            0L);
-        federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
+        FederationArgs federationArgs = new FederationArgs(fedMembers, Instant.ofEpochMilli(1000), 0L, btcParams);
+        federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-        erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST),
-            erpFedKeys,
-            5063,
-            mock(ActivationConfig.ForBlock.class)
-        );
+        long activationDelay = 5063;
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000), 0L, btcParams,
+            erpFedKeys, activationDelay);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         federationList = Collections.singletonList(federation);
         erpFederationList = Collections.singletonList(erpFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -43,17 +43,16 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
     @BeforeEach
     void setup() {
 
-        federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembers(3),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L,
+            0L);
+        federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
         erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationTestUtils.getFederationMembers(3),
-            Instant.ofEpochMilli(1000),
-            0L,
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST),
             erpFedKeys,
             5063,

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -37,8 +37,8 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
 
     private Federation federation;
     private ErpFederation nonStandardErpFederation;
+    private List<Federation> federationList;
     private List<Federation> nonStandardErpFederationList;
-    private List<Federation> erpFederationList;
 
     @BeforeEach
     void setup() {
@@ -47,14 +47,13 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
 
         FederationArgs federationArgs = new FederationArgs(fedMembers, Instant.ofEpochMilli(1000), 0L, btcParams);
         federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        federationList = Collections.singletonList(federation);
 
         long activationDelay = 5063;
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, activationDelay);
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-
-        nonStandardErpFederationList = Collections.singletonList(federation);
-        erpFederationList = Collections.singletonList(nonStandardErpFederation);
+        nonStandardErpFederationList = Collections.singletonList(nonStandardErpFederation);
     }
 
     @Test
@@ -63,7 +62,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         when(provider.getFlyoverFederationInformation(any(byte[].class))).thenReturn(Optional.empty());
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage = new FlyoverCompatibleBtcWalletWithStorage(
-            mock(Context.class), nonStandardErpFederationList, provider);
+            mock(Context.class), federationList, provider);
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(
             federation.getP2SHScript().getPubKeyHash());
@@ -93,7 +92,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
             .thenReturn(Optional.of(flyoverFederationInformation));
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage = new FlyoverCompatibleBtcWalletWithStorage(
-            mock(Context.class), nonStandardErpFederationList, provider
+            mock(Context.class), federationList, provider
         );
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(flyoverFederationP2SH);
@@ -128,7 +127,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage =
             new FlyoverCompatibleBtcWalletWithStorage(
                 mock(Context.class),
-                erpFederationList,
+                nonStandardErpFederationList,
                 provider
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -41,14 +41,14 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
     @BeforeEach
     void setup() {
 
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
             0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         activations = mock(ActivationConfig.ForBlock.class);
@@ -57,7 +57,7 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs erpArgs = new ErpFederationArgs(
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
             0L,
@@ -66,7 +66,7 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
             5063
         );
         erpFederation = FederationFactory.buildNonStandardErpFederation(
-            erpArgs,
+            erpFederationArgs,
             activations
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -41,15 +41,11 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
     @BeforeEach
     void setup() {
 
-        FederationArgs federationArgs = new FederationArgs(
-            FederationTestUtils.getFederationMembers(3),
-            Instant.ofEpochMilli(1000),
-            0L,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
-        federation = FederationFactory.buildStandardMultiSigFederation(
-            federationArgs
-        );
+        List<FederationMember> fedMembers = FederationTestUtils.getFederationMembers(3);
+        Instant creationTime = Instant.ofEpochMilli(1000);
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+        FederationArgs federationArgs = new FederationArgs(fedMembers, creationTime, 0L, btcParams);
+        federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
@@ -57,18 +53,8 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
-            FederationTestUtils.getFederationMembers(3),
-            Instant.ofEpochMilli(1000),
-            0L,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST),
-            erpFedKeys,
-            5063
-        );
-        erpFederation = FederationFactory.buildNonStandardErpFederation(
-            erpFederationArgs,
-            activations
-        );
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, 5063);
+        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         federationList = Collections.singletonList(federation);
         erpFederationList = Collections.singletonList(erpFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -44,11 +44,11 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
 
         activations = mock(ActivationConfig.ForBlock.class);
@@ -56,11 +56,17 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
-        erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
+
+        ErpFederationArgs erpArgs = new ErpFederationArgs(
+            FederationTestUtils.getFederationMembers(3),
+            Instant.ofEpochMilli(1000),
+            0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST),
             erpFedKeys,
-            5063,
+            5063
+        );
+        erpFederation = FederationFactory.buildNonStandardErpFederation(
+            erpArgs,
             activations
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -41,10 +41,13 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
     @BeforeEach
     void setup() {
 
-        federation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
-            0L,
+            0L
+        );
+        federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -54,9 +57,7 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
         erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationTestUtils.getFederationMembers(3),
-            Instant.ofEpochMilli(1000),
-            0L,
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST),
             erpFedKeys,
             5063,

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -40,13 +40,15 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
 
     @BeforeEach
     void setup() {
-
+        // set up standard multisig federation
         List<FederationMember> fedMembers = FederationTestUtils.getFederationMembers(3);
         Instant creationTime = Instant.ofEpochMilli(1000);
         NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         FederationArgs federationArgs = new FederationArgs(fedMembers, creationTime, 0L, btcParams);
         federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        federationList = Collections.singletonList(federation);
 
+        // set up non-standard erp federation
         activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -55,8 +57,6 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
 
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, 5063);
         nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-
-        federationList = Collections.singletonList(federation);
         nonStandardErpFederationList = Collections.singletonList(nonStandardErpFederation);
     }
 
@@ -101,7 +101,7 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
     }
 
     @Test
-    void findRedeemDataFromScriptHash_with_flyoverInformation_and_erp_federation() {
+    void findRedeemDataFromScriptHash_with_flyoverInformation_and_non_standard_erp_federation() {
         byte[] flyoverScriptHash = new byte[]{(byte)0x22};
         FlyoverFederationInformation flyoverFederationInformation =
             new FlyoverFederationInformation(

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -33,9 +33,9 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
     }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
     private Federation federation;
-    private ErpFederation erpFederation;
+    private ErpFederation nonStandardErpFederation;
     private List<Federation> federationList;
-    private List<Federation> erpFederationList;
+    private List<Federation> nonStandardErpFederationList;
     private ActivationConfig.ForBlock activations;
 
     @BeforeEach
@@ -54,10 +54,10 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, 5063);
-        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         federationList = Collections.singletonList(federation);
-        erpFederationList = Collections.singletonList(erpFederation);
+        nonStandardErpFederationList = Collections.singletonList(nonStandardErpFederation);
     }
 
     @Test
@@ -106,20 +106,20 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         FlyoverFederationInformation flyoverFederationInformation =
             new FlyoverFederationInformation(
                 PegTestUtils.createHash3(2),
-                erpFederation.getP2SHScript().getPubKeyHash(),
+                nonStandardErpFederation.getP2SHScript().getPubKeyHash(),
                 flyoverScriptHash);
 
         FlyoverCompatibleBtcWalletWithSingleScript flyoverCompatibleBtcWalletWithSingleScript =
             new FlyoverCompatibleBtcWalletWithSingleScript(
                 mock(Context.class),
-                erpFederationList,
+                nonStandardErpFederationList,
                 flyoverFederationInformation);
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithSingleScript.findRedeemDataFromScriptHash(
-            erpFederation.getP2SHScript().getPubKeyHash());
+            nonStandardErpFederation.getP2SHScript().getPubKeyHash());
 
         Script flyoverRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             Sha256Hash.wrap(flyoverFederationInformation.getDerivationHash().getBytes())
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -26,10 +26,7 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.config.BridgeConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.federation.ErpFederation;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationTestUtils;
+import co.rsk.peg.federation.*;
 import co.rsk.peg.simples.SimpleRskTransaction;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Transaction;
@@ -302,20 +299,22 @@ public final class PegTestUtils {
 
     public static Federation createFederation(BridgeConstants bridgeConstants, List<BtcECKey> federationKeys) {
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        return FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        return FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstants.getBtcParams()
         );
     }
 
     public static ErpFederation createP2shErpFederation(BridgeConstants bridgeConstants, List<BtcECKey> federationKeys) {
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        return FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        return FederationFactory.buildP2shErpFederation(
+            args,
             bridgeConstants.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay()

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -300,19 +300,23 @@ public final class PegTestUtils {
     public static Federation createFederation(BridgeConstants bridgeConstants, List<BtcECKey> federationKeys) {
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys);
+        Instant creationTime = Instant.ofEpochMilli(1000L);
         NetworkParameters btcParams = bridgeConstants.getBtcParams();
-        FederationArgs federationArgs = new FederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcParams);
+
+        FederationArgs federationArgs = new FederationArgs(fedMembers, creationTime, 0L, btcParams);
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
     public static ErpFederation createP2shErpFederation(BridgeConstants bridgeConstants, List<BtcECKey> federationKeys) {
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys);
+        Instant creationTime = Instant.ofEpochMilli(1000L);
         NetworkParameters btcParams = bridgeConstants.getBtcParams();
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcParams,
-                erpPubKeys, activationDelay);
+
+        ErpFederationArgs erpFederationArgs = new
+            ErpFederationArgs(fedMembers, creationTime, 0L, btcParams, erpPubKeys, activationDelay);
         return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -299,26 +299,21 @@ public final class PegTestUtils {
 
     public static Federation createFederation(BridgeConstants bridgeConstants, List<BtcECKey> federationKeys) {
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L);
-        return FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeConstants.getBtcParams()
-        );
+        List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys);
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        FederationArgs args = new FederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcParams);
+        return FederationFactory.buildStandardMultiSigFederation(args);
     }
 
     public static ErpFederation createP2shErpFederation(BridgeConstants bridgeConstants, List<BtcECKey> federationKeys) {
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L);
-        return FederationFactory.buildP2shErpFederation(
-            args,
-            bridgeConstants.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay()
-        );
+        List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys);
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcParams,
+                erpPubKeys, activationDelay);
+        return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
 
     public static BtcTransaction createBtcTransactionWithOutputToAddress(NetworkParameters networkParameters, Coin amount, Address btcAddress) {

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -301,8 +301,8 @@ public final class PegTestUtils {
         federationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys);
         NetworkParameters btcParams = bridgeConstants.getBtcParams();
-        FederationArgs args = new FederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcParams);
-        return FederationFactory.buildStandardMultiSigFederation(args);
+        FederationArgs federationArgs = new FederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcParams);
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
     public static ErpFederation createP2shErpFederation(BridgeConstants bridgeConstants, List<BtcECKey> federationKeys) {

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -63,7 +63,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
             federator3PublicKey, federator4PublicKey, federator5PublicKey,
             federator6PublicKey, federator7PublicKey, federator8PublicKey
         );
-        ErpFederationArgs activeFedArgs = new ErpFederationArgs(
+        ErpFederationArgs activeErpFedArgs = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys),
             bridgeMainnetConstants.getGenesisFederation().getCreationTime(),
             5L,
@@ -74,14 +74,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
 
         // Arrange
         ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
-            activeFedArgs
+            activeErpFedArgs
         );
 
         List<BtcECKey> fedKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        ErpFederationArgs retiringFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
+        ErpFederationArgs retiringErpFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
             0L,
             btcMainnetParams,
@@ -89,7 +89,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
             bridgeMainnetConstants.getErpFedActivationDelay()
         );
         ErpFederation p2shRetiringFederation = FederationFactory.buildP2shErpFederation(
-            retiringFedArgs
+            retiringErpFedArgs
         );
 
         // Create a migrationTx from the p2sh erp fed
@@ -138,12 +138,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
         );
 
         // Arrange
-        FederationArgs args = new FederationArgs(bridgeRegTestConstants.getGenesisFederation().getMembers(),
+        FederationArgs federationArgs = new FederationArgs(
+            bridgeRegTestConstants.getGenesisFederation().getMembers(),
             bridgeRegTestConstants.getGenesisFederation().getCreationTime(),
             5L,
-            bridgeRegTestConstants.getGenesisFederation().getBtcParams());
+            bridgeRegTestConstants.getGenesisFederation().getBtcParams()
+        );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         Federation retiredFederation = createFederation(bridgeRegTestConstants, REGTEST_OLD_FEDERATION_PRIVATE_KEYS);
@@ -343,7 +345,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa04", "fa05", "fa06"}, true
         );
 
-        ErpFederationArgs args = new ErpFederationArgs(
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(activeFedKeys),
             Instant.ofEpochMilli(1000L),
             0L,
@@ -352,7 +354,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
             100L
         );
         ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
-            args
+            erpFederationArgs
         );
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
@@ -384,13 +386,13 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
             0L,
             btcMainnetParams
         );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         // Create a pegoutBtcTx from active fed to a user btc address
@@ -429,14 +431,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys),
             Instant.ofEpochMilli(1000L),
             0L,
             btcMainnetParams
         );
         Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         BtcTransaction migrationTx = new BtcTransaction(btcMainnetParams);
@@ -470,13 +472,13 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys),
+        FederationArgs federationArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys),
             Instant.ofEpochMilli(1000L),
             0L,
             btcMainnetParams
         );
         Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         List<BtcECKey> activeFedKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -7,10 +7,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
-import co.rsk.peg.federation.ErpFederation;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationTestUtils;
+import co.rsk.peg.federation.*;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
@@ -66,12 +63,15 @@ class PegUtilsLegacyGetTransactionTypeTest {
             federator3PublicKey, federator4PublicKey, federator5PublicKey,
             federator6PublicKey, federator7PublicKey, federator8PublicKey
         );
+        FederationArgs activeFedArgs = new FederationArgs(
+            FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys),
+            bridgeMainnetConstants.getGenesisFederation().getCreationTime(),
+            5L
+        );
 
         // Arrange
         ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys),
-            bridgeMainnetConstants.getGenesisFederation().getCreationTime(),
-            5L,
+            activeFedArgs,
             bridgeMainnetConstants.getGenesisFederation().getBtcParams(),
             bridgeMainnetConstants.getErpFedPubKeysList(),
             bridgeMainnetConstants.getErpFedActivationDelay()
@@ -81,10 +81,11 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        ErpFederation p2shRetiringFederation = FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
+        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        ErpFederation p2shRetiringFederation = FederationFactory.buildP2shErpFederation(
+            retiringFedArgs,
             btcMainnetParams,
             bridgeMainnetConstants.getErpFedPubKeysList(),
             bridgeMainnetConstants.getErpFedActivationDelay()
@@ -136,10 +137,11 @@ class PegUtilsLegacyGetTransactionTypeTest {
         );
 
         // Arrange
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            bridgeRegTestConstants.getGenesisFederation().getMembers(),
+        FederationArgs args = new FederationArgs(bridgeRegTestConstants.getGenesisFederation().getMembers(),
             bridgeRegTestConstants.getGenesisFederation().getCreationTime(),
-            5L,
+            5L);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeRegTestConstants.getGenesisFederation().getBtcParams()
         );
 
@@ -340,10 +342,12 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa04", "fa05", "fa06"}, true
         );
 
-        ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(activeFedKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
+            args,
             btcMainnetParams,
             erpFedKeys,
             100L
@@ -378,10 +382,11 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             btcMainnetParams
         );
 
@@ -419,12 +424,15 @@ class PegUtilsLegacyGetTransactionTypeTest {
 
         List<BtcECKey> retiringFedKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
-        );;
+        );
 
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             btcMainnetParams
         );
 
@@ -459,10 +467,11 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             btcMainnetParams
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -63,32 +63,33 @@ class PegUtilsLegacyGetTransactionTypeTest {
             federator3PublicKey, federator4PublicKey, federator5PublicKey,
             federator6PublicKey, federator7PublicKey, federator8PublicKey
         );
-        FederationArgs activeFedArgs = new FederationArgs(
+        ErpFederationArgs activeFedArgs = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys),
             bridgeMainnetConstants.getGenesisFederation().getCreationTime(),
-            5L
+            5L,
+            bridgeMainnetConstants.getGenesisFederation().getBtcParams(),
+            bridgeMainnetConstants.getErpFedPubKeysList(),
+            bridgeMainnetConstants.getErpFedActivationDelay()
         );
 
         // Arrange
         ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
-            activeFedArgs,
-            bridgeMainnetConstants.getGenesisFederation().getBtcParams(),
-            bridgeMainnetConstants.getErpFedPubKeysList(),
-            bridgeMainnetConstants.getErpFedActivationDelay()
+            activeFedArgs
         );
 
         List<BtcECKey> fedKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
+        ErpFederationArgs retiringFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
-            0L);
-        ErpFederation p2shRetiringFederation = FederationFactory.buildP2shErpFederation(
-            retiringFedArgs,
+            0L,
             btcMainnetParams,
             bridgeMainnetConstants.getErpFedPubKeysList(),
             bridgeMainnetConstants.getErpFedActivationDelay()
+        );
+        ErpFederation p2shRetiringFederation = FederationFactory.buildP2shErpFederation(
+            retiringFedArgs
         );
 
         // Create a migrationTx from the p2sh erp fed
@@ -139,10 +140,10 @@ class PegUtilsLegacyGetTransactionTypeTest {
         // Arrange
         FederationArgs args = new FederationArgs(bridgeRegTestConstants.getGenesisFederation().getMembers(),
             bridgeRegTestConstants.getGenesisFederation().getCreationTime(),
-            5L);
+            5L,
+            bridgeRegTestConstants.getGenesisFederation().getBtcParams());
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            bridgeRegTestConstants.getGenesisFederation().getBtcParams()
+            args
         );
 
         Federation retiredFederation = createFederation(bridgeRegTestConstants, REGTEST_OLD_FEDERATION_PRIVATE_KEYS);
@@ -342,15 +343,16 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa04", "fa05", "fa06"}, true
         );
 
-        FederationArgs args = new FederationArgs(
+        ErpFederationArgs args = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(activeFedKeys),
             Instant.ofEpochMilli(1000L),
-            0L);
-        ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
-            args,
+            0L,
             btcMainnetParams,
             erpFedKeys,
             100L
+        );
+        ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
@@ -384,10 +386,11 @@ class PegUtilsLegacyGetTransactionTypeTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
             Instant.ofEpochMilli(1000L),
-            0L);
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
+            0L,
             btcMainnetParams
+        );
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            args
         );
 
         // Create a pegoutBtcTx from active fed to a user btc address
@@ -429,11 +432,11 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys),
             Instant.ofEpochMilli(1000L),
-            0L
+            0L,
+            btcMainnetParams
         );
         Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            btcMainnetParams
+            args
         );
 
         BtcTransaction migrationTx = new BtcTransaction(btcMainnetParams);
@@ -469,10 +472,11 @@ class PegUtilsLegacyGetTransactionTypeTest {
 
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys),
             Instant.ofEpochMilli(1000L),
-            0L);
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
+            0L,
             btcMainnetParams
+        );
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+            args
         );
 
         List<BtcECKey> activeFedKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -63,31 +63,26 @@ class PegUtilsLegacyGetTransactionTypeTest {
             federator3PublicKey, federator4PublicKey, federator5PublicKey,
             federator6PublicKey, federator7PublicKey, federator8PublicKey
         );
-        ErpFederationArgs activeErpFedArgs = new ErpFederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys),
-            bridgeMainnetConstants.getGenesisFederation().getCreationTime(),
-            5L,
-            bridgeMainnetConstants.getGenesisFederation().getBtcParams(),
-            bridgeMainnetConstants.getErpFedPubKeysList(),
-            bridgeMainnetConstants.getErpFedActivationDelay()
-        );
+
+        List<FederationMember> federationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys);
+        Federation genesisFederation = bridgeMainnetConstants.getGenesisFederation();
+        List<BtcECKey> erpPubKeys = bridgeMainnetConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeMainnetConstants.getErpFedActivationDelay();
+
+        ErpFederationArgs activeErpFedArgs =
+            new ErpFederationArgs(federationMembers, genesisFederation.getCreationTime(), 5L, btcMainnetParams, erpPubKeys, activationDelay);
 
         // Arrange
-        ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
-            activeErpFedArgs
-        );
+        ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(activeErpFedArgs);
 
         List<BtcECKey> fedKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
         );
 
-        ErpFederationArgs retiringErpFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            btcMainnetParams,
-            bridgeMainnetConstants.getErpFedPubKeysList(),
-            bridgeMainnetConstants.getErpFedActivationDelay()
-        );
+        List<FederationMember> retiringFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(fedKeys);
+        Instant creationTime = Instant.ofEpochMilli(1000L);
+        ErpFederationArgs retiringErpFedArgs =
+            new ErpFederationArgs(retiringFedMembers, creationTime, 0L, btcMainnetParams, erpPubKeys, activationDelay);
         ErpFederation p2shRetiringFederation = FederationFactory.buildP2shErpFederation(
             retiringErpFedArgs
         );
@@ -345,17 +340,11 @@ class PegUtilsLegacyGetTransactionTypeTest {
             new String[]{"fa04", "fa05", "fa06"}, true
         );
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFedKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            btcMainnetParams,
-            erpFedKeys,
-            100L
-        );
-        ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(
-            erpFederationArgs
-        );
+        List<FederationMember> activeFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFedKeys);
+        Instant creationTime = Instant.ofEpochMilli(1000L);
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(activeFedMembers, creationTime, 0L, btcMainnetParams, erpFedKeys, 100L);
+        ErpFederation activeFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -530,6 +530,7 @@ class PegUtilsLegacyTest {
         Context btcContext = new Context(networkParameters);
 
         Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        FederationArgs federationArgs = activeFederation.getArgs();
 
         List<BtcECKey> erpPubKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
@@ -538,7 +539,7 @@ class PegUtilsLegacyTest {
         erpPubKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         long activationDelay = 500L;
 
-        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(activeFederation.getArgs(), erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         Script redeemScript = erpFederation.getRedeemScript();
@@ -794,15 +795,15 @@ class PegUtilsLegacyTest {
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         List<FederationMember> retiredFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys);
 
-        FederationArgs federationArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        FederationArgs retiredFederationArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(retiredFederationArgs);
 
         List<BtcECKey> erpFederationPublicKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
             BtcECKey.fromPrivate(Hex.decode("fa04"))
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFederationPublicKeys, 500L);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(retiredFederationArgs, erpFederationPublicKeys, 500L);
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired fast bridge fed to the active fed
@@ -847,8 +848,8 @@ class PegUtilsLegacyTest {
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         
         List<FederationMember> retiredFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys);
-        FederationArgs federationArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        FederationArgs retiredFederationArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(retiredFederationArgs);
 
         List<BtcECKey> erpFederationPublicKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
@@ -856,7 +857,7 @@ class PegUtilsLegacyTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFederationPublicKeys, 500L);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(retiredFederationArgs, erpFederationPublicKeys, 500L);
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired fast bridge fed to the active fed

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -37,6 +37,7 @@ class PegUtilsLegacyTest {
     private BridgeConstants bridgeConstantsRegtest;
     private BridgeConstants bridgeConstantsMainnet;
     private NetworkParameters networkParameters;
+    private final Instant creationTime = Instant.ofEpochMilli(1000L);
 
     @BeforeEach
     void setupConfig() {
@@ -210,7 +211,7 @@ class PegUtilsLegacyTest {
         );
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
         List<FederationMember> fed1Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys);
-        FederationArgs federation1Args = new FederationArgs(fed1Members, Instant.ofEpochMilli(1000L), 0L, btcParams);
+        FederationArgs federation1Args = new FederationArgs(fed1Members, creationTime, 0L, btcParams);
         Federation federation1 = FederationFactory.buildStandardMultiSigFederation(federation1Args);
 
         List<BtcECKey> federation2Keys = Arrays.asList(
@@ -220,7 +221,7 @@ class PegUtilsLegacyTest {
         );
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
         List<FederationMember> fed2Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys);
-        FederationArgs federation2Args = new FederationArgs(fed2Members, Instant.ofEpochMilli(1000L), 0L, btcParams);
+        FederationArgs federation2Args = new FederationArgs(fed2Members, creationTime, 0L, btcParams);
         Federation federation2 = FederationFactory.buildStandardMultiSigFederation(federation2Args);
 
         Address address1 = federation1.getAddress();
@@ -527,10 +528,9 @@ class PegUtilsLegacyTest {
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
         Context btcContext = new Context(networkParameters);
-        NetworkParameters btcParams = btcContext.getParams();
 
         Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
-        List<FederationMember> fedMembers = activeFederation.getMembers();
+
         List<BtcECKey> erpPubKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
@@ -538,8 +538,7 @@ class PegUtilsLegacyTest {
         erpPubKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         long activationDelay = 500L;
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(activeFederation.getArgs(), erpPubKeys, activationDelay);
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         Script redeemScript = erpFederation.getRedeemScript();
@@ -577,7 +576,7 @@ class PegUtilsLegacyTest {
         erpFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         List<FederationMember> erpFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys);
-        FederationArgs args = new FederationArgs(erpFedMembers, Instant.ofEpochMilli(1000L), 0L, networkParameters);
+        FederationArgs args = new FederationArgs(erpFedMembers, creationTime, 0L, networkParameters);
         Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
@@ -619,7 +618,7 @@ class PegUtilsLegacyTest {
         erpFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             0L,
             networkParameters
         );
@@ -657,7 +656,7 @@ class PegUtilsLegacyTest {
         erpFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             0L,
             networkParameters
         );
@@ -695,7 +694,7 @@ class PegUtilsLegacyTest {
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             0L,
             networkParameters
         );
@@ -745,7 +744,7 @@ class PegUtilsLegacyTest {
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             0L,
             networkParameters
         );
@@ -793,29 +792,17 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs args = new FederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters
-        );
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+        List<FederationMember> retiredFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys);
+
+        FederationArgs federationArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         List<BtcECKey> erpFederationPublicKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
             BtcECKey.fromPrivate(Hex.decode("fa04"))
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters,
-            erpFederationPublicKeys,
-            500L
-        );
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFederationPublicKeys, 500L);
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired fast bridge fed to the active fed
@@ -858,15 +845,10 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs args = new FederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters
-        );
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+        
+        List<FederationMember> retiredFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys);
+        FederationArgs federationArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         List<BtcECKey> erpFederationPublicKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
@@ -874,14 +856,7 @@ class PegUtilsLegacyTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters,
-            erpFederationPublicKeys,
-            500L
-        );
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFederationPublicKeys, 500L);
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired fast bridge fed to the active fed
@@ -923,15 +898,10 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs args = new FederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters
-        );
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+
+        List<FederationMember> retiredFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys);
+        FederationArgs retiredFederationArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(retiredFederationArgs);
 
         List<BtcECKey> erpFederationPublicKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
@@ -939,14 +909,7 @@ class PegUtilsLegacyTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters,
-            erpFederationPublicKeys,
-            500L
-        );
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(retiredFederationArgs, erpFederationPublicKeys, 500L);
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired erp fed to the active fed
@@ -984,33 +947,18 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs retiredFedArgs = new FederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters
-        );
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
-            retiredFedArgs
-        );
+
+        List<FederationMember> retiredFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys);
+        FederationArgs retiredFedArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(retiredFedArgs);
 
         List<BtcECKey> erpFederationPublicKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
             BtcECKey.fromPrivate(Hex.decode("fa04"))
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        ErpFederationArgs erpFedArgs = new ErpFederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters,
-            erpFederationPublicKeys,
-            500L
-        );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            erpFedArgs,
-            activations
-        );
+        ErpFederationArgs erpFedArgs = ErpFederationArgs.fromFederationArgs(retiredFedArgs, erpFederationPublicKeys, 500L);
+        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFedArgs, activations);
 
         // Create a tx from the retired erp fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -1247,20 +1195,13 @@ class PegUtilsLegacyTest {
 
         Context btcContext = new Context(networkParameters);
         Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        FederationArgs activeFederationArgs = activeFederation.getArgs();
 
         List<BtcECKey> emergencyKeys = PegTestUtils.createRandomBtcECKeys(3);
         long activationDelay = 256L;
 
-        ErpFederationArgs args = new ErpFederationArgs(activeFederation.getMembers(),
-            activeFederation.getCreationTime(),
-            activeFederation.getCreationBlockNumber(),
-            networkParameters,
-            emergencyKeys,
-            activationDelay
-        );
-        Federation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            args
-        );
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(activeFederationArgs, emergencyKeys, activationDelay);
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         Script flyoverP2shErpRedeemScript = FastBridgeP2shErpRedeemScriptParser.createFastBridgeP2shErpRedeemScript(
             p2shErpFederation.getRedeemScript(),
@@ -1321,7 +1262,7 @@ class PegUtilsLegacyTest {
 
         ErpFederationArgs retiredFedArgs = new ErpFederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
@@ -1337,7 +1278,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         ErpFederationArgs activeFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
@@ -1389,34 +1330,27 @@ class PegUtilsLegacyTest {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        List<BtcECKey> retiringFed = Stream.of(
+        List<BtcECKey> retiringFedKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fc01")),
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        ErpFederationArgs retiringFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFed),
-            Instant.ofEpochMilli(1000L),
-            1L,
-            bridgeConstantsMainnet.getBtcParams(),
-            bridgeConstantsMainnet.getErpFedPubKeysList(),
-            bridgeConstantsMainnet.getErpFedActivationDelay()
-        );
-        Federation retiringFederation = FederationFactory.buildP2shErpFederation(
-            retiringFedArgs
-        );
+        List<FederationMember> retiringFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedKeys);
+        NetworkParameters btcParams = bridgeConstantsMainnet.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstantsMainnet.getErpFedPubKeysList();
+        long activationDelay = bridgeConstantsMainnet.getErpFedActivationDelay();
+
+        ErpFederationArgs retiringFedArgs =
+            new ErpFederationArgs(retiringFedMembers, creationTime, 1L, btcParams, erpPubKeys, activationDelay);
+        Federation retiringFederation = FederationFactory.buildP2shErpFederation(retiringFedArgs);
 
         List<BtcECKey> activeFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-
-        ErpFederationArgs activeFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            1L,
-            bridgeConstantsMainnet.getBtcParams(),
-            bridgeConstantsMainnet.getErpFedPubKeysList(),
-            bridgeConstantsMainnet.getErpFedActivationDelay()
-        );
+        List<FederationMember> activeFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys);
+        ErpFederationArgs activeFedArgs =
+            new ErpFederationArgs(activeFedMembers, creationTime, 1L, btcParams, erpPubKeys, activationDelay);
         Federation activeFederation = FederationFactory.buildP2shErpFederation(
             activeFedArgs
         );
@@ -1432,7 +1366,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         migrationTx.addInput(migrationTxInput);
-        signWithNecessaryKeys(retiringFederation, retiringFed, migrationTxInput, migrationTx);
+        signWithNecessaryKeys(retiringFederation, retiringFedKeys, migrationTxInput, migrationTx);
 
         Wallet federationsWallet = new BridgeBtcWallet(btcContext, Arrays.asList(activeFederation, retiringFederation));
 
@@ -1459,7 +1393,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         FederationArgs retiredFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams()
         );
@@ -1473,7 +1407,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         ErpFederationArgs activeFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
@@ -1531,7 +1465,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams()
         );
@@ -1545,7 +1479,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         ErpFederationArgs activeFedArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
@@ -1593,7 +1527,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         FederationArgs retiredFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams()
         );
@@ -1607,7 +1541,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams()
         );
@@ -1664,7 +1598,7 @@ class PegUtilsLegacyTest {
 
         FederationArgs retiringFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams()
         );
@@ -1678,7 +1612,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             bridgeConstantsMainnet.getBtcParams()
         );
@@ -1737,7 +1671,7 @@ class PegUtilsLegacyTest {
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
         FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             networkParameters
         );
@@ -1750,7 +1684,7 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
         FederationArgs retiredFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             1L,
             networkParameters
         );
@@ -1927,7 +1861,7 @@ class PegUtilsLegacyTest {
         );
         flyoverFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(flyoverFederationKeys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             0L,
             networkParameters
         );
@@ -1986,14 +1920,10 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa03"))
         );
         defaultFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters
-        );
-        Federation defaultFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+        List<FederationMember> federationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys);
+
+        FederationArgs federationArgs = new FederationArgs(federationMembers, creationTime, 0L, networkParameters);
+        Federation defaultFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         List<BtcECKey> erpFederationPublicKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
@@ -2001,17 +1931,8 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa05"))
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        ErpFederationArgs erpArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters,
-            erpFederationPublicKeys,
-            500L
-        );
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            erpArgs,
-            activations
-        );
+        ErpFederationArgs erpArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFederationPublicKeys, 500L);
+        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpArgs, activations);
 
         Federation standardFederation = bridgeConstantsRegtest.getGenesisFederation();
 
@@ -2065,14 +1986,10 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa03"))
         );
         defaultFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters
-        );
-        Federation defaultFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
-        );
+
+        List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys);
+        FederationArgs federationArgs = new FederationArgs(fedMembers, creationTime, 0L, networkParameters);
+        Federation defaultFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         List<BtcECKey> erpFederationPublicKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
@@ -2081,17 +1998,8 @@ class PegUtilsLegacyTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
-        ErpFederationArgs erpArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
-            networkParameters,
-            erpFederationPublicKeys,
-            500L
-        );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            erpArgs,
-            activations
-        );
+        ErpFederationArgs erpArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFederationPublicKeys, 500L);
+        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpArgs, activations);
 
         Federation standardFederation = bridgeConstantsRegtest.getGenesisFederation();
 
@@ -2185,7 +2093,7 @@ class PegUtilsLegacyTest {
             .collect(Collectors.toList());
         FederationArgs args1 = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-            Instant.ofEpochMilli(1000L),
+            creationTime,
             0L,
             networkParameters
         );

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -207,10 +207,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         federation1Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args1 = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+            args1,
             networkParameters
         );
 
@@ -220,10 +223,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fb03"))
         );
         federation2Keys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args2 = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys),
             Instant.ofEpochMilli(2000L),
-            0L,
+            0L
+        );
+        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
+            args2,
             networkParameters
         );
 
@@ -537,10 +543,14 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         erpFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -581,10 +591,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         erpFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -625,10 +638,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         erpFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -660,10 +676,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         erpFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -695,10 +714,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -742,10 +764,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -789,10 +814,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -803,9 +831,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
+            args,
             networkParameters,
             erpFederationPublicKeys,
             500L,
@@ -852,10 +878,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -866,9 +895,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
+            args,
             networkParameters,
             erpFederationPublicKeys,
             500L,
@@ -914,10 +941,13 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -928,9 +958,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
+            args,
             networkParameters,
             erpFederationPublicKeys,
             500L,
@@ -972,10 +1000,12 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs retiredFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            retiredFedArgs,
             networkParameters
         );
 
@@ -986,9 +1016,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
+            retiredFedArgs,
             networkParameters,
             erpFederationPublicKeys,
             500L,
@@ -1234,10 +1262,11 @@ class PegUtilsLegacyTest {
         List<BtcECKey> emergencyKeys = PegTestUtils.createRandomBtcECKeys(3);
         long activationDelay = 256L;
 
-        Federation p2shErpFederation = FederationFactory.buildP2shErpFederation(
-            activeFederation.getMembers(),
+        FederationArgs args = new FederationArgs(activeFederation.getMembers(),
             activeFederation.getCreationTime(),
-            activeFederation.getCreationBlockNumber(),
+            activeFederation.getCreationBlockNumber());
+        Federation p2shErpFederation = FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             emergencyKeys,
             activationDelay
@@ -1300,10 +1329,12 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        ErpFederation retiredFederation = FederationFactory.buildP2shErpFederation(
+        FederationArgs retiredFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        ErpFederation retiredFederation = FederationFactory.buildP2shErpFederation(
+            retiredFedArgs,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
             bridgeConstantsMainnet.getErpFedActivationDelay()
@@ -1314,10 +1345,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation activeFederation = FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation activeFederation = FederationFactory.buildP2shErpFederation(
+            activeFedArgs,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
             bridgeConstantsMainnet.getErpFedActivationDelay()
@@ -1370,10 +1402,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation retiringFederation = FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiringFed),
+        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFed),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation retiringFederation = FederationFactory.buildP2shErpFederation(
+            retiringFedArgs,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
             bridgeConstantsMainnet.getErpFedActivationDelay()
@@ -1384,10 +1417,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation activeFederation = FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation activeFederation = FederationFactory.buildP2shErpFederation(
+            activeFedArgs,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
             bridgeConstantsMainnet.getErpFedActivationDelay()
@@ -1430,10 +1464,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
+        FederationArgs retiredFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            retiredFedArgs,
             bridgeConstantsMainnet.getBtcParams()
         );
 
@@ -1442,10 +1477,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation activeFederation = FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation activeFederation = FederationFactory.buildP2shErpFederation(
+            activeFedArgs,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
             bridgeConstantsMainnet.getErpFedActivationDelay()
@@ -1498,10 +1534,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
+        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+            retiringFedArgs,
             bridgeConstantsMainnet.getBtcParams()
         );
 
@@ -1510,10 +1547,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation activeFederation = FederationFactory.buildP2shErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation activeFederation = FederationFactory.buildP2shErpFederation(
+            activeFedArgs,
             bridgeConstantsMainnet.getBtcParams(),
             bridgeConstantsMainnet.getErpFedPubKeysList(),
             bridgeConstantsMainnet.getErpFedActivationDelay()
@@ -1556,10 +1594,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
+        FederationArgs retiredFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            retiredFedArgs,
             bridgeConstantsMainnet.getBtcParams()
         );
 
@@ -1568,10 +1607,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            activeFedArgs,
             bridgeConstantsMainnet.getBtcParams()
         );
 
@@ -1622,10 +1662,12 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs retiringFedArgs = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+            retiringFedArgs,
             bridgeConstantsMainnet.getBtcParams()
         );
 
@@ -1634,10 +1676,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
 
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            activeFedArgs,
             bridgeConstantsMainnet.getBtcParams()
         );
 
@@ -1675,10 +1718,12 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+
+        FederationArgs activeFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(2000L),
-            2L,
+            2L);
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+            activeFedArgs,
             networkParameters
         );
 
@@ -1687,10 +1732,12 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fb02")),
             BtcECKey.fromPrivate(Hex.decode("fb03"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
+
+        FederationArgs retiringFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiringFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation retiringFederation = FederationFactory.buildStandardMultiSigFederation(
+            retiringFedArgs,
             networkParameters
         );
 
@@ -1698,10 +1745,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fc01")),
             BtcECKey.fromPrivate(Hex.decode("fc02"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
+        FederationArgs retiredFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys),
             Instant.ofEpochMilli(1000L),
-            1L,
+            1L);
+        Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(
+            retiredFedArgs,
             networkParameters
         );
 
@@ -1834,10 +1882,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02")),
             BtcECKey.fromPrivate(Hex.decode("fa03"))
         ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
-        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(2000L),
-            2L,
+            2L);
+        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
+            args,
             bridgeConstantsRegtest.getBtcParams()
         );
         List<BtcECKey> federationPrivateKeys = BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS;
@@ -1871,10 +1920,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa03"))
         );
         flyoverFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation flyoverFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(flyoverFederationKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(flyoverFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation flyoverFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -1929,10 +1979,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa03"))
         );
         defaultFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation defaultFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation defaultFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -1944,9 +1995,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
+            args,
             networkParameters,
             erpFederationPublicKeys,
             500L,
@@ -2005,10 +2054,11 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa03"))
         );
         defaultFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        Federation defaultFederation = FederationFactory.buildStandardMultiSigFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L);
+        Federation defaultFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -2020,9 +2070,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationTestUtils.getFederationMembersWithBtcKeys(defaultFederationKeys),
-            Instant.ofEpochMilli(1000L),
-            0L,
+            args,
             networkParameters,
             erpFederationPublicKeys,
             500L,
@@ -2119,9 +2167,14 @@ class PegUtilsLegacyTest {
             .map(BtcECKey::fromPrivate)
             .sorted(BtcECKey.PUBKEY_COMPARATOR)
             .collect(Collectors.toList());
-        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args1 = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(federation1Keys),
-            Instant.ofEpochMilli(1000L), 0L, networkParameters
+            Instant.ofEpochMilli(1000L),
+            0L
+        );
+        Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
+            args1,
+            networkParameters
         );
 
         List<BtcECKey> federation2Keys = Stream.of("fb01", "fb02", "fb03")
@@ -2130,10 +2183,11 @@ class PegUtilsLegacyTest {
             .sorted(BtcECKey.PUBKEY_COMPARATOR)
             .collect(Collectors.toList());
         List<FederationMember> federation2Members = FederationTestUtils.getFederationMembersWithBtcKeys(federation2Keys);
-        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            federation2Members,
+        FederationArgs args2 = new FederationArgs(federation2Members,
             Instant.ofEpochMilli(2000L),
-            0L,
+            0L);
+        Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
+            args2,
             networkParameters
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -540,9 +540,9 @@ class PegUtilsLegacyTest {
         long activationDelay = 500L;
 
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        Script redeemScript = erpFederation.getRedeemScript();
+        Script redeemScript = nonStandardErpFederation.getRedeemScript();
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
             redeemScript,
             Sha256Hash.of(PegTestUtils.createHash(1).getBytes())
@@ -578,11 +578,11 @@ class PegUtilsLegacyTest {
 
         List<FederationMember> erpFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys);
         FederationArgs args = new FederationArgs(erpFedMembers, creationTime, 0L, networkParameters);
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
             activeFederation.getRedeemScript(),
-            erpFederation.getRedeemScript(),
+            standardMultisigFederation.getRedeemScript(),
             500L
         );
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
@@ -623,13 +623,13 @@ class PegUtilsLegacyTest {
             0L,
             networkParameters
         );
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(
             args
         );
 
         Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
             activeFederation.getRedeemScript(),
-            erpFederation.getRedeemScript(),
+            standardMultisigFederation.getRedeemScript(),
             500L
         );
 
@@ -661,13 +661,13 @@ class PegUtilsLegacyTest {
             0L,
             networkParameters
         );
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(
             args
         );
 
         Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
             activeFederation.getRedeemScript(),
-            erpFederation.getRedeemScript(),
+            standardMultisigFederation.getRedeemScript(),
             500L
         );
 
@@ -804,7 +804,7 @@ class PegUtilsLegacyTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(retiredFederationArgs, erpFederationPublicKeys, 500L);
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired fast bridge fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -818,10 +818,10 @@ class PegUtilsLegacyTest {
         tx.addInput(txInput);
 
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             PegTestUtils.createHash(2)
         );
-        signWithNecessaryKeys(erpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -846,7 +846,7 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa02"))
         );
         retiredFederationKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
-        
+
         List<FederationMember> retiredFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiredFederationKeys);
         FederationArgs retiredFederationArgs = new FederationArgs(retiredFederationMembers, creationTime, 0L, networkParameters);
         Federation retiredFederation = FederationFactory.buildStandardMultiSigFederation(retiredFederationArgs);
@@ -858,7 +858,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(retiredFederationArgs, erpFederationPublicKeys, 500L);
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired fast bridge fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -872,10 +872,10 @@ class PegUtilsLegacyTest {
         tx.addInput(txInput);
 
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             PegTestUtils.createHash(2)
         );
-        signWithNecessaryKeys(erpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -911,7 +911,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(retiredFederationArgs, erpFederationPublicKeys, 500L);
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired erp fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -923,7 +923,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         tx.addInput(txInput);
-        signWithErpFederation(erpFederation, retiredFederationKeys, txInput, tx);
+        signWithErpFederation(nonStandardErpFederation, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -959,7 +959,7 @@ class PegUtilsLegacyTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         ErpFederationArgs erpFedArgs = ErpFederationArgs.fromFederationArgs(retiredFedArgs, erpFederationPublicKeys, 500L);
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFedArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFedArgs, activations);
 
         // Create a tx from the retired erp fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -971,7 +971,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         tx.addInput(txInput);
-        signWithErpFederation(erpFederation, retiredFederationKeys, txInput, tx);
+        signWithErpFederation(nonStandardErpFederation, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -1933,7 +1933,7 @@ class PegUtilsLegacyTest {
         );
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         ErpFederationArgs erpArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFederationPublicKeys, 500L);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpArgs, activations);
 
         Federation standardFederation = bridgeConstantsRegtest.getGenesisFederation();
 
@@ -1948,7 +1948,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         pegOutTx1.addInput(pegOutInput1);
-        signWithErpFederation(erpFederation, defaultFederationKeys, pegOutInput1, pegOutTx1);
+        signWithErpFederation(nonStandardErpFederation, defaultFederationKeys, pegOutInput1, pegOutTx1);
 
         // Before RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
@@ -1961,8 +1961,8 @@ class PegUtilsLegacyTest {
         assertFalse(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript(), standardFederation.getP2SHScript()));
         assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(erpFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, activations, erpFederation.getDefaultP2SHScript()));
+        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(nonStandardErpFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, activations, nonStandardErpFederation.getDefaultP2SHScript()));
 
         // After RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1975,8 +1975,8 @@ class PegUtilsLegacyTest {
         assertTrue(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript(), standardFederation.getP2SHScript()));
         assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
 
-        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(erpFederation), activations));
-        assertTrue(isPegOutTx(pegOutTx1, activations, erpFederation.getDefaultP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(nonStandardErpFederation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, activations, nonStandardErpFederation.getDefaultP2SHScript()));
     }
 
     @Test
@@ -2000,7 +2000,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
 
         ErpFederationArgs erpArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFederationPublicKeys, 500L);
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpArgs, activations);
 
         Federation standardFederation = bridgeConstantsRegtest.getGenesisFederation();
 
@@ -2017,10 +2017,10 @@ class PegUtilsLegacyTest {
         pegOutTx1.addInput(pegOutInput1);
 
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             PegTestUtils.createHash(2)
         );
-        signWithNecessaryKeys(erpFederation, flyoverErpRedeemScript, defaultFederationKeys, pegOutInput1, pegOutTx1);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, defaultFederationKeys, pegOutInput1, pegOutTx1);
 
         // Before RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
@@ -2304,7 +2304,7 @@ class PegUtilsLegacyTest {
         assertFalse(scriptCorrectlySpendsTx(tx, 0, genesisFederation.getP2SHScript()));
     }
 
-    private void signWithErpFederation(Federation erpFederation, List<BtcECKey> privateKeys, TransactionInput txIn, BtcTransaction tx) {
+    private void signWithErpFederation(ErpFederation erpFederation, List<BtcECKey> privateKeys, TransactionInput txIn, BtcTransaction tx) {
         signWithNecessaryKeys(erpFederation, privateKeys, txIn, tx);
         // Add OP_0 prefix to make it a valid erp federation script
         Script erpInputScript = new ScriptBuilder()

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
@@ -10,10 +10,7 @@ import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
-import co.rsk.peg.federation.ErpFederation;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationTestUtils;
+import co.rsk.peg.federation.*;
 import co.rsk.test.builders.BridgeSupportBuilder;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -207,10 +204,13 @@ class PegUtilsTest {
         List<BtcECKey> signers = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
         );
-        ErpFederation activeFed = FederationFactory.buildP2shErpFederation(
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(signers),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        ErpFederation activeFed = FederationFactory.buildP2shErpFederation(
+            args,
             btcMainnetParams,
             bridgeMainnetConstants.getErpFedPubKeysList(),
             bridgeMainnetConstants.getErpFedActivationDelay()
@@ -609,10 +609,14 @@ class PegUtilsTest {
         List<BtcECKey> signers = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
         );
-        ErpFederation activeFed = FederationFactory.buildP2shErpFederation(
+
+        FederationArgs args = new FederationArgs(
             FederationTestUtils.getFederationMembersWithBtcKeys(signers),
             Instant.ofEpochMilli(1000L),
-            0L,
+            0L
+        );
+        ErpFederation activeFed = FederationFactory.buildP2shErpFederation(
+            args,
             btcTestNetParams,
             bridgeTestNetConstants.getErpFedPubKeysList(),
             bridgeTestNetConstants.getErpFedActivationDelay()

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
@@ -205,10 +205,11 @@ class PegUtilsTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
         List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(signers);
+        Instant creationTime = Instant.ofEpochMilli(1000L);
         List<BtcECKey> erpPubKeys = bridgeMainnetConstants.getErpFedPubKeysList();
         long activationDelay = bridgeMainnetConstants.getErpFedActivationDelay();
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcMainnetParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(fedMembers, creationTime, 0L, btcMainnetParams, erpPubKeys, activationDelay);
         ErpFederation activeFed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
         Wallet liveFederationWallet = new BridgeBtcWallet(context, Arrays.asList(retiringFed, activeFed));
 
@@ -605,11 +606,12 @@ class PegUtilsTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
         List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(signers);
+        Instant creationTime = Instant.ofEpochMilli(1000L);
         List<BtcECKey> erpPubKeys = bridgeTestNetConstants.getErpFedPubKeysList();
         long activationDelay = bridgeTestNetConstants.getErpFedActivationDelay();
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcTestNetParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(fedMembers, creationTime, 0L, btcTestNetParams, erpPubKeys, activationDelay);
         ErpFederation activeFed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
         Wallet liveFederationWallet = new BridgeBtcWallet(context, Arrays.asList(retiringFed, activeFed));
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
@@ -204,17 +204,12 @@ class PegUtilsTest {
         List<BtcECKey> signers = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
         );
-        FederationArgs args = new FederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(signers),
-            Instant.ofEpochMilli(1000L),
-            0L
-        );
-        ErpFederation activeFed = FederationFactory.buildP2shErpFederation(
-            args,
-            btcMainnetParams,
-            bridgeMainnetConstants.getErpFedPubKeysList(),
-            bridgeMainnetConstants.getErpFedActivationDelay()
-        );
+        List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(signers);
+        List<BtcECKey> erpPubKeys = bridgeMainnetConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeMainnetConstants.getErpFedActivationDelay();
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcMainnetParams,
+            erpPubKeys, activationDelay);
+        ErpFederation activeFed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
         Wallet liveFederationWallet = new BridgeBtcWallet(context, Arrays.asList(retiringFed, activeFed));
 
         BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
@@ -609,18 +604,13 @@ class PegUtilsTest {
         List<BtcECKey> signers = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
         );
+        List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(signers);
+        List<BtcECKey> erpPubKeys = bridgeTestNetConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeTestNetConstants.getErpFedActivationDelay();
 
-        FederationArgs args = new FederationArgs(
-            FederationTestUtils.getFederationMembersWithBtcKeys(signers),
-            Instant.ofEpochMilli(1000L),
-            0L
-        );
-        ErpFederation activeFed = FederationFactory.buildP2shErpFederation(
-            args,
-            btcTestNetParams,
-            bridgeTestNetConstants.getErpFedPubKeysList(),
-            bridgeTestNetConstants.getErpFedActivationDelay()
-        );
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcTestNetParams,
+            erpPubKeys, activationDelay);
+        ErpFederation activeFed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
         Wallet liveFederationWallet = new BridgeBtcWallet(context, Arrays.asList(retiringFed, activeFed));
 
         String segwitTxHex = "020000000001011f668117f2ca3314806ade1d99ae400f5413d7e9d4bfcbd11d52645e060e22fb0100000000fdffffff0300000000000000001b6a1952534b5401a27c6f697954357247e78f9900023cfe01a9d49c0412030000000000160014b413f59a7ee6e34321140e83ea661e0484a79bc2988708000000000017a9145e6cf80958803e9b3c81cd90422152520d2a505c870247304402203fce49b39f79581d93720f462b5f33f9174e66dc6efb635d4f41aacb33b08d0302201221aec5db31e269454fcc7a4df2936ccedd566ccf48828d4f97050954f196540121021831c5ba44b739521d635e521560525672087e4d5db053801f4aeb60e782f6d6d0f02400";

--- a/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
@@ -65,7 +65,7 @@ class PocSighashTest {
         List<FederationMember> fedMembers = fedSigners.stream().map(FedSigner::getFed).collect(Collectors.toList());
         List<BtcECKey> erpFedPubKeys = erpFedSigners.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
-        ErpFederationArgs args = new ErpFederationArgs(fedMembers,
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers,
             Instant.now(),
             0L,
             networkParameters,
@@ -73,7 +73,7 @@ class PocSighashTest {
             erpFedActivationDelay
         );
         ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args
+            erpFederationArgs
         );
 
         List<FedUtxo> utxos = new ArrayList<>();
@@ -140,7 +140,7 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs args = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
             0L,
             networkParameters,
@@ -148,7 +148,7 @@ class PocSighashTest {
             erpFedActivationDelay
         );
         ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args
+            erpFederationArgs
         );
 
         List<FedUtxo> utxos = new ArrayList<>();
@@ -238,7 +238,7 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs args = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
             0L,
             networkParameters,
@@ -246,7 +246,7 @@ class PocSighashTest {
             erpFedActivationDelay
         );
         ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args
+            erpFederationArgs
         );
 
         List<FedUtxo> utxos = new ArrayList<>();
@@ -301,7 +301,7 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs args = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
             0L,
             networkParameters,
@@ -309,7 +309,7 @@ class PocSighashTest {
             erpFedActivationDelay
         );
         ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args
+            erpFederationArgs
         );
 
         Address expectedAddress = Address.fromBase58(
@@ -389,7 +389,7 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs args = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
             0L,
             networkParameters,
@@ -397,7 +397,7 @@ class PocSighashTest {
             erpFedActivationDelay
         );
         ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args
+            erpFederationArgs
         );
 
         Address expectedAddress = Address.fromBase58(
@@ -481,7 +481,7 @@ class PocSighashTest {
             FedSigner::getFed
         ).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
-        ErpFederationArgs args = new ErpFederationArgs(fedMembers,
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers,
             Instant.now(),
             0L,
             networkParameters,
@@ -489,7 +489,7 @@ class PocSighashTest {
             erpFedActivationDelay
         );
         ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args
+            erpFederationArgs
         );
 
         Address expectedAddress = Address.fromBase58(

--- a/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
@@ -9,10 +9,7 @@ import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.config.BridgeTestNetConstants;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
-import co.rsk.peg.federation.ErpFederation;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.*;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -67,10 +64,12 @@ class PocSighashTest {
 
         List<FederationMember> fedMembers = fedSigners.stream().map(FedSigner::getFed).collect(Collectors.toList());
         List<BtcECKey> erpFedPubKeys = erpFedSigners.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            fedMembers,
+
+        FederationArgs args = new FederationArgs(fedMembers,
             Instant.now(),
-            0L,
+            0L);
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             erpFedPubKeys,
             erpFedActivationDelay
@@ -140,10 +139,11 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        FederationArgs args = new FederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
-            0L,
+            0L);
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList()),
             erpFedActivationDelay
@@ -236,10 +236,11 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        FederationArgs args = new FederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
-            0L,
+            0L);
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList()),
             erpFedActivationDelay
@@ -297,10 +298,11 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        FederationArgs args = new FederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
-            0L,
+            0L);
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList()),
             erpFedActivationDelay
@@ -383,10 +385,11 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        FederationArgs args = new FederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
-            0L,
+            0L);
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             fedPubKeys,
             erpFedActivationDelay
@@ -473,10 +476,11 @@ class PocSighashTest {
             FedSigner::getFed
         ).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            fedMembers,
+        FederationArgs args = new FederationArgs(fedMembers,
             Instant.now(),
-            0L,
+            0L);
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             erpPubKeys,
             erpFedActivationDelay

--- a/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
@@ -16,7 +16,6 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
-import org.ethereum.util.MapSnapshot;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -370,7 +369,9 @@ class PocSighashTest {
         NetworkParameters networkParameters = BridgeTestNetConstants.getInstance().getBtcParams();
         int erpFedActivationDelay = 720;
 
-        List<FedSigner> fedMembers = FedSigner.listOf("federator1", "federator2", "federator6");
+        List<FedSigner> fedSigners = FedSigner.listOf("federator1", "federator2", "federator6");
+        List<FederationMember> fedMembers = fedSigners.stream().map(FedSigner::getFed).collect(Collectors.toList());
+        Instant creationTime = Instant.now();
         List<FedSigner> erpFedMembers = FedSigner.listOf("erp-fed-01", "erp-fed-02", "erp-fed-03");
         List<BtcECKey> erpPubKeys = erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
@@ -378,13 +379,8 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
-            Instant.now(),
-            0L,
-            networkParameters,
-            erpPubKeys,
-            erpFedActivationDelay
-        );
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(fedMembers, creationTime, 0L, networkParameters, erpPubKeys, erpFedActivationDelay);
         ErpFederation fed = FederationFactory.buildP2shErpFederation(
             erpFederationArgs
         );

--- a/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
@@ -16,6 +16,7 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
+import org.ethereum.util.MapSnapshot;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,15 +64,11 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
         List<FederationMember> fedMembers = fedSigners.stream().map(FedSigner::getFed).collect(Collectors.toList());
+        Instant creationTime = Instant.now();
         List<BtcECKey> erpFedPubKeys = erpFedSigners.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers,
-            Instant.now(),
-            0L,
-            networkParameters,
-            erpFedPubKeys,
-            erpFedActivationDelay
-        );
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(fedMembers, creationTime, 0L, networkParameters, erpFedPubKeys, erpFedActivationDelay);
         ErpFederation fed = FederationFactory.buildP2shErpFederation(
             erpFederationArgs
         );
@@ -133,27 +130,23 @@ class PocSighashTest {
         // Arrange
         int erpFedActivationDelay = 720;
 
-        List<FedSigner> fedMembers = FedSigner.listOf("fed1", "fed2", "fed3", "fed4", "fed5", "fed6", "fed7");
-        List<FedSigner> erpFedMembers = FedSigner.listOf("erp-fed-01", "erp-fed-02", "erp-fed-03");
+        List<FedSigner> fedSigners = FedSigner.listOf("fed1", "fed2", "fed3", "fed4", "fed5", "fed6", "fed7");
+        List<FederationMember> fedMembers = fedSigners.stream().map(FedSigner::getFed).collect(Collectors.toList());
+        Instant creationTime = Instant.now();
+        List<FedSigner> erpSigners = FedSigner.listOf("erp-fed-01", "erp-fed-02", "erp-fed-03");
+        List<BtcECKey> erpPubKeys = erpSigners.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
-            Instant.now(),
-            0L,
-            networkParameters,
-            erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList()),
-            erpFedActivationDelay
-        );
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            erpFederationArgs
-        );
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(fedMembers, creationTime, 0L, networkParameters, erpPubKeys, erpFedActivationDelay);
+        ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         List<FedUtxo> utxos = new ArrayList<>();
         BtcTransaction peginTx = new BtcTransaction(networkParameters);
-        peginTx.addOutput(Coin.valueOf(100_000), fed.getAddress());
+        peginTx.addOutput(Coin.valueOf(100_000), p2shErpFederation.getAddress());
         utxos.add(FedUtxo.of(peginTx, 0));
 
         Address destinationAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
@@ -164,8 +157,8 @@ class PocSighashTest {
         BtcTransaction pegOutTx = spendFromFed(
             networkParameters,
             erpFedActivationDelay,
-            fed,
-            fedMembers,
+            p2shErpFederation,
+            fedSigners,
             false,
             utxos,
             totalAmount.minus(Coin.valueOf(15_000)),
@@ -180,7 +173,7 @@ class PocSighashTest {
         for (int i = 0; i < pegOutTx.getInputs().size(); i++) {
             Sha256Hash sighashFromSignedTx = pegOutTx.hashForSignature(
                 i,
-                fed.getRedeemScript(),
+                p2shErpFederation.getRedeemScript(),
                 BtcTransaction.SigHash.ALL,
                 false
             );
@@ -189,7 +182,7 @@ class PocSighashTest {
 
 
         BtcTransaction peginTx2 = new BtcTransaction(networkParameters);
-        peginTx2.addOutput(Coin.valueOf(100_000), fed.getAddress());
+        peginTx2.addOutput(Coin.valueOf(100_000), p2shErpFederation.getAddress());
         utxos.add(FedUtxo.of(peginTx2, 0));
 
         Coin alteredTxTotalAmount = utxos.stream().map(fedUtxo -> fedUtxo.btcTransaction.getOutput(fedUtxo.getOutputIdx()).getValue()).reduce(Coin.ZERO, Coin::add);
@@ -198,8 +191,8 @@ class PocSighashTest {
         spendFromFed(
             networkParameters,
             erpFedActivationDelay,
-            fed,
-            fedMembers,
+            p2shErpFederation,
+            fedSigners,
             false,
             utxos,
             alteredTxTotalAmount.minus(Coin.valueOf(15_000)),
@@ -231,23 +224,19 @@ class PocSighashTest {
         // Arrange
         int erpFedActivationDelay = 720;
 
-        List<FedSigner> fedMembers = FedSigner.listOf("fed1", "fed2", "fed3");
-        List<FedSigner> erpFedMembers = FedSigner.listOf("erp-fed-01", "erp-fed-02", "erp-fed-03");
+        List<FedSigner> fedSigners = FedSigner.listOf("fed1", "fed2", "fed3");
+        List<FederationMember> fedMembers = fedSigners.stream().map(FedSigner::getFed).collect(Collectors.toList());
+        Instant creationTime = Instant.now();
+        List<FedSigner> erpSigners = FedSigner.listOf("erp-fed-01", "erp-fed-02", "erp-fed-03");
+        List<BtcECKey> erpPubKeys = erpSigners.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
-            Instant.now(),
-            0L,
-            networkParameters,
-            erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList()),
-            erpFedActivationDelay
-        );
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            erpFederationArgs
-        );
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(fedMembers, creationTime, 0L, networkParameters, erpPubKeys, erpFedActivationDelay);
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         List<FedUtxo> utxos = new ArrayList<>();
         for (int i = 0; i < 7; i++) {
@@ -265,7 +254,7 @@ class PocSighashTest {
             networkParameters,
             erpFedActivationDelay,
             fed,
-            fedMembers,
+            fedSigners,
             false,
             utxos,
             totalAmount.minus(Coin.valueOf(15_000)),
@@ -383,7 +372,7 @@ class PocSighashTest {
 
         List<FedSigner> fedMembers = FedSigner.listOf("federator1", "federator2", "federator6");
         List<FedSigner> erpFedMembers = FedSigner.listOf("erp-fed-01", "erp-fed-02", "erp-fed-03");
-        List<BtcECKey> fedPubKeys = erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
+        List<BtcECKey> erpPubKeys = erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
@@ -393,7 +382,7 @@ class PocSighashTest {
             Instant.now(),
             0L,
             networkParameters,
-            fedPubKeys,
+            erpPubKeys,
             erpFedActivationDelay
         );
         ErpFederation fed = FederationFactory.buildP2shErpFederation(

--- a/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PocSighashTest.java
@@ -65,14 +65,15 @@ class PocSighashTest {
         List<FederationMember> fedMembers = fedSigners.stream().map(FedSigner::getFed).collect(Collectors.toList());
         List<BtcECKey> erpFedPubKeys = erpFedSigners.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
-        FederationArgs args = new FederationArgs(fedMembers,
+        ErpFederationArgs args = new ErpFederationArgs(fedMembers,
             Instant.now(),
-            0L);
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args,
+            0L,
             networkParameters,
             erpFedPubKeys,
             erpFedActivationDelay
+        );
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         List<FedUtxo> utxos = new ArrayList<>();
@@ -139,14 +140,15 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        FederationArgs args = new FederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        ErpFederationArgs args = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
-            0L);
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args,
+            0L,
             networkParameters,
             erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList()),
             erpFedActivationDelay
+        );
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         List<FedUtxo> utxos = new ArrayList<>();
@@ -236,14 +238,15 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        FederationArgs args = new FederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        ErpFederationArgs args = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
-            0L);
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args,
+            0L,
             networkParameters,
             erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList()),
             erpFedActivationDelay
+        );
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         List<FedUtxo> utxos = new ArrayList<>();
@@ -298,14 +301,15 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        FederationArgs args = new FederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        ErpFederationArgs args = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
-            0L);
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args,
+            0L,
             networkParameters,
             erpFedMembers.stream().map(FedSigner::getFed).map(FederationMember::getBtcPublicKey).collect(Collectors.toList()),
             erpFedActivationDelay
+        );
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         Address expectedAddress = Address.fromBase58(
@@ -385,14 +389,15 @@ class PocSighashTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        FederationArgs args = new FederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
+        ErpFederationArgs args = new ErpFederationArgs(fedMembers.stream().map(FedSigner::getFed).collect(Collectors.toList()),
             Instant.now(),
-            0L);
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args,
+            0L,
             networkParameters,
             fedPubKeys,
             erpFedActivationDelay
+        );
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         Address expectedAddress = Address.fromBase58(
@@ -476,14 +481,15 @@ class PocSighashTest {
             FedSigner::getFed
         ).map(FederationMember::getBtcPublicKey).collect(Collectors.toList());
 
-        FederationArgs args = new FederationArgs(fedMembers,
+        ErpFederationArgs args = new ErpFederationArgs(fedMembers,
             Instant.now(),
-            0L);
-        ErpFederation fed = FederationFactory.buildP2shErpFederation(
-            args,
+            0L,
             networkParameters,
             erpPubKeys,
             erpFedActivationDelay
+        );
+        ErpFederation fed = FederationFactory.buildP2shErpFederation(
+            args
         );
 
         Address expectedAddress = Address.fromBase58(

--- a/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
@@ -134,8 +134,9 @@ class PowpegMigrationTest {
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
         Federation originalPowpeg;
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(originalPowpegMembers, Instant.now(), 0, btcParams,
-            erpPubKeys, activationDelay);
+        Instant creationTime = Instant.now();
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(originalPowpegMembers, creationTime, 0, btcParams, erpPubKeys, activationDelay);
         switch (oldPowPegFederationType) {
             case legacyErp:
                 originalPowpeg = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);

--- a/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
@@ -131,12 +131,13 @@ class PowpegMigrationTest {
         ).collect(Collectors.toList());
 
         Federation originalPowpeg;
+        FederationArgs args = new FederationArgs(originalPowpegMembers,
+            Instant.now(),
+            0);
         switch (oldPowPegFederationType) {
             case legacyErp:
                 originalPowpeg = FederationFactory.buildNonStandardErpFederation(
-                    originalPowpegMembers,
-                    Instant.now(),
-                    0,
+                    args,
                     bridgeConstants.getBtcParams(),
                     bridgeConstants.getErpFedPubKeysList(),
                     bridgeConstants.getErpFedActivationDelay(),
@@ -145,9 +146,7 @@ class PowpegMigrationTest {
                 break;
             case p2shErp:
                 originalPowpeg = FederationFactory.buildP2shErpFederation(
-                    originalPowpegMembers,
-                    Instant.now(),
-                    0,
+                    args,
                     bridgeConstants.getBtcParams(),
                     bridgeConstants.getErpFedPubKeysList(),
                     bridgeConstants.getErpFedActivationDelay()

--- a/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
@@ -129,28 +129,19 @@ class PowpegMigrationTest {
                 theseKeys.getRight()
             )
         ).collect(Collectors.toList());
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
 
         Federation originalPowpeg;
-        FederationArgs args = new FederationArgs(originalPowpegMembers,
-            Instant.now(),
-            0);
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(originalPowpegMembers, Instant.now(), 0, btcParams,
+            erpPubKeys, activationDelay);
         switch (oldPowPegFederationType) {
             case legacyErp:
-                originalPowpeg = FederationFactory.buildNonStandardErpFederation(
-                    args,
-                    bridgeConstants.getBtcParams(),
-                    bridgeConstants.getErpFedPubKeysList(),
-                    bridgeConstants.getErpFedActivationDelay(),
-                    activations
-                );
+                originalPowpeg = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
                 break;
             case p2shErp:
-                originalPowpeg = FederationFactory.buildP2shErpFederation(
-                    args,
-                    bridgeConstants.getBtcParams(),
-                    bridgeConstants.getErpFedPubKeysList(),
-                    bridgeConstants.getErpFedActivationDelay()
-                );
+                originalPowpeg = FederationFactory.buildP2shErpFederation(erpFederationArgs);
                 // TODO: CHECK REDEEMSCRIPT
                 break;
             default:

--- a/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
@@ -138,7 +138,7 @@ class PowpegMigrationTest {
         ErpFederationArgs erpFederationArgs =
             new ErpFederationArgs(originalPowpegMembers, creationTime, 0, btcParams, erpPubKeys, activationDelay);
         switch (oldPowPegFederationType) {
-            case legacyErp:
+            case nonStandardErp:
                 originalPowpeg = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
                 break;
             case p2shErp:
@@ -192,7 +192,7 @@ class PowpegMigrationTest {
         Federation newPowPeg = argumentCaptor.getValue();
         assertEquals(newPowPegAddress, newPowPeg.getAddress());
         switch (newPowPegFederationType) {
-            case legacyErp:
+            case nonStandardErp:
                 assertSame(ErpFederation.class, newPowPeg.getClass());
                 assertTrue(((ErpFederation) newPowPeg).getErpRedeemScriptBuilder() instanceof NonStandardErpRedeemScriptBuilder);
                 break;
@@ -588,12 +588,12 @@ class PowpegMigrationTest {
         Script lastRetiredFederationP2SHScript = lastRetiredFederationP2SHScriptOptional.get();
 
         if (activations.isActive(ConsensusRule.RSKIP377)){
-            if (oldPowPegFederationType == FederationType.legacyErp || oldPowPegFederationType == FederationType.p2shErp){
+            if (oldPowPegFederationType == FederationType.nonStandardErp || oldPowPegFederationType == FederationType.p2shErp){
                 assertNotEquals(lastRetiredFederationP2SHScript, originalPowpeg.getP2SHScript());
             }
             assertEquals(lastRetiredFederationP2SHScript, getFederationDefaultP2SHScript(originalPowpeg));
         } else {
-            if (oldPowPegFederationType == FederationType.legacyErp || oldPowPegFederationType == FederationType.p2shErp){
+            if (oldPowPegFederationType == FederationType.nonStandardErp || oldPowPegFederationType == FederationType.p2shErp){
                 assertEquals(lastRetiredFederationP2SHScript, originalPowpeg.getP2SHScript());
                 assertNotEquals(lastRetiredFederationP2SHScript, getFederationDefaultP2SHScript(originalPowpeg));
             } else {
@@ -1345,11 +1345,11 @@ class PowpegMigrationTest {
         );
 
         testChangePowpeg(
-            FederationType.legacyErp,
+            FederationType.nonStandardErp,
             getMainnetPowpegKeys(),
             originalPowpegAddress,
             utxos,
-            FederationType.legacyErp,
+            FederationType.nonStandardErp,
             newPowpegKeys,
             newPowpegAddress,
             bridgeConstants,
@@ -1371,7 +1371,7 @@ class PowpegMigrationTest {
         );
 
         testChangePowpeg(
-            FederationType.legacyErp,
+            FederationType.nonStandardErp,
             getMainnetPowpegKeys(),
             originalPowpegAddress,
             utxos,
@@ -1592,7 +1592,7 @@ class PowpegMigrationTest {
     }
 
     private enum FederationType {
-        legacyErp,
+        nonStandardErp,
         p2shErp,
         standardMultisig
     }

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -102,11 +102,11 @@ class ReleaseTransactionBuilderTest {
         FederationArgs args = new FederationArgs(
             members,
             Instant.now(),
-            0
+            0,
+            networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         List<UTXO> utxos = Arrays.asList(
@@ -170,6 +170,9 @@ class ReleaseTransactionBuilderTest {
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
 
+        // Use mainnet constants to test a real situation
+        BridgeConstants bridgeConstants = BridgeMainNetConstants.getInstance();
+
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(
             Arrays.asList(
                 new BtcECKey(),
@@ -177,19 +180,17 @@ class ReleaseTransactionBuilderTest {
                 new BtcECKey()
             )
         );
-        FederationArgs args = new FederationArgs(
+        ErpFederationArgs args = new ErpFederationArgs(
             members,
             Instant.now(),
-            0
+            0,
+            bridgeConstants.getBtcParams(),
+            bridgeConstants.getErpFedPubKeysList(),
+            bridgeConstants.getErpFedActivationDelay()
         );
-        // Use mainnet constants to test a real situation
-        BridgeConstants bridgeConstants = BridgeMainNetConstants.getInstance();
 
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
             args,
-            bridgeConstants.getBtcParams(),
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
             activations
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -92,14 +92,20 @@ class ReleaseTransactionBuilderTest {
 
     @Test
     void first_output_pay_fees() {
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationMember.getFederationMembersFromKeys(Arrays.asList(
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(
+            Arrays.asList(
                 new BtcECKey(),
                 new BtcECKey(),
-                new BtcECKey())
-            ),
+                new BtcECKey()
+            )
+        );
+        FederationArgs args = new FederationArgs(
+            members,
             Instant.now(),
-            0,
+            0
+        );
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 
@@ -164,17 +170,23 @@ class ReleaseTransactionBuilderTest {
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
 
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(
+            Arrays.asList(
+                new BtcECKey(),
+                new BtcECKey(),
+                new BtcECKey()
+            )
+        );
+        FederationArgs args = new FederationArgs(
+            members,
+            Instant.now(),
+            0
+        );
         // Use mainnet constants to test a real situation
         BridgeConstants bridgeConstants = BridgeMainNetConstants.getInstance();
 
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            FederationMember.getFederationMembersFromKeys(Arrays.asList(
-                new BtcECKey(),
-                new BtcECKey(),
-                new BtcECKey())
-            ),
-            Instant.now(),
-            0,
+            args,
             bridgeConstants.getBtcParams(),
             bridgeConstants.getErpFedPubKeysList(),
             bridgeConstants.getErpFedActivationDelay(),

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -99,14 +99,14 @@ class ReleaseTransactionBuilderTest {
                 new BtcECKey()
             )
         );
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             members,
             Instant.now(),
             0,
             networkParameters
         );
         Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         List<UTXO> utxos = Arrays.asList(
@@ -180,7 +180,7 @@ class ReleaseTransactionBuilderTest {
                 new BtcECKey()
             )
         );
-        ErpFederationArgs args = new ErpFederationArgs(
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
             members,
             Instant.now(),
             0,
@@ -190,7 +190,7 @@ class ReleaseTransactionBuilderTest {
         );
 
         Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
+            erpFederationArgs,
             activations
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -165,7 +165,7 @@ class ReleaseTransactionBuilderTest {
     }
 
     @Test
-    void build_pegout_tx_from_erp_federation() {
+    void build_pegout_tx_from_non_standard_erp_federation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
@@ -189,7 +189,7 @@ class ReleaseTransactionBuilderTest {
             bridgeConstants.getErpFedActivationDelay()
         );
 
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpFederationArgs,
             activations
         );
@@ -201,7 +201,7 @@ class ReleaseTransactionBuilderTest {
                 Coin.COIN,
                 0,
                 false,
-                erpFederation.getP2SHScript()
+                nonStandardErpFederation.getP2SHScript()
             ),
             new UTXO(
                 Sha256Hash.of(new byte[]{1}),
@@ -209,13 +209,13 @@ class ReleaseTransactionBuilderTest {
                 Coin.COIN,
                 0,
                 false,
-                erpFederation.getP2SHScript()
+                nonStandardErpFederation.getP2SHScript()
             )
         );
 
         Wallet thisWallet = BridgeUtils.getFederationSpendWallet(
             new Context(bridgeConstants.getBtcParams()),
-            erpFederation,
+            nonStandardErpFederation,
             utxos,
             false,
             mock(BridgeStorageProvider.class)
@@ -224,7 +224,7 @@ class ReleaseTransactionBuilderTest {
         ReleaseTransactionBuilder releaseTransactionBuilder = new ReleaseTransactionBuilder(
             bridgeConstants.getBtcParams(),
             thisWallet,
-            erpFederation.getAddress(),
+            nonStandardErpFederation.getAddress(),
             Coin.SATOSHI.multiply(1000),
             activations
         );

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationFactoryTest.java
@@ -172,19 +172,25 @@ class FederationFactoryTest {
     }
 
     private Federation createStandardMultisigFederation() {
-        return FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             federationMembers,
             creationTime,
-            creationBlockNumber,
+            creationBlockNumber
+        );
+        return FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
     }
 
     private ErpFederation createNonStandardErpFederation() {
-        return FederationFactory.buildNonStandardErpFederation(
+        FederationArgs args = new FederationArgs(
             federationMembers,
             creationTime,
-            creationBlockNumber,
+            creationBlockNumber
+        );
+        return FederationFactory.buildNonStandardErpFederation(
+            args,
             networkParameters,
             emergencyKeys,
             activationDelayValue,
@@ -193,10 +199,13 @@ class FederationFactoryTest {
     }
 
     private ErpFederation createP2shErpFederation() {
-        return FederationFactory.buildP2shErpFederation(
+        FederationArgs args = new FederationArgs(
             federationMembers,
             creationTime,
-            creationBlockNumber,
+            creationBlockNumber
+        );
+        return FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             emergencyKeys,
             activationDelayValue

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationFactoryTest.java
@@ -172,44 +172,22 @@ class FederationFactoryTest {
     }
 
     private Federation createStandardMultisigFederation() {
-        FederationArgs args = new FederationArgs(
-            federationMembers,
-            creationTime,
-            creationBlockNumber
-        );
-        return FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
-        );
+        FederationArgs args = new FederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters);
+        return FederationFactory.buildStandardMultiSigFederation(args);
     }
 
     private ErpFederation createNonStandardErpFederation() {
-        FederationArgs args = new FederationArgs(
-            federationMembers,
-            creationTime,
-            creationBlockNumber
+        ErpFederationArgs args = new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters,
+            emergencyKeys, activationDelayValue
         );
-        return FederationFactory.buildNonStandardErpFederation(
-            args,
-            networkParameters,
-            emergencyKeys,
-            activationDelayValue,
-            activations
-        );
+        return FederationFactory.buildNonStandardErpFederation(args, activations);
     }
 
     private ErpFederation createP2shErpFederation() {
-        FederationArgs args = new FederationArgs(
-            federationMembers,
-            creationTime,
-            creationBlockNumber
+        ErpFederationArgs args = new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters,
+            emergencyKeys, activationDelayValue
         );
-        return FederationFactory.buildP2shErpFederation(
-            args,
-            networkParameters,
-            emergencyKeys,
-            activationDelayValue
-        );
+        return FederationFactory.buildP2shErpFederation(args);
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationFactoryTest.java
@@ -177,16 +177,14 @@ class FederationFactoryTest {
     }
 
     private ErpFederation createNonStandardErpFederation() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters,
-            emergencyKeys, activationDelayValue
-        );
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters, emergencyKeys, activationDelayValue);
         return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
     }
 
     private ErpFederation createP2shErpFederation() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters,
-            emergencyKeys, activationDelayValue
-        );
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters, emergencyKeys, activationDelayValue);
         return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationFactoryTest.java
@@ -172,22 +172,22 @@ class FederationFactoryTest {
     }
 
     private Federation createStandardMultisigFederation() {
-        FederationArgs args = new FederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters);
-        return FederationFactory.buildStandardMultiSigFederation(args);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters);
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
     private ErpFederation createNonStandardErpFederation() {
-        ErpFederationArgs args = new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters,
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters,
             emergencyKeys, activationDelayValue
         );
-        return FederationFactory.buildNonStandardErpFederation(args, activations);
+        return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
     }
 
     private ErpFederation createP2shErpFederation() {
-        ErpFederationArgs args = new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters,
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, networkParameters,
             emergencyKeys, activationDelayValue
         );
-        return FederationFactory.buildP2shErpFederation(args);
+        return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
 
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
@@ -41,14 +41,14 @@ import org.ethereum.crypto.ECKey;
 public class FederationTestUtils {
 
     public static Federation getFederation(Integer... federationMemberPks) {
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             getFederationMembersFromPks(federationMemberPks),
             ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
             0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         return FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
@@ -44,11 +44,11 @@ public class FederationTestUtils {
         FederationArgs args = new FederationArgs(
             getFederationMembersFromPks(federationMemberPks),
             ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
-            0L
+            0L,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         return FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
@@ -41,10 +41,13 @@ import org.ethereum.crypto.ECKey;
 public class FederationTestUtils {
 
     public static Federation getFederation(Integer... federationMemberPks) {
-        return FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             getFederationMembersFromPks(federationMemberPks),
             ZonedDateTime.parse("2017-06-10T02:30:01Z").toInstant(),
-            0L,
+            0L
+        );
+        return FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -731,7 +731,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_standard_multisig_can_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Should validate since it's not executing the path of the script with the CSV value
@@ -774,7 +774,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_standard_multisig_can_spend() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // Should validate since it's not executing the path of the script with the CSV value
@@ -787,7 +787,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_erp_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_erp_multisig_can_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Post RSKIP293 activation it should encode the CSV value correctly
@@ -800,7 +800,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_standard_multisig_can_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         assertDoesNotThrow(() -> spendFromNonStandardErpFed(
@@ -812,7 +812,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_erp_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_erp_multisig_can_spend() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // Post RSKIP293 activation it should encode the CSV value correctly
@@ -825,7 +825,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_standard_multisig_can_spend() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         assertDoesNotThrow(() -> spendFromNonStandardErpFed(

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -251,29 +251,29 @@ class NonStandardErpFederationsTest {
 
     @Test
     void testEquals_same() {
-        ErpFederationArgs args = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(),
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(),
             federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
         );
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(args, activations);
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         assertEquals(federation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationTime() {
-        ErpFederationArgs args = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
             federation.getCreationBlockNumber(), federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
         );
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(args, activations);
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         assertEquals(federation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationBlockNumber() {
-        ErpFederationArgs args = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber() + 1,
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber() + 1,
             federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
         );
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(args, activations);
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         assertEquals(federation, otherFederation);
     }
@@ -692,10 +692,10 @@ class NonStandardErpFederationsTest {
 
         List<FederationMember> federationMembersWithBtcKeys = FederationTestUtils.getFederationMembersWithBtcKeys(standardMultisigKeys);
         Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
-        ErpFederationArgs args = new ErpFederationArgs(federationMembersWithBtcKeys, creationTime, 1, btcParams,
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federationMembersWithBtcKeys, creationTime, 1, btcParams,
             emergencyMultisigKeys, activationDelay);
 
-        assertThrows(ErpFederationCreationException.class, () -> FederationFactory.buildNonStandardErpFederation(args, activations));
+        assertThrows(ErpFederationCreationException.class, () -> FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class NonStandardErpFederationsTest {
-    private ErpFederation federation;
+    private ErpFederation nonStandardErpFederation;
     private NetworkParameters networkParameters;
     private List<BtcECKey> defaultKeys;
     private int defaultThreshold;
@@ -87,7 +87,7 @@ class NonStandardErpFederationsTest {
         activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
     }
 
     private ErpFederation createDefaultNonStandardErpFederation() {
@@ -167,7 +167,7 @@ class NonStandardErpFederationsTest {
         createAndValidateFederation();
 
         // Also check the builder is the expected one considering the activations
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         assertTrue(builder instanceof NonStandardErpRedeemScriptBuilder);
     }
 
@@ -182,7 +182,7 @@ class NonStandardErpFederationsTest {
         createAndValidateFederation();
 
         // Also check the builder is the expected one considering the activations
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         assertTrue(builder instanceof NonStandardErpRedeemScriptBuilderWithCsvUnsignedBE);
     }
 
@@ -194,14 +194,14 @@ class NonStandardErpFederationsTest {
 
         activationDelayValue = csvValue;
 
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
         ErpFederationCreationException fedException = assertThrows(
             ErpFederationCreationException.class,
-            () -> federation.getRedeemScript());
+            () -> nonStandardErpFederation.getRedeemScript());
         assertEquals(REDEEM_SCRIPT_CREATION_FAILED, fedException.getReason());
 
         // Check the builder throws the particular expected exception
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         RedeemScriptCreationException exception = assertThrows(
             RedeemScriptCreationException.class,
             () -> builder.createRedeemScriptFromKeys(
@@ -215,7 +215,7 @@ class NonStandardErpFederationsTest {
     @Test
     void createFederation_withRedeemScriptSizeAboveMaximum_throwsScriptCreationException() {
         // add one member to exceed redeem script size limit
-        List<BtcECKey> newDefaultKeys = federation.getBtcPublicKeys();
+        List<BtcECKey> newDefaultKeys = nonStandardErpFederation.getBtcPublicKeys();
         BtcECKey federator10PublicKey = BtcECKey.fromPublicOnly(
             Hex.decode("02550cc87fa9061162b1dd395a16662529c9d8094c0feca17905a3244713d65fe8")
         );
@@ -232,50 +232,50 @@ class NonStandardErpFederationsTest {
 
     @Test
     void getErpPubKeys() {
-        assertEquals(emergencyKeys, federation.getErpPubKeys());
+        assertEquals(emergencyKeys, nonStandardErpFederation.getErpPubKeys());
     }
 
     @Test
     void getActivationDelay() {
-        assertEquals(activationDelayValue, federation.getActivationDelay());
+        assertEquals(activationDelayValue, nonStandardErpFederation.getActivationDelay());
     }
 
     @Test
     void testEquals_basic() {
-        assertEquals(federation, federation);
+        assertEquals(nonStandardErpFederation, nonStandardErpFederation);
 
-        assertNotEquals(null, federation);
-        assertNotEquals(federation, new Object());
-        assertNotEquals("something else", federation);
+        assertNotEquals(null, nonStandardErpFederation);
+        assertNotEquals(nonStandardErpFederation, new Object());
+        assertNotEquals("something else", nonStandardErpFederation);
     }
 
     @Test
     void testEquals_same() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(),
-            federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(nonStandardErpFederation.getMembers(), nonStandardErpFederation.getCreationTime(), nonStandardErpFederation.getCreationBlockNumber(),
+            nonStandardErpFederation.getBtcParams(), nonStandardErpFederation.getErpPubKeys(), nonStandardErpFederation.getActivationDelay()
         );
         ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        assertEquals(federation, otherFederation);
+        assertEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationTime() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
-            federation.getCreationBlockNumber(), federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(nonStandardErpFederation.getMembers(), nonStandardErpFederation.getCreationTime().plus(1, ChronoUnit.MILLIS),
+            nonStandardErpFederation.getCreationBlockNumber(), nonStandardErpFederation.getBtcParams(), nonStandardErpFederation.getErpPubKeys(), nonStandardErpFederation.getActivationDelay()
         );
         ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        assertEquals(federation, otherFederation);
+        assertEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationBlockNumber() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber() + 1,
-            federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(nonStandardErpFederation.getMembers(), nonStandardErpFederation.getCreationTime(), nonStandardErpFederation.getCreationBlockNumber() + 1,
+            nonStandardErpFederation.getBtcParams(), nonStandardErpFederation.getErpPubKeys(), nonStandardErpFederation.getActivationDelay()
         );
         ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        assertEquals(federation, otherFederation);
+        assertEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
@@ -283,18 +283,18 @@ class NonStandardErpFederationsTest {
         networkParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
         ErpFederation otherFederation = createDefaultNonStandardErpFederation();
-        Assertions.assertNotEquals(federation, otherFederation);
+        Assertions.assertNotEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
     void testEquals_differentNumberOfMembers() {
         // remove federator9
-        List<BtcECKey> newDefaultKeys = federation.getBtcPublicKeys();
+        List<BtcECKey> newDefaultKeys = nonStandardErpFederation.getBtcPublicKeys();
         newDefaultKeys.remove(newDefaultKeys.size() - 1);
         defaultKeys = newDefaultKeys;
 
         ErpFederation otherFederation = createDefaultNonStandardErpFederation();
-        Assertions.assertNotEquals(federation, otherFederation);
+        Assertions.assertNotEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
@@ -303,13 +303,13 @@ class NonStandardErpFederationsTest {
         BtcECKey federator9PublicKey = BtcECKey.fromPublicOnly(
             Hex.decode("0245ef34f5ee218005c9c21227133e8568a4f3f11aeab919c66ff7b816ae1ffeea")
         );
-        List<BtcECKey> newDefaultKeys = federation.getBtcPublicKeys();
+        List<BtcECKey> newDefaultKeys = nonStandardErpFederation.getBtcPublicKeys();
         newDefaultKeys.remove(8);
         newDefaultKeys.add(federator9PublicKey);
         defaultKeys = newDefaultKeys;
 
         ErpFederation otherFederation = createDefaultNonStandardErpFederation();
-        Assertions.assertNotEquals(federation, otherFederation);
+        Assertions.assertNotEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
@@ -342,9 +342,9 @@ class NonStandardErpFederationsTest {
         networkParameters = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
 
         // this should create the expected non-standard hardcoded fed
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         Script obtainedRedeemScript = builder
             .createRedeemScriptFromKeys(defaultKeys, defaultThreshold,
                 emergencyKeys, emergencyThreshold,
@@ -383,9 +383,9 @@ class NonStandardErpFederationsTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
 
         // this should create the expected non-standard with csv unsigned be fed
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         Script obtainedRedeemScript = builder
             .createRedeemScriptFromKeys(
                 defaultKeys, defaultThreshold,
@@ -426,9 +426,9 @@ class NonStandardErpFederationsTest {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
         // this should create the expected non-standard fed
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         Script obtainedRedeemScript = builder
             .createRedeemScriptFromKeys(defaultKeys, defaultThreshold,
                 emergencyKeys, emergencyThreshold,
@@ -458,9 +458,9 @@ class NonStandardErpFederationsTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
         // this should create the real fed
-        ErpFederation realLegacyErpFederation = createDefaultNonStandardErpFederation();
-        Script p2shScript = realLegacyErpFederation.getP2SHScript();
-        Address address = realLegacyErpFederation.getAddress();
+        ErpFederation realNonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script p2shScript = realNonStandardErpFederation.getP2SHScript();
+        Address address = realNonStandardErpFederation.getAddress();
 
         assertEquals(expectedProgram, Hex.toHexString(p2shScript.getProgram()));
         assertEquals(3, p2shScript.getChunks().size());
@@ -470,19 +470,19 @@ class NonStandardErpFederationsTest {
 
     @Test
     void getErpPubKeys_fromUncompressedPublicKeys_equals() {
-        // Public keys used for creating federation, but uncompressed format now
+        // Public keys used for creating nonStandardErpFederation, but uncompressed format now
         emergencyKeys = emergencyKeys
             .stream()
             .map(BtcECKey::decompress)
             .collect(Collectors.toList());
 
-        // Recreate federation
+        // Recreate nonStandardErpFederation
         ErpFederation federationWithUncompressedKeys = createDefaultNonStandardErpFederation();
         assertEquals(emergencyKeys, federationWithUncompressedKeys.getErpPubKeys());
     }
 
     @Test
-    void getLegacyErpRedeemScript_compareOtherImplementation() throws IOException {
+    void getNonStandardErpRedeemScript_compareOtherImplementation() throws IOException {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
@@ -503,8 +503,8 @@ class NonStandardErpFederationsTest {
                 emergencyKeys = generatedScript.emergencyFed;
                 activationDelayValue = generatedScript.timelock;
 
-                federation = createDefaultNonStandardErpFederation();
-                Script rskjScript = federation.getRedeemScript();
+                nonStandardErpFederation = createDefaultNonStandardErpFederation();
+                Script rskjScript = nonStandardErpFederation.getRedeemScript();
                 Script alternativeScript = generatedScript.script;
 
                 assertEquals(alternativeScript, rskjScript);
@@ -515,8 +515,8 @@ class NonStandardErpFederationsTest {
     @Test
     void getRedeemScript_before_RSKIP293() {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-        federation = createDefaultNonStandardErpFederation();
-        Script redeemScript = federation.getRedeemScript();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script redeemScript = nonStandardErpFederation.getRedeemScript();
         validateErpRedeemScript(
             redeemScript,
             activationDelayValue
@@ -526,8 +526,8 @@ class NonStandardErpFederationsTest {
     @Test
     void getRedeemScript_after_RSKIP293() {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
-        federation = createDefaultNonStandardErpFederation();
-        Script redeemScript = federation.getRedeemScript();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script redeemScript = nonStandardErpFederation.getRedeemScript();
 
         validateErpRedeemScript(
             redeemScript,
@@ -542,12 +542,12 @@ class NonStandardErpFederationsTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
 
-        federation = createDefaultNonStandardErpFederation();
-        Script preRskip293RedeemScript = federation.getRedeemScript();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script preRskip293RedeemScript = nonStandardErpFederation.getRedeemScript();
 
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
-        federation = createDefaultNonStandardErpFederation();
-        Script postRskip293RedeemScript = federation.getRedeemScript();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script postRskip293RedeemScript = nonStandardErpFederation.getRedeemScript();
 
         Assertions.assertNotEquals(preRskip293RedeemScript, postRskip293RedeemScript);
     }
@@ -588,20 +588,20 @@ class NonStandardErpFederationsTest {
         networkParameters = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(false);
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, federation.getRedeemScript());
+        assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, nonStandardErpFederation.getRedeemScript());
     }
 
     @Test
     void getRedeemScript_before_RSKIP_284_mainnet() {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(false);
         //when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, federation.getRedeemScript());
+        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, nonStandardErpFederation.getRedeemScript());
         validateErpRedeemScript(
-            federation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             activationDelayValue
         );
     }
@@ -611,14 +611,14 @@ class NonStandardErpFederationsTest {
         networkParameters = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         assertTrue(builder instanceof NonStandardErpRedeemScriptBuilderWithCsvUnsignedBE);
-        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, federation.getRedeemScript());
+        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, nonStandardErpFederation.getRedeemScript());
 
         validateErpRedeemScript(
-            federation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             activationDelayValue
         );
     }
@@ -628,19 +628,19 @@ class NonStandardErpFederationsTest {
         ErpRedeemScriptBuilder builder;
 
         // check the hardcoded fed didnt exist on mainnet after rskip201
-        federation = createDefaultNonStandardErpFederation();
-        builder = federation.getErpRedeemScriptBuilder();
-        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, federation.getRedeemScript());
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
+        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, nonStandardErpFederation.getRedeemScript());
         assertFalse(builder instanceof NonStandardErpRedeemScriptBuilderHardcoded);
 
         // check the hardcoded fed didnt exist on mainnet after rskip284
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
-        federation = createDefaultNonStandardErpFederation();
-        builder = federation.getErpRedeemScriptBuilder();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         assertFalse(builder instanceof NonStandardErpRedeemScriptBuilderHardcoded);
 
         validateErpRedeemScript(
-            federation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             activationDelayValue
         );
     }
@@ -651,23 +651,23 @@ class NonStandardErpFederationsTest {
 
         // Both federations created before RSKIP284 with the same data, should have the same redeem script
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(false);
-        Federation erpFederation = createDefaultNonStandardErpFederation();
+        ErpFederation nonStandardErpFederation = createDefaultNonStandardErpFederation();
         Federation otherErpFederation = createDefaultNonStandardErpFederation();
-        assertEquals(erpFederation, otherErpFederation);
+        assertEquals(nonStandardErpFederation, otherErpFederation);
 
-        // One federation created after RSKIP284 with the same data, should have different redeem script
+        // One nonStandardErpFederation created after RSKIP284 with the same data, should have different redeem script
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         otherErpFederation = createDefaultNonStandardErpFederation();
-        assertNotEquals(erpFederation, otherErpFederation);
+        assertNotEquals(nonStandardErpFederation, otherErpFederation);
 
-        // The other federation created after RSKIP284 with the same data, should have same redeem script
-        erpFederation = createDefaultNonStandardErpFederation();
-        assertEquals(erpFederation, otherErpFederation);
+        // The other nonStandardErpFederation created after RSKIP284 with the same data, should have same redeem script
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        assertEquals(nonStandardErpFederation, otherErpFederation);
     }
 
     @Disabled("Can't recreate the hardcoded redeem script since the needed CSV value is above the max. Keeping the test ignored as testimonial")
     @Test
-    void createErpFedWithSameRedeemScriptAsHardcodedOne_after_RSKIP293_fails() {
+    void createNonStandardErpFedWithSameRedeemScriptAsHardcodedOne_after_RSKIP293_fails() {
         // We can't test the same condition before RSKIP293 since the serialization used by bj-thin
         // prior to RSKIP293 enforces the CSV value to be encoded using 2 bytes.
         // The hardcoded script has a 3 byte long CSV value
@@ -699,14 +699,14 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_testnet_using_erp_multisig_can_spend() {
+    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_erp_multisig_can_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // The CSV value defined in BridgeTestnetConstants,
         // actually allows the emergency multisig to spend before the expected amount of blocks
         // Since it's encoded as BE and decoded as LE, the result is a number lower than the one defined in the constant
         assertDoesNotThrow(() ->
-            spendFromErpFed(
+            spendFromNonStandardErpFed(
                 constants.getBtcParams(),
                 constants.getErpFedActivationDelay(),
                 false,
@@ -715,14 +715,14 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_testnet_using_erp_multisig_cant_spend() {
+    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_erp_multisig_cant_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Should fail due to the wrong encoding of the CSV value
         // In this case, the value 300 when encoded as BE and decoded as LE results in a larger number
         // This causes the validation to fail
         NetworkParameters btcParams = constants.getBtcParams();
-        assertThrows(ScriptException.class, () -> spendFromErpFed(
+        assertThrows(ScriptException.class, () -> spendFromNonStandardErpFed(
             btcParams,
             300,
             false,
@@ -731,11 +731,11 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_testnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_standard_multisig() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Should validate since it's not executing the path of the script with the CSV value
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             false,
@@ -744,13 +744,13 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_mainnet_using_erp_multisig_can_spend() {
+    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_erp_multisig_can_spend() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // The CSV value defined in BridgeMainnetConstants,
         // actually allows the emergency multisig to spend before the expected amount of blocks
         // Since it's encoded as BE and decoded as LE, the result is a number lower than the one defined in the constant
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             false,
@@ -759,13 +759,13 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_mainnet_using_erp_multisig_cant_spend() {
+    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_erp_multisig_cant_spend() {
         // Should fail due to the wrong encoding of the CSV value
         // In this case, the value 300 when encoded as BE and decoded as LE results in a larger number
         // This causes the validation to fail
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-        assertThrows(ScriptException.class, () -> spendFromErpFed(
+        assertThrows(ScriptException.class, () -> spendFromNonStandardErpFed(
             networkParameters,
             300,
             false,
@@ -774,11 +774,11 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_mainnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_standard_multisig() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // Should validate since it's not executing the path of the script with the CSV value
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             false,
@@ -787,11 +787,11 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_after_RSKIP293_testnet_using_erp_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_erp_multisig() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Post RSKIP293 activation it should encode the CSV value correctly
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             true,
@@ -800,10 +800,10 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_after_RSKIP293_testnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_standard_multisig() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             true,
@@ -812,11 +812,11 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_after_RSKIP293_mainnet_using_erp_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_erp_multisig() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // Post RSKIP293 activation it should encode the CSV value correctly
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             true,
@@ -825,10 +825,10 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_after_RSKIP293_mainnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_standard_multisig() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             true,
@@ -838,17 +838,17 @@ class NonStandardErpFederationsTest {
 
     private void createAndValidateFederation() {
 
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
         validateErpRedeemScript(
-            federation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             defaultKeys,
             emergencyKeys,
             activationDelayValue
         );
     }
 
-    private void spendFromErpFed(
+    private void spendFromNonStandardErpFed(
         NetworkParameters networkParametersValue,
         long activationDelay,
         boolean isRskip293Active,
@@ -871,12 +871,12 @@ class NonStandardErpFederationsTest {
             Collections.singletonList(ConsensusRule.RSKIP293);
         activations = ActivationConfigsForTest.hop400(except).forBlock(0);
 
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
         Coin value = Coin.valueOf(1_000_000);
         Coin fee = Coin.valueOf(10_000);
         BtcTransaction fundTx = new BtcTransaction(networkParameters);
-        fundTx.addOutput(value, federation.getAddress());
+        fundTx.addOutput(value, nonStandardErpFederation.getAddress());
 
         Address destinationAddress = BitcoinTestUtils.createP2PKHAddress(
             networkParameters,
@@ -885,7 +885,7 @@ class NonStandardErpFederationsTest {
 
         FederationTestUtils.spendFromErpFed(
             networkParameters,
-            federation,
+            nonStandardErpFederation,
             signWithEmergencyMultisig ? emergencyKeys : defaultKeys,
             fundTx.getHash(),
             0,

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -95,18 +95,9 @@ class NonStandardErpFederationsTest {
         Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
         long creationBlockNumber = 0L;
 
-        FederationArgs args = new FederationArgs(
-            standardMembers,
-            creationTime,
-            creationBlockNumber
-        );
-        return FederationFactory.buildNonStandardErpFederation(
-            args,
-            networkParameters,
-            emergencyKeys,
-            activationDelayValue,
-            activations
-        );
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(standardMembers, creationTime, creationBlockNumber, networkParameters,
+            emergencyKeys, activationDelayValue);
+        return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
     }
 
     @Test
@@ -260,52 +251,30 @@ class NonStandardErpFederationsTest {
 
     @Test
     void testEquals_same() {
-        FederationArgs args = new FederationArgs(
-            federation.getMembers(),
-            federation.getCreationTime(),
-            federation.getCreationBlockNumber()
+        ErpFederationArgs args = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(),
+            federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
         );
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            federation.getBtcParams(),
-            federation.getErpPubKeys(),
-            federation.getActivationDelay(),
-            activations
-        );
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(args, activations);
         assertEquals(federation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationTime() {
-        FederationArgs args = new FederationArgs(
-            federation.getMembers(),
-            federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
-            federation.getCreationBlockNumber()
+        ErpFederationArgs args = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
+            federation.getCreationBlockNumber(), federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
         );
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            federation.getBtcParams(),
-            federation.getErpPubKeys(),
-            federation.getActivationDelay(),
-            activations
-        );
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(args, activations);
+
         assertEquals(federation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationBlockNumber() {
-        FederationArgs args = new FederationArgs(
-            federation.getMembers(),
-            federation.getCreationTime(),
-            federation.getCreationBlockNumber() + 1
+        ErpFederationArgs args = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber() + 1,
+            federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
         );
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
-            args,
-            federation.getBtcParams(),
-            federation.getErpPubKeys(),
-            federation.getActivationDelay(),
-            activations
-        );
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(args, activations);
+
         assertEquals(federation, otherFederation);
     }
 
@@ -703,6 +672,7 @@ class NonStandardErpFederationsTest {
         // prior to RSKIP293 enforces the CSV value to be encoded using 2 bytes.
         // The hardcoded script has a 3 byte long CSV value
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
 
         List<BtcECKey> standardMultisigKeys = Arrays.stream(new String[]{
             "0208f40073a9e43b3e9103acec79767a6de9b0409749884e989960fee578012fce",
@@ -722,21 +692,10 @@ class NonStandardErpFederationsTest {
 
         List<FederationMember> federationMembersWithBtcKeys = FederationTestUtils.getFederationMembersWithBtcKeys(standardMultisigKeys);
         Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
-        FederationArgs args = new FederationArgs(
-            federationMembersWithBtcKeys,
-            creationTime,
-            1
-        );
-        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
+        ErpFederationArgs args = new ErpFederationArgs(federationMembersWithBtcKeys, creationTime, 1, btcParams,
+            emergencyMultisigKeys, activationDelay);
 
-        assertThrows(ErpFederationCreationException.class,
-            () -> FederationFactory.buildNonStandardErpFederation(
-            args,
-            btcParams,
-            emergencyMultisigKeys,
-            activationDelay,
-            activations
-        ));
+        assertThrows(ErpFederationCreationException.class, () -> FederationFactory.buildNonStandardErpFederation(args, activations));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -95,10 +95,13 @@ class NonStandardErpFederationsTest {
         Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
         long creationBlockNumber = 0L;
 
-        return FederationFactory.buildNonStandardErpFederation(
+        FederationArgs args = new FederationArgs(
             standardMembers,
             creationTime,
-            creationBlockNumber,
+            creationBlockNumber
+        );
+        return FederationFactory.buildNonStandardErpFederation(
+            args,
             networkParameters,
             emergencyKeys,
             activationDelayValue,
@@ -257,10 +260,13 @@ class NonStandardErpFederationsTest {
 
     @Test
     void testEquals_same() {
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
+        FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
+            federation.getCreationBlockNumber()
+        );
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
+            args,
             federation.getBtcParams(),
             federation.getErpPubKeys(),
             federation.getActivationDelay(),
@@ -271,10 +277,13 @@ class NonStandardErpFederationsTest {
 
     @Test
     void testEquals_differentCreationTime() {
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
+        FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
-            federation.getCreationBlockNumber(),
+            federation.getCreationBlockNumber()
+        );
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
+            args,
             federation.getBtcParams(),
             federation.getErpPubKeys(),
             federation.getActivationDelay(),
@@ -285,10 +294,13 @@ class NonStandardErpFederationsTest {
 
     @Test
     void testEquals_differentCreationBlockNumber() {
-        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
+        FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber() + 1,
+            federation.getCreationBlockNumber() + 1
+        );
+        ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(
+            args,
             federation.getBtcParams(),
             federation.getErpPubKeys(),
             federation.getActivationDelay(),
@@ -710,13 +722,16 @@ class NonStandardErpFederationsTest {
 
         List<FederationMember> federationMembersWithBtcKeys = FederationTestUtils.getFederationMembersWithBtcKeys(standardMultisigKeys);
         Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
+        FederationArgs args = new FederationArgs(
+            federationMembersWithBtcKeys,
+            creationTime,
+            1
+        );
         NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
 
         assertThrows(ErpFederationCreationException.class,
             () -> FederationFactory.buildNonStandardErpFederation(
-            federationMembersWithBtcKeys,
-            creationTime,
-            1,
+            args,
             btcParams,
             emergencyMultisigKeys,
             activationDelay,

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -222,9 +222,8 @@ class P2shErpFederationTest {
 
     @Test
     void testEquals_same() {
-        ErpFederationArgs erpFederationArgs =new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(), federation.getBtcParams(),
-            federation.getErpPubKeys(), federation.getActivationDelay()
-        );
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(),
+            federation.getCreationBlockNumber(), federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay());
         ErpFederation otherFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         assertEquals(federation, otherFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -81,11 +81,14 @@ class P2shErpFederationTest {
         List<FederationMember> standardMembers = FederationTestUtils.getFederationMembersWithBtcKeys(defaultKeys);
         Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
         long creationBlockNumber = 0L;
-
-        return FederationFactory.buildP2shErpFederation(
+        FederationArgs args = new FederationArgs(
             standardMembers,
             creationTime,
-            creationBlockNumber,
+            creationBlockNumber
+        );
+
+        return FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             emergencyKeys,
             activationDelayValue
@@ -227,10 +230,13 @@ class P2shErpFederationTest {
 
     @Test
     void testEquals_same() {
-        ErpFederation otherFederation = FederationFactory.buildP2shErpFederation(
+        FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
+            federation.getCreationBlockNumber()
+        );
+        ErpFederation otherFederation = FederationFactory.buildP2shErpFederation(
+            args,
             federation.getBtcParams(),
             federation.getErpPubKeys(),
             federation.getActivationDelay()
@@ -343,19 +349,20 @@ class P2shErpFederationTest {
         );
         Instant creationTime = Instant.now();
         int creationBlock = 0;
+        FederationArgs args = new FederationArgs(
+            members,
+            creationTime,
+            creationBlock
+        );
         NetworkParameters btcParams = BridgeRegTestConstants.getInstance().getBtcParams();
 
         // Create a standard multisig powpeg and then a p2sh valid one. Both of them should produce the same default redeem script
         StandardMultisigFederation standardMultisigFed = FederationFactory.buildStandardMultiSigFederation(
-            members,
-            creationTime,
-            creationBlock,
+            args,
             btcParams
         );
         ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(
-            members,
-            creationTime,
-            creationBlock,
+            args,
             btcParams,
             Arrays.asList(new BtcECKey(), new BtcECKey()),
             10_000
@@ -463,10 +470,13 @@ class P2shErpFederationTest {
         for (RawGeneratedRedeemScript generatedScript : generatedScripts) {
             // Skip test cases with invalid redeem script that exceed the maximum size
             if (generatedScript.script.getProgram().length <= MAX_SCRIPT_ELEMENT_SIZE) {
-                Federation erpFederation = FederationFactory.buildP2shErpFederation(
+                FederationArgs args = new FederationArgs(
                     FederationTestUtils.getFederationMembersWithBtcKeys(generatedScript.mainFed),
                     ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
-                    1,
+                    1
+                );
+                Federation erpFederation = FederationFactory.buildP2shErpFederation(
+                    args,
                     NetworkParameters.fromID(NetworkParameters.ID_TESTNET),
                     generatedScript.emergencyFed,
                     generatedScript.timelock
@@ -496,10 +506,13 @@ class P2shErpFederationTest {
             true
         );
 
-        ErpFederation p2shErpFed = FederationFactory.buildP2shErpFederation(
+        FederationArgs args = new FederationArgs(
             FederationMember.getFederationMembersFromKeys(defaultKeys),
             ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
-            0L,
+            0L
+        );
+        ErpFederation p2shErpFed = FederationFactory.buildP2shErpFederation(
+            args,
             networkParameters,
             emergencyKeys,
             activationDelay

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -81,11 +81,11 @@ class P2shErpFederationTest {
         List<FederationMember> standardMembers = FederationTestUtils.getFederationMembersWithBtcKeys(defaultKeys);
         Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
         long creationBlockNumber = 0L;
-        ErpFederationArgs args = new ErpFederationArgs(standardMembers, creationTime, creationBlockNumber, networkParameters,
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(standardMembers, creationTime, creationBlockNumber, networkParameters,
             emergencyKeys, activationDelayValue
         );
 
-        return FederationFactory.buildP2shErpFederation(args);
+        return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
 
     private void createAndValidateFederation() {
@@ -223,10 +223,10 @@ class P2shErpFederationTest {
 
     @Test
     void testEquals_same() {
-        ErpFederationArgs args = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(), federation.getBtcParams(),
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(), federation.getBtcParams(),
             federation.getErpPubKeys(), federation.getActivationDelay()
         );
-        ErpFederation otherFederation = FederationFactory.buildP2shErpFederation(args);
+        ErpFederation otherFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         assertEquals(federation, otherFederation);
     }
@@ -336,14 +336,14 @@ class P2shErpFederationTest {
         );
         Instant creationTime = Instant.now();
         int creationBlock = 0;
-        FederationArgs args = new FederationArgs(members, creationTime, creationBlock, btcParams);
-
-        // Create a standard multisig powpeg and then a p2sh valid one. Both of them should produce the same default redeem script
-        StandardMultisigFederation standardMultisigFed = FederationFactory.buildStandardMultiSigFederation(args);
-        ErpFederationArgs erpArgs = new ErpFederationArgs(members, creationTime, creationBlock, btcParams,
+        FederationArgs federationArgs = new FederationArgs(members, creationTime, creationBlock, btcParams);
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(members, creationTime, creationBlock, btcParams,
             Arrays.asList(new BtcECKey(), new BtcECKey()),
             10_000);
-        ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(erpArgs);
+
+        // Create a standard multisig powpeg and then a p2sh valid one. Both of them should produce the same default redeem script
+        StandardMultisigFederation standardMultisigFed = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         assertEquals(standardMultisigFed.getRedeemScript(), p2shFed.getDefaultRedeemScript());
         Assertions.assertNotEquals(p2shFed.getRedeemScript(), p2shFed.getDefaultRedeemScript());
@@ -447,12 +447,12 @@ class P2shErpFederationTest {
         for (RawGeneratedRedeemScript generatedScript : generatedScripts) {
             // Skip test cases with invalid redeem script that exceed the maximum size
             if (generatedScript.script.getProgram().length <= MAX_SCRIPT_ELEMENT_SIZE) {
-                ErpFederationArgs args = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(generatedScript.mainFed),
+                ErpFederationArgs erpFederationArgs = new ErpFederationArgs(FederationTestUtils.getFederationMembersWithBtcKeys(generatedScript.mainFed),
                     ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(), 1,
                     NetworkParameters.fromID(NetworkParameters.ID_TESTNET),
                     generatedScript.emergencyFed,
                     generatedScript.timelock);
-                Federation erpFederation = FederationFactory.buildP2shErpFederation(args);
+                Federation erpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
                 Script rskjScript = erpFederation.getRedeemScript();
                 Script alternativeScript = generatedScript.script;
@@ -478,11 +478,11 @@ class P2shErpFederationTest {
             true
         );
 
-        ErpFederationArgs args = new ErpFederationArgs(
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
             FederationMember.getFederationMembersFromKeys(defaultKeys), ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
             0L, networkParameters, emergencyKeys, activationDelay
         );
-        ErpFederation p2shErpFed = FederationFactory.buildP2shErpFederation(args);
+        ErpFederation p2shErpFed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         Coin value = Coin.valueOf(1_000_000);
         Coin fee = Coin.valueOf(10_000);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -81,9 +81,8 @@ class P2shErpFederationTest {
         List<FederationMember> standardMembers = FederationTestUtils.getFederationMembersWithBtcKeys(defaultKeys);
         Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
         long creationBlockNumber = 0L;
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(standardMembers, creationTime, creationBlockNumber, networkParameters,
-            emergencyKeys, activationDelayValue
-        );
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(standardMembers, creationTime, creationBlockNumber, networkParameters, emergencyKeys, activationDelayValue);
 
         return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
@@ -223,7 +222,7 @@ class P2shErpFederationTest {
 
     @Test
     void testEquals_same() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(), federation.getBtcParams(),
+        ErpFederationArgs erpFederationArgs =new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(), federation.getBtcParams(),
             federation.getErpPubKeys(), federation.getActivationDelay()
         );
         ErpFederation otherFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
@@ -337,12 +336,12 @@ class P2shErpFederationTest {
         Instant creationTime = Instant.now();
         int creationBlock = 0;
         FederationArgs federationArgs = new FederationArgs(members, creationTime, creationBlock, btcParams);
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(members, creationTime, creationBlock, btcParams,
-            Arrays.asList(new BtcECKey(), new BtcECKey()),
-            10_000);
 
         // Create a standard multisig powpeg and then a p2sh valid one. Both of them should produce the same default redeem script
         StandardMultisigFederation standardMultisigFed = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+
+        List<BtcECKey> erpPubKeys = Arrays.asList(new BtcECKey(), new BtcECKey());
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, 10_000);
         ErpFederation p2shFed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         assertEquals(standardMultisigFed.getRedeemScript(), p2shFed.getDefaultRedeemScript());
@@ -472,16 +471,16 @@ class P2shErpFederationTest {
             new String[]{"fed1", "fed2", "fed3", "fed4", "fed5", "fed6", "fed7", "fed8", "fed9", "fed10"},
             true
         );
+        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(defaultKeys);
+        Instant creationTime = ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant();
 
         List<BtcECKey> emergencyKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"erp1", "erp2", "erp3", "erp4"},
             true
         );
 
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
-            FederationMember.getFederationMembersFromKeys(defaultKeys), ZonedDateTime.parse("2017-06-10T02:30:00Z").toInstant(),
-            0L, networkParameters, emergencyKeys, activationDelay
-        );
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(federationMembers, creationTime, 0L, networkParameters, emergencyKeys, activationDelay);
         ErpFederation p2shErpFed = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
         Coin value = Coin.valueOf(1_000_000);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
@@ -424,8 +424,7 @@ class PendingFederationTest {
 
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, 0L, btcParams,
-            erpPubKeys, activationDelay);
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpPubKeys, activationDelay);
 
         if (isRskip353Active) {
             expectedFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
@@ -374,7 +374,7 @@ class PendingFederationTest {
 
         byte[] data = RLP.encodeList(rlpBytes);
 
-        PendingFederation deserializedPendingFederation = PendingFederation.deserializeFromBtcKeys(data);
+        PendingFederation deserializedPendingFederation = PendingFederation.deserializeFromBtcKeysOnly(data);
 
         Assertions.assertEquals(6, deserializedPendingFederation.getBtcPublicKeys().size());
         for (int i = 0; i < 6; i++) {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
@@ -418,20 +418,19 @@ class PendingFederationTest {
         );
 
         Federation expectedFederation;
+        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersFromPks(privateKeys),
+            creationTime,
+            0L);
         if (isRskip353Active) {
             expectedFederation = FederationFactory.buildP2shErpFederation(
-                FederationTestUtils.getFederationMembersFromPks(privateKeys),
-                creationTime,
-                0L,
+                args,
                 bridgeConstants.getBtcParams(),
                 bridgeConstants.getErpFedPubKeysList(),
                 bridgeConstants.getErpFedActivationDelay()
             );
         } else if (isRskip201Active) {
             expectedFederation = FederationFactory.buildNonStandardErpFederation(
-                FederationTestUtils.getFederationMembersFromPks(privateKeys),
-                creationTime,
-                0L,
+                args,
                 bridgeConstants.getBtcParams(),
                 bridgeConstants.getErpFedPubKeysList(),
                 bridgeConstants.getErpFedActivationDelay(),
@@ -439,9 +438,7 @@ class PendingFederationTest {
             );
         } else {
             expectedFederation = FederationFactory.buildStandardMultiSigFederation(
-                FederationTestUtils.getFederationMembersFromPks(privateKeys),
-                creationTime,
-                0L,
+                args,
                 bridgeConstants.getBtcParams()
             );
         }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PendingFederationTest.java
@@ -418,29 +418,21 @@ class PendingFederationTest {
         );
 
         Federation expectedFederation;
-        FederationArgs args = new FederationArgs(FederationTestUtils.getFederationMembersFromPks(privateKeys),
-            creationTime,
-            0L);
+        List<FederationMember> fedMembers = FederationTestUtils.getFederationMembersFromPks(privateKeys);
+        NetworkParameters btcParams = bridgeConstants.getBtcParams();
+        FederationArgs federationArgs = new FederationArgs(fedMembers, creationTime, 0L, btcParams);
+
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, 0L, btcParams,
+            erpPubKeys, activationDelay);
+
         if (isRskip353Active) {
-            expectedFederation = FederationFactory.buildP2shErpFederation(
-                args,
-                bridgeConstants.getBtcParams(),
-                bridgeConstants.getErpFedPubKeysList(),
-                bridgeConstants.getErpFedActivationDelay()
-            );
+            expectedFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
         } else if (isRskip201Active) {
-            expectedFederation = FederationFactory.buildNonStandardErpFederation(
-                args,
-                bridgeConstants.getBtcParams(),
-                bridgeConstants.getErpFedPubKeysList(),
-                bridgeConstants.getErpFedActivationDelay(),
-                activations
-            );
+            expectedFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         } else {
-            expectedFederation = FederationFactory.buildStandardMultiSigFederation(
-                args,
-                bridgeConstants.getBtcParams()
-            );
+            expectedFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
         }
 
         assertEquals(expectedFederation, builtFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
@@ -84,19 +84,11 @@ class StandardMultisigFederationTest {
         List<FederationMember> newMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newKeys);
         Instant creationTime = federation.getCreationTime();
         long creationBlockNumber = federation.getCreationBlockNumber();
-        FederationArgs args = new FederationArgs(
-            newMembers,
-            creationTime,
-            creationBlockNumber
-        );
         NetworkParameters networkParameters = federation.getBtcParams();
-
+        FederationArgs args = new FederationArgs(newMembers, creationTime, creationBlockNumber, networkParameters);
         ScriptCreationException exception =
             assertThrows(ScriptCreationException.class,
-                () -> FederationFactory.buildStandardMultiSigFederation(
-                args,
-                networkParameters
-            ));
+                () -> FederationFactory.buildStandardMultiSigFederation(args));
         assertEquals(ABOVE_MAX_SCRIPT_ELEMENT_SIZE, exception.getReason());
     }
 
@@ -133,11 +125,11 @@ class StandardMultisigFederationTest {
         FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber()
+            federation.getCreationBlockNumber(),
+            federation.getBtcParams()
         );
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            federation.getBtcParams()
+            args
         );
 
         assertEquals(federation, otherFederation);
@@ -148,11 +140,11 @@ class StandardMultisigFederationTest {
         FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
-            federation.getCreationBlockNumber()
+            federation.getCreationBlockNumber(),
+            networkParameters
         );
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
         assertEquals(federation, otherFederation);
     }
@@ -162,11 +154,11 @@ class StandardMultisigFederationTest {
         FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber() + 1
+            federation.getCreationBlockNumber() + 1,
+            networkParameters
         );
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
         assertEquals(federation, otherFederation);
     }
@@ -176,11 +168,11 @@ class StandardMultisigFederationTest {
         FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber()
+            federation.getCreationBlockNumber(),
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+            args
         );
         // Different network parameters will result in a different address
         assertNotEquals(federation, otherFederation);
@@ -195,12 +187,12 @@ class StandardMultisigFederationTest {
         FederationArgs args = new FederationArgs(
             newMembers,
             federation.getCreationTime(),
-            federation.getCreationBlockNumber()
+            federation.getCreationBlockNumber(),
+            federation.getBtcParams()
         );
 
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            federation.getBtcParams()
+            args
         );
 
         Assertions.assertNotEquals(federation, otherFederation);
@@ -222,12 +214,12 @@ class StandardMultisigFederationTest {
         FederationArgs args = new FederationArgs(
             differentMembers,
             creationTime,
-            creationBlockNumber
+            creationBlockNumber,
+            networkParameters
         );
 
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            networkParameters
+            args
         );
 
         assertNotEquals(federation, otherFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
@@ -85,10 +85,10 @@ class StandardMultisigFederationTest {
         Instant creationTime = federation.getCreationTime();
         long creationBlockNumber = federation.getCreationBlockNumber();
         NetworkParameters networkParameters = federation.getBtcParams();
-        FederationArgs args = new FederationArgs(newMembers, creationTime, creationBlockNumber, networkParameters);
+        FederationArgs federationArgs = new FederationArgs(newMembers, creationTime, creationBlockNumber, networkParameters);
         ScriptCreationException exception =
             assertThrows(ScriptCreationException.class,
-                () -> FederationFactory.buildStandardMultiSigFederation(args));
+                () -> FederationFactory.buildStandardMultiSigFederation(federationArgs));
         assertEquals(ABOVE_MAX_SCRIPT_ELEMENT_SIZE, exception.getReason());
     }
 
@@ -122,14 +122,14 @@ class StandardMultisigFederationTest {
 
     @Test
     void testEquals_same() {
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
             federation.getCreationBlockNumber(),
             federation.getBtcParams()
         );
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         assertEquals(federation, otherFederation);
@@ -137,42 +137,42 @@ class StandardMultisigFederationTest {
 
     @Test
     void testEquals_differentCreationTime() {
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
             federation.getCreationBlockNumber(),
             networkParameters
         );
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
         assertEquals(federation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationBlockNumber() {
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
             federation.getCreationBlockNumber() + 1,
             networkParameters
         );
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
         assertEquals(federation, otherFederation);
     }
 
     @Test
     void testEquals_differentNetworkParameters() {
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
             federation.getCreationBlockNumber(),
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
         // Different network parameters will result in a different address
         assertNotEquals(federation, otherFederation);
@@ -184,7 +184,7 @@ class StandardMultisigFederationTest {
         List<BtcECKey> newKeys = federation.getBtcPublicKeys();
         newKeys.remove(14);
         List<FederationMember> newMembers = FederationTestUtils.getFederationMembersWithKeys(newKeys);
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             newMembers,
             federation.getCreationTime(),
             federation.getCreationBlockNumber(),
@@ -192,7 +192,7 @@ class StandardMultisigFederationTest {
         );
 
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         Assertions.assertNotEquals(federation, otherFederation);
@@ -211,7 +211,7 @@ class StandardMultisigFederationTest {
 
         Instant creationTime = federation.getCreationTime();
         long creationBlockNumber = federation.getCreationBlockNumber();
-        FederationArgs args = new FederationArgs(
+        FederationArgs federationArgs = new FederationArgs(
             differentMembers,
             creationTime,
             creationBlockNumber,
@@ -219,7 +219,7 @@ class StandardMultisigFederationTest {
         );
 
         Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
-            args
+            federationArgs
         );
 
         assertNotEquals(federation, otherFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
@@ -84,13 +84,17 @@ class StandardMultisigFederationTest {
         List<FederationMember> newMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newKeys);
         Instant creationTime = federation.getCreationTime();
         long creationBlockNumber = federation.getCreationBlockNumber();
+        FederationArgs args = new FederationArgs(
+            newMembers,
+            creationTime,
+            creationBlockNumber
+        );
         NetworkParameters networkParameters = federation.getBtcParams();
+
         ScriptCreationException exception =
             assertThrows(ScriptCreationException.class,
                 () -> FederationFactory.buildStandardMultiSigFederation(
-                newMembers,
-                creationTime,
-                creationBlockNumber,
+                args,
                 networkParameters
             ));
         assertEquals(ABOVE_MAX_SCRIPT_ELEMENT_SIZE, exception.getReason());
@@ -126,10 +130,13 @@ class StandardMultisigFederationTest {
 
     @Test
     void testEquals_same() {
-        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
+            federation.getCreationBlockNumber()
+        );
+        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             federation.getBtcParams()
         );
 
@@ -138,10 +145,13 @@ class StandardMultisigFederationTest {
 
     @Test
     void testEquals_differentCreationTime() {
-        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
-            federation.getCreationBlockNumber(),
+            federation.getCreationBlockNumber()
+        );
+        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
         assertEquals(federation, otherFederation);
@@ -149,10 +159,13 @@ class StandardMultisigFederationTest {
 
     @Test
     void testEquals_differentCreationBlockNumber() {
-        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber() + 1,
+            federation.getCreationBlockNumber() + 1
+        );
+        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
         assertEquals(federation, otherFederation);
@@ -160,10 +173,13 @@ class StandardMultisigFederationTest {
 
     @Test
     void testEquals_differentNetworkParameters() {
-        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             federation.getMembers(),
             federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
+            federation.getCreationBlockNumber()
+        );
+        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
         // Different network parameters will result in a different address
@@ -176,11 +192,14 @@ class StandardMultisigFederationTest {
         List<BtcECKey> newKeys = federation.getBtcPublicKeys();
         newKeys.remove(14);
         List<FederationMember> newMembers = FederationTestUtils.getFederationMembersWithKeys(newKeys);
-
-        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             newMembers,
             federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
+            federation.getCreationBlockNumber()
+        );
+
+        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             federation.getBtcParams()
         );
 
@@ -200,10 +219,14 @@ class StandardMultisigFederationTest {
 
         Instant creationTime = federation.getCreationTime();
         long creationBlockNumber = federation.getCreationBlockNumber();
-        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+        FederationArgs args = new FederationArgs(
             differentMembers,
             creationTime,
-            creationBlockNumber,
+            creationBlockNumber
+        );
+
+        Federation otherFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
             networkParameters
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.peg.*;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationMember;
 import org.ethereum.TestUtils;
@@ -116,11 +117,14 @@ class ActiveFederationTest extends BridgePerformanceTestCase {
             if (!genesis) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
                 List<FederationMember> members = getNRandomFederationMembers(numFederators);
+                FederationArgs args = new FederationArgs(
+                    members,
+                    Instant.ofEpochMilli(TestUtils.generateLong(String.valueOf(executionIndex))),
+                    Helper.randomInRange(1, 10)
+                );
 
                 federation = FederationFactory.buildStandardMultiSigFederation(
-                        members,
-                        Instant.ofEpochMilli(TestUtils.generateLong(String.valueOf(executionIndex))),
-                        Helper.randomInRange(1, 10),
+                        args,
                         networkParameters
                 );
                 provider.setNewFederation(federation);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -120,12 +120,12 @@ class ActiveFederationTest extends BridgePerformanceTestCase {
                 FederationArgs args = new FederationArgs(
                     members,
                     Instant.ofEpochMilli(TestUtils.generateLong(String.valueOf(executionIndex))),
-                    Helper.randomInRange(1, 10)
+                    Helper.randomInRange(1, 10),
+                    networkParameters
                 );
 
                 federation = FederationFactory.buildStandardMultiSigFederation(
-                        args,
-                        networkParameters
+                        args
                 );
                 provider.setNewFederation(federation);
             } else {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -117,7 +117,7 @@ class ActiveFederationTest extends BridgePerformanceTestCase {
             if (!genesis) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
                 List<FederationMember> members = getNRandomFederationMembers(numFederators);
-                FederationArgs args = new FederationArgs(
+                FederationArgs federationArgs = new FederationArgs(
                     members,
                     Instant.ofEpochMilli(TestUtils.generateLong(String.valueOf(executionIndex))),
                     Helper.randomInRange(1, 10),
@@ -125,7 +125,7 @@ class ActiveFederationTest extends BridgePerformanceTestCase {
                 );
 
                 federation = FederationFactory.buildStandardMultiSigFederation(
-                        args
+                    federationArgs
                 );
                 provider.setNewFederation(federation);
             } else {

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -105,14 +105,14 @@ class RetiringFederationTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
             if (present) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
-                FederationArgs args = new FederationArgs(
+                FederationArgs federationArgs = new FederationArgs(
                     ActiveFederationTest.getNRandomFederationMembers(numFederators),
                     Instant.ofEpochMilli(random.nextLong()),
                     Helper.randomInRange(1, 10),
                     networkParameters
                 );
                 retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-                        args
+                    federationArgs
                 );
                 provider.setNewFederation(bridgeConstants.getGenesisFederation());
                 provider.setOldFederation(retiringFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
@@ -104,10 +105,13 @@ class RetiringFederationTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
             if (present) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
+                FederationArgs args = new FederationArgs(
+                    ActiveFederationTest.getNRandomFederationMembers(numFederators),
+                    Instant.ofEpochMilli(random.nextLong()),
+                    Helper.randomInRange(1, 10)
+                );
                 retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-                        ActiveFederationTest.getNRandomFederationMembers(numFederators),
-                        Instant.ofEpochMilli(random.nextLong()),
-                        Helper.randomInRange(1, 10),
+                        args,
                         networkParameters
                 );
                 provider.setNewFederation(bridgeConstants.getGenesisFederation());

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -108,11 +108,11 @@ class RetiringFederationTest extends BridgePerformanceTestCase {
                 FederationArgs args = new FederationArgs(
                     ActiveFederationTest.getNRandomFederationMembers(numFederators),
                     Instant.ofEpochMilli(random.nextLong()),
-                    Helper.randomInRange(1, 10)
+                    Helper.randomInRange(1, 10),
+                    networkParameters
                 );
                 retiringFederation = FederationFactory.buildStandardMultiSigFederation(
-                        args,
-                        networkParameters
+                        args
                 );
                 provider.setNewFederation(bridgeConstants.getGenesisFederation());
                 provider.setOldFederation(retiringFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -224,21 +224,19 @@ class BridgeEventLoggerImplTest {
 
         List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
         NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        FederationArgs args;
-        args = new FederationArgs(oldFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
+        FederationArgs oldFedArgs = new FederationArgs(oldFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
 
-        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(oldFedArgs);
 
         List<BtcECKey> newFederationKeys = Arrays.asList(
             BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
             BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
             BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
         );
-
         List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
-        args = new FederationArgs(newFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
+        FederationArgs newFedArgs = new FederationArgs(newFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(newFedArgs);
 
         // Act
         eventLogger.logCommitFederation(executionBlock, oldFederation, newFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -23,11 +23,8 @@ import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.*;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.*;
 import co.rsk.peg.PegTestUtils;
-import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -226,11 +223,13 @@ class BridgeEventLoggerImplTest {
         );
 
         List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
+        FederationArgs args;
+        args = new FederationArgs(oldFederationMembers,
+            Instant.ofEpochMilli(15005L),
+            15L);
 
         Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-            oldFederationMembers,
-            Instant.ofEpochMilli(15005L),
-            15L,
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 
@@ -241,11 +240,12 @@ class BridgeEventLoggerImplTest {
         );
 
         List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
+        args = new FederationArgs(newFederationMembers,
+            Instant.ofEpochMilli(5005L),
+            0L);
 
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            newFederationMembers,
-            Instant.ofEpochMilli(5005L),
-            0L,
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -223,15 +223,11 @@ class BridgeEventLoggerImplTest {
         );
 
         List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         FederationArgs args;
-        args = new FederationArgs(oldFederationMembers,
-            Instant.ofEpochMilli(15005L),
-            15L);
+        args = new FederationArgs(oldFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
 
-        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
+        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         List<BtcECKey> newFederationKeys = Arrays.asList(
             BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
@@ -240,14 +236,9 @@ class BridgeEventLoggerImplTest {
         );
 
         List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
-        args = new FederationArgs(newFederationMembers,
-            Instant.ofEpochMilli(5005L),
-            0L);
+        args = new FederationArgs(newFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         // Act
         eventLogger.logCommitFederation(executionBlock, oldFederation, newFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
@@ -209,21 +209,19 @@ class BridgeEventLoggerLegacyImplTest {
 
         List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
         NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-        FederationArgs args;
-        args = new FederationArgs(oldFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
+        FederationArgs oldFedArgs = new FederationArgs(oldFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
 
-        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(oldFedArgs);
 
         List<BtcECKey> newFederationKeys = Arrays.asList(
             BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
             BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
             BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
         );
-
         List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
-        args = new FederationArgs(newFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
+        FederationArgs newFedArgs  = new FederationArgs(newFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(newFedArgs);
 
         // Act
         eventLogger.logCommitFederation(executionBlock, oldFederation, newFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
@@ -208,14 +208,11 @@ class BridgeEventLoggerLegacyImplTest {
         );
 
         List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
+        NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
         FederationArgs args;
-        args = new FederationArgs(oldFederationMembers,
-            Instant.ofEpochMilli(15005L), 15L);
+        args = new FederationArgs(oldFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
 
-        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
+        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         List<BtcECKey> newFederationKeys = Arrays.asList(
             BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
@@ -224,14 +221,9 @@ class BridgeEventLoggerLegacyImplTest {
         );
 
         List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
-        args = new FederationArgs(newFederationMembers,
-            Instant.ofEpochMilli(5005L),
-            0L);
+        args = new FederationArgs(newFederationMembers, Instant.ofEpochMilli(15005L), 15L, btcParams);
 
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            args,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-        );
+        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         // Act
         eventLogger.logCommitFederation(executionBlock, oldFederation, newFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
@@ -24,11 +24,8 @@ import co.rsk.config.BridgeRegTestConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.*;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.*;
 import co.rsk.peg.PegTestUtils;
-import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.federation.FederationTestUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -211,9 +208,14 @@ class BridgeEventLoggerLegacyImplTest {
         );
 
         List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
+        FederationArgs args;
+        args = new FederationArgs(oldFederationMembers,
+            Instant.ofEpochMilli(15005L), 15L);
 
-        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(oldFederationMembers,
-            Instant.ofEpochMilli(15005L), 15L, NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
+        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(
+            args,
+            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
+        );
 
         List<BtcECKey> newFederationKeys = Arrays.asList(
             BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
@@ -222,11 +224,12 @@ class BridgeEventLoggerLegacyImplTest {
         );
 
         List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
+        args = new FederationArgs(newFederationMembers,
+            Instant.ofEpochMilli(5005L),
+            0L);
 
         Federation newFederation = FederationFactory.buildStandardMultiSigFederation(
-            newFederationMembers,
-            Instant.ofEpochMilli(5005L),
-            0L,
+            args,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
 


### PR DESCRIPTION
In order to reduce the amount of fields we pass to Federation and ErpFederation constructors, FederationArgs and ErpFederationArgs were created.
FederationArgs contains the federation members, the creation time, the creation block number and the btc params.
ErpFederationArgs extends FederationArgs by adding the erp pub keys and the activation delay value.