### PR TITLE
Added getMemberByBtcPublicKey new method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -64,6 +64,10 @@ public abstract class Federation {
         return members;
     }
 
+    public Optional<FederationMember> getMemberByBtcPublicKey(BtcECKey btcPublicKey) {
+        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKey)).findFirst();
+    }
+
     public List<BtcECKey> getBtcPublicKeys() {
         // Copy instances since we don't control
         // immutability of BtcECKey instances

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -65,7 +65,7 @@ public abstract class Federation {
     }
 
     public Optional<FederationMember> getMemberByBtcPublicKey(BtcECKey btcPublicKey) {
-        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKey)).findFirst();
+        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKey)).findAny();
     }
 
     public List<BtcECKey> getBtcPublicKeys() {

--- a/rskj-core/src/test/java/co/rsk/peg/LegacyErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/LegacyErpFederationTest.java
@@ -698,7 +698,7 @@ class LegacyErpFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_existing_btcPublicKey_should_return_found_member(){
         BtcECKey existingMemberBtcPublicKey = standardKeys.get(0);
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
         Assertions.assertTrue(foundMember.isPresent());
@@ -706,14 +706,14 @@ class LegacyErpFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_non_existing_btcPublicKey_should_return_empty(){
         BtcECKey noExistingBtcPublicKey = new BtcECKey();
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
         Assertions.assertFalse(foundMember.isPresent());
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_null_btcPublicKey_should_return_empty(){
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
         Assertions.assertFalse(foundMember.isPresent());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/LegacyErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/LegacyErpFederationTest.java
@@ -14,7 +14,6 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.ScriptException;
 import co.rsk.bitcoinj.core.Utils;
-import co.rsk.bitcoinj.script.ErpFederationRedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptOpCodes;
 import co.rsk.config.BridgeConstants;
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -695,6 +695,27 @@ class LegacyErpFederationTest {
             true,
             false
         ));
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+        BtcECKey existingMemberBtcPublicKey = standardKeys.get(0);
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
+        Assertions.assertTrue(foundMember.isPresent());
+        Assertions.assertEquals(existingMemberBtcPublicKey, foundMember.get().getBtcPublicKey());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+        BtcECKey noExistingBtcPublicKey = new BtcECKey();
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
+        Assertions.assertFalse(foundMember.isPresent());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
+        Assertions.assertFalse(foundMember.isPresent());
     }
 
     private void createErpFederation(BridgeConstants constants, boolean isRskip293Active) {

--- a/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -452,6 +453,27 @@ class P2shErpFederationTest {
             value.minus(fee),
             signWithEmergencyMultisig
         ));
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+        BtcECKey existingMemberBtcPublicKey = standardKeys.get(0);
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
+        Assertions.assertTrue(foundMember.isPresent());
+        Assertions.assertEquals(existingMemberBtcPublicKey, foundMember.get().getBtcPublicKey());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+        BtcECKey noExistingBtcPublicKey = new BtcECKey();
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
+        Assertions.assertFalse(foundMember.isPresent());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
+        Assertions.assertFalse(foundMember.isPresent());
     }
 
     private void validateP2shErpRedeemScript(

--- a/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
@@ -456,7 +456,7 @@ class P2shErpFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_existing_btcPublicKey_should_return_found_member(){
         BtcECKey existingMemberBtcPublicKey = standardKeys.get(0);
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
         Assertions.assertTrue(foundMember.isPresent());
@@ -464,14 +464,14 @@ class P2shErpFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_non_existing_btcPublicKey_should_return_empty(){
         BtcECKey noExistingBtcPublicKey = new BtcECKey();
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
         Assertions.assertFalse(foundMember.isPresent());
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_null_btcPublicKey_should_return_empty(){
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
         Assertions.assertFalse(foundMember.isPresent());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StandardMultisigFederationTest.java
@@ -320,4 +320,25 @@ class StandardMultisigFederationTest {
         FederationMember invalidPubKeys = new FederationMember(invalidBtcKey, invalidRskKey, invalidRskKey);
         assertFalse(federation.isMember(invalidPubKeys));
     }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+        BtcECKey existingMemberBtcPublicKey = sortedPublicKeys.get(0);
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
+        Assertions.assertTrue(foundMember.isPresent());
+        Assertions.assertEquals(existingMemberBtcPublicKey, foundMember.get().getBtcPublicKey());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+        BtcECKey noExistingBtcPublicKey = new BtcECKey();
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
+        Assertions.assertFalse(foundMember.isPresent());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
+        Assertions.assertFalse(foundMember.isPresent());
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StandardMultisigFederationTest.java
@@ -322,7 +322,7 @@ class StandardMultisigFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_existing_btcPublicKey_should_return_found_member(){
         BtcECKey existingMemberBtcPublicKey = sortedPublicKeys.get(0);
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
         Assertions.assertTrue(foundMember.isPresent());
@@ -330,14 +330,14 @@ class StandardMultisigFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_non_existing_btcPublicKey_should_return_empty(){
         BtcECKey noExistingBtcPublicKey = new BtcECKey();
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
         Assertions.assertFalse(foundMember.isPresent());
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_null_btcPublicKey_should_return_empty(){
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
         Assertions.assertFalse(foundMember.isPresent());
     }


### PR DESCRIPTION
- Created a new method to get federation member by btc public key
- Added new tests for the new method:
  - Passing a null should return an empty optional.
  - Passing a random BTC public key should return an empty optional.
  - Passing an existing BTC public key should return the matched federation member.