### PR TITLE
Correct legacyProcessPegin name in logs

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -582,12 +582,12 @@ public class BridgeSupport {
                 btcTx.getHash(),
                 e.getMessage()
             );
-            logger.warn("[processPegIn] {}", message);
+            logger.warn("[legacyProcessPegin] {}", message);
             throw new RegisterBtcTransactionException(message);
         }
 
         int protocolVersion = peginInformation.getProtocolVersion();
-        logger.debug("[processPegIn] Protocol version: {}", protocolVersion);
+        logger.debug("[legacyProcessPegin] Protocol version: {}", protocolVersion);
         switch (protocolVersion) {
             case 0:
                 processPegInVersionLegacy(btcTx, rskTxHash, height, peginInformation, totalAmount);
@@ -598,7 +598,7 @@ public class BridgeSupport {
             default:
                 markTxAsProcessed(btcTx);
                 String message = String.format("Invalid peg-in protocol version: %d", protocolVersion);
-                logger.warn("[processPegIn] {}", message);
+                logger.warn("[legacyProcessPegin] {}", message);
                 throw new RegisterBtcTransactionException(message);
         }
 


### PR DESCRIPTION
Correct legacyProcessPegin name in logs.

Inside the `legacyProcessPegin` method, the logs where printing `processPegIn` as the method name, which is not correct. So, this pr is changing that to print the correct one.