### PR TITLE
Fix the web 3 retriever with block hash as identifier

### DIFF
--- a/rskj-core/src/test/java/co/rsk/rpc/Web3InformationRetrieverTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/Web3InformationRetrieverTest.java
@@ -6,6 +6,7 @@ import co.rsk.core.bc.PendingState;
 import co.rsk.crypto.Keccak256;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.RepositorySnapshot;
+import co.rsk.util.HexUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.core.*;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
@@ -85,6 +86,18 @@ class Web3InformationRetrieverTest {
         Block secondBlock = mock(Block.class);
         when(blockchain.getBlockByNumber(2)).thenReturn(secondBlock);
         Optional<Block> result = target.getBlock("0x2");
+
+        assertTrue(result.isPresent());
+        assertEquals(secondBlock, result.get());
+    }
+
+    @Test
+    void getBlock_hash() {
+        String hash = "0x0000000000000000000000000000000000000000000000000000000000000002";
+        byte[] bytesHash = HexUtils.stringHexToByteArray(hash);
+        Block secondBlock = mock(Block.class);
+        when(blockchain.getBlockByHash(bytesHash)).thenReturn(secondBlock);
+        Optional<Block> result = target.getBlock(hash);
 
         assertTrue(result.isPresent());
         assertEquals(secondBlock, result.get());

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -384,6 +384,34 @@ class Web3ImplTest {
     }
 
     @Test
+        //[ "0x<address>",  "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" -> return storage at given address in genesis block
+    void getStorageAtAccountAndBlockHashWithSingleIdentifier() {
+        //given
+        final ChainParams chain = chainWithAccount10kBalance(false);
+        // when
+        String result = chain.web3.eth_getStorageAt(
+                new HexAddressParam(chain.accountAddress),
+                new HexNumberParam("0x0"),
+                new BlockRefParam( "0x" + chain.block.getPrintableHash()));
+        // then
+        assertEquals(NON_EXISTING_KEY_RESPONSE, result );
+    }
+
+    @Test
+        //[ "0x<address>",  "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" -> return storage at given address in genesis block
+    void getStorageAtAccountAndBlockHashWithSingleIdentifier_whenItsAInvalidHash() {
+        //given
+        String invalidBlockIdentifier = "0x00011231234123";
+        final ChainParams chain = chainWithAccount10kBalance(false);
+        //when-then
+        Exception ex = assertThrows(RskJsonRpcRequestException.class, () -> chain.web3.eth_getStorageAt(
+                new HexAddressParam(chain.accountAddress),
+                new HexNumberParam("0x0"),
+                new BlockRefParam( invalidBlockIdentifier)));
+        assertEquals("Block " + invalidBlockIdentifier + " not found", ex.getMessage());
+    }
+
+    @Test
         //[ "0x<address>", { "blockHash": "0x<non-existent-block-hash>" } -> raise block-not-found error
     void getStorageAtAccountAndNonExistentBlockHash() {
         final ChainParams chain = chainWithAccount10kBalance(false);
@@ -810,7 +838,7 @@ class Web3ImplTest {
         txs.add(tx);
         Block genesis = world.getBlockChain().getBestBlock();
         Block block1 = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
-                world.getBlockStore()).trieStore(world.getTrieStore()).parent(genesis).difficulty(3l).transactions(txs).build();
+                world.getBlockStore()).trieStore(world.getTrieStore()).parent(genesis).difficulty(3L).transactions(txs).build();
         assertEquals(ImportResult.IMPORTED_BEST, world.getBlockChain().tryToConnect(block1));
         Block block1b = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(),
                 world.getBlockStore()).trieStore(world.getTrieStore()).parent(genesis)
@@ -1018,7 +1046,7 @@ class Web3ImplTest {
         Transaction tx = new TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
         List<Transaction> txs = new ArrayList<>();
         txs.add(tx);
-        Block block1 = createCanonicalBlock(world, txs);
+        createCanonicalBlock(world, txs);
 
         String accountAddress = ByteUtil.toHexString(acc1.getAddress().getBytes());
 
@@ -3108,7 +3136,7 @@ class Web3ImplTest {
         Transaction tx = new TransactionBuilder().sender(acc1).receiver(acc2).value(BigInteger.valueOf(1000000)).build();
         List<Transaction> txs = new ArrayList<>();
         txs.add(tx);
-        Block block1 = createCanonicalBlock(world, txs);
+        createCanonicalBlock(world, txs);
 
         String hashString = tx.getHash().toHexString();
         TxHashParam txHashParam = new TxHashParam(hashString);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With the current logic implementation, the hash is working to retrieve the block. We had to change the way to get blockReference that wasn't considering the identifier to be a hash.

With the change, we try to get the bockReference as if the identifier was a number, if it still doesn't work, we try as a hash. Since both ways are accepted as a string identifier.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
