### PR TITLE
Rebase rename legacy to non standard

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -312,7 +312,7 @@ public class BridgeSerializationUtils {
             FederationMember::deserialize
         );
     }
-    public static ErpFederation deserializeLegacyErpFederation(
+    public static ErpFederation deserializeNonStandardErpFederation(
         byte[] data,
         BridgeConstants bridgeConstants,
         ActivationConfig.ForBlock activations

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -1078,7 +1078,7 @@ public class BridgeStorageProvider {
             );
         }
         if (version == NON_STANDARD_ERP_FEDERATION.getFormatVersion()) {
-            return BridgeSerializationUtils.deserializeLegacyErpFederation(
+            return BridgeSerializationUtils.deserializeNonStandardErpFederation(
                 data,
                 bridgeConstants,
                 activations

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -170,16 +170,16 @@ class BridgeSerializationUtilsTest {
             creationBlockNumber,
             btcParams
         );
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-        byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(federation);
+        byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(standardMultisigFederation);
         StringBuilder expectedBuilder = new StringBuilder();
         expectedBuilder.append("f8d3"); // Outer list
         expectedBuilder.append("83abcdef"); // Creation time
         expectedBuilder.append("2a"); // Creation block number
         expectedBuilder.append("f8cc"); // Inner list
 
-        federation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
+        standardMultisigFederation.getBtcPublicKeys().stream().sorted(BtcECKey.PUBKEY_COMPARATOR).forEach(key -> {
             expectedBuilder.append("a1");
             expectedBuilder.append(ByteUtil.toHexString(key.getPubKey()));
         });
@@ -315,8 +315,8 @@ class BridgeSerializationUtilsTest {
 
         FederationArgs federationArgs =
             new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
-        Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-        byte[] serializedFederation = BridgeSerializationUtils.serializeFederation(testFederation);
+        Federation testStandardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        byte[] serializedFederation = BridgeSerializationUtils.serializeFederation(testStandardMultisigFederation);
 
         RLPList serializedList = (RLPList) RLP.decode2(serializedFederation).get(0);
         Assertions.assertEquals(3, serializedList.size());
@@ -682,11 +682,11 @@ class BridgeSerializationUtilsTest {
         ));
         FederationArgs federationArgs = new FederationArgs(members, Instant.ofEpochMilli(0xabcdef), 42L,
             networkParams);
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-        byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(federation);
+        byte[] result = BridgeSerializationUtils.serializeFederationOnlyBtcKeys(standardMultisigFederation);
         Federation deserializedFederation = BridgeSerializationUtils.deserializeStandardMultisigFederationOnlyBtcKeys(result, networkParams);
-        MatcherAssert.assertThat(federation, is(deserializedFederation));
+        MatcherAssert.assertThat(standardMultisigFederation, is(deserializedFederation));
     }
 
     @Test
@@ -1135,8 +1135,8 @@ class BridgeSerializationUtilsTest {
 
             FederationArgs federationArgs =
                 new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
-            Federation testFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-            byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testFederation);
+            Federation testStandardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+            byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testStandardMultisigFederation);
 
             Federation deserializedTestFederation = BridgeSerializationUtils.deserializeStandardMultisigFederation(
                 serializedTestFederation,
@@ -1148,25 +1148,25 @@ class BridgeSerializationUtilsTest {
                 bridgeConstants.getErpFedPubKeysList(),
                 bridgeConstants.getErpFedActivationDelay()
             );
-            Federation testErpFederation = FederationFactory.buildNonStandardErpFederation(
+            ErpFederation testNonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
                 erpFederationArgs,
                 activations
             );
-            byte[] serializedTestErpFederation = BridgeSerializationUtils.serializeFederation(testErpFederation);
+            byte[] serializedTestErpFederation = BridgeSerializationUtils.serializeFederation(testNonStandardErpFederation);
 
-            Federation deserializedTestErpFederation = BridgeSerializationUtils.deserializeLegacyErpFederation(
+            Federation deserializedTestErpFederation = BridgeSerializationUtils.deserializeNonStandardErpFederation(
                 serializedTestErpFederation,
                 bridgeConstants,
                 activations
             );
 
-            Assertions.assertEquals(testFederation, deserializedTestFederation);
-            Assertions.assertEquals(testErpFederation, deserializedTestErpFederation);
-            assertNotEquals(testFederation, deserializedTestErpFederation);
-            assertNotEquals(testErpFederation, deserializedTestFederation);
+            Assertions.assertEquals(testStandardMultisigFederation, deserializedTestFederation);
+            Assertions.assertEquals(testNonStandardErpFederation, deserializedTestErpFederation);
+            assertNotEquals(testStandardMultisigFederation, deserializedTestErpFederation);
+            assertNotEquals(testNonStandardErpFederation, deserializedTestFederation);
 
             if (!isRskip284Active && networkId.equals(NetworkParameters.ID_TESTNET)) {
-                Assertions.assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, testErpFederation.getRedeemScript());
+                Assertions.assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, testNonStandardErpFederation.getRedeemScript());
             }
 
             if (isRskip353Active) {
@@ -1179,8 +1179,8 @@ class BridgeSerializationUtilsTest {
                 );
 
                 assertEquals(testP2shErpFederation, deserializedTestP2shErpFederation);
-                assertNotEquals(testFederation, deserializedTestP2shErpFederation);
-                assertNotEquals(testErpFederation, deserializedTestP2shErpFederation);
+                assertNotEquals(testStandardMultisigFederation, deserializedTestP2shErpFederation);
+                assertNotEquals(testNonStandardErpFederation, deserializedTestP2shErpFederation);
             }
         }
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -1136,10 +1136,10 @@ class BridgeSerializationUtilsTest {
             FederationArgs federationArgs =
                 new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
             Federation testStandardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-            byte[] serializedTestFederation = BridgeSerializationUtils.serializeFederation(testStandardMultisigFederation);
+            byte[] serializedTestStandardMultisigFederation = BridgeSerializationUtils.serializeFederation(testStandardMultisigFederation);
 
-            Federation deserializedTestFederation = BridgeSerializationUtils.deserializeStandardMultisigFederation(
-                serializedTestFederation,
+            Federation deserializedTestStandardMultisigFederation = BridgeSerializationUtils.deserializeStandardMultisigFederation(
+                serializedTestStandardMultisigFederation,
                 bridgeConstants.getBtcParams()
             );
 
@@ -1152,18 +1152,18 @@ class BridgeSerializationUtilsTest {
                 erpFederationArgs,
                 activations
             );
-            byte[] serializedTestErpFederation = BridgeSerializationUtils.serializeFederation(testNonStandardErpFederation);
+            byte[] serializedTestNonStandardErpFederation = BridgeSerializationUtils.serializeFederation(testNonStandardErpFederation);
 
-            Federation deserializedTestErpFederation = BridgeSerializationUtils.deserializeNonStandardErpFederation(
-                serializedTestErpFederation,
+            ErpFederation deserializedTestNonStandardErpFederation = BridgeSerializationUtils.deserializeNonStandardErpFederation(
+                serializedTestNonStandardErpFederation,
                 bridgeConstants,
                 activations
             );
 
-            Assertions.assertEquals(testStandardMultisigFederation, deserializedTestFederation);
-            Assertions.assertEquals(testNonStandardErpFederation, deserializedTestErpFederation);
-            assertNotEquals(testStandardMultisigFederation, deserializedTestErpFederation);
-            assertNotEquals(testNonStandardErpFederation, deserializedTestFederation);
+            Assertions.assertEquals(testStandardMultisigFederation, deserializedTestStandardMultisigFederation);
+            Assertions.assertEquals(testNonStandardErpFederation, deserializedTestNonStandardErpFederation);
+            assertNotEquals(testStandardMultisigFederation, deserializedTestNonStandardErpFederation);
+            assertNotEquals(testNonStandardErpFederation, deserializedTestStandardMultisigFederation);
 
             if (!isRskip284Active && networkId.equals(NetworkParameters.ID_TESTNET)) {
                 Assertions.assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, testNonStandardErpFederation.getRedeemScript());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderFederationTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderFederationTests.java
@@ -36,7 +36,7 @@ class BridgeStorageProviderFederationTests {
     private ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
 
     @Test
-    void getNewFederation_should_return_P2shErpFederation() {
+    void getNewFederation_should_return_p2sh_erp_federation() {
         Federation federation = createFederation(P2SH_ERP_FEDERATION_FORMAT_VERSION);
 
         testGetNewFederation(
@@ -46,7 +46,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getNewFederation_should_return_erp_federation() {
+    void getNewFederation_should_return_non_standard_erp_federation() {
         Federation federation = createFederation(NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION);
         testGetNewFederation(
             NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION,
@@ -55,7 +55,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getNewFederation_should_return_legacy_federation() {
+    void getNewFederation_should_return_standard_multisig_federation() {
         Federation federation = createFederation(STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION);
         testGetNewFederation(
             STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION,
@@ -141,7 +141,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getOldFederation_should_return_P2shErpFederation() {
+    void getOldFederation_should_return_p2sh_erp_federation() {
         Federation federation = createFederation(P2SH_ERP_FEDERATION_FORMAT_VERSION);
 
         testGetOldFederation(
@@ -151,7 +151,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getOldFederation_should_return_erp_federation() {
+    void getOldFederation_should_return_non_standard_erp_federation() {
         Federation federation = createFederation(NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION);
         testGetOldFederation(
             NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION,
@@ -160,7 +160,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void getOldFederation_should_return_legacy_fed() {
+    void getOldFederation_should_return_standard_multisig_fed() {
         Federation federation = createFederation(STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION);
         testGetOldFederation(
             STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION,
@@ -264,7 +264,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP123_should_save_legacy_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP123_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(ConsensusRule.RSKIP123).forBlock(0);
         testSaveNewFederation(
             STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION,
@@ -273,7 +273,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP201_should_save_legacy_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP201_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201
@@ -285,7 +285,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP353_should_save_legacy_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP353_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201,
@@ -298,7 +298,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP201_should_save_erp_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP201_should_save_non_standard_erp_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201
@@ -310,7 +310,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveNewFederation_after_RSKIP353_should_save_erp_fed_format() throws IOException {
+    void saveNewFederation_after_RSKIP353_should_save_non_standard_erp_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201,
@@ -437,7 +437,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP123_should_save_legacy_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP123_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(ConsensusRule.RSKIP123).forBlock(0);
         testSaveOldFederation(
             STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION,
@@ -446,7 +446,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP201_should_save_legacy_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP201_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201
@@ -458,7 +458,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP353_should_save_legacy_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP353_should_save_standard_multisig_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201,
@@ -471,7 +471,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP201_should_save_erp_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP201_should_save_non_standard_erp_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201
@@ -483,7 +483,7 @@ class BridgeStorageProviderFederationTests {
     }
 
     @Test
-    void saveOldFederation_after_RSKIP353_should_save_erp_fed_format() throws IOException {
+    void saveOldFederation_after_RSKIP353_should_save_non_standard_erp_fed_format() throws IOException {
         activations = ActivationConfigsForTest.only(
             ConsensusRule.RSKIP123,
             ConsensusRule.RSKIP201,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -402,7 +402,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void getNewFederation_erp_and_p2sh_erp_feds() {
+    void getNewFederation_non_standard_erp_and_p2sh_erp_feds() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
         Federation newFederation = buildMockFederation(100, 200, 300);
 
@@ -416,10 +416,10 @@ class BridgeStorageProviderTest {
 
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
             erpPubKeys, activationDelay);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
-        testGetNewFederationPostMultiKey(erpFederation);
+        testGetNewFederationPostMultiKey(nonStandardErpFederation);
         testGetNewFederationPostMultiKey(p2shErpFederation);
     }
 
@@ -529,7 +529,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void saveNewFederation_postMultiKey_RSKIP_201_active_erp_fed() {
+    void saveNewFederation_postMultiKey_RSKIP_201_active_non_standard_erp_fed() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
         Federation newFederation = buildMockFederation(100, 200, 300);
 
@@ -543,9 +543,9 @@ class BridgeStorageProviderTest {
 
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
             erpPubKeys, activationDelay);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        testSaveNewFederationPostMultiKey(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
+        testSaveNewFederationPostMultiKey(nonStandardErpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
     }
 
     @Test
@@ -680,17 +680,17 @@ class BridgeStorageProviderTest {
 
         // this should get non-standard hardcoded fed
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.iris300().forBlock(0);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        testGetOldFederation(erpFederation, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testGetOldFederation(nonStandardErpFederation, activations);
 
         // this should get non-standard with csv unsigned BE fed
-        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        testGetOldFederation(erpFederation, activations);
+        nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testGetOldFederation(nonStandardErpFederation, activations);
 
         // this should get non-standard fed
         activations = ActivationConfigsForTest.hop400().forBlock(0);
-        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        testGetOldFederation(erpFederation, activations);
+        nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testGetOldFederation(nonStandardErpFederation, activations);
     }
 
     @Test
@@ -816,7 +816,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void saveOldFederation_postMultikey_RSKIP_201_active_erp_fed() {
+    void saveOldFederation_postMultikey_RSKIP_201_active_non_standard_erp_fed() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -833,8 +833,8 @@ class BridgeStorageProviderTest {
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, creationTime, creationBlockNumber, btcParams,
             erpPubKeys, activationDelay);
 
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        testSaveOldFederation(erpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        testSaveOldFederation(nonStandardErpFederation, NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, activations);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -665,7 +665,7 @@ class BridgeStorageProviderTest {
     }
 
     @Test
-    void getOldFederation_nonStandard_feds() {
+    void getOldFederation_non_standard_erp_feds() {
         Federation oldFederation = buildMockFederation(100, 200, 300);
         List<FederationMember> fedMembers = oldFederation.getMembers();
         Instant creationTime = oldFederation.getCreationTime();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -163,12 +163,12 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void hasEnoughSignatures_several_inputs_all_signed_erp_fed() {
+    void hasEnoughSignatures_several_inputs_all_signed_non_standard_erp_fed() {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createErpFederation();
+        Federation erpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTx(
             Arrays.asList(sign1, sign2),
             3,
@@ -195,12 +195,12 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void hasEnoughSignatures_several_inputs_all_signed_erp_fast_bridge() {
+    void hasEnoughSignatures_several_inputs_all_signed_non_standard_erp_fast_bridge() {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createErpFederation();
+        Federation erpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTxForFlyover(
             Arrays.asList(sign1, sign2),
             3,
@@ -256,12 +256,12 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void countMissingSignatures_several_inputs_all_signed_erp_fed() {
+    void countMissingSignatures_several_inputs_all_signed_non_standard_erp_fed() {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createErpFederation();
+        Federation erpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTx(
             Arrays.asList(sign1, sign2),
             3,
@@ -288,12 +288,12 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void countMissingSignatures_several_inputs_all_signed_erp_fast_bridge() {
+    void countMissingSignatures_several_inputs_all_signed_non_standard_erp_fast_bridge() {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        Federation erpFederation = createErpFederation();
+        Federation erpFederation = createNonStandardErpFederation();
         BtcTransaction btcTx = createPegOutTxForFlyover(
             Arrays.asList(sign1, sign2),
             3,
@@ -1053,7 +1053,7 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void testCalculatePegoutTxSize_50Inputs_200Outputs_erpFederation() {
+    void testCalculatePegoutTxSize_50Inputs_200Outputs_nonStandardErpFederation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
@@ -1079,7 +1079,7 @@ class BridgeUtilsTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpFederationArgs,
             activations
         );
@@ -1087,9 +1087,9 @@ class BridgeUtilsTest {
         // Create a pegout tx with 50 inputs and 200 outputs
         int inputSize = 50;
         int outputSize = 200;
-        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, erpFederation, defaultFederationKeys);
+        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, nonStandardErpFederation, defaultFederationKeys);
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, erpFederation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, nonStandardErpFederation, inputSize, outputSize);
 
         // The difference between the calculated size and a real tx size should be smaller than 3% in any direction
         int origTxSize = pegoutTx.bitcoinSerialize().length;
@@ -1100,7 +1100,7 @@ class BridgeUtilsTest {
     }
 
     @Test
-    void testCalculatePegoutTxSize_100Inputs_50Outputs_erpFederation() {
+    void testCalculatePegoutTxSize_100Inputs_50Outputs_nonStandardErpFederation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
@@ -1126,7 +1126,7 @@ class BridgeUtilsTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpFederationArgs,
             activations
         );
@@ -1134,9 +1134,9 @@ class BridgeUtilsTest {
         // Create a pegout tx with 100 inputs and 50 outputs
         int inputSize = 100;
         int outputSize = 50;
-        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, erpFederation, defaultFederationKeys);
+        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, nonStandardErpFederation, defaultFederationKeys);
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, erpFederation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, nonStandardErpFederation, inputSize, outputSize);
 
         // The difference between the calculated size and a real tx size should be smaller than 3% in any direction
         int origTxSize = pegoutTx.bitcoinSerialize().length;
@@ -1472,7 +1472,7 @@ class BridgeUtilsTest {
         return new TestGenesisLoader(trieStore, "frontier.json", constants.getInitialNonce(), false, true, true).load();
     }
 
-    private ErpFederation createErpFederation() {
+    private ErpFederation createNonStandardErpFederation() {
         Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(
             genesisFederation.getMembers(),
@@ -1618,7 +1618,7 @@ class BridgeUtilsTest {
         return privKey;
     }
 
-    private void signWithErpFederation(Federation erpFederation, List<BtcECKey> privateKeys, TransactionInput txIn, BtcTransaction tx) {
+    private void signWithErpFederation(ErpFederation erpFederation, List<BtcECKey> privateKeys, TransactionInput txIn, BtcTransaction tx) {
         signWithNecessaryKeys(erpFederation, privateKeys, txIn, tx);
         // Add OP_0 prefix to make it a valid erp federation script
         Script erpInputScript = new ScriptBuilder()

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -37,8 +37,8 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
 
     private Federation federation;
     private ErpFederation nonStandardErpFederation;
+    private List<Federation> federationList;
     private List<Federation> nonStandardErpFederationList;
-    private List<Federation> erpFederationList;
 
     @BeforeEach
     void setup() {
@@ -47,15 +47,14 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
 
         FederationArgs federationArgs = new FederationArgs(fedMembers, Instant.ofEpochMilli(1000), 0L, btcParams);
         federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        federationList = Collections.singletonList(federation);
 
         long activationDelay = 5063;
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000), 0L, btcParams,
             erpFedKeys, activationDelay);
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-
-        nonStandardErpFederationList = Collections.singletonList(federation);
-        erpFederationList = Collections.singletonList(nonStandardErpFederation);
+        nonStandardErpFederationList = Collections.singletonList(nonStandardErpFederation);
     }
 
     @Test
@@ -64,7 +63,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         when(provider.getFlyoverFederationInformation(any(byte[].class))).thenReturn(Optional.empty());
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage = new FlyoverCompatibleBtcWalletWithStorage(
-            mock(Context.class), nonStandardErpFederationList, provider);
+            mock(Context.class), federationList, provider);
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(
             federation.getP2SHScript().getPubKeyHash());
@@ -94,7 +93,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
             .thenReturn(Optional.of(flyoverFederationInformation));
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage = new FlyoverCompatibleBtcWalletWithStorage(
-            mock(Context.class), nonStandardErpFederationList, provider
+            mock(Context.class), federationList, provider
         );
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(flyoverFederationP2SH);
@@ -129,7 +128,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage =
             new FlyoverCompatibleBtcWalletWithStorage(
                 mock(Context.class),
-                erpFederationList,
+                nonStandardErpFederationList,
                 provider
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -36,8 +36,8 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
     }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
     private Federation federation;
-    private ErpFederation erpFederation;
-    private List<Federation> federationList;
+    private ErpFederation nonStandardErpFederation;
+    private List<Federation> nonStandardErpFederationList;
     private List<Federation> erpFederationList;
 
     @BeforeEach
@@ -52,10 +52,10 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000), 0L, btcParams,
             erpFedKeys, activationDelay);
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        federationList = Collections.singletonList(federation);
-        erpFederationList = Collections.singletonList(erpFederation);
+        nonStandardErpFederationList = Collections.singletonList(federation);
+        erpFederationList = Collections.singletonList(nonStandardErpFederation);
     }
 
     @Test
@@ -64,7 +64,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         when(provider.getFlyoverFederationInformation(any(byte[].class))).thenReturn(Optional.empty());
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage = new FlyoverCompatibleBtcWalletWithStorage(
-            mock(Context.class), federationList, provider);
+            mock(Context.class), nonStandardErpFederationList, provider);
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(
             federation.getP2SHScript().getPubKeyHash());
@@ -94,7 +94,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
             .thenReturn(Optional.of(flyoverFederationInformation));
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage = new FlyoverCompatibleBtcWalletWithStorage(
-            mock(Context.class), federationList, provider
+            mock(Context.class), nonStandardErpFederationList, provider
         );
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(flyoverFederationP2SH);
@@ -104,13 +104,13 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
     }
 
     @Test
-    void findRedeemDataFromScriptHash_with_flyoverInformation_in_storage_and_erp_fed() {
+    void findRedeemDataFromScriptHash_with_flyoverInformation_in_storage_and_non_standard_erp_fed() {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Keccak256 derivationArgumentsHash = PegTestUtils.createHash3(1);
 
         Script flyoverRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
-            Sha256Hash.wrap(derivationArgumentsHash.getBytes()
+                nonStandardErpFederation.getRedeemScript(),
+                Sha256Hash.wrap(derivationArgumentsHash.getBytes()
             )
         );
 
@@ -120,7 +120,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         FlyoverFederationInformation flyoverFederationInformation =
             new FlyoverFederationInformation(
                 derivationArgumentsHash,
-                erpFederation.getP2SHScript().getPubKeyHash(),
+                nonStandardErpFederation.getP2SHScript().getPubKeyHash(),
                 flyoverFederationP2SH);
 
         when(provider.getFlyoverFederationInformation(flyoverFederationP2SH))
@@ -155,7 +155,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         );
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage =
-            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), federationList, provider);
+            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), nonStandardErpFederationList, provider);
 
         Assertions.assertNull(flyoverCompatibleBtcWalletWithStorage.findRedeemDataFromScriptHash(new byte[]{1}));
     }
@@ -175,7 +175,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         );
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage =
-            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), federationList, provider);
+            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), nonStandardErpFederationList, provider);
 
         Optional<FlyoverFederationInformation> result = flyoverCompatibleBtcWalletWithStorage.
             getFlyoverFederationInformation(flyoverScriptHash);
@@ -192,7 +192,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         );
 
         FlyoverCompatibleBtcWalletWithStorage flyoverCompatibleBtcWalletWithStorage =
-            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), federationList, provider);
+            new FlyoverCompatibleBtcWalletWithStorage(mock(Context.class), nonStandardErpFederationList, provider);
 
         Optional<FlyoverFederationInformation> result = flyoverCompatibleBtcWalletWithStorage.
             getFlyoverFederationInformation(new byte[1]);

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -33,9 +33,9 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
     }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
     private Federation federation;
-    private ErpFederation erpFederation;
+    private ErpFederation nonStandardErpFederation;
     private List<Federation> federationList;
-    private List<Federation> erpFederationList;
+    private List<Federation> nonStandardErpFederationList;
     private ActivationConfig.ForBlock activations;
 
     @BeforeEach
@@ -65,13 +65,13 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
             erpFedKeys,
             5063
         );
-        erpFederation = FederationFactory.buildNonStandardErpFederation(
+        nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpFederationArgs,
             activations
         );
 
         federationList = Collections.singletonList(federation);
-        erpFederationList = Collections.singletonList(erpFederation);
+        nonStandardErpFederationList = Collections.singletonList(nonStandardErpFederation);
     }
 
     @Test
@@ -120,20 +120,20 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         FlyoverFederationInformation flyoverFederationInformation =
             new FlyoverFederationInformation(
                 PegTestUtils.createHash3(2),
-                erpFederation.getP2SHScript().getPubKeyHash(),
+                nonStandardErpFederation.getP2SHScript().getPubKeyHash(),
                 flyoverScriptHash);
 
         FlyoverCompatibleBtcWalletWithSingleScript flyoverCompatibleBtcWalletWithSingleScript =
             new FlyoverCompatibleBtcWalletWithSingleScript(
                 mock(Context.class),
-                erpFederationList,
+                nonStandardErpFederationList,
                 flyoverFederationInformation);
 
         RedeemData redeemData = flyoverCompatibleBtcWalletWithSingleScript.findRedeemDataFromScriptHash(
-            erpFederation.getP2SHScript().getPubKeyHash());
+            nonStandardErpFederation.getP2SHScript().getPubKeyHash());
 
         Script flyoverRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             Sha256Hash.wrap(flyoverFederationInformation.getDerivationHash().getBytes())
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -40,7 +40,7 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
 
     @BeforeEach
     void setup() {
-
+        // set up standard multisig federation
         FederationArgs federationArgs = new FederationArgs(
             FederationTestUtils.getFederationMembers(3),
             Instant.ofEpochMilli(1000),
@@ -50,7 +50,9 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         federation = FederationFactory.buildStandardMultiSigFederation(
             federationArgs
         );
+        federationList = Collections.singletonList(federation);
 
+        // set up non-standard erp federation
         activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP123)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -69,8 +71,6 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
             erpFederationArgs,
             activations
         );
-
-        federationList = Collections.singletonList(federation);
         nonStandardErpFederationList = Collections.singletonList(nonStandardErpFederation);
     }
 
@@ -115,7 +115,7 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
     }
 
     @Test
-    void findRedeemDataFromScriptHash_with_flyoverInformation_and_erp_federation() {
+    void findRedeemDataFromScriptHash_with_flyoverInformation_and_non_standard_erp_federation() {
         byte[] flyoverScriptHash = new byte[]{(byte)0x22};
         FlyoverFederationInformation flyoverFederationInformation =
             new FlyoverFederationInformation(

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -540,9 +540,9 @@ class PegUtilsLegacyTest {
 
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(fedMembers, Instant.ofEpochMilli(1000L), 0L, btcParams,
             erpPubKeys, activationDelay);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        Script redeemScript = erpFederation.getRedeemScript();
+        Script redeemScript = nonStandardErpFederation.getRedeemScript();
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
             redeemScript,
             Sha256Hash.of(PegTestUtils.createHash(1).getBytes())
@@ -578,11 +578,11 @@ class PegUtilsLegacyTest {
 
         List<FederationMember> erpFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(erpFederationKeys);
         FederationArgs args = new FederationArgs(erpFedMembers, Instant.ofEpochMilli(1000L), 0L, networkParameters);
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(args);
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(args);
 
         Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
             activeFederation.getRedeemScript(),
-            erpFederation.getRedeemScript(),
+            standardMultisigFederation.getRedeemScript(),
             500L
         );
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
@@ -623,13 +623,13 @@ class PegUtilsLegacyTest {
             0L,
             networkParameters
         );
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(
             args
         );
 
         Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
             activeFederation.getRedeemScript(),
-            erpFederation.getRedeemScript(),
+            standardMultisigFederation.getRedeemScript(),
             500L
         );
 
@@ -661,13 +661,13 @@ class PegUtilsLegacyTest {
             0L,
             networkParameters
         );
-        Federation erpFederation = FederationFactory.buildStandardMultiSigFederation(
+        Federation standardMultisigFederation = FederationFactory.buildStandardMultiSigFederation(
             args
         );
 
         Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
             activeFederation.getRedeemScript(),
-            erpFederation.getRedeemScript(),
+            standardMultisigFederation.getRedeemScript(),
             500L
         );
 
@@ -816,7 +816,7 @@ class PegUtilsLegacyTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired fast bridge fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -830,10 +830,10 @@ class PegUtilsLegacyTest {
         tx.addInput(txInput);
 
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             PegTestUtils.createHash(2)
         );
-        signWithNecessaryKeys(erpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -882,7 +882,7 @@ class PegUtilsLegacyTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired fast bridge fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -896,10 +896,10 @@ class PegUtilsLegacyTest {
         tx.addInput(txInput);
 
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             PegTestUtils.createHash(2)
         );
-        signWithNecessaryKeys(erpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -947,7 +947,7 @@ class PegUtilsLegacyTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
         // Create a tx from the retired erp fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -959,7 +959,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         tx.addInput(txInput);
-        signWithErpFederation(erpFederation, retiredFederationKeys, txInput, tx);
+        signWithErpFederation(nonStandardErpFederation, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -1007,7 +1007,7 @@ class PegUtilsLegacyTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpFedArgs,
             activations
         );
@@ -1022,7 +1022,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         tx.addInput(txInput);
-        signWithErpFederation(erpFederation, retiredFederationKeys, txInput, tx);
+        signWithErpFederation(nonStandardErpFederation, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -2008,7 +2008,7 @@ class PegUtilsLegacyTest {
             erpFederationPublicKeys,
             500L
         );
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpArgs,
             activations
         );
@@ -2026,7 +2026,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         pegOutTx1.addInput(pegOutInput1);
-        signWithErpFederation(erpFederation, defaultFederationKeys, pegOutInput1, pegOutTx1);
+        signWithErpFederation(nonStandardErpFederation, defaultFederationKeys, pegOutInput1, pegOutTx1);
 
         // Before RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
@@ -2039,8 +2039,8 @@ class PegUtilsLegacyTest {
         assertFalse(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript(), standardFederation.getP2SHScript()));
         assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(erpFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, activations, erpFederation.getDefaultP2SHScript()));
+        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(nonStandardErpFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, activations, nonStandardErpFederation.getDefaultP2SHScript()));
 
         // After RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -2053,8 +2053,8 @@ class PegUtilsLegacyTest {
         assertTrue(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript(), standardFederation.getP2SHScript()));
         assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
 
-        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(erpFederation), activations));
-        assertTrue(isPegOutTx(pegOutTx1, activations, erpFederation.getDefaultP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(nonStandardErpFederation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, activations, nonStandardErpFederation.getDefaultP2SHScript()));
     }
 
     @Test
@@ -2088,7 +2088,7 @@ class PegUtilsLegacyTest {
             erpFederationPublicKeys,
             500L
         );
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpArgs,
             activations
         );
@@ -2108,10 +2108,10 @@ class PegUtilsLegacyTest {
         pegOutTx1.addInput(pegOutInput1);
 
         Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpFederation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             PegTestUtils.createHash(2)
         );
-        signWithNecessaryKeys(erpFederation, flyoverErpRedeemScript, defaultFederationKeys, pegOutInput1, pegOutTx1);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, defaultFederationKeys, pegOutInput1, pegOutTx1);
 
         // Before RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
@@ -2395,7 +2395,7 @@ class PegUtilsLegacyTest {
         assertFalse(scriptCorrectlySpendsTx(tx, 0, genesisFederation.getP2SHScript()));
     }
 
-    private void signWithErpFederation(Federation erpFederation, List<BtcECKey> privateKeys, TransactionInput txIn, BtcTransaction tx) {
+    private void signWithErpFederation(ErpFederation erpFederation, List<BtcECKey> privateKeys, TransactionInput txIn, BtcTransaction tx) {
         signWithNecessaryKeys(erpFederation, privateKeys, txIn, tx);
         // Add OP_0 prefix to make it a valid erp federation script
         Script erpInputScript = new ScriptBuilder()

--- a/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
@@ -137,7 +137,7 @@ class PowpegMigrationTest {
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(originalPowpegMembers, Instant.now(), 0, btcParams,
             erpPubKeys, activationDelay);
         switch (oldPowPegFederationType) {
-            case legacyErp:
+            case nonStandardErp:
                 originalPowpeg = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
                 break;
             case p2shErp:
@@ -191,7 +191,7 @@ class PowpegMigrationTest {
         Federation newPowPeg = argumentCaptor.getValue();
         assertEquals(newPowPegAddress, newPowPeg.getAddress());
         switch (newPowPegFederationType) {
-            case legacyErp:
+            case nonStandardErp:
                 assertSame(ErpFederation.class, newPowPeg.getClass());
                 assertTrue(((ErpFederation) newPowPeg).getErpRedeemScriptBuilder() instanceof NonStandardErpRedeemScriptBuilder);
                 break;
@@ -587,12 +587,12 @@ class PowpegMigrationTest {
         Script lastRetiredFederationP2SHScript = lastRetiredFederationP2SHScriptOptional.get();
 
         if (activations.isActive(ConsensusRule.RSKIP377)){
-            if (oldPowPegFederationType == FederationType.legacyErp || oldPowPegFederationType == FederationType.p2shErp){
+            if (oldPowPegFederationType == FederationType.nonStandardErp || oldPowPegFederationType == FederationType.p2shErp){
                 assertNotEquals(lastRetiredFederationP2SHScript, originalPowpeg.getP2SHScript());
             }
             assertEquals(lastRetiredFederationP2SHScript, getFederationDefaultP2SHScript(originalPowpeg));
         } else {
-            if (oldPowPegFederationType == FederationType.legacyErp || oldPowPegFederationType == FederationType.p2shErp){
+            if (oldPowPegFederationType == FederationType.nonStandardErp || oldPowPegFederationType == FederationType.p2shErp){
                 assertEquals(lastRetiredFederationP2SHScript, originalPowpeg.getP2SHScript());
                 assertNotEquals(lastRetiredFederationP2SHScript, getFederationDefaultP2SHScript(originalPowpeg));
             } else {
@@ -1344,11 +1344,11 @@ class PowpegMigrationTest {
         );
 
         testChangePowpeg(
-            FederationType.legacyErp,
+            FederationType.nonStandardErp,
             getMainnetPowpegKeys(),
             originalPowpegAddress,
             utxos,
-            FederationType.legacyErp,
+            FederationType.nonStandardErp,
             newPowpegKeys,
             newPowpegAddress,
             bridgeConstants,
@@ -1370,7 +1370,7 @@ class PowpegMigrationTest {
         );
 
         testChangePowpeg(
-            FederationType.legacyErp,
+            FederationType.nonStandardErp,
             getMainnetPowpegKeys(),
             originalPowpegAddress,
             utxos,
@@ -1591,7 +1591,7 @@ class PowpegMigrationTest {
     }
 
     private enum FederationType {
-        legacyErp,
+        nonStandardErp,
         p2shErp,
         standardMultisig
     }

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -165,7 +165,7 @@ class ReleaseTransactionBuilderTest {
     }
 
     @Test
-    void build_pegout_tx_from_erp_federation() {
+    void build_pegout_tx_from_non_standard_erp_federation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
@@ -189,7 +189,7 @@ class ReleaseTransactionBuilderTest {
             bridgeConstants.getErpFedActivationDelay()
         );
 
-        Federation erpFederation = FederationFactory.buildNonStandardErpFederation(
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(
             erpFederationArgs,
             activations
         );
@@ -201,7 +201,7 @@ class ReleaseTransactionBuilderTest {
                 Coin.COIN,
                 0,
                 false,
-                erpFederation.getP2SHScript()
+                nonStandardErpFederation.getP2SHScript()
             ),
             new UTXO(
                 Sha256Hash.of(new byte[]{1}),
@@ -209,13 +209,13 @@ class ReleaseTransactionBuilderTest {
                 Coin.COIN,
                 0,
                 false,
-                erpFederation.getP2SHScript()
+                nonStandardErpFederation.getP2SHScript()
             )
         );
 
         Wallet thisWallet = BridgeUtils.getFederationSpendWallet(
             new Context(bridgeConstants.getBtcParams()),
-            erpFederation,
+            nonStandardErpFederation,
             utxos,
             false,
             mock(BridgeStorageProvider.class)
@@ -224,7 +224,7 @@ class ReleaseTransactionBuilderTest {
         ReleaseTransactionBuilder releaseTransactionBuilder = new ReleaseTransactionBuilder(
             bridgeConstants.getBtcParams(),
             thisWallet,
-            erpFederation.getAddress(),
+            nonStandardErpFederation.getAddress(),
             Coin.SATOSHI.multiply(1000),
             activations
         );

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -731,7 +731,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_standard_multisig_can_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Should validate since it's not executing the path of the script with the CSV value
@@ -774,7 +774,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_standard_multisig_can_spend() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // Should validate since it's not executing the path of the script with the CSV value
@@ -787,7 +787,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_erp_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_erp_multisig_can_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Post RSKIP293 activation it should encode the CSV value correctly
@@ -800,7 +800,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_standard_multisig_can_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         assertDoesNotThrow(() -> spendFromNonStandardErpFed(
@@ -812,7 +812,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_erp_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_erp_multisig_can_spend() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // Post RSKIP293 activation it should encode the CSV value correctly
@@ -825,7 +825,7 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_standard_multisig_can_spend() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         assertDoesNotThrow(() -> spendFromNonStandardErpFed(

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class NonStandardErpFederationsTest {
-    private ErpFederation federation;
+    private ErpFederation nonStandardErpFederation;
     private NetworkParameters networkParameters;
     private List<BtcECKey> defaultKeys;
     private int defaultThreshold;
@@ -87,7 +87,7 @@ class NonStandardErpFederationsTest {
         activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
     }
 
     private ErpFederation createDefaultNonStandardErpFederation() {
@@ -167,7 +167,7 @@ class NonStandardErpFederationsTest {
         createAndValidateFederation();
 
         // Also check the builder is the expected one considering the activations
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         assertTrue(builder instanceof NonStandardErpRedeemScriptBuilder);
     }
 
@@ -182,7 +182,7 @@ class NonStandardErpFederationsTest {
         createAndValidateFederation();
 
         // Also check the builder is the expected one considering the activations
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         assertTrue(builder instanceof NonStandardErpRedeemScriptBuilderWithCsvUnsignedBE);
     }
 
@@ -194,14 +194,14 @@ class NonStandardErpFederationsTest {
 
         activationDelayValue = csvValue;
 
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
         ErpFederationCreationException fedException = assertThrows(
             ErpFederationCreationException.class,
-            () -> federation.getRedeemScript());
+            () -> nonStandardErpFederation.getRedeemScript());
         assertEquals(REDEEM_SCRIPT_CREATION_FAILED, fedException.getReason());
 
         // Check the builder throws the particular expected exception
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         RedeemScriptCreationException exception = assertThrows(
             RedeemScriptCreationException.class,
             () -> builder.createRedeemScriptFromKeys(
@@ -215,7 +215,7 @@ class NonStandardErpFederationsTest {
     @Test
     void createFederation_withRedeemScriptSizeAboveMaximum_throwsScriptCreationException() {
         // add one member to exceed redeem script size limit
-        List<BtcECKey> newDefaultKeys = federation.getBtcPublicKeys();
+        List<BtcECKey> newDefaultKeys = nonStandardErpFederation.getBtcPublicKeys();
         BtcECKey federator10PublicKey = BtcECKey.fromPublicOnly(
             Hex.decode("02550cc87fa9061162b1dd395a16662529c9d8094c0feca17905a3244713d65fe8")
         );
@@ -232,50 +232,50 @@ class NonStandardErpFederationsTest {
 
     @Test
     void getErpPubKeys() {
-        assertEquals(emergencyKeys, federation.getErpPubKeys());
+        assertEquals(emergencyKeys, nonStandardErpFederation.getErpPubKeys());
     }
 
     @Test
     void getActivationDelay() {
-        assertEquals(activationDelayValue, federation.getActivationDelay());
+        assertEquals(activationDelayValue, nonStandardErpFederation.getActivationDelay());
     }
 
     @Test
     void testEquals_basic() {
-        assertEquals(federation, federation);
+        assertEquals(nonStandardErpFederation, nonStandardErpFederation);
 
-        assertNotEquals(null, federation);
-        assertNotEquals(federation, new Object());
-        assertNotEquals("something else", federation);
+        assertNotEquals(null, nonStandardErpFederation);
+        assertNotEquals(nonStandardErpFederation, new Object());
+        assertNotEquals("something else", nonStandardErpFederation);
     }
 
     @Test
     void testEquals_same() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber(),
-            federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(nonStandardErpFederation.getMembers(), nonStandardErpFederation.getCreationTime(), nonStandardErpFederation.getCreationBlockNumber(),
+            nonStandardErpFederation.getBtcParams(), nonStandardErpFederation.getErpPubKeys(), nonStandardErpFederation.getActivationDelay()
         );
         ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
-        assertEquals(federation, otherFederation);
+        assertEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationTime() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime().plus(1, ChronoUnit.MILLIS),
-            federation.getCreationBlockNumber(), federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(nonStandardErpFederation.getMembers(), nonStandardErpFederation.getCreationTime().plus(1, ChronoUnit.MILLIS),
+            nonStandardErpFederation.getCreationBlockNumber(), nonStandardErpFederation.getBtcParams(), nonStandardErpFederation.getErpPubKeys(), nonStandardErpFederation.getActivationDelay()
         );
         ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        assertEquals(federation, otherFederation);
+        assertEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
     void testEquals_differentCreationBlockNumber() {
-        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(federation.getMembers(), federation.getCreationTime(), federation.getCreationBlockNumber() + 1,
-            federation.getBtcParams(), federation.getErpPubKeys(), federation.getActivationDelay()
+        ErpFederationArgs erpFederationArgs = new ErpFederationArgs(nonStandardErpFederation.getMembers(), nonStandardErpFederation.getCreationTime(), nonStandardErpFederation.getCreationBlockNumber() + 1,
+            nonStandardErpFederation.getBtcParams(), nonStandardErpFederation.getErpPubKeys(), nonStandardErpFederation.getActivationDelay()
         );
         ErpFederation otherFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
 
-        assertEquals(federation, otherFederation);
+        assertEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
@@ -283,18 +283,18 @@ class NonStandardErpFederationsTest {
         networkParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
         ErpFederation otherFederation = createDefaultNonStandardErpFederation();
-        Assertions.assertNotEquals(federation, otherFederation);
+        Assertions.assertNotEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
     void testEquals_differentNumberOfMembers() {
         // remove federator9
-        List<BtcECKey> newDefaultKeys = federation.getBtcPublicKeys();
+        List<BtcECKey> newDefaultKeys = nonStandardErpFederation.getBtcPublicKeys();
         newDefaultKeys.remove(newDefaultKeys.size() - 1);
         defaultKeys = newDefaultKeys;
 
         ErpFederation otherFederation = createDefaultNonStandardErpFederation();
-        Assertions.assertNotEquals(federation, otherFederation);
+        Assertions.assertNotEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
@@ -303,13 +303,13 @@ class NonStandardErpFederationsTest {
         BtcECKey federator9PublicKey = BtcECKey.fromPublicOnly(
             Hex.decode("0245ef34f5ee218005c9c21227133e8568a4f3f11aeab919c66ff7b816ae1ffeea")
         );
-        List<BtcECKey> newDefaultKeys = federation.getBtcPublicKeys();
+        List<BtcECKey> newDefaultKeys = nonStandardErpFederation.getBtcPublicKeys();
         newDefaultKeys.remove(8);
         newDefaultKeys.add(federator9PublicKey);
         defaultKeys = newDefaultKeys;
 
         ErpFederation otherFederation = createDefaultNonStandardErpFederation();
-        Assertions.assertNotEquals(federation, otherFederation);
+        Assertions.assertNotEquals(nonStandardErpFederation, otherFederation);
     }
 
     @Test
@@ -342,9 +342,9 @@ class NonStandardErpFederationsTest {
         networkParameters = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
 
         // this should create the expected non-standard hardcoded fed
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         Script obtainedRedeemScript = builder
             .createRedeemScriptFromKeys(defaultKeys, defaultThreshold,
                 emergencyKeys, emergencyThreshold,
@@ -383,9 +383,9 @@ class NonStandardErpFederationsTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
 
         // this should create the expected non-standard with csv unsigned be fed
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         Script obtainedRedeemScript = builder
             .createRedeemScriptFromKeys(
                 defaultKeys, defaultThreshold,
@@ -426,9 +426,9 @@ class NonStandardErpFederationsTest {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
         // this should create the expected non-standard fed
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         Script obtainedRedeemScript = builder
             .createRedeemScriptFromKeys(defaultKeys, defaultThreshold,
                 emergencyKeys, emergencyThreshold,
@@ -458,9 +458,9 @@ class NonStandardErpFederationsTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
         // this should create the real fed
-        ErpFederation realLegacyErpFederation = createDefaultNonStandardErpFederation();
-        Script p2shScript = realLegacyErpFederation.getP2SHScript();
-        Address address = realLegacyErpFederation.getAddress();
+        ErpFederation realNonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script p2shScript = realNonStandardErpFederation.getP2SHScript();
+        Address address = realNonStandardErpFederation.getAddress();
 
         assertEquals(expectedProgram, Hex.toHexString(p2shScript.getProgram()));
         assertEquals(3, p2shScript.getChunks().size());
@@ -470,19 +470,19 @@ class NonStandardErpFederationsTest {
 
     @Test
     void getErpPubKeys_fromUncompressedPublicKeys_equals() {
-        // Public keys used for creating federation, but uncompressed format now
+        // Public keys used for creating nonStandardErpFederation, but uncompressed format now
         emergencyKeys = emergencyKeys
             .stream()
             .map(BtcECKey::decompress)
             .collect(Collectors.toList());
 
-        // Recreate federation
+        // Recreate nonStandardErpFederation
         ErpFederation federationWithUncompressedKeys = createDefaultNonStandardErpFederation();
         assertEquals(emergencyKeys, federationWithUncompressedKeys.getErpPubKeys());
     }
 
     @Test
-    void getLegacyErpRedeemScript_compareOtherImplementation() throws IOException {
+    void getNonStandardErpRedeemScript_compareOtherImplementation() throws IOException {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
@@ -503,8 +503,8 @@ class NonStandardErpFederationsTest {
                 emergencyKeys = generatedScript.emergencyFed;
                 activationDelayValue = generatedScript.timelock;
 
-                federation = createDefaultNonStandardErpFederation();
-                Script rskjScript = federation.getRedeemScript();
+                nonStandardErpFederation = createDefaultNonStandardErpFederation();
+                Script rskjScript = nonStandardErpFederation.getRedeemScript();
                 Script alternativeScript = generatedScript.script;
 
                 assertEquals(alternativeScript, rskjScript);
@@ -515,8 +515,8 @@ class NonStandardErpFederationsTest {
     @Test
     void getRedeemScript_before_RSKIP293() {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-        federation = createDefaultNonStandardErpFederation();
-        Script redeemScript = federation.getRedeemScript();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script redeemScript = nonStandardErpFederation.getRedeemScript();
         validateErpRedeemScript(
             redeemScript,
             activationDelayValue
@@ -526,8 +526,8 @@ class NonStandardErpFederationsTest {
     @Test
     void getRedeemScript_after_RSKIP293() {
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
-        federation = createDefaultNonStandardErpFederation();
-        Script redeemScript = federation.getRedeemScript();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script redeemScript = nonStandardErpFederation.getRedeemScript();
 
         validateErpRedeemScript(
             redeemScript,
@@ -542,12 +542,12 @@ class NonStandardErpFederationsTest {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
 
-        federation = createDefaultNonStandardErpFederation();
-        Script preRskip293RedeemScript = federation.getRedeemScript();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script preRskip293RedeemScript = nonStandardErpFederation.getRedeemScript();
 
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
-        federation = createDefaultNonStandardErpFederation();
-        Script postRskip293RedeemScript = federation.getRedeemScript();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        Script postRskip293RedeemScript = nonStandardErpFederation.getRedeemScript();
 
         Assertions.assertNotEquals(preRskip293RedeemScript, postRskip293RedeemScript);
     }
@@ -588,20 +588,20 @@ class NonStandardErpFederationsTest {
         networkParameters = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(false);
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, federation.getRedeemScript());
+        assertEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, nonStandardErpFederation.getRedeemScript());
     }
 
     @Test
     void getRedeemScript_before_RSKIP_284_mainnet() {
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(false);
         //when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, federation.getRedeemScript());
+        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, nonStandardErpFederation.getRedeemScript());
         validateErpRedeemScript(
-            federation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             activationDelayValue
         );
     }
@@ -611,14 +611,14 @@ class NonStandardErpFederationsTest {
         networkParameters = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
-        ErpRedeemScriptBuilder builder = federation.getErpRedeemScriptBuilder();
+        ErpRedeemScriptBuilder builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         assertTrue(builder instanceof NonStandardErpRedeemScriptBuilderWithCsvUnsignedBE);
-        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, federation.getRedeemScript());
+        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, nonStandardErpFederation.getRedeemScript());
 
         validateErpRedeemScript(
-            federation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             activationDelayValue
         );
     }
@@ -628,19 +628,19 @@ class NonStandardErpFederationsTest {
         ErpRedeemScriptBuilder builder;
 
         // check the hardcoded fed didnt exist on mainnet after rskip201
-        federation = createDefaultNonStandardErpFederation();
-        builder = federation.getErpRedeemScriptBuilder();
-        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, federation.getRedeemScript());
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
+        Assertions.assertNotEquals(TestConstants.ERP_TESTNET_REDEEM_SCRIPT, nonStandardErpFederation.getRedeemScript());
         assertFalse(builder instanceof NonStandardErpRedeemScriptBuilderHardcoded);
 
         // check the hardcoded fed didnt exist on mainnet after rskip284
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
-        federation = createDefaultNonStandardErpFederation();
-        builder = federation.getErpRedeemScriptBuilder();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        builder = nonStandardErpFederation.getErpRedeemScriptBuilder();
         assertFalse(builder instanceof NonStandardErpRedeemScriptBuilderHardcoded);
 
         validateErpRedeemScript(
-            federation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             activationDelayValue
         );
     }
@@ -651,23 +651,23 @@ class NonStandardErpFederationsTest {
 
         // Both federations created before RSKIP284 with the same data, should have the same redeem script
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(false);
-        Federation erpFederation = createDefaultNonStandardErpFederation();
+        ErpFederation nonStandardErpFederation = createDefaultNonStandardErpFederation();
         Federation otherErpFederation = createDefaultNonStandardErpFederation();
-        assertEquals(erpFederation, otherErpFederation);
+        assertEquals(nonStandardErpFederation, otherErpFederation);
 
-        // One federation created after RSKIP284 with the same data, should have different redeem script
+        // One nonStandardErpFederation created after RSKIP284 with the same data, should have different redeem script
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         otherErpFederation = createDefaultNonStandardErpFederation();
-        assertNotEquals(erpFederation, otherErpFederation);
+        assertNotEquals(nonStandardErpFederation, otherErpFederation);
 
-        // The other federation created after RSKIP284 with the same data, should have same redeem script
-        erpFederation = createDefaultNonStandardErpFederation();
-        assertEquals(erpFederation, otherErpFederation);
+        // The other nonStandardErpFederation created after RSKIP284 with the same data, should have same redeem script
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
+        assertEquals(nonStandardErpFederation, otherErpFederation);
     }
 
     @Disabled("Can't recreate the hardcoded redeem script since the needed CSV value is above the max. Keeping the test ignored as testimonial")
     @Test
-    void createErpFedWithSameRedeemScriptAsHardcodedOne_after_RSKIP293_fails() {
+    void createNonStandardErpFedWithSameRedeemScriptAsHardcodedOne_after_RSKIP293_fails() {
         // We can't test the same condition before RSKIP293 since the serialization used by bj-thin
         // prior to RSKIP293 enforces the CSV value to be encoded using 2 bytes.
         // The hardcoded script has a 3 byte long CSV value
@@ -699,14 +699,14 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_testnet_using_erp_multisig_can_spend() {
+    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_erp_multisig_can_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // The CSV value defined in BridgeTestnetConstants,
         // actually allows the emergency multisig to spend before the expected amount of blocks
         // Since it's encoded as BE and decoded as LE, the result is a number lower than the one defined in the constant
         assertDoesNotThrow(() ->
-            spendFromErpFed(
+            spendFromNonStandardErpFed(
                 constants.getBtcParams(),
                 constants.getErpFedActivationDelay(),
                 false,
@@ -715,14 +715,14 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_testnet_using_erp_multisig_cant_spend() {
+    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_erp_multisig_cant_spend() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Should fail due to the wrong encoding of the CSV value
         // In this case, the value 300 when encoded as BE and decoded as LE results in a larger number
         // This causes the validation to fail
         NetworkParameters btcParams = constants.getBtcParams();
-        assertThrows(ScriptException.class, () -> spendFromErpFed(
+        assertThrows(ScriptException.class, () -> spendFromNonStandardErpFed(
             btcParams,
             300,
             false,
@@ -731,11 +731,11 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_testnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_before_RSKIP293_testnet_using_standard_multisig() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Should validate since it's not executing the path of the script with the CSV value
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             false,
@@ -744,13 +744,13 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_mainnet_using_erp_multisig_can_spend() {
+    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_erp_multisig_can_spend() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // The CSV value defined in BridgeMainnetConstants,
         // actually allows the emergency multisig to spend before the expected amount of blocks
         // Since it's encoded as BE and decoded as LE, the result is a number lower than the one defined in the constant
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             false,
@@ -759,13 +759,13 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_mainnet_using_erp_multisig_cant_spend() {
+    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_erp_multisig_cant_spend() {
         // Should fail due to the wrong encoding of the CSV value
         // In this case, the value 300 when encoded as BE and decoded as LE results in a larger number
         // This causes the validation to fail
         when(activations.isActive(ConsensusRule.RSKIP284)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-        assertThrows(ScriptException.class, () -> spendFromErpFed(
+        assertThrows(ScriptException.class, () -> spendFromNonStandardErpFed(
             networkParameters,
             300,
             false,
@@ -774,11 +774,11 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_before_RSKIP293_mainnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_before_RSKIP293_mainnet_using_standard_multisig() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // Should validate since it's not executing the path of the script with the CSV value
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             false,
@@ -787,11 +787,11 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_after_RSKIP293_testnet_using_erp_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_erp_multisig() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
         // Post RSKIP293 activation it should encode the CSV value correctly
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             true,
@@ -800,10 +800,10 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_after_RSKIP293_testnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_testnet_using_standard_multisig() {
         BridgeConstants constants = BridgeTestNetConstants.getInstance();
 
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             true,
@@ -812,11 +812,11 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_after_RSKIP293_mainnet_using_erp_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_erp_multisig() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
         // Post RSKIP293 activation it should encode the CSV value correctly
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             true,
@@ -825,10 +825,10 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void spendFromErpFed_after_RSKIP293_mainnet_using_standard_multisig() {
+    void spendFromNonStandardErpFed_after_RSKIP293_mainnet_using_standard_multisig() {
         BridgeConstants constants = BridgeMainNetConstants.getInstance();
 
-        assertDoesNotThrow(() -> spendFromErpFed(
+        assertDoesNotThrow(() -> spendFromNonStandardErpFed(
             constants.getBtcParams(),
             constants.getErpFedActivationDelay(),
             true,
@@ -838,17 +838,17 @@ class NonStandardErpFederationsTest {
 
     private void createAndValidateFederation() {
 
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
         validateErpRedeemScript(
-            federation.getRedeemScript(),
+            nonStandardErpFederation.getRedeemScript(),
             defaultKeys,
             emergencyKeys,
             activationDelayValue
         );
     }
 
-    private void spendFromErpFed(
+    private void spendFromNonStandardErpFed(
         NetworkParameters networkParametersValue,
         long activationDelay,
         boolean isRskip293Active,
@@ -871,12 +871,12 @@ class NonStandardErpFederationsTest {
             Collections.singletonList(ConsensusRule.RSKIP293);
         activations = ActivationConfigsForTest.hop400(except).forBlock(0);
 
-        federation = createDefaultNonStandardErpFederation();
+        nonStandardErpFederation = createDefaultNonStandardErpFederation();
 
         Coin value = Coin.valueOf(1_000_000);
         Coin fee = Coin.valueOf(10_000);
         BtcTransaction fundTx = new BtcTransaction(networkParameters);
-        fundTx.addOutput(value, federation.getAddress());
+        fundTx.addOutput(value, nonStandardErpFederation.getAddress());
 
         Address destinationAddress = BitcoinTestUtils.createP2PKHAddress(
             networkParameters,
@@ -885,7 +885,7 @@ class NonStandardErpFederationsTest {
 
         FederationTestUtils.spendFromErpFed(
             networkParameters,
-            federation,
+            nonStandardErpFederation,
             signWithEmergencyMultisig ? emergencyKeys : defaultKeys,
             fundTx.getHash(),
             0,


### PR DESCRIPTION
With the Federations refactor, what we used to call the legacy // legacy erp federation has been renamed to NonStandardErpFederation, due to its non-standardness.
Therefore, we ended up having instances with the old naming and instances with the new one.
This pr aims to rename legacy // legacy erp // erp to non standard erp to make the code more consistent and clear.

Also, the same was done in some 'standard multisig fed' cases.

**This rebase was done against rebase-create-federation-args due to new changes**
