### PR TITLE
Fix logAddSignature method where pegnatory RSK address is wrongly being derived from the btc public key for key file and hsm pegnatories

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1428,7 +1428,7 @@ public class BridgeSupport {
         Optional<Federation> optionalFederation = getFederationFromPublicKey(federatorPublicKey);
         if (!optionalFederation.isPresent()) {
             logger.warn(
-                "Supplied federator public key {} does not belong to any of the federators.",
+                "[addSignature] Supplied federator btc public key {} does not belong to any of the federators.",
                 federatorPublicKey
             );
             return;
@@ -1438,8 +1438,8 @@ public class BridgeSupport {
         Optional<FederationMember> federationMember = federation.getMemberByBtcPublicKey(federatorPublicKey);
         if (!federationMember.isPresent()){
             logger.warn(
-                "Supplied federator public key {} does not belong to any of the federators.",
-                federatorPublicKey
+                "[addSignature] Supplied federator btc public key {} doest not match any of the federator member btc public keys {}.",
+                federatorPublicKey, federation.getBtcPublicKeys()
             );
             return;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1435,7 +1435,15 @@ public class BridgeSupport {
         }
 
         Federation federation = optionalFederation.get();
-        FederationMember signingFederationMember = federation.getMemberByBtcPublicKey(federatorPublicKey).get();
+        Optional<FederationMember> federationMember = federation.getMemberByBtcPublicKey(federatorPublicKey);
+        if (!federationMember.isPresent()){
+            logger.warn(
+                "Supplied federator public key {} does not belong to any of the federators.",
+                federatorPublicKey
+            );
+            return;
+        }
+        FederationMember signingFederationMember = federationMember.get();
 
         BtcTransaction btcTx = provider.getPegoutsWaitingForSignatures().get(new Keccak256(rskTxHash));
         if (btcTx == null) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1490,7 +1490,7 @@ public class BridgeSupport {
         BtcTransaction btcTx,
         Federation federation) throws IOException {
 
-        BtcECKey federatorPublicKey = federatorMember.getBtcPublicKey();
+        BtcECKey federatorBtcPublicKey = federatorMember.getBtcPublicKey();
         // Build input hashes for signatures
         int numInputs = btcTx.getInputs().size();
 
@@ -1522,13 +1522,13 @@ public class BridgeSupport {
 
             Sha256Hash sighash = sighashes.get(i);
 
-            if (!federatorPublicKey.verify(sighash, sig)) {
+            if (!federatorBtcPublicKey.verify(sighash, sig)) {
                 logger.warn(
                     "Signature {} {} is not valid for hash {} and public key {}",
                     i,
                     ByteUtil.toHexString(sig.encodeToDER()),
                     sighash,
-                    federatorPublicKey
+                    federatorBtcPublicKey
                 );
                 return;
             }
@@ -1550,24 +1550,24 @@ public class BridgeSupport {
             Script inputScript = input.getScriptSig();
 
             boolean alreadySignedByThisFederator = BridgeUtils.isInputSignedByThisFederator(
-                    federatorPublicKey,
+                    federatorBtcPublicKey,
                     sighash,
                     input);
 
             // Sign the input if it wasn't already
             if (!alreadySignedByThisFederator) {
                 try {
-                    int sigIndex = inputScript.getSigInsertionIndex(sighash, federatorPublicKey);
+                    int sigIndex = inputScript.getSigInsertionIndex(sighash, federatorBtcPublicKey);
                     inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, txSigs.get(i).encodeToBitcoin(), sigIndex, 1, 1);
                     input.setScriptSig(inputScript);
                     logger.debug("Tx input {} for tx {} signed.", i, new Keccak256(rskTxHash));
                     signed = true;
                 } catch (IllegalStateException e) {
                     Federation retiringFederation = getRetiringFederation();
-                    if (getActiveFederation().hasBtcPublicKey(federatorPublicKey)) {
+                    if (getActiveFederation().hasBtcPublicKey(federatorBtcPublicKey)) {
                         logger.debug("A member of the active federation is trying to sign a tx of the retiring one");
                         return;
-                    } else if (retiringFederation != null && retiringFederation.hasBtcPublicKey(federatorPublicKey)) {
+                    } else if (retiringFederation != null && retiringFederation.hasBtcPublicKey(federatorBtcPublicKey)) {
                         logger.debug("A member of the retiring federation is trying to sign a tx of the active one");
                         return;
                     }

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -68,7 +68,8 @@ public abstract class Federation {
         if (btcPublicKey == null){
             return Optional.empty();
         }
-        return members.stream().filter(federationMember -> Arrays.equals(federationMember.getBtcPublicKey().getPubKey(), btcPublicKey.getPubKey())).findAny();
+        final BtcECKey btcPublicKeyOnly = BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
+        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKeyOnly)).findAny();
     }
 
     public List<BtcECKey> getBtcPublicKeys() {

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -65,7 +65,10 @@ public abstract class Federation {
     }
 
     public Optional<FederationMember> getMemberByBtcPublicKey(BtcECKey btcPublicKey) {
-        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKey)).findAny();
+        if (btcPublicKey == null){
+            return Optional.empty();
+        }
+        return members.stream().filter(federationMember -> Arrays.equals(federationMember.getBtcPublicKey().getPubKey(), btcPublicKey.getPubKey())).findAny();
     }
 
     public List<BtcECKey> getBtcPublicKeys() {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
@@ -36,7 +37,7 @@ public interface BridgeEventLogger {
 
     void logUpdateCollections(Transaction rskTx);
 
-    void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash);
+    void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash);
 
     void logReleaseBtc(BtcTransaction btcTx, byte[] rskTxHash);
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -77,7 +77,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
-        String federatorRskAddress = ByteUtil.toHexString(getFederatorPublicKey(federationMember).getAddress());;
+        String federatorRskAddress = ByteUtil.toHexString(getFederatorPublicKey(federationMember).getAddress());
         logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -23,6 +23,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.BridgeEvents;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -75,10 +76,19 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     }
 
     @Override
-    public void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
-        ECKey key = ECKey.fromPublicOnly(federatorPublicKey.getPubKey());
-        String federatorRskAddress = ByteUtil.toHexString(key.getAddress());
-        logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federatorPublicKey);
+    public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
+        if (shouldUseRskPublicKey()){
+            String federatorRskAddress = ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
+            logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
+        } else {
+            ECKey ecKeyFromBtcPublicKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
+            String federatorRskAddressFromBtcPublicKey = ByteUtil.toHexString(ecKeyFromBtcPublicKey.getAddress());
+            logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddressFromBtcPublicKey, federationMember.getBtcPublicKey());
+        }
+    }
+
+    private boolean shouldUseRskPublicKey() {
+        return activations.isActive(ConsensusRule.RSKIP415);
     }
 
     private void logAddSignatureInSolidityFormat(byte[] rskTxHash, String federatorRskAddress, BtcECKey federatorPublicKey) {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -77,17 +77,16 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
-        String federatorRskAddress = getFederatorRskAddress(federationMember);
+        String federatorRskAddress = ByteUtil.toHexString(getFederatorPublicKey(federationMember).getAddress());;
         logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
     }
 
-    private String getFederatorRskAddress(FederationMember federationMember){
-        if (shouldUseRskPublicKey()){
-            return ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
+    private ECKey getFederatorPublicKey(FederationMember federationMember) {
+        if (!shouldUseRskPublicKey()) {
+            return ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
         }
 
-        ECKey ecKeyFromBtcPublicKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
-        return ByteUtil.toHexString(ecKeyFromBtcPublicKey.getAddress());
+        return federationMember.getRskPublicKey();
     }
 
     private boolean shouldUseRskPublicKey() {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -77,7 +77,8 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
-        String federatorRskAddress = ByteUtil.toHexString(getFederatorPublicKey(federationMember).getAddress());
+        ECKey federatorPublicKey = getFederatorPublicKey(federationMember);
+        String federatorRskAddress = ByteUtil.toHexString(federatorPublicKey.getAddress());
         logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -77,14 +77,17 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
+        String federatorRskAddress = getFederatorRskAddress(federationMember);
+        logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
+    }
+
+    private String getFederatorRskAddress(FederationMember federationMember){
         if (shouldUseRskPublicKey()){
-            String federatorRskAddress = ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
-            logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
-        } else {
-            ECKey ecKeyFromBtcPublicKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
-            String federatorRskAddressFromBtcPublicKey = ByteUtil.toHexString(ecKeyFromBtcPublicKey.getAddress());
-            logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddressFromBtcPublicKey, federationMember.getBtcPublicKey());
+            return ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
         }
+
+        ECKey ecKeyFromBtcPublicKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
+        return ByteUtil.toHexString(ecKeyFromBtcPublicKey.getAddress());
     }
 
     private boolean shouldUseRskPublicKey() {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
@@ -23,6 +23,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.DeprecatedMethodCallException;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
@@ -77,7 +78,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     }
 
     @Override
-    public void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
+    public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
                 "Calling BrigeEventLoggerLegacyImpl.logAddSignature method after RSKIP146 activation"
@@ -85,7 +86,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
         }
         List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
         byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
-            RLP.encodeElement(federatorPublicKey.getPubKeyHash()),
+            RLP.encodeElement(federationMember.getBtcPublicKey().getPubKeyHash()),
             RLP.encodeElement(rskTxHash));
 
         this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -377,12 +377,13 @@ class BridgeSupportAddSignatureTest {
         }
 
         BtcECKey federatorPubKey = BridgeRegTestConstants.REGTEST_FEDERATION_PUBLIC_KEYS.get(indexOfKeyToSignWith);
+        FederationMember federationMember = FederationTestUtils.getFederationMemberWithKey(federatorPubKey);
         bridgeSupport.addSignature(federatorPubKey, derEncodedSigs, rskTxHash.getBytes());
         if(shouldSignTwice) {
             bridgeSupport.addSignature(federatorPubKey, derEncodedSigs, rskTxHash.getBytes());
         }
 
-        verify(eventLogger, times(wantedNumberOfInvocations)).logAddSignature(federatorPubKey, btcTx, rskTxHash.getBytes());
+        verify(eventLogger, times(wantedNumberOfInvocations)).logAddSignature(federationMember, btcTx, rskTxHash.getBytes());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -193,7 +193,8 @@ class BridgeEventLoggerImplTest {
         );
 
         return Stream.of(
-            Arguments.of(singleKeyFedMember, multiKeyFedMember)
+            Arguments.of(singleKeyFedMember),
+            Arguments.of(multiKeyFedMember)
         );
     }
 
@@ -224,8 +225,13 @@ class BridgeEventLoggerImplTest {
         assertTopics(3, eventLogs);
 
         ECKey federatorECKeyFromBtcPubKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
-        String derivedRskAddress = ByteUtil.toHexString(federatorECKeyFromBtcPubKey.getAddress());
-        assertEvent(eventLogs, 0, BridgeEvents.ADD_SIGNATURE.getEvent(), new Object[]{rskTxHash.getBytes(), derivedRskAddress}, new Object[]{federatorBtcPubKey.getPubKey()});
+        String expectedRskAddress = ByteUtil.toHexString(federatorECKeyFromBtcPubKey.getAddress());
+
+        CallTransaction.Function bridgeEvent = BridgeEvents.ADD_SIGNATURE.getEvent();
+        Object[] eventTopics = new Object[]{rskTxHash.getBytes(), expectedRskAddress};
+        Object[] eventParams = new Object[]{federatorBtcPubKey.getPubKey()};
+
+        assertEvent(eventLogs, 0, bridgeEvent, eventTopics, eventParams);
     }
 
     @ParameterizedTest()
@@ -253,8 +259,13 @@ class BridgeEventLoggerImplTest {
         commonAssertLogs(eventLogs);
         assertTopics(3, eventLogs);
 
-        String derivedRskAddress = ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
-        assertEvent(eventLogs, 0, BridgeEvents.ADD_SIGNATURE.getEvent(), new Object[]{rskTxHash.getBytes(), derivedRskAddress}, new Object[]{federatorBtcPubKey.getPubKey()});
+        String expectedRskAddress = ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
+
+        CallTransaction.Function bridgeEvent = BridgeEvents.ADD_SIGNATURE.getEvent();
+        Object[] eventTopics = new Object[]{rskTxHash.getBytes(), expectedRskAddress};
+        Object[] eventParams = new Object[]{federatorBtcPubKey.getPubKey()};
+
+        assertEvent(eventLogs, 0, bridgeEvent, eventTopics, eventParams);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
@@ -115,10 +115,11 @@ class BridgeEventLoggerLegacyImplTest {
 
         // Setup logAddSignature params
         BtcECKey federatorPubKey = BtcECKey.fromPrivate(BigInteger.valueOf(2L));
+        FederationMember federationMember = FederationTestUtils.getFederationMemberWithKey(federatorPubKey);
         when(btcTxMock.getHashAsString()).thenReturn("3e72fdbae7bbd103f08e876c765e3d5ba35db30ea46cb45ab52803f987ead9fb");
 
         // Act
-        eventLogger.logAddSignature(federatorPubKey, btcTxMock, rskTxHash.getBytes());
+        eventLogger.logAddSignature(federationMember, btcTxMock, rskTxHash.getBytes());
 
         // Assert log size
         Assertions.assertEquals(1, eventLogs.size());
@@ -147,8 +148,9 @@ class BridgeEventLoggerLegacyImplTest {
     void testLogAddSignatureAfterRskip146() {
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
         BtcECKey federatorPublicKey = new BtcECKey();
+        FederationMember federationMember = FederationTestUtils.getFederationMemberWithKey(federatorPublicKey);
         byte[] bytes = rskTxHash.getBytes();
-        assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logAddSignature(federatorPublicKey, btcTxMock, bytes));
+        assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logAddSignature(federationMember, btcTxMock, bytes));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -182,7 +182,8 @@ public class ActivationConfigsForTest {
             ConsensusRule.RSKIP379,
             ConsensusRule.RSKIP398,
             ConsensusRule.RSKIP400,
-            ConsensusRule.RSKIP203
+            ConsensusRule.RSKIP203,
+            ConsensusRule.RSKIP415
         ));
 
         return rskips;

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -178,11 +178,11 @@ public class ActivationConfigsForTest {
     private static List<ConsensusRule> getArrowhead600Rskips() {
         List<ConsensusRule> rskips = new ArrayList<>();
         rskips.addAll(Arrays.asList(
+            ConsensusRule.RSKIP203,
             ConsensusRule.RSKIP376,
             ConsensusRule.RSKIP379,
             ConsensusRule.RSKIP398,
             ConsensusRule.RSKIP400,
-            ConsensusRule.RSKIP203,
             ConsensusRule.RSKIP415
         ));
 


### PR DESCRIPTION
-  logAddSignature method was refactored to receive a federation member instead of a btcPublicKey. Regarding, getting rid of btcTx, it was not removed because legacy implementation of BridgeEventLogger is using that parameter and logging it.
- New tests were added, and existing tests were updated to call the method using the new signature.