### PR TITLE
Create getErpArgs method for ErpFederation. Create tests for both FederationArgs and ErpFederationArgs classes

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
@@ -33,6 +33,9 @@ public class ErpFederation extends Federation {
         this.erpRedeemScriptBuilder = erpRedeemScriptBuilder;
     }
 
+    public ErpFederationArgs getErpArgs() {
+        return new ErpFederationArgs(members, creationTime, creationBlockNumber, btcParams, erpPubKeys, activationDelay);
+    }
 
     public ErpRedeemScriptBuilder getErpRedeemScriptBuilder() { return erpRedeemScriptBuilder; }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
@@ -33,6 +33,13 @@ public class ErpFederationArgs extends FederationArgs{
     public long getActivationDelay() { return activationDelay; }
 
     @Override
+    public String toString() {
+        return String.format("Got erp federation args with values %s, %s, %d, %s, %s, %d",
+            getMembers(), getCreationTime(), getCreationBlockNumber(), getBtcParams(), getErpPubKeys(), getActivationDelay()
+        );
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (this == other) {
             return true;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederationArgs.java
@@ -5,6 +5,7 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 
 import static co.rsk.peg.federation.ErpFederationCreationException.Reason.NULL_OR_EMPTY_EMERGENCY_KEYS;
 
@@ -30,6 +31,36 @@ public class ErpFederationArgs extends FederationArgs{
     public List<BtcECKey> getErpPubKeys() { return erpPubKeys; }
 
     public long getActivationDelay() { return activationDelay; }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || this.getClass() != other.getClass()) {
+            return false;
+        }
+
+        ErpFederationArgs otherErpFederationArgs = (ErpFederationArgs) other;
+        return allValuesAreEqual(otherErpFederationArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return
+            Objects.hash(getMembers(), getCreationTime(), getCreationBlockNumber(), getBtcParams(), getErpPubKeys(), getActivationDelay());
+    }
+
+    private boolean allValuesAreEqual(ErpFederationArgs otherErpFederationArgs) {
+        return
+            otherErpFederationArgs.getMembers().equals(this.getMembers())
+            && otherErpFederationArgs.getCreationTime().equals(this.getCreationTime())
+            && otherErpFederationArgs.getCreationBlockNumber() == this.getCreationBlockNumber()
+            && otherErpFederationArgs.getBtcParams().equals(this.getBtcParams())
+            && otherErpFederationArgs.getErpPubKeys().equals(this.getErpPubKeys())
+            && otherErpFederationArgs.getActivationDelay() == this.getActivationDelay();
+    }
 
     public static ErpFederationArgs fromFederationArgs(FederationArgs federationArgs, List<BtcECKey> erpPubKeys, long activationDelay){
         return new ErpFederationArgs(federationArgs.getMembers(), federationArgs.getCreationTime(),

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
@@ -32,6 +32,13 @@ public class FederationArgs {
     public NetworkParameters getBtcParams() { return btcParams; }
 
     @Override
+    public String toString() {
+        return String.format("Got federation args with values %s, %s, %d, %s",
+            getMembers(), getCreationTime(), getCreationBlockNumber(), getBtcParams()
+        );
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (this == other) {
             return true;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationArgs.java
@@ -4,6 +4,7 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 
 public class FederationArgs {
     private final List<FederationMember> members;
@@ -29,5 +30,34 @@ public class FederationArgs {
 
     public long getCreationBlockNumber() { return creationBlockNumber; }
     public NetworkParameters getBtcParams() { return btcParams; }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || this.getClass() != other.getClass()) {
+            return false;
+        }
+
+        FederationArgs otherFederationArgs = (FederationArgs) other;
+        return allValuesAreEqual(otherFederationArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return
+            Objects.hash(getMembers(), getCreationTime(), getCreationBlockNumber(), getBtcParams());
+    }
+
+    private boolean allValuesAreEqual(FederationArgs otherFederationArgs) {
+        return
+            otherFederationArgs.getMembers().equals(this.getMembers())
+            && otherFederationArgs.getCreationTime().equals(this.getCreationTime())
+            && otherFederationArgs.getCreationBlockNumber() == this.getCreationBlockNumber()
+            && otherFederationArgs.getBtcParams().equals(this.getBtcParams());
+
+    }
 
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -259,25 +259,18 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
-    void values_from_erpFederationArgs_equal_values_from_nonStandardErpFederation() {
-        ErpFederationArgs erpFederationArgs = nonStandardErpFederation.getErpArgs();
-        List<FederationMember> federationMembersFromErpArgs = erpFederationArgs.getMembers();
-        Instant creationTimeFromErpArgs = erpFederationArgs.getCreationTime();
-        long creationBlockNumberFromErpArgs = erpFederationArgs.getCreationBlockNumber();
-        NetworkParameters btcParamsFromErpArgs = erpFederationArgs.getBtcParams();
-        List<BtcECKey> emergencyKeysFromErpArgs = erpFederationArgs.getErpPubKeys();
-        long activationDelayFromErpArgs = erpFederationArgs.getActivationDelay();
-
-        List<FederationMember> members = nonStandardErpFederation.getMembers();
+    void erpFederationArgs_from_values_equals_erpFederationArgs_from_nonStandardErpFederation() {
+        List<FederationMember> federationMembers = nonStandardErpFederation.getMembers();
         Instant creationTime = nonStandardErpFederation.getCreationTime();
         long creationBlockNumber = nonStandardErpFederation.getCreationBlockNumber();
+        NetworkParameters btcParams = nonStandardErpFederation.getBtcParams();
+        List<BtcECKey> emergencyKeys = nonStandardErpFederation.getErpPubKeys();
+        long activationDelay = nonStandardErpFederation.getActivationDelay();
+        ErpFederationArgs erpFederationArgsFromValues =
+            new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, btcParams, emergencyKeys, activationDelay);
 
-        assertEquals(members, federationMembersFromErpArgs);
-        assertEquals(creationTime, creationTimeFromErpArgs);
-        assertEquals(creationBlockNumber, creationBlockNumberFromErpArgs);
-        assertEquals(networkParameters, btcParamsFromErpArgs);
-        assertEquals(emergencyKeys, emergencyKeysFromErpArgs);
-        assertEquals(activationDelayValue, activationDelayFromErpArgs);
+        ErpFederationArgs erpFederationArgs = nonStandardErpFederation.getErpArgs();
+        assertEquals(erpFederationArgs, erpFederationArgsFromValues);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/NonStandardErpFederationsTest.java
@@ -259,6 +259,45 @@ class NonStandardErpFederationsTest {
     }
 
     @Test
+    void values_from_erpFederationArgs_equal_values_from_nonStandardErpFederation() {
+        ErpFederationArgs erpFederationArgs = nonStandardErpFederation.getErpArgs();
+        List<FederationMember> federationMembersFromErpArgs = erpFederationArgs.getMembers();
+        Instant creationTimeFromErpArgs = erpFederationArgs.getCreationTime();
+        long creationBlockNumberFromErpArgs = erpFederationArgs.getCreationBlockNumber();
+        NetworkParameters btcParamsFromErpArgs = erpFederationArgs.getBtcParams();
+        List<BtcECKey> emergencyKeysFromErpArgs = erpFederationArgs.getErpPubKeys();
+        long activationDelayFromErpArgs = erpFederationArgs.getActivationDelay();
+
+        List<FederationMember> members = nonStandardErpFederation.getMembers();
+        Instant creationTime = nonStandardErpFederation.getCreationTime();
+        long creationBlockNumber = nonStandardErpFederation.getCreationBlockNumber();
+
+        assertEquals(members, federationMembersFromErpArgs);
+        assertEquals(creationTime, creationTimeFromErpArgs);
+        assertEquals(creationBlockNumber, creationBlockNumberFromErpArgs);
+        assertEquals(networkParameters, btcParamsFromErpArgs);
+        assertEquals(emergencyKeys, emergencyKeysFromErpArgs);
+        assertEquals(activationDelayValue, activationDelayFromErpArgs);
+    }
+
+    @Test
+    void nonStandardErpFederation_from_federationArgs_and_erp_values_equals_nonStandardErpFederation() {
+        FederationArgs federationArgs = nonStandardErpFederation.getArgs();
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, emergencyKeys, activationDelayValue);
+        ErpFederation nonStandardErpFederationFromFederationArgs = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+
+        assertEquals(nonStandardErpFederation, nonStandardErpFederationFromFederationArgs);
+    }
+
+    @Test
+    void nonStandardErpFederation_from_erpFederationArgs_equals_nonStandardErpFederation() {
+        ErpFederationArgs erpFederationArgs = nonStandardErpFederation.getErpArgs();
+        ErpFederation federationFromFederationArgs = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+
+        assertEquals(nonStandardErpFederation, federationFromFederationArgs);
+    }
+
+    @Test
     void testEquals_differentCreationTime() {
         ErpFederationArgs erpFederationArgs = new ErpFederationArgs(nonStandardErpFederation.getMembers(), nonStandardErpFederation.getCreationTime().plus(1, ChronoUnit.MILLIS),
             nonStandardErpFederation.getCreationBlockNumber(), nonStandardErpFederation.getBtcParams(), nonStandardErpFederation.getErpPubKeys(), nonStandardErpFederation.getActivationDelay()

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -230,35 +230,27 @@ class P2shErpFederationTest {
     }
 
     @Test
-    void values_from_erpFederationArgs_equal_values_from_p2shErpFederation() {
-        ErpFederationArgs erpFederationArgs = federation.getErpArgs();
-        List<FederationMember> federationMembersFromErpArgs = erpFederationArgs.getMembers();
-        Instant creationTimeFromErpArgs = erpFederationArgs.getCreationTime();
-        long creationBlockNumberFromErpArgs = erpFederationArgs.getCreationBlockNumber();
-        NetworkParameters btcParamsFromErpArgs = erpFederationArgs.getBtcParams();
-        List<BtcECKey> emergencyKeysFromErpArgs = erpFederationArgs.getErpPubKeys();
-        long activationDelayFromErpArgs = erpFederationArgs.getActivationDelay();
-
-        List<FederationMember> members = federation.getMembers();
+    void erpFederationArgs_from_values_equals_erpFederationArgs_from_p2shErpFederation() {
+        List<FederationMember> federationMembers = federation.getMembers();
         Instant creationTime = federation.getCreationTime();
         long creationBlockNumber = federation.getCreationBlockNumber();
+        NetworkParameters btcParams = federation.getBtcParams();
+        List<BtcECKey> emergencyKeys = federation.getErpPubKeys();
+        long activationDelay = federation.getActivationDelay();
+        ErpFederationArgs erpFederationArgsFromValues =
+            new ErpFederationArgs(federationMembers, creationTime, creationBlockNumber, btcParams, emergencyKeys, activationDelay);
 
-        assertEquals(members, federationMembersFromErpArgs);
-        assertEquals(creationTime, creationTimeFromErpArgs);
-        assertEquals(creationBlockNumber, creationBlockNumberFromErpArgs);
-        assertEquals(networkParameters, btcParamsFromErpArgs);
-        assertEquals(emergencyKeys, emergencyKeysFromErpArgs);
-        assertEquals(activationDelayValue, activationDelayFromErpArgs);
+        ErpFederationArgs erpFederationArgs = federation.getErpArgs();
+        assertEquals(erpFederationArgs, erpFederationArgsFromValues);
     }
 
     @Test
     void p2shErpFederation_from_federationArgs_and_erp_values_equals_p2shErpFederation() {
         FederationArgs federationArgs = federation.getArgs();
         ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, emergencyKeys, activationDelayValue);
+        ErpFederation federationFromErpFederationArgs = FederationFactory.buildP2shErpFederation(erpFederationArgs);
 
-        ErpFederation federationFromFederationArgs = FederationFactory.buildP2shErpFederation(erpFederationArgs);
-
-        assertEquals(federation, federationFromFederationArgs);
+        assertEquals(federation, federationFromErpFederationArgs);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -230,6 +230,46 @@ class P2shErpFederationTest {
     }
 
     @Test
+    void values_from_erpFederationArgs_equal_values_from_p2shErpFederation() {
+        ErpFederationArgs erpFederationArgs = federation.getErpArgs();
+        List<FederationMember> federationMembersFromErpArgs = erpFederationArgs.getMembers();
+        Instant creationTimeFromErpArgs = erpFederationArgs.getCreationTime();
+        long creationBlockNumberFromErpArgs = erpFederationArgs.getCreationBlockNumber();
+        NetworkParameters btcParamsFromErpArgs = erpFederationArgs.getBtcParams();
+        List<BtcECKey> emergencyKeysFromErpArgs = erpFederationArgs.getErpPubKeys();
+        long activationDelayFromErpArgs = erpFederationArgs.getActivationDelay();
+
+        List<FederationMember> members = federation.getMembers();
+        Instant creationTime = federation.getCreationTime();
+        long creationBlockNumber = federation.getCreationBlockNumber();
+
+        assertEquals(members, federationMembersFromErpArgs);
+        assertEquals(creationTime, creationTimeFromErpArgs);
+        assertEquals(creationBlockNumber, creationBlockNumberFromErpArgs);
+        assertEquals(networkParameters, btcParamsFromErpArgs);
+        assertEquals(emergencyKeys, emergencyKeysFromErpArgs);
+        assertEquals(activationDelayValue, activationDelayFromErpArgs);
+    }
+
+    @Test
+    void p2shErpFederation_from_federationArgs_and_erp_values_equals_p2shErpFederation() {
+        FederationArgs federationArgs = federation.getArgs();
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, emergencyKeys, activationDelayValue);
+
+        ErpFederation federationFromFederationArgs = FederationFactory.buildP2shErpFederation(erpFederationArgs);
+
+        assertEquals(federation, federationFromFederationArgs);
+    }
+
+    @Test
+    void p2shErpFederation_from_erpFederationArgs_equals_p2shErpFederation() {
+        ErpFederationArgs erpFederationArgs = federation.getErpArgs();
+        ErpFederation federationFromFederationArgs = FederationFactory.buildP2shErpFederation(erpFederationArgs);
+
+        assertEquals(federation, federationFromFederationArgs);
+    }
+
+    @Test
     void testEquals_differentNumberOfMembers() {
         // remove federator9
         List<BtcECKey> newDefaultKeys = federation.getBtcPublicKeys();

--- a/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
@@ -137,21 +137,14 @@ class StandardMultisigFederationTest {
 
     @Test
     void values_from_federationArgs_equal_values_from_federation() {
-        FederationArgs actualFederationArgs = federation.getArgs();
-        List<FederationMember> federationMembersFromArgs = actualFederationArgs.getMembers();
-        Instant creationTimeFromArgs = actualFederationArgs.getCreationTime();
-        long creationBlockNumberFromArgs = actualFederationArgs.getCreationBlockNumber();
-        NetworkParameters btcParamsFromArgs = actualFederationArgs.getBtcParams();
-
         List<FederationMember> federationMembers = federation.getMembers();
         Instant creationTime = federation.getCreationTime();
         long creationBlockNumber = federation.getCreationBlockNumber();
         NetworkParameters btcParams = federation.getBtcParams();
+        FederationArgs federationArgsFromValues = new FederationArgs(federationMembers, creationTime, creationBlockNumber, btcParams);
 
-        assertEquals(federationMembers, federationMembersFromArgs);
-        assertEquals(creationTime, creationTimeFromArgs);
-        assertEquals(creationBlockNumber, creationBlockNumberFromArgs);
-        assertEquals(btcParams, btcParamsFromArgs);
+        FederationArgs federationArgs = federation.getArgs();
+        assertEquals(federationArgs, federationArgsFromValues);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
@@ -136,6 +136,33 @@ class StandardMultisigFederationTest {
     }
 
     @Test
+    void values_from_federationArgs_equal_values_from_federation() {
+        FederationArgs actualFederationArgs = federation.getArgs();
+        List<FederationMember> federationMembersFromArgs = actualFederationArgs.getMembers();
+        Instant creationTimeFromArgs = actualFederationArgs.getCreationTime();
+        long creationBlockNumberFromArgs = actualFederationArgs.getCreationBlockNumber();
+        NetworkParameters btcParamsFromArgs = actualFederationArgs.getBtcParams();
+
+        List<FederationMember> federationMembers = federation.getMembers();
+        Instant creationTime = federation.getCreationTime();
+        long creationBlockNumber = federation.getCreationBlockNumber();
+        NetworkParameters btcParams = federation.getBtcParams();
+
+        assertEquals(federationMembers, federationMembersFromArgs);
+        assertEquals(creationTime, creationTimeFromArgs);
+        assertEquals(creationBlockNumber, creationBlockNumberFromArgs);
+        assertEquals(btcParams, btcParamsFromArgs);
+    }
+
+    @Test
+    void federation_from_federationArgs_equals_federation() {
+        FederationArgs federationArgs = federation.getArgs();
+        Federation federationFromFederationArgs = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+
+        assertEquals(federation, federationFromFederationArgs);
+    }
+
+    @Test
     void testEquals_differentCreationTime() {
         FederationArgs federationArgs = new FederationArgs(
             federation.getMembers(),


### PR DESCRIPTION
This pr creates tests for the new FederationArgs and ErpFederationArgs added classes.
Also, it includes the creation of the getErpArgs() method to return erpFederationArgs from erp federations.
The method getArgs() that returns federationArgs from federations was already created
