### PR TITLE
Return properly encoded value by eth_getStorageAt RPC method for non-existing keys

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -86,6 +86,7 @@ public class Web3Impl implements Web3 {
     private static final Logger logger = LoggerFactory.getLogger("web3");
 
     private static final String CLIENT_VERSION_PREFIX = "RskJ";
+    private static final String NON_EXISTING_KEY_RESPONSE = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
     private final MinerClient minerClient;
     private final MinerServer minerServer;
@@ -484,7 +485,7 @@ public class Web3Impl implements Web3 {
             response = Optional.ofNullable(accountInformationProvider.getStorageValue(address.getAddress(), key))
                     .map(DataWord::getData)
                     .map(HexUtils::toUnformattedJsonHex)
-                    .orElse("0x0");
+                    .orElse(NON_EXISTING_KEY_RESPONSE);
             return response;
         } finally {
             logger.debug("eth_getStorageAt({}, {}, {}): {}", address, storageIdx, blockId, response);

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -107,9 +107,9 @@ import static org.mockito.Mockito.*;
  * Created by Ruben Altman on 09/06/2016.
  */
 class Web3ImplTest {
-
     private static final String BALANCE_10K_HEX = "0x2710"; //10.000
     private static final String CALL_RESPOND = "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000";
+    private static final String NON_EXISTING_KEY_RESPONSE = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
     private final TestSystemProperties config = new TestSystemProperties();
     private final BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
@@ -367,7 +367,7 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockNumber": "0x0" } -> return storage at given address in genesis block
     void getStorageAtAccountAndBlockNumber() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertByBlockNumber("0x0", blockRef -> chain.web3.eth_getStorageAt(
+        assertByBlockNumber(NON_EXISTING_KEY_RESPONSE, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -377,7 +377,7 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" } -> return storage at given address in genesis block
     void getStorageAtAccountAndBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertByBlockHash("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertByBlockHash(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -428,7 +428,7 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": true } -> return storage at given address in genesis block
     void getStorageAtAccountAndCanonicalBlockHashWhenCanonicalIsRequired() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertCanonicalBlockHashWhenCanonical("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertCanonicalBlockHashWhenCanonical(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -438,7 +438,7 @@ class Web3ImplTest {
         //[ "0x<address>", { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "requireCanonical": false } -> return storage at given address in genesis block
     void getStorageAtAccountAndCanonicalBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = chainWithAccount10kBalance(false);
-        assertCanonicalBlockHashWhenNotCanonical("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertCanonicalBlockHashWhenNotCanonical(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -448,7 +448,7 @@ class Web3ImplTest {
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>", "requireCanonical": false } -> return storage at given address in specified block
     void getStorageAtAccountAndNonCanonicalBlockHashWhenCanonicalIsNotRequired() {
         final ChainParams chain = chainWithAccount10kBalance(true);
-        assertNonCanonicalBlockHashWhenNotCanonical("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertNonCanonicalBlockHashWhenNotCanonical(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));
@@ -458,7 +458,7 @@ class Web3ImplTest {
         // [ "0x<address>", { "blockHash": "0x<non-canonical-block-hash>" } -> return storage at given address in specified bloc
     void getStorageAtAccountAndNonCanonicalBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(true);
-        assertNonCanonicalBlockHash("0x0", chain.block, blockRef -> chain.web3.eth_getStorageAt(
+        assertNonCanonicalBlockHash(NON_EXISTING_KEY_RESPONSE, chain.block, blockRef -> chain.web3.eth_getStorageAt(
                 new HexAddressParam(chain.accountAddress),
                 new HexNumberParam("0x0"),
                 new BlockRefParam(blockRef)));

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplUnitTest.java
@@ -209,8 +209,7 @@ class Web3ImplUnitTest {
                 .thenReturn(null);
 
         String result = target.eth_getStorageAt(hexAddressParam, hexNumberParam, blockRefParam);
-        assertEquals("0x0",
-                result);
+        assertEquals("0x0000000000000000000000000000000000000000000000000000000000000000", result);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated eth_getStorageAt to return a 32-byte zero value for non-existing keys, aligning with geth client behavior.

## Motivation and Context
Ensures compatibility with Ethers.js and other clients like Geth, which expect a 32-byte zero value for non-existing keys.

## How Has This Been Tested?
Tested in local development environment; unit tests updated to reflect new return value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
